### PR TITLE
chore(docs): style guide audit on docs beginning with `t`

### DIFF
--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -13,7 +13,7 @@ There are two ways you can use Tailwind with Gatsby:
 
 You have to install and configure Tailwind for both of these methods, so this guide will walk through that step first, then you can follow the instructions for either PostCSS or CSS-in-JS.
 
-## Installing and Configuring Tailwind
+## Installing and configuring Tailwind
 
 This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [**Quick Start guide**](/docs/quick-start), then come back.
 
@@ -27,7 +27,7 @@ npm install tailwindcss --save-dev
 
 **Note**: A config file isn't required for Tailwind 1.0.0+
 
-To configure Tailwind, we'll need to add a Tailwind configuration file. Luckily, Tailwind has a built-in script to do this. Just run the following command:
+To configure Tailwind, you'll need to add a Tailwind configuration file. Luckily, Tailwind has a built-in script to do this. Just run the following command:
 
 ```shell
 npx tailwind init

--- a/docs/docs/testing-components-with-graphql.md
+++ b/docs/docs/testing-components-with-graphql.md
@@ -1,5 +1,5 @@
 ---
-title: Testing components with GraphQL
+title: Testing Components with GraphQL
 ---
 
 If you try to run unit tests on components that use GraphQL queries, you will
@@ -69,8 +69,8 @@ describe("Index", () =>
   }))
 ```
 
-This should fix the `StaticQuery` error, but in a more real-world example you may also be using a page query with the `graphql` helper from Gatsby. In this case, there is no GraphQL data being passed to the component. We can pass this in too,
-but the structure is a little more complicated. Luckily there's an easy way to
+This should fix the `StaticQuery` error, but in a more real-world example you may also be using a page query with the `graphql` helper from Gatsby. In this case, there is no GraphQL data being passed to the component. You can pass this in too,
+but the structure is a little more complicated. Luckily there's a way to
 get some suitable data. Run `npm run develop` and go to
 http://localhost:8000/___graphql to load the GraphiQL IDE. You can now get the
 right data using the same query that you used on the page. If it is a simple
@@ -178,7 +178,7 @@ the output.
 
 The method above works for page queries, as you can pass the data in directly to
 the component. This doesn't work for components that use `StaticQuery` though,
-as that uses `context` rather than `props` so we need to take a slightly
+as that uses `context` rather than `props` so you need to take a slightly
 different approach to testing these types of components.
 
 Using `StaticQuery` allows you to make queries in any component, not just pages.
@@ -256,12 +256,12 @@ GraphQL.
 
 This is a good example of the benefits of keeping components "pure", meaning
 they always generate the same output if given the same inputs and have no
-side-effects apart from their return value. This means we can be sure the tests
+side-effects apart from their return value. This means you can be sure the tests
 are always reproducible and don't fail if, for example, the network is down or
 the data source changes. In this example, `Header` is impure as it makes a
 query, so the output depends on something apart from its props. `PureHeader` is
 pure because its return value is entirely dependent on the props passed to it.
-This means it's very easy to test, and a snapshot should never change.
+This means it's easier to test, and a snapshot should never change.
 
 Here's how:
 

--- a/docs/docs/testing-css-in-js.md
+++ b/docs/docs/testing-css-in-js.md
@@ -8,7 +8,7 @@ _Snapshot serializers_ like `jest-styled-components` or `jest-emotion` modify th
 
 By default snapshots of your styled components show the generated class names (which you didn't set) and no styling information. When changing the styles you'll only see the diff of some cryptic class names (hashes). That's why you should use the above mentioned _snapshot serializers_. They remove the hashes and format the CSS in style elements.
 
-For this example we'll use emotion. The testing utilities of emotion and glamor are largely based on [jest-styled-components](https://github.com/styled-components/jest-styled-components) so they have a similar usage. Please have a look at the testing section of your library to follow along.
+For this example you'll use emotion. The testing utilities of emotion and glamor are largely based on [jest-styled-components](https://github.com/styled-components/jest-styled-components) so they have a similar usage. Please have a look at the testing section of your library to follow along.
 
 ## Installation
 

--- a/docs/docs/testing-react-components.md
+++ b/docs/docs/testing-react-components.md
@@ -1,5 +1,5 @@
 ---
-title: "Testing React components"
+title: "Testing React Components"
 ---
 
 _The recommended testing framework is [Jest](https://jestjs.io/). This guide assumes that you followed the [Unit testing](/docs/unit-testing) guide to setup Jest._

--- a/docs/docs/theme-api.md
+++ b/docs/docs/theme-api.md
@@ -15,7 +15,7 @@ If you're new to Gatsby you can get started by following along with the guides f
 
 ## Configuration
 
-Plugins can now include a `gatsby-config` in addition to the other `gatsby-*` files. We typically refer to plugins that include a `gatsby-config.js` as a theme (more on that in [theme composition](#theme-composition)). A typical `gatsby-config.js` in a user's site that uses your theme could look like this. In this example we pass in two options to `gatsby-theme-name`: `postsPath` and `colors`.
+Plugins can now include a `gatsby-config` in addition to the other `gatsby-*` files. We typically refer to plugins that include a `gatsby-config.js` as a theme (more on that in [theme composition](#theme-composition)). A typical `gatsby-config.js` in a user's site that uses your theme could look like this. This example passes in two options to `gatsby-theme-name`: `postsPath` and `colors`.
 
 ```js:title=gatsby-config.js
 module.exports = {
@@ -52,7 +52,7 @@ module.exports = themeOptions => {
 
 While using the usual object export (`module.exports = {}`) in your theme means that you can run the theme standalone as its own site, when using a function in your theme to accept options you will need to run the theme as part of an example site. See how the [theme authoring starter](https://github.com/gatsbyjs/gatsby/tree/master/themes/gatsby-starter-theme-workspace) handles this using Yarn Workspaces.
 
-### Accessing Options elsewhere
+### Accessing options elsewhere
 
 Note that because themes are plugins you can also access the options in any of the lifecycle methods that you're used to. For example, in your theme's `gatsby-node.js` you can access the options as the second argument to `createPages`:
 
@@ -64,23 +64,23 @@ exports.createPages = async ({ graphql, actions }, themeOptions) => {
 
 ## Shadowing
 
-Since themes are usually deployed as npm packages that other people use in their sites, we need a way to modify certain files, such as React components, without making changes to the source code of the theme. This is called _Shadowing_.
+Since themes are usually deployed as npm packages that other people use in their sites, you need a way to modify certain files, such as React components, without making changes to the source code of the theme. This is called _Shadowing_.
 
-Shadowing is a filesystem-based API that allows us to replace one file with another at build time. For example, if we had a theme with a `Header` component we could replace that `Header` with our own by creating a new file in our site and placing it in the correct location for Shadowing to find it.
+Shadowing is a filesystem-based API that allows us to replace one file with another at build time. For example, if you had a theme with a `Header` component you could replace that `Header` with your own by creating a new file and placing it in the correct location for Shadowing to find it.
 
 ### Overriding
 
-Taking a closer look at our `Header` example, let's say we have a theme called `gatsby-theme-amazing`. That theme uses a `Header` component to render navigation and other miscellaneous items. The path to the component from the root of the npm package is `gatsby-theme-amazing/src/components/header.js`.
+Taking a closer look at the `Header` example, let's say you have a theme called `gatsby-theme-amazing`. That theme uses a `Header` component to render navigation and other miscellaneous items. The path to the component from the root of the npm package is `gatsby-theme-amazing/src/components/header.js`.
 
-We'd like the `Header` component to do something different (maybe change colors, maybe add additional navigation items, really anything you can think of). To do that, we create a file in our site at `src/gatsby-theme-amazing/components/header.js`. We can now export any React component we want from this file and Gatsby will use it instead of the theme's component.
+You might want the `Header` component to do something different (maybe change colors, maybe add additional navigation items, really anything you can think of). To do that, you create a file in your site at `src/gatsby-theme-amazing/components/header.js`. You can now export any React component you want from this file and Gatsby will use it instead of the theme's component.
 
 > 💡 Note: you can shadow components from other themes using the same method. Read more about advanced applications in [latent shadowing](https://johno.com/latent-component-shadowing).
 
 ### Extending
 
-In the last section we talked about completely replacing one component with another. What if we want to make a smaller change that doesn't require copy/pasting the entire theme component into our own? We can take advantage of the ability to extend components.
+In the last section we talked about completely replacing one component with another. What if you want to make a smaller change that doesn't require copy/pasting the entire theme component into your own? You can take advantage of the ability to extend components.
 
-Taking the `Header` example from before, when we write our shadowing file at `src/gatsby-theme-amazing/components/header.js`, we can import the original component and re-export it as such, adding our own overridden prop to the component.
+Taking the `Header` example from before, when you write your shadowing file at `src/gatsby-theme-amazing/components/header.js`, you can import the original component and re-export it as such, adding your own overridden prop to the component.
 
 ```js
 import Header from "gatsby-theme-amazing/src/components/header"
@@ -89,19 +89,19 @@ import Header from "gatsby-theme-amazing/src/components/header"
 export default props => <Header {...props} myProp="true" />
 ```
 
-Taking this approach means that when we upgrade our theme later we can also take advantage of all the updates to the `Header` component because we haven't fully replaced it, just modified it.
+Taking this approach means that when you upgrade your theme later you can also take advantage of all the updates to the `Header` component because you haven't fully replaced it, just modified it.
 
 ### What path should be used to shadow a file?
 
-Until we build tooling to support automatically handling shadowing, you will have to manually locate paths in a theme and create the correct shadowing paths in your site.
+Until gatsby has tooling to automatically handle shadowing, you will have to manually locate paths in a theme and create the correct shadowing paths in your site.
 
-Luckily, the way to do that is only a few steps. Take the `src` directory from the theme, and move it to the front of the path, then write a file at that location in your site. Looking back on our `Header` example, this is the path to the component in our theme:
+Luckily, the way to do that is only a few steps. Take the `src` directory from the theme, and move it to the front of the path, then write a file at that location in your site. Looking back on the `Header` example, this is the path to the component in your theme:
 
 ```
 gatsby-theme-amazing/src/components/header.js
 ```
 
-and here is the path where we would shadow it in our site:
+and here is the path where you would shadow it in your site:
 
 ```
 <our-site>/src/gatsby-theme-amazing/components/header.js
@@ -109,7 +109,7 @@ and here is the path where we would shadow it in our site:
 
 Shadowing only works on imported files in the `src` directory. This is because shadowing is built on top of Webpack, so the module graph needs to include the shadowable file.
 
-Since we can use multiple themes in a given site, there are many potential places to shadow a given file (one for each theme and one for the user's site). In the event that multiple themes are attempting to shadow `gatsby-theme-amazing/src/components/header.js`, the last theme included in the plugins array will win. The site itself takes the highest priority in shadowing.
+Since you can use multiple themes in a given site, there are many potential places to shadow a given file (one for each theme and one for the user's site). In the event that multiple themes are attempting to shadow `gatsby-theme-amazing/src/components/header.js`, the last theme included in the plugins array will win. The site itself takes the highest priority in shadowing.
 
 ## Theme composition
 
@@ -129,11 +129,11 @@ module.exports = {
 }
 ```
 
-Themes at their core are an algorithm that merges multiple `gatsby-config.js` files together into a single config your site can use to build with. To do that we need to define how to combine two `gatsby-config.js`s together. Before we can do that, we need to flatten the parent/child relationships into a single array. This results in the final ordering when considering which shadowing file to use if multiple are available.
+Themes at their core are an algorithm that merges multiple `gatsby-config.js` files together into a single config your site can use to build with. To do that you need to define how to combine two `gatsby-config.js`s together. Before you can do that, you need to flatten the parent/child relationships into a single array. This results in the final ordering when considering which shadowing file to use if multiple are available.
 
-Our first example results in a final ordering of `['gatsby-theme-parent', 'gatsby-theme-child']` (parents always come before their children so that children can override functionality), while our second example results in `['gatsby-theme-blog', 'gatsby-theme-notes']`.
+The first example results in a final ordering of `['gatsby-theme-parent', 'gatsby-theme-child']` (parents always come before their children so that children can override functionality), while the second example results in `['gatsby-theme-blog', 'gatsby-theme-notes']`.
 
-Once we have the final ordering of themes we merge them together using a reduce function. [This reduce function](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/merge-gatsby-config.js) specifies the way each key in `gatsby-config.js` will merge together. Unless otherwise specified below, the last value wins.
+Once you have the final ordering of themes you merge them together using a reduce function. [This reduce function](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/merge-gatsby-config.js) specifies the way each key in `gatsby-config.js` will merge together. Unless otherwise specified below, the last value wins.
 
 - `siteMetadata` and `mapping` both merge deeply using lodash's `merge` function. This means a theme can set default values in `siteMetadata` and the site can override them using the standard `siteMetadata` object in `gatsby-config.js`.
 - `plugins` are normalized to remove duplicates, then concatenated together.

--- a/docs/docs/theme-api.md
+++ b/docs/docs/theme-api.md
@@ -93,7 +93,7 @@ Taking this approach means that when you upgrade your theme later you can also t
 
 ### What path should be used to shadow a file?
 
-Until gatsby has tooling to automatically handle shadowing, you will have to manually locate paths in a theme and create the correct shadowing paths in your site.
+Until Gatsby has tooling to automatically handle shadowing, you will have to manually locate paths in a theme and create the correct shadowing paths in your site.
 
 Luckily, the way to do that is only a few steps. Take the `src` directory from the theme, and move it to the front of the path, then write a file at that location in your site. Looking back on the `Header` example, this is the path to the component in your theme:
 

--- a/docs/docs/third-party-graphql.md
+++ b/docs/docs/third-party-graphql.md
@@ -1,5 +1,5 @@
 ---
-title: "Using third-party GraphQL APIs"
+title: "Using Third-Party GraphQL APIs"
 ---
 
 Gatsby v2 introduces a simple way to integrate any GraphQL API into Gatsby's GraphQL. You can integrate both third-party APIs, like GitHub's, APIs of services like GraphCMS or your custom GraphQL API.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Style guide audit for all docs files starting with `t`
- Change we/ours to you/yours where appropriate
- Checked heading order made sense
- Applied title case to article titles and sentence case to headings
- Removed 'easy' where appropriate

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Addresses https://github.com/gatsbyjs/gatsby/issues/18284
