### PR TITLE
fix(www): Add bottom spacing to center the close button

### DIFF
--- a/www/src/components/guidelines/color/modal.js
+++ b/www/src/components/guidelines/color/modal.js
@@ -196,6 +196,7 @@ const ColorModal = ({ palette, color, handleModalClose }) => {
         <CloseButton
           onClick={handleModalClose}
           aria-label={`Close “${palette[color].name}” modal`}
+          paddingBottom="6"
         >
           &times;
         </CloseButton>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The x in the close button (when you hover), on the modal that shows up when you click on a color in the guidelines page (https://www.gatsbyjs.org/guidelines/color/) is not vertically centered.

<img width="70" alt="Screen Shot 2019-10-12 at 2 37 09 PM" src="https://user-images.githubusercontent.com/2272928/66706877-3a91e900-ecfe-11e9-855b-24967e469df8.png">

The reason is that, that "x" is a character (lower case one), and that character includes some top whitespace.

When you inspect it, you can see that the letter element is actually centered:

<img width="75" alt="Screen Shot 2019-10-12 at 2 36 59 PM" src="https://user-images.githubusercontent.com/2272928/66706881-3fef3380-ecfe-11e9-8990-156a991cc319.png">

This pr adds some bottom padding to counter the letter top spacing (only to that specific button, so it doesn't break any current and future buttons made with that same component, via a prop that the styled component receives) and makes it look like this.

<img width="68" alt="Screen Shot 2019-10-12 at 2 37 49 PM" src="https://user-images.githubusercontent.com/2272928/66706898-69a85a80-ecfe-11e9-835d-39458510ae9f.png">


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
