### PR TITLE
chore(docs): Update path-prefix

### DIFF
--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -11,7 +11,7 @@ Each of these sites need a prefix added to all paths on the site. So a link to
 
 In addition, links to various resources (JavaScript, CSS, images, and other static content) need the same prefix, so that the site continues to function correctly when served with the path prefix in place.
 
-Adding the path prefix is a two step process, as follows:
+Adding the path prefix is a three step process, as follows:
 
 ### Add to `gatsby-config.js`
 
@@ -25,13 +25,23 @@ module.exports = {
 
 ### Build
 
-The final step is to build your application with the `--prefix-paths` flag, like so:
+Next step is to build your application with the `--prefix-paths` flag, like so:
 
 ```shell
 gatsby build --prefix-paths
 ```
 
 If this flag is not passed, Gatsby will ignore your `pathPrefix` and build the site as if hosted from the root domain.
+
+### Serve
+
+The final step is to serve your application with the `--prefix-paths` flag, like so:
+
+```shell
+gatsby serve --prefix-paths
+```
+
+If this flag is not passed, Gatsby will ignore your `pathPrefix` and serve the site as if hosted from the root domain.
 
 ### In-app linking
 


### PR DESCRIPTION
Missing step when added path prefix.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
