### PR TITLE
chore(docs): Remove extraneous words from gatsby-repl

### DIFF
--- a/docs/docs/gatsby-repl.md
+++ b/docs/docs/gatsby-repl.md
@@ -83,7 +83,7 @@ gatsby > getNode('SitePage /404.html')
 
 ### `getNodes()`
 
-Returns an array of objects (the nodes). Because this is
+Returns an array of objects (the nodes).
 
 Usage: `getNodes()`
 


### PR DESCRIPTION
Removing an extra unfinished line at getNodes().

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
There was an unfinished sentence under getNodes(). Removing that.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
Not found
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
