### PR TITLE
chore(gatsby-cli): changed the new command gist

### DIFF
--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -32,7 +32,7 @@ You can also use the `package.json` script variant of these commands, typically 
 
 ### `new`
 
-`gatsby new <my-gatsby-site>`
+`gatsby new <my-gatsby-site> [<gatsby-starter>]`
 
 See the [Gatsby starters docs](https://www.gatsbyjs.org/docs/gatsby-starters/)
 for more.

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -32,7 +32,7 @@ You can also use the `package.json` script variant of these commands, typically 
 
 ### `new`
 
-`gatsby new gatsby-site`
+`gatsby new <my-gatsby-site>`
 
 See the [Gatsby starters docs](https://www.gatsbyjs.org/docs/gatsby-starters/)
 for more.

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -34,7 +34,7 @@ You can also use the `package.json` script variant of these commands, typically 
 
 `gatsby new <my-gatsby-site> [<gatsby-starter>]`
 
-See the [Gatsby starters docs](https://www.gatsbyjs.org/docs/gatsby-starters/)
+See the [Gatsby starters docs](https://www.gatsbyjs.org/docs/starters/)
 for more.
 
 ### `develop`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
In the CLI, the new command gist is `gatsby new gatsby-site` which is not so beginner  friendly as many will be fond to create their project with `gatsby-site` name, instead added a template mark to show it as it is customizable
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
NA

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
