### PR TITLE
feat(gatsby-telemetry): add exitCode to `BUILD_END` event

### DIFF
--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -44,8 +44,8 @@ module.exports = async function build(program: BuildArgs) {
   initTracer(program.openTracingConfigFile)
 
   telemetry.trackCli(`BUILD_START`)
-  signalExit(() => {
-    telemetry.trackCli(`BUILD_END`)
+  signalExit(exitCode => {
+    telemetry.trackCli(`BUILD_END`, { exitCode })
   })
 
   const buildSpan = tracer.startSpan(`build`)


### PR DESCRIPTION
This adds `exitCode` field to `BUILD_END` event so it's easier to determine if build was successful or it crashed (or was interrupted)