### PR TITLE
chore(docs): Fix MD syntax in MDX docs

### DIFF
--- a/docs/docs/mdx/customizing-components.md
+++ b/docs/docs/mdx/customizing-components.md
@@ -44,15 +44,15 @@ The following components can be customized with the MDXProvider:
 | `ul`            | [List](https://github.com/syntax-tree/mdast#list)                    | `-`                                                 |
 | `ol`            | [Ordered list](https://github.com/syntax-tree/mdast#list)            | `1.`                                                |
 | `li`            | [List item](https://github.com/syntax-tree/mdast#listitem)           |                                                     |
-| `table`         | [Table](https://github.com/syntax-tree/mdast#table)                  | `--- \| --- \| --- \| ---`                                   |
-| `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           | `This \| is \| a \| table row`                       |
+| `table`         | [Table](https://github.com/syntax-tree/mdast#table)                  | `--- \| --- \| --- \| ---`                          |
+| `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           | `This \| is \| a \| table row`                      |
 | `td`/`th`       | [Table cell](https://github.com/syntax-tree/mdast#tablecell)         |                                                     |
-| `pre`           | [Pre](https://github.com/syntax-tree/mdast#code)                     | ```` ```js console.log()``` ````                                            |
-| `code`          | [Code](https://github.com/syntax-tree/mdast#code)                    | ``` `console.log()` ```                                           |
+| `pre`           | [Pre](https://github.com/syntax-tree/mdast#code)                     | ` ```js console.log()``` `                          |
+| `code`          | [Code](https://github.com/syntax-tree/mdast#code)                    | `` `console.log()` ``                               |
 | `em`            | [Emphasis](https://github.com/syntax-tree/mdast#emphasis)            | `_emphasis_`                                        |
 | `strong`        | [Strong](https://github.com/syntax-tree/mdast#strong)                | `**strong**`                                        |
 | `delete`        | [Delete](https://github.com/syntax-tree/mdast#delete)                | `~~strikethrough~~`                                 |
-| `code`          | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | ``` `console.log()` ```                                              |
+| `code`          | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | `` `console.log()` ``                               |
 | `hr`            | [Break](https://github.com/syntax-tree/mdast#break)                  | `---`                                               |
 | `a`             | [Link](https://github.com/syntax-tree/mdast#link)                    | `<https://mdxjs.com>` or `[MDX](https://mdxjs.com)` |
 | `img`           | [Image](https://github.com/syntax-tree/mdast#image)                  | `![alt](https://mdx-logo.now.sh)`                   |

--- a/docs/docs/mdx/customizing-components.md
+++ b/docs/docs/mdx/customizing-components.md
@@ -44,15 +44,15 @@ The following components can be customized with the MDXProvider:
 | `ul`            | [List](https://github.com/syntax-tree/mdast#list)                    | `-`                                                 |
 | `ol`            | [Ordered list](https://github.com/syntax-tree/mdast#list)            | `1.`                                                |
 | `li`            | [List item](https://github.com/syntax-tree/mdast#listitem)           |                                                     |
-| `table`         | [Table](https://github.com/syntax-tree/mdast#table)                  | `--- | --- | ---`                                   |
-| `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           | `This | is | a | table row`                         |
+| `table`         | [Table](https://github.com/syntax-tree/mdast#table)                  | `--- \| --- \| --- \| ---`                                   |
+| `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           | `This \| is \| a \| table row`                       |
 | `td`/`th`       | [Table cell](https://github.com/syntax-tree/mdast#tablecell)         |                                                     |
-| `pre`           | [Pre](https://github.com/syntax-tree/mdast#code)                     |                                                     |
-| `code`          | [Code](https://github.com/syntax-tree/mdast#code)                    |                                                     |
+| `pre`           | [Pre](https://github.com/syntax-tree/mdast#code)                     | ```` ```js console.log()``` ````                                            |
+| `code`          | [Code](https://github.com/syntax-tree/mdast#code)                    | ``` `console.log()` ```                                           |
 | `em`            | [Emphasis](https://github.com/syntax-tree/mdast#emphasis)            | `_emphasis_`                                        |
 | `strong`        | [Strong](https://github.com/syntax-tree/mdast#strong)                | `**strong**`                                        |
 | `delete`        | [Delete](https://github.com/syntax-tree/mdast#delete)                | `~~strikethrough~~`                                 |
-| `code`          | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        |                                                     |
+| `code`          | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | ``` `console.log()` ```                                              |
 | `hr`            | [Break](https://github.com/syntax-tree/mdast#break)                  | `---`                                               |
 | `a`             | [Link](https://github.com/syntax-tree/mdast#link)                    | `<https://mdxjs.com>` or `[MDX](https://mdxjs.com)` |
 | `img`           | [Image](https://github.com/syntax-tree/mdast#image)                  | `![alt](https://mdx-logo.now.sh)`                   |


### PR DESCRIPTION
Fix rendering syntax inside `code` for `table` and `tr` and add examples of `code` and `pre`.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
