### PR TITLE
fix(blog): Impossible Foods headings rendering

### DIFF
--- a/docs/blog/2019-09-11-impossible-foods/index.md
+++ b/docs/blog/2019-09-11-impossible-foods/index.md
@@ -5,24 +5,25 @@ author: Hashim Warren
 excerpt: "Impossible Foods needed a website with new functionality, that could withstand surges in traffic. These challenges and requirements led the Impossible Foods team to adopt a Content Mesh approach to their website architecture."
 tags:
   - case-studies
+  - ecommerce
 ---
 
 Impossible Foods’ mission is to restore biodiversity and reduce the impact of climate change by transforming the global food system. The company is doing that by releasing plant-based foods that taste more like beef, chicken, and fish than what consumers have come to expect from traditional meat alternatives.
 
 The Impossible Burger is the breakout offering from the company, and it made a splash last year after Burger King added it to its fast food menu. Suddenly Impossible Foods grew from supplying 100 restaurants to 5000, overnight.
 
-##The Need for a New Website Experience
+## The Need for a New Website Experience
 
 The first version of the Impossible Foods website was adequate, but as the company grew several problems became evident. Designers and writers struggled with slow turn around times because the website could only be updated by a developer. The site’s pages and map section were both static, providing no experience to users other than the delivery of flat information.
 
 Impossible Foods needed a website with new functionality, that could withstand surges in traffic as interest and demand for their innovative burgers grew around the world. And the website needed to offer a first-class experience to all stakeholders - from content editors and IT staff, to restaurants and consumers. These challenges and requirements led the Impossible Foods team to adopt a ["Content Mesh"](/blog/2018-10-04-journey-to-the-content-mesh) approach to their website architecture, with Contentful as a [headless CMS](/docs/headless-cms), Shopify for ecommerce, and Gatsby.
 
-##The Content Mesh Approach for Ecommerce
+## The Content Mesh Approach for Ecommerce
 
 The development team created reusable components in Gatsby and sourced content from “modules” created within Contentful. They also connected the site to Shopify to power the checkout experience, as well as display in-stock products, descriptions, and prices. Content producers were now free to create and update content on the site, simply by using the editing experience with Contentful and Shopify. This new workflow dramatically reduced the turnaround time for new announcements to be published on the website.
 
 The Impossible Foods team raved that their new architecture enables their content strategy to keep pace with the acceleration of their business.
 
-##Learn More About Gatsby and Ecommerce
+## Learn More About Gatsby and Ecommerce
 
 To watch the full case study, including a presentation from Gatsby’s co-founder Kyle Mathews on why Gatsby is a smart choice for ecommerce sites, register here: [Impossible Foods Webinar](https://www.gatsbyjs.com/impossible-foods-webinar/).


### PR DESCRIPTION
## Description

Me and @hashimwarren missed the headers on this post: https://www.gatsbyjs.org/blog/2019-09-11-impossible-foods/

This fixes the markdown so they'll render correctly.

## Preview

<details>
<summary>Details</summary>

![localhost_8000_blog_2019-09-11-impossible-foods_](https://user-images.githubusercontent.com/21114044/64995701-33132780-d899-11e9-9f4b-7e1e89146b41.png)

</details>
