### PR TITLE
fix(gatsby-source-contentful): Allow proxy to be passed in to contentful client

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -156,6 +156,10 @@ List of locales and their codes can be found in Contentful app -> Settings -> Lo
 
 Prevents the use of sync tokens when accessing the Contentful API.
 
+**`proxy`** [object][optional] [default: `undefined`]
+
+Axios proxy configuration. See the [axios request config documentation](https://github.com/mzabriskie/axios#request-config) for further information about the supported values.
+
 ## Notes on Contentful Content Models
 
 There are currently some things to keep in mind when building your content models at Contentful.

--- a/packages/gatsby-source-contentful/src/__tests__/fetch.js
+++ b/packages/gatsby-source-contentful/src/__tests__/fetch.js
@@ -51,11 +51,16 @@ const {
   createPluginConfig,
 } = require(`../plugin-options`)
 
+const proxyOption = {
+  host: `localhost`,
+  port: 9001,
+}
 const options = {
   spaceId: `rocybtov1ozk`,
   accessToken: `6f35edf0db39085e9b9c19bd92943e4519c77e72c852d961968665f1324bfc94`,
   host: `host`,
   environment: `env`,
+  proxy: proxyOption,
 }
 
 const pluginConfig = createPluginConfig(options)
@@ -95,6 +100,7 @@ it(`calls contentful.createClient with expected params`, async () => {
       environment: `env`,
       host: `host`,
       space: `rocybtov1ozk`,
+      proxy: proxyOption,
     })
   )
 })

--- a/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
@@ -95,7 +95,6 @@ describe(`Options validation`, () => {
         accessToken: `accessToken`,
         localeFilter: locale => locale.code === `de`,
         downloadLocal: false,
-        proxy: {},
       }
     )
 

--- a/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
@@ -95,6 +95,7 @@ describe(`Options validation`, () => {
         accessToken: `accessToken`,
         localeFilter: locale => locale.code === `de`,
         downloadLocal: false,
+        proxy: {},
       }
     )
 

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -15,6 +15,7 @@ module.exports = async ({ syncToken, reporter, pluginConfig }) => {
     accessToken: pluginConfig.get(`accessToken`),
     host: pluginConfig.get(`host`),
     environment: pluginConfig.get(`environment`),
+    proxy: pluginConfig.get(`proxy`),
   }
 
   const client = contentful.createClient(contentfulClientOptions)

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -32,7 +32,14 @@ const optionsSchema = Joi.object().keys({
   downloadLocal: Joi.boolean(),
   localeFilter: Joi.func(),
   forceFullSync: Joi.boolean(),
-  proxy: Joi.object(),
+  proxy: Joi.object().keys({
+    host: Joi.string().required(),
+    port:  Joi.number().required(),
+    auth:  Joi.object().keys({
+      username: Joi.string(),
+      password: Joi.string(),
+    }),
+  }),
   // default plugins passed by gatsby
   plugins: Joi.array(),
 })

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -32,6 +32,7 @@ const optionsSchema = Joi.object().keys({
   downloadLocal: Joi.boolean(),
   localeFilter: Joi.func(),
   forceFullSync: Joi.boolean(),
+  proxy: Joi.object(),
   // default plugins passed by gatsby
   plugins: Joi.array(),
 })

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -34,8 +34,8 @@ const optionsSchema = Joi.object().keys({
   forceFullSync: Joi.boolean(),
   proxy: Joi.object().keys({
     host: Joi.string().required(),
-    port:  Joi.number().required(),
-    auth:  Joi.object().keys({
+    port: Joi.number().required(),
+    auth: Joi.object().keys({
       username: Joi.string(),
       password: Joi.string(),
     }),


### PR DESCRIPTION
## Description

Allows the proxy option to be passed into the contentful client. This was enabled in #5950 but seems to have gone away in later versions

## Related Issues

Fixes #4744
