### PR TITLE
chore(docs): Add info about withPrefix to path-prefix

### DIFF
--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -76,6 +76,10 @@ export default function Index() {
 }
 ```
 
+### Add the path prefix to paths using withPrefix
+
+For pathnames you construct manually, there’s a helper function, [`withPrefix`](/docs/gatsby-link/#add-the-path-prefix-to-paths-using-withprefix) that prepends your path prefix in production (but doesn’t during development where paths don’t need prefixed).
+
 ### Additional Considerations
 
 The [`assetPrefix`](/docs/asset-prefix/) feature can be thought of as semi-related to this feature. That feature allows your assets (non-HTML files, e.g. images, JavaScript, etc.) to be hosted on a separate domain, for example a CDN.

--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -76,7 +76,7 @@ export default function Index() {
 }
 ```
 
-### Add the path prefix to paths using withPrefix
+### Add the path prefix to paths using `withPrefix`
 
 For pathnames you construct manually, there’s a helper function, [`withPrefix`](/docs/gatsby-link/#add-the-path-prefix-to-paths-using-withprefix) that prepends your path prefix in production (but doesn’t during development where paths don’t need prefixed).
 


### PR DESCRIPTION
## Description

Adds info about the withPrefix helper to Path Prefix doc page, I was looking for something like this helper, but did not find it on this page. Luckily I found it in the source code and also on another doc page. I think it makes sense to refer to the page here as well.