### PR TITLE
docs(creating-a-starter) Add site-name before starter-url

### DIFF
--- a/docs/docs/creating-a-starter.md
+++ b/docs/docs/creating-a-starter.md
@@ -27,13 +27,13 @@ Let's expand upon these items to prepare you for creating a winning starter.
 
 ## Open source and available from a stable URL
 
-The Gatsby CLI allows users to install a new site with a starter using the command `gatsby new <starter-url>`. For this to work, your starter needs to be available to download. The easiest way to accomplish this is to host your starter on GitHub or GitLab and use the publicly available repo URL, such as:
+The Gatsby CLI allows users to install a new site with a starter using the command `gatsby new <site-name> <starter-url>`. For this to work, your starter needs to be available to download. The easiest way to accomplish this is to host your starter on GitHub or GitLab and use the publicly available repo URL, such as:
 
-`gatsby new https://github.com/gatsbyjs/gatsby-starter-blog`
+`gatsby new my-app https://github.com/gatsbyjs/gatsby-starter-blog`
 
 Although the official starters live in the Gatsby repo, community members can offer their own starters from their own repos. Here's an example of installing a community starter:
 
-`gatsby new https://github.com/netlify-templates/gatsby-starter-netlify-cms`
+`gatsby new my-app https://github.com/netlify-templates/gatsby-starter-netlify-cms`
 
 ## Configurable
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
When using starter, we need input site-name before starter-url. However I can't see that.
So I correct `creating-a-starter.md`

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
