### PR TITLE
docs(blog): lowercase netlify toml keys

### DIFF
--- a/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
+++ b/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
@@ -63,9 +63,9 @@ When deploying to Netlify, `gatsby build` must be run before `netlify-lambda bui
 
 ```toml
 [build]
-  Command = "npm run build"
-  Functions = "lambda"
-  Publish = "public"
+  command = "npm run build"
+  functions = "lambda"
+  publish = "public"
 ```
 
 For more info or configuration options (e.g. in different branches and build environments), check [the Netlify.toml reference](https://www.netlify.com/docs/netlify-toml-reference/).

--- a/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
+++ b/docs/blog/2018-12-17-turning-the-static-dynamic/index.md
@@ -70,7 +70,7 @@ When deploying to Netlify, `gatsby build` must be run before `netlify-lambda bui
 
 For more info or configuration options (e.g. in different branches and build environments), check [the Netlify.toml reference](https://www.netlify.com/docs/netlify-toml-reference/).
 
-**NOTE:** the `Command` specified in `netlify.toml` overrides the build command specified in your site's Netlify UI Build settings.
+**NOTE:** the `command` specified in `netlify.toml` overrides the build command specified in your site's Netlify UI Build settings.
 
 4. **Proxy the emulated functions for local development**: Head to `gatsby-config.js` and add this to your `module.exports`:
 


### PR DESCRIPTION
Change to: https://www.gatsbyjs.org/blog/2018-12-17-turning-the-static-dynamic/

Lowercased the `netlify.toml` keys in the example to fit [the netlify reference](https://www.netlify.com/docs/netlify-toml-reference/)

Thank for the blogpost @sw-yx ! Really helped a lot setting up a project that uses Netlify functions (with TypeScript, hence `netlify-lambda` and not `netlify-dev`)

