### PR TITLE
chore(docs): fix merge from gatsby repo to fork shell script

### DIFF
--- a/docs/contributing/how-to-open-a-pull-request.md
+++ b/docs/contributing/how-to-open-a-pull-request.md
@@ -110,7 +110,7 @@ The Gatsby GitHub repo is very active, so it's likely you'll need to update your
   ```
 - [In the branch](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging) you want to update, merge any changes from Gatsby into your fork:
   ```shell
-  git merge upstream master
+  git merge upstream/master
   ```
   - If there are any [merge conflicts](https://help.github.com/en/articles/resolving-a-merge-conflict-on-github), you'll want to address those to get a clean merge.
 - Once your branch is in good working order, push the changes to your fork:

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+console.log(`hello world`)

--- a/test.js
+++ b/test.js
@@ -1,1 +1,0 @@
-console.log(`hello world`)


### PR DESCRIPTION
In [gatsby docs](https://www.gatsbyjs.org/contributing/how-to-open-a-pull-request/#update-your-fork-with-the-latest-gatsby-changes) 'Update your fork with the latest Gatsby changes':

> In the branch you want to update, merge any changes from Gatsby into your fork:
git merge upstream master

`git merge upstream master` gives an error, I think there is a typo, and it should be `git merge upstream/master` instead.

![Screenshot 2019-10-02 at 23 30 17](https://user-images.githubusercontent.com/28235413/66083773-4eef1c80-e56d-11e9-9015-a72be373bfe7.png)


