### PR TITLE
docs: Move `__tests__` dir out of `src`

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -40,7 +40,7 @@ module.exports = {
     ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
     ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`,
   },
-  testPathIgnorePatterns: [`node_modules`, `.cache`, `public`],
+  testPathIgnorePatterns: [`node_modules`, `.cache`],
   transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],
   globals: {
     __PATH_PREFIX__: ``,
@@ -165,13 +165,13 @@ start with a simple snapshot test to check that everything is working.
 First, create the test file. You can either put these in a `__tests__`
 directory, or put them elsewhere (usually next to the component itself), with
 the extension `.spec.js` or `.test.js`. The decision comes down to your own
-preference. In this guide, we will use the `__tests__` folder convention. Let's create a test for our header component, so create a `header.js` file in `src/components/__tests__/`:
+preference. In this guide, we will use the `__tests__` folder convention. Let's create a test for our header component. Create a `header.js` file in `__tests__/`:
 
-```js:title=src/components/__tests__/header.js
+```js:title=__tests__/header.js
 import React from "react"
 import renderer from "react-test-renderer"
 
-import Header from "../header"
+import Header from "../src/components/header"
 
 describe("Header", () => {
   it("renders correctly", () => {
@@ -239,7 +239,7 @@ module.exports = {
       "<rootDir>/__mocks__/file-mock.js",
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-  testPathIgnorePatterns: ["node_modules", ".cache", "public"],
+  testPathIgnorePatterns: ["node_modules", ".cache"],
   transformIgnorePatterns: ["node_modules/(?!(gatsby)/)"],
   globals: {
     __PATH_PREFIX__: "",


### PR DESCRIPTION
## Description

I've got the realization that it's not intuitive to have `__tests__` dir in `src` dir while having the reply: https://github.com/gatsbyjs/gatsby/pull/17077#pullrequestreview-279460456

I sort of revert my previous change PR:17077 and move `__tests__` dir to project root dir instead, so people don't need extra work to handle the test dir.

## Related Issues

Not an issue but PR: https://github.com/gatsbyjs/gatsby/pull/17077