### PR TITLE
Ability to transform external graphql schemas client-side

### DIFF
--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -96,7 +96,7 @@ exports.sourceNodes = async (
     })
     return {}
   }
-  
+
   let resultSchema = remoteSchema
   if (customSchemaTransformer) {
     resultSchema = customSchemaTransformer(remoteSchema)

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -26,10 +26,10 @@ exports.sourceNodes = async (
     fieldName,
     headers = {},
     fetchOptions = {},
-    customSchemaTransfomer,
     createLink,
     createSchema,
     refetchInterval,
+    customSchemaTransformer,
   } = options
 
   invariant(
@@ -97,9 +97,9 @@ exports.sourceNodes = async (
     return {}
   }
   
-  let resultSchema = remoteSchema;
-  if (customSchemaTransfomer){
-    resultSchema = customSchemaTransfomer(remoteSchema);
+  let resultSchema = remoteSchema
+  if (customSchemaTransformer) {
+    resultSchema = customSchemaTransformer(remoteSchema)
   }
 
   const schema = transformSchema(resultSchema, [

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -26,6 +26,7 @@ exports.sourceNodes = async (
     fieldName,
     headers = {},
     fetchOptions = {},
+    customSchemaTransfomer,
     createLink,
     createSchema,
     refetchInterval,
@@ -95,8 +96,13 @@ exports.sourceNodes = async (
     })
     return {}
   }
+  
+  let resultSchema = remoteSchema;
+  if (customSchemaTransfomer){
+    resultSchema = customSchemaTransfomer(remoteSchema);
+  }
 
-  const schema = transformSchema(remoteSchema, [
+  const schema = transformSchema(resultSchema, [
     new StripNonQueryTransform(),
     new RenameTypes(name => `${typeName}_${name}`),
     new NamespaceUnderFieldTransform({


### PR DESCRIPTION
## Description

This adds a callback to transform client-side an external graphql schema, to add for example custom resolvers when the schema doesn't natively support this.

Example:
```
const customTransformSchema = (schema) => {

  const linkTypeDefs = `
    extend type StructuredContentLink {
      content: StructuredContent
    }
  `;
  
  const customRemoteSchema = mergeSchemas({
    schemas: [schema, linkTypeDefs ],
    resolvers: {
      StructuredContentLink: {
        content: {
          resolve(source, _args, context, info) {
            return info.mergeInfo.delegateToSchema({
              schema: schema,
              operation: 'query',
              fieldName: 'structuredContent',
              args: {
                structuredContentId: source.id,
              },
              context,
              info,
            });
          },
        },
      },
    },
  });

  return customRemoteSchema;
}
```

In this example schema, the type StructuredContentLink contains a reference to a StructuredContent by id, but the schema does not allow to query inside the relation directly. The transform function extends the schema and adds a resolver that queries the linked node.

With this option it will be possible to create new relations in native graphql schemas, and it's entirely optional.

It's not possible to achieve the same result by using the existing createSchema option, since the modified schema would be linked to the remote source, and that would result in validation errors server-side.

## Related Issues

This is very similar, but about a relation between different third-party schemas: #10692.
