### PR TITLE
chore(showcase): Remove Tenon.io blog

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -3968,18 +3968,6 @@
     - Portfolio
   built_by: Maxim Andries
   featured: false
-- title: The Tenon.io blog
-  main_url: https://blog.tenon.io/
-  url: https://blog.tenon.io/
-  description: >
-    The Tenon.io blog features articles on accessibility written by some of the industry's leading lights and includes news, guidance, and education.
-  categories:
-    - Accessibility
-    - Blog
-    - Education
-  built_by: Tenon.io
-  built_by_url: https://tenon.io
-  featured: false
 - title: Algolia
   url: https://algolia.com
   main_url: https://algolia.com


### PR DESCRIPTION
## Description

The blog has been 404ing for the past week and no word from Tenon, so I'll be taking it off the showcase.

@karlgroves if this not intentional that the blog is down, the site can be added again to the showcase.

## Related Issues

N/A