### PR TITLE
chore(docs): make ordered list more consistent

### DIFF
--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -254,9 +254,7 @@ The `console.log(styles)` code will log the resulting import so you can see the 
 
 If you compare that to your CSS file, you'll see that each class is now a key in the imported object pointing to a long string e.g. `avatar` points to `src-pages----about-css-modules-module---avatar---2lRF7`. These are the class names CSS Modules generates. They're guaranteed to be unique across your site. And because you have to import them to use the classes, there's never any question about where some CSS is being used.
 
-4. Create a `User` component.
-
-Create a new `<User />` component inline in the `about-css-modules.js` page
+4. Create a new `<User />` component inline in the `about-css-modules.js` page
 component. Modify `about-css-modules.js` so it looks like the following:
 
 ```jsx:title=src/pages/about-css-modules.js

--- a/docs/tutorial/part-two/index.md
+++ b/docs/tutorial/part-two/index.md
@@ -255,7 +255,7 @@ The `console.log(styles)` code will log the resulting import so you can see the 
 If you compare that to your CSS file, you'll see that each class is now a key in the imported object pointing to a long string e.g. `avatar` points to `src-pages----about-css-modules-module---avatar---2lRF7`. These are the class names CSS Modules generates. They're guaranteed to be unique across your site. And because you have to import them to use the classes, there's never any question about where some CSS is being used.
 
 4. Create a new `<User />` component inline in the `about-css-modules.js` page
-component. Modify `about-css-modules.js` so it looks like the following:
+   component. Modify `about-css-modules.js` so it looks like the following:
 
 ```jsx:title=src/pages/about-css-modules.js
 import React from "react"


### PR DESCRIPTION
## Description

While going through the tutorial, it felt a little weird that the first three items in the ordered list didn't have any kind of heading, but the fourth one seems to. I removed the header to make the fourth item more consistent with the other three.

## Related Issues

There are no related issues. This is something I noticed while working through the tutorial.
