### PR TITLE
www(fix): upgrade mdx to fix prepended backslashes

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -7,7 +7,7 @@
     "@emotion/core": "^10.0.16",
     "@emotion/styled": "^10.0.12",
     "@loadable/component": "^5.10.2",
-    "@mdx-js/mdx": "^1.0.14",
+    "@mdx-js/mdx": "^1.5.0",
     "@mdx-js/react": "^1.0.6",
     "@reach/skip-nav": "^0.1.1",
     "@reach/visually-hidden": "^0.1.2",


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

Prepended backslashes have been an issue in the site for awhile, this got fixed in MDX here: https://github.com/mdx-js/mdx/pull/740

The issue keeps getting reported and it turns out renovate bot hasn't been bumping dependencies in `www` so I just updated this real quick myself to be sure to do away with this pesky problem once and for all 🎉 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to #17921 and probably like 50 others I'm too lazy to go find.
