### PR TITLE
chore(docs): Add freecodecamp community to other resources section

### DIFF
--- a/docs/docs/awesome-gatsby-resources.md
+++ b/docs/docs/awesome-gatsby-resources.md
@@ -111,3 +111,7 @@ See the [library of official and community plugins](/plugins/)
 ### Reddit Community
 
 [Gatsby community on Reddit](https://www.reddit.com/r/gatsbyjs) is a place where you can read news about Gatsby, interact with other Gatsby developers and get advice on Gatsby-related Questions.
+
+### FreeCodeCamp Community
+
+[The FreeCodeCamp News Gatsby tag](https://www.freecodecamp.org/news/tag/gatsby/) is a place where you can write and read substantial articles around Gatsby-related topics.


### PR DESCRIPTION
This PR adds the FreeCodeCamp community link to the 'Other resources' section.

[FreeCodeCamp News](https://www.freecodecamp.org/news) is a global community that helps people learn to code for free by creating thousands of videos, articles, and interactive coding lessons. 

This would point to a place where you can write and read substantial articles around [Gatsby-related topics](https://www.freecodecamp.org/news/tag/gatsby/).