### PR TITLE
Docs: add details about the CI environment variable available to gatsby build for dumb terminals

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -6,8 +6,8 @@ title: "Environment Variables"
 
 You can provide environment variables to your site to customise its behavior in different environments.
 
-First we need to distinguish between different types of Env variables.  
-There are env variables that are defined in special places intended to be used in different deployment environments. Let's call these “Project Env Vars”.  
+First we need to distinguish between different types of Env variables.
+There are env variables that are defined in special places intended to be used in different deployment environments. Let's call these “Project Env Vars”.
 And there are true OS-level environment variables that might be used in command-line calls. Let's call these “OS Env Vars”.
 
 In both cases we want to be able to access the relevant value of these variables for the environment we’re in.
@@ -137,6 +137,14 @@ Gatsby also allows you to specify another environment variable when running the 
 If set to true, this will expose a `/__refresh` webhook that is able to receive `POST` requests to _refresh_ the sourced content. This exposed webhook can be triggered whenever remote data changes, which means you can update your data without re-launching the development server.
 
 You can trigger this endpoint locally for example on Unix-based operating systems (like Ubuntu and MacOS) you can use `curl -X POST http://localhost:8000/__refresh`.
+
+## Build Variables
+
+Gatsby has uses additional environment variables in the build step to fine-tune the outcome of a build. These are likely reserved for more advanced configurations, such as using [CI/CD](https://en.wikipedia.org/wiki/CI/CD) to deploy a Gatsby site.
+
+For example, you can set `CI=true` as an environment variable to allow Gatsby's build script to tailor the terminal output to an automated deployment environment. Some CI/CD tooling may already set this environment variable. This is useful for limiting the verbosity of the build output for [dumb terminals](https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals), such as terminal in progress animations.
+
+Gatsby detects an optimal level of parallelism for the render phase of `gatsby build` based on the reported number of physical CPUs. For builds that are run in virtual environments, you may need to adjust the number of worker parallelism with the `GATSBY_CPU_COUNT` environment variable. See [Multi-core builds](https://www.gatsbyjs.org/docs/multi-core-builds/).
 
 ## Additional Environments (Staging, Test, etc)
 

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -140,7 +140,7 @@ You can trigger this endpoint locally for example on Unix-based operating system
 
 ## Build Variables
 
-Gatsby has uses additional environment variables in the build step to fine-tune the outcome of a build. These are likely reserved for more advanced configurations, such as using [CI/CD](https://en.wikipedia.org/wiki/CI/CD) to deploy a Gatsby site.
+Gatsby uses additional environment variables in the build step to fine-tune the outcome of a build. You may find these helpful for more advanced configurations, such as using [CI/CD](https://en.wikipedia.org/wiki/CI/CD) to deploy a Gatsby site.
 
 For example, you can set `CI=true` as an environment variable to allow Gatsby's build script to tailor the terminal output to an automated deployment environment. Some CI/CD tooling may already set this environment variable. This is useful for limiting the verbosity of the build output for [dumb terminals](https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals), such as terminal in progress animations.
 

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -83,6 +83,8 @@ At the root of a Gatsby site, compile your application and make it ready for dep
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
 | `--no-color`, `--no-colors`  | Disables colored terminal output                                                                          |
 
+In addition to these build options, there are some optional [build environment variables](/docs/environment-variables/#build-variables) for more advanced configurations that can adjust how a build runs. For example, setting `CI=true` as an environment variable will tailor output for [dumb terminals](https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals).
+
 ### `serve`
 
 At the root of a Gatsby site, serve the production build of your site for testing:


### PR DESCRIPTION
## Description

Some [dumb terminals](https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals) print to the console excessively with Gatsby's build output, printing a new line for each animation.

![gatsby build animations per line in jenkins](https://user-images.githubusercontent.com/20871604/65544458-7b050080-ded0-11e9-9f4c-5a9c681604eb.png)

While [ci-info](https://github.com/gatsbyjs/gatsby/blob/c78338912f93495734d60a2b355c592291e7e60b/packages/gatsby-cli/src/reporter/reporters/index.js#L2) does detect many CI/CD environments, it may be necessary to explicitly declare `CI=true` to [make `ci-info` aware of its CI environment](https://github.com/watson/ci-info/blob/8d2b5bd5ebd11a3a7cc4ae7457aaf6c2188c5ca6/index.js#L53). As far as I understand, `ci-info`'s module `isCI` [conditionally determines](https://github.com/gatsbyjs/gatsby/blob/c78338912f93495734d60a2b355c592291e7e60b/packages/gatsby-cli/src/reporter/reporters/index.js#L10) whether `ink` will be used to update build activity to the console.

In addition to `CI`, the multi-core build environment variable is relevant to document alongside since both are likely to be useful in virtual integration environments, as I found in constructing my own build pipeline with Gatsby. Some connection should be made from `gatsby build` to the available environmental variable side effects.

## Related Issues

Addresses #17873 
