### PR TITLE
fix(www): Fix heading color on dark theme

### DIFF
--- a/www/src/gatsby-plugin-theme-ui/index.js
+++ b/www/src/gatsby-plugin-theme-ui/index.js
@@ -212,7 +212,7 @@ const col = {
     dark: {
       background: darkBackground,
       text: c.grey[30],
-      heading: c.whiteFade[90],
+      heading: c.whiteFade[80],
       textMuted: c.grey[40],
       banner: hex2rgba(c.purple[90], 0.975),
       muted: c.grey[90],


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
As per https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-design-tokens/src/colors.js  whiteFade colors go only up to 80.

I think this is the reason for unreadable titles on the [Ecosystem](https://www.gatsbyjs.org/ecosystem/) page in dark mode:

![image](https://user-images.githubusercontent.com/27918662/66709347-3b5c6680-ed62-11e9-98a2-80b4ed94729d.png)
