### PR TITLE
chore(showcase): Remove oern.tv

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4380,19 +4380,6 @@
   categories:
     - Blog
     - WordPress
-- title: On Earth Right Now
-  main_url: https://oern.tv
-  url: https://oern.tv
-  source_url: https://github.com/cadejscroggins/oern.tv
-  description: >
-    A curated list of live video feeds from around the world—built with GatsbyJS.
-  categories:
-    - Directory
-    - Entertainment
-    - Gallery
-  built_by: Cade Scroggins
-  built_by_url: https://cadejs.com
-  featured: false
 - title: Oliver Gomes Portfolio
   main_url: https://oliver-gomes.github.io/v4/
   url: https://oliver-gomes.github.io/v4/


### PR DESCRIPTION
## Description

@cadejscroggins just a heads up. The Gatsby Site Showcase Validator found that this site returned the GitHub Pages 404 so it seems the site is no longer available. I'm removing it from the showcase as such.