### PR TITLE
add strapi to showcase categories

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -14,6 +14,7 @@ starter:
   - CMS:Netlify
   - CMS:Wordpress
   - CMS:sanity.io
+  - CMS:Strapi
   - CMS:Forestry.io
   - CMS:Other
   - Disqus


### PR DESCRIPTION
Strapi CMS is open source,self-hosted, headless and made with node. There is many Gatsby websites currently using it.

