### PR TITLE
chore(docs): Remove outdated IE11 browser support notes

### DIFF
--- a/docs/docs/browser-support.md
+++ b/docs/docs/browser-support.md
@@ -46,9 +46,3 @@ By default, Gatsby emulates the following config:
 
 If you only support newer browsers, make sure to specify this in your
 `package.json`. This will often enable you to ship smaller JavaScript files.
-
-## Note about IE < 11
-
-React depends on collection types `Map` and `Set`. While these are not used by Gatsby, Gatsby uses React and you will need to polyfill these if you support older browsers and devices including IE < 11.
-
-Read more about this in [ReactJS Docs - JavaScript Environment Requirements](https://reactjs.org/docs/javascript-environment-requirements.html)


### PR DESCRIPTION
## Description

Removes outdated instructions for IE11 support. Babel 7 and browserlist remove the requirement for manual steps. @mendaomn did the research verifying this.

## Related Issues

Fixes #16945