### PR TITLE
fix(gatsby): In public actions, don't let actionOptions overwrite type

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -778,9 +778,9 @@ const createNode = (
   // Check if the node has already been processed.
   if (oldNode && !hasNodeChanged(node.id, node.internal.contentDigest)) {
     updateNodeAction = {
-      type: `TOUCH_NODE`,
-      plugin,
       ...actionOptions,
+      plugin,
+      type: `TOUCH_NODE`,
       payload: node.id,
     }
   } else {
@@ -789,9 +789,9 @@ const createNode = (
     if (oldNode) {
       const createDeleteAction = node => {
         return {
+          ...actionOptions,
           type: `DELETE_NODE`,
           plugin,
-          ...actionOptions,
           payload: node,
         }
       }
@@ -801,10 +801,10 @@ const createNode = (
     }
 
     updateNodeAction = {
+      ...actionOptions,
       type: `CREATE_NODE`,
       plugin,
       oldNode,
-      ...actionOptions,
       payload: node,
     }
   }
@@ -959,9 +959,9 @@ actions.createNodeField = (
   node = sanitizeNode(node)
 
   return {
+    ...actionOptions,
     type: `ADD_FIELD_TO_NODE`,
     plugin,
-    ...actionOptions,
     payload: node,
   }
 }


### PR DESCRIPTION
## Description

Hi folks!

This will resolve #18136. You can find the bug description & reproduction repo over there as well.

I couldn't pinpoint where the `actionOptions` with `{ type: ... }` comes from, however when I inspect the code today I saw that `actionOptions` was already put on top in `createPage`:

```js
  return {
    ...actionOptions,
    type: `CREATE_PAGE`,
    contextModified,
    plugin,
    payload: internalPage,
  }
```

So it probably makes sense to do the same for other actions as well.

## Related Issues

Fixes #18136 
