### PR TITLE
fix(babel-preset-gatsby-package): apply "corejs" only to non-browser target

### DIFF
--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -5,7 +5,6 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
-      "corejs": 2,
       "debug": false,
       "loose": true,
       "modules": "commonjs",
@@ -17,7 +16,7 @@ Array [
           "not android 4.4.3",
         ],
       },
-      "useBuiltIns": "entry",
+      "useBuiltIns": false,
     },
   ],
   Array [
@@ -35,7 +34,6 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
-      "corejs": 2,
       "debug": true,
       "loose": true,
       "modules": "commonjs",
@@ -47,7 +45,7 @@ Array [
           "not android 4.4.3",
         ],
       },
-      "useBuiltIns": "entry",
+      "useBuiltIns": false,
     },
   ],
   Array [
@@ -137,7 +135,6 @@ Array [
   Array [
     "@babel/preset-env",
     Object {
-      "corejs": 2,
       "debug": false,
       "loose": true,
       "modules": "commonjs",
@@ -149,7 +146,7 @@ Array [
           "ie >= 9",
         ],
       },
-      "useBuiltIns": "entry",
+      "useBuiltIns": false,
     },
   ],
   Array [

--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -17,7 +17,7 @@ Array [
           "not android 4.4.3",
         ],
       },
-      "useBuiltIns": false,
+      "useBuiltIns": "entry",
     },
   ],
   Array [
@@ -47,7 +47,7 @@ Array [
           "not android 4.4.3",
         ],
       },
-      "useBuiltIns": false,
+      "useBuiltIns": "entry",
     },
   ],
   Array [
@@ -149,7 +149,7 @@ Array [
           "ie >= 9",
         ],
       },
-      "useBuiltIns": false,
+      "useBuiltIns": "entry",
     },
   ],
   Array [

--- a/packages/babel-preset-gatsby-package/index.js
+++ b/packages/babel-preset-gatsby-package/index.js
@@ -8,6 +8,7 @@ function preset(context, options = {}) {
   const IS_TEST  = (BABEL_ENV || NODE_ENV) === `test`
 
   const browserConfig = {
+    useBuiltIns: false,
     targets: {
       browsers: IS_PRODUCTION
         ? [`last 4 versions`, `safari >= 7`, `ie >= 9`]
@@ -16,6 +17,8 @@ function preset(context, options = {}) {
   }
 
   const nodeConfig = {
+    corejs: 2,
+    useBuiltIns: `entry`,
     targets: {
       node: IS_PRODUCTION ? nodeVersion : `current`,
     },
@@ -27,10 +30,8 @@ function preset(context, options = {}) {
         r(`@babel/preset-env`),
         Object.assign(
           {
-            corejs: 2,
             loose: true,
             debug: !!debug,
-            useBuiltIns: `entry`,
             shippedProposals: true,
             modules: `commonjs`,
           },

--- a/packages/babel-preset-gatsby-package/index.js
+++ b/packages/babel-preset-gatsby-package/index.js
@@ -8,7 +8,6 @@ function preset(context, options = {}) {
   const IS_TEST  = (BABEL_ENV || NODE_ENV) === `test`
 
   const browserConfig = {
-    useBuiltIns: false,
     targets: {
       browsers: IS_PRODUCTION
         ? [`last 4 versions`, `safari >= 7`, `ie >= 9`]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10788,7 +10788,7 @@ is-text-path@^2.0.0:
   dependencies:
     text-extensions "^2.0.0"
 
-is-typedarray@^1.0.0, is-typedarray@~1.0.0:
+is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
@@ -18799,13 +18799,6 @@ type-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
 
-typedarray-to-buffer@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
-  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  dependencies:
-    is-typedarray "^1.0.0"
-
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -20105,7 +20098,7 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
+write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2, write-file-atomic@^3.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
   integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
@@ -20113,25 +20106,6 @@ write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
-
-write-file-atomic@^2.4.2:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
-  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
-
-write-file-atomic@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.0.tgz#1b64dbbf77cb58fd09056963d63e62667ab4fb21"
-  integrity sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==
-  dependencies:
-    imurmurhash "^0.1.4"
-    is-typedarray "^1.0.0"
-    signal-exit "^3.0.2"
-    typedarray-to-buffer "^3.1.5"
 
 write-file-stdout@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Appears to have been introduced in https://github.com/gatsbyjs/gatsby/pull/17723