### PR TITLE
fix(gatsby-cli): added effective condition to check empty path

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -206,8 +206,10 @@ const getPaths = async (starterPath: string, rootPath: string) => {
       },
     ])
     // exit gracefully if responses aren't provided
-    if (!response.starter || !response.path) {
-      process.exit()
+    if (!response.starter || !response.path.trim()) {
+      throw new Error(
+        `Please mention both starter package and project name along with path(if its not in the root)`
+      )
     }
 
     selectedOtherStarter = response.starter === `different`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
this is a bugfix
command referenced `gatsby-cli new`, thats it
in gatsby-cli, when the cli prompts for `starter` and `project name` , it checks for an empty value, 
Now in the project name prompt, if a user enters `space` then [`this condition`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/src/init-starter.js#L209), will be skipped even though the path is empty, in order to have an effective checking, I used `trimmed` path to check for the empty.
Secondly, in that condition itself, the process is being exited there and then it's going to execution and later it's showing the message. It is better to have a throw condition in this if statement itself.
*The throw error message can be changed if need if requires*

## Related Issues
None
