### PR TITLE
fix(gatsby-plugin-guess-js): don't leak jwt in gatsby-browser

### DIFF
--- a/packages/gatsby-plugin-guess-js/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-guess-js/src/__tests__/gatsby-node.js
@@ -1,17 +1,42 @@
-import { onPreBootstrap } from "../gatsby-node"
+import { onPreInit, onPreBootstrap } from "../gatsby-node"
+import { GuessPlugin } from "guess-webpack"
 
 jest.mock(`guess-webpack`)
 
 describe(`gatsby-plugin-guess-js`, () => {
-  describe(`onPreBootstrap`, () => {
+  describe(`onPreInit`, () => {
     it(`should delete jwt pluginOptions`, () => {
       const pluginOptions = {
         jwt: `mykeys`,
       }
 
-      onPreBootstrap({}, pluginOptions)
+      onPreInit({}, pluginOptions)
 
       expect(pluginOptions).not.toHaveProperty(`jwt`)
+    })
+  })
+
+  describe(`onPreBootstrap`, () => {
+    it(`should still have a jwt token to be used in jwt`, () => {
+      const pluginOptions = {
+        jwt: `mykeys`,
+        // period: {
+        //   start: `2019-10-09`,
+        //   end: `2019-10-10`,
+        // },
+        GAViewID: `1234`,
+      }
+
+      onPreInit({}, pluginOptions)
+      onPreBootstrap({}, pluginOptions)
+
+      expect(GuessPlugin).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          jwt: `mykeys`,
+          GA: `1234`,
+        })
+      )
     })
   })
 })

--- a/packages/gatsby-plugin-guess-js/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-guess-js/src/__tests__/gatsby-node.js
@@ -1,0 +1,17 @@
+import { onPreBootstrap } from "../gatsby-node"
+
+jest.mock(`guess-webpack`)
+
+describe(`gatsby-plugin-guess-js`, () => {
+  describe(`onPreBootstrap`, () => {
+    it(`should delete jwt pluginOptions`, () => {
+      const pluginOptions = {
+        jwt: `mykeys`,
+      }
+
+      onPreBootstrap({}, pluginOptions)
+
+      expect(pluginOptions).not.toHaveProperty(`jwt`)
+    })
+  })
+})

--- a/packages/gatsby-plugin-guess-js/src/gatsby-node.js
+++ b/packages/gatsby-plugin-guess-js/src/gatsby-node.js
@@ -3,8 +3,11 @@ const { GuessPlugin } = require(`guess-webpack`)
 let guessPlugin
 exports.onPreBootstrap = (_, pluginOptions) => {
   const { period, jwt, GAViewID, reportProvider } = pluginOptions
-  period.startDate = new Date(period.startDate)
-  period.endDate = new Date(period.endDate)
+  if (period) {
+    period.startDate = new Date(period.startDate)
+    period.endDate = new Date(period.endDate)
+  }
+
   guessPlugin = new GuessPlugin({
     // GA view ID.
     GA: GAViewID,

--- a/packages/gatsby-plugin-guess-js/src/gatsby-node.js
+++ b/packages/gatsby-plugin-guess-js/src/gatsby-node.js
@@ -1,11 +1,30 @@
 const { GuessPlugin } = require(`guess-webpack`)
 
 let guessPlugin
+let jwt
+
+exports.onPreInit = (_, pluginOptions) => {
+  jwt = pluginOptions.jwt
+
+  // remove jwt from our config as we don't want it to leak into gatsby-browser.js
+  delete pluginOptions.jwt
+}
+
 exports.onPreBootstrap = (_, pluginOptions) => {
-  const { period, jwt, GAViewID, reportProvider } = pluginOptions
+  const { GAViewID, reportProvider } = pluginOptions
+  let { period } = pluginOptions
+
   if (period) {
     period.startDate = new Date(period.startDate)
     period.endDate = new Date(period.endDate)
+  } else {
+    const startDate = new Date()
+    // We'll load 1 year of data if no period is being specified
+    startDate.setDate(startDate.getDate() - 365)
+    period = {
+      startDate,
+      endDate: new Date(),
+    }
   }
 
   guessPlugin = new GuessPlugin({
@@ -29,16 +48,8 @@ exports.onPreBootstrap = (_, pluginOptions) => {
 
     // Optional argument. It takes the data for the last year if not
     // specified.
-    period: period
-      ? period
-      : {
-          startDate: new Date(`2018-1-1`),
-          endDate: new Date(),
-        },
+    period,
   })
-
-  // remove jwt from our config as we don't want it to leak into gatsby-browser.js
-  delete pluginOptions.jwt
 }
 
 exports.onCreateWebpackConfig = ({ actions }) => {

--- a/packages/gatsby-plugin-guess-js/src/gatsby-node.js
+++ b/packages/gatsby-plugin-guess-js/src/gatsby-node.js
@@ -33,6 +33,9 @@ exports.onPreBootstrap = (_, pluginOptions) => {
           endDate: new Date(),
         },
   })
+
+  // remove jwt from our config as we don't want it to leak into gatsby-browser.js
+  delete pluginOptions.jwt
 }
 
 exports.onCreateWebpackConfig = ({ actions }) => {


### PR DESCRIPTION
## Description
Removes the jwt token from pluginOptions so we don't leak into gatsby-browser. We might want to do this cleanup by default where we can ourselves.

When we remove options inside preInit it's no stored and won't be passed around.

Before:
![image](https://user-images.githubusercontent.com/1120926/66546289-facfd380-eb3c-11e9-8dca-e52defa46132.png)

After:
![image](https://user-images.githubusercontent.com/1120926/66546339-16d37500-eb3d-11e9-9109-9334a31c9666.png)


## Related Issues
#18376