### PR TITLE
[docs] added code blocks to highlight code specific to steps 4 and 5 in Using Gatsby Image doc

### DIFF
--- a/docs/docs/using-gatsby-image.md
+++ b/docs/docs/using-gatsby-image.md
@@ -83,31 +83,30 @@ module.exports = {
 
 ```jsx:title=src/pages/my-dogs.js
 import React from "react"
-import { graphql } from "gatsby"
+import { useStaticQuery, graphql } from "gatsby" // highlight-line
 import Layout from "../components/layout"
 
-export default ({ data }) => {
+export default () => {
+  // highlight-start
+  const data = useStaticQuery(graphql`
+    query MyQuery {
+      file(relativePath: { eq: "images/corgi.jpg" }) {
+        childImageSharp {
+          # Specify the image processing specifications right in the query.
+          fluid {
+            ...GatsbyImageSharpFluid
+          }
+        }
+      }
+    }
+  `)
+  // highlight-end
   return (
     <Layout>
       <h1>I love my corgi!</h1>
     </Layout>
   )
 }
-
-// highlight-start
-export const query = graphql`
-  query {
-    fileName: file(relativePath: { eq: "images/corgi.jpg" }) {
-      childImageSharp {
-        # Specify the image processing specifications right in the query.
-        fluid {
-          ...GatsbyImageSharpFluid
-        }
-      }
-    }
-  }
-`
-// highlight-end
 ```
 
 <EggheadEmbed
@@ -119,35 +118,35 @@ export const query = graphql`
 
 ```jsx:title=src/pages/my-dogs.js
 import React from "react"
-import { graphql } from "gatsby"
+import { useStaticQuery, graphql } from "gatsby"
 import Layout from "../components/layout"
 import Img from "gatsby-image" // highlight-line
 
-export default ({ data }) => {
+export default () => {
+  const data = useStaticQuery(graphql`
+    query MyQuery {
+      file(relativePath: { eq: "images/corgi.jpg" }) {
+        childImageSharp {
+          # Specify the image processing specifications right in the query.
+          fluid {
+            ...GatsbyImageSharpFluid
+          }
+        }
+      }
+    }
+  `)
   return (
     <Layout>
       <h1>I love my corgi!</h1>
       // highlight-start
       <Img
-        fluid={data.fileName.childImageSharp.fluid}
+        fluid={data.file.childImageSharp.fluid}
         alt="A corgi smiling happily"
       />
       // highlight-end
     </Layout>
   )
 }
-
-export const query = graphql`
-  query {
-    fileName: file(relativePath: { eq: "images/corgi.jpg" }) {
-      childImageSharp {
-        fluid {
-          ...GatsbyImageSharpFluid
-        }
-      }
-    }
-  }
-`
 ```
 
 <EggheadEmbed

--- a/docs/docs/using-gatsby-image.md
+++ b/docs/docs/using-gatsby-image.md
@@ -81,15 +81,33 @@ module.exports = {
 
 4. Write a GraphQL query using one of the included [GraphQL “fragments”](/packages/gatsby-image/#fragments) which specify the fields needed by `gatsby-image` to create a responsive, optimized image. This example queries for an image at a path relative to the location specified in the `gatsby-source-filesystem` options using the `GatsbyImageSharpFluid` fragment.
 
-```graphql
-file(relativePath: { eq: "images/default.jpg" }) {
+```jsx:title=src/pages/my-dogs.js
+import React from "react"
+import { graphql } from "gatsby"
+import Layout from "../components/layout"
+
+export default ({ data }) => {
+  return (
+    <Layout>
+      <h1>I love my corgi!</h1>
+    </Layout>
+  )
+}
+
+// highlight-start
+export const query = graphql`
+  query {
+    fileName: file(relativePath: { eq: "images/corgi.jpg" }) {
       childImageSharp {
         # Specify the image processing specifications right in the query.
         fluid {
           ...GatsbyImageSharpFluid
         }
       }
-}
+    }
+  }
+`
+// highlight-end
 ```
 
 <EggheadEmbed
@@ -99,18 +117,37 @@ file(relativePath: { eq: "images/default.jpg" }) {
 
 5. Import `Img` to display the fragment in JSX. There are additional features available with the `Img` tag as well, such as the `alt` attribute for accessibility.
 
-```jsx
-import Img from "gatsby-image"
+```jsx:title=src/pages/my-dogs.js
+import React from "react"
+import { graphql } from "gatsby"
+import Layout from "../components/layout"
+import Img from "gatsby-image" // highlight-line
 
-export default ({ data }) => (
-  <div>
-    <h1>Hello gatsby-image</h1>
-    <Img
-      fluid={data.file.childImageSharp.fluid}
-      alt="Gatsby Docs are awesome"
-    />
-  </div>
-)
+export default ({ data }) => {
+  return (
+    <Layout>
+      <h1>I love my corgi!</h1>
+      // highlight-start
+      <Img
+        fluid={data.fileName.childImageSharp.fluid}
+        alt="A corgi smiling happily"
+      />
+      // highlight-end
+    </Layout>
+  )
+}
+
+export const query = graphql`
+  query {
+    fileName: file(relativePath: { eq: "images/corgi.jpg" }) {
+      childImageSharp {
+        fluid {
+          ...GatsbyImageSharpFluid
+        }
+      }
+    }
+  }
+`
 ```
 
 <EggheadEmbed


### PR DESCRIPTION
## Description
In using-gatsby-image.md, 
1. under Step 4 - replaced the graphql fragment block with a jsx code block that contains the graphql fragment
2. under Step 5 - added the Img component to the jsx code block from Step 4

## Related Issues
Fixes #18775 
