### PR TITLE
chore(docs): Lazy/suspense as workaround for client side only

### DIFF
--- a/docs/docs/using-client-side-only-packages.md
+++ b/docs/docs/using-client-side-only-packages.md
@@ -80,6 +80,29 @@ const LoadableBuyButton = Loadable(() => import("./ShopifyBuyButton"))
 export default LoadableBuyButton
 ```
 
+## Workaround 4: Use React.lazy and Suspense on client side only
+
+React.lazy and Suspense are still not ready for server side rendering but they can still be used by checking if we are doing server side rendering.
+
+```jsx
+const MyPage = () => {
+  const isSSR = typeof window === "undefined"
+  const ClientSideOnlyLazy = React.lazy(() =>
+    import("../components/ClientSideOnly")
+  )
+
+  return (
+    <>
+      {!isSSR && (
+        <React.Suspense fallback={<div />}>
+          <ClientSideOnlyLazy />
+        </React.Suspense>
+      )}
+    </>
+  )
+}
+```
+
 > **Note:** There are other potential workarounds than those listed here. If you've had success with another method, check out the [contributing docs](/contributing/docs-contributions/) and add yours!
 
 If all else fails, you may also want to check out the documentation on [Debugging HTML Builds](/docs/debugging-html-builds/).

--- a/docs/docs/using-client-side-only-packages.md
+++ b/docs/docs/using-client-side-only-packages.md
@@ -82,7 +82,9 @@ export default LoadableBuyButton
 
 ## Workaround 4: Use React.lazy and Suspense on client side only
 
-React.lazy and Suspense are still not ready for server side rendering but they can still be used by checking if we are doing server side rendering.
+React.lazy and Suspense are still not ready for server side rendering, but they can still be used by checking that the code is executed only on the client.
+While this solution is inferior to `loadable-components`, that works both on server side and client, it still provides an alternative for dealing with client side only packages, without an added dependency.
+Remember that the following code could break if executed without the `isSSR` guard.
 
 ```jsx
 const MyPage = () => {

--- a/docs/docs/using-client-side-only-packages.md
+++ b/docs/docs/using-client-side-only-packages.md
@@ -87,11 +87,13 @@ While this solution is inferior to `loadable-components`, that works both on ser
 Remember that the following code could break if executed without the `isSSR` guard.
 
 ```jsx
+import React from "react"
+
+const ClientSideOnlyLazy = React.lazy(() =>
+  import("../components/ClientSideOnly")
+)
 const MyPage = () => {
   const isSSR = typeof window === "undefined"
-  const ClientSideOnlyLazy = React.lazy(() =>
-    import("../components/ClientSideOnly")
-  )
 
   return (
     <>


### PR DESCRIPTION
## Description

I added a dependency to my [Gatsby starter project](https://github.com/giacomorebonato/semantic-starter) that fails on server side rendering: it's [Firebase UI authentication](https://github.com/firebase/firebaseui-web-react).
`React.lazy` and `suspense` don't work already on server side rendering, but still they can be forced to be used on client side only by doing a check on the existence of the window object.

This seemed to solve the situation for me; do you think that this is a viable workaround to introduce to the docs?