### PR TITLE
add missing back-tick (`) to install script

### DIFF
--- a/packages/gatsby-plugin-preact/README.md
+++ b/packages/gatsby-plugin-preact/README.md
@@ -10,7 +10,7 @@ React.
 
 ## Install
 
-`npm install --save gatsby-plugin-preact preact
+`npm install --save gatsby-plugin-preact preact`
 
 ## How to use
 


### PR DESCRIPTION
## Description

add missing back-tick (\`) to [gatsby-plugin-preact](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact) install script
