### PR TITLE
Reference to localhost link

### DIFF
--- a/docs/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/index.md
+++ b/docs/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/index.md
@@ -179,7 +179,7 @@ import React from "react"
 export default props => <h1>Hello, from the theme!</h1>
 ```
 
-Stop and restart the Gatsby development server to pick up the new page from the theme. The theme's page should be visible at `http://localhost:8080/theme-page`.
+Stop and restart the Gatsby development server to pick up the new page from the theme. The theme's page should be visible at `http://localhost:8000/theme-page`.
 
 That's it! By now you should have a basic Yarn workspaces setup to develop Gatsby themes with.
 Be sure to look for more posts on developing Gatsby themes in the near future,


### PR DESCRIPTION
A reference was made to localhost:8080 to view a new page but it should be localhost:8000.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
