### PR TITLE
fix: (gatsby-plugin-mdx) - update readme - String reference is supported

### DIFF
--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -340,9 +340,7 @@ module.exports = {
 }
 ```
 
-###### Note:
-
-Using a string reference is currently not supported for `gatsbyRemarkPlugins`. (A PR would be accepted for this)
+Using a string reference is also supported for `gatsbyRemarkPlugins`.
 
 ```js
 gatsbyRemarkPlugins: [`gatsby-remark-images`]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Update readme as string references are also supported.
