### PR TITLE
chore(showcase): Removing Distrupting Nate

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -2812,17 +2812,6 @@
   built_by: Gabe Ragland
   built_by_url: https://twitter.com/gabe_ragland
   featured: false
-- title: Disrupting Nate
-  description: >
-    Ketogenic Diet, Podcasts, and Blockchain.
-  url: https://www.disruptingnate.com/
-  main_url: https://www.disruptingnate.com/
-  categories:
-    - Technology
-    - Podcast
-  built_by: Nathan Olmstead
-  built_by_url: https://twitter.com/disruptingnate
-  featured: false
 - title: Ambassador
   url: https://www.getambassador.io
   main_url: https://www.getambassador.io


### PR DESCRIPTION
## Description

The site is no longer available and it seems the creator poof'd off the internet as their content is still in Google's index, but it all directs to errorred pages. Removing from the showcase

## Related Issues

N/A