### PR TITLE
docs: add link from headless-cms guide to creating plugins guide

### DIFF
--- a/docs/docs/headless-cms.md
+++ b/docs/docs/headless-cms.md
@@ -47,3 +47,5 @@ Here are more resources for guides, plugins, and starters for CMS systems you ca
 ## How to add new guides to this section
 
 If you don’t see your preferred CMS in this list, you can [write a new guide yourself](/contributing/how-to-contribute/) or [open an issue to request it](https://github.com/gatsbyjs/gatsby/issues/new/choose).
+
+You can also [write your own source plugin](/docs/creating-a-source-plugin/) to integrate Gatsby with a CMS that is not in the list.


### PR DESCRIPTION
## The Problem

Feedback from the docs in the [headless CMS](https://www.gatsbyjs.org/docs/headless-cms/) page asked about how one would add a new source plugin for a CMS if it didn't already exist.

## The Solution

This PR adds a link to the [Creating a Source Plugin](https://www.gatsbyjs.org/docs/creating-a-source-plugin/) guide in the [headless CMS](https://www.gatsbyjs.org/docs/headless-cms/) page.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/18329