### PR TITLE
typo -- Client Data Fetching

### DIFF
--- a/docs/docs/client-data-fetching.md
+++ b/docs/docs/client-data-fetching.md
@@ -184,7 +184,7 @@ class ClientFetchingExample extends Component {
             </>
           ) : (
             <p>Oh noes, error fetching pupper :(</p>
-          )}
+          ))}
         </div>
        </div> {/* highlight-end */}
     )


### PR DESCRIPTION
## Description

fixed typo in Client Data Fetching docs - missing closing parenthesis in code example for fetching pupper data


