### PR TITLE
Add title in Customizing the GraphQL Schema

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -1,4 +1,6 @@
-# Customizing the GraphQL Schema
+---
+title: Customizing the GraphQL Schema
+---
 
 One of Gatsby's main strengths is the ability to query data from a variety of
 sources in a uniform way with GraphQL. For this to work, a GraphQL Schema must


### PR DESCRIPTION
Move title from H1 to frontmatter so the page title is set properly and shows in the browser tab as "Customizing the GraphQL Schema | GatsbyJS" instead of just "GatsbyJS".
