### PR TITLE
chore(docs): Fix broken link

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -2098,7 +2098,7 @@ Use [`netlify-cli`](https://www.netlify.com/docs/cli/) to deploy your Gatsby app
 
 4. Choose a custom website name if you want or press enter to receive a random one.
 
-5. Choose your [Team](/docs/teams/).
+5. Choose your [Team](https://www.netlify.com/docs/teams/).
 
 6. Change the deploy path to `public/`
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In the page https://www.gatsbyjs.org/docs/recipes/ the link under the `Choose your Team.` text is broken it points to https://www.gatsbyjs.org/docs/teams/ that returns a 404 response.

Fix the link to use the netlify docs about teams -> https://www.netlify.com/docs/teams/

## Related Issues
Fixes #18507
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
