### PR TITLE
chore(gatsby-cli): better error messages with wrong arguments in new command

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -246,11 +246,20 @@ module.exports = async (starter: string, options: InitOptions = {}) => {
     opn(`https://gatsby.dev/starters?v=2`)
     return
   }
-
   if (urlObject.protocol && urlObject.host) {
     trackError(`NEW_PROJECT_NAME_MISSING`)
+
+    const isStarterAUrl =
+      starter && !url.parse(starter).hostname && !url.parse(starter).protocol
+
+    if (/gatsby-starter/gi.test(rootPath) && isStarterAUrl) {
+      report.panic(
+        `It looks like you gave wrong argument orders . Try running instead "gatsby new ${starter} ${rootPath}"`
+      )
+      return
+    }
     report.panic(
-      `It looks like you forgot to add a name for your new project. Try running instead "gatsby new new-gatsby-project ${rootPath}"`
+      `It looks like you passed a URL to your project name. Try running instead "gatsby new new-gatsby-project ${rootPath}"`
     )
     return
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Added a better condition check where if arguments are passed in wrong order, it will check for the argument types and will try to arrange them in proper order in `new` command
Also changed the error message to a more explanatory message.

Try running `gatsby new https://github.com/gatsbyjs/gatsby-starter-blog my-project` It will recommend with running in proper order like this `gatsby new my-project https://github.com/gatsbyjs/gatsby-starter-blog `

## Related Issues
NA
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
