### PR TITLE
docs: fixed typo in layer-content-sections.js

### DIFF
--- a/www/src/components/layer-model/layer-content-sections.js
+++ b/www/src/components/layer-model/layer-content-sections.js
@@ -197,7 +197,7 @@ const ContentLayerContent = ({ sourceIndex, setSourceIndex, index }) => (
         management systems, files, or external APIs.
       </p>
       <p>
-        Any source of data can be connected Gatsby through plugins or using
+        Any source of data can be connected to Gatsby through plugins or using
         Gatsby's APIs.
       </p>
     </div>


### PR DESCRIPTION
Fixed typo in Content to indicate that data is connected *to* Gatsby.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
