### PR TITLE
feat(site-showcase-validator): check 'source_url' for private repos

### DIFF
--- a/.github/actions/gatsby-site-showcase-validator/index.js
+++ b/.github/actions/gatsby-site-showcase-validator/index.js
@@ -86,8 +86,9 @@ async function run() {
     )
   )
 
-  // If there are any non Gatsby sites, fail (non-zero exit code)
-  process.exit(nonGatsbySiteCount > 0 ? 1 : 0)
+  // If there are any non Gatsby sites or their `source_url` is private, fail (non-zero exit code)
+  const exitCode = nonGatsbySiteCount > 0 || nonPublicRepoCount > 0 ? 1 : 0
+  process.exit(exitCode)
 }
 
 run()

--- a/.github/actions/gatsby-site-showcase-validator/index.js
+++ b/.github/actions/gatsby-site-showcase-validator/index.js
@@ -6,7 +6,7 @@ const chalk = require("chalk")
 
 async function run() {
   // Grab down sites.yml
-  let url =
+  const url =
     "https://raw.githubusercontent.com/gatsbyjs/gatsby/master/docs/sites.yml"
 
   let yamlStr
@@ -19,17 +19,18 @@ async function run() {
   }
 
   // Parse YAML
-  let parsedYaml = yaml.safeLoad(yamlStr, "utf8")
+  const parsedYaml = yaml.safeLoad(yamlStr, "utf8")
 
   let sitesVisited = 0
   let nonGatsbySiteCount = 0
+  let nonPublicRepoCount = 0
   let erroredOut = 0
-  let totalSitesCount = parsedYaml.length
+  const totalSitesCount = parsedYaml.length
 
   // Loop over each site
   for (let site of parsedYaml) {
-    let siteUrl = site.main_url
-
+    const siteUrl = site.main_url
+    const sourceUrl = site.source_url
     let siteHtml
 
     // Fetch site
@@ -47,29 +48,41 @@ async function run() {
     }
 
     // Pass html into a parser
-    let $ = cheerio.load(siteHtml)
+    const $ = cheerio.load(siteHtml)
 
     // Most Gatsby sites have an id of "___gatsby"
-    let gatsbyContainer = $("#___gatsby")
+    const gatsbyContainer = $("#___gatsby")
 
-    if (gatsbyContainer.length !== 0) {
-      // The site is a gatsby site don't do anything
-      sitesVisited++
-    } else {
-      // The site is not a gatsby site, print out some info
+    // The site is not a gatsby site, print out some info
+    if (!gatsbyContainer.length) {
       console.log(
         `${chalk.yellow(`[Notice]`)}: ${
           site.title
         } (${siteUrl}) is not a Gatsby site`
       )
-      sitesVisited++
       nonGatsbySiteCount++
     }
+
+    // Check if provided repository is public
+    if (sourceUrl) {
+      const status = await fetch(sourceUrl).then(({ status }) => status)
+
+      if (status !== 200) {
+        console.log(
+          `${chalk.yellow(`[Notice]`)}: ${
+            site.title
+          } (${siteUrl}) provided a 'source_url', but it's repository is private (${sourceUrl})`
+        )
+        nonPublicRepoCount++
+      }
+    }
+
+    sitesVisited++
   }
 
   console.log(
     chalk.green(
-      `We visited ${sitesVisited}/${totalSitesCount} sites. Out of them, ${nonGatsbySiteCount} sites were not a Gatsby site and ${erroredOut} errored out when visiting it.`
+      `We visited ${sitesVisited}/${totalSitesCount} sites. Out of them, ${nonGatsbySiteCount} sites were not a Gatsby site, ${nonPublicRepoCount} provided private repositories, and ${erroredOut} errored out when visiting it.`
     )
   )
 

--- a/.github/actions/gatsby-site-showcase-validator/index.js
+++ b/.github/actions/gatsby-site-showcase-validator/index.js
@@ -23,7 +23,7 @@ async function run() {
 
   let sitesVisited = 0
   let nonGatsbySiteCount = 0
-  let nonPublicRepoCount = 0
+  let inaccessibleRepoCount = 0
   let erroredOut = 0
   const totalSitesCount = parsedYaml.length
 
@@ -71,9 +71,9 @@ async function run() {
         console.log(
           `${chalk.yellow(`[Notice]`)}: ${
             site.title
-          } (${siteUrl}) provided a 'source_url', but it's repository is private (${sourceUrl})`
+          } (${siteUrl}) provided a 'source_url', but it's repository is inaccessible (${sourceUrl})`
         )
-        nonPublicRepoCount++
+        inaccessibleRepoCount++
       }
     }
 
@@ -82,12 +82,12 @@ async function run() {
 
   console.log(
     chalk.green(
-      `We visited ${sitesVisited}/${totalSitesCount} sites. Out of them, ${nonGatsbySiteCount} sites were not a Gatsby site, ${nonPublicRepoCount} provided private repositories, and ${erroredOut} errored out when visiting it.`
+      `We visited ${sitesVisited}/${totalSitesCount} sites. Out of them, ${nonGatsbySiteCount} sites were not a Gatsby site, ${inaccessibleRepoCount} provided inaccessible repositories, and ${erroredOut} errored out when visiting it.`
     )
   )
 
-  // If there are any non Gatsby sites or their `source_url` is private, fail (non-zero exit code)
-  const exitCode = nonGatsbySiteCount > 0 || nonPublicRepoCount > 0 ? 1 : 0
+  // If there are any non Gatsby sites or their `source_url` is inaccessible, fail (non-zero exit code)
+  const exitCode = nonGatsbySiteCount > 0 || inaccessibleRepoCount > 0 ? 1 : 0
   process.exit(exitCode)
 }
 


### PR DESCRIPTION
## Description

I've added a check for private repositories in `source_url` entry. For non-public repos there's a notice printed and the summary message contains a total number of them. Except for that, I've also refactored the code a little to make it easier to read, moved the `sitesVisited` increment to the end of the loop and made constants use `const` for clarity.

Example run:
<img width="1564" alt="Zrzut ekranu 2019-10-19 o 20 26 20" src="https://user-images.githubusercontent.com/23037261/67149824-35a9d800-f2b0-11e9-85f3-6b96f99fde8c.png">


## Related Issues

Closes #18805 
