### PR TITLE
fix: override default options of gatsby-plugin-page-creator on Windows

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -223,7 +223,8 @@ module.exports = (config = {}, rootDir = null) => {
     const pageCreatorPlugin = config.plugins.find(
       plugin =>
         plugin.resolve === `gatsby-plugin-page-creator` &&
-        plugin.options.path === slash(path.join(program.directory, `src/pages`))
+        slash(plugin.options.path || ``) ===
+          slash(path.join(program.directory, `src/pages`))
     )
     if (pageCreatorPlugin) {
       // override the options if there are any user specified options


### PR DESCRIPTION

## Description

Fix override default options of gatsby-plugin-page-creator doesn't work on windows.

## Related Issues

Fixes #18795
