### PR TITLE
fix(gatsby-remark-images-contentful): avoid modifying options when passed by reference

### DIFF
--- a/packages/gatsby-remark-images-contentful/src/index.js
+++ b/packages/gatsby-remark-images-contentful/src/index.js
@@ -61,10 +61,10 @@ module.exports = async (
     const optionsHash = createContentDigest(options)
 
     const cacheKey = `remark-images-ctf-${fileName}-${optionsHash}`
-    let cahedRawHTML = await cache.get(cacheKey)
+    let cachedRawHTML = await cache.get(cacheKey)
 
-    if (cahedRawHTML) {
-      return cahedRawHTML
+    if (cachedRawHTML) {
+      return cachedRawHTML
     }
     const metaReader = sharp()
 

--- a/packages/gatsby-remark-images-contentful/src/utils/index.js
+++ b/packages/gatsby-remark-images-contentful/src/utils/index.js
@@ -16,21 +16,17 @@ const getBase64Img = async url => {
 
 const buildResponsiveSizes = async ({ metadata, imageUrl, options = {} }) => {
   const { width, height, density } = metadata
+  const { sizeByPixelDensity, maxWidth, sizes } = options
   const aspectRatio = width / height
   const pixelRatio =
-    options.sizeByPixelDensity && typeof density === `number` && density > 0
+    sizeByPixelDensity && typeof density === `number` && density > 0
       ? density / 72
       : 1
 
-  const presentationWidth = Math.min(
-    options.maxWidth,
-    Math.round(width / pixelRatio)
-  )
+  const presentationWidth = Math.min(maxWidth, Math.round(width / pixelRatio))
   const presentationHeight = Math.round(presentationWidth * (height / width))
-
-  if (!options.sizes) {
-    options.sizes = `(max-width: ${presentationWidth}px) 100vw, ${presentationWidth}px`
-  }
+  const sizesQuery =
+    sizes || `(max-width: ${presentationWidth}px) 100vw, ${presentationWidth}px`
 
   const images = []
 
@@ -64,7 +60,7 @@ const buildResponsiveSizes = async ({ metadata, imageUrl, options = {} }) => {
     srcSet,
     webpSrcSet,
     src: imageUrl,
-    sizes: options.sizes,
+    sizes: sizesQuery,
     density,
     presentationWidth,
     presentationHeight,


### PR DESCRIPTION
## Description
When using `gatsby-remark-images-contentful`, images of different sizes would end up having the wrong sizes for breakpoints defined and were based on the first image that finished processing. This is because `options` is being passed in by reference and the `sizes` key was being set on it causing `options.sizes` to now be defined for all images. 

This change makes it so that nothing is ever set on `options` within the `buildResponsiveSizes` function and all option values are destructured from the passed in `options` object. This ensure that each image will have the proper sizes set based on the images metadata or the size option that is set.

I also fixed a typo for `cahedRawHTML` to `cachedRawHTML`.

