### PR TITLE
fix(gatsby-cli): Add isGlobal to update notifier.

### DIFF
--- a/packages/gatsby-cli/src/index.js
+++ b/packages/gatsby-cli/src/index.js
@@ -12,7 +12,7 @@ const report = require(`./reporter`)
 const pkg = require(`../package.json`)
 const updateNotifier = require(`update-notifier`)
 // Check if update is available
-updateNotifier({ pkg }).notify()
+updateNotifier({ pkg }).notify({ isGlobal: true })
 
 const MIN_NODE_VERSION = `>=8.0.0`
 


### PR DESCRIPTION
## Description

updating post install message

## Related Issues

Fixes #17963
