### PR TITLE
docs(tutorial): added note about telemetry, and added doc to sidebar

### DIFF
--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -68,6 +68,8 @@ The Gatsby CLI tool lets you quickly create new Gatsby-powered sites and run com
 
 The Gatsby CLI is available via npm and should be installed globally by running `npm install -g gatsby-cli`.
 
+_**Note**: when you install Gatsby and run it for the first time, you'll see a short message notifying you about anonymous usage data that is being collected for Gatsby commands, you can read more about how that data is pulled out and used in the [telemetry doc](/docs/telemetry)._
+
 To see the commands available, run `gatsby --help`.
 
 ![Check gatsby commands in terminal](05-gatsby-help.png)
@@ -84,7 +86,7 @@ Now you are ready to use the Gatsby CLI tool to create your first Gatsby site. U
 4.  Run `gatsby develop`.
 
 <video controls="controls" autoplay="true" loop="true">
-  <source type="video/mp4" src="./03-create-site.mp4"></source>
+  <source type="video/mp4" src="./03-create-site.mp4" />
   <p>Sorry! You browser doesn't support this video.</p>
 </video>
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -665,5 +665,7 @@
       link: /docs/cheat-sheet/
     - title: Glossary
       link: /docs/glossary/
+    - title: Gatsby Telemetry
+      link: /docs/telemetry/
     - title: Gatsby REPL
       link: /docs/gatsby-repl/


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

Based on discussion about the telemetry doc which argued that it isn't visible enough in the current state of the docs since it needs to be searched for and isn't linked to from the tutorial, this PR adds a note about telemetry in the tutorial when the CLI is installed, as well as adds the Telemetry doc that already exists to the docs sidebar.

I wasn't sure where best to include the telemetry doc in the sidebar but figured at the top level next to the REPL command might make sense since I reasoned this isn't really something of a Gatsby Internal that users would leverage, but I'm happy to be convinced otherwise 🙂 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

This tweet: https://twitter.com/carolstran/status/1182577059010437121?s=20

## Preview 

![image](https://user-images.githubusercontent.com/21114044/66872034-3bc35000-ef62-11e9-8f39-551353e8902c.png)
