### PR TITLE
doc(gatsby-plugin-create-client-paths): add link to example

### DIFF
--- a/packages/gatsby-plugin-create-client-paths/README.md
+++ b/packages/gatsby-plugin-create-client-paths/README.md
@@ -20,4 +20,4 @@ Then configure via `gatsby-config.js`:
 ```
 
 In this example, all paths prefixed by `/app/` will render the route described
-in `src/pages/app.js`.
+in `src/pages/app.js`. (Check out the [`src/pages/app.js`](https://github.com/gatsbyjs/gatsby/blob/master/examples/simple-auth/src/pages/app.js) in the "simple auth" example site.)


### PR DESCRIPTION
add link to an example `app.js`

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
