### PR TITLE
fix(gatsby-plugin-netlify): add warning instead for invalid headers

### DIFF
--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`with badly headers configuration 1`] = `
+exports[`build-headers-program with badly headers configuration 1`] = `
 "## Created with gatsby-plugin-netlify
 
 /*
@@ -78,7 +78,7 @@ X-Frame-Options
 "
 `;
 
-exports[`with caching headers 1`] = `
+exports[`build-headers-program with caching headers 1`] = `
 "## Created with gatsby-plugin-netlify
 
 /*
@@ -154,7 +154,7 @@ exports[`with caching headers 1`] = `
 "
 `;
 
-exports[`with security headers 1`] = `
+exports[`build-headers-program with security headers 1`] = `
 "## Created with gatsby-plugin-netlify
 
 /*
@@ -233,7 +233,7 @@ exports[`with security headers 1`] = `
 "
 `;
 
-exports[`without caching headers 1`] = `
+exports[`build-headers-program without caching headers 1`] = `
 "## Created with gatsby-plugin-netlify
 
 /*

--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -1,5 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`with badly headers configuration 1`] = `
+"## Created with gatsby-plugin-netlify
+
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: same-origin
+X-Frame-Options
+  sameorigin
+/component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js
+  Cache-Control: public, max-age=31536000, immutable
+/0-0180cd94ef2497ac7db8.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-templates-blog-post-js-517987eae96e75cddbe7.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-pages-404-js-53e6c51a5a7e73090f50.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-pages-index-js-0bdd01c77ee09ef0224c.js
+  Cache-Control: public, max-age=31536000, immutable
+/pages-manifest-ab11f09e0ca7ecd3b43e.js
+  Cache-Control: public, max-age=31536000, immutable
+/webpack-runtime-acaa8994f1f704475e21.js
+  Cache-Control: public, max-age=31536000, immutable
+/styles.1025963f4f2ec7abbad4.css
+  Cache-Control: public, max-age=31536000, immutable
+/styles-565f081c8374bbda155f.js
+  Cache-Control: public, max-age=31536000, immutable
+/app-f33c13590352da20930f.js
+  Cache-Control: public, max-age=31536000, immutable
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+/sw.js
+  Cache-Control: no-cache
+/offline-plugin-app-shell-fallback/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+/hi-folks/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/my-second-post/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/hello-world/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+/404/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+/404.html
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+"
+`;
+
 exports[`with caching headers 1`] = `
 "## Created with gatsby-plugin-netlify
 

--- a/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
@@ -4,222 +4,231 @@ import os from "os"
 import fs from "fs-extra"
 import { DEFAULT_OPTIONS } from "../constants"
 
-const reporter = {
-  warn: jest.fn(),
-}
+describe(`build-headers-program`, () => {
+  let reporter
 
-const createPluginData = async () => {
-  const tmpDir = await fs.mkdtemp(
-    path.join(os.tmpdir(), `gatsby-plugin-netlify-`)
-  )
+  beforeEach(() => {
+    reporter = {
+      warn: jest.fn(),
+    }
+  })
 
-  return {
-    pages: new Map([
-      [
-        `/offline-plugin-app-shell-fallback/`,
-        {
-          jsonName: `offline-plugin-app-shell-fallback-a30`,
-          internalComponentName: `ComponentOfflinePluginAppShellFallback`,
-          path: `/offline-plugin-app-shell-fallback/`,
-          matchPath: undefined,
-          componentChunkName: `component---node-modules-gatsby-plugin-offline-app-shell-js`,
-          isCreatedByStatefulCreatePages: false,
-          context: {},
-          updatedAt: 1557740602268,
-          pluginCreator___NODE: `63e5f7ff-e5f1-58f7-8e2c-55872ac42281`,
-          pluginCreatorId: `63e5f7ff-e5f1-58f7-8e2c-55872ac42281`,
-        },
-      ],
-      [
-        `/hi-folks/`,
-        {
-          jsonName: `hi-folks-a2b`,
-          internalComponentName: `ComponentHiFolks`,
-          path: `/hi-folks/`,
-          matchPath: undefined,
-          componentChunkName: `component---src-templates-blog-post-js`,
-          isCreatedByStatefulCreatePages: false,
-          context: {},
-          updatedAt: 1557740602330,
-          pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
-          pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
-        },
-      ],
-      [
-        `/my-second-post/`,
-        {
-          jsonName: `my-second-post-2aa`,
-          internalComponentName: `ComponentMySecondPost`,
-          path: `/my-second-post/`,
-          matchPath: undefined,
-          componentChunkName: `component---src-templates-blog-post-js`,
-          isCreatedByStatefulCreatePages: false,
-          context: {},
-          updatedAt: 1557740602333,
-          pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
-          pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
-        },
-      ],
-      [
-        `/hello-world/`,
-        {
-          jsonName: `hello-world-8bc`,
-          internalComponentName: `ComponentHelloWorld`,
-          path: `/hello-world/`,
-          matchPath: undefined,
-          componentChunkName: `component---src-templates-blog-post-js`,
-          isCreatedByStatefulCreatePages: false,
-          context: {},
-          updatedAt: 1557740602335,
-          pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
-          pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
-        },
-      ],
-      [
-        `/404/`,
-        {
-          jsonName: `404-22d`,
-          internalComponentName: `Component404`,
-          path: `/404/`,
-          matchPath: undefined,
-          componentChunkName: `component---src-pages-404-js`,
-          isCreatedByStatefulCreatePages: true,
-          context: {},
-          updatedAt: 1557740602358,
-          pluginCreator___NODE: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
-          pluginCreatorId: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
-        },
-      ],
-      [
-        `/`,
-        {
-          jsonName: `index`,
-          internalComponentName: `ComponentIndex`,
-          path: `/`,
-          matchPath: undefined,
-          componentChunkName: `component---src-pages-index-js`,
-          isCreatedByStatefulCreatePages: true,
-          context: {},
-          updatedAt: 1557740602361,
-          pluginCreator___NODE: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
-          pluginCreatorId: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
-        },
-      ],
-      [
-        `/404.html`,
-        {
-          jsonName: `404-html-516`,
-          internalComponentName: `Component404Html`,
-          path: `/404.html`,
-          matchPath: undefined,
-          componentChunkName: `component---src-pages-404-js`,
-          isCreatedByStatefulCreatePages: true,
-          context: {},
-          updatedAt: 1557740602382,
-          pluginCreator___NODE: `f795702c-a3b8-5a88-88ee-5d06019d44fa`,
-          pluginCreatorId: `f795702c-a3b8-5a88-88ee-5d06019d44fa`,
-        },
-      ],
-    ]),
-    manifest: {
-      "main.js": `render-page.js`,
-      "main.js.map": `render-page.js.map`,
-      app: [
-        `webpack-runtime-acaa8994f1f704475e21.js`,
-        `styles.1025963f4f2ec7abbad4.css`,
-        `styles-565f081c8374bbda155f.js`,
-        `app-f33c13590352da20930f.js`,
-      ],
-      "component---node-modules-gatsby-plugin-offline-app-shell-js": [
-        `component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js`,
-      ],
-      "component---src-templates-blog-post-js": [
-        `0-0180cd94ef2497ac7db8.js`,
-        `component---src-templates-blog-post-js-517987eae96e75cddbe7.js`,
-      ],
-      "component---src-pages-404-js": [
-        `0-0180cd94ef2497ac7db8.js`,
-        `component---src-pages-404-js-53e6c51a5a7e73090f50.js`,
-      ],
-      "component---src-pages-index-js": [
-        `0-0180cd94ef2497ac7db8.js`,
-        `component---src-pages-index-js-0bdd01c77ee09ef0224c.js`,
-      ],
-      "pages-manifest": [`pages-manifest-ab11f09e0ca7ecd3b43e.js`],
-    },
-    pathPrefix: ``,
-    publicFolder: fileName => path.join(tmpDir, fileName),
-  }
-}
+  const createPluginData = async () => {
+    const tmpDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), `gatsby-plugin-netlify-`)
+    )
 
-test(`with caching headers`, async () => {
-  const pluginData = await createPluginData()
-
-  const pluginOptions = {
-    ...DEFAULT_OPTIONS,
-    mergeCachingHeaders: true,
+    return {
+      pages: new Map([
+        [
+          `/offline-plugin-app-shell-fallback/`,
+          {
+            jsonName: `offline-plugin-app-shell-fallback-a30`,
+            internalComponentName: `ComponentOfflinePluginAppShellFallback`,
+            path: `/offline-plugin-app-shell-fallback/`,
+            matchPath: undefined,
+            componentChunkName: `component---node-modules-gatsby-plugin-offline-app-shell-js`,
+            isCreatedByStatefulCreatePages: false,
+            context: {},
+            updatedAt: 1557740602268,
+            pluginCreator___NODE: `63e5f7ff-e5f1-58f7-8e2c-55872ac42281`,
+            pluginCreatorId: `63e5f7ff-e5f1-58f7-8e2c-55872ac42281`,
+          },
+        ],
+        [
+          `/hi-folks/`,
+          {
+            jsonName: `hi-folks-a2b`,
+            internalComponentName: `ComponentHiFolks`,
+            path: `/hi-folks/`,
+            matchPath: undefined,
+            componentChunkName: `component---src-templates-blog-post-js`,
+            isCreatedByStatefulCreatePages: false,
+            context: {},
+            updatedAt: 1557740602330,
+            pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+            pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+          },
+        ],
+        [
+          `/my-second-post/`,
+          {
+            jsonName: `my-second-post-2aa`,
+            internalComponentName: `ComponentMySecondPost`,
+            path: `/my-second-post/`,
+            matchPath: undefined,
+            componentChunkName: `component---src-templates-blog-post-js`,
+            isCreatedByStatefulCreatePages: false,
+            context: {},
+            updatedAt: 1557740602333,
+            pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+            pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+          },
+        ],
+        [
+          `/hello-world/`,
+          {
+            jsonName: `hello-world-8bc`,
+            internalComponentName: `ComponentHelloWorld`,
+            path: `/hello-world/`,
+            matchPath: undefined,
+            componentChunkName: `component---src-templates-blog-post-js`,
+            isCreatedByStatefulCreatePages: false,
+            context: {},
+            updatedAt: 1557740602335,
+            pluginCreator___NODE: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+            pluginCreatorId: `7374ebf2-d961-52ee-92a2-c25e7cb387a9`,
+          },
+        ],
+        [
+          `/404/`,
+          {
+            jsonName: `404-22d`,
+            internalComponentName: `Component404`,
+            path: `/404/`,
+            matchPath: undefined,
+            componentChunkName: `component---src-pages-404-js`,
+            isCreatedByStatefulCreatePages: true,
+            context: {},
+            updatedAt: 1557740602358,
+            pluginCreator___NODE: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
+            pluginCreatorId: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
+          },
+        ],
+        [
+          `/`,
+          {
+            jsonName: `index`,
+            internalComponentName: `ComponentIndex`,
+            path: `/`,
+            matchPath: undefined,
+            componentChunkName: `component---src-pages-index-js`,
+            isCreatedByStatefulCreatePages: true,
+            context: {},
+            updatedAt: 1557740602361,
+            pluginCreator___NODE: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
+            pluginCreatorId: `049c1cfd-95f7-5555-a4ac-9b396d098b26`,
+          },
+        ],
+        [
+          `/404.html`,
+          {
+            jsonName: `404-html-516`,
+            internalComponentName: `Component404Html`,
+            path: `/404.html`,
+            matchPath: undefined,
+            componentChunkName: `component---src-pages-404-js`,
+            isCreatedByStatefulCreatePages: true,
+            context: {},
+            updatedAt: 1557740602382,
+            pluginCreator___NODE: `f795702c-a3b8-5a88-88ee-5d06019d44fa`,
+            pluginCreatorId: `f795702c-a3b8-5a88-88ee-5d06019d44fa`,
+          },
+        ],
+      ]),
+      manifest: {
+        "main.js": `render-page.js`,
+        "main.js.map": `render-page.js.map`,
+        app: [
+          `webpack-runtime-acaa8994f1f704475e21.js`,
+          `styles.1025963f4f2ec7abbad4.css`,
+          `styles-565f081c8374bbda155f.js`,
+          `app-f33c13590352da20930f.js`,
+        ],
+        "component---node-modules-gatsby-plugin-offline-app-shell-js": [
+          `component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js`,
+        ],
+        "component---src-templates-blog-post-js": [
+          `0-0180cd94ef2497ac7db8.js`,
+          `component---src-templates-blog-post-js-517987eae96e75cddbe7.js`,
+        ],
+        "component---src-pages-404-js": [
+          `0-0180cd94ef2497ac7db8.js`,
+          `component---src-pages-404-js-53e6c51a5a7e73090f50.js`,
+        ],
+        "component---src-pages-index-js": [
+          `0-0180cd94ef2497ac7db8.js`,
+          `component---src-pages-index-js-0bdd01c77ee09ef0224c.js`,
+        ],
+        "pages-manifest": [`pages-manifest-ab11f09e0ca7ecd3b43e.js`],
+      },
+      pathPrefix: ``,
+      publicFolder: fileName => path.join(tmpDir, fileName),
+    }
   }
 
-  await buildHeadersProgram(pluginData, pluginOptions, reporter)
+  it(`with caching headers`, async () => {
+    const pluginData = await createPluginData()
 
-  expect(
-    await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
-  ).toMatchSnapshot()
-})
+    const pluginOptions = {
+      ...DEFAULT_OPTIONS,
+      mergeCachingHeaders: true,
+    }
 
-test(`without caching headers`, async () => {
-  const pluginData = await createPluginData()
+    await buildHeadersProgram(pluginData, pluginOptions, reporter)
 
-  const pluginOptions = {
-    ...DEFAULT_OPTIONS,
-    mergeCachingHeaders: false,
-  }
+    expect(reporter.warn).not.toHaveBeenCalled()
+    expect(
+      await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
+    ).toMatchSnapshot()
+  })
 
-  await buildHeadersProgram(pluginData, pluginOptions, reporter)
+  it(`without caching headers`, async () => {
+    const pluginData = await createPluginData()
 
-  expect(
-    await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
-  ).toMatchSnapshot()
-})
+    const pluginOptions = {
+      ...DEFAULT_OPTIONS,
+      mergeCachingHeaders: false,
+    }
 
-test(`with security headers`, async () => {
-  const pluginData = await createPluginData()
+    await buildHeadersProgram(pluginData, pluginOptions, reporter)
 
-  const pluginOptions = {
-    ...DEFAULT_OPTIONS,
-    mergeSecurityHeaders: true,
-    headers: {
-      "/*": [
-        `Content-Security-Policy: frame-ancestors 'self' https://*.storyblok.com/`,
-        `X-Frame-Options: ALLOW-FROM https://app.storyblok.com/`,
-      ],
-      "/hello": [`X-Frame-Options: SAMEORIGIN`],
-    },
-  }
+    expect(reporter.warn).not.toHaveBeenCalled()
+    expect(
+      await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
+    ).toMatchSnapshot()
+  })
 
-  await buildHeadersProgram(pluginData, pluginOptions, reporter)
+  it(`with security headers`, async () => {
+    const pluginData = await createPluginData()
 
-  expect(
-    await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
-  ).toMatchSnapshot()
-})
+    const pluginOptions = {
+      ...DEFAULT_OPTIONS,
+      mergeSecurityHeaders: true,
+      headers: {
+        "/*": [
+          `Content-Security-Policy: frame-ancestors 'self' https://*.storyblok.com/`,
+          `X-Frame-Options: ALLOW-FROM https://app.storyblok.com/`,
+        ],
+        "/hello": [`X-Frame-Options: SAMEORIGIN`],
+      },
+    }
 
-test(`with badly headers configuration`, async () => {
-  const pluginData = await createPluginData()
+    await buildHeadersProgram(pluginData, pluginOptions, reporter)
 
-  const pluginOptions = {
-    ...DEFAULT_OPTIONS,
-    mergeSecurityHeaders: true,
-    headers: {
-      "X-Frame-Options": [`sameorigin`],
-    },
-  }
+    expect(reporter.warn).not.toHaveBeenCalled()
+    expect(
+      await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
+    ).toMatchSnapshot()
+  })
 
-  await buildHeadersProgram(pluginData, pluginOptions, reporter)
+  it(`with badly headers configuration`, async () => {
+    const pluginData = await createPluginData()
 
-  expect(reporter.warn).toHaveBeenCalled()
+    const pluginOptions = {
+      ...DEFAULT_OPTIONS,
+      mergeSecurityHeaders: true,
+      headers: {
+        "X-Frame-Options": [`sameorigin`],
+      },
+    }
 
-  expect(
-    await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
-  ).toMatchSnapshot()
+    await buildHeadersProgram(pluginData, pluginOptions, reporter)
+
+    expect(reporter.warn).toHaveBeenCalled()
+
+    expect(
+      await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
+    ).toMatchSnapshot()
+  })
 })

--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -29,8 +29,9 @@ function validHeaders(headers, reporter) {
       _.every(headersList, header => {
         if (_.isString(header)) {
           if (!getHeaderName(header)) {
+            // TODO panic on builds on v3
             reporter.warn(
-              `${path} contains an invalid header (${header}). Please check your plugin configuration`
+              `[gatsby-plugin-netlify] ${path} contains an invalid header (${header}). Please check your plugin configuration`
             )
           }
 

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -25,7 +25,10 @@ exports.onCreateWebpackConfig = ({ actions, stage }) => {
   })
 }
 
-exports.onPostBuild = async ({ store, pathPrefix }, userPluginOptions) => {
+exports.onPostBuild = async (
+  { store, pathPrefix, reporter },
+  userPluginOptions
+) => {
   const pluginData = makePluginData(store, assetsManifest, pathPrefix)
   const pluginOptions = { ...DEFAULT_OPTIONS, ...userPluginOptions }
 
@@ -45,7 +48,7 @@ exports.onPostBuild = async ({ store, pathPrefix }, userPluginOptions) => {
   }
 
   await Promise.all([
-    buildHeadersProgram(pluginData, pluginOptions),
+    buildHeadersProgram(pluginData, pluginOptions, reporter),
     createRedirects(pluginData, redirects, rewrites),
   ])
 }


### PR DESCRIPTION
## Description
Fixes a regression in #17538

Instead of failing we show a warning
![image](https://user-images.githubusercontent.com/1120926/66409460-e5e62980-e9f0-11e9-9856-d60139f5a6e2.png)

You can mimic previous behaviour with:
```
{
  resolve: "gatsby-plugin-netlify",
  options: {
    mergeSecurityHeaders: false,
    headers: {
      "X-Frame-Options": ["sameorigin"],
    },
  },
},
```

## Related Issues
PR introducing regression https://github.com/gatsbyjs/gatsby/pull/17538
Fixes https://github.com/gatsbyjs/gatsby/issues/18319