### PR TITLE
chore(docs): Add notes to internal documentation pages that are outdated

### DIFF
--- a/docs/docs/gatsby-internals-terminology.md
+++ b/docs/docs/gatsby-internals-terminology.md
@@ -2,6 +2,16 @@
 title: Terminology
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - `data.json` doesn't exist anymore
+> - Add `page-data.json`
+> - Add `match-paths.json`
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 Throughout the Gatsby code, you'll see the below object fields and variables mentioned. Their definitions and reason for existence are defined below.
 
 ## Page

--- a/docs/docs/gatsby-internals.md
+++ b/docs/docs/gatsby-internals.md
@@ -12,7 +12,7 @@ A few more things. These docs are mostly focused on the build lifecycle (`gatsby
 
 The graph below shows roughly how all the sub systems of Gatsby fit together and the input/output artifacts at different parts of the build. To find out how different parts work, click on the nodes in the graph, or use the menu on the left.
 
-> Note: This diagram isn't up to date with the latest version of Gatsby.
+> Note: This diagram isn't up to date with the latest version of Gatsby. You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228)
 
 ```dot
 digraph graphname {

--- a/docs/docs/gatsby-internals.md
+++ b/docs/docs/gatsby-internals.md
@@ -12,6 +12,8 @@ A few more things. These docs are mostly focused on the build lifecycle (`gatsby
 
 The graph below shows roughly how all the sub systems of Gatsby fit together and the input/output artifacts at different parts of the build. To find out how different parts work, click on the nodes in the graph, or use the menu on the left.
 
+> Note: This diagram isn't up to date with the latest version of Gatsby.
+
 ```dot
 digraph graphname {
 

--- a/docs/docs/how-plugins-apis-are-run.md
+++ b/docs/docs/how-plugins-apis-are-run.md
@@ -2,6 +2,14 @@
 title: How APIs/Plugins Are Run
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> - mention how multiple configurations are merged
+> - the node creation flow in the diagram is no longer correct
+> - `CREATE_NODE` and `onCreateNode` are handled differently than described
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 For most sites, plugins take up the majority of the build time. So what's really happening when APIs are called?
 
 _Note: this section only explains how `gatsby-node` plugins are run. Not browser or ssr plugins_

--- a/docs/docs/html-generation.md
+++ b/docs/docs/html-generation.md
@@ -2,6 +2,14 @@
 title: Page HTML Generation
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - replace mentions of `data.json` with `page-data.json`
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 In the [previous section](/docs/production-app/), we saw how Gatsby uses webpack to build the JavaScript bundles required to take over the user experience once the first HTML page has finished loading. But how do the original HTML pages get generated?
 
 The high level process is:

--- a/docs/docs/internal-data-bridge.md
+++ b/docs/docs/internal-data-bridge.md
@@ -2,6 +2,14 @@
 title: Internal Data Bridge
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - should mention `siteMetaData` as an internal type
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 The Internal Data Bridge is an internal Gatsby plugin located at [internal-plugins/internal-data-bridge](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby/src/internal-plugins/internal-data-bridge). Its purpose is to create nodes representing pages, plugins, and site config so that they can be introspected for arbitrary purposes. As of writing, the only usage of this is by the [gatsby-plugin-sitemap](/packages/gatsby-plugin-sitemap) which uses it to... yes you guessed it, create a site map of your site.
 
 ## Example usage

--- a/docs/docs/page-node-dependencies.md
+++ b/docs/docs/page-node-dependencies.md
@@ -2,6 +2,15 @@
 title: Page -> Node Dependency Tracking
 ---
 
+> This documentation isn't up to date with the latest [schema customization changes](/docs/schema-customization).
+>
+> Outdated areas are:
+>
+> - `createPageDependency` is not the only way to mutate dependencies now
+> - other helpers exist now
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 In almost every GraphQL Resolver, you'll see the [createPageDependency](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/redux/actions.js#L788), or [getNodeAndSavePathDependency](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/redux/index.js#L198) functions. These are responsible for recording which nodes are depended on by which pages. In `develop` mode, if a node's content changes, we re-run pages whose queries depend on that node. This is one of the things that makes `develop` so awesome.
 
 ## How dependencies are recorded

--- a/docs/docs/production-app.md
+++ b/docs/docs/production-app.md
@@ -2,6 +2,14 @@
 title: Building the JavaScript App
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - _Load page resources_ section needs to be updated
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 Gatsby generates your site's HTML pages, but also creates a JavaScript runtime that takes over in the browser once the initial HTML has loaded. This enables other pages to load instantaneously. Read on to find out how that runtime is generated.
 
 ## Webpack config

--- a/docs/docs/query-execution.md
+++ b/docs/docs/query-execution.md
@@ -2,6 +2,14 @@
 title: Query Execution
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - implementation details are out of date
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 ### Query Execution
 
 Query Execution is kicked off by bootstrap by calling [page-query-runner.js runInitialQuerys()](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js#L29). The main files involved in this step are:

--- a/docs/docs/query-extraction.md
+++ b/docs/docs/query-extraction.md
@@ -2,6 +2,15 @@
 title: Query Extraction
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - queries in dependencies (node_modules) and themes are now extracted as well
+> - add meta key for hook in JSON in diagram
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 ### Extracting Queries from Files
 
 Up until now, we have [sourced all nodes](/docs/node-creation/) into redux, [inferred a schema](/docs/schema-generation/) from them, and [created all pages](/docs/page-creation/). The next step is to extract and compile all graphql queries from our source files. The entrypoint to this phase is [query-watcher extractQueries()](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/query-watcher.js), which immediately compiles all graphql queries by calling into [query-compiler.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/query-compiler.js).

--- a/docs/docs/resource-handling-and-service-workers.md
+++ b/docs/docs/resource-handling-and-service-workers.md
@@ -2,6 +2,14 @@
 title: Resource Handling & Service Workers
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - mention the page shell
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 This document aims to outline how resources are fetched and cached by various parts of Gatsby.
 
 ## Offline Plugin (gatsby-plugin-offline)

--- a/docs/docs/schema-connections.md
+++ b/docs/docs/schema-connections.md
@@ -2,9 +2,14 @@
 title: Schema connections
 ---
 
-> This documentation isn't up to date with latest
-> [schema customization changes](/docs/schema-customization). Help Gatsby by
-> making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228)!
+> This documentation isn't up to date with the latest [schema customization changes](/docs/schema-customization).
+>
+> Outdated areas are:
+>
+> - add `nodes` as a sibling to `edges`
+> - there might be more convenience fields (ask @freiksenet)
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
 
 ## What are schema connections?
 

--- a/docs/docs/schema-generation.md
+++ b/docs/docs/schema-generation.md
@@ -2,9 +2,8 @@
 title: Schema Generation
 ---
 
-> This documentation isn't up to date with latest
-> [schema customization changes](/docs/schema-customization). Help Gatsby by
-> making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228)!
+> This page isn't up to date with the latest [schema customization changes](/docs/schema-customization).
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
 
 Once the nodes have been sourced and transformed, the next step is to generate the GraphQL Schema. This is one of the more complex parts of the Gatsby code base. In fact, as of writing, it accounts for a third of the lines of code in core Gatsby. It involves inferring a GraphQL schema from all the nodes that have been sourced and transformed so far. Read on to find out how it's done.
 

--- a/docs/docs/schema-generation.md
+++ b/docs/docs/schema-generation.md
@@ -2,7 +2,7 @@
 title: Schema Generation
 ---
 
-> This page isn't up to date with the latest [schema customization changes](/docs/schema-customization).
+> This documentation isn't up to date with the latest [schema customization changes](/docs/schema-customization).
 > You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
 
 Once the nodes have been sourced and transformed, the next step is to generate the GraphQL Schema. This is one of the more complex parts of the Gatsby code base. In fact, as of writing, it accounts for a third of the lines of code in core Gatsby. It involves inferring a GraphQL schema from all the nodes that have been sourced and transformed so far. Read on to find out how it's done.

--- a/docs/docs/schema-gql-type.md
+++ b/docs/docs/schema-gql-type.md
@@ -2,9 +2,15 @@
 title: GraphQL Node Types Creation
 ---
 
-> This documentation isn't up to date with latest
-> [schema customization changes](/docs/schema-customization). Help Gatsby by
-> making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228)!
+> This documentation isn't up to date with the latest [schema customization changes](/docs/schema-customization).
+>
+> Outdated areas are:
+>
+> - the `inferObjectStructureFromNodes` function doesn't exist anymore
+> - `setFieldsOnGraphQLNodeType` has been deprecated due to the new `createTypes` action
+> - file node creation has been moved away from `setFileNodeRootType`
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
 
 Gatsby creates a [GraphQLObjectType](https://graphql.org/graphql-js/type/#graphqlobjecttype) for each distinct `node.internal.type` that is created during the source-nodes phase. Find out below how this is done.
 

--- a/docs/docs/schema-input-gql.md
+++ b/docs/docs/schema-input-gql.md
@@ -2,7 +2,7 @@
 title: Inferring Input Filters
 ---
 
-> This page isn't up to date with the latest [schema customization changes](/docs/schema-customization).
+> This documentation isn't up to date with the latest [schema customization changes](/docs/schema-customization).
 >
 > Outdated areas are:
 >

--- a/docs/docs/schema-input-gql.md
+++ b/docs/docs/schema-input-gql.md
@@ -2,9 +2,14 @@
 title: Inferring Input Filters
 ---
 
-> This documentation isn't up to date with latest
-> [schema customization changes](/docs/schema-customization). Help Gatsby by
-> making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228)!
+> This page isn't up to date with the latest [schema customization changes](/docs/schema-customization).
+>
+> Outdated areas are:
+>
+> - `inferObjectStructureFromNodes` does not exist anymore
+> - input fields are generated differently. Gatsby previously inferred values one by one, now graphql-compose handles this
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
 
 ## Input Filters vs gqlType
 

--- a/docs/docs/schema-sift.md
+++ b/docs/docs/schema-sift.md
@@ -2,9 +2,11 @@
 title: Querying with Sift
 ---
 
-> This documentation isn't up to date with latest
-> [schema customization changes](/docs/schema-customization). Help Gatsby by
-> making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228)!
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> The [schema customization](/docs/schema-customization) and [node materialisation](https://github.com/gatsbyjs/gatsby/pull/16091) features have both made changes to this part of Gatsby.
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
 
 ## Summary
 

--- a/docs/docs/static-vs-normal-queries.md
+++ b/docs/docs/static-vs-normal-queries.md
@@ -2,6 +2,15 @@
 title: Static vs Normal Queries
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - mention the useStaticQuery hook
+> - describe how queries are stripped and JSON imports are rewritten
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 ## How StaticQuery differs from page query
 
 StaticQuery can do most of the things that page query can, including fragments. The main differences are:

--- a/docs/docs/write-pages.md
+++ b/docs/docs/write-pages.md
@@ -2,6 +2,16 @@
 title: Write Out Pages
 ---
 
+> This documentation isn't up to date with the latest version of Gatsby.
+>
+> Outdated areas are:
+>
+> - `data.json` should be replaced with `page-data.json`
+> - remove mentions of `pages.json`
+> - describe `match-paths.json`
+>
+> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
+
 This is one of the last bootstrap stages before we hand off to webpack to perform code optimization and code splitting. Webpack builds a web bundle. It has no knowledge of Gatsby's core code. Instead, it operates only on files in the `.cache` directory. It also doesn't have access to all the Redux information that was built up during bootstrap. So instead, we create dynamic JavaScript and JSON files that are dependent on by the webpack application in the `.cache` directory (see [Building the JavaScript App](/docs/production-app/)).
 
 You can think of this step as taking all the data that was generated during bootstrap and saving it to disk for consumption by webpack.


### PR DESCRIPTION
## Description

Add notes to outdated parts of the internals documentation. 

Earlier this year @sidharthachatterjee, @pieh and @DSchau audited the internals section of the docs. They identified which parts were outdated due to recent changes in Gatsby. I've taken their notes and added the info to relevant pages in the docs.

Question - updating these pages will require knowledge of Gatsby's innards (or the ability to work it out). Should I mention that in the pr request section?

