### PR TITLE
tests: loose assertion - latest node 12 release seemed to change output

### DIFF
--- a/peril/tests/validate-yaml/validate-yaml-starters.test.ts
+++ b/peril/tests/validate-yaml/validate-yaml-starters.test.ts
@@ -212,7 +212,7 @@ describe("a new PR", () => {
     expect(mockedUtils.addErrorMsg).toHaveBeenCalledWith(
       0,
       expect.stringContaining(
-        '"repo" with value "https://gitlab.com/gatsbyjs/gatsby-starter-default" fails to match the required pattern: /^https?:\\/\\/github.com\\/[^\\/]+\\/[^\\/]+$/'
+        '"repo" with value "https://gitlab.com/gatsbyjs/gatsby-starter-default" fails to match the required pattern'
       ),
       expect.anything()
     )


### PR DESCRIPTION
Seems like recent Node 12 release made it so our strict assertion on failing validation message is not working anymore and fails with:

```
FAIL  peril/tests/validate-yaml/validate-yaml-starters.test.ts
  ● a new PR › Doesn't allow non GitHub repos

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: 0, StringContaining "\"repo\" with value \"https://gitlab.com/gatsbyjs/gatsby-starter-default\" fails to match the required pattern: /^https?:\\/\\/github.com\\/[^\\/]+\\/[^\\/]+$/", Anything
    Received: 0, "\"repo\" with value \"https://gitlab.com/gatsbyjs/gatsby-starter-default\" fails to match the required pattern: /^https?:\\/\\/github.com\\/[^/]+\\/[^/]+$/", {}

    Number of calls: 1

      210 |     expect(dm.warn).toBeCalled()
      211 |     expect(mockedUtils.addErrorMsg).toHaveBeenCalledTimes(1)
    > 212 |     expect(mockedUtils.addErrorMsg).toHaveBeenCalledWith(
          |                                     ^
      213 |       0,
      214 |       expect.stringContaining(
      215 |         '"repo" with value "https://gitlab.com/gatsbyjs/gatsby-starter-default" fails to match the required pattern: /^https?:\\/\\/github.com\\/[^\\/]+\\/[^\\/]+$/'

      at peril/tests/validate-yaml/validate-yaml-starters.test.ts:212:37
      at step (peril/tests/validate-yaml/validate-yaml-starters.test.ts:1:37)
      at Object.next (peril/tests/validate-yaml/validate-yaml-starters.test.ts:1:37)
      at fulfilled (peril/tests/validate-yaml/validate-yaml-starters.test.ts:1:37)
```

Seems like pattern is reformatted or something, but in any case - we don't need to check pattern part - only that validation fails here.

For reference here's example of this test failing in CI: https://circleci.com/gh/gatsbyjs/gatsby/239280?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

It's also pretty weird that this has changed - on Node 12.6 it was passing, but on Node 12.11 it was failing