### PR TITLE
[docs] improving Themes completeness

### DIFF
--- a/docs/docs/themes/what-are-gatsby-themes.md
+++ b/docs/docs/themes/what-are-gatsby-themes.md
@@ -33,7 +33,7 @@ Themes solve the problems that traditional starters experience:
 
 - You already have an existing Gatsby site and can't start from a starter
 - You want to be able to update to the latest version of a feature on your site
-- You have multiple features you want on your site, but there is no starter for all the features -- you can use multiple themes in one Gatsby site
+- You want multiple features on your site, but there is no starter with all the features -- you can use multiple themes, composed in one Gatsby site
 
 **Consider building a theme if:**
 

--- a/docs/docs/themes/what-are-gatsby-themes.md
+++ b/docs/docs/themes/what-are-gatsby-themes.md
@@ -27,11 +27,28 @@ Themes solve the problems that traditional starters experience:
 
 > A Gatsby theme is effectively a composable Gatsby config. They provide a higher-level approach to working with Gatsby that abstracts away the complex or repetitive parts into a reusable package.
 
+## When should I use or build a theme?
+
+**Consider using a theme if:**
+
+- You already have an existing Gatsby site and can't start from a starter
+- You want to be able to update to the latest version of a feature on your site
+- You have multiple features you want on your site, but there is no starter for all the features -- you can use multiple themes in one Gatsby site
+
+**Consider building a theme if:**
+
+- You plan on re-using similar functionality across multiple Gatsby sites
+- You would like to share new Gatsby functionality to the community
+
 ## What's next?
 
 - [Using a Gatsby Theme](/docs/themes/using-a-gatsby-theme)
 - [Using Multiple Gatsby Themes](/docs/themes/using-multiple-gatsby-themes)
+- [Shadowing](/docs/themes/shadowing/)
 - [Building Themes](/docs/themes/building-themes)
+- [Converting a Starter](/docs/themes/converting-a-starter/)
+- [Theme Composition](/docs/themes/theme-composition/)
+- [Conventions](/docs/themes/conventions/)
 
 ## Related blog posts
 


### PR DESCRIPTION
## Description

The objective of this PR is to improve the completeness of the current Themes documentation.

- Add explanation of when to use themes vs. starters
<img width="739" alt="Screen Shot 2019-10-14 at 1 49 38 AM" src="https://user-images.githubusercontent.com/41944255/66739280-39a7a700-ee25-11e9-8abe-9b2106b5ed40.png">

- Add all themes sections to "What's next?"
<img width="379" alt="Screen Shot 2019-10-14 at 1 49 42 AM" src="https://user-images.githubusercontent.com/41944255/66739301-44623c00-ee25-11e9-8d84-1d78fae1dddb.png">


## Related Issues

Part of the Top 25 Workflows, #9 - "Using Gatsby Themes" #18242
