### PR TITLE
chore(docs): fixed a broken URL on the Code Contributions page

### DIFF
--- a/docs/contributing/code-contributions.md
+++ b/docs/contributing/code-contributions.md
@@ -19,7 +19,7 @@ This page includes details specific to the Gatsby core and ecosystem codebase.
 
 To start setting up the Gatsby repo on your machine using git, Yarn and Gatsby-CLI, check out the page on [setting up your local dev environment](/contributing/setting-up-your-local-dev-environment/).
 
-Alternatively, you can skip the local setup and [use an online dev environment](/contributing/use-an-online-dev-environment/).
+Alternatively, you can skip the local setup and [use an online dev environment](/contributing/using-an-online-dev-environment/).
 
 To contribute to the blog or Gatsbyjs.org website, check out the setup steps on the [blog and website contributions](/contributing/blog-and-website-contributions/) page. For instructions on contributing to the docs, visit the [docs contributions page](/contributing/docs-contributions/).
 


### PR DESCRIPTION
Changed a URL so it points to the correct page.