### PR TITLE
fix(gitpod): accelerate automated dev setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
       gatsby-dev --scan-once &&
       npx gatsby build &&
       cd ../.. &&
-      touch /tmp/done.txt
+      gp sync-done build
     command: >
       yarn run watch --scope={gatsby,gatsby-image,gatsby-link}
   - openMode: split-right
@@ -21,11 +21,8 @@ tasks:
       gatsby-dev
   - before: >
       cd ./examples/gatsbygram
-    init: |
-      until [ -f /tmp/done.txt ]
-      do
-          sleep 2
-      done
+    init: >
+      gp sync-await build
     command: >
       npx gatsby develop
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -33,3 +33,21 @@ ports:
     onOpen: open-preview
   - port: 31997 # yarn mutex
     onOpen: ignore
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false

--- a/README.md
+++ b/README.md
@@ -32,8 +32,13 @@
   <a href="https://npmcharts.com/compare/gatsby?minimal=true">
     <img src="https://img.shields.io/npm/dt/gatsby.svg" alt="Total downloads on npm." />
   </a>
+</p>
+<p align="center">
   <a href="https://gatsbyjs.org/contributing/how-to-contribute/">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />
+  </a>
+  <a href="https://gitpod.io/from-referrer/">
+    <img src="https://img.shields.io/badge/setup-automated-blue?logo=gitpod" alt="Setup automated" />
   </a>
   <a href="https://twitter.com/intent/follow?screen_name=gatsbyjs">
     <img src="https://img.shields.io/twitter/follow/gatsbyjs.svg?label=Follow%20@gatsbyjs" alt="Follow @gatsbyjs" />


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Hi Gatsby developers! 👋 

I really like Gatsby, but I noticed that initializing a Gatsby workspace on Gitpod takes a long time, so I wanted to optimize the setup, in order to save contributors and maintainers a lot of time.

In this PR, I've configured Gitpod to continuously prebuild all Gatsby branches and Pull Requests in the background, saving up to **~7 minutes** every time you start a workspace.
Please note that for this config to work, an admin needs to install the [Gitpod hook](https://github.com/marketplace/gitpod-io) for this repository -- I'm happy to help with that, but can't do it myself.

The optimized setup now takes ~2-3 minutes. It can probably be made even faster, by pre-building more things in the `init` and `before` steps, but I'll likely need some help with that.

You can try this accelerated setup by opening my fork in Gitpod like so:
https://gitpod.io/#https://github.com/jankeromnes/gatsby

There, you should see a message like this in the Terminal:
<img width="432" alt="Screenshot 2019-09-13 at 18 33 27" src="https://user-images.githubusercontent.com/599268/65161461-eade3b80-da37-11e9-9b9c-db047d8300e9.png">

I've also added a new README badge, with a URL that can open any Gatsby fork / branch in Gitpod:
[![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/from-referrer/)

(It's referrer-based, so if you click on it here, it will open my Pull Request in Gitpod. That's another way to try my changes.)

Please let me know what you think. 🙂 

## Related Issues

(N/A)

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
