### PR TITLE
refactor(gatsby-transformer-sharp): Use explicit graphql type definition vs inferring

### DIFF
--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.33",
+    "gatsby": "^2.12.0",
     "gatsby-plugin-sharp": "^2.0.0-beta.3"
   },
   "repository": {

--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -51,7 +51,6 @@ const getTracedSVG = async ({ file, image, fieldArgs, cache, reporter }) =>
   })
 
 const fixedNodeType = ({
-  type,
   pathPrefix,
   getNodeAndSavePathDependency,
   reporter,
@@ -200,7 +199,6 @@ const fixedNodeType = ({
 }
 
 const fluidNodeType = ({
-  type,
   pathPrefix,
   getNodeAndSavePathDependency,
   reporter,
@@ -357,19 +355,13 @@ const fluidNodeType = ({
   }
 }
 
-module.exports = ({
-  type,
+const createFields = ({
   pathPrefix,
   getNodeAndSavePathDependency,
   reporter,
   cache,
 }) => {
-  if (type.name !== `ImageSharp`) {
-    return {}
-  }
-
   const nodeOptions = {
-    type,
     pathPrefix,
     getNodeAndSavePathDependency,
     reporter,
@@ -544,5 +536,37 @@ module.exports = ({
         })
       },
     },
+  }
+}
+
+module.exports = ({
+  actions,
+  schema,
+  pathPrefix,
+  getNodeAndSavePathDependency,
+  reporter,
+  cache,
+}) => {
+  const { createTypes } = actions
+
+  const imageSharpType = schema.buildObjectType({
+    name: `ImageSharp`,
+    fields: createFields({
+      pathPrefix,
+      getNodeAndSavePathDependency,
+      reporter,
+      cache,
+    }),
+    interfaces: [`Node`],
+    extensions: {
+      infer: true,
+      childOf: {
+        types: [`File`],
+      },
+    },
+  })
+
+  if (createTypes) {
+    createTypes([imageSharpType])
   }
 }

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -1,32 +1,14 @@
 const fs = require(`fs-extra`)
 
 exports.onCreateNode = require(`./on-node-create`)
-exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)
+exports.createSchemaCustomization = require(`./customize-schema`)
 
-exports.onPreExtractQueries = async ({ store, getNodesByType }) => {
+exports.onPreExtractQueries = async ({ store }) => {
   const program = store.getState().program
 
-  // Check if there are any ImageSharp nodes. If so add fragments for ImageSharp.
-  // The fragment will cause an error if there are no ImageSharp nodes.
-  if (getNodesByType(`ImageSharp`).length == 0) {
-    return
-  }
-
-  // We have ImageSharp nodes so let's add our fragments to .cache/fragments.
+  // Add fragments for ImageSharp to .cache/fragments.
   await fs.copy(
     require.resolve(`gatsby-transformer-sharp/src/fragments.js`),
     `${program.directory}/.cache/fragments/image-sharp-fragments.js`
   )
-}
-
-exports.sourceNodes = ({ actions }) => {
-  const { createTypes } = actions
-
-  if (createTypes) {
-    createTypes(`
-      type ImageSharp implements Node @infer @childOf(types: ["File"]) {
-        id: ID!
-      }
-    `)
-  }
 }


### PR DESCRIPTION
## Description

Convert gatsby-transformer-sharp to use schema customization API (vs. relying on type inference)

Fixes #17531 
