### PR TITLE
docs: update "ca-" to "co-" files to match style guide

### DIFF
--- a/docs/docs/caching.md
+++ b/docs/docs/caching.md
@@ -20,7 +20,7 @@ The `cache-control` header should be `cache-control: public, max-age=0, must-rev
 
 ## Static files
 
-All files in `static/` should be cached forever. For files in this directory, Gatsby creates paths that are directly tied to the content of the file. Meaning that if the file content changes, then the file path changes also. These paths look weird e.g. `reactnext-gatsby-performance.001-a3e9d70183ff294e097c4319d0f8cff6-0b1ba.png` but since we know that we'll always get the same file when we request that path, we can cache it forever.
+All files in `static/` should be cached forever. For files in this directory, Gatsby creates paths that are directly tied to the content of the file. Meaning that if the file content changes, then the file path changes also. These paths look weird e.g. `reactnext-gatsby-performance.001-a3e9d70183ff294e097c4319d0f8cff6-0b1ba.png` but since you know that you'll always get the same file when you request that path, you can cache it forever.
 
 The `cache-control` header should be `cache-control: public, max-age=31536000, immutable`
 

--- a/docs/docs/centralizing-your-sites-navigation.md
+++ b/docs/docs/centralizing-your-sites-navigation.md
@@ -1,5 +1,5 @@
 ---
-title: Centralizing your site's navigation
+title: Centralizing Your Site's Navigation
 ---
 
 ## Creating dynamic navigation in Gatsby

--- a/docs/docs/client-data-fetching.md
+++ b/docs/docs/client-data-fetching.md
@@ -14,13 +14,13 @@ Compiling pages at [build-time](/docs/glossary#build) is useful when your websit
 
 Because a Gatsby site [hydrates](/docs/glossary#hydration) into a React app after loading statically, Gatsby is not just for static sites. You can also fetch data dynamically on the client-side as needed, like you would with any other React app.
 
-To illustrate this, we'll walk through a small example site that uses both Gatsby's data layer at build-time and data on the client at run-time. This example is based loosely on Jason Lengstorf's [Gatsby with Apollo](https://github.com/jlengstorf/gatsby-with-apollo) example. We'll be fetching character data for Rick (of Rick and Morty) and a random pupper image.
+To illustrate this, you'll walk through a small example site that uses both Gatsby's data layer at build-time and data on the client at run-time. This example is based loosely on Jason Lengstorf's [Gatsby with Apollo](https://github.com/jlengstorf/gatsby-with-apollo) example. You'll be fetching character data for Rick (of Rick and Morty) and a random pupper image.
 
 > Note: Check out the [full example here](https://github.com/amberleyromo/gatsby-client-data-fetching), if helpful.
 
 ### 1. Create a Gatsby page component
 
-No data yet. Just the basic React page that we'll be populating.
+No data yet. Just the basic React page that you'll be populating.
 
 ```jsx:title=index.js
 import React, { Component } from "react"
@@ -45,7 +45,7 @@ export default ClientFetchingExample
 
 ### 2. Query for character info at build time
 
-To query for Rick's character info and image, we'll use the `gatsby-source-graphql` plugin. This will allow us to query the Rick and Morty API using Gatsby queries.
+To query for Rick's character info and image, you'll use the `gatsby-source-graphql` plugin. This will allow you to query the Rick and Morty API using Gatsby queries.
 
 > Note: To learn more about using [`gatsby-source-graphql`](/packages/gatsby-source-graphql/), or about [Gatsby's GraphQL data layer](/docs/graphql/), check out their respective docs. The purpose of including it here is only for comparison.
 
@@ -64,7 +64,7 @@ module.exports = {
 }
 ```
 
-Now we can add the query to our `index.js` page:
+Now you can add the query to your `index.js` page:
 
 ```jsx:title=index.js
 import React, { Component } from "react"
@@ -117,7 +117,7 @@ export default ClientFetchingExample
 
 ### 3. Fetch pupper info and image data on the client
 
-Now we'll finish out by fetching pupper info from the [Dog CEO Dog API](https://dog.ceo/dog-api/). (We'll fetch a random pupper. Rick isn't picky.)
+Now you'll finish out by fetching pupper info from the [Dog CEO Dog API](https://dog.ceo/dog-api/). (You'll fetch a random pupper. Rick isn't picky.)
 
 ```jsx:title=index.js
 import React, { Component } from "react"

--- a/docs/docs/client-only-routes-and-user-authentication.md
+++ b/docs/docs/client-only-routes-and-user-authentication.md
@@ -1,5 +1,5 @@
 ---
-title: "Client-only routes & user authentication"
+title: "Client-Only Routes & User Authentication"
 ---
 
 Often you want to create a site with client-only portions that are gated by authentication.

--- a/docs/docs/content-and-data.md
+++ b/docs/docs/content-and-data.md
@@ -1,5 +1,5 @@
 ---
-title: Sourcing Content and Data
+title: Sourcing Content & Data
 ---
 
 A core feature of Gatsby is its ability to **load data from anywhere**. This is part of what makes Gatsby more powerful than static site generators that are limited to only loading content from Markdown files.


### PR DESCRIPTION
## Description

For markdown files in the folder `/docs/docs` starting with ca- through co-, updates titles to use Title Case and changes "we/our" to "you/yours."

## Related Issues

Addresses Issue #18284 