### PR TITLE
chore(showcase): Add AtomLinter

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -7670,3 +7670,19 @@
   built_by: Phil Tietjen
   built_by_url: "https://github.com/Phizzard"
   featured: false
+- title: AtomLinter
+  url: https://atomlinter.github.io/
+  main_url: https://atomlinter.github.io/
+  source_url: https://github.com/AtomLinter/atomlinter.github.io
+  description: >
+    Landing page for the AtomLinter project, offering a curation of Atom packages associated with the project.
+  categories:
+    - Directory
+    - Landing Page
+    - Open Source
+    - Programming
+    - Technology
+  built_by: Kepler Sticka-Jones
+  built_by_url: https://keplersj.com/
+  featured: false
+  

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -7685,4 +7685,3 @@
   built_by: Kepler Sticka-Jones
   built_by_url: https://keplersj.com/
   featured: false
-  


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The [AtomLinter website](https://atomlinter.github.io) has been hosted on GitHub Pages for years, and allow developers in the Atom community to list their linter-related Atom packages on it using a YAML file. A year ago we transitioned the website to Gatsby from Jekyll, and this week transitioned to using a [Gatsby Theme](https://github.com/keplersj/gatsby-theme-atom-service). This Pull Request just adds AtomLinter's website to the Site Showcase.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to AtomLinter/atomlinter.github.io#260
