### PR TITLE
Updated babel.md to adhere to gatsby style guide

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -10,8 +10,8 @@ support for writing modern JavaScript — while still supporting older browsers.
 Gatsby supports by default the last two versions of major browsers, IE 9+, as well as
 any browser that still has 1%+ browser share.
 
-This means we automatically compile your JavaScript to ensure it works on older browsers.
-We also automatically add polyfills as needed — no more shipping code which mysteriously
+This means you automatically compile your JavaScript to ensure it works on older browsers.
+you also automatically add polyfills as needed — no more shipping code which mysteriously
 breaks on older browsers!
 
 If you only target newer browsers, see the [Browser


### PR DESCRIPTION
# Description
Mainly change `we` to `you`

# Related Issue
#18284