### PR TITLE
fix(www): fix issue with showcase titles

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -279,8 +279,8 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
             }}
           >
             <div css={{ width: `100%` }}>
-              <Helmet>
-                <title>{data.sitesYaml.title}: Showcase | GatsbyJS</title>
+              <Helmet titleTemplate="%s | GatsbyJS">
+                <title>{`${data.sitesYaml.title}: Showcase`}</title>
                 <meta
                   property="og:image"
                   content={`https://www.gatsbyjs.org${screenshotFile.resize.src}`}


### PR DESCRIPTION
## Description

There is this open issue for React Helmet about the extra commas being added into the titles. The current workaround for this is to wrap the title text in a string inside {}. Doing this in `components/showcase-details.js` removes the extra comma that is sometimes appearing in the title.

I'm also setting the titleTemplate prop on the Helmet component in showcase-details.js to be "%s | GatsbyJS". This is because sometimes this is the only Helmet component on the page, so it needs the template. Before, this was being worked around by hardcoding " | GatsbyJS" into the title, which was causing the double "| GatsbyJS" when the `Helmet` component from `site-metadata.js` rendered. By using titleTemplate, this will only render once.

## Related Issues

Fixes [18571](https://github.com/gatsbyjs/gatsby/issues/18571)
