### PR TITLE
docs(gatsby-plugin-google-analytics): Fix typo in README

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -74,7 +74,7 @@ Here you place your Google Analytics tracking id.
 
 ### `head`
 
-Where do you want to place the GA script? By putting `head` to `true`, it will be placed in the "<head>" of your website. By setting it to `false`, it will be placed in the "<body>". The default value resolves to `false`.
+Where do you want to place the GA script? By putting `head` to `true`, it will be placed in the "&lt;head&gt;" of your website. By setting it to `false`, it will be placed in the "&lt;body&gt;". The default value resolves to `false`.
 
 ### `anonymize`
 


### PR DESCRIPTION
## Description
Fixes typo in `gatsby-plugin-google-analytics` README
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
none