### PR TITLE
fix(gatsby-plugin-netlify): cast `status` to string

### DIFF
--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -28,7 +28,7 @@ export default async function writeRedirectsFile(
     let status = isPermanent ? `301` : `302`
     if (statusCode) status = statusCode
 
-    if (force) status = status.concat(`!`)
+    if (force) status = `${status}!`
 
     // The order of the first 3 parameters is significant.
     // The order for rest params (key-value pairs) is arbitrary.

--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -26,7 +26,7 @@ export default async function writeRedirectsFile(
     } = redirect
 
     let status = isPermanent ? `301` : `302`
-    if (statusCode) status = statusCode
+    if (statusCode) status = String(statusCode)
 
     if (force) status = `${status}!`
 


### PR DESCRIPTION
## Description

If you pass the `statusCode` like in the example from the docs:
```js
createRedirect({
  fromPath: "/url_that_is/not_pretty",
  toPath: "/pretty/url",
  statusCode: 200,
})
```

... and try to add the `force` param then you are going to get the following error:
> status.concat is not a function

This is because `statusCode` is a `Numer`, and this PR makes a tiny change which casts the `status` to a `String` when appending the exclamation point.
