### PR TITLE
Update broken link

### DIFF
--- a/docs/accessibility-statement.md
+++ b/docs/accessibility-statement.md
@@ -24,7 +24,7 @@ Alternatively, we welcome you to reach out directly to Marcy Sutton, Head of Lea
 
 ## Building with Gatsby
 
-To learn how to build an accessible website with Gatsby, visit our [docs accessibility page](/docs/making-your-site-accessible/). Contributions are very welcome as this page evolves.
+To learn how to build an accessible website with Gatsby, visit our [docs accessibility page](https://www.gatsbyjs.org/docs/making-your-site-accessible/). Contributions are very welcome as this page evolves.
 
 ## Third-party platforms, products and services
 


### PR DESCRIPTION
## Description

Update link to `docs accessibility page`. Old link was leading to a 404, new link leads to the same page on gatsbyjs.org

