### PR TITLE
fix(www): Add space between prev and next article links

### DIFF
--- a/www/src/components/prev-and-next.js
+++ b/www/src/components/prev-and-next.js
@@ -42,12 +42,13 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
       css={{
         [mediaQueries.sm]: {
           display: `flex`,
+          justifyContent: `space-between`,
           width: `100%`,
         },
       }}
       {...props}
     >
-      <div css={{ [mediaQueries.sm]: { width: `50%` } }}>
+      <div css={{ [mediaQueries.sm]: { width: `48%` } }}>
         {prev && (
           <Link to={prev.link} css={prevNextLinkStyles}>
             <h4 css={prevNextLabelStyles}>Previous</h4>
@@ -68,7 +69,7 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
         css={{
           textAlign: `right`,
           marginTop: space[5],
-          [mediaQueries.sm]: { marginTop: 0, width: `50%` },
+          [mediaQueries.sm]: { marginTop: 0, width: `48%` },
         }}
       >
         {next && (


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

In some cases when lines of text of a prev and next article take the full width of their containers there is no space between them so it's hard to tell that they are actually two different elements [Like here](https://www.gatsbyjs.org/blog/2018-08-09-swag-store/#reach-skip-nav). I've added some space to make sure that it won't happen anymore.

Before:
<img width="1680" alt="Zrzut ekranu 2019-10-6 o 13 39 58" src="https://user-images.githubusercontent.com/23037261/66268714-6580c680-e840-11e9-92f6-c0f538116770.png">

After:
<img width="1680" alt="Zrzut ekranu 2019-10-6 o 13 39 50" src="https://user-images.githubusercontent.com/23037261/66268716-6ca7d480-e840-11e9-873e-8d197026167a.png">

