### PR TITLE
chore(docs): Added a couple of words to tutorial

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -131,7 +131,7 @@ One of the big mental shifts you make when starting to build with components (if
 
 While a seemingly simple change, this has profound implications for how you think about building websites.
 
-Take the example of creating a custom button. In the past, you would create a CSS class (perhaps `.primary-button`) with your custom styles and then whenever you want to apply those styles e.g.
+Take the example of creating a custom button. In the past, you would create a CSS class (perhaps `.primary-button`) with your custom styles and then use it whenever you want to apply those styles. For example:
 
 ```html
 <button class="primary-button">Click me</button>


### PR DESCRIPTION
In this paragraph:

"Take the example of creating a custom button. In the past, you would create a CSS class (perhaps .primary-button) with your custom styles and then whenever you want to apply those styles e.g."

It doesn't read clearly - "and then whenever you want to apply those styles e.g"

Have added a couple of words for clarity, and changed "e.g." to "for example" (Latinate abbreviations aren't very friendly to people with English as a second language, and raise the reading level required for native speakers as well)

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
