### PR TITLE
feat(gatsby-source-wordpress): get posts by all statuses when authenticated with JWT

### DIFF
--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -349,11 +349,13 @@ async function getPages(
     let result = []
 
     const getOptions = page => {
+      const hasPrivilage = _accessToken && url.includes("wp/v2/posts")
       let o = {
         method: `get`,
         url: `${url}?${querystring.stringify({
           per_page: _perPage,
           page: page,
+          ...(hasPrivilage ? { status: "any" } : {}),
         })}`,
       }
 


### PR DESCRIPTION
Needed to get draft post from WP too, so added status=any to the URL in the source WP plugin.

the hardcoded endpoint may be not the best solution if you have a proposal fixing that I'll change it.

## Description

Get posts with all status (even custom ones)
