### PR TITLE
fix(www): Main nav partially active state; improve dark mode contrast, ToC (dark mode aftercare, episode 5)

### DIFF
--- a/www/src/components/docs-table-of-contents.js
+++ b/www/src/components/docs-table-of-contents.js
@@ -50,7 +50,7 @@ function createItems(items, location, depth, maxDepth) {
           {item.title}
         </Link>
         {item.items && isUnderDepthLimit(depth, maxDepth) && (
-          <ul sx={{ ml: 6 }}>
+          <ul sx={{ color: `textMuted`, listStyle: `none`, ml: 5 }}>
             {createItems(item.items, location, depth + 1, maxDepth)}
           </ul>
         )}
@@ -61,24 +61,35 @@ function createItems(items, location, depth, maxDepth) {
 
 function TableOfContents({ page, location }) {
   return page.tableOfContents.items ? (
-    <nav>
+    <nav
+      sx={{
+        mb: [8, null, null, null, null, 0],
+        pb: [6, null, null, null, null, 0],
+        borderBottom: t => [
+          `1px solid ${t.colors.ui.border}`,
+          null,
+          null,
+          null,
+          null,
+          0,
+        ],
+      }}
+    >
       <h2
         sx={{
-          textTransform: `uppercase`,
-          fontSize: 1,
           color: `textMuted`,
+          fontSize: 1,
           letterSpacing: `tracked`,
           mt: 0,
+          textTransform: `uppercase`,
         }}
       >
         Table of Contents
       </h2>
       <ul
         sx={{
-          [mediaQueries.xl]: {
-            listStyle: `none`,
-            m: 0,
-          },
+          listStyle: `none`,
+          m: 0,
         }}
       >
         {createItems(

--- a/www/src/components/masthead.js
+++ b/www/src/components/masthead.js
@@ -17,7 +17,7 @@ const MastheadContent = () => (
   >
     <h1
       sx={{
-        fontSize: `calc(16px + 1vh + 2.25vw)`,
+        fontSize: `calc(28px + 0.5vh + 1.5vw)`,
         letterSpacing: `tight`,
         lineHeight: `solid`,
         maxWidth: `15em`,

--- a/www/src/components/navigation.js
+++ b/www/src/components/navigation.js
@@ -51,6 +51,7 @@ const NavItem = ({ linkTo, children }) => (
     <Link
       to={linkTo}
       activeClassName="active"
+      partiallyActive={true}
       sx={{
         ...navItemStyles,
         "&.active": {

--- a/www/src/components/package-readme.js
+++ b/www/src/components/package-readme.js
@@ -33,7 +33,7 @@ const PackageReadMe = props => {
             display: `flex`,
             flexWrap: `wrap`,
             justifyContent: `space-between`,
-            pb: 9,
+            pb: 6,
             "&&:hover": {
               color: `inherit`,
             },

--- a/www/src/gatsby-plugin-theme-ui/index.js
+++ b/www/src/gatsby-plugin-theme-ui/index.js
@@ -47,7 +47,7 @@ const lineHeightsTokens = {
   heading: lh.dense,
 }
 
-const darkBackground = `#111014` // meh
+const darkBackground = `#131217` // meh
 const darkBorder = c.grey[90]
 // const darkBackground = c.purple[90]
 // const darkBorder = c.purple[80]
@@ -211,8 +211,8 @@ const col = {
   modes: {
     dark: {
       background: darkBackground,
-      text: c.grey[20],
-      heading: c.white,
+      text: c.grey[30],
+      heading: c.whiteFade[90],
       textMuted: c.grey[40],
       banner: hex2rgba(c.purple[90], 0.975),
       muted: c.grey[90],

--- a/www/src/utils/typography.js
+++ b/www/src/utils/typography.js
@@ -10,8 +10,8 @@ const _options = {
   headerFontFamily: fonts.header,
   baseLineHeight: lineHeights.body,
   headerLineHeight: lineHeights.heading,
-  headerColor: colors.text.header,
-  bodyColor: colors.text.primary,
+  headerColor: colors.heading,
+  bodyColor: colors.text,
   plugins: [new CodePlugin()],
 }
 


### PR DESCRIPTION
- Bring back main nav items' `partiallyActive` state
- Reduce dark mode text, heading, background contrast
- Fix undefined vars in `typography.js`
- Reduce whitespace below plugin meta
- Adjust homepage masthead font size
- Tweak "inline ToC" bottom margin, add border; set `list-style` to `none`

(Ref. #18027)