### PR TITLE
chore(docs): Update tutorial part 8

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -338,7 +338,7 @@ The above example is based off the [Gatsby Starter Blog](/starters/gatsbyjs/gats
 
 Now, if you run the Lighthouse audit again as laid out above, you should get close to--if not a perfect-- 100 score!
 
-> 💡 For further reading and examples, check out [Adding an SEO Component](https://www.gatsbyjs.org/docs/add-seo-component/) and the [React Helmet docs](https://github.com/nfl/react-helmet#example)!
+> 💡 For further reading and examples, check out [Adding an SEO Component](/docs/add-seo-component/) and the [React Helmet docs](https://github.com/nfl/react-helmet#example)!
 
 ## Keep making it better
 

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -338,7 +338,7 @@ The above example is based off the [Gatsby Starter Blog](/starters/gatsbyjs/gats
 
 Now, if you run the Lighthouse audit again as laid out above, you should get close to--if not a perfect-- 100 score!
 
-> 💡 For further reading and examples, check out [Adding an SEO Component](docs/add-seo-component) and the [React Helmet docs](https://github.com/nfl/react-helmet#example)!
+> 💡 For further reading and examples, check out [Adding an SEO Component](https://www.gatsbyjs.org/docs/add-seo-component/) and the [React Helmet docs](https://github.com/nfl/react-helmet#example)!
 
 ## Keep making it better
 


### PR DESCRIPTION
Fix broken link `Adding an SEO component`

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

- On page https://www.gatsbyjs.org/tutorial/part-eight/ in the link Adding an SEO Component is broken leading the user to a 404 page.

- Fixed link
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Fixes #18511 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
