### PR TITLE
test(structured-logging): fix gatsby version in test site

### DIFF
--- a/integration-tests/structured-logging/package.json
+++ b/integration-tests/structured-logging/package.json
@@ -10,7 +10,7 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
-    "gatsby": "2.15.34-dev-1570799776640",
+    "gatsby": "^2.16.0",
     "gray-percentage": "^2.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"


### PR DESCRIPTION
This fixes test failing on lot of PRs - structured logging PR was merged with package.json using dev version instead of regular one, and now CI can't install gatsby if there are no dependency changes