### PR TITLE
Fix padding on gatsby-code-title class

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -51,7 +51,7 @@ In `gatsby-plugin-offline` 3.x, the following options are available:
   ]
   ```
 
-  <br>
+  <br />
 
   ```javascript:title=src/custom-sw-code.js
   // show a notification after 15 seconds (the notification

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -51,6 +51,8 @@ In `gatsby-plugin-offline` 3.x, the following options are available:
   ]
   ```
 
+  <br>
+
   ```javascript:title=src/custom-sw-code.js
   // show a notification after 15 seconds (the notification
   // permission must be granted first)

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -277,7 +277,6 @@ const _options = {
         color: colors.code.text,
         padding: `${space[5]} ${space[6]} ${space[4]}`,
         fontSize: fontSizes[0],
-        margin: `${space[2]} ${space[0]}`,
       },
       [mediaQueries.md]: {
         ".gatsby-highlight, .gatsby-resp-image-link, .gatsby-code-title": {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes  #18120, by inserting manual linebreak and removing css margin.

## Related Issues
 #18120

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
