### PR TITLE
chore(showcase): Removing Fusion Media Group site

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1068,12 +1068,6 @@
   categories:
     - Web Development
     - Agency
-- title: Fusion Media Group
-  main_url: "http://thefmg.com/"
-  url: "http://thefmg.com/"
-  featured: false
-  categories:
-    - Entertainment
 - title: Dovetail
   main_url: "https://dovetailapp.com/"
   url: "https://dovetailapp.com/"


### PR DESCRIPTION
## Description

Removing this site from the showcase as it seems they've rebranded as G/O Media Inc. and also switched their site to be built with Wordpress.

## Related Issues

N/A