### PR TITLE
Added ternary operator to allow sourcemaps on gatsby-cli develop

### DIFF
--- a/packages/gatsby-plugin-no-sourcemaps/gatsby-node.js
+++ b/packages/gatsby-plugin-no-sourcemaps/gatsby-node.js
@@ -1,7 +1,7 @@
 exports.onCreateWebpackConfig = ({ stage, actions }) => {
   if (stage === `build-javascript`) {
     actions.setWebpackConfig({
-      devtool: false,
-    })
+      devtool: process.env.NODE_ENV === 'development' ? 'source-map' : false,
+    });
   }
 }


### PR DESCRIPTION


## Description

I added a Ternary operator to allow the source-map devtool in development environments while using the 'gatsby-plugin-no-sourcemaps' plugin.

## Why did i make this PR?

Sourcemaps are still totes useful for debugging when running gatsby develop

## Could this be better?

yeah, if i could pass in a plugin option to configure sourcemap generation 

Ex:
```js
{
  resolve: `gatsby-plugin-no-sourcemaps`,
  options: {
    allowDev:true,
  }
}
```

### why didn't you make this better 👀 

... i don't know how to take plugin options as an argument 🤷‍♂. i'm welcome to suggestions.

## Related Issues

kind of a half-way fix for https://github.com/gatsbyjs/gatsby/issues/3817

