### PR TITLE
chore(gatsby): Add deprecation msg for `__experimentalThemes`

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -89,7 +89,7 @@ module.exports = async (args: BootstrapArgs) => {
   // theme gatsby configs can be functions or objects
   if (config && config.__experimentalThemes) {
     report.warn(
-      `The gatsby-config key "__experimentalThemes" has been deprecated. Please use the "plugin" key instead.`
+      `The gatsby-config key "__experimentalThemes" has been deprecated. Please use the "plugins" key instead.`
     )
     const themes = await loadThemes(config, { useLegacyThemes: true })
     config = themes.config

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -88,7 +88,9 @@ module.exports = async (args: BootstrapArgs) => {
 
   // theme gatsby configs can be functions or objects
   if (config && config.__experimentalThemes) {
-    // TODO: deprecation message for old __experimentalThemes
+    report.warn(
+      `The gatsby-config key "__experimentalThemes" has been deprecated. Please use the "plugin" key instead.`
+    )
     const themes = await loadThemes(config, { useLegacyThemes: true })
     config = themes.config
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

As described by @robin-macpherson, I have added a warning so that if the user uses the gatsby-config `__experimentalThemes` key, it will warn them to use the `plugins` key instead.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->


Fixes #17147