### PR TITLE
added margin to code blocks solves #17954

### DIFF
--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -277,7 +277,7 @@ const _options = {
         color: colors.code.text,
         padding: `${space[5]} ${space[6]} ${space[4]}`,
         fontSize: fontSizes[0],
-        margin:  `${space[2]} ${space[0]}`
+        margin: `${space[2]} ${space[0]}`,
       },
       [mediaQueries.md]: {
         ".gatsby-highlight, .gatsby-resp-image-link, .gatsby-code-title": {

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -277,6 +277,7 @@ const _options = {
         color: colors.code.text,
         padding: `${space[5]} ${space[6]} ${space[4]}`,
         fontSize: fontSizes[0],
+        margin:`${space[2]} ${space[0]}`
       },
       [mediaQueries.md]: {
         ".gatsby-highlight, .gatsby-resp-image-link, .gatsby-code-title": {

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -277,7 +277,7 @@ const _options = {
         color: colors.code.text,
         padding: `${space[5]} ${space[6]} ${space[4]}`,
         fontSize: fontSizes[0],
-        margin:`${space[2]} ${space[0]}`
+        margin:  `${space[2]} ${space[0]}`
       },
       [mediaQueries.md]: {
         ".gatsby-highlight, .gatsby-resp-image-link, .gatsby-code-title": {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Code block in plugin document page missed margin so caused collapse effect , it's bad for read：
So Added a margin from top and bottom
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/17954
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
