### PR TITLE
chore(gatsby-plugin-typography): tweak readme for clarity

### DIFF
--- a/docs/docs/typography-js.md
+++ b/docs/docs/typography-js.md
@@ -21,11 +21,11 @@ module.exports = {
     {
       resolve: `gatsby-plugin-typography`,
       options: {
-        pathToConfigModule: `src/utils/typography`
-      }
-    }
+        pathToConfigModule: `src/utils/typography`,
+      },
+    },
     // highlight-end
-  ]
+  ],
 }
 ```
 

--- a/docs/docs/typography-js.md
+++ b/docs/docs/typography-js.md
@@ -16,17 +16,14 @@ After the installation of the plugin has completed, navigate to your `gatsby-con
 
 ```diff:title=gatsby-config.js
 module.exports = {
-siteMetadata: {
-    title: 'Gatsby Default Starter',
-},
-plugins: [
-+ {
-+  resolve: `gatsby-plugin-typography`,
-+  options: {
-+    pathToConfigModule: `src/utils/typography`,
-+  }
-+ }
-],
+  plugins: [
+    {
+      resolve: `gatsby-plugin-typography`,
+      options: {
+        pathToConfigModule: `src/utils/typography`,
+      },
+    },
+  ],
 }
 ```
 

--- a/docs/docs/typography-js.md
+++ b/docs/docs/typography-js.md
@@ -14,16 +14,18 @@ You can install the plugin and its peer dependencies into your project by runnin
 
 After the installation of the plugin has completed, navigate to your `gatsby-config.js` file located in the root of your project's directory and add the plugin to the configuration:
 
-```diff:title=gatsby-config.js
+```js:title=gatsby-config.js
 module.exports = {
   plugins: [
+    // highlight-start
     {
       resolve: `gatsby-plugin-typography`,
       options: {
-        pathToConfigModule: `src/utils/typography`,
-      },
-    },
-  ],
+        pathToConfigModule: `src/utils/typography`
+      }
+    }
+    // highlight-end
+  ]
 }
 ```
 


### PR DESCRIPTION
Missing commas on the examples throw errors on the terminal. Suggest we take the example from the package itself (found here: https://www.gatsbyjs.org/packages/gatsby-plugin-typography/).
