### PR TITLE
docs: fix typo in gatsby-repl

### DIFF
--- a/docs/docs/gatsby-repl.md
+++ b/docs/docs/gatsby-repl.md
@@ -4,7 +4,7 @@ title: Gatsby REPL
 
 The Gatsby REPL ("read-eval-print loop") is available via the Gatsby CLI by running the command `gatsby repl`. This gives you access to an interactive REPL shell within the context of your Gatsby environment. It can be used to retrieve general data and programmatically interact with it. If you have an idea for a new command, feel free to submit a PR for it!
 
-This doc will give a brief description of each REPL command, expected output, and an example of what you can do with the command to digest the data. Examples are using the [Gatsby Starter Blog](/starters/gatsbyjs/gatsby-starter-blog/) as an demo environment, since it is currently the highest rated starter, and provides standard output for most of these commands.
+This doc will give a brief description of each REPL command, expected output, and an example of what you can do with the command to digest the data. Examples are using the [Gatsby Starter Blog](/starters/gatsbyjs/gatsby-starter-blog/) as a demo environment, since it is currently the highest rated starter, and provides standard output for most of these commands.
 
 To get started, in your terminal, after running the initial site setup steps [here](/docs/quick-start), run the command `gatsby repl` to enter the interactive shell. If you are writing out a function, you can write that over multiple lines, as long as you do not use a semicolon or close a parenthesis or brace prematurely. This is helpful for running graphql queries and callback functions.
 


### PR DESCRIPTION
## Description

Correct spelling: `an demo` becomes `a demo`

## Related Issues

None