### PR TITLE
fix(www): fix alignment of search bar on tags page

### DIFF
--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -140,6 +140,7 @@ class TagsPage extends React.Component {
                 flexFlow: `row nowrap`,
                 justifyContent: `space-between`,
                 pb: 4,
+                alignItems: `center`,
               }}
             >
               <h2>All tags</h2>


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Updated the search bar alignment in tags.js. [(https://www.gatsbyjs.org/blog/tags/)](https://www.gatsbyjs.org/blog/tags/)
#### Before fix:
![All tags unfixed](https://user-images.githubusercontent.com/14818143/66599434-d4ec1280-ebc0-11e9-913c-3c2b2d6f1225.PNG)
#### After fix:
![image](https://user-images.githubusercontent.com/14818143/66599612-462bc580-ebc1-11e9-885e-a880b0b143aa.png)


<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
None