### PR TITLE
Edit document heading order

### DIFF
--- a/docs/docs/add-a-service-worker.md
+++ b/docs/docs/add-a-service-worker.md
@@ -24,7 +24,7 @@ Add this plugin to your `gatsby-config.js`
 plugins: [`gatsby-plugin-offline`]
 ```
 
-### References
+## References
 
 - [Service Workers: an Introduction](https://developers.google.com/web/fundamentals/primers/service-workers/)
 - [Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)

--- a/docs/docs/add-a-service-worker.md
+++ b/docs/docs/add-a-service-worker.md
@@ -2,19 +2,19 @@
 title: Add a Service Worker
 ---
 
-### What is a service worker
+## What is a service worker
 
 A service worker is a script that your browser runs in the background, separate from a web page, opening the door to features that don't need a web page or user interaction. They increase your site availability in spotty connections, and are essential to making a nice user experience.
 
 It supports features like push notifications and background sync.
 
-### Using service workers in Gatsby with `gatsby-plugin-offline`
+## Using service workers in Gatsby with `gatsby-plugin-offline`
 
 Gatsby provides awesome plugin interface to create and load a service worker into your site [gatsby-plugin-offline](https://www.npmjs.com/package/gatsby-plugin-offline).
 
 You can use this plugin together with the [manifest plugin](https://www.npmjs.com/package/gatsby-plugin-manifest). (Don’t forget to list the offline plugin after the manifest plugin so that the manifest file can be included in the service worker).
 
-### Installing `gatsby-plugin-offline`
+## Installing `gatsby-plugin-offline`
 
 `npm install --save gatsby-plugin-offline`
 
@@ -24,7 +24,7 @@ Add this plugin to your `gatsby-config.js`
 plugins: [`gatsby-plugin-offline`]
 ```
 
-## References
+### References
 
 - [Service Workers: an Introduction](https://developers.google.com/web/fundamentals/primers/service-workers/)
 - [Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
h2 heading was used for the References section, which followed the h3 headings used for the previous parts of the article. Not semantically correct.


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
