### PR TITLE
Docs: update Adding Analytics with Parse.ly plugin

### DIFF
--- a/docs/docs/adding-analytics.md
+++ b/docs/docs/adding-analytics.md
@@ -68,3 +68,4 @@ Once this is configured you can deploy your site to test! If you navigate to the
 - [Baidu](/packages/gatsby-plugin-baidu-analytics/)
 - [Matomo (formerly Piwik)](/packages/gatsby-plugin-matomo/)
 - [Simple Analytics](/packages/gatsby-plugin-simple-analytics)
+- [Parse.ly Analytics](/packages/gatsby-plugin-parsely-analytics/)


### PR DESCRIPTION
Add gatsby-plugin-parsely-analytics plugin to bottom list on adding-analytics.md.

[https://www.gatsbyjs.org/packages/gatsby-plugin-parsely-analytics/](https://www.gatsbyjs.org/packages/gatsby-plugin-parsely-analytics/)
