### PR TITLE
fix flow version in .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.42.0
+0.109.0
 
 [ignore]
 .*/test/.*


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I've been waiting for this to be fixed in master, but it seems to have been overlooked.  I always get errors when working on Gatsby because the version of `flow` in `.flowconfig` does not match.  Not really a big deal, because I just change the version; it's just a minor annoyance to have to do it every time.

## Current state

`package.json`
```json
    ...
    "flow-bin": "^0.109.0",
    ...
```

`.flowconfig`
```
[version]
0.42.0
...
```