### PR TITLE
docs(blog): update turning-the-static-dynamic blog post

### DIFF
--- a/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
+++ b/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
@@ -57,7 +57,7 @@ Let's walk through the steps:
   },
 ```
 
-When deploying to Netlify, `gatsby build` must be run before `netlify-lambda build src/lambda` or else your Netlify function builds will fail.  To avoid this, do not set your build script command to `"build": "run-p build:**"` when you replace `scripts` in `package.json`.  Doing so will run all build scripts in parallel.  This will make it possible for `netlify-lambda build src/lambda` to run before `gatsby build`.  
+When deploying to Netlify, `gatsby build` must be run before `netlify-lambda build src/lambda` or else your Netlify function builds will fail. To avoid this, do not set your build script command to `"build": "run-p build:**"` when you replace `scripts` in `package.json`. Doing so will run all build scripts in parallel. This will make it possible for `netlify-lambda build src/lambda` to run before `gatsby build`.
 
 3. **Configure your Netlify build**: When serving your site on Netlify, `netlify-lambda` will now build each JavaScript/TypeScript file in your `src/lambda` folder as a standalone Netlify function (with a path corresponding to the filename). Make sure you have a Functions path in a `netlify.toml` file at root of your repository:
 
@@ -370,8 +370,8 @@ export function handler(event, context, callback) {
     })
   } else {
     console.log(`
-    Note that netlify-lambda only locally emulates Netlify Functions, 
-    while netlify-identity-widget interacts with a real Netlify Identity instance. 
+    Note that netlify-lambda only locally emulates Netlify Functions,
+    while netlify-identity-widget interacts with a real Netlify Identity instance.
     This means that netlify-lambda doesn't support Netlify Functions + Netlify Identity integration.
     `)
     callback(null, {

--- a/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
+++ b/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
@@ -51,11 +51,13 @@ Let's walk through the steps:
     "start": "run-p start:**",
     "start:app": "npm run develop",
     "start:lambda": "netlify-lambda serve src/lambda",
-    "build": "run-p build:**",
+    "build": "gatsby build && netlify-lambda build src/lambda",
     "build:app": "gatsby build",
     "build:lambda": "netlify-lambda build src/lambda",
   },
 ```
+
+When deploying to Netlify, `gatsby build` must be run before `netlify-lambda build src/lambda` or else your Netlify function builds will fail.  To avoid this, do not set your build script command to `"build": "run-p build:**"` when you replace `scripts` in `package.json`.  Doing so will run all build scripts in parallel.  This will make it possible for `netlify-lambda build src/lambda` to run before `gatsby build`.  
 
 3. **Configure your Netlify build**: When serving your site on Netlify, `netlify-lambda` will now build each JavaScript/TypeScript file in your `src/lambda` folder as a standalone Netlify function (with a path corresponding to the filename). Make sure you have a Functions path in a `netlify.toml` file at root of your repository:
 
@@ -67,6 +69,8 @@ Let's walk through the steps:
 ```
 
 For more info or configuration options (e.g. in different branches and build environments), check [the Netlify.toml reference](https://www.netlify.com/docs/netlify-toml-reference/).
+
+**NOTE:** the `Command` specified in `netlify.toml` overrides the build command specified in your site's Netlify UI Build settings.
 
 4. **Proxy the emulated functions for local development**: Head to `gatsby-config.js` and add this to your `module.exports`:
 


### PR DESCRIPTION
## Description

The build command in index.md on line 54 is currently incorrect.  It will run all build scripts in parallel which will cause the Netlify functions build to fail when deploying to Netlify.  This is the build log for the Netlify functions:

8:31:58 AM: > run-p build:**
8:31:59 AM: > bscs-mw@0.1.0 build:lambda /opt/build/repo
8:31:59 AM: > netlify-lambda build src/lambda
8:31:59 AM: > bscs-mw@0.1.0 build:app /opt/build/repo
8:31:59 AM: > gatsby build
8:32:00 AM: netlify-lambda: Building functions

This causes this error:

8:32:02 AM: Module build failed (from /opt/build/repo/node_modules/babel-loader/lib/index.js):
8:32:02 AM: Error: [BABEL] /opt/build/repo/src/lambda/canvas-registration.js: `babel-preset-gatsby` has been loaded, which consumes config generated by the Gatsby CLI. Set `NODE_ENV=test` to bypass, or run `gatsby build` first. (While processing: "/opt/build/repo/node_modules/babel-preset-gatsby/index.js")
8:32:02 AM:     at loadCachedConfig (/opt/build/repo/node_modules/babel-preset-gatsby/index.js:18:15)
8:32:02 AM:     at preset (/opt/build/repo/node_modules/babel-preset-gatsby/index.js:34:29)
8:32:02 AM:     at loadDescriptor (/opt/build/repo/node_modules/@babel/core/lib/config/full.js:167:14)
8:32:02 AM:     at cachedFunction (/opt/build/repo/node_modules/@babel/core/lib/config/caching.js:33:19)
8:32:02 AM:     at loadPresetDescriptor (/opt/build/repo/node_modules/@babel/core/lib/config/full.js:257:36)
8:32:02 AM:     at config.presets.reduce (/opt/build/repo/node_modules/@babel/core/lib/config/full.js:79:21)
8:32:02 AM:     at Array.reduce (<anonymous>)
8:32:02 AM:     at recurseDescriptors (/opt/build/repo/node_modules/@babel/core/lib/config/full.js:76:38)
8:32:02 AM:     at loadFullConfig (/opt/build/repo/node_modules/@babel/core/lib/config/full.js:110:6)
8:32:02 AM:     at process.nextTick (/opt/build/repo/node_modules/@babel/core/lib/transform.js:28:33)
8:32:02 AM:     at _combinedTickCallback (internal/process/next_tick.js:132:7)
8:32:02 AM:     at process._tickCallback (internal/process/next_tick.js:181:9)

I changed the package.json build script to be: `"build": "gatsby build && netlify-lambda build src/lambda"`.  This fixes the build problem on Netlify.  I also added a description of why the build script needs to be what it is.  Finally, I added a note to explain that build commands in the `netlify.toml` file override the Netlify Build settings command.  This adds clarity for developers.