### PR TITLE
fix(scripts): useless use of cat

### DIFF
--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -13,8 +13,8 @@ for folder in $GLOB; do
   [ -d "$folder" ] || continue # only directories
   cd $BASE
 
-  NAME=$(cat $folder/package.json | jq -r '.name')
-  IS_WORKSPACE=$(cat $folder/package.json | jq -r '.workspaces')
+  NAME=$(jq -r '.name' $folder/package.json)
+  IS_WORKSPACE=$(jq -r '.workspaces' $folder/package.json)
   CLONE_DIR="__${NAME}__clone__"
   
   # sync to read-only clones


### PR DESCRIPTION
Hello.

I modified the UUOC(useless use of cat)

Pointing out UUOC is a long standing shell programming tradition, and removing them from a short-lived pipeline in a loop can speed it up by 2x. However, it's not necessarily a good use of time in practice, and rarely affects correctness.

what do you think?

Thanks.

Ref: https://en.wikipedia.org/wiki/Cat_(Unix)#Useless_use_of_cat