### PR TITLE
fix(www): Fix `theme-ui` theme `breakpoints` (dark mode aftercare, episode 4)

### DIFF
--- a/www/src/components/card.js
+++ b/www/src/components/card.js
@@ -29,10 +29,9 @@ const Card = ({ children }) => (
   >
     <div
       sx={{
-        p: 6,
-        pb: 0,
+        p: 8,
+        pb: [0, 8],
         transform: `translateZ(0)`,
-        [mediaQueries.sm]: { p: 8 },
       }}
     >
       {children}

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -4,7 +4,6 @@ import { Fragment } from "react"
 import { keyframes } from "@emotion/core"
 import { Link, StaticQuery, graphql } from "gatsby"
 
-import { mediaQueries } from "../gatsby-plugin-theme-ui"
 import logo from "../assets/monogram.svg"
 import { GraphQLIcon, ReactJSIcon } from "../assets/tech-logos"
 import FuturaParagraph from "../components/futura-paragraph"
@@ -108,17 +107,11 @@ const boxPadding = { py: 3, px: 4 }
 const SourceItem = ({ children }) => (
   <div
     sx={{
-      boxSizing: `border-box`,
       py: 4,
       px: 5,
       display: `flex`,
-      [mediaQueries.xs]: {
-        flex: `1 1 50%`,
-      },
-      [mediaQueries.sm]: {
-        flex: `1 1 33%`,
-        maxWidth: `33%`,
-      },
+      flex: [null, `1 1 50%`, null, `1 1 33%`],
+      maxWidth: [null, null, null, `33%`],
     }}
   >
     <div
@@ -181,13 +174,10 @@ const Gatsby = () => (
       src={logo}
       sx={{
         display: `inline-block`,
-        height: t => t.space[8],
+        height: [t => t.space[8], null, null, null, t => t.space[9]],
         margin: 0,
         verticalAlign: `middle`,
         width: `auto`,
-        [mediaQueries.lg]: {
-          height: t => t.space[9],
-        },
       }}
       alt="Gatsby"
     />
@@ -237,10 +227,6 @@ const Diagram = () => (
           sx={{
             fontWeight: `heading`,
             mb: 6,
-            mt: 0,
-            [mediaQueries.md]: {
-              mt: 6,
-            },
           }}
         >
           How Gatsby works

--- a/www/src/components/docs-breadcrumb.js
+++ b/www/src/components/docs-breadcrumb.js
@@ -6,7 +6,6 @@ import ChevronRight from "react-icons/lib/md/chevron-right"
 import ChevronLeft from "react-icons/lib/md/chevron-left"
 import getActiveItem from "../utils/sidebar/get-active-item"
 import getActiveItemParents from "../utils/sidebar/get-active-item-parents"
-import { mediaQueries } from "../gatsby-plugin-theme-ui"
 
 const Separator = ({ character = <ChevronRight /> }) => (
   <span sx={{ my: 0, mx: 1 }} role="presentation">
@@ -19,13 +18,13 @@ const BreadcrumbNav = ({ children, mobile = false }) => (
     aria-label="breadcrumb"
     sx={{
       color: `textMuted`,
-      display: `${mobile ? `inherit` : `none`}`,
+      display: [
+        `${mobile ? `inherit` : `none`}`,
+        null,
+        `${mobile ? `none` : `inherit`}`,
+      ],
       fontSize: 1,
-      mb: 6,
-      [mediaQueries.md]: {
-        display: `${mobile ? `none` : `inherit`}`,
-        mb: 8,
-      },
+      mb: [6, null, 8],
     }}
   >
     {children}

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -2,7 +2,6 @@
 import { jsx } from "theme-ui"
 import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"
 
-import { mediaQueries } from "../gatsby-plugin-theme-ui"
 import Button from "./button"
 
 const MastheadContent = () => (
@@ -11,9 +10,9 @@ const MastheadContent = () => (
     sx={{
       margin: `0 auto`,
       px: 8,
-      py: 9,
+      py: [9, null, null, 12],
+      mb: [null, null, null, 6],
       textAlign: `center`,
-      [mediaQueries.md]: { py: 12 },
     }}
   >
     <h1
@@ -33,13 +32,12 @@ const MastheadContent = () => (
       sx={{
         color: `text`,
         fontFamily: `header`,
-        fontSize: 4,
+        fontSize: [4, 5],
         lineHeight: `dense`,
         maxWidth: `45rem`,
         mb: 10,
         mt: 0,
         mx: `auto`,
-        [mediaQueries.sm]: { fontSize: 5 },
       }}
     >
       Gatsby is a free and open source framework based on React that helps

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -17,7 +17,7 @@ import DarkModeToggle from "../components/dark-mode-toggle"
 // on the baseline of the logo's wordmark
 const navItemTopOffset = `0.4rem`
 // theme-ui values
-const navItemHorizontalSpacing = [1, 1, 1, 2]
+const navItemHorizontalSpacing = [1, null, 2]
 
 const overrideDefaultMdLineHeight = {
   [mediaQueries.md]: {
@@ -142,11 +142,11 @@ const Navigation = ({ pathname }) => {
             display: `flex`,
             flexShrink: 0,
             height: `logo`,
-            mr: [1, 1, 1, 3],
+            mr: [1, null, 3],
             textDecoration: `none`,
             /* chop logo down to just the monogram for small screens */
-            width: [`24px`, `24px`, `24px`, `auto`],
-            overflow: [`hidden`, `hidden`, `hidden`, `visible`],
+            width: [`24px`, null, `auto`],
+            overflow: [`hidden`, null, `visible`],
           }}
           aria-label="Gatsby, Back to homepage"
         >

--- a/www/src/components/page-with-sidebar.js
+++ b/www/src/components/page-with-sidebar.js
@@ -3,7 +3,6 @@ import { jsx } from "theme-ui"
 import { Fragment } from "react"
 
 import StickyResponsiveSidebar from "./sidebar/sticky-responsive-sidebar"
-import { mediaQueries } from "../gatsby-plugin-theme-ui"
 
 export default props => {
   if (props.disable) {
@@ -13,8 +12,13 @@ export default props => {
       <Fragment>
         <div
           sx={{
-            [mediaQueries.md]: { pl: t => t.sizes.sidebarWidth.default },
-            [mediaQueries.lg]: { pl: t => t.sizes.sidebarWidth.large },
+            pl: [
+              null,
+              null,
+              null,
+              t => t.sizes.sidebarWidth.default,
+              t => t.sizes.sidebarWidth.large,
+            ],
           }}
         >
           {props.renderContent()}

--- a/www/src/components/plugin-searchbar-body.js
+++ b/www/src/components/plugin-searchbar-body.js
@@ -195,14 +195,7 @@ const searchBoxStyles = t => css`
 class Search extends Component {
   render() {
     return (
-      <div
-        sx={{
-          pb: 11,
-          [mediaQueries.md]: {
-            pb: 0,
-          },
-        }}
-      >
+      <div sx={{ pb: [11, null, null, 0] }}>
         <div
           sx={{
             borderBottomWidth: `1px`,

--- a/www/src/components/search-form.js
+++ b/www/src/components/search-form.js
@@ -383,20 +383,13 @@ class SearchForm extends Component {
           alignItems: `flex-end`,
           justifyContent: `flex-end`,
           display: `flex`,
-          flex: [
-            `1 1 auto`,
-            `1 1 auto`,
-            `1 0 auto`,
-            `1 0 auto`,
-            `0 0 auto`,
-            `1 0 auto`,
-          ],
+          flex: [`1 1 auto`, null, `1 0 auto`, null, `0 0 auto`, `1 0 auto`],
           flexDirection: `row`,
           mb: 0,
-          mx: [3, 3, 3, 3, 4],
+          mx: [3, null, null, 4],
           position: `relative`,
-          // minWidth: [null, null, null, null, null, `12rem`],
-          // maxWidth: [`100%`, `100%`, `100%`, `100%`, null, `24rem`],
+          // minWidth: [null, null, null, null, `12rem`],
+          // maxWidth: [`100%`, `100%`, `100%`, null, `24rem`],
           "& .algolia-autocomplete": {
             width: `100%`,
             display: `block !important`,
@@ -411,14 +404,7 @@ class SearchForm extends Component {
         <label
           sx={{
             position: `relative`,
-            width: [
-              `100%`,
-              `100%`,
-              `100%`,
-              `100%`,
-              focussed ? `14rem` : 24,
-              `100%`,
-            ],
+            width: [`100%`, `100%`, `100%`, focussed ? `14rem` : 24, `100%`],
             transition: t =>
               `width ${t.transition.speed.default} ${t.transition.curve.default}, padding ${t.transition.speed.default} ${t.transition.curve.default}`,
           }}
@@ -429,21 +415,13 @@ class SearchForm extends Component {
               ...themedInput,
               bg: [
                 `themedInput.background`,
-                `themedInput.background`,
-                `themedInput.background`,
-                `themedInput.background`,
+                null,
+                null,
                 focussed ? `themedInput.background` : `transparent`,
                 `themedInput.background`,
               ],
-              pl: [7, 7, 7, 7, focussed ? 7 : 24, 7],
-              width: [
-                `100%`,
-                `100%`,
-                `100%`,
-                `100%`,
-                focussed ? `14rem` : 24,
-                `100%`,
-              ],
+              pl: [7, null, null, focussed ? 7 : 24, 7],
+              width: [`100%`, null, null, focussed ? `14rem` : 24, `100%`],
               transition: t =>
                 `width ${t.transition.speed.default} ${t.transition.curve.default}, padding ${t.transition.speed.default} ${t.transition.curve.default}`,
             }}

--- a/www/src/gatsby-plugin-theme-ui/index.js
+++ b/www/src/gatsby-plugin-theme-ui/index.js
@@ -24,6 +24,11 @@ for (let b in bp) {
   breakpointsTokens.push(bp[b])
 }
 
+// remove the first breakpoint, `xxs: 0`
+// this made sense for styled-system and using an object
+// to define breakpoints, but not here
+breakpointsTokens.splice(0, 1)
+
 let fontsTokens = {}
 for (let fontFamily in f) {
   fontsTokens[fontFamily] = f[fontFamily].join(`, `)

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -176,7 +176,7 @@ class BlogPostTemplate extends React.Component {
                   order: 0,
                   letterSpacing: `tight`,
                   lineHeight: `dense`,
-                  fontSize: [5, 6, 7, 8, 9, 11],
+                  fontSize: [6, 7, 8, 9, 11],
                   [mediaQueries.lg]: {
                     mb: 8,
                   },

--- a/www/src/templates/template-starter-page.js
+++ b/www/src/templates/template-starter-page.js
@@ -1,8 +1,9 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
 import React from "react"
 import { Helmet } from "react-helmet"
 import { graphql } from "gatsby"
 
-import { mediaQueries } from "../gatsby-plugin-theme-ui"
 import Layout from "../components/layout"
 import StarterHeader from "../views/starter/header"
 import StarterMeta from "../views/starter/meta"
@@ -94,12 +95,9 @@ class StarterTemplate extends React.Component {
             </Helmet>
             <StarterHeader stub={starterShowcase.stub} />
             <div
-              css={{
+              sx={{
                 display: `flex`,
-                flexDirection: `column-reverse`,
-                [mediaQueries.sm]: {
-                  flexDirection: `column`,
-                },
+                flexDirection: [`column-reverse`, `column`],
               }}
             >
               <StarterMeta


### PR DESCRIPTION
The first breakpoint we get from `gatsby-design-tokens` breakpoints object is `xxs: 0`.
While this did make sense in the context of `styled-system`, it creates an unnecessary breakpoint in the context of `theme-ui`, which provides this "default" breakpoint for us already.

Switch a couple of `mediaQuery` usages to theme-ui's array syntax.

(Ref. #18027)