### PR TITLE
fix(showcase): re-add categories and other metadata after weird master merge

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -7702,6 +7702,15 @@
   source_url: https://github.com/AtomBuild/atombuild.github.io
   description: >
     Landing page for the AtomBuild project, offering a curation of Atom packages associated with the project.
+  categories:
+    - Directory
+    - Landing Page
+    - Open Source
+    - Programming
+    - Technology
+  built_by: Kepler Sticka-Jones
+  built_by_url: https://keplersj.com/
+  featured: false
 - title: Josh Pensky
   main_url: https://joshpensky.com
   url: https://joshpensky.com


### PR DESCRIPTION
seems like master merge in https://github.com/gatsbyjs/gatsby/pull/18417 removed categoried, built_by, etc from that PR because there was very similar entry for other site