### PR TITLE
Correct Gatsby ESLint config link

### DIFF
--- a/docs/docs/eslint.md
+++ b/docs/docs/eslint.md
@@ -10,7 +10,7 @@ JavaScript, being a dynamic and loosely-typed language, is especially prone to d
 
 Gatsby ships with a built-in [ESLint](https://eslint.org) setup. For _most_ users, our built-in ESlint setup is all you need. If you know however that you'd like to customize your ESlint config e.g. your company has their own custom ESlint setup, this shows how this can be done.
 
-We'll replicate (mostly) the [ESlint config Gatsby ships with](https://github.com/gatsbyjs/gatsby/blob/master/.eslintrc.json) so you can then add additional presets, plugins, and rules.
+We'll replicate (mostly) the [ESLint config Gatsby ships with](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/eslint-config.js) so you can then add additional presets, plugins, and rules.
 
 ```shell
 


### PR DESCRIPTION
I was looking into how to have VS Code detect my ESLint config and found [an issue](https://github.com/gatsbyjs/gatsby/issues/15959) which advises creating a custom ESLint config file.

The file referenced by @wardpeet in that comment is https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/eslint-config.js whereas the link in the [Gatsby's ESLint doc](https://www.gatsbyjs.org/docs/eslint/) points to the file https://github.com/gatsbyjs/gatsby/blob/master/.eslintrc.json.

I believe the difference is that the former is for projects *using* Gatsby whereas the latter is for *working on* Gatsby itself. In the case of people looking into adding ESLint to their Gatsby project, the former seems to be more relevant.