### PR TITLE
Only trim pathPrefix when loading from location.pathname

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/find-path.js
+++ b/packages/gatsby/cache-dir/__tests__/find-path.js
@@ -14,9 +14,9 @@ describe(`find-path`, () => {
       expect(cleanPath(`/index.html`)).toBe(`/`)
     })
 
-    it(`strip out a basePrefix`, () => {
+    it(`does NOT strip out a pathPrefix`, () => {
       global.__BASE_PATH__ = `/blog`
-      expect(cleanPath(`/blog/mypath`)).toBe(`/mypath`)
+      expect(cleanPath(`/blog/mypath`)).toBe(`/blog/mypath`)
     })
   })
 

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -8,6 +8,7 @@ import { apiRunner, apiRunnerAsync } from "./api-runner-browser"
 import { setLoader, publicLoader } from "./loader"
 import DevLoader from "./dev-loader"
 import syncRequires from "./sync-requires"
+import stripPrefix from "./stripPrefix"
 // Generated during bootstrap
 import matchPaths from "./match-paths.json"
 
@@ -59,7 +60,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   Promise.all([
     loader.loadPage(`/dev-404-page/`),
     loader.loadPage(`/404.html`),
-    loader.loadPage(window.location.pathname),
+    loader.loadPage(stripPrefix(window.location.pathname, __BASE_PATH__)),
   ]).then(() => {
     const preferDefault = m => (m && m.default) || m
     let Root = preferDefault(require(`./root`))

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -8,7 +8,7 @@ import { apiRunner, apiRunnerAsync } from "./api-runner-browser"
 import { setLoader, publicLoader } from "./loader"
 import DevLoader from "./dev-loader"
 import syncRequires from "./sync-requires"
-import stripPrefix from "./stripPrefix"
+import stripPrefix from "./strip-prefix"
 // Generated during bootstrap
 import matchPaths from "./match-paths.json"
 

--- a/packages/gatsby/cache-dir/ensure-resources.js
+++ b/packages/gatsby/cache-dir/ensure-resources.js
@@ -1,6 +1,7 @@
 import React from "react"
-import loader from "./loader"
 import shallowCompare from "shallow-compare"
+import loader from "./loader"
+import stripPrefix from "./strip-prefix"
 
 class EnsureResources extends React.Component {
   constructor(props) {
@@ -8,13 +9,17 @@ class EnsureResources extends React.Component {
     const { location, pageResources } = props
     this.state = {
       location: { ...location },
-      pageResources: pageResources || loader.loadPageSync(location.pathname),
+      pageResources:
+        pageResources ||
+        loader.loadPageSync(stripPrefix(location.pathname, __BASE_PATH__)),
     }
   }
 
   static getDerivedStateFromProps({ location }, prevState) {
     if (prevState.location.href !== location.href) {
-      const pageResources = loader.loadPageSync(location.pathname)
+      const pageResources = loader.loadPageSync(
+        stripPrefix(location.pathname, __BASE_PATH__)
+      )
       return {
         pageResources,
         location: { ...location },
@@ -41,7 +46,9 @@ class EnsureResources extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     // Always return false if we're missing resources.
     if (!nextState.pageResources) {
-      this.loadResources(nextProps.location.pathname)
+      this.loadResources(
+        stripPrefix(nextProps.location.pathname, __BASE_PATH__)
+      )
       return false
     }
 

--- a/packages/gatsby/cache-dir/find-path.js
+++ b/packages/gatsby/cache-dir/find-path.js
@@ -1,14 +1,12 @@
 import { match } from "@reach/router/lib/utils"
-import stripPrefix from "./strip-prefix"
 import normalizePagePath from "./normalize-page-path"
 
 const pathCache = new Map()
 let matchPaths = []
 
 const trimPathname = rawPathname => {
-  let pathname = decodeURIComponent(rawPathname)
-  // Remove the pathPrefix from the pathname.
-  let trimmedPathname = stripPrefix(pathname, __BASE_PATH__)
+  // rawPathname should NOT have a pathPrefix
+  const trimmedPathname = decodeURIComponent(rawPathname)
     // Remove any hashfragment
     .split(`#`)[0]
     // Remove search query

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -1,11 +1,12 @@
 import React from "react"
 import PropTypes from "prop-types"
+import { navigate as reachNavigate } from "@reach/router"
+import { parsePath } from "gatsby-link"
 import loader from "./loader"
 import redirects from "./redirects.json"
 import { apiRunner } from "./api-runner-browser"
 import emitter from "./emitter"
-import { navigate as reachNavigate } from "@reach/router"
-import { parsePath } from "gatsby-link"
+import stripPrefix from "./strip-prefix"
 
 // Convert to a map for faster lookup in maybeRedirect()
 const redirectMap = redirects.reduce((map, redirect) => {
@@ -13,7 +14,8 @@ const redirectMap = redirects.reduce((map, redirect) => {
   return map
 }, {})
 
-function maybeRedirect(pathname) {
+function maybeRedirect(locationPathname) {
+  const pathname = stripPrefix(locationPathname, __BASE_PATH__)
   const redirect = redirectMap[pathname]
 
   if (redirect != null) {

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -117,45 +117,47 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     })
   }
 
-  publicLoader.loadPage(browserLoc.pathname).then(page => {
-    if (!page || page.status === `error`) {
-      throw new Error(
-        `page resources for ${browserLoc.pathname} not found. Not rendering React`
-      )
-    }
-    const Root = () => (
-      <Location>
-        {locationContext => <LocationHandler {...locationContext} />}
-      </Location>
-    )
-
-    const WrappedRoot = apiRunner(
-      `wrapRootElement`,
-      { element: <Root /> },
-      <Root />,
-      ({ result }) => {
-        return { element: result }
+  publicLoader
+    .loadPage(stripPrefix(browserLoc.pathname, __BASE_PATH__))
+    .then(page => {
+      if (!page || page.status === `error`) {
+        throw new Error(
+          `page resources for ${browserLoc.pathname} not found. Not rendering React`
+        )
       }
-    ).pop()
-
-    let NewRoot = () => WrappedRoot
-
-    const renderer = apiRunner(
-      `replaceHydrateFunction`,
-      undefined,
-      ReactDOM.hydrate
-    )[0]
-
-    domReady(() => {
-      renderer(
-        <NewRoot />,
-        typeof window !== `undefined`
-          ? document.getElementById(`___gatsby`)
-          : void 0,
-        () => {
-          apiRunner(`onInitialClientRender`)
-        }
+      const Root = () => (
+        <Location>
+          {locationContext => <LocationHandler {...locationContext} />}
+        </Location>
       )
+
+      const WrappedRoot = apiRunner(
+        `wrapRootElement`,
+        { element: <Root /> },
+        <Root />,
+        ({ result }) => {
+          return { element: result }
+        }
+      ).pop()
+
+      let NewRoot = () => WrappedRoot
+
+      const renderer = apiRunner(
+        `replaceHydrateFunction`,
+        undefined,
+        ReactDOM.hydrate
+      )[0]
+
+      domReady(() => {
+        renderer(
+          <NewRoot />,
+          typeof window !== `undefined`
+            ? document.getElementById(`___gatsby`)
+            : void 0,
+          () => {
+            apiRunner(`onInitialClientRender`)
+          }
+        )
+      })
     })
-  })
 })

--- a/packages/gatsby/cache-dir/public-page-renderer-dev.js
+++ b/packages/gatsby/cache-dir/public-page-renderer-dev.js
@@ -3,9 +3,12 @@ import PropTypes from "prop-types"
 
 import loader from "./loader"
 import JSONStore from "./json-store"
+import stripPrefix from "./strip-prefix"
 
 const DevPageRenderer = ({ location }) => {
-  const pageResources = loader.loadPageSync(location.pathname)
+  const pageResources = loader.loadPageSync(
+    stripPrefix(location.pathname, __BASE_PATH__)
+  )
   return React.createElement(JSONStore, {
     location,
     pageResources,

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { Router, Location, BaseContext } from "@reach/router"
 import { ScrollContext } from "gatsby-react-router-scroll"
+import stripPrefix from "./strip-prefix"
 
 import {
   shouldUpdateScroll,
@@ -56,7 +57,7 @@ class LocationHandler extends React.Component {
   render() {
     let { location } = this.props
 
-    if (!loader.isPageNotFound(location.pathname)) {
+    if (!loader.isPageNotFound(stripPrefix(location.pathname, __BASE_PATH__))) {
       return (
         <EnsureResources location={location}>
           {locationAndPageResources => (


### PR DESCRIPTION
## Description

When a page had a path that coincidentally started with the same string as `pathPrefix`, its data request would fail. This happened because the path processing was overzealous about trying to remove the prefix from the string.

This PR changes `trimPathname` so that it no longer tries to remove the path prefix. Instead, it calls `stripPrefix` on the location just before it's passed to `loadPage` or `loadPageSync`. The idea is that we should only attempt to remove a path prefix when the path may actually be prefixed.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/16457

### Side effects?

This change means that `findPath()` will no longer attempt to strip the path prefix. I'm not sure whether anything was relying on this behavior (seems like it shouldn't in the first place?), but hopefully someone who knows a little more can flag it if this is going to be a problem.
