### PR TITLE
docs: add embeds and links to egghead videos on using gatsby-image

### DIFF
--- a/docs/docs/importing-assets-into-files.md
+++ b/docs/docs/importing-assets-into-files.md
@@ -43,6 +43,11 @@ If you're using SCSS the imports are relative to the entry SCSS file.
 
 Please be advised that this is also a custom feature of Webpack.
 
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-import-a-local-image-into-a-gatsby-component-with-webpack"
+  lessonTitle="Import a Local Image into a Gatsby Component with webpack"
+/>
+
 ## Querying for a `File` in GraphQL using gatsby-source-filesystem
 
 You can also import files using GraphQL by querying for them in your data layer, which will trigger copying of those files to the public directory. Querying for the `publicURL` field of `File` nodes will provide URLs you can use in your JavaScript components, pages and templates.

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1529,6 +1529,11 @@ Fragments can be nested inside other fragments, and multiple fragments can be us
 
 Images can be imported right into a JavaScript module with webpack. This process automatically minifies and copies the image to your site's `public` folder, providing a dynamic image URL for you to pass to an HTML `<img>` element like a regular file path.
 
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-import-a-local-image-into-a-gatsby-component-with-webpack"
+  lessonTitle="Import a Local Image into a Gatsby Component with webpack"
+/>
+
 #### Prerequisites
 
 - A [Gatsby Site](/docs/quick-start) with a `.js` file exporting a React component
@@ -1569,6 +1574,11 @@ export default () => (
 As an alternative to importing assets with webpack, the `static` folder allows access to content that gets automatically copied into the `public` folder when built.
 
 This is an **escape route** for [specific use cases](/docs/static-folder/#when-to-use-the-static-folder), and other methods like [importing with webpack](#import-an-image-into-a-component-with-webpack) are recommended to leverage optimizations made by Gatsby.
+
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-use-a-local-image-from-the-static-folder-in-a-gatsby-component"
+  lessonTitle="Use a local image from the static folder in a Gatsby component"
+/>
 
 #### Prerequisites
 
@@ -1806,6 +1816,7 @@ return (
 - [Gatsby Image API](/docs/gatsby-image/)
 - [Using Gatsby Image](/docs/using-gatsby-image)
 - [More on working with images in Gatsby](/docs/working-with-images/)
+- [Free egghead.io videos explaining these steps](https://egghead.io/playlists/using-gatsby-image-with-gatsby-ea85129e)
 
 ### Optimizing and querying images in post frontmatter with gatsby-image
 

--- a/docs/docs/static-folder.md
+++ b/docs/docs/static-folder.md
@@ -28,6 +28,11 @@ render() {
 }
 ```
 
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-use-a-local-image-from-the-static-folder-in-a-gatsby-component"
+  lessonTitle="Use a local image from the static folder in a Gatsby component"
+/>
+
 ### Downsides
 
 Keep in mind the downsides of this approach:

--- a/docs/docs/using-gatsby-image.md
+++ b/docs/docs/using-gatsby-image.md
@@ -74,6 +74,11 @@ module.exports = {
 }
 ```
 
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-install-gatsby-image-and-source-local-images-from-the-filesystem"
+  lessonTitle="Install gatsby-image and source local images from the filesystem"
+/>
+
 4. Write a GraphQL query using one of the included [GraphQL “fragments”](/packages/gatsby-image/#fragments) which specify the fields needed by `gatsby-image` to create a responsive, optimized image. This example queries for an image at a path relative to the location specified in the `gatsby-source-filesystem` options using the `GatsbyImageSharpFluid` fragment.
 
 ```graphql
@@ -86,6 +91,11 @@ file(relativePath: { eq: "images/default.jpg" }) {
       }
 }
 ```
+
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-use-gatsby-image-with-an-image-from-a-relative-path"
+  lessonTitle="Use gatsby-image with an image from a relative path"
+/>
 
 5. Import `Img` to display the fragment in JSX. There are additional features available with the `Img` tag as well, such as the `alt` attribute for accessibility.
 
@@ -102,6 +112,11 @@ export default ({ data }) => (
   </div>
 )
 ```
+
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-use-gatsby-image-s-graphql-fragments-for-blurred-up-and-traced-svg-images"
+  lessonTitle="Use gatsby-image's GraphQL fragments for blurred-up and traced SVG images"
+/>
 
 This GraphQL query creates multiple sizes of the image and when the page is rendered the image that is appropriate for the current screen resolution (e.g. desktop, mobile, and everything in between) is used. The `gatsby-image` component automatically enables a blur-up effect as well as lazy loading images that are not currently on screen.
 

--- a/docs/docs/working-with-images.md
+++ b/docs/docs/working-with-images.md
@@ -94,6 +94,7 @@ export const query = graphql`
 ### Additional resources
 
 - [Gatsby Image API docs](/docs/gatsby-image/)
+- [Using gatsby-image with Gatsby](https://egghead.io/playlists/using-gatsby-image-with-gatsby-ea85129e), free egghead.io playlist
 - [gatsby-image plugin README file](/packages/gatsby-image/)
 - [gatsby-plugin-sharp README file](/packages/gatsby-plugin-sharp/)
 - [gatsby-transformer-sharp README file](/packages/gatsby-transformer-sharp/)

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -145,7 +145,7 @@ export const query = graphql`
 `
 ```
 
-For other explanations of how to get started with gatsby-image, see this blog post by community member Kyle Gill [Image Optimization Made Easy with Gatsby.js](https://medium.com/@kyle.robert.gill/ridiculously-easy-image-optimization-with-gatsby-js-59d48e15db6e) or this one by Hunter Chang (which also includes some details about changes to gatsby-image for Gatsby v2): [An Intro To Gatsby Image V2](https://codebushi.com/using-gatsby-image/)
+For other explanations of how to get started with gatsby-image, see this blog post by community member Kyle Gill [Image Optimization Made Easy with Gatsby.js](https://medium.com/@kyle.robert.gill/ridiculously-easy-image-optimization-with-gatsby-js-59d48e15db6e), this post by Hunter Chang (which also includes some details about changes to gatsby-image for Gatsby v2): [An Intro To Gatsby Image V2](https://codebushi.com/using-gatsby-image/), or [this free playlist on egghead.io](https://egghead.io/playlists/using-gatsby-image-with-gatsby-ea85129e) with examples for using `gatsby-image`.
 
 ## Polyfilling object-fit/object-position for IE
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

To help explain using `gatsby-image` in more media formats, [these egghead videos](https://egghead.io/playlists/using-gatsby-image-with-gatsby-ea85129e) were made alongside the recipes for using images.

This adds links in additional resources on several pages, as well as embeds in places where they seem applicable.

## Related Issues

None
