### PR TITLE
docs(www): Use yarn consistently in the README.md file

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -5,7 +5,7 @@ The main Gatsby site at gatsbyjs.org
 Run locally with:
 
 - `yarn install`
-- `npm run develop`
+- `yarn develop`
 
 See the full contributing instructions at https://www.gatsbyjs.org/contributing/how-to-contribute/.
 

--- a/www/README.md
+++ b/www/README.md
@@ -5,7 +5,7 @@ The main Gatsby site at gatsbyjs.org
 Run locally with:
 
 - `yarn install`
-- `yarn develop`
+- `gatsby develop`
 
 See the full contributing instructions at https://www.gatsbyjs.org/contributing/how-to-contribute/.
 


### PR DESCRIPTION
## Description

The purpose of this `PR` is to keep consistency with using yarn inside the README.md file (Gatsby docs).

