### PR TITLE
chore(showcase): add opensourcegalaxy.com to showcases

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -7846,3 +7846,15 @@
   built_by: Arturo Alviar
   built_by_url: "https://github.com/arturoalviar"
   featured: false
+- title: Open Source Galaxy
+  main_url: https://www.opensourcegalaxy.com
+  url: https://www.opensourcegalaxy.com
+  description: >
+    Explore the Open Source Galaxy and help other earthlings by contributing to open source.
+  categories:
+    - Open Source
+    - Programming
+    - Web Development
+  built_by: Justin Juno
+  built_by_url: https://www.justinjuno.dev
+  featured: false


### PR DESCRIPTION
## Description
Adding [Open Source Galaxy](https://www.opensourcegalaxy.com) to the Gatsby showcase. 

With Open Source Galaxy you can explore the latest Github issues by popular languages/labels and help other earthlings by contributing to open source. 

## Related Issues
No issues or concerns at this time. 
