### PR TITLE
Fix issue 18571  - showcase details page titles

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -279,7 +279,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
             }}
           >
             <div css={{ width: `100%` }}>
-              <Helmet>
+              <Helmet titleTemplate="">
                 <title>{data.sitesYaml.title}: Showcase | GatsbyJS</title>
                 <meta
                   property="og:image"

--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -50,7 +50,7 @@ class ShowcaseView extends Component {
 
     return (
       <Layout location={location}>
-        <Helmet>
+        <Helmet defer={false}>
           <title>Showcase</title>
           <meta
             name="description"


### PR DESCRIPTION
## Description

Adds  `titleTemplate=""` prop to the `Helmet` component in components/showcase-details.js. Also adds `defer={false}` prop to the `Helmet` in views/showcase/index.js. There are multiple `Helmet` components being rendered at the same time, which was causing strange behavior for when the details page was a modal versus the full page.

For the React details page, you would sometimes get the title:
"React.js,: Showcase | GatsbyJS | GatsbyJS"

This PR fixes it so that it is now whether rendered as a modal or a full page:
"React.js: Showcase | GatsbyJS"

 The `titleTemplate="%s | GatsbyJS"` prop from the top-level `Helmet` in site-metadata.js was interfering with the title rendering correctly in the showcase-details. Once that was fixed by overwriting it in the showcase-details.js `Helmet`, the `defer={false}` prop was needed to prevent the `Helmet` in views/showcase/index.js from flickering with the bad version of the title while transitioning between modal open and closed state.

## Related Issues

Fixes [18571](https://github.com/gatsbyjs/gatsby/issues/18571)
