### PR TITLE
chore(memory): very minor memory churn improvements

### DIFF
--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -118,18 +118,16 @@ class Runner {
     let files = [
       path.join(this.base, `src`),
       path.join(this.base, `.cache`, `fragments`),
-    ]
-      .concat(this.additional.map(additional => path.join(additional, `src`)))
-      .concat(modulesThatUseGatsby.map(module => module.path))
-      .reduce(
-        (merged, folderPath) =>
-          merged.concat(
-            glob.sync(path.join(folderPath, pathRegex), {
-              nodir: true,
-            })
-          ),
-        []
+      ...this.additional.map(additional => path.join(additional, `src`)),
+      ...modulesThatUseGatsby.map(module => module.path),
+    ].reduce((merged, folderPath) => {
+      merged.push(
+        ...glob.sync(path.join(folderPath, pathRegex), {
+          nodir: true,
+        })
       )
+      return merged
+    }, [])
 
     files = files.filter(d => !d.match(/\.d\.ts$/))
 

--- a/packages/gatsby/src/query/queue.js
+++ b/packages/gatsby/src/query/queue.js
@@ -29,8 +29,7 @@ const createDevelopQueue = getRunner => {
   const queueOptions = {
     ...createBaseOptions(),
     priority: (job, cb) => {
-      const activePaths = Array.from(websocketManager.activePaths.values())
-      if (job.id && activePaths.includes(job.id)) {
+      if (job.id && websocketManager.activePaths.has(job.id)) {
         cb(null, 10)
       } else {
         cb(null, 1)


### PR DESCRIPTION
## Description

I've been dealing with a few overly-active GC events and did a bit of an investigation throughout Gatsby to just hit a few of the more minor locations that don't show up too much on a profiler, but over time add up. The main thing I looked for was `reduce` statements that created a new array each time, however, I believe a vast majority of the ones that can make an impact have already been fixed.

The change to the query queue feels like it's made a small impact, however it is hard to measure.  The query compiler most likely does not at this stage, but I feel will improve things once the temporary code immediately following it is removed.