### PR TITLE
chore(docs): Fix tutorial part 8 react helmet step 4

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -309,7 +309,7 @@ export default ({ data }) => {
       // highlight-start
       <SEO
         title={post.frontmatter.title}
-        description={post.frontmatter.excerpt}
+        description={post.excerpt}
       />
       // highlight-end
       <div>
@@ -326,9 +326,9 @@ export const query = graphql`
       html
       frontmatter {
         title
-        // highlight-next-line
-        excerpt
       }
+      // highlight-next-line
+      excerpt
     }
   }
 `

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -307,10 +307,7 @@ export default ({ data }) => {
   return (
     <Layout>
       // highlight-start
-      <SEO
-        title={post.frontmatter.title}
-        description={post.excerpt}
-      />
+      <SEO title={post.frontmatter.title} description={post.excerpt} />
       // highlight-end
       <div>
         <h1>{post.frontmatter.title}</h1>


### PR DESCRIPTION
## Description

On following the [tutorial 08](https://www.gatsbyjs.org/tutorial/part-eight/#add-page-metadata) in Step 4, `gatsby develop` crashes and this error is thrown.

![image](https://user-images.githubusercontent.com/21246070/66829482-8645cc00-ef64-11e9-88c6-dcdfc317dfd4.png)

On running this query in GraphiQL,
```
{
  markdownRemark(fields: { slug: { eq: "/pandas-and-bananas/" } }) {
    html
    frontmatter {
      title
      excerpt
    }
  }
}
```

I get the error as :
```
{
  "errors": [
    {
      "message": "Cannot query field \"excerpt\" on type \"MarkdownRemarkFrontmatter\".",
      "locations": [
        {
          "line": 6,
          "column": 7
        }
      ],
      "stack": [
        "GraphQLError: Cannot query field \"excerpt\" on type \"MarkdownRemarkFrontmatter\".",
        "    at Object.Field (/Users/devs1993/Desktop/Develop/gatsby/jo/node_modules/graphql/validation/rules/FieldsOnCorrectType.js:53:31)",
        "    at Object.enter (/Users/devs1993/Desktop/Develop/gatsby/jo/node_modules/graphql/language/visitor.js:324:29)",
        "    at Object.enter (/Users/devs1993/Desktop/Develop/gatsby/jo/node_modules/graphql/language/visitor.js:375:25)",
        "    at visit (/Users/devs1993/Desktop/Develop/gatsby/jo/node_modules/graphql/language/visitor.js:242:26)",
        "    at validate (/Users/devs1993/Desktop/Develop/gatsby/jo/node_modules/graphql/validation/validate.js:73:24)",
        "    at getGraphQLParams.then.then.optionsData (/Users/devs1993/Desktop/Develop/gatsby/jo/node_modules/express-graphql/index.js:121:32)",
        "    at process._tickCallback (internal/process/next_tick.js:178:7)"
      ]
    }
  ]
}
```

The changes in this PR should make the code work as the tutorial intended and add the description to the site metadata.