### PR TITLE
fix(gatsby): add timeout so fetching API info doesn't fail on very slow connections

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -12,7 +12,6 @@ const telemetry = require(`gatsby-telemetry`)
 
 const apiRunnerNode = require(`../utils/api-runner-node`)
 const getBrowserslist = require(`../utils/browserslist`)
-const getLatestAPIs = require(`../utils/get-latest-apis`)
 const { store, emitter } = require(`../redux`)
 const loadPlugins = require(`./load-plugins`)
 const loadThemes = require(`./load-themes`)
@@ -116,11 +115,9 @@ module.exports = async (args: BootstrapArgs) => {
 
   activity.end()
 
-  const apis = await getLatestAPIs()
-
   activity = report.activityTimer(`load plugins`, { parentSpan: bootstrapSpan })
   activity.start()
-  const flattenedPlugins = await loadPlugins(config, program.directory, apis)
+  const flattenedPlugins = await loadPlugins(config, program.directory)
   activity.end()
 
   telemetry.decorateEvent(`BUILD_END`, {

--- a/packages/gatsby/src/bootstrap/load-plugins/index.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.js
@@ -38,14 +38,11 @@ const flattenPlugins = plugins => {
 }
 
 module.exports = async (config = {}, rootDir = null, latestAPIs = {}) => {
-  const apis = {
-    currentAPIs: getAPI({
-      browser: browserAPIs,
-      node: nodeAPIs,
-      ssr: ssrAPIs,
-    }),
-    latestAPIs,
-  }
+  const currentAPIs = getAPI({
+    browser: browserAPIs,
+    node: nodeAPIs,
+    ssr: ssrAPIs,
+  })
   // Collate internal plugins, site config plugins, site default plugins
   const plugins = loadPlugins(config, rootDir)
 
@@ -54,12 +51,12 @@ module.exports = async (config = {}, rootDir = null, latestAPIs = {}) => {
 
   // Work out which plugins use which APIs, including those which are not
   // valid Gatsby APIs, aka 'badExports'
-  const x = collatePluginAPIs({ ...apis, flattenedPlugins })
+  const x = collatePluginAPIs({ currentAPIs, flattenedPlugins })
   flattenedPlugins = x.flattenedPlugins
   const badExports = x.badExports
 
   // Show errors for any non-Gatsby APIs exported from plugins
-  handleBadExports({ ...apis, badExports })
+  await handleBadExports({ currentAPIs, badExports })
 
   // Show errors when ReplaceRenderer has been implemented multiple times
   flattenedPlugins = handleMultipleReplaceRenderers({

--- a/packages/gatsby/src/bootstrap/load-plugins/index.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.js
@@ -37,7 +37,7 @@ const flattenPlugins = plugins => {
   return flattened
 }
 
-module.exports = async (config = {}, rootDir = null, latestAPIs = {}) => {
+module.exports = async (config = {}, rootDir = null) => {
   const currentAPIs = getAPI({
     browser: browserAPIs,
     node: nodeAPIs,

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.js
@@ -4,6 +4,7 @@ const stringSimiliarity = require(`string-similarity`)
 const { version: gatsbyVersion } = require(`gatsby/package.json`)
 const reporter = require(`gatsby-cli/lib/reporter`)
 const resolveModuleExports = require(`../resolve-module-exports`)
+const getLatestAPIs = require(`../../utils/get-latest-apis`)
 
 const getGatsbyUpgradeVersion = entries =>
   entries.reduce((version, entry) => {
@@ -98,23 +99,29 @@ const getErrorContext = (badExports, exportType, currentAPIs, latestAPIs) => {
   }
 }
 
-const handleBadExports = ({ currentAPIs, latestAPIs, badExports }) => {
-  // Output error messages for all bad exports
-  _.toPairs(badExports).forEach(badItem => {
-    const [exportType, entries] = badItem
-    if (entries.length > 0) {
-      const context = getErrorContext(
-        entries,
-        exportType,
-        currentAPIs,
-        latestAPIs
-      )
-      reporter.error({
-        id: `11329`,
-        context,
-      })
-    }
-  })
+const handleBadExports = async ({ currentAPIs, badExports }) => {
+  const hasBadExports = Object.keys(badExports).find(
+    api => badExports[api].length > 0
+  )
+  if (hasBadExports) {
+    const latestAPIs = await getLatestAPIs()
+    // Output error messages for all bad exports
+    _.toPairs(badExports).forEach(badItem => {
+      const [exportType, entries] = badItem
+      if (entries.length > 0) {
+        const context = getErrorContext(
+          entries,
+          exportType,
+          currentAPIs,
+          latestAPIs
+        )
+        reporter.error({
+          id: `11329`,
+          context,
+        })
+      }
+    })
+  }
 }
 
 /**

--- a/packages/gatsby/src/utils/__tests__/get-latest-apis.js
+++ b/packages/gatsby/src/utils/__tests__/get-latest-apis.js
@@ -38,7 +38,10 @@ describe(`default behavior: has network connectivity`, () => {
   it(`makes a request to unpkg to request file`, async () => {
     const data = await getLatestAPIs()
 
-    expect(axios.get).toHaveBeenCalledWith(expect.stringContaining(`unpkg.com`))
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining(`unpkg.com`),
+      expect.any(Object)
+    )
     expect(data).toEqual(getMockAPIFile())
   })
 

--- a/packages/gatsby/src/utils/get-latest-apis.js
+++ b/packages/gatsby/src/utils/get-latest-apis.js
@@ -8,7 +8,7 @@ const OUTPUT_FILE = path.join(ROOT, `latest-apis.json`)
 
 module.exports = async function getLatestAPI() {
   try {
-    const { data } = await axios.get(API_FILE)
+    const { data } = await axios.get(API_FILE, { timeout: 5000 })
 
     await fs.writeFile(OUTPUT_FILE, JSON.stringify(data, null, 2), `utf8`)
 

--- a/packages/gatsby/src/utils/get-latest-apis.js
+++ b/packages/gatsby/src/utils/get-latest-apis.js
@@ -8,7 +8,7 @@ const OUTPUT_FILE = path.join(ROOT, `latest-apis.json`)
 
 module.exports = async function getLatestAPI() {
   try {
-    const { data } = await axios.get(API_FILE, { timeout: 1000 })
+    const { data } = await axios.get(API_FILE)
 
     await fs.writeFile(OUTPUT_FILE, JSON.stringify(data, null, 2), `utf8`)
 

--- a/packages/gatsby/src/utils/get-latest-apis.js
+++ b/packages/gatsby/src/utils/get-latest-apis.js
@@ -8,7 +8,7 @@ const OUTPUT_FILE = path.join(ROOT, `latest-apis.json`)
 
 module.exports = async function getLatestAPI() {
   try {
-    const { data } = await axios.get(API_FILE)
+    const { data } = await axios.get(API_FILE, { timeout: 1000 })
 
     await fs.writeFile(OUTPUT_FILE, JSON.stringify(data, null, 2), `utf8`)
 


### PR DESCRIPTION
I was on an airplane trying to run `gatsby develop` and bootstrap hung here. I dug around and found adding a timeout fixed it.