### PR TITLE
fix(gatsby-source-wordpress): add undefined check to avoid mapPostsToTagsCategories error

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -240,26 +240,38 @@ exports.mapPostsToTagsCategories = entities => {
 
     let entityHasTags = e.tags && Array.isArray(e.tags) && e.tags.length
     if (tags.length && entityHasTags) {
-      e.tags___NODE = e.tags.map(
-        t =>
-          tags.find(
+      e.tags___NODE = e.tags
+        .map(t => {
+          const tagNode = tags.find(
             tObj =>
               (Number.isInteger(t) ? t : t.wordpress_id) === tObj.wordpress_id
-          ).id
-      )
+          )
+          if (tagNode) {
+            return tagNode.id
+          } else {
+            return undefined
+          }
+        })
+        .filter(node => node != undefined)
       delete e.tags
     }
 
     let entityHasCategories =
       e.categories && Array.isArray(e.categories) && e.categories.length
     if (categories.length && entityHasCategories) {
-      e.categories___NODE = e.categories.map(
-        c =>
-          categories.find(
+      e.categories___NODE = e.categories
+        .map(c => {
+          const categoryNode = categories.find(
             cObj =>
               (Number.isInteger(c) ? c : c.wordpress_id) === cObj.wordpress_id
-          ).id
-      )
+          )
+          if (categoryNode) {
+            return categoryNode.id
+          } else {
+            return undefined
+          }
+        })
+        .filter(node => node != undefined)
       delete e.categories
     }
 


### PR DESCRIPTION
This is addressing null checking in the `mapPostsToTagsCategories` function in `normalize.js` for the plugin `gatsby-source-wordpress`.

Some of my posts seem to have categories, others do not, so I was recieving `TypeError - Cannot read property 'id' of undefined` on some of them. This code adds checks.

This is a similar issue as was solved here: https://github.com/gatsbyjs/gatsby/issues/10138