### PR TITLE
fix(gatsby-plugin-sharp): Set a unique uuid for each job

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -24,7 +24,8 @@
     "progress": "^2.0.3",
     "semver": "^5.7.1",
     "sharp": "^0.23.0",
-    "svgo": "^1.3.0"
+    "svgo": "^1.3.0",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.0",

--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -1,5 +1,6 @@
 const _ = require(`lodash`)
 const { existsSync } = require(`fs`)
+const uuidv4 = require(`uuid/v4`)
 const queue = require(`async/queue`)
 const { processFile } = require(`./process-file`)
 const { createProgress } = require(`./utils`)
@@ -66,9 +67,11 @@ exports.scheduleJob = async (
 
   if (!isQueued) {
     // Create image job
+    const jobId = uuidv4()
     boundActionCreators.createJob(
       {
-        id: `processing image ${job.inputPath}`,
+        id: jobId,
+        description: `processing image ${job.inputPath}`,
         imagesCount: 1,
       },
       { name: `gatsby-plugin-sharp` }
@@ -76,6 +79,7 @@ exports.scheduleJob = async (
 
     q.push(cb => {
       runJobs(
+        jobId,
         inputFileKey,
         boundActionCreators,
         pluginOptions,
@@ -89,6 +93,7 @@ exports.scheduleJob = async (
 }
 
 function runJobs(
+  jobId,
   inputFileKey,
   boundActionCreators,
   pluginOptions,
@@ -105,7 +110,7 @@ function runJobs(
   // Update job info
   boundActionCreators.setJob(
     {
-      id: `processing image ${job.inputPath}`,
+      id: jobId,
       imagesCount: jobs.length,
     },
     { name: `gatsby-plugin-sharp` }
@@ -143,7 +148,7 @@ function runJobs(
 
           boundActionCreators.setJob(
             {
-              id: `processing image ${job.inputPath}`,
+              id: jobId,
               imagesFinished,
             },
             { name: `gatsby-plugin-sharp` }
@@ -152,10 +157,7 @@ function runJobs(
     )
 
     Promise.all(promises).then(() => {
-      boundActionCreators.endJob(
-        { id: `processing image ${job.inputPath}` },
-        { name: `gatsby-plugin-sharp` }
-      )
+      boundActionCreators.endJob({ id: jobId }, { name: `gatsby-plugin-sharp` })
       cb()
     })
   } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11065,7 +11065,7 @@ is-text-path@^2.0.0:
   dependencies:
     text-extensions "^2.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
@@ -19111,6 +19111,13 @@ type-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -20439,7 +20446,7 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2, write-file-atomic@^3.0.0:
+write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
   integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
@@ -20447,6 +20454,25 @@ write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, wri
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-atomic@^2.4.2:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+write-file-atomic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.0.tgz#1b64dbbf77cb58fd09056963d63e62667ab4fb21"
+  integrity sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 write-file-stdout@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
This was a bug we discovered while working on structured logging where multiple jobs for the same image (for instance a fluid version and a fixed version of the same image) create _two_ jobs (as one would expect) but the jobs have identical `id` fields and there is no way to differentiate them. 

We fix this by generating a `uuid` for every new job. 