### PR TITLE
fix(gatsby): support `export { X as default }` syntax when checking if page template files have default export

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -379,7 +379,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
       !fileContent.includes(`module.exports`) &&
       !fileContent.includes(`exports.default`) &&
       !fileContent.includes(`exports["default"]`) &&
-      !fileContent.match(/export {.* as default.*}/s) &&
+      !fileContent.match(/export \{.* as default.*\}/s) &&
       // this check only applies to js and ts, not mdx
       /\.(jsx?|tsx?)/.test(path.extname(fileName))
     ) {

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -379,6 +379,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
       !fileContent.includes(`module.exports`) &&
       !fileContent.includes(`exports.default`) &&
       !fileContent.includes(`exports["default"]`) &&
+      !fileContent.match(/export {.* as default.*}/s) &&
       // this check only applies to js and ts, not mdx
       /\.(jsx?|tsx?)/.test(path.extname(fileName))
     ) {


### PR DESCRIPTION
## Description
`gatsby build` checks to see that all pages export a default react component. It does this by searching the file for strings like `module.exports`, `exports.default`,  `exports["default"]`  etc.

While this covers many of the [possible ways](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export) to export a default value, one is missed:
```js
export { name1 as default, … };
``` 

Unfortunately, this is the form used by [bucklescript](https://bucklescript.github.io/), a ReasonML-to-JS compiler that I'm trying to use with gatsby. 

Bucklescript generates code for default export that looks something like this:
```js
var $$default = Index;
export {
  Styles ,
  make ,
  $$default ,
  $$default as default,
}
```

Looks a little funny but the main point is that it uses the  ` as default` syntax. I tried to add detection for this case, it seems to be working locally on my machine. Not sure how precise you want this check to be, we could also do something simpler like `!fileContent.includes(' as default')`.

Thanks for taking a look and let me know if I misunderstood anything!

## Related Issues
Fixes https://github.com/Schmavery/reason-gatsby/issues/1
