### PR TITLE
Default Starter Theme duplicate H1

### DIFF
--- a/starters/default/src/components/header.js
+++ b/starters/default/src/components/header.js
@@ -16,7 +16,15 @@ const Header = ({ siteTitle }) => (
         padding: `1.45rem 1.0875rem`,
       }}
     >
-      <h1 style={{ margin: 0 }}>
+      <div
+        style={{
+          fontSize: `2.25rem`,
+          fontFamily: `-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif`,
+          fontWeight: 700,
+          textRendering: `optimizeLegibility`,
+          lineHeight: 1.1,
+        }}
+      >
         <Link
           to="/"
           style={{
@@ -26,7 +34,7 @@ const Header = ({ siteTitle }) => (
         >
           {siteTitle}
         </Link>
-      </h1>
+      </div>
     </div>
   </header>
 )


### PR DESCRIPTION
## Description

This PR updates the default starter theme to remove the duplicate h1 in the header. This will promote better accessibility and SEO best practice. 

