### PR TITLE
Remove title case from the heading to match the sidebar menu

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Styling in Gatsby
+title: Introduction to styling in Gatsby
 typora-copy-images-to: ./
 disableTableOfContents: true
 ---


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The sidebar menu doesn't have steps denoted by title case, but the page itself still has the title with the title case capitalization. This edit makes the two match up.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
