### PR TITLE
docs(gatsby-plugin-offline): update appendScript in readme

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -45,7 +45,7 @@ In `gatsby-plugin-offline` 3.x, the following options are available:
     {
       resolve: `gatsby-plugin-offline`,
       options: {
-        appendScript: `src/custom-sw-code.js`,
+        appendScript: require.resolve(`src/custom-sw-code.js`),
       },
     },
   ]


### PR DESCRIPTION
## Description

Since the appendScript is resolved/read directly from the [`gatsby-node.js`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-offline/src/gatsby-node.js#L175) file, it needs to be an absolute filepath. At least that what worked for me.

Writing `require.resolve` makes this more explicit in my opinion. :slightly_smiling_face: 

Have a nice day :wave: 
