### PR TITLE
fix(gatsby-cli): handle git commit failures

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -92,6 +92,7 @@ const createInitialGitCommit = async (rootPath, starterUrl) => {
     })
   } catch {
     // Remove git support if intial commit fails
+    report.info(`Initial git commit failed - removing git support\n`)
     fs.removeSync(sysPath.join(rootPath, `.git`))
   }
 }

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -86,9 +86,14 @@ const createInitialGitCommit = async (rootPath, starterUrl) => {
   await spawn(`git add -A`, { cwd: rootPath })
   // use execSync instead of spawn to handle git clients using
   // pgp signatures (with password)
-  execSync(`git commit -m "Initial commit from gatsby: (${starterUrl})"`, {
-    cwd: rootPath,
-  })
+  try {
+    execSync(`git commit -m "Initial commit from gatsby: (${starterUrl})"`, {
+      cwd: rootPath,
+    })
+  } catch {
+    // Remove git support if intial commit fails
+    fs.removeSync(sysPath.join(rootPath, `.git`))
+  }
 }
 
 // Executes `npm install` or `yarn install` in rootPath.


### PR DESCRIPTION
## Description

If initial commit fails, revert to not adding git support by removing the `.git` directory as discussed in issue #17766

Have tested this locally by removing `~/.gitconfig` so initial commit fails and running `gatsby new gatsby-site` from source.

## Related Issues

Fixes #17766
