### PR TITLE
feat(www): Updating colors on the Showcase Cards improve their dark mode appearance 

### DIFF
--- a/www/src/components/layout.js
+++ b/www/src/components/layout.js
@@ -108,7 +108,7 @@ class DefaultLayout extends React.Component {
           >
             <div
               sx={{
-                bg: `widget.background`,
+                bg: `card.background`,
                 borderRadius: 2,
                 boxShadow: `dialog`,
                 position: `relative`,
@@ -117,7 +117,7 @@ class DefaultLayout extends React.Component {
               <button
                 onClick={this.handleCloseModal}
                 sx={{
-                  bg: `widget.background`,
+                  bg: `card.background`,
                   border: 0,
                   borderRadius: 6,
                   color: `textMuted`,

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -23,7 +23,7 @@ const gutterDesktop = 8
 
 const styles = {
   link: {
-    color: `link.default`,
+    color: `link.color`,
     textDecoration: `none`,
   },
   prevNextLink: {
@@ -415,6 +415,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                         <Link
                           to={`/showcase?${qs.stringify({ filters: [c] })}`}
                           state={{ isModal: true }}
+                          sx={styles.link}
                         >
                           {c}
                         </Link>

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -130,9 +130,10 @@ const SourceLink = ({ ...props }) => (
       display: `flex`,
       alignItems: `center`,
       mr: 3,
+      color: `link.color`,
     }}
   >
-    <GithubIcon sx={{ fontSize: 3, mr: 2 }} />
+    <GithubIcon sx={{ fontSize: 3, mr: 2, color: `link.color` }} />
     Source
   </a>
 )

--- a/www/src/gatsby-plugin-theme-ui/index.js
+++ b/www/src/gatsby-plugin-theme-ui/index.js
@@ -298,7 +298,7 @@ const col = {
         border: darkBorder,
       },
       widget: {
-        background: darkBackground,
+        background: c.grey[90],
         border: darkBorder,
         color: c.white,
       },

--- a/www/src/gatsby-plugin-theme-ui/index.js
+++ b/www/src/gatsby-plugin-theme-ui/index.js
@@ -298,7 +298,7 @@ const col = {
         border: darkBorder,
       },
       widget: {
-        background: c.grey[90],
+        background: darkBackground,
         border: darkBorder,
         color: c.white,
       },


### PR DESCRIPTION
## Description

I noticed this line in in the PR referenced below `improve showcase/starter sidebar and item/card styles—dark mode shows a lot of its issues` and decided to take a crack at it. Made some color adjustments for the card background and links since those stood out the most as being issues, to me. Happy to keep tweaking this as needed. 

Updated with screenshots (from local, placeholder images of course) 
<img width="800" alt="dh-gatsby-screen-dark" src="https://user-images.githubusercontent.com/1581290/66448585-3ec4ba80-ea0f-11e9-8849-c11a4de6b73c.png">
<img width="800" alt="dh-gatsby-screen-light" src="https://user-images.githubusercontent.com/1581290/66448586-3ec4ba80-ea0f-11e9-8d16-ada884137855.png">

## Related Issues
https://github.com/gatsbyjs/gatsby/pull/18027
