### PR TITLE
chore(blog): Add excerpt to funding announcement post

### DIFF
--- a/docs/blog/2019-09-26-announcing-gatsby-15m-series-a-funding-round/index.md
+++ b/docs/blog/2019-09-26-announcing-gatsby-15m-series-a-funding-round/index.md
@@ -2,6 +2,7 @@
 title: "Announcing Gatsby’s $15M Series A Funding Round"
 date: 2019-09-26
 author: "Kyle Mathews"
+excerpt: "I’m incredibly excited to announce that Gatsby has raised a $15M Series A funding round, led by CRV, to drive the reinvention of website…"
 tags: ["gatsby-inc"]
 ---
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR adds the excerpt to the frontmatter of the funding announcement post. Without it the excerpt is extracted from the first 140 characters of the post body, which includes markdown code ("\\$" to escape the dollar sign present in "$15m") which is printed unescaped in the blog index (https://www.gatsbyjs.org/blog/). The rest of the posts in the blog index seem to have the excerpt in the frontmatter.

Before this pr in https://www.gatsbyjs.org/blog/:

<img width="603" alt="Screen Shot 2019-10-05 at 3 39 00 PM" src="https://user-images.githubusercontent.com/2272928/66260612-5e957d80-e786-11e9-9b40-a73e6348057d.png">

After:

<img width="621" alt="Screen Shot 2019-10-05 at 3 39 29 PM" src="https://user-images.githubusercontent.com/2272928/66260616-635a3180-e786-11e9-9c00-48de5be14974.png">


