### PR TITLE
docs(importing-media-content): fix incorrect url

### DIFF
--- a/docs/docs/importing-media-content.md
+++ b/docs/docs/importing-media-content.md
@@ -8,7 +8,7 @@ title: Importing Media Content
 
 - [Image graphics can be imported](/docs/importing-assets-into-files/) with Webpack and queried with GraphQL.
 - Images can also be [included from the `static folder`](/docs/static-folder/).
-- SVG content can be embedded into JSX. Here's a [handy JSX converter](https://transform.now.sh/html-to-jsx/).
+- SVG content can be embedded into JSX. Here's a [handy JSX converter](https://transform.tools/).
 - SVG can be included in `img` tags or CSS backgrounds. [SVG Tips from CSS Tricks](https://css-tricks.com/using-svg/).
 - For PDF files, we recommend embedding an [image of the PDF](https://helpx.adobe.com/acrobat/using/exporting-pdfs-file-formats.html) with [alternative text](https://a11y-101.com/development/infographics), and providing a link to download a [tagged PDF](https://helpx.adobe.com/acrobat/using/creating-accessible-pdfs.html).
 

--- a/docs/docs/importing-media-content.md
+++ b/docs/docs/importing-media-content.md
@@ -8,7 +8,7 @@ title: Importing Media Content
 
 - [Image graphics can be imported](/docs/importing-assets-into-files/) with Webpack and queried with GraphQL.
 - Images can also be [included from the `static folder`](/docs/static-folder/).
-- SVG content can be embedded into JSX. Here's a [handy JSX converter](https://transform.tools/).
+- SVG content can be embedded into JSX. Here's a [handy JSX converter](https://transform.tools/svg-to-jsx).
 - SVG can be included in `img` tags or CSS backgrounds. [SVG Tips from CSS Tricks](https://css-tricks.com/using-svg/).
 - For PDF files, we recommend embedding an [image of the PDF](https://helpx.adobe.com/acrobat/using/exporting-pdfs-file-formats.html) with [alternative text](https://a11y-101.com/development/infographics), and providing a link to download a [tagged PDF](https://helpx.adobe.com/acrobat/using/creating-accessible-pdfs.html).
 


### PR DESCRIPTION
## Description

When following the Importing Media Content page, I noticed the link for embedding SVG in JSX lead to a 404 and was also trying to send the user to a tool that converts HTML to JSX.

Fixed this URL to land on the index which by default is the SVG to JSX tool

## Related Issues

N/A