### PR TITLE
chore(blog): Fix broken link

### DIFF
--- a/docs/blog/2019-08-30-speed-up-your-time-to-interactive-by-delaying-third-party-scripts/index.md
+++ b/docs/blog/2019-08-30-speed-up-your-time-to-interactive-by-delaying-third-party-scripts/index.md
@@ -28,7 +28,7 @@ Harry from [marketingexamples.com](https://marketingexamples.com/) linked me to 
 
 When looking at the performance data, the site's first meaningful paint took slightly over a second, but the time to interactive was _eleven seconds_. Yikes!
 
-The reason for this was that I recently switched to [Segment](https://segment.com) (using [gatsby-plugin-segment-js](https://www.gatsbyjs.org/packages/gatsby-plugin-segment-js/)) and was loading other scripts through that, like support chat and analytics. These scripts all counted towards my "time to interactive".
+The reason for this was that I recently switched to [Segment](https://segment.com) (using [gatsby-plugin-segment-js](/packages/gatsby-plugin-segment-js/)) and was loading other scripts through that, like support chat and analytics. These scripts all counted towards my "time to interactive".
 
 The SEO performance post included a tip from Dave of [ToDesktop](https://www.todesktop.com/) who has similar problems. His tip: Prevent loading the scripts until after a user has scrolled, along with some timeout to prevent [scroll jank](http://jankfree.org/).
 

--- a/docs/blog/2019-08-30-speed-up-your-time-to-interactive-by-delaying-third-party-scripts/index.md
+++ b/docs/blog/2019-08-30-speed-up-your-time-to-interactive-by-delaying-third-party-scripts/index.md
@@ -28,7 +28,7 @@ Harry from [marketingexamples.com](https://marketingexamples.com/) linked me to 
 
 When looking at the performance data, the site's first meaningful paint took slightly over a second, but the time to interactive was _eleven seconds_. Yikes!
 
-The reason for this was that I recently switched to [Segment](https://segment.com) (using [gatsby-plugin-segment-js](//packages/gatsby-plugin-segment-js/)) and was loading other scripts through that, like support chat and analytics. These scripts all counted towards my "time to interactive".
+The reason for this was that I recently switched to [Segment](https://segment.com) (using [gatsby-plugin-segment-js](https://www.gatsbyjs.org/packages/gatsby-plugin-segment-js/)) and was loading other scripts through that, like support chat and analytics. These scripts all counted towards my "time to interactive".
 
 The SEO performance post included a tip from Dave of [ToDesktop](https://www.todesktop.com/) who has similar problems. His tip: Prevent loading the scripts until after a user has scrolled, along with some timeout to prevent [scroll jank](http://jankfree.org/).
 


### PR DESCRIPTION
Fix broken link to **gatsby-plugin-segment-js** docs

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Fix a broken link on this post:
https://www.gatsbyjs.org/blog/2019-08-30-speed-up-your-time-to-interactive-by-delaying-third-party-scripts/

It now links to https://www.gatsbyjs.org/packages/gatsby-plugin-segment-js/ correctly

## Related Issues
 Fixes #18727
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
