### PR TITLE
docs: Slight update to surge deployment instructions

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -345,7 +345,7 @@ If you haven't previously installed &amp; set up Surge, open a new terminal wind
 npm install --global surge
 
 # Then create a (free) account with them
-surge
+surge login
 ```
 
 Next, build your site by running the following command in the terminal at the root of your site (tip: make sure you're running this command at the root of your site, in this case in the hello-world folder, which you can do by opening a new tab in the same window you used to run `gatsby develop`):


### PR DESCRIPTION
## Description

Docs are currently specifying to use `surge` after installing the Surge
CLI to create an account, but after account creation it continues with
steps for deploying to surge. It is too soon to deploy at this point in
the tutorial because `gatsby build` has not been run yet. Using `surge
login` instead, it will end after the user creates an account by logging
in with email and password.