### PR TITLE
fix(gatsby): fix mapping stack trace to source file after dependency upgrade

### DIFF
--- a/packages/gatsby-cli/src/reporter/__tests__/errors.js
+++ b/packages/gatsby-cli/src/reporter/__tests__/errors.js
@@ -5,8 +5,8 @@ const errorStr = `./src/pages/index.module.scss\nModule build failed: /project/s
 // TODO: Add tests for sourcemap mapping in prepareStackTrace[]
 
 describe(`createErrorFromString`, () => {
-  it(`converts a string to an Error object`, () => {
-    const err = createErrorFromString(errorStr)
+  it(`converts a string to an Error object`, async () => {
+    const err = await createErrorFromString(errorStr)
     expect(typeof err).toEqual(`object`)
     expect(err.name).toEqual(`WebpackError`)
     expect(err.message).toEqual(`./src/pages/index.module.scss`)

--- a/packages/gatsby-cli/src/reporter/errors.js
+++ b/packages/gatsby-cli/src/reporter/errors.js
@@ -54,7 +54,10 @@ function getErrorFormatter() {
  * an Error instance so it can be formatted properly
  * @param {string} errorStr
  */
-function createErrorFromString(errorStr: string = ``, sourceMapFile: string) {
+async function createErrorFromString(
+  errorStr: string = ``,
+  sourceMapFile: string
+) {
   let [message, ...rest] = errorStr.split(/\r\n|[\n\r]/g)
   // pull the message from the first line then remove the `Error:` prefix
   // FIXME: when https://github.com/AriaMinaei/pretty-error/pull/49 is merged
@@ -67,7 +70,7 @@ function createErrorFromString(errorStr: string = ``, sourceMapFile: string) {
 
   error.name = `WebpackError`
   try {
-    if (sourceMapFile) prepareStackTrace(error, sourceMapFile)
+    if (sourceMapFile) await prepareStackTrace(error, sourceMapFile)
   } catch (err) {
     // don't shadow a real error because of a parsing issue
   }

--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.js
@@ -7,8 +7,8 @@ const { codeFrameColumns } = require(`@babel/code-frame`)
 const stackTrace = require(`stack-trace`)
 const { SourceMapConsumer } = require(`source-map`)
 
-module.exports = function prepareStackTrace(error, source) {
-  const map = new SourceMapConsumer(readFileSync(source, `utf8`))
+module.exports = async function prepareStackTrace(error, source) {
+  const map = await new SourceMapConsumer(readFileSync(source, `utf8`))
   const stack = stackTrace
     .parse(error)
     .map(frame => wrapCallSite(map, frame))

--- a/packages/gatsby/src/commands/build-html.js
+++ b/packages/gatsby/src/commands/build-html.js
@@ -109,7 +109,10 @@ const doBuildPages = async ({
   try {
     await renderHTMLQueue({ workerPool, activity }, rendererPath, pagePaths)
   } catch (e) {
-    const prettyError = createErrorFromString(e.stack, `${rendererPath}.map`)
+    const prettyError = await createErrorFromString(
+      e.stack,
+      `${rendererPath}.map`
+    )
     prettyError.context = e.context
     throw prettyError
   }


### PR DESCRIPTION
Bug was introduced in dependencies bump in https://github.com/gatsbyjs/gatsby/pull/16942 - particularly with `source-map` upgrade:

```
source-map | dependencies | minor | 0.5.7 -> 0.7.3
```

There was number of breaking changes in `0.7.0`: https://github.com/mozilla/source-map/blob/master/CHANGELOG.md#070

We are affected by this one:
```
Breaking change: new SourceMapConsumer now returns a Promise object that resolves to the newly constructed SourceMapConsumer instance, rather than returning the new instance immediately.
```

And it's what this PR is addressing

You can reproduce this using this repo https://github.com/pieh/gatsby-html-render-stack-trace-repro

Current:
```
 ERROR #95313

Building static HTML failed for path "/"

See our docs page for more info on this error: https://gatsby.dev/debug-html



  TypeError: Cannot read property 'someField' of undefined

  - render-page.js:1964 IndexPage
    /Users/misiek/test/gatsby-html-render-stack-trace-repro/public/render-page.js:1964:92

  - react-dom-server.node.production.min.js:36 c
    [gatsby-html-render-stack-trace-repro]/[react-dom]/cjs/react-dom-server.node.production.min.js:36:500

  - react-dom-server.node.production.min.js:39 Ua
    [gatsby-html-render-stack-trace-repro]/[react-dom]/cjs/react-dom-server.node.production.min.js:39:16

  - react-dom-server.node.production.min.js:45 a.render
    [gatsby-html-render-stack-trace-repro]/[react-dom]/cjs/react-dom-server.node.production.min.js:45:48

  - react-dom-server.node.production.min.js:44 a.read
    [gatsby-html-render-stack-trace-repro]/[react-dom]/cjs/react-dom-server.node.production.min.js:44:161

  - react-dom-server.node.production.min.js:55 renderToString
    [gatsby-html-render-stack-trace-repro]/[react-dom]/cjs/react-dom-server.node.production.min.js:55:83

  - render-page.js:552 Module../.cache/static-entry.js.__webpack_exports__.default
    /Users/misiek/test/gatsby-html-render-stack-trace-repro/public/render-page.js:552:28

  - render-html.js:35 Promise
    [gatsby-html-render-stack-trace-repro]/[gatsby]/dist/utils/worker/render-html.js:35:36

  - debuggability.js:313 Promise._execute
    [gatsby-html-render-stack-trace-repro]/[bluebird]/js/release/debuggability.js:313:9

  - promise.js:488 Promise._resolveFromExecutor
    [gatsby-html-render-stack-trace-repro]/[bluebird]/js/release/promise.js:488:18

  - promise.js:79 new Promise
    [gatsby-html-render-stack-trace-repro]/[bluebird]/js/release/promise.js:79:10

  - render-html.js:31 Promise.map.path
    [gatsby-html-render-stack-trace-repro]/[gatsby]/dist/utils/worker/render-html.js:31:37

  - util.js:16 tryCatcher
    [gatsby-html-render-stack-trace-repro]/[bluebird]/js/release/util.js:16:23

  - map.js:61 MappingPromiseArray._promiseFulfilled
    [gatsby-html-render-stack-trace-repro]/[bluebird]/js/release/map.js:61:38

  - promise_array.js:114 MappingPromiseArray.PromiseArray._iterate
    [gatsby-html-render-stack-trace-repro]/[bluebird]/js/release/promise_array.js:114:31

  - promise_array.js:78 MappingPromiseArray.init
    [gatsby-html-render-stack-trace-repro]/[bluebird]/js/release/promise_array.js:78:10


⠏ Building static HTML for pages
```

With changes in PR:

```
 ERROR #95313

Building static HTML failed for path "/"

See our docs page for more info on this error: https://gatsby.dev/debug-html


   7 |
   8 | const IndexPage = ({ notExistingProp }) => {
>  9 |   const tryingToAccessFieldOnUndefined = notExistingProp.someField
     |                                                          ^
  10 |
  11 |   return (
  12 |     <Layout>


  WebpackError: TypeError: Cannot read property 'someField' of undefined

  - index.js:9 IndexPage
    src/pages/index.js:9:58


⠏ Building static HTML for pages
```


Side note - we need to look at renovate and make it consider minor version changes in `0.x` version range as breaking