### PR TITLE
fix(gatsby-cli): work around react-redux hidden dependency on react-dom

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
@@ -1,6 +1,7 @@
 describe(`hot reloading new page component`, () => {
   before(() => {
     cy.exec(`npm run update -- --file src/pages/sample.js`)
+    cy.wait(1000)
   })
 
   beforeEach(() => {

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
@@ -1,6 +1,9 @@
 describe(`hot reloading new page component`, () => {
   before(() => {
     cy.exec(`npm run update -- --file src/pages/sample.js`)
+    // TO-DO remove `wait` below and fix this properly in core,
+    // we shouldn't have to wait here and core
+    // should be smart enough to recover on it's own.
     cy.wait(1000)
   })
 

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -38,6 +38,7 @@
     "progress": "^2.0.3",
     "prompts": "^2.2.1",
     "react": "^16.10.2",
+    "react-dom": "^16.10.2",
     "react-redux": "^7.1.1",
     "redux": "^4.0.4",
     "resolve-cwd": "^2.0.0",


### PR DESCRIPTION
This is super weird - `react-redux` his hidden dependency on `react-dom`, and we didn't caught that because we weren't installing cli globally (it worked because `react-dom` was available in monorepo node_modules or in project directory)

fixes #18603