### PR TITLE
chore(docs): Clear up wording in Winning Over Stakeholders

### DIFF
--- a/docs/docs/winning-over-stakeholders.md
+++ b/docs/docs/winning-over-stakeholders.md
@@ -6,9 +6,9 @@ Any website project has multiple stakeholders, such as developers, marketers, co
 
 In smaller projects and organizations, one person may wear multiple hats. As a freelancer, you may be the developer, marketer, content creator, and engineering leader rolled into one. Working at a mid-sized agency or organization, you are likely to only wear one hat at a time.
 
-When working with other stakeholders, it's important to understand their motivations, and what they're being measured on, so you can explain the benefits of Gatsby in a way that resonates with them.
+When working with other stakeholders, it's important to understand their motivations so you can explain the benefits of Gatsby in a way that resonates with them.
 
-For example, marketers typically care about increasing leads and conversion rates, while executives focus on driving revenue, and clients prioritize the project shipping on time and under budget.
+For example, marketers typically care about increasing leads and conversion rates, executives focus on driving revenue, and clients prioritize the project shipping on time and under budget.
 
 This section includes guides to explaining the benefits of Gatsby to the various types of stakeholders that you may work with.
 


### PR DESCRIPTION
## Description
While reading through the docs, a couple of the sentences in the "Winning Over Stakeholders" section felt a little off. I've changed them so that they make more sense to me, but I'm happy to revert either or both of these things if y'all disagree.

Removed `, and what they're being measured on` because the next paragraph seems to explain that these are the motivations being referred to, and it makes the sentence a little more digestable in my opinion.

Typically style guides recommend using the same structure between commas so that it's more repetitive, so I removed `while` to make the next sentence follow that pattern.

## Related Issues
There is no issue for this. It was just something I noticed as I was reading through, and so I figured I would make a PR to be considered.
