### PR TITLE
Highlight empty lines without breaking line numbering or hiding them

### DIFF
--- a/packages/gatsby-remark-prismjs/src/directives.js
+++ b/packages/gatsby-remark-prismjs/src/directives.js
@@ -154,7 +154,12 @@ module.exports = function highlightLineRange(code, highlights = []) {
       })
       .map(line => {
         if (line.highlight) {
-          line.code = highlightWrap(line.code)
+          
+          // use non-breakable space to retain empty line in source listing 
+          // as it is important when both line highlight and line numbering are used.
+          line.code
+            ? (line.code = highlightWrap(line.code))
+            : (line.code = highlightWrap("&nbsp;"))
         }
         return line
       })

--- a/packages/gatsby-remark-prismjs/src/directives.js
+++ b/packages/gatsby-remark-prismjs/src/directives.js
@@ -154,9 +154,6 @@ module.exports = function highlightLineRange(code, highlights = []) {
       })
       .map(line => {
         if (line.highlight) {
-          
-          // use non-breakable space to retain empty line in source listing 
-          // as it is important when both line highlight and line numbering are used.
           line.code
             ? (line.code = highlightWrap(line.code))
             : (line.code = highlightWrap("&nbsp;"))


### PR DESCRIPTION
Highlight empty lines without breaking line numbering or hiding them. See #17849

## Description

Allows to highlight empty lines without breaking line numbering and prevents highlighted line from being hidden. Currently that is broken if empty line is highlighted. See #17849 for screenshots and description.

## Related Issues

Fixes: #17849