### PR TITLE
fix(gatsby-source-drupal): add error handling for empty body

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -195,7 +195,7 @@ exports.onCreateDevServer = (
           pluginOptions
         )
       } else {
-        res.status(500).send(`Received body was empty!`)
+        res.status(400).send(`Received body was empty!`)
       }
     }
   )

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -177,22 +177,26 @@ exports.onCreateDevServer = (
       type: `application/json`,
     }),
     async (req, res) => {
-      // we are missing handling of node deletion
-      const nodeToUpdate = JSON.parse(JSON.parse(req.body)).data
+      if (!_.isEmpty(req.body)) {
+        // we are missing handling of node deletion
+        const nodeToUpdate = JSON.parse(JSON.parse(req.body)).data
 
-      await handleWebhookUpdate(
-        {
-          nodeToUpdate,
-          actions,
-          cache,
-          createNodeId,
-          createContentDigest,
-          getNode,
-          reporter,
-          store,
-        },
-        pluginOptions
-      )
+        await handleWebhookUpdate(
+          {
+            nodeToUpdate,
+            actions,
+            cache,
+            createNodeId,
+            createContentDigest,
+            getNode,
+            reporter,
+            store,
+          },
+          pluginOptions
+        )
+      } else {
+        res.status(500).send(`Received body was empty!`)
+      }
     }
   )
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
While I was testing the preview functionality of the development server, it completely broke when an empty body was sent. With this PR it now will rather return a `500` Server Error.

## Related Issues

I reckoned this too small a change to open an issue for it ; ).

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
