### PR TITLE
Docs/audit md files for style - docs folder md files starting with 'w'

### DIFF
--- a/docs/docs/why-gatsby-uses-graphql.md
+++ b/docs/docs/why-gatsby-uses-graphql.md
@@ -203,7 +203,7 @@ Using `data/products.json` as an example, by using GraphQL we’re able to solve
 1. The images can be collocated with the products in `data/images/`.
 2. Image paths in `data/products.json` can be relative to the JSON file.
 3. Gatsby can automatically optimize images for faster loading and better user experience.
-4. We no longer need to pass all product data into `context` when creating pages.
+4. You no longer need to pass all product data into `context` when creating pages.
 5. Data is loaded using GraphQL in the components where it’s used, making it much easier to see where data comes from and how to change it.
 
 ### Add the necessary plugins to load data into GraphQL
@@ -213,10 +213,10 @@ Using `data/products.json` as an example, by using GraphQL we’re able to solve
   lessonTitle="Make Data Queryable in GraphQL With Gatsby"
 />
 
-In order to load the product and image data into GraphQL, we need to add a few [Gatsby plugins](/plugins/). Namely, we need plugins to:
+In order to load the product and image data into GraphQL, you need to add a few [Gatsby plugins](/plugins/). Namely, you need plugins to:
 
 - Load the JSON file into Gatsby’s internal data store, which can be queried using GraphQL ([`gatsby-source-filesystem`](/packages/gatsby-source-filesystem/))
-- Convert JSON files into a format we can query with GraphQL ([`gatsby-transformer-json`](/packages/gatsby-transformer-json/))
+- Convert JSON files into a format you can query with GraphQL ([`gatsby-transformer-json`](/packages/gatsby-transformer-json/))
 - Optimize images ([`gatsby-plugin-sharp`](/packages/gatsby-plugin-sharp/))
 - Add data about optimized images to Gatsby’s data store ([`gatsby-transformer-sharp`](/packages/gatsby-transformer-sharp/))
 
@@ -246,7 +246,7 @@ module.exports = {
 }
 ```
 
-To check that this worked, let’s use the GraphQL Playground, which is available during development, by running:
+To check that this worked, you can use the GraphQL Playground, which is available during development, by running:
 
 ```shell
 GATSBY_GRAPHQL_IDE=playground gatsby develop
@@ -258,7 +258,7 @@ You can explore the available data schema using the “Docs” tab at the right.
 
 One of the available options is `allProductsJson`, which contains “edges”, and those contain “nodes”.
 
-The JSON transformer plugin has created one node for each product, and inside the node we can select the data we need for that product.
+The JSON transformer plugin has created one node for each product, and inside the node you can select the data you need for that product.
 
 You can write a query to select each product’s slug like this:
 
@@ -287,7 +287,7 @@ The results will appear in the panel between the query and the docs, and they’
   lessonTitle="Create Pages in Gatsby Using GraphQL"
 />
 
-In `gatsby-node.js`, we can use the GraphQL query we just wrote to generate pages.
+In `gatsby-node.js`, you can use the GraphQL query you just wrote to generate pages.
 
 ```js:title=gatsby-node.js
 exports.createPages = async ({ actions: { createPage }, graphql }) => {

--- a/docs/docs/winning-over-developers.md
+++ b/docs/docs/winning-over-developers.md
@@ -11,7 +11,7 @@ Some things that developers care about include:
 - **Not getting bogged down in configuration and setup** These things are often time consuming, frustrating, and prevent developers from getting to focus on the work they actually care about.
 - **Developing as efficiently and effectively as possible** The more things can be streamlined, automated, and/or simplified, the better.
 
-## Basic Explanation
+## Basic explanation
 
 Here's an example of a basic explanation of Gatsby for developers:
 

--- a/docs/docs/winning-over-engineering-leaders.md
+++ b/docs/docs/winning-over-engineering-leaders.md
@@ -1,5 +1,5 @@
 ---
-title: Winning over Engineering Leaders
+title: Winning Over Engineering Leaders
 ---
 
 Engineering leaders and managers typically make decisions about how to build the sites and products that fall under their ownership. These decisions are based on things like cost, complexity, team needs, business requirements, and the success metrics they are accountable for.
@@ -13,7 +13,7 @@ Some specific things that engineering leaders and managers care about include:
 - **Not reinventing the wheel** While many managers appreciate and sympathize with their team's or colleagues' desire to try out cool new tech, they'd rather not spend valuable time and resources on a new thing when the job is already being done to their satisfaction. As the saying goes, "If it ain't broke, don't fix it."
 - **Helping their team work smarter** New tech is interesting to managers when it removes obstacles for their team, helps them be more effective, and/or reduces [yak shaving](https://www.hanselman.com/blog/YakShavingDefinedIllGetThatDoneAsSoonAsIShaveThisYak.aspx). However, these benefits have to outweigh the cost of integrating a new tool and/or re-implementing an existing product.
 
-## Basic Explanation
+## Basic explanation
 
 Here's an example of a basic explanation of Gatsby for engineering leaders and managers:
 
@@ -39,7 +39,7 @@ Gatsby has many benefits that will appeal to engineering leaders and help them m
 
 > CDN hosting for static sites is much, _much_ less expensive than traditional hosting costs. Read more about this here: [Enterprise Gatsby: How to Reduce Your Digital Total Cost of Ownership (TCO) with Gatsby](/blog/2019-05-15-enterprise-gatsby-how-to-reduce-your-digital-total-cost-of-ownership-with-gatsby/). You'll also save money on team resources as your developers will spend much less time working on performance optimization and configuring integrations. Many managers have also found it easier and less expensive to recruit for Gatsby projects because they don't require specialized CMS skills or the advanced expertise needed to handle complex tooling and development environments.
 
-### Improved Development Process
+### Improved development process
 
 > Gatsby [unifies your stack](/docs/sanitize-your-stack) and eliminates a lot of the complicated and time-consuming configuration steps that come with most development processes. This means happier developers and clearer division between front-end and back-end tasks. Front-end developers can spend more time making great UIs and back-end developers can focus on adding the features and integrations that make your product better. You can find more information on this subject in Sam Bhagwat's article [How Gatsby Changes Teams' Website Development Workflow](/blog/2018-04-25-how-gatsby-changes-teams-website-development-workflow/#architecture)
 

--- a/docs/docs/winning-over-executives.md
+++ b/docs/docs/winning-over-executives.md
@@ -12,7 +12,7 @@ Some things executives care about include:
 - **Competitive edge** Distinguishing yourself from your competitors by delivering unique value that helps you claim a greater share of the market.
 - **Growing the business** For most executives, success means gaining clients, leads, users, purchases and awareness - getting more orders moving through that sales funnel.
 
-## Basic Explanation
+## Basic explanation
 
 Here's an example of a basic explanation of Gatsby for executives:
 
@@ -26,7 +26,7 @@ Sites built with Gatsby have experienced major sales and engagement benefits as 
 
 > Site speed and performance has a huge impact on sales and customer engagement. A [recent Akamai study](https://www.akamai.com/uk/en/about/news/press/2017-press/akamai-releases-spring-2017-state-of-online-retail-performance-report.jsp) showed that a 100 millisecond delay in a site's load time hurt conversion rates by 7%, and 53% of mobile users will leave pages that take more than 3 seconds to load. Gatsby sites are consistently 2-3x faster than similar sites built with different tools, and site owners have seen their [lead generation increase by up to 60% after transitioning to Gatsby](/blog/2018-11-16-youfit-case-study/).
 
-### Improved Search Traffic
+### Improved search traffic
 
 > Site speed is one of the factors Google uses in its search ranking algorithm, and slow site speeds can have a negative snowball effect on your SEO. Slower sites take longer to be crawled and indexed by search engines, they have higher bounce rates, and lower conversion rates, all of which will hurt your rankings. Gatsby sites have [built-in web and mobile performance optimizations](/blog/2018-11-07-gatsby-for-apps/#why-gatsby-for-apps). It actually takes _more_ effort to make a Gatsby site perform badly. Learn more about [the impact of page speed on SEO](https://moz.com/learn/seo/page-speed) on Moz.
 

--- a/docs/docs/winning-over-marketers.md
+++ b/docs/docs/winning-over-marketers.md
@@ -9,7 +9,7 @@ Some things that marketers care about include:
 - **Making the website faster**. This tends to decrease the "bounce rate", which is the proportion of visitors leaving the website.
 - **Generating revenue**. If the product is bought online through a checkout flow, such as e-commerce, marketers are often measured on revenue the site generates -- the dollar value of total sales.
 
-## Basic Explanation
+## Basic explanation
 
 A basic explanation of Gatsby to marketers is often along these lines:
 
@@ -23,15 +23,15 @@ Marketers may be curious about more information on specific topics such as SEO, 
 
 > Think rocket ship vs. sea turtle. Gatsby takes fast to a whole new level with websites that are pre-built and live on the edge—right where your customers are. Pages load in milliseconds rather than seconds. Gatsby enables teams to create lightning-fast, content-driven websites without needing to become performance experts.
 
-### SEO Optimized
+### SEO optimized
 
 > Think of all the time a team spends on creating compelling, optimized content just to have the search ranking penalized by a slow website. A Search Engine Optimized website means a higher organic search ranking and more website traffic, which can mean more leads and revenue. Get as much out of your website as you do your content and see the impact.
 
-### Optimized for Lead Conversion
+### Optimized for lead conversion
 
 > For every second it takes a page to load, the bounce rate increases and the lead conversion drops. For e-commerce sites, some estimates say you may lose up to 1% in revenue for every 100ms delay in page load time. The longer it takes a page to load, the more customers/leads/revenue you lose. Get greater lead conversion with a fast website that loads on even slow connections.
 
-### Generating Revenue
+### Generating revenue
 
 > Generating revenue with your website is especially important for e-commerce sites. If an e-commerce company doesn’t get a high enough ROI (return on investment), then they may be out of business in a few months. Even just a one second improvement in page load time can increase revenue by 7%. The less time it takes a page to load, the more money you make.
 

--- a/docs/docs/working-with-images-in-markdown.md
+++ b/docs/docs/working-with-images-in-markdown.md
@@ -2,11 +2,11 @@
 title: Working With Images in Markdown Posts and Pages
 ---
 
-When building Gatsby sites composed primarily of Markdown pages or posts, insertion of images can enhance the content. Adding images can be done in multiple ways.
+When building Gatsby sites composed primarily of Markdown pages or posts, insertion of images can enhance the content. You can add images in multiple ways.
 
 ## Featured images with Frontmatter metadata
 
-In sites like a blog, you may want to include a featured image that appears at the top of a page. One way to do this is to grab the image filename from a frontmatter field and then transforming it with `gatsby-plugin-sharp` in a GraphQL query.
+In sites like a blog, you may want to include a featured image that appears at the top of a page. One way to do this is to grab the image filename from a frontmatter field and then transform it with `gatsby-plugin-sharp` in a GraphQL query.
 
 This solution assumes you already have programmatically generated pages from Markdown with renderers like `gatsby-transformer-remark` or `gatsby-plugin-mdx`. If not, take a read through up to [Part 7 of the Gatsby Tutorial](/tutorial/part-seven/). This will build upon the tutorial and as such, `gatsby-transformer-remark` will be used for this example.
 
@@ -75,7 +75,7 @@ export const query = graphql`
 `
 ```
 
-Also in the Markdown post template, import the `gatsby-image` package and pass the results of the graphQL query into an `<Img />` component.
+Also in the Markdown post template, import the `gatsby-image` package and pass the results of the GraphQL query into an `<Img />` component.
 
 ```jsx:title=src/templates/blog-post.js
 import React from "react"
@@ -128,7 +128,7 @@ Your featured image should now appear on the generated page right below the main
 
 ## Inline images with `gatsby-remark-images`
 
-Images also may be included in the Markdown body itself. The plugin [gatsby-remark-images](/packages/gatsby-remark-images) comes in handy for this.
+You may also include images in the Markdown body itself. The plugin [gatsby-remark-images](/packages/gatsby-remark-images) comes in handy for this.
 
 Start out by installing `gatsby-remark-images` and `gatsby-plugin-sharp`.
 

--- a/docs/docs/working-with-images.md
+++ b/docs/docs/working-with-images.md
@@ -1,5 +1,5 @@
 ---
-title: Working With Images in Gatsby
+title: Working with Images in Gatsby
 ---
 
 Optimizing images is a challenge on any website. To utilize best practices for performance across devices, you need multiple sizes and resolutions of each image. Luckily, Gatsby has several useful [plugins](/docs/plugins/) that work together to do that for images on [page components](/docs/building-with-components/#page-components).

--- a/docs/docs/working-with-images.md
+++ b/docs/docs/working-with-images.md
@@ -1,12 +1,12 @@
 ---
-title: Working With Images In Gatsby
+title: Working With Images in Gatsby
 ---
 
 Optimizing images is a challenge on any website. To utilize best practices for performance across devices, you need multiple sizes and resolutions of each image. Luckily, Gatsby has several useful [plugins](/docs/plugins/) that work together to do that for images on [page components](/docs/building-with-components/#page-components).
 
 The recommended approach is to use [GraphQL queries](/docs/querying-with-graphql/) to get images of the optimal size or resolution, then, display them with the [`gatsby-image`](/packages/gatsby-image/) component.
 
-## Query Images With GraphQL
+## Query images with GraphQL
 
 Querying images with GraphQL allows you to access the image's data as well as perform transformations with [Sharp](https://github.com/lovell/sharp), a high-performance image processing library.
 
@@ -36,7 +36,7 @@ export const query = graphql`
 `
 ```
 
-## Optimizing Images With Gatsby Image
+## Optimizing images with gatsby-image
 
 [`gatsby-image`](/packages/gatsby-image/) is a plugin that automatically creates React components for optimized images that:
 
@@ -53,7 +53,7 @@ Here is an image component that uses the query from the previous example:
 <Img fluid={data.fileName.childImageSharp.fluid} alt="" />
 ```
 
-## Using Fragments To Standardize Formatting
+## Using fragments to standardize formatting
 
 What if you have a bunch of images and you want them all to use the same formatting?
 

--- a/docs/docs/working-with-video.md
+++ b/docs/docs/working-with-video.md
@@ -1,5 +1,5 @@
 ---
-title: Working With Video
+title: Working with Video
 ---
 
 - [Sourcing video from a host](#sourcing-video-from-a-host)

--- a/docs/docs/working-with-video.md
+++ b/docs/docs/working-with-video.md
@@ -68,7 +68,7 @@ export default NotFoundPage
 
 ## Querying video data from Markdown with GraphQL
 
-If a Markdown page or post has a featured video, you might want to include a video URL and title in [its frontmatter](/docs/adding-markdown-pages#note-on-creating-markdown-files). That makes it easy to pass those values into our custom component:
+If a Markdown page or post has a featured video, you might want to include a video URL and title in [its frontmatter](/docs/adding-markdown-pages#note-on-creating-markdown-files). This allows you to pass those values into your custom component:
 
 ```markdown:title=my-first-post.md
 ---
@@ -173,7 +173,7 @@ export default () => (
 
 Even though there are two `<source>` elements, only one video will be displayed, first `mp4` if it is supported, then `.ogg`.
 
-**Note**: this requires importing a video in the format of the type specified, i.e. adding a `<source>` element with `type=video/ogg` would also need a file import with a format of `.ogg`. Alternatively, you can specify a URL to where a video is remotely hosted as the `src` instead of importing a local file.
+**Note**: This requires importing a video in the format of the type specified, i.e. adding a `<source>` element with `type=video/ogg` would also need a file import with a format of `.ogg`. Alternatively, you can specify a URL to where a video is remotely hosted as the `src` instead of importing a local file.
 
 [See an example repository using `<video>` elements](https://github.com/gatsbyjs/gatsby/blob/master/examples/using-video/)
 
@@ -207,6 +207,6 @@ export default () => (
 
 The kind attribute can be of a variety of different types including `captions`, `subtitles`, and `descriptions`, among others. The `srcLang` defines English as the language used in the captions in the example, and the captions file imported is used as the source. You can read about the specific attributes of a [`<track>` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track).
 
-**Note**: the filepath to import the captions in the above code snippet includes the `file-loader!` prefix, which helps webpack import the `.vtt` caption file.
+**Note**: The filepath to import the captions in the above code snippet includes the `file-loader!` prefix, which helps webpack import the `.vtt` caption file.
 
 Check out the accessible [HTML5 video player from PayPal](https://github.com/paypal/accessible-html5-video-player#react-version) for an example compatible with Gatsby and React.

--- a/docs/docs/write-pages.md
+++ b/docs/docs/write-pages.md
@@ -47,7 +47,7 @@ The dynamic files that are created are (all under the `.cache` directory).
 - [async-requires.js](#async-requiresjs)
 - [data.json](#datajson)
 
-### pages.json
+## pages.json
 
 This is a collection of page objects, created from redux `pages` namespace. For each page it includes the
 
@@ -73,7 +73,7 @@ e.g
 
 `pages.json` is generated for `gatsby develop` purposes only. In `npm run build`, we use [data.json](/docs/write-pages/#datajson) (below) which includes the pages info plus more.
 
-### sync-requires.js
+## sync-requires.js
 
 This is a dynamically generated JavaScript file that exports `components`. It is an object created by iterating over the `components` redux namespace. The keys are the [componentChunkName](/docs/behind-the-scenes-terminology/#componentchunkname) (e.g. `component---src-blog-2-js`), and the values are expressions that require the component. E.g. `/home/site/src/blog/2.js`. The file will look something like this:
 
@@ -86,7 +86,7 @@ exports.components = {
 
 It is used during [static-entry.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/static-entry.js) so that it can map componentChunkNames to their component implementations. Whereas the [production-app.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/production-app.js) must use `async-requires.js` (below) since it performs [code splitting](/docs/how-code-splitting-works/).
 
-### async-requires.js
+## async-requires.js
 
 ---
 
@@ -110,7 +110,7 @@ exports.data = () => import("/home/site/.cache/data.json")
 
 Remember, `sync-requires.js` is used during [Page HTML Generation](/docs/html-generation/). And `async-requires.js` is used by [Building the JavaScript App](/docs/production-app/).
 
-### data.json
+## data.json
 
 This is a generated json file. It contains the entire `pages.json` contents ([as above](/docs/write-pages/#pagesjson)), and the entire redux `jsonDataPaths` which was created at the end of the [Query Execution](/docs/query-execution/#save-query-results-to-redux-and-disk) stage. So, it looks like:
 


### PR DESCRIPTION

## Description

This PR introduces some minor style fixes for markdown files in the docs. Files audited are all in the docs folder beginning with "w", ie: 'webpack-and-ssr.md' down to 'write-pages.md'

Changes include:
- Correction of heading levels to only increase by one
- Minor fixes of titles to ensure conformity with style guide
- Minor fixes of headings casing to ensure conformity with style guide
- Some changes from use of "we" to "you" as per style guide
- Some changes of passive voice to active voice as per style guide

## Related Issues

This related to Issue:
#18284 