### PR TITLE
docs: update contributing docs for how to open a PR

### DIFF
--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -31,7 +31,9 @@ Docs with frontmatter metadata at the top including a `title` will automatically
 
 For the purposes of an accessible document outline, content headings should go in order from h2-h4 (`####`) until all levels have been established. This will ensure the Gatsby docs have a content hierarchy that works well for users of assistive technology. Read more about the importance of [headings and semantic structure in HTML](https://webaim.org/techniques/semanticstructure/).
 
-## Modifying markdown files
+## Modifying Markdown files
+
+> 💡 New to writing Markdown? Check out the Gatsby [guide on Markdown Syntax](/docs/mdx/markdown-syntax/)!
 
 1. If you want to add/modify any Gatsby documentation, go to the
    [docs folder](https://github.com/gatsbyjs/gatsby/tree/master/docs) or [contributing folder](https://github.com/gatsbyjs/gatsby/tree/master/docs/contributing) on GitHub and

--- a/docs/contributing/how-to-open-a-pull-request.md
+++ b/docs/contributing/how-to-open-a-pull-request.md
@@ -132,3 +132,4 @@ _**Note:** as a member of the Gatsby repo, you can also clone it directly (inste
 - [Feature Branching and Workflows](https://git-scm.com/book/en/v1/Git-Branching-Branching-Workflows)
 - [Resolving merge conflicts](https://help.github.com/en/articles/resolving-a-merge-conflict-on-github)
 - [Managing Pull Requests](/contributing/managing-pull-requests/) on the Gatsby core team
+- [Guide on Markdown Syntax](/docs/mdx/markdown-syntax/)

--- a/docs/contributing/how-to-open-a-pull-request.md
+++ b/docs/contributing/how-to-open-a-pull-request.md
@@ -97,7 +97,7 @@ The Gatsby GitHub repo is very active, so it's likely you'll need to update your
 
 - Set Gatsby's repo URL as a remote source. The name of the remote is arbitrary; this example uses `upstream`.
   ```shell
-  git remote set-url upstream git@github.com:gatsbyjs/gatsby.git
+  git remote add upstream git@github.com:gatsbyjs/gatsby.git
   ```
   - _Note: this syntax [uses SSH and keys: you can also use `https`](https://help.github.com/en/articles/which-remote-url-should-i-use) and your username/password._
 - You can verify the remote name and URL at any time:
@@ -120,7 +120,7 @@ The Gatsby GitHub repo is very active, so it's likely you'll need to update your
 
 For more information on working with upstream repos, [visit the GitHub docs](https://help.github.com/en/articles/configuring-a-remote-for-a-fork).
 
-_**Note:** as a member of the Gatsby repo, you can also clone it directly instead of forking and push your changes to [feature branches](https://git-scm.com/book/en/v1/Git-Branching-Branching-Workflows)._
+_**Note:** as a member of the Gatsby repo, you can also clone it directly (instead of forking and using an upstream remote workflow). You can then push changes to [feature branches](https://git-scm.com/book/en/v1/Git-Branching-Branching-Workflows) to open PRs._
 
 ## Additional resources
 


### PR DESCRIPTION
## Description

In talking a contributor through using git and submitting their first PR, I noticed my instructions for setting up a remote were wrong: you have to **add** a remote before you can run **set-url**. This PR makes that update and adjusts the language around working directly in the repo.

I also added some links to the doc on Markdown Syntax, since people may not have written Markdown before.

## Related Issues

N/A