### PR TITLE
fix(www): remove showcase ref prop from FeaturedSites

### DIFF
--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -60,7 +60,6 @@ class ShowcaseView extends Component {
         <FeaturedSites
           setFilters={this.setFilters}
           featured={data.featured.edges}
-          showcase={this.showcase}
         />
         <div id="showcase" css={{ height: 0 }} ref={this.showcase} />
         <FilteredShowcase


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

'showcase' ref prop is not used in the FeaturedSites component anymore (since [#12105](https://github.com/gatsbyjs/gatsby/commit/25786720ee6ff550f03f96d738fa245adcba062a#diff-b8226183ef427c89d128d6d47d8c31dcL30)) so I took it out
<!-- Write a brief description of the changes introduced by this PR -->
