### PR TITLE
Add using-bootstrap in examples

### DIFF
--- a/examples/using-bootstrap/.eslintrc.json
+++ b/examples/using-bootstrap/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "graphql": false
+  }
+}

--- a/examples/using-bootstrap/README.md
+++ b/examples/using-bootstrap/README.md
@@ -1,7 +1,3 @@
-# Using Bootstrap
+# using-bootstrap
 
-Example site that demonstrates how to build Gatsby sites with
-[Boostrap](https://getbootstrap.com/).
-
-### References
-[React Bootstrap - https://react-bootstrap.github.io](https://react-bootstrap.github.io)
+Example site that demonstrates how to build Gatsby sites with Bootstrap

--- a/examples/using-bootstrap/README.md
+++ b/examples/using-bootstrap/README.md
@@ -1,0 +1,7 @@
+# Using Bootstrap
+
+Example site that demonstrates how to build Gatsby sites with
+[Boostrap](https://getbootstrap.com/).
+
+### References
+[React Bootstrap - https://react-bootstrap.github.io](https://react-bootstrap.github.io)

--- a/examples/using-bootstrap/gatsby-config.js
+++ b/examples/using-bootstrap/gatsby-config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  siteMetadata: {
+    title: `Gatsby with Bootstrap`,
+    description: `Example of using Gatsby with Bootstrap`,
+  },
+}

--- a/examples/using-bootstrap/package.json
+++ b/examples/using-bootstrap/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "gatsby-example-using-boostrap",
+  "private": true,
+  "description": "Example of using Gatsby with Bootstrap",
+  "version": "1.0.0",
+  "author": "Chun Rapeepat <chunza2542@gmail.com>",
+  "dependencies": {
+    "bootstrap": "^4.3.1",
+    "gatsby": "^2.0.91",
+    "react": "^16.7.0",
+    "react-bootstrap": "^1.0.0-beta.14",
+    "react-dom": "^16.7.0"
+  },
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "n/a",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "start": "npm run develop"
+  }
+}

--- a/examples/using-bootstrap/src/pages/index.js
+++ b/examples/using-bootstrap/src/pages/index.js
@@ -12,14 +12,18 @@ class IndexPage extends React.Component {
           <p>
             The example of using Gatsby with Bootstrap. You can see all
             components here{` `}
-            <a href="https://react-bootstrap.netlify.com" target="_blank">
+            <a
+              href="https://react-bootstrap.netlify.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               React Bootstrap
             </a>
           </p>
           <br />
 
           <Row>
-            <Col>
+            <Col key={1}>
               <Card>
                 <Card.Body>
                   <Card.Title>Card Title</Card.Title>
@@ -31,7 +35,7 @@ class IndexPage extends React.Component {
                 </Card.Body>
               </Card>
             </Col>
-            <Col>
+            <Col key={2}>
               <Card>
                 <Card.Body>
                   <Card.Title>Card Title</Card.Title>
@@ -43,7 +47,7 @@ class IndexPage extends React.Component {
                 </Card.Body>
               </Card>
             </Col>
-            <Col>
+            <Col key={3}>
               <Card>
                 <Card.Body>
                   <Card.Title>Card Title</Card.Title>

--- a/examples/using-bootstrap/src/pages/index.js
+++ b/examples/using-bootstrap/src/pages/index.js
@@ -1,0 +1,59 @@
+import React from "react"
+import {Button, Container, Card, Col, Row} from "react-bootstrap";
+
+import 'bootstrap/dist/css/bootstrap.min.css'
+
+class IndexPage extends React.Component {
+  render() {
+    return (
+      <>
+        <Container style={{margin: "50px auto"}}>
+          <h1>Hello World, Gatsby</h1>
+          <p>The example of using Gatsby with Bootstrap. You can see all components here <a href="https://react-bootstrap.netlify.com" target="_blank">React Bootstrap</a></p>
+          <br/>
+
+          <Row>
+            <Col>
+              <Card>
+                <Card.Body>
+                  <Card.Title>Card Title</Card.Title>
+                  <Card.Text>
+                    Some quick example text to build on the card title and make up the bulk of
+                    the card's content.
+                  </Card.Text>
+                  <Button variant="primary">Go somewhere</Button>
+                </Card.Body>
+              </Card>
+            </Col>
+            <Col>
+              <Card>
+                <Card.Body>
+                  <Card.Title>Card Title</Card.Title>
+                  <Card.Text>
+                    Some quick example text to build on the card title and make up the bulk of
+                    the card's content.
+                  </Card.Text>
+                  <Button variant="primary">Go somewhere</Button>
+                </Card.Body>
+              </Card>
+            </Col>
+            <Col>
+              <Card>
+                <Card.Body>
+                  <Card.Title>Card Title</Card.Title>
+                  <Card.Text>
+                    Some quick example text to build on the card title and make up the bulk of
+                    the card's content.
+                  </Card.Text>
+                  <Button variant="primary">Go somewhere</Button>
+                </Card.Body>
+              </Card>
+            </Col>
+          </Row>
+        </Container>
+      </>
+    )
+  }
+}
+
+export default IndexPage

--- a/examples/using-bootstrap/src/pages/index.js
+++ b/examples/using-bootstrap/src/pages/index.js
@@ -1,16 +1,22 @@
 import React from "react"
-import {Button, Container, Card, Col, Row} from "react-bootstrap";
+import { Button, Container, Card, Col, Row } from "react-bootstrap"
 
-import 'bootstrap/dist/css/bootstrap.min.css'
+import "bootstrap/dist/css/bootstrap.min.css"
 
 class IndexPage extends React.Component {
   render() {
     return (
       <>
-        <Container style={{margin: "50px auto"}}>
+        <Container style={{ margin: `50px auto` }}>
           <h1>Hello World, Gatsby</h1>
-          <p>The example of using Gatsby with Bootstrap. You can see all components here <a href="https://react-bootstrap.netlify.com" target="_blank">React Bootstrap</a></p>
-          <br/>
+          <p>
+            The example of using Gatsby with Bootstrap. You can see all
+            components here{` `}
+            <a href="https://react-bootstrap.netlify.com" target="_blank">
+              React Bootstrap
+            </a>
+          </p>
+          <br />
 
           <Row>
             <Col>
@@ -18,8 +24,8 @@ class IndexPage extends React.Component {
                 <Card.Body>
                   <Card.Title>Card Title</Card.Title>
                   <Card.Text>
-                    Some quick example text to build on the card title and make up the bulk of
-                    the card's content.
+                    Some quick example text to build on the card title and make
+                    up the bulk of the card's content.
                   </Card.Text>
                   <Button variant="primary">Go somewhere</Button>
                 </Card.Body>
@@ -30,8 +36,8 @@ class IndexPage extends React.Component {
                 <Card.Body>
                   <Card.Title>Card Title</Card.Title>
                   <Card.Text>
-                    Some quick example text to build on the card title and make up the bulk of
-                    the card's content.
+                    Some quick example text to build on the card title and make
+                    up the bulk of the card's content.
                   </Card.Text>
                   <Button variant="primary">Go somewhere</Button>
                 </Card.Body>
@@ -42,8 +48,8 @@ class IndexPage extends React.Component {
                 <Card.Body>
                   <Card.Title>Card Title</Card.Title>
                   <Card.Text>
-                    Some quick example text to build on the card title and make up the bulk of
-                    the card's content.
+                    Some quick example text to build on the card title and make
+                    up the bulk of the card's content.
                   </Card.Text>
                   <Button variant="primary">Go somewhere</Button>
                 </Card.Body>


### PR DESCRIPTION
### Description 
Add the example site that demonstrates how to build Gatsby sites with Bootstrap (react-bootstrap)