### PR TITLE
Don't remove an ending / to calculate a correct score

### DIFF
--- a/packages/gatsby/src/bootstrap/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/requires-writer.js
@@ -27,7 +27,7 @@ const getComponents = pages =>
  */
 const getMatchPaths = pages => {
   const createMatchPathEntry = (page, index) => {
-    let score = page.matchPath.replace(/\/$/, ``).split(`/`).length
+    let score = page.matchPath.split(`/`).length
     if (!page.matchPath.includes(`*`)) {
       score += 1
     }


### PR DESCRIPTION
## Description

When calculating the score of matchPath, the system is removing ending slashes.
This leads to following scores:
- /uk/ => 3
- /uk/* => 3

It has the same score, but as a result, my 404 /uk/* is ending up before the /uk, because the onCreatePage comes before the createPages hook. The result is a 404 on the homepage/

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/18604


