### PR TITLE
chore(gatsby-plugin-typescript): Update Caveats

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -63,6 +63,10 @@ compiler is not involved, the following applies:
 > cannot be compiled to ES.next. Workaround: Convert
 > to using export default and export const,
 > and import x, {y} from "z".
+>
+> Does not support baseUrl.
+> Workaround: use [gatsby-plugin-root-import](https://www.gatsbyjs.org/packages/gatsby-plugin-root-import/)
+> and configure it to point the baseUrl value (also set baseUrl option in tsconfig.json file).
 
 https://babeljs.io/docs/en/babel-plugin-transform-typescript.html
 

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -63,10 +63,6 @@ compiler is not involved, the following applies:
 > cannot be compiled to ES.next. Workaround: Convert
 > to using export default and export const,
 > and import x, {y} from "z".
->
-> Does not support baseUrl.
-> Workaround: use [gatsby-plugin-root-import](/packages/gatsby-plugin-root-import/)
-> and configure it to point the baseUrl value (also set baseUrl option in tsconfig.json file).
 
 https://babeljs.io/docs/en/babel-plugin-transform-typescript.html
 

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -63,9 +63,8 @@ compiler is not involved, the following applies:
 > cannot be compiled to ES.next. Workaround: Convert
 > to using export default and export const,
 > and import x, {y} from "z".
->	
-> Does not support baseUrl.	
-> Workaround: use [gatsby-plugin-root-import](https://www.gatsbyjs.org/packages/gatsby-plugin-root-import/)	
+> Does not support baseUrl.
+> Workaround: use [gatsby-plugin-root-import](https://www.gatsbyjs.org/packages/gatsby-plugin-root-import/)
 > and configure it to point the baseUrl value (also set baseUrl option in tsconfig.json file).
 
 https://babeljs.io/docs/en/babel-plugin-transform-typescript.html

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -65,7 +65,7 @@ compiler is not involved, the following applies:
 > and import x, {y} from "z".
 >
 > Does not support baseUrl.
-> Workaround: use [gatsby-plugin-root-import](https://www.gatsbyjs.org/packages/gatsby-plugin-root-import/)
+> Workaround: use [gatsby-plugin-root-import](/packages/gatsby-plugin-root-import/)
 > and configure it to point the baseUrl value (also set baseUrl option in tsconfig.json file).
 
 https://babeljs.io/docs/en/babel-plugin-transform-typescript.html

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -63,6 +63,10 @@ compiler is not involved, the following applies:
 > cannot be compiled to ES.next. Workaround: Convert
 > to using export default and export const,
 > and import x, {y} from "z".
+>	
+> Does not support baseUrl.	
+> Workaround: use [gatsby-plugin-root-import](/packages/gatsby-plugin-root-import/)	
+> and configure it to point the baseUrl value (also set baseUrl option in tsconfig.json file).
 
 https://babeljs.io/docs/en/babel-plugin-transform-typescript.html
 

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -65,7 +65,7 @@ compiler is not involved, the following applies:
 > and import x, {y} from "z".
 >	
 > Does not support baseUrl.	
-> Workaround: use [gatsby-plugin-root-import](/packages/gatsby-plugin-root-import/)	
+> Workaround: use [gatsby-plugin-root-import](https://www.gatsbyjs.org/packages/gatsby-plugin-root-import/)	
 > and configure it to point the baseUrl value (also set baseUrl option in tsconfig.json file).
 
 https://babeljs.io/docs/en/babel-plugin-transform-typescript.html

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -63,6 +63,7 @@ compiler is not involved, the following applies:
 > cannot be compiled to ES.next. Workaround: Convert
 > to using export default and export const,
 > and import x, {y} from "z".
+>
 > Does not support baseUrl.
 > Workaround: use [gatsby-plugin-root-import](https://www.gatsbyjs.org/packages/gatsby-plugin-root-import/)
 > and configure it to point the baseUrl value (also set baseUrl option in tsconfig.json file).


### PR DESCRIPTION
## Description

I just add some lines to make developers aware `baseUrl` option not work. actually it works perfectly but not in the way we expected.
since `babel-plugin-transform-typescript` is not transpiling our code when babel AST visits import statements like blow it just bailout.
```
import Foo from "components/Foo"
```

to fix this problem we simply add `src` directory to webpack `resolve.alias` config.

maybe add a section about this in `gatsby-plugin-root-import` whould be good idea, or adding a new feture to `gatsby-plugin-root-import` so it can read value of `baseUrl` and `paths` from `tsconfig.json` or `jsconfig.json` just like `create-react-app`.