### PR TITLE
fix(gatsby-source-contentful): Fixing when assets are in draft state

### DIFF
--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -45,7 +45,7 @@ const downloadContentfulAssets = async gatsbyFunctions => {
       const { contentful_id: id, node_locale: locale } = node
       const remoteDataCacheKey = `contentful-asset-${id}-${locale}`
       const cacheRemoteData = await cache.get(remoteDataCacheKey)
-      if(!node.file){
+      if (!node.file) {
         return Promise.resolve() 
       }
       const url = `http://${node.file.url.slice(2)}`

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -45,6 +45,9 @@ const downloadContentfulAssets = async gatsbyFunctions => {
       const { contentful_id: id, node_locale: locale } = node
       const remoteDataCacheKey = `contentful-asset-${id}-${locale}`
       const cacheRemoteData = await cache.get(remoteDataCacheKey)
+      if(!node.file){
+        return Promise.resolve() 
+      }
       const url = `http://${node.file.url.slice(2)}`
 
       // Avoid downloading the asset again if it's been cached

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -46,6 +46,7 @@ const downloadContentfulAssets = async gatsbyFunctions => {
       const remoteDataCacheKey = `contentful-asset-${id}-${locale}`
       const cacheRemoteData = await cache.get(remoteDataCacheKey)
       if (!node.file) {
+        reporter.warn(`The asset with id: ${id}, contains no file.`)
         return Promise.resolve()
       }
       const url = `http://${node.file.url.slice(2)}`

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -46,7 +46,7 @@ const downloadContentfulAssets = async gatsbyFunctions => {
       const remoteDataCacheKey = `contentful-asset-${id}-${locale}`
       const cacheRemoteData = await cache.get(remoteDataCacheKey)
       if (!node.file) {
-        return Promise.resolve() 
+        return Promise.resolve()
       }
       const url = `http://${node.file.url.slice(2)}`
 


### PR DESCRIPTION
When in draft, an asset could not have a file attached to it yet. Fixing this scenario.

## Description

When downloading assets from Contentful in preview, we can face problems with assets in draft that does not have a file attached to it yet. This leads to errors trying to process node.file.url.

