### PR TITLE
fix(blog): removed large margin-left from blog post layout

### DIFF
--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -59,7 +59,9 @@ class BlogPostTemplate extends React.Component {
               <title>{post.frontmatter.title}</title>
               <link
                 rel="author"
-                href={`https://gatsbyjs.org${post.frontmatter.author.fields.slug}`}
+                href={`https://gatsbyjs.org${
+                  post.frontmatter.author.fields.slug
+                }`}
               />
               <meta
                 name="description"
@@ -77,13 +79,17 @@ class BlogPostTemplate extends React.Component {
               {post.frontmatter.image && (
                 <meta
                   property="og:image"
-                  content={`https://gatsbyjs.org${post.frontmatter.image.childImageSharp.resize.src}`}
+                  content={`https://gatsbyjs.org${
+                    post.frontmatter.image.childImageSharp.resize.src
+                  }`}
                 />
               )}
               {post.frontmatter.image && (
                 <meta
                   name="twitter:image"
-                  content={`https://gatsbyjs.org${post.frontmatter.image.childImageSharp.resize.src}`}
+                  content={`https://gatsbyjs.org${
+                    post.frontmatter.image.childImageSharp.resize.src
+                  }`}
                 />
               )}
               <meta property="og:type" content="article" />
@@ -116,9 +122,6 @@ class BlogPostTemplate extends React.Component {
                     mt: 3,
                     mb: 9,
                   },
-                  [mediaQueries.lg]: {
-                    ml: `-8em`,
-                  },
                 }}
               >
                 <div css={{ flex: `0 0 auto` }}>
@@ -148,7 +151,9 @@ class BlogPostTemplate extends React.Component {
                           borderBottom: t =>
                             `1px solid ${t.colors.link.border}`,
                           transition: t =>
-                            `all ${t.transition.speed.fast} ${t.transition.curve.default}`,
+                            `all ${t.transition.speed.fast} ${
+                              t.transition.curve.default
+                            }`,
                           "&:hover": { borderColor: `link.hoverBorder` },
                         }}
                       >
@@ -181,7 +186,6 @@ class BlogPostTemplate extends React.Component {
                   lineHeight: `dense`,
                   fontSize: [5, 6, 7, 8, 9, 11],
                   [mediaQueries.lg]: {
-                    ml: `-8rem`,
                     mb: 8,
                   },
                 }}

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -59,9 +59,7 @@ class BlogPostTemplate extends React.Component {
               <title>{post.frontmatter.title}</title>
               <link
                 rel="author"
-                href={`https://gatsbyjs.org${
-                  post.frontmatter.author.fields.slug
-                }`}
+                href={`https://gatsbyjs.org${post.frontmatter.author.fields.slug}`}
               />
               <meta
                 name="description"
@@ -79,17 +77,13 @@ class BlogPostTemplate extends React.Component {
               {post.frontmatter.image && (
                 <meta
                   property="og:image"
-                  content={`https://gatsbyjs.org${
-                    post.frontmatter.image.childImageSharp.resize.src
-                  }`}
+                  content={`https://gatsbyjs.org${post.frontmatter.image.childImageSharp.resize.src}`}
                 />
               )}
               {post.frontmatter.image && (
                 <meta
                   name="twitter:image"
-                  content={`https://gatsbyjs.org${
-                    post.frontmatter.image.childImageSharp.resize.src
-                  }`}
+                  content={`https://gatsbyjs.org${post.frontmatter.image.childImageSharp.resize.src}`}
                 />
               )}
               <meta property="og:type" content="article" />
@@ -151,9 +145,7 @@ class BlogPostTemplate extends React.Component {
                           borderBottom: t =>
                             `1px solid ${t.colors.link.border}`,
                           transition: t =>
-                            `all ${t.transition.speed.fast} ${
-                              t.transition.curve.default
-                            }`,
+                            `all ${t.transition.speed.fast} ${t.transition.curve.default}`,
                           "&:hover": { borderColor: `link.hoverBorder` },
                         }}
                       >


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The blog layout got a large amount of margin with the dark mode updates in #18027.

Looks like this:

<img width="1492" alt="Screen Shot 2019-10-08 at 6 33 43 PM" src="https://user-images.githubusercontent.com/21114044/66443047-c81dc200-e9fa-11e9-96b8-5ccc0c0f5020.png">
 
Removing that margin returns it back to this:

<img width="1491" alt="Screen Shot 2019-10-08 at 6 33 57 PM" src="https://user-images.githubusercontent.com/21114044/66443056-ce13a300-e9fa-11e9-9f8d-d9639913e3b5.png">
