### PR TITLE
chore(docs): Remove reach-router stub asterisk from sidebar

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -402,7 +402,7 @@
             - title: Routing
               link: /docs/routing/
               items:
-                - title: "@reach/router and Gatsby*"
+                - title: "@reach/router and Gatsby"
                   link: /docs/reach-router-and-gatsby/
                 - title: Linking and Prefetching with Gatsby*
                   link: /docs/linking-and-prefetching-with-gatsby/


### PR DESCRIPTION
## Description

As a followup of #18784, removed the asterisk to notify it is no longer a stub article.

## Related Issues