### PR TITLE
chore: upgrade better-opn to 1.0.0

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -33,7 +33,7 @@
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-remove-graphql-queries": "^2.7.6",
     "babel-preset-gatsby": "^0.2.12",
-    "better-opn": "0.1.4",
+    "better-opn": "1.0.0",
     "better-queue": "^3.8.10",
     "bluebird": "^3.5.5",
     "browserslist": "3.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4130,7 +4130,14 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
-better-opn@0.1.4, better-opn@^0.1.4:
+better-opn@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/better-opn/-/better-opn-1.0.0.tgz#0454e4bb9115c6a9e4e5744417dd9c97fb9fce41"
+  integrity sha512-q3eO2se4sFbTERB1dFBDdjTiIIpRohMErpwBX21lhPvmgmQNNrcQj0zbWRhMREDesJvyod9kxBS3kOtdAvkB/A==
+  dependencies:
+    open "^6.4.0"
+
+better-opn@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/better-opn/-/better-opn-0.1.4.tgz#271d03bd8bcb8406d2d9d4cda5c0944d726ea171"
   dependencies:
@@ -14077,6 +14084,13 @@ onetime@^5.1.0:
   integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-6.4.0.tgz#5c13e96d0dc894686164f18965ecfe889ecfc8a9"
+  integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
+  dependencies:
+    is-wsl "^1.1.0"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Upgrade `better-opn` to `v1.0.0`, [changelog](https://github.com/ExiaSR/better-opn/blob/master/CHANGELOG.md#100---2019-09-06)

## Related Issues

### Changed
- Drop support for Node.js version lower than 8
- Migrate fr from `opn` to `open`, [more detail](https://github.com/sindresorhus/open/commit/eca88d863dde48695a5f931390d57d3b805a072a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)
