### PR TITLE
chore(using-jest): Mock useStaticQuery

### DIFF
--- a/examples/using-jest/__mocks__/gatsby.js
+++ b/examples/using-jest/__mocks__/gatsby.js
@@ -11,4 +11,5 @@ module.exports = {
     })
   ),
   StaticQuery: jest.fn(),
+  useStaticQuery: jest.fn(),
 }


### PR DESCRIPTION
## Description

I was following the [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/#mocking-gatsby) tutorial and realized that the `useStaticQuery` was not being mocked on the [using-jest](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-jest) example, so I created this PR to add it.

## Related Issues

Not related to any issues.
