### PR TITLE
Fix `feature_request.md` formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,9 +9,9 @@ about: Suggest a new language translation of the repo.
   - *Name*: Language name in *English*
   - *Code*: [ISO-693 Code]() or [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) of the language
   - *Maintainers*: list of GitHub usernames of proposed maintainers (at least 2 required)
-  
+
   Each maintainer listed should respond to the issue with:
-  
+
   - your experience level in open source
   - your level of experience in the target language and localization
 -->
@@ -20,6 +20,6 @@ about: Suggest a new language translation of the repo.
 name: English
 code: en
 maintainers:
- - tesseralis
- - marcysutton
+  - tesseralis
+  - marcysutton
 ```


### PR DESCRIPTION
##  Description

Latest commit (49e94f3e9c89340947a4395ef03b5f9cd6bb5f2c) tests fail because of formatting errors in `feature_request.md`.  The file has been updated with prettier's proposed whitespace fixes.

## Related Issues

