### PR TITLE
chore(showcase): Removing Design Systems Weekly

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -560,13 +560,6 @@
     - Design
     - Marketing
     - Portfolio
-- title: Design Systems Weekly
-  main_url: "https://designsystems.email/"
-  url: "https://designsystems.email/"
-  featured: false
-  categories:
-    - Education
-    - Web Development
 - title: Dalbinaco's Website
   main_url: "https://dlbn.co/en/"
   url: "https://dlbn.co/en/"


### PR DESCRIPTION
## Description

This site has been throwing a Timeout error for a while and I couldn't find who to contact about it as it was added as part of the initial push of the showcase. Removing it for now

## Related Issues

N/A
