### PR TITLE
Replaced dead link

### DIFF
--- a/www/src/components/layer-model/layer-content-sections.js
+++ b/www/src/components/layer-model/layer-content-sections.js
@@ -281,7 +281,7 @@ const ViewLayerContent = ({ index }) => (
     <div>
       <p>
         React powers components in Gatsby sites that are{` `}
-        <Link to="/docs/glossary#rehydrate"> rehydrated</Link>, whatever you can
+        <Link to="/docs/glossary#hydration"> rehydrated</Link>, whatever you can
         do in React you can do with Gatsby.
       </p>
       <p>


### PR DESCRIPTION
Replaced "rehydrated" link with "hydration" because the word was removed from the glossary.