### PR TITLE
docs: document the commit naming convention

### DIFF
--- a/docs/contributing/how-to-open-a-pull-request.md
+++ b/docs/contributing/how-to-open-a-pull-request.md
@@ -52,6 +52,10 @@ To test changes locally against the Gatsby [site and project files](https://gith
   git add .
   ```
   - Using a visual tool like [GitHub Desktop](https://desktop.github.com/) or [GitX](https://rowanj.github.io/gitx/) can help for choosing which files and lines to commit.
+- To make it easier for the new contributors we don't lint the commit names, but our preffered convention is [conventional commits](https://www.conventionalcommits.org)
+  ```shell
+  git commit -m '<type>(optional scope): <description>'
+  ```
 - Committing code will run the automated linter using [Prettier](https://prettier.io). To run the linter manually, run an npm script in the project's base directory:
   ```shell
   npm run format


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Just a small note of our preferred commit-naming convention so that it would leave less work for the people merging them. [Link](https://github.com/gatsbyjs/gatsby/pull/18218#issuecomment-539431399) to a small discussion we've had with @wardpeet regarding this.

