### PR TITLE
chore(docs): Used “you” and "you're" as the pronoun

### DIFF
--- a/docs/tutorial/prismic-source-graphql-tutorial.md
+++ b/docs/tutorial/prismic-source-graphql-tutorial.md
@@ -137,7 +137,7 @@ export default ({ data }) => {
 
 Save the file and check on your site running at [`http://localhost:8000`](http://localhost:8000)
 
-You can use the helper function `RichText` to [render formatted text](https://prismic.io/docs/reactjs/rendering/rich-text) and generally, this is the process you will use to query your Prismic repository and then render it. We can clean this up and include a function that will render the array of queried blog posts.
+You can use the helper function `RichText` to [render formatted text](https://prismic.io/docs/reactjs/rendering/rich-text) and generally, this is the process you will use to query your Prismic repository and then render it. You can clean this up and include a function that will render the array of queried blog posts.
 
 ```js:title=src/pages/index.js
 //highlight-start
@@ -181,7 +181,7 @@ export default ({ data }) => {
 
 ## Building links to your documents
 
-Now things are really taking shape. We will turn these blog post titles into links by building a [link resolver function](https://prismic.io/docs/reactjs/beyond-the-api/link-resolving), which will build the correct route for your posts.
+Now things are really taking shape. You will turn these blog post titles into links by building a [link resolver function](https://prismic.io/docs/reactjs/beyond-the-api/link-resolving), which will build the correct route for your posts.
 
 ```javascript:title=src/utils/linkResolver.js
 exports.linkResolver = function linkResolver(doc) {
@@ -277,7 +277,7 @@ export default ({ data }) => {
 }
 ```
 
-We're rendering a very minimalistic page for each blog post; consisting of:
+You're rendering a very minimalistic page for each blog post; consisting of:
 
 - A link back to the homepage.
 - The article's title and page.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
Changed texts "we" and "we're" by "you" and "youre".
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
