### PR TITLE
feat(gatsby-image): add `nativeLazyLoading` prop to allow users decide which lazy loading strategy to use

### DIFF
--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -168,13 +168,22 @@ describe(`<Image />`, () => {
     expect(component).toMatchSnapshot()
   })
 
-  it(`should have the the "critical" prop set "loading='eager'"`, () => {
+  it(`should have the "critical" prop set "loading='eager'"`, () => {
     jest.spyOn(global.console, `log`)
 
     const props = { critical: true }
     const imageTag = setup(false, props).querySelector(`picture img`)
     expect(imageTag.getAttribute(`loading`)).toEqual(`eager`)
     expect(console.log).toBeCalled()
+  })
+
+  it(`should not have the "loading" prop when "nativeLazyLoading" is set to false`, () => {
+    const props = { nativeLazyLoading: false }
+    const component = setup(false, props)
+    const imageTag = component.querySelector(`picture img`)
+    const noscriptTag = component.querySelector(`noscript`)
+    expect(imageTag.getAttribute(`loading`)).toEqual(null)
+    expect(noscriptTag.innerHTML).not.toContain(`loading`)
   })
 
   it(`should warn if image variants provided are missing media keys.`, () => {


### PR DESCRIPTION
## Description

The native lazy loading is supported only by Chrome 75+ and even though I am currently using 77, I was not getting the results I was looking for. All the images were loading regardless of the setting, on both fast and slow network.

This PR adds a prop called `nativeLazyLoading` which allow users decide which strategy should be used: native `loading` or `IO`.