### PR TITLE
fix(gatsby-remark-responsive-iframe): content is wrapped in <undefined> block when used with gatsby-plugin-mdx

### DIFF
--- a/packages/gatsby-remark-responsive-iframe/src/index.js
+++ b/packages/gatsby-remark-responsive-iframe/src/index.js
@@ -71,8 +71,7 @@ module.exports = ({ markdownAST }, pluginOptions = {}) =>
           }"
           >
             ${newIframe}
-          </div>
-          `
+          </div>`
 
           node.type = `html`
           node.value = rawHTML


### PR DESCRIPTION
## Description

When used with gatsby-plugin-mdx, the html generated by this plugin is wrapped in a `<undefined>` block:

```html
<undefined>
    <div class="gatsby-resp-iframe-wrapper" style="padding-bottom: 75%; position: relative; height: 0px; overflow: hidden; margin-bottom: 1.0725rem;">
      <iframe src="asdads" style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%;"></iframe>
    </div>
</undefined>
```

## Cause

The html generated by this plugin has a bit of extra space at the end <sup>[source](https://github.com/gatsbyjs/gatsby/blob/57e5d69c17abfed74fa05c069a7467107e1aadfc/packages/gatsby-remark-responsive-iframe/src/index.js#L75)</sup>:

```js
          const rawHTML = `
          <div ...>
            ${newIframe}
          </div>
          ` // <-- extra space with new line
```

When passed via `hast-util-raw` in mdxjs/mdx <sup>[source](https://github.com/mdx-js/mdx/blob/4ee999cbe3e82bb4a56e43df14151835f14da400/packages/mdx/index.js#L67)</sup>, this resulted in a tree that looks like this:

```js
{ type: 'root',
  children:
   [ { type: 'element',
       tagName: 'div',
       properties: [Object],
       children: [Array] },
     { type: 'text', value: '\n          ' } ], // <----- extra space is now turned into a child of type 'text'
  data: { quirksMode: false } }
```

Unfortunately, `hast-util-raw` can't unwrap (remove root) nodes with more than 1 child <sup>[source](https://github.com/syntax-tree/hast-util-raw/blob/aba08a50352998f770de7656c7ca5138a2883c64/index.js#L47)</sup>.

```js
  // Unpack if possible and when not given a `root`.
  if (tree.type !== 'root' && result.children.length === 1) { // <-- here, result.children.length is 2
    return result.children[0]
  }
```

Because of this, the `root` node was not removed, and thus cause `const { tagName } = raw(node)` in mdx-js/mdx to be `undefined`, which made it to the rendered html. 

## Related Issues

https://github.com/borgfriend/gatsby-remark-embed-video/issues/20