### PR TITLE
fix(gatsby): don't add undefined query id

### DIFF
--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -76,9 +76,11 @@ const popNodeQueries = state => {
 
     // Find components that depend on this node so are now dirty.
     if (state.componentDataDependencies.nodes.has(node.id)) {
-      state.componentDataDependencies.nodes
-        .get(node.id)
-        .forEach(n => dirtyIds.add(n))
+      state.componentDataDependencies.nodes.get(node.id).forEach(n => {
+        if (n) {
+          dirtyIds.add(n)
+        }
+      })
     }
 
     // Find connections that depend on this node so are now invalid.


### PR DESCRIPTION
This is hotfix for regression added in https://github.com/gatsbyjs/gatsby/pull/17682

fixes #17882

I want to investigate further why `undefined` and up in dependencies, but this is meant for hot-fix in the meantime