### PR TITLE
fix(babel-preset-gatsby-package): Add corejs to config

### DIFF
--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -5,6 +5,7 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
+      "corejs": 2,
       "debug": false,
       "loose": true,
       "modules": "commonjs",
@@ -34,6 +35,7 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
+      "corejs": 2,
       "debug": true,
       "loose": true,
       "modules": "commonjs",
@@ -73,6 +75,7 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
+      "corejs": 2,
       "debug": false,
       "loose": true,
       "modules": "commonjs",
@@ -98,6 +101,7 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
+      "corejs": 2,
       "debug": true,
       "loose": true,
       "modules": "commonjs",
@@ -133,6 +137,7 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
+      "corejs": 2,
       "debug": false,
       "loose": true,
       "modules": "commonjs",
@@ -162,6 +167,7 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
+      "corejs": 2,
       "debug": false,
       "loose": true,
       "modules": "commonjs",

--- a/packages/babel-preset-gatsby-package/index.js
+++ b/packages/babel-preset-gatsby-package/index.js
@@ -28,7 +28,7 @@ function preset(context, options = {}) {
         r(`@babel/preset-env`),
         Object.assign(
           {
-            corejs: 3,
+            corejs: 2,
             loose: true,
             debug: !!debug,
             useBuiltIns: `entry`,

--- a/packages/babel-preset-gatsby-package/index.js
+++ b/packages/babel-preset-gatsby-package/index.js
@@ -28,6 +28,7 @@ function preset(context, options = {}) {
         r(`@babel/preset-env`),
         Object.assign(
           {
+            corejs: 3,
             loose: true,
             debug: !!debug,
             useBuiltIns: `entry`,

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -16,7 +16,8 @@
     "@babel/preset-env": "^7.6.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "babel-plugin-dynamic-import-node": "^1.2.0"
+    "babel-plugin-dynamic-import-node": "^1.2.0",
+    "core-js": "2"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
-    "core-js": "2"
+    "core-js": "^2.6.9"
   },
   "license": "MIT",
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10788,7 +10788,7 @@ is-text-path@^2.0.0:
   dependencies:
     text-extensions "^2.0.0"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
@@ -18799,6 +18799,13 @@ type-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -20098,7 +20105,7 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2, write-file-atomic@^3.0.0:
+write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
   integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
@@ -20106,6 +20113,25 @@ write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, wri
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-atomic@^2.4.2:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+write-file-atomic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.0.tgz#1b64dbbf77cb58fd09056963d63e62667ab4fb21"
+  integrity sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 write-file-stdout@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This is a warning in development about a missing `corejs` config in babel, the issue below tracks down the source of the problem, and this fix quiets it down, thanks!

Edit: I specified the version 3 as it seems to be the recommended version on the docs [(here)](https://github.com/zloirock/core-js#babelpreset-env)

## Related Issues

Fixed #17706

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
