### PR TITLE
docs: use 'datetime' widget instead of depreacted 'date'

### DIFF
--- a/docs/docs/sourcing-from-netlify-cms.md
+++ b/docs/docs/sourcing-from-netlify-cms.md
@@ -72,7 +72,7 @@ collections:
     create: true
     fields:
       - { name: path, label: Path }
-      - { name: date, label: Date, widget: date }
+      - { name: date, label: Date, widget: datetime }
       - { name: title, label: Title }
       - { name: body, label: Body, widget: markdown }
 ```


### PR DESCRIPTION
## Description

According to netlify-cms [docs](https://www.netlifycms.org/docs/widgets/#date): 

> Deprecation notice: the date widget has been deprecated and will be removed in the next major release. Please use the datetime widget instead.


