### PR TITLE
Add backslash escapes for "Code formatting: Line highlighting"

### DIFF
--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -273,7 +273,7 @@ You may also choose to include line highlighting in your code snippets, using th
 ```javascript:title=gatsby-config.js
 module.exports = {
 	siteMetadata: {
-		title: `GatsbyJS`, // highlight-line
+		title: `GatsbyJS`, \/\/ highlight-line
 		siteUrl: `https://www.gatsbyjs.org`,
 	},
 }
@@ -296,7 +296,7 @@ module.exports = {
 module.exports = {
 	siteMetadata: {
 		title: `GatsbyJS`,
-		// highlight-next-line
+		\/\/ highlight-next-line
 		siteUrl: `https://www.gatsbyjs.org`,
 	},
 }
@@ -318,12 +318,12 @@ module.exports = {
 ````
 ```javascript:title=gatsby-config.js
 module.exports = {
-	// highlight-start
+	\/\/ highlight-start
 	siteMetadata: {
 		title: `GatsbyJS`,
 		siteUrl: `https://www.gatsbyjs.org`,
 	},
-	// highlight-end
+	\/\/ highlight-end
 }
 ```
 ````


### PR DESCRIPTION
## Description

Highlighting comment needs to be visible, but is treated as comment in the markdown. Escaped the comment forward slashes in the example markdown.

From this:
<img width="864" alt="Screen Shot 2019-10-04 at 3 56 50 PM" src="https://user-images.githubusercontent.com/41944255/66245010-f8debe00-e6bf-11e9-993f-c72c42a60217.png">

To this: 
<img width="905" alt="Screen Shot 2019-10-04 at 3 59 14 PM" src="https://user-images.githubusercontent.com/41944255/66245015-ff6d3580-e6bf-11e9-8d0e-8351cf1e8eda.png">



