### PR TITLE
chore(docs): image tutorial syntax typo

### DIFF
--- a/docs/tutorial/gatsby-image-tutorial/index.md
+++ b/docs/tutorial/gatsby-image-tutorial/index.md
@@ -63,7 +63,7 @@ npm install gatsby-source-filesystem
 plugins: [
   `gatsby-transformer-sharp`,
   `gatsby-plugin-sharp`,
-  { resolve: `gatsby-source-filesystem`, options: { path: `./src/data/` },
+  { resolve: `gatsby-source-filesystem`, options: { path: `./src/data/` } },
 ]
 ```
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fixes syntax typo in step 3, `gatsby-config.js` code snippet on [Gatsby Image Tutorial documentation](https://www.gatsbyjs.org/tutorial/gatsby-image-tutorial/).

## Related Issues

Fixes #18087 