### PR TITLE
Fixed: 404 Link for Template Usage Example

### DIFF
--- a/docs/docs/add-seo-component.md
+++ b/docs/docs/add-seo-component.md
@@ -221,4 +221,4 @@ You could also put the Facebook and Twitter meta-tags into their own components,
 - [marisamorby.com](https://github.com/marisamorby/marisamorby.com/blob/master/packages/gatsby-theme-blog-sanity/src/components/seo.js)
 - [gatsby-starter-prismic](https://github.com/LeKoArts/gatsby-starter-prismic/blob/master/src/components/SEO/SEO.jsx)
 
-As mentioned at the beginning you are also able to use the component in templates, like in [this example](https://github.com/jlengstorf/marisamorby.com/blob/master/src/templates/post.js#L12-L18).
+As mentioned at the beginning you are also able to use the component in templates, like in [this example](https://github.com/jlengstorf/marisamorby.com/blob/6e86f845185f9650ff95316d3475bb8ac86b15bf/src/templates/post.js#L12-L18).


### PR DESCRIPTION
## Description

Since of https://github.com/jlengstorf/marisamorby.com/pull/15 - the project structure changed so much that the SEO component usage in the example was lost. I went back in history and simply updated the link to just before the big change. **Hurrah for Git versioning!**
