### PR TITLE
Fix link in docs that is returning a 404 Page Not Found.

### DIFF
--- a/docs/accessibility-statement.md
+++ b/docs/accessibility-statement.md
@@ -24,7 +24,7 @@ Alternatively, we welcome you to reach out directly to Marcy Sutton, Head of Lea
 
 ## Building with Gatsby
 
-To learn how to build an accessible website with Gatsby, visit our guide [Making Your Site Accessible](/docs/making-your-site-accessible/). Contributions are very welcome as this page evolves.
+To learn how to build an accessible website with Gatsby, visit our guide [Making Your Site Accessible](/docs/docs/making-your-site-accessible.md). Contributions are very welcome as this page evolves.
 
 ## Third-party platforms, products and services
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Links in the docs are returning 404 Page Not Found when clicking on them. The first one I tried was the `accessibility-statement.md` in which the link to the article *Making Your Site Accessible* returned a 404 error.

### Documentation Issue

I changed the link to be `/docs/docs/making-your-site-accessible.md` rather than `/docs/making-your-site-accessible/` in VSCode and could get the link to work correctly between documents. Then I tested this on the Gatsby docs website by manually entering the url in the address bar, and it also worked correctly.

This issue is apparent in several other links I have come across so far and perhaps need to be fixed, of which I would be excited to help.

## Related Issues

I am submitting this for Hacktoberfest 2019 @marcysutton , and I am relatively new to contributing (making my first contributions ever literally this past week). So hopefully I have submitted to Gatsby correctly and I welcome any feedback.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234

-->
[[Epic] Hacktoberfest 2019! #18129](https://github.com/gatsbyjs/gatsby/issues/18129)
