### PR TITLE
fix(gatsby): Fixed error message when path is undefined

### DIFF
--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -199,6 +199,9 @@ const fileByPath = (options = {}, fieldConfig) => async (
   const findLinkedFileNode = relativePath => {
     // Use the parent File node to create the absolute path to
     // the linked file.
+    
+    if (parentFileNode.dir === null || parentFileNode.dir === undefined) return null;
+
     const fileLinkPath = normalize(
       systemPath.resolve(parentFileNode.dir, relativePath)
     )

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -199,8 +199,10 @@ const fileByPath = (options = {}, fieldConfig) => async (
   const findLinkedFileNode = relativePath => {
     // Use the parent File node to create the absolute path to
     // the linked file.
-    
-    if (parentFileNode.dir === null || parentFileNode.dir === undefined) return null;
+
+    if (parentFileNode.dir === null || parentFileNode.dir === undefined) {
+        return null;
+    }
 
     const fileLinkPath = normalize(
       systemPath.resolve(parentFileNode.dir, relativePath)

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -201,7 +201,7 @@ const fileByPath = (options = {}, fieldConfig) => async (
     // the linked file.
 
     if (parentFileNode.dir === null || parentFileNode.dir === undefined) {
-      return null;
+      return null
     }
 
     const fileLinkPath = normalize(

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -201,7 +201,7 @@ const fileByPath = (options = {}, fieldConfig) => async (
     // the linked file.
 
     if (parentFileNode.dir === null || parentFileNode.dir === undefined) {
-        return null;
+      return null;
     }
 
     const fileLinkPath = normalize(


### PR DESCRIPTION
## Description

PR to fix the issue with the findLinkedFileNode assuming that 'dir' attribute exists on the object. Adds null and undefined check so that Path.resolve is not passed erroneous data. 

## Related Issues

Link to the issue that is fixed by this PR (if there is one)
Fixes #18661
