### PR TITLE
fix(www): Change of slider text to support light and dark mode

### DIFF
--- a/www/src/components/rotator.js
+++ b/www/src/components/rotator.js
@@ -155,7 +155,7 @@ class Rotator extends Component {
                 {!enableSlider ? (
                   <>{text}</>
                 ) : (
-                  <Slider items={[text]} color="black" />
+                  <Slider items={[text]} color="inherit" />
                 )}
               </span>
             </span>


### PR DESCRIPTION
## Description

The color of the slider text was fixed on black, so the text would be impossible to read on dark mode.
This PR changes the color to `inherit`, so it can adapt to background changes alongside the text _"Need"_