### PR TITLE
fix(gatsby-plugin-guess-js): Sanitise pluginOptions to remove jwt tokens

### DIFF
--- a/packages/gatsby-plugin-guess-js/src/gatsby-node.js
+++ b/packages/gatsby-plugin-guess-js/src/gatsby-node.js
@@ -1,8 +1,10 @@
 const { GuessPlugin } = require(`guess-webpack`)
 
 let guessPlugin
-exports.onPreBootstrap = (_, pluginOptions) => {
+exports.onPreInit = (_, pluginOptions) => {
   const { period, jwt, GAViewID, reportProvider } = pluginOptions
+  // delete sensitive information after use
+  delete pluginOptions.jwt
   period.startDate = new Date(period.startDate)
   period.endDate = new Date(period.endDate)
   guessPlugin = new GuessPlugin({


### PR DESCRIPTION
## Description

`gatsby-plugin-guess-js` uses browser APIs; hence, `projectOptions` are written out to `cache-dir/api-runner-browser-plugins.js`.
The problem here is that `projectOptions` also contains sensitive credentials which are exposed.

This PR aims to sanitize `projectOptions` to remove the `jwt` field after using it. We need to use `onPreInit` hook instead of `onPreBootstrap` because `onPreBootstrap` runs after `api-runner-browser-plugins.js` is written.

## Related Issues
Fixes #18376 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->