### PR TITLE
chore(docs): Update pronouns in gatsby-cli

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -13,7 +13,7 @@ The Gatsby CLI (`gatsby-cli`) is packaged as an executable that can be used glob
 
 Run `gatsby --help` for full help.
 
-You can also use the `package.json` script variant of these commands, typically exposed _for you_ with most [starters](/docs/starters/). For example, if we want to make the [`gatsby develop`](#develop) command available in our application, we would open up `package.json` and add a script like so:
+You can also use the `package.json` script variant of these commands, typically exposed _for you_ with most [starters](/docs/starters/). For example, if you want to make the [`gatsby develop`](#develop) command available in your application, open up `package.json` and add a script like so:
 
 ```json:title=package.json
 {


### PR DESCRIPTION
Adhering to Gatsby Style Guide: Update pronouns in a doc to use "you" and "your" instead of "we" and "our"

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Adhering to Gatsby Style Guide: Update pronouns in a doc to use "you" and "your" instead of "we" and "our"
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
[docs] Gatsby Style Guide blitz for those new to open source #18284
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
