### PR TITLE
Added instructions for Sass/SCSS implementation

### DIFF
--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -6,12 +6,13 @@ Tailwind is a utility-first CSS framework for rapidly building custom user inter
 
 ## Overview
 
-There are two ways you can use Tailwind with Gatsby:
+There are three ways you can use Tailwind with Gatsby:
 
 1. Standard: Use PostCSS to generate Tailwind classes, then you can apply those classes using `className`.
 2. CSS-in-JS: Integrate Tailwind classes into Styled Components.
+3. Sass/SCSS: Use [gatsby-plugin-sass](https://www.gatsbyjs.org/packages/gatsby-plugin-sass/) to support Tailwind classes in your Sass/SCSS files.
 
-You have to install and configure Tailwind for both of these methods, so this guide will walk through that step first, then you can follow the instructions for either PostCSS or CSS-in-JS.
+You have to install and configure Tailwind for all of these methods, so this guide will walk through that step first, then you can follow the instructions for PostCSS, CSS-in-JS or Sass/SCSS.
 
 ## Installing and Configuring Tailwind
 
@@ -104,6 +105,42 @@ const Button = tw.button`
   bg-blue hover:bg-blue-dark text-white p-2 rounded
 `
 ```
+
+### Option #3: Sass/SCSS
+
+1.  Install the Gatsby Sass plugin [**gatsby-plugin-sass**](https://www.gatsbyjs.org/packages/gatsby-plugin-sass/) and `node-sass`.
+
+```shell
+npm install --save node-sass gatsby-plugin-sass
+```
+
+*The default Sass implementation wil lbe `node-sass`, but can be changed. Alternatively you can switch to the Dart implementation `sass`:*
+
+```shell
+npm install --save-dev sass
+npm install --save gatsby-plugin-sass
+```
+
+2. To be able to use Tailwind classes in your Sass/SCSS files, add the `tailwindcss` package into the `postCSSPlugins` parameter in your `gatsby-config.js`. If you want to use the Dart implementation of Sass, you will need to add the `implementation` parameter.
+
+```javascript:title=gatsby-config.js
+// in gatsby-config.js
+plugins: [
+  {
+    resolve: `gatsby-plugin-sass`,
+    options: {
+      postCssPlugins: [
+        require("tailwindcss"),
+        // require("./tailwind.config.js"), // Optional: Load custom tailwindcss configuration
+      ],
+      // implementation: require("sass"), // Alternatively you can use another Sass implementation
+    },
+  },
+],
+```
+
+**Note:** Optionally you can add a corresponding configuration file (by default it will be `tailwind.config.js`).
+If you are adding a custom configuration, you will need to load it after `tailwindcss`.
 
 ## Other resources
 


### PR DESCRIPTION
# Description

I was missing a documentation how to implement the tailwindcss framework. After searching the web I found lot of blog posts about how to implement tailwindcss with postcss plugin, but not with sass/scss support.

This plugin looks to be perfect for this and makes it so easy to implement tailwindcss, but there is somethings to care for. That's why I tought about adding a brief instruction how to implement tailwindcss.

Additionally I've found some mistakes in the highlighting and some missing information about which file is displayed in the code samples. Instead of splitting it into different PR's I've done it at once to save some time.
