### PR TITLE
Reload chalk on setNoColor

### DIFF
--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -42,7 +42,7 @@ if (process.env.GATSBY_LOGGER.includes(`json`)) {
 
 const util = require(`util`)
 const { stripIndent } = require(`common-tags`)
-const chalk = require(`chalk`)
+let chalk = require(`chalk`)
 const { trackError } = require(`gatsby-telemetry`)
 const tracer = require(`opentracing`).globalTracer()
 
@@ -119,6 +119,7 @@ const reporter: Reporter = {
     //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7
     if (isNoColor) {
       process.env.FORCE_COLOR = `0`
+      chalk = require(`chalk`)
     }
   },
   /**


### PR DESCRIPTION
## Description

Reloads `chalk` when `process.env.FORCE_COLOR` is set to 0.

## Related Issues

Fixes #18514