### PR TITLE
fix(gatsby-plugin-netlify): fix merging of path headers

### DIFF
--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -85,6 +85,8 @@ exports[`with security headers 1`] = `
   X-Content-Type-Options: nosniff
   Referrer-Policy: same-origin
   Content-Security-Policy: frame-ancestors 'self' https://*.storyblok.com/
+/hello
+  X-Frame-Options: SAMEORIGIN
 /component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js
   Cache-Control: public, max-age=31536000, immutable
 /0-0180cd94ef2497ac7db8.js

--- a/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
@@ -189,6 +189,7 @@ test(`with security headers`, async () => {
         `Content-Security-Policy: frame-ancestors 'self' https://*.storyblok.com/`,
         `X-Frame-Options: ALLOW-FROM https://app.storyblok.com/`,
       ],
+      "/hello": [`X-Frame-Options: SAMEORIGIN`],
     },
   }
 

--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -121,6 +121,11 @@ function headersMerge(userHeaders, defaultHeaders) {
     })
     merged[path] = Object.values(headersMap)
   })
+  Object.keys(userHeaders).forEach(path => {
+    if (!merged[path]) {
+      merged[path] = userHeaders[path]
+    }
+  })
   return merged
 }
 


### PR DESCRIPTION
## Description

I realized that with `mergeSecurityHeaders: true`, passing headers for other paths than `/*` was not working: they would be ignored.
This PR fixes the issue.

## Related Issues

Following PR #17538
Initial issue #8020
