### PR TITLE
chore(gatsby-design-tokens): add message when microbundle fails

### DIFF
--- a/packages/gatsby-design-tokens/package.json
+++ b/packages/gatsby-design-tokens/package.json
@@ -17,7 +17,7 @@
     "./dist/**/*"
   ],
   "scripts": {
-    "build": "(microbundle build --sourcemap=false -f es,cjs && agadoo dist/index.esm.js) || node -e \"console.log('\\nMicrobundle failed, make sure you\\'re using node version 10.16 or higher\\n')\"",
+    "build": "(microbundle build --sourcemap=false -f es,cjs && agadoo dist/index.esm.js) || node -e \"console.log('\\nMicrobundle failed, make sure you\\'re using node version 10.16 or higher\\n');process.exit(1)\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "microbundle watch --sourcemap=false -f es,cjs"
   },

--- a/packages/gatsby-design-tokens/package.json
+++ b/packages/gatsby-design-tokens/package.json
@@ -17,7 +17,7 @@
     "./dist/**/*"
   ],
   "scripts": {
-    "build": "microbundle build --sourcemap=false -f es,cjs && agadoo dist/index.esm.js",
+    "build": "(microbundle build --sourcemap=false -f es,cjs && agadoo dist/index.esm.js) || node -e \"console.log('\\n\\u001b[1m\\u001b[4mMicrobundle failed, make sure you\\'re using node version 10.16 or higher\\u001b[24m\\u001b[22m\\n')\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "microbundle watch --sourcemap=false -f es,cjs"
   },

--- a/packages/gatsby-design-tokens/package.json
+++ b/packages/gatsby-design-tokens/package.json
@@ -17,7 +17,7 @@
     "./dist/**/*"
   ],
   "scripts": {
-    "build": "(microbundle build --sourcemap=false -f es,cjs && agadoo dist/index.esm.js) || node -e \"console.log('\\n\\u001b[1m\\u001b[4mMicrobundle failed, make sure you\\'re using node version 10.16 or higher\\u001b[24m\\u001b[22m\\n')\"",
+    "build": "(microbundle build --sourcemap=false -f es,cjs && agadoo dist/index.esm.js) || node -e \"console.log('\\nMicrobundle failed, make sure you\\'re using node version 10.16 or higher\\n')\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "microbundle watch --sourcemap=false -f es,cjs"
   },


### PR DESCRIPTION
## Description
Improve dx for people using node < 10.16 and trying to run `yarn bootstrap` or building `gatsby-design-tokens`

![image](https://user-images.githubusercontent.com/1120926/65765306-2fe52a80-e128-11e9-9378-5afd14a9fdde.png)
