### PR TITLE
fix(query): improve query performance

### DIFF
--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -215,10 +215,10 @@ function doesSortFieldsHaveArray(type, sortArgs) {
  */
 async function runQuery(args) {
   if (args.nodeTypeNames.length > 1) {
-    const nodes = args.nodeTypeNames.reduce(
-      (acc, typeName) => acc.concat(getNodesByType(typeName)),
-      []
-    )
+    const nodes = args.nodeTypeNames.reduce((acc, typeName) => {
+      acc.push(...getNodesByType(typeName))
+      return acc
+    }, [])
     return runSiftOnNodes(nodes, args, getNode)
   }
 

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -36,11 +36,15 @@ const popExtractedQueries = () => {
 }
 
 const findIdsWithoutDataDependencies = state => {
-  const allTrackedIds = new Set(
-    _.flatten([
-      ...state.componentDataDependencies.nodes.values(),
-      ...state.componentDataDependencies.connections.values(),
-    ])
+  const allTrackedIds = new Set()
+  const boundAddToTrackedIds = allTrackedIds.add.bind(allTrackedIds)
+  state.componentDataDependencies.nodes.forEach(dependenciesOnNode => {
+    dependenciesOnNode.forEach(boundAddToTrackedIds)
+  })
+  state.componentDataDependencies.connections.forEach(
+    dependenciesOnConnection => {
+      dependenciesOnConnection.forEach(boundAddToTrackedIds)
+    }
   )
 
   // Get list of paths not already tracked and run the queries for these

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -72,7 +72,11 @@ const popNodeQueries = state => {
 
     // Find components that depend on this node so are now dirty.
     if (state.componentDataDependencies.nodes.has(node.id)) {
-      state.componentDataDependencies.nodes.get(node.id).forEach(dirtyIds)
+      state.componentDataDependencies.nodes.get(node.id).forEach(n => {
+        if (n) {
+          dirtyIds.add(n)
+        }
+      })
     }
 
     // Find connections that depend on this node so are now invalid.

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -8,16 +8,14 @@ const { boundActionCreators } = require(`../redux/actions`)
 const queryQueue = require(`./queue`)
 const GraphQLRunner = require(`./graphql-runner`)
 
-let seenIdsWithoutDataDependencies = []
+const seenIdsWithoutDataDependencies = new Set()
 let queuedDirtyActions = []
 const extractedQueryIds = new Set()
 
 // Remove pages from seenIdsWithoutDataDependencies when they're deleted
 // so their query will be run again if they're created again.
 emitter.on(`DELETE_PAGE`, action => {
-  seenIdsWithoutDataDependencies = seenIdsWithoutDataDependencies.filter(
-    p => p !== action.payload.path
-  )
+  seenIdsWithoutDataDependencies.delete(action.payload.path)
 })
 
 emitter.on(`CREATE_NODE`, action => {
@@ -38,54 +36,54 @@ const popExtractedQueries = () => {
 }
 
 const findIdsWithoutDataDependencies = state => {
-  const allTrackedIds = _.uniq(
-    _.flatten(
-      _.concat(
-        _.values(state.componentDataDependencies.nodes),
-        _.values(state.componentDataDependencies.connections)
-      )
-    )
+  const allTrackedIds = new Set(
+    _.flatten([
+      ...state.componentDataDependencies.nodes.values(),
+      ...state.componentDataDependencies.connections.values(),
+    ])
   )
 
   // Get list of paths not already tracked and run the queries for these
   // paths.
-  const notTrackedIds = _.difference(
+  const notTrackedIds = new Set(
     [
       ...Array.from(state.pages.values(), p => p.path),
       ...[...state.staticQueryComponents.values()].map(c => c.id),
-    ],
-    [...allTrackedIds, ...seenIdsWithoutDataDependencies]
+    ].filter(
+      x => !allTrackedIds.has(x) && !seenIdsWithoutDataDependencies.has(x)
+    )
   )
 
   // Add new IDs to our seen array so we don't keep trying to run queries for them.
   // Pages without queries can't be tracked.
-  seenIdsWithoutDataDependencies = _.uniq([
-    ...notTrackedIds,
-    ...seenIdsWithoutDataDependencies,
-  ])
+  for (const notTrackedId of notTrackedIds) {
+    seenIdsWithoutDataDependencies.add(notTrackedId)
+  }
 
   return notTrackedIds
 }
 
 const popNodeQueries = state => {
   const actions = _.uniq(queuedDirtyActions, a => a.payload.id)
-  const uniqDirties = _.uniq(
-    actions.reduce((dirtyIds, action) => {
-      const node = action.payload
+  const uniqDirties = actions.reduce((dirtyIds, action) => {
+    const node = action.payload
 
-      if (!node || !node.id || !node.internal.type) return dirtyIds
+    if (!node || !node.id || !node.internal.type) return dirtyIds
 
-      // Find components that depend on this node so are now dirty.
-      dirtyIds = dirtyIds.concat(state.componentDataDependencies.nodes[node.id])
+    // Find components that depend on this node so are now dirty.
+    if (state.componentDataDependencies.nodes.has(node.id)) {
+      state.componentDataDependencies.nodes.get(node.id).forEach(dirtyIds.add)
+    }
 
-      // Find connections that depend on this node so are now invalid.
-      dirtyIds = dirtyIds.concat(
-        state.componentDataDependencies.connections[node.internal.type]
-      )
+    // Find connections that depend on this node so are now invalid.
+    if (state.componentDataDependencies.connections.has(node.internal.type)) {
+      state.componentDataDependencies.connections
+        .get(node.internal.type)
+        .forEach(dirtyIds.add)
+    }
 
-      return _.compact(dirtyIds)
-    }, [])
-  )
+    return dirtyIds
+  }, new Set())
   queuedDirtyActions = []
   return uniqDirties
 }

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -72,11 +72,9 @@ const popNodeQueries = state => {
 
     // Find components that depend on this node so are now dirty.
     if (state.componentDataDependencies.nodes.has(node.id)) {
-      state.componentDataDependencies.nodes.get(node.id).forEach(n => {
-        if (n) {
-          dirtyIds.add(n)
-        }
-      })
+      state.componentDataDependencies.nodes
+        .get(node.id)
+        .forEach(n => dirtyIds.add(n))
     }
 
     // Find connections that depend on this node so are now invalid.

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -72,11 +72,7 @@ const popNodeQueries = state => {
 
     // Find components that depend on this node so are now dirty.
     if (state.componentDataDependencies.nodes.has(node.id)) {
-      state.componentDataDependencies.nodes.get(node.id).forEach(n => {
-        if (n) {
-          dirtyIds.add(n)
-        }
-      })
+      state.componentDataDependencies.nodes.get(node.id).forEach(dirtyIds)
     }
 
     // Find connections that depend on this node so are now invalid.

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -72,14 +72,22 @@ const popNodeQueries = state => {
 
     // Find components that depend on this node so are now dirty.
     if (state.componentDataDependencies.nodes.has(node.id)) {
-      state.componentDataDependencies.nodes.get(node.id).forEach(dirtyIds.add)
+      state.componentDataDependencies.nodes.get(node.id).forEach(n => {
+        if (n) {
+          dirtyIds.add(n)
+        }
+      })
     }
 
     // Find connections that depend on this node so are now invalid.
     if (state.componentDataDependencies.connections.has(node.internal.type)) {
       state.componentDataDependencies.connections
         .get(node.internal.type)
-        .forEach(dirtyIds.add)
+        .forEach(n => {
+          if (n) {
+            dirtyIds.add(n)
+          }
+        })
     }
 
     return dirtyIds

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -3,8 +3,8 @@
 exports[`redux db should write cache to disk 1`] = `
 Object {
   "componentDataDependencies": Object {
-    "connections": Object {},
-    "nodes": Object {},
+    "connections": Map {},
+    "nodes": Map {},
   },
   "components": Map {
     "/Users/username/dev/site/src/templates/my-sweet-new-page.js" => Object {

--- a/packages/gatsby/src/redux/actions/add-page-dependency.js
+++ b/packages/gatsby/src/redux/actions/add-page-dependency.js
@@ -23,7 +23,8 @@ function createPageDependency({ path, nodeId, connection }) {
   }
   if (
     connection &&
-    state.componentDataDependencies.connections.has(connection)
+    state.componentDataDependencies.connections.has(connection) &&
+    state.componentDataDependencies.connections.get(connection).has(path)
   ) {
     connectionDependencyExists = true
   }

--- a/packages/gatsby/src/redux/actions/add-page-dependency.js
+++ b/packages/gatsby/src/redux/actions/add-page-dependency.js
@@ -1,5 +1,3 @@
-const _ = require(`lodash`)
-
 const { store } = require(`../`)
 const { actions } = require(`./internal.js`)
 
@@ -15,7 +13,8 @@ function createPageDependency({ path, nodeId, connection }) {
   }
   if (
     nodeId &&
-    _.includes(state.componentDataDependencies.nodes[nodeId], path)
+    state.componentDataDependencies.nodes.has(nodeId) &&
+    state.componentDataDependencies.nodes.get(nodeId).has(path)
   ) {
     nodeDependencyExists = true
   }
@@ -24,7 +23,7 @@ function createPageDependency({ path, nodeId, connection }) {
   }
   if (
     connection &&
-    _.includes(state.componentDataDependencies.connections, connection)
+    state.componentDataDependencies.connections.has(connection)
   ) {
     connectionDependencyExists = true
   }

--- a/packages/gatsby/src/redux/reducers/__tests__/__snapshots__/page-data-dependencies.js.snap
+++ b/packages/gatsby/src/redux/reducers/__tests__/__snapshots__/page-data-dependencies.js.snap
@@ -2,15 +2,15 @@
 
 exports[`add page data dependency lets you add both a node and connection in one action 1`] = `
 Object {
-  "connections": Object {
-    "MarkdownRemark": Array [
+  "connections": Map {
+    "MarkdownRemark" => Set {
       "/hi/",
-    ],
+    },
   },
-  "nodes": Object {
-    "SuperCoolNode": Array [
+  "nodes": Map {
+    "SuperCoolNode" => Set {
       "/hi/",
-    ],
+    },
   },
 }
 `;

--- a/packages/gatsby/src/redux/reducers/__tests__/page-data-dependencies.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/page-data-dependencies.js
@@ -11,10 +11,8 @@ describe(`add page data dependency`, () => {
     }
 
     expect(reducer(undefined, action)).toEqual({
-      connections: {},
-      nodes: {
-        "123": [`/hi/`],
-      },
+      connections: new Map(),
+      nodes: new Map([[`123`, new Set([`/hi/`])]]),
     })
   })
   it(`lets you add a node dependency to multiple paths`, () => {
@@ -45,10 +43,8 @@ describe(`add page data dependency`, () => {
     state = reducer(state, action3)
 
     expect(state).toEqual({
-      connections: {},
-      nodes: {
-        "1.2.3": [`/hi/`, `/hi2/`, `/blog/`],
-      },
+      connections: new Map(),
+      nodes: new Map([[`1.2.3`, new Set([`/hi/`, `/hi2/`, `/blog/`])]]),
     })
   })
   it(`lets you add a connection dependency`, () => {
@@ -71,10 +67,8 @@ describe(`add page data dependency`, () => {
     state = reducer(state, action2)
 
     expect(state).toEqual({
-      connections: {
-        "Markdown.Remark": [`/hi/`, `/hi2/`],
-      },
-      nodes: {},
+      connections: new Map([[`Markdown.Remark`, new Set([`/hi/`, `/hi2/`])]]),
+      nodes: new Map(),
     })
   })
   it(`removes duplicate paths`, () => {
@@ -101,8 +95,8 @@ describe(`add page data dependency`, () => {
     // Add different action
     state = reducer(state, action2)
 
-    expect(state.connections[`MarkdownRemark`].length).toEqual(2)
-    expect(state.nodes[1].length).toEqual(2)
+    expect(state.connections.get(`MarkdownRemark`).size).toEqual(2)
+    expect(state.nodes.get(1).size).toEqual(2)
   })
   it(`lets you add both a node and connection in one action`, () => {
     const action = {

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -126,10 +126,10 @@ const runSift = (args: Object) => {
   let nodes
 
   if (nodeTypeNames.length > 1) {
-    nodes = nodeTypeNames.reduce(
-      (acc, typeName) => acc.concat(getNodesAndResolvedNodes(typeName)),
-      []
-    )
+    nodes = nodeTypeNames.reduce((acc, typeName) => {
+      acc.push(...getNodesAndResolvedNodes(typeName))
+      return acc
+    }, [])
   } else {
     nodes = getNodesAndResolvedNodes(nodeTypeNames[0])
   }
@@ -161,7 +161,7 @@ const runSiftOnNodes = (nodes, args, getNode) => {
 
     if (
       !node ||
-      (node.internal && !nodeTypeNames.includes(node.internal.type))
+      (node.internal && !new Set(nodeTypeNames).has(node.internal.type))
     ) {
       return []
     }

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -161,7 +161,7 @@ const runSiftOnNodes = (nodes, args, getNode) => {
 
     if (
       !node ||
-      (node.internal && !new Set(nodeTypeNames).has(node.internal.type))
+      (node.internal && !nodeTypeNames.includes(node.internal.type))
     ) {
       return []
     }

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -97,8 +97,8 @@ class LocalNodeModel {
     } else if (!type) {
       result = node
     } else {
-      const nodeTypeNames = toNodeTypeNames(this.schema, type)
-      result = nodeTypeNames.includes(node.internal.type) ? node : null
+      const nodeTypeNames = new Set(toNodeTypeNames(this.schema, type))
+      result = nodeTypeNames.has(node.internal.type) ? node : null
     }
 
     if (result) {
@@ -128,8 +128,8 @@ class LocalNodeModel {
     if (!nodes.length || !type) {
       result = nodes
     } else {
-      const nodeTypeNames = toNodeTypeNames(this.schema, type)
-      result = nodes.filter(node => nodeTypeNames.includes(node.internal.type))
+      const nodeTypeNames = new Set(toNodeTypeNames(this.schema, type))
+      result = nodes.filter(node => nodeTypeNames.has(node.internal.type))
     }
 
     if (result) {
@@ -157,10 +157,10 @@ class LocalNodeModel {
       result = this.nodeStore.getNodes()
     } else {
       const nodeTypeNames = toNodeTypeNames(this.schema, type)
-      const nodes = nodeTypeNames.reduce(
-        (acc, typeName) => acc.concat(this.nodeStore.getNodesByType(typeName)),
-        []
-      )
+      const nodes = nodeTypeNames.reduce((acc, typeName) => {
+        acc.push(...this.nodeStore.getNodesByType(typeName))
+        return acc
+      }, [])
       result = nodes.filter(Boolean)
     }
 
@@ -389,9 +389,11 @@ class LocalNodeModel {
         this.createPageDependency({ path, connection: connectionType })
       } else {
         const nodes = Array.isArray(result) ? result : [result]
-        nodes
-          .filter(Boolean)
-          .map(node => this.createPageDependency({ path, nodeId: node.id }))
+        for (const node of nodes) {
+          if (node) {
+            this.createPageDependency({ path, nodeId: node.id })
+          }
+        }
       }
     }
 

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -97,8 +97,8 @@ class LocalNodeModel {
     } else if (!type) {
       result = node
     } else {
-      const nodeTypeNames = new Set(toNodeTypeNames(this.schema, type))
-      result = nodeTypeNames.has(node.internal.type) ? node : null
+      const nodeTypeNames = toNodeTypeNames(this.schema, type)
+      result = nodeTypeNames.includes(node.internal.type) ? node : null
     }
 
     if (result) {
@@ -128,8 +128,8 @@ class LocalNodeModel {
     if (!nodes.length || !type) {
       result = nodes
     } else {
-      const nodeTypeNames = new Set(toNodeTypeNames(this.schema, type))
-      result = nodes.filter(node => nodeTypeNames.has(node.internal.type))
+      const nodeTypeNames = toNodeTypeNames(this.schema, type)
+      result = nodes.filter(node => nodeTypeNames.includes(node.internal.type))
     }
 
     if (result) {


### PR DESCRIPTION
# Description

One of the big caveats currently of large sites in Gatsby is having to use gatsby-node when performing large numbers of queries. This has downsides, such as losing the ability to reload pages when the data changes.

I encountered an issue recently which made it much more preferable to use page queries, so I've looked into /why/ this is slow.

This PR is only a start, but it's taken 18k page queries from 11 minutes to 4.5 minutes, so over a 50% reduction in build time, which I feel is a decent improvement.
