### PR TITLE
chore(docs): Fix broken link (docs/audit with Lighthouse)

### DIFF
--- a/docs/docs/audit-with-lighthouse.md
+++ b/docs/docs/audit-with-lighthouse.md
@@ -47,5 +47,5 @@ As you can see, Gatsby's performance is excellent out of the box but we're missi
 Next steps:
 
 - [Add a manifest file](/docs/add-a-manifest-file/)
-- [Add offline support](/docs/add-offline-support/)
+- [Add offline support](/docs/add-offline-support-with-a-service-worker/)
 - [Add page metadata](/docs/add-page-metadata/)


### PR DESCRIPTION
## Description

I found broken link to `/docs/add-offline-support/` instead of `/docs/add-offline-support-with-a-service-worker/` and fixed that. Not sure is it necessary to add permalink to staled url so i did not do that. Also can't find out how you will fix that in other language repos so if you want i can make PR in each of them.