### PR TITLE
chore(showcase): Updating Quick Stop Nicaragua catgories

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -7266,9 +7266,6 @@
   description: >
     Convenience Store Website
   categories:
-    - CMS:Contentful
-    - Netlify
-    - PWA
     - Food
   built_by: Gerald Martinez
   built_by_url: https://twitter.com/GeraldM_92


### PR DESCRIPTION
## Description

Removing some categories from the Quick Stop Nicaragua entry as it was triggering Danger as some of the categories were not valid categories.

## Related Issues

N/A