### PR TITLE
docs: title case in building docs

### DIFF
--- a/docs/docs/building-a-blog.md
+++ b/docs/docs/building-a-blog.md
@@ -1,5 +1,5 @@
 ---
-title: Building a blog
+title: Building a Blog
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/building-a-portfolio.md
+++ b/docs/docs/building-a-portfolio.md
@@ -1,5 +1,5 @@
 ---
-title: Building a portfolio
+title: Building a Portfolio
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/building-a-site-with-asynchronous-data.md
+++ b/docs/docs/building-a-site-with-asynchronous-data.md
@@ -1,5 +1,5 @@
 ---
-title: Building a site with asynchronous data
+title: Building a Site with Asynchronous Data
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/building-a-site-with-authentication.md
+++ b/docs/docs/building-a-site-with-authentication.md
@@ -1,5 +1,5 @@
 ---
-title: Building a site with authentication
+title: Building a Site with Authentication
 ---
 
 With Gatsby, you are able to create restricted areas in your app. For that, you

--- a/docs/docs/building-an-e-commerce-site.md
+++ b/docs/docs/building-an-e-commerce-site.md
@@ -1,5 +1,5 @@
 ---
-title: Building an e-commerce site
+title: Building an E-commerce Site
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/building-an-image-heavy-site.md
+++ b/docs/docs/building-an-image-heavy-site.md
@@ -1,5 +1,5 @@
 ---
-title: Building an image heavy site
+title: Building an Image Heavy Site
 ---
 
 This is a stub. Help our community expand it.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Fixes title case for docs prefixed with `building`. Includes a couple of stubs and an article.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Related to #18284
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
