### PR TITLE
Delete nodes that no longer exist from the lastest source fetch

### DIFF
--- a/packages/gatsby-source-wordpress/src/__tests__/__snapshots__/normalize.js.snap
+++ b/packages/gatsby-source-wordpress/src/__tests__/__snapshots__/normalize.js.snap
@@ -15925,3 +15925,23 @@ Array [
   ],
 ]
 `;
+
+exports[`Process WordPress data deletes nodes not found in entities 1`] = `
+Array [
+  Array [
+    9998,
+  ],
+]
+`;
+
+exports[`Process WordPress data deletes nodes not found in entities 2`] = `
+Array [
+  Array [
+    Object {
+      "node": Object {
+        "id": 9998,
+      },
+    },
+  ],
+]
+`;

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -29,6 +29,7 @@ exports.sourceNodes = async (
   {
     actions,
     getNode,
+    getNodes,
     store,
     cache,
     createNodeId,
@@ -53,7 +54,7 @@ exports.sourceNodes = async (
     keepMediaSizes = false,
   }
 ) => {
-  const { createNode, touchNode } = actions
+  const { createNode, deleteNode, touchNode } = actions
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
 
   _verbose = verboseOutput
@@ -186,6 +187,13 @@ exports.sourceNodes = async (
       keepMediaSizes,
     })
   }
+
+  normalize.deleteNodesThatDoNotExistInEntities({
+    entities,
+    getNode,
+    getNodes,
+    deleteNode,
+  })
 
   // creates nodes for each entry
   normalize.createNodesFromEntities({

--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -2,6 +2,7 @@ const deepMapKeys = require(`deep-map-keys`)
 const _ = require(`lodash`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 const { URL } = require(`url`)
+const { name: packageName } = require(`../package.json`)
 
 const colorized = require(`./output-color`)
 const conflictFieldPrefix = `wordpress_`
@@ -588,6 +589,27 @@ const prepareACFChildNodes = (
   childrenNodes.unshift(acfChildNode)
 
   return acfChildNode
+}
+
+exports.deleteNodesThatDoNotExistInEntities = ({
+  entities,
+  getNode,
+  getNodes,
+  deleteNode,
+}) => {
+  const nodes = getNodes()
+  const wordpressIds = nodes
+    .filter(node => node.internal.owner === packageName)
+    .map(node => node.id)
+
+  const entityIds = entities.map(entity => entity.id)
+
+  wordpressIds
+    .filter(x => !entityIds.includes(x))
+    .forEach(id => {
+      const node = getNode(id)
+      deleteNode({ node })
+    })
 }
 
 exports.createNodesFromEntities = ({


### PR DESCRIPTION
Intended to update from a __refresh call

## Description

Currently, when a `__refresh` call is made with `gatsby-source-wordpress` only new nodes are added - this removes any nodes created with `gatsby-source-wordpress` that no longer exist in the latest in the latest fetch.

## Related Issues

Fixes #18040 
