### PR TITLE
feat(gatsby-cli): Add instructions after new

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -228,7 +228,7 @@ type InitOptions = {
   rootPath?: string,
 }
 
-const endInstruction = Path => {
+const successMessage = path => {
   report.info(`
 Your new Gatsby site has been successfully bootstrapped. Start developing it by running:
   $ cd ${Path}

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -232,7 +232,7 @@ const successMessage = path => {
   report.info(`
 Your new Gatsby site has been successfully bootstrapped. Start developing it by running:
   $ cd ${path}
-  $ ${getPackageManager()} run develop
+  $ gatsby develop
 `)
 }
 

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -228,6 +228,15 @@ type InitOptions = {
   rootPath?: string,
 }
 
+const endInstruction = Path => {
+  report.info(`
+Successfully Added Gatsby site !!
+start developing your site now by running the following instructions
+  $ cd ${Path}
+  $ ${getPackageManager()} run develop
+`)
+}
+
 /**
  * Main function that clones or copies the starter.
  */
@@ -286,5 +295,6 @@ module.exports = async (starter: string, options: InitOptions = {}) => {
   })
   if (hostedInfo) await clone(hostedInfo, rootPath)
   else await copy(starterPath, rootPath)
+  await endInstruction(rootPath)
   trackCli(`NEW_PROJECT_END`)
 }

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -294,6 +294,6 @@ module.exports = async (starter: string, options: InitOptions = {}) => {
   })
   if (hostedInfo) await clone(hostedInfo, rootPath)
   else await copy(starterPath, rootPath)
-  await endInstruction(rootPath)
+  successMessage(rootPath)
   trackCli(`NEW_PROJECT_END`)
 }

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -230,7 +230,7 @@ type InitOptions = {
 
 const endInstruction = Path => {
   report.info(`
-Successfully Added Gatsby site !!
+Your new Gatsby site has been successfully bootstrapped. Start developing it by running:
 start developing your site now by running the following instructions
   $ cd ${Path}
   $ ${getPackageManager()} run develop

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -231,7 +231,6 @@ type InitOptions = {
 const endInstruction = Path => {
   report.info(`
 Your new Gatsby site has been successfully bootstrapped. Start developing it by running:
-start developing your site now by running the following instructions
   $ cd ${Path}
   $ ${getPackageManager()} run develop
 `)

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -231,7 +231,7 @@ type InitOptions = {
 const successMessage = path => {
   report.info(`
 Your new Gatsby site has been successfully bootstrapped. Start developing it by running:
-  $ cd ${Path}
+  $ cd ${path}
   $ ${getPackageManager()} run develop
 `)
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
In this PR, I have added an after setup instruction for the `gatbsy-cli new` command.
Which looks something like this..

![image](https://user-images.githubusercontent.com/26347874/66415545-72a4dd80-ea19-11e9-9908-efaca9447523.png)

The above log will be printed when the installation and project setup is getting successful 
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
