### PR TITLE
Add step to check node version

### DIFF
--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -19,6 +19,7 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
 
 ## Gatsby repo install instructions
 
+- Ensure you have the latest version of Node installed (>= 10.16.0). `node --version`
 - [Install](https://yarnpkg.com/en/docs/install) the Yarn package manager.
 - Ensure you have the latest version of Yarn installed (>= 1.0.2). `yarn --version`
 - Fork the [official repository](https://github.com/gatsbyjs/gatsby).


### PR DESCRIPTION
When running yarn run bootstrap on a node version older than 10.16, there is console output letting you know to update node, but it is very high up in the logs, not colorized, and easy to miss. You probably won't realize something is wrong until you run yarn run test and see ~65 tests failing. This can take a bit of time to solve for first-time contributors.

## Description

Add a step in environment setup to check that you are using the latest node version. 

## Related Issues

Fixes [#18550](https://github.com/gatsbyjs/gatsby/issues/18550)
