### PR TITLE
chore(starters): add gatsby-starter-grommet-file

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -3903,3 +3903,26 @@
     - no boilerplate
     - Great for advanced users
     - VSCode ready
+- url: https://grommet-file.netlify.com/
+  repo: https://github.com/metinsenturk/gatsby-starter-grommet-file
+  description: Grommet-File is made with Grommet V2 and a blog starter
+  tags:
+    - Blog
+    - Gallery
+    - Markdown
+    - SEO
+    - Portfolio
+    - Netlify
+    - Grommet
+  features:
+    - Responsive Design
+    - Pagination
+    - Page creation
+    - Content is Markdown files
+    - Google Analytics
+    - Grommet V2
+    - Support for RSS feed
+    - SEO friendly
+    - Mobile and responsive
+    - Sitemap & Robots.txt generation
+    - Optimized images with gatsby-image


### PR DESCRIPTION
## Description

This is a Gatsby V2 starter built with Grommet V2. It is an easy starter to start blogging and creating a gallery for your photos. Hope you guys like it! 

## Related Issues
No related issues for this pull.