### PR TITLE
Missing comma and missing "you"

### DIFF
--- a/docs/docs/graphql-concepts.md
+++ b/docs/docs/graphql-concepts.md
@@ -239,7 +239,7 @@ Notice that in the above example for [querying images](#images), we used `...Gat
 
 If you wish to define your own fragments for use in your application, you can use named exports to export them in any JavaScript file, and they will be automatically processed by Gatsby for use in your GraphQL queries.
 
-For example if I put a fragment in a helper component, I can use that fragment in any other query:
+For example, if I put a fragment in a helper component, I can use that fragment in any other query:
 
 ```jsx:title=src/components/PostItem.js
 export const markdownFrontmatterFragment = graphql`
@@ -263,7 +263,7 @@ query($path: String!) {
 }
 ```
 
-It’s good practice for your helper components to define and export a fragment for the data they need. For example, on your index page might map over all of your posts to show them in a list.
+It’s good practice for your helper components to define and export a fragment for the data they need. For example, on your index page you might map over all of your posts to show them in a list.
 
 ```jsx:title=src/pages/index.jsx
 import React from "react"


### PR DESCRIPTION
Two small changes. 

1. Added a missing comma after the introductory phrase "For example".
2. Added the missing "you" in "For example, on your index page might map over all of your posts to show them in a list".

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
