### PR TITLE
chore(gatsby-plugin-mdx): add typings

### DIFF
--- a/packages/gatsby-plugin-mdx/index.d.ts
+++ b/packages/gatsby-plugin-mdx/index.d.ts
@@ -1,0 +1,12 @@
+import * as React from "react"
+
+export interface MDXRendererProps {
+  scope?: any
+  components?: {
+    [key: string]: React.ComponentType<any>
+  }
+  children: string
+  [propName: string]: any
+}
+
+export class MDXRenderer extends React.Component<MDXRendererProps> {}

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -72,5 +72,6 @@
     "markdown",
     "remark",
     "rehype"
-  ]
+  ],
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Added a type file for gatsby-plugin-mdx, typing the `MDXRenderer` component.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Fixes #15924 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

This relies on the presence of `@types/react` in the parent project, which should be there if the parent project is a TypeScript one.