### PR TITLE
test(babel-preset-gatsby): create custom snapshot serializer

### DIFF
--- a/packages/babel-preset-gatsby/package.json
+++ b/packages/babel-preset-gatsby/package.json
@@ -26,14 +26,15 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "build": "babel src --out-dir . --ignore **/__tests__",
+    "build": "babel src --out-dir . --ignore **/__tests__ --ignore **/utils/path-serializer.js",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore **/__tests__"
+    "watch": "babel -w src --out-dir . --ignore **/__tests__ --ignore **/utils/path-serializer.js"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.0",
     "babel-preset-gatsby-package": "^0.2.5",
-    "cross-env": "^5.2.1"
+    "cross-env": "^5.2.1",
+    "slash": "^3.0.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/babel-preset-gatsby/src/__tests__/dependencies.js
+++ b/packages/babel-preset-gatsby/src/__tests__/dependencies.js
@@ -1,5 +1,7 @@
 const preset = require(`../dependencies`)
 
+expect.addSnapshotSerializer(require(`../utils/path-serializer`))
+
 describe(`dependencies`, () => {
   it(`should specify proper presets and plugins`, () => {
     expect(preset()).toMatchSnapshot()

--- a/packages/babel-preset-gatsby/src/__tests__/index.js
+++ b/packages/babel-preset-gatsby/src/__tests__/index.js
@@ -1,6 +1,8 @@
 const preset = require(`../`)
 const path = require(`path`)
 
+expect.addSnapshotSerializer(require(`../utils/path-serializer`))
+
 describe(`babel-preset-gatsby`, () => {
   it.each([`build-stage`, `develop`, `build-javascript`, `build-html`])(
     `should specify proper presets and plugins when stage is %s`,

--- a/packages/babel-preset-gatsby/src/utils/path-serializer.js
+++ b/packages/babel-preset-gatsby/src/utils/path-serializer.js
@@ -1,0 +1,16 @@
+const path = require(`path`)
+const slash = require(`slash`)
+const localPackageRoot = path.resolve(__dirname, `../..`)
+const monoRepoRoot = path.resolve(localPackageRoot, `../..`)
+
+const cleanNodeModules = dir =>
+  slash(
+    dir
+      .replace(localPackageRoot, `<PROJECT_ROOT>`)
+      .replace(monoRepoRoot, `<PROJECT_ROOT>`)
+  )
+
+export const test = val =>
+  typeof val === `string` && val !== cleanNodeModules(val)
+
+export const print = (val, serialize) => serialize(cleanNodeModules(val))


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I've created a custom snapshot serializer that replaces the directory from the local node-modules & mono node_modules. It should fix the jumping around when renovates try to upgrade babel packages.


## Related Issues
https://github.com/gatsbyjs/gatsby/pull/17830