### PR TITLE
chore(issue-templates): add comma after otherwise

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Something isn't working as expected? Here is the right place to report.
 ---
 
 <!--
-  Please fill out each section below, otherwise your issue will be closed. This info allows Gatsby maintainers to diagnose (and fix!) your issue as quickly as possible.
+  Please fill out each section below, otherwise, your issue will be closed. This info allows Gatsby maintainers to diagnose (and fix!) your issue as quickly as possible.
 
   Useful Links:
   - Documentation: https://www.gatsbyjs.org/docs/

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest a new idea for the project.
 ---
 
 <!--
-  Please fill out each section below, otherwise your issue will be closed.
+  Please fill out each section below, otherwise, your issue will be closed.
 
   Useful Links:
   - Gatsby RFCs: https://github.com/gatsbyjs/rfcs

--- a/.github/ISSUE_TEMPLATE/new_translation.md
+++ b/.github/ISSUE_TEMPLATE/new_translation.md
@@ -4,7 +4,7 @@ about: Suggest a new language translation of the repo.
 ---
 
 <!--
-  Please fill out the YAML form below, otherwise your issue will be closed.
+  Please fill out the YAML form below, otherwise, your issue will be closed.
 
   - *Name*: Language name in *English*
   - *Code*: [ISO-693 Code]() or [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) of the language


### PR DESCRIPTION
## Description

Grammarly seems to have a very strong opinion about adding a comma after a word `otherwise` in some of the issue templates. English is not my native so I'm not sure if it really is an error, but after a quick research, I believe that both versions are acceptable so I'd go with the one with a comma just to make the warning disappear.

<img width="763" alt="Zrzut ekranu 2019-10-14 o 23 23 25" src="https://user-images.githubusercontent.com/23037261/66784044-a67c7900-eed9-11e9-984f-a2c6230e64e4.png">

