### PR TITLE
docs: deploying to Heroku, update to headers config

### DIFF
--- a/docs/docs/deploying-to-heroku.md
+++ b/docs/docs/deploying-to-heroku.md
@@ -44,7 +44,7 @@ The following configuration will give you a good start point in line with Gatsby
 {
   "root": "public/",
   "headers": {
-    "/**/": {
+    "/**": {
       "Cache-Control": "public, max-age=0, must-revalidate"
     },
     "/**.css": {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
URLs without a trailing slash were not applying the correct caching header.

This small config change means that `"Cache-Control": "public, max-age=0, must-revalidate"` headers will also get implicitly applied to page-data.json files, which is desirable, and the manifest.webmanifest file which I don't believe we'd want to set far-future (or even a near future) header on.

Other far-future header settings remain as they were.
