### PR TITLE
Add run-static-queries cli command

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -259,6 +259,15 @@ function buildLocalCommands(cli, isLocalSite) {
   })
 
   cli.command({
+    command: `run-static-queries`,
+    desc: `Run static queries and generate JSON files`,
+    handler: getCommandHandler(`run-static-queries`, (args, cmd) => {
+      process.env.NODE_ENV = process.env.NODE_ENV || `development`
+      return cmd(args)
+    }),
+  })
+
+  cli.command({
     command: `repl`,
     desc: `Get a node repl with context of Gatsby environment, see (https://www.gatsbyjs.org/docs/gatsby-repl/)`,
     handler: getCommandHandler(`repl`, (args, cmd) => {

--- a/packages/gatsby/src/commands/run-static-queries.js
+++ b/packages/gatsby/src/commands/run-static-queries.js
@@ -1,0 +1,32 @@
+const bootstrap = require(`../bootstrap`)
+const report = require(`gatsby-cli/lib/reporter`)
+const queryUtil = require(`../query`)
+const tracer = require(`opentracing`).globalTracer()
+
+const { store } = require(`../redux`)
+
+module.exports = async program => {
+  const buildSpan = tracer.startSpan(`build`)
+  buildSpan.setTag(`directory`, program.directory)
+
+  await bootstrap({
+    ...program,
+    parentSpan: buildSpan,
+  })
+
+  const queryIds = queryUtil.calcInitialDirtyQueryIds(store.getState())
+  const { staticQueryIds } = queryUtil.groupQueryIds(queryIds)
+
+  const activity = report.activityTimer(`run static queries`, {
+    parentSpan: buildSpan,
+  })
+  activity.start()
+
+  await queryUtil.processStaticQueries(staticQueryIds, {
+    activity,
+    state: store.getState(),
+  })
+
+  buildSpan.finish()
+  activity.end()
+}


### PR DESCRIPTION
This is a bit of a speculative PR, because I'm not sure if this is a useful addition to the CLI, and if my approahc is good. I was experimenting with ways to get Storybooks working with static queries and found a solution, and thought it might help others.

Static queries make it hard to use components outside of a full Gatsby site, because the component doesn't have access to the data from the query. Mocking can solve this for unit tests, but there are still situations where it is useful to be able to use a component with a static query outside of a site. I ran into this when trying to run Storybooks. If I didn't use the Babel plugin to remove queries then it would fail when it tried to call `graphql`, but if I did include it then there would be no data unless I had built the site. This was fine for local development, but I like to build Storybooks in CI and it's not realistic to build the whole site.

This PR adds a new CLI command: `gatsby run-static-queries`. This runs the static queries in the site, and generates the JSON files in `public/static`. This is a lot faster than doing a full site build, and can be run from CI before building Storybooks.

I've not written any docs on this, but if people think this will be a useful addition to the CLI then I can write docs.