### PR TITLE
chore(docs): Replaced occurences of 'we' and 'our' with 'you' and 'your'

### DIFF
--- a/docs/tutorial/building-a-theme.md
+++ b/docs/tutorial/building-a-theme.md
@@ -274,7 +274,7 @@ When you execute the query, you should see the GraphQL server successfully retur
 
 Create a `gatsby-node.js` file in `gatsby-theme-events`.
 
-If you fire up our theme, and the "data" directory doesn't exist, `gatsby-source-filesystem` will throw an error. To guard against this, you'll use the `onPreBootstrap` API hook to check if the data directory exists, and, if not, create it:
+If you fire up your theme, and the "data" directory doesn't exist, `gatsby-source-filesystem` will throw an error. To guard against this, you'll use the `onPreBootstrap` API hook to check if the data directory exists, and, if not, create it:
 
 ```javascript:title=gatsby-theme-events/gatsby-node.js
 const fs = require("fs")
@@ -1047,7 +1047,7 @@ exports.createPages = async ({ actions, graphql, reporter }, options) => {
 }
 ```
 
-> 💡 Up till now, you've mostly worked in the `gatsby-theme-events` space. Because we've converted the theme to use a function export, we can no longer run the theme on its own. The function export in `gatsby-config.js` is only supported for themes. From now on you'll be running `site` -- the Gatsby site consuming `gatsby-theme-events`, instead. Gatsby sites still require the object export in `gatsby-config.js`.
+> 💡 Up till now, you've mostly worked in the `gatsby-theme-events` space. Because you've converted the theme to use a function export, you can no longer run the theme on its own. The function export in `gatsby-config.js` is only supported for themes. From now on you'll be running `site` -- the Gatsby site consuming `gatsby-theme-events`, instead. Gatsby sites still require the object export in `gatsby-config.js`.
 
 Test out this new options-setting by making some adjustments to `site`.
 

--- a/docs/tutorial/ecommerce-tutorial/index.md
+++ b/docs/tutorial/ecommerce-tutorial/index.md
@@ -213,7 +213,7 @@ The `redirectToCheckout()` function validates your checkout request and either r
   }
 ```
 
-The `render()` function applies our styles to the button and binds the `redirectToCheckout()` function to the button's onclick event.
+The `render()` function applies your styles to the button and binds the `redirectToCheckout()` function to the button's onclick event.
 
 #### Importing the checkout component into the homepage
 
@@ -282,7 +282,7 @@ module.exports = {
 }
 ```
 
-To retrieve your SKUs from your Stripe account you will need to provide your secret API key. This key needs to kept secret and must never be shared on the frontend or on GitHub. Therefore we need to set an environment variable to store the secret key. You can read more about the usage of env variables in Gatsby [here](https://www.gatsbyjs.org/docs/environment-variables/).
+To retrieve your SKUs from your Stripe account you will need to provide your secret API key. This key needs to kept secret and must never be shared on the frontend or on GitHub. Therefore you need to set an environment variable to store the secret key. You can read more about the usage of env variables in Gatsby [here](https://www.gatsbyjs.org/docs/environment-variables/).
 
 In the root directory of your project add a `.env.development` file:
 
@@ -448,7 +448,7 @@ export default SkuCard
 
 This component renders a neat card for each individual SKU, with the SKU name, nicely formatted pricing, and a "BUY ME" button. The button triggers the `redirectToCheckout()` function with the corresponding SKU ID.
 
-Lastly, we need to refactor our `Skus` component to initialize the Stripe.js client, and render `SkuCards` while handing down the Stripe.js client in the `props`:
+Lastly, you need to refactor your `Skus` component to initialize the Stripe.js client, and render `SkuCards` while handing down the Stripe.js client in the `props`:
 
 ```jsx:title=src/components/Products/Skus.js
 import React, { Component } from 'react'

--- a/docs/tutorial/gatsby-image-tutorial/index.md
+++ b/docs/tutorial/gatsby-image-tutorial/index.md
@@ -249,7 +249,7 @@ Instead of a query constant and data that references the result like in the firs
 
 The last use case you may come across is how to handle a situation where you have multiple queries in the same file/page.
 
-This example is attempting to query for all the data in `speaking.yaml` and the direct file query in our first example. In order to do this you want to use aliasing in GraphQL.
+This example is attempting to query for all the data in `speaking.yaml` and the direct file query in the first example. In order to do this you want to use aliasing in GraphQL.
 
 The first thing to know is that an alias is assigning a name to a query. The second thing to know is that aliases are optional, but they can make your life easier! Below is an example.
 

--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -274,7 +274,7 @@ It worked! 🎉
 
 ![Page title pulling from siteMetadata](site-metadata-title.png)
 
-The basic GraphQL query that retrieves the `title` in our `about.js` changes above is:
+The basic GraphQL query that retrieves the `title` in your `about.js` changes above is:
 
 ```graphql:title=src/pages/about.js
 {
@@ -292,7 +292,7 @@ Page queries live outside of the component definition -- by convention at the en
 
 ### Use a StaticQuery
 
-[StaticQuery](/docs/static-query/) is a new API introduced in Gatsby v2 that allows non-page components (like our `layout.js` component), to retrieve data via GraphQL queries.
+[StaticQuery](/docs/static-query/) is a new API introduced in Gatsby v2 that allows non-page components (like your `layout.js` component), to retrieve data via GraphQL queries.
 Let's use its newly introduced hook version — [`useStaticQuery`](/docs/use-static-query/).
 
 Go ahead and make some changes to your `src/components/layout.js` file to use the `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done, your file will look like this:

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -246,7 +246,7 @@ Over in `header.js`, the header component expects to receive the `headerText` pr
 
 > 💡 In JSX, you can embed any JavaScript expression by wrapping it with `{}`. This is how you can access the `headerText` property (or “prop!”) from the “props” object.
 
-If you had passed another prop to our `<Header />` component, like so...
+If you had passed another prop to your `<Header />` component, like so...
 
 ```jsx:title=src/pages/about.js
 <Header headerText="About Gatsby" arbitraryPhrase="is arbitrary" />
@@ -308,7 +308,7 @@ When you click the new "Contact" link on the homepage, you should see...
 
 ...the Gatsby development 404 page. Why? Because you're attempting to link to a page that doesn't exist yet.
 
-2.  Now you'll have to create a page component for our new "Contact" page at `src/pages/contact.js` and have it link back to the homepage:
+2.  Now you'll have to create a page component for your new "Contact" page at `src/pages/contact.js` and have it link back to the homepage:
 
 ```jsx:title=src/pages/contact.js
 import React from "react"
@@ -385,4 +385,4 @@ In this section you:
 - Learned about Gatsby page components and sub-components
 - Learned about React “props” and reusing React components
 
-Now, move on to [**adding styles to our site**](/tutorial/part-two/)!
+Now, move on to [**adding styles to your site**](/tutorial/part-two/)!

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -112,7 +112,7 @@ Now you can add your new slugs directly onto the `MarkdownRemark` nodes. This is
 powerful, as any data you add to nodes is available to query later with GraphQL.
 So, it'll be easy to get the slug when it comes time to create the pages.
 
-To do so, you'll use a function passed to our API implementation called
+To do so, you'll use a function passed to your API implementation called
 [`createNodeField`](/docs/actions/#createNodeField). This function
 allows you to create additional fields on nodes created by other plugins. Only
 the original creator of a node can directly modify the node—all other plugins

--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -161,7 +161,7 @@ export default ({ children }) => (
 )
 ```
 
-You'll notice we imported a css module file named `container.module.css`. Let's create that file now.
+You'll notice you imported a css module file named `container.module.css`. Let's create that file now.
 
 2. In the same directory (`src/components`), create a `container.module.css` file and copy/paste the following:
 

--- a/docs/tutorial/prismic-source-graphql-tutorial.md
+++ b/docs/tutorial/prismic-source-graphql-tutorial.md
@@ -137,7 +137,7 @@ export default ({ data }) => {
 
 Save the file and check on your site running at [`http://localhost:8000`](http://localhost:8000)
 
-You can use the helper function `RichText` to [render formatted text](https://prismic.io/docs/reactjs/rendering/rich-text) and generally, this is the process you will use to query your Prismic repository and then render it. We can clean this up and include a function that will render the array of queried blog posts.
+You can use the helper function `RichText` to [render formatted text](https://prismic.io/docs/reactjs/rendering/rich-text) and generally, this is the process you will use to query your Prismic repository and then render it. You can clean this up and include a function that will render the array of queried blog posts.
 
 ```js:title=src/pages/index.js
 //highlight-start
@@ -181,7 +181,7 @@ export default ({ data }) => {
 
 ## Building links to your documents
 
-Now things are really taking shape. We will turn these blog post titles into links by building a [link resolver function](https://prismic.io/docs/reactjs/beyond-the-api/link-resolving), which will build the correct route for your posts.
+Now things are really taking shape. You will turn these blog post titles into links by building a [link resolver function](https://prismic.io/docs/reactjs/beyond-the-api/link-resolving), which will build the correct route for your posts.
 
 ```javascript:title=src/utils/linkResolver.js
 exports.linkResolver = function linkResolver(doc) {


### PR DESCRIPTION
## Description

Replaced occurrences of "we" and "our" (where applicable) in the docs/tutorials folder.

## Related Issues

Addresses #18284 

