### PR TITLE
test(load-plugins): fix snapshot

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -490,18 +490,6 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "default-site-plugin",
-    "nodeAPIs": Array [],
-    "pluginOptions": Object {
-      "plugins": Array [],
-    },
-    "resolve": "",
-    "ssrAPIs": Array [],
-    "version": "1.0.0",
-  },
-  Object {
-    "browserAPIs": Array [],
-    "id": "",
     "name": "gatsby-plugin-page-creator",
     "nodeAPIs": Array [
       "createPagesStatefully",
@@ -598,13 +586,9 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "gatsby-plugin-page-creator",
-    "nodeAPIs": Array [
-      "createPagesStatefully",
-    ],
+    "name": "default-site-plugin",
+    "nodeAPIs": Array [],
     "pluginOptions": Object {
-      "path": "<PROJECT_ROOT>/src/pages",
-      "pathCheck": false,
       "plugins": Array [],
     },
     "resolve": "",


### PR DESCRIPTION
there were recently 2 separate PRs that updated this snapshot:
- https://github.com/gatsbyjs/gatsby/pull/17420
- https://github.com/gatsbyjs/gatsby/pull/17409

and seems like one that was merged last wasn't rebased on master which caused snapshot to desync and now it fails consistently (i.e. https://circleci.com/gh/gatsbyjs/gatsby/219854?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link )

I'm not exactly sure if this just hides the issue or not so need some eyes on this to verify

/cc @universse @akshayymahajan 