### PR TITLE
docs(gatsby-plugin-create-client-paths): Update Readme to show how to access route params

### DIFF
--- a/packages/gatsby-plugin-create-client-paths/README.md
+++ b/packages/gatsby-plugin-create-client-paths/README.md
@@ -23,3 +23,10 @@ Then configure via `gatsby-config.js`:
 
 In this example, all paths prefixed by `/app/` will render the route described
 in `src/pages/app.js`.
+
+The current route param can be accessed via the location object.
+```
+const MyComponent = (location) => (
+  <h1>{location.location.pathname.slice(location.path.length - 1)}
+)
+```


### PR DESCRIPTION
Shows the reader an easy way to access the new param param that works every time (for single params, at least 😉 )