### PR TITLE
grouping together minor updates in renovate.json rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,10 @@
     {
       "groupName": "minor updates in packages",
       "updateTypes": ["minor"]
+    },
+    {
+      "groupName": "patch updates in packages",
+      "updateTypes": ["patch"]
     }
   ],
   "timezone": "GMT",

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,12 @@
   "bumpVersion": null,
   "semanticCommitScope": null,
   "prHourlyLimit": 0,
+  "packageRules": [
+    {
+      "groupName": "minor updates in packages",
+      "updateTypes": ["minor"]
+    }
+  ],
   "timezone": "GMT",
   "schedule": "after 10am on Monday"
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Adding Renovate grouping rule to batch all minor updates in a single PR

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/18615
