### PR TITLE
docs: Update "Images, Files & Video" & link titles in sidebar

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -93,26 +93,32 @@
               breadcrumbTitle: ESLint
             - title: Proxying API Requests
               link: /docs/api-proxy/
-        - title: Images, Files, and Video
+        - title: Images, Files & Video
           link: /docs/images-and-files/
           items:
-            - title: Importing Assets Directly Into Files
+            - title: Importing Assets Directly into Files
               link: /docs/importing-assets-into-files/
-              breadcrumbTitle: Importing Assets Into Files
+              breadcrumbTitle: Importing Assets into Files
             - title: Using the Static Folder
               link: /docs/static-folder/
+              breadcrumbTitle: Static Folder
             - title: Using gatsby-image
               link: /docs/using-gatsby-image/
+              breadcrumbTitle: gatsby-image
             - title: Working with Images in Gatsby
               link: /docs/working-with-images/
-            - title: Preoptimizing your Images
+              breadcrumbTitle: Images in Gatsby
+            - title: Preoptimizing Your Images
               link: /docs/preoptimizing-images/
-            - title: Working With Video
+              breadcrumbTitle: Preoptimizing Images
+            - title: Working with Video
               link: /docs/working-with-video/
+              breadcrumbTitle: Video
             - title: Importing Media Content
               link: /docs/importing-media-content/
             - title: Working with GIFs
               link: /docs/working-with-gifs/
+              breadcrumbTitle: GIFs
             - title: Working with Images in Markdown
               link: /docs/working-with-images-in-markdown/
               breadcrumbTitle: Images in Markdown

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -117,7 +117,7 @@
               link: /docs/importing-media-content/
             - title: Working with GIFs
               link: /docs/working-with-gifs/
-              breadcrumbTitle: GIFs
+              breadcrumbTitle: GIFs in Gatsby
             - title: Working with Images in Markdown
               link: /docs/working-with-images-in-markdown/
               breadcrumbTitle: Images in Markdown

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -112,7 +112,7 @@
               breadcrumbTitle: Preoptimizing Images
             - title: Working with Video
               link: /docs/working-with-video/
-              breadcrumbTitle: Video
+              breadcrumbTitle: Videos in Gatsby
             - title: Importing Media Content
               link: /docs/importing-media-content/
             - title: Working with GIFs

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -104,7 +104,6 @@
               breadcrumbTitle: Static Folder
             - title: Using gatsby-image
               link: /docs/using-gatsby-image/
-              breadcrumbTitle: gatsby-image
             - title: Working with Images in Gatsby
               link: /docs/working-with-images/
               breadcrumbTitle: Images in Gatsby


### PR DESCRIPTION
## Description

Updated sidebar titles and breadcrumb titles of items listed under the "Images, Files & Video" section of the docs to adhere to the [Gatsby Style Guide](https://www.gatsbyjs.org/contributing/gatsby-style-guide/).

Changes include:

* Revising sidebar titles to use title case
* Revising breadcrumb titles to use title case
* Adding suggestions for breadcrumb titles where breadcrumb titles weren't already provided

## Related Issues

Related to #18284 