### PR TITLE
fix(gatsby-cli): re-add reporter._setStage as no-op function

### DIFF
--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -394,7 +394,7 @@ const reporter: Reporter = {
     }
   },
   // This method was called in older versions of gatsby, so we need to keep it to avoid
-  // "reporter._setStage is not a function" error when gatsby@<=2.16 is used with gatsby-cli@>=2.8
+  // "reporter._setStage is not a function" error when gatsby@<2.16 is used with gatsby-cli@>=2.8
   _setStage() {},
 }
 

--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -393,6 +393,9 @@ const reporter: Reporter = {
       span,
     }
   },
+  // This method was called in older versions of gatsby, so we need to keep it to avoid
+  // "reporter._setStage is not a function" error when gatsby@<=2.16 is used with gatsby-cli@>=2.8
+  _setStage() {},
 }
 
 console.log = (...args) => reporter.log(util.format(...args))


### PR DESCRIPTION
gatsby has dependency on gatsby-cli using caret version selector, which means that in case of using npm lock file or pinning gatsby version in project's dependency and not using any lock files, it will always install latest gatsby-cli

This means we need to preserve interface for backward compatibility.

Related issue/comment: https://github.com/gatsbyjs/gatsby/issues/18728#issuecomment-542777122