### PR TITLE
Update Community.md - Add DEV Community to Support Section

### DIFF
--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -77,7 +77,7 @@ tagged with **gatsby** or
 
 DEV Community is another informative platform to ask questions and share tips as well. Read through
 the [existing questions and posts](https://dev.to/t/gatsby)
-tagged with **gatsby** or
+tagged with `gatsby` or
 [ask for help](https://dev.to/new/help). You could also [write your post](https://dev.to/new/gatsby) with the `gatsby` tag.
 
 ## Learn More About Gatsby:

--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -73,6 +73,13 @@ the [existing questions and posts](https://hashnode.com/n/gatsby)
 tagged with **gatsby** or
 [ask your own question](https://hashnode.com/create/question) or [share your story](https://hashnode.com/create/story) and add the `gatsby` tag.
 
+### DEV Community
+
+DEV Community is another informative platform to ask questions and share tips as well. Read through
+the [existing questions and posts](https://dev.to/t/gatsby)
+tagged with **gatsby** or
+[ask for help](https://dev.to/new/help). You could also [write your post](https://dev.to/new/gatsby) with the `gatsby` tag.
+
 ## Learn More About Gatsby:
 
 - [Why Contribute to Gatsby?](/contributing/why-contribute-to-gatsby/)


### PR DESCRIPTION
This PR adds the DEV Community link to 'Where to get support' section.

[DEV Community](https://dev.to) is a platform where software developers share articles and engage in discussions on different topics of which [Gatsby Content](dev.to/t/gatsby) has been growing in popularity.

This will be a useful link to point to the official place to discuss Gatsby matters on the platform.
