### PR TITLE
fix: fix bottom navbar on Iphone X

### DIFF
--- a/www/src/components/navigation-mobile.js
+++ b/www/src/components/navigation-mobile.js
@@ -51,7 +51,7 @@ const MobileNavigation = () => (
       bottom: 0,
       display: `flex`,
       fontFamily: `header`,
-      height: `headerHeight`,
+      height: `headerHeight + env(safe-area-inset-bottom)`,
       justifyContent: `space-around`,
       left: 0,
       paddingBottom: `env(safe-area-inset-bottom)`,

--- a/www/src/components/navigation-mobile.js
+++ b/www/src/components/navigation-mobile.js
@@ -51,7 +51,6 @@ const MobileNavigation = () => (
       bottom: 0,
       display: `flex`,
       fontFamily: `header`,
-      height: `headerHeight + env(safe-area-inset-bottom)`,
       justifyContent: `space-around`,
       left: 0,
       paddingBottom: `env(safe-area-inset-bottom)`,


### PR DESCRIPTION
## Description

Height of the mobile bottom navbar now includes its padding.

How it looks on iPhone X:
![IMG_0110](https://user-images.githubusercontent.com/23037261/67151736-731b5f00-f2ca-11e9-9637-eeb8f089a98e.png)

How it looks on iPhone 8:
![IMG_0929](https://user-images.githubusercontent.com/23037261/67151754-8e866a00-f2ca-11e9-82fb-5bca54f8b0cf.png)


## Related Issues

Fixes #18836 