### PR TITLE
chore(showcase): Removing Mixkit

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4231,19 +4231,6 @@
   built_by: Kirankumar Ambati
   built_by_url: https://github.com/kirankumarambati
   featured: false
-- title: Mixkit by Envato
-  url: https://mixkit.co
-  main_url: https://mixkit.co
-  description: >
-    Extraordinary free HD videos
-  categories:
-    - Video
-    - Design
-    - Gallery
-    - Video
-  built_by: Envato
-  built_by_url: https://github.com/envato
-  featured: false
 - title: Rou Hun Fan's portfolio
   main_url: https://flowen.me
   url: https://flowen.me


### PR DESCRIPTION
## Description

The Site Showcase found it was no longer a Gatsby site (now using NextJS), so I'm removing it from the showcase

## Related Issues

N/A