### PR TITLE
Add Fathom Analytics to Gatsby Starter Blog

### DIFF
--- a/starters/blog/gatsby-config.js
+++ b/starters/blog/gatsby-config.js
@@ -53,6 +53,15 @@ module.exports = {
         //trackingId: `ADD YOUR TRACKING ID HERE`,
       },
     },
+    {
+      resolve: 'gatsby-plugin-fathom',
+      options: {
+        // Fathom server URL. Defaults to `cdn.usefathom.com`
+        // trackingUrl: 'your-fathom-instance.com',
+
+        // siteId: 'ADD YOUR SITE ID HERE'
+      }
+    },
     `gatsby-plugin-feed`,
     {
       resolve: `gatsby-plugin-manifest`,

--- a/starters/blog/package.json
+++ b/starters/blog/package.json
@@ -12,6 +12,7 @@
     "gatsby-image": "^2.2.17",
     "gatsby-plugin-feed": "^2.3.11",
     "gatsby-plugin-google-analytics": "^2.1.14",
+    "gatsby-plugin-fathom": "^1.1.0",
     "gatsby-plugin-manifest": "^2.2.14",
     "gatsby-plugin-offline": "^2.2.10",
     "gatsby-plugin-react-helmet": "^3.1.6",


### PR DESCRIPTION
## Description
This PR adds the functionality to add the [Fathom Analytics](https://usefathom.com) tracking script to your site created with the gatsby-starter-blog
