### PR TITLE
Docs: Use `you` pronoun in add-a-service-worker.md

### DIFF
--- a/docs/docs/add-a-service-worker.md
+++ b/docs/docs/add-a-service-worker.md
@@ -12,7 +12,7 @@ It supports features like push notifications and background sync.
 
 Gatsby provides awesome plugin interface to create and load a service worker into your site [gatsby-plugin-offline](https://www.npmjs.com/package/gatsby-plugin-offline).
 
-We recommend using this plugin together with the [manifest plugin](https://www.npmjs.com/package/gatsby-plugin-manifest). (Don’t forget to list the offline plugin after the manifest plugin so that the manifest file can be included in the service worker).
+You can use this plugin together with the [manifest plugin](https://www.npmjs.com/package/gatsby-plugin-manifest). (Don’t forget to list the offline plugin after the manifest plugin so that the manifest file can be included in the service worker).
 
 ### Installing `gatsby-plugin-offline`
 


### PR DESCRIPTION
## Description

Use _you_ pronoun instead of _we_ according to the [Gatsby Styling Guide](https://www.gatsbyjs.org/contributing/gatsby-style-guide/#use-you-as-the-pronoun)

## Related Issues

Related to #18284 