### PR TITLE
adding --clean option to gatsby build

### DIFF
--- a/docs/docs/cheat-sheet.md
+++ b/docs/docs/cheat-sheet.md
@@ -206,6 +206,14 @@ Get the PDF: <a href="/gatsby-cheat-sheet.pdf" download>gatsby-cheat-sheet.pdf</
                     <p>Tracer configuration file (OpenTracing compatible). See <a href="https://gatsby.dev/tracing">gatsby.dev/tracing</a></p>
                 </td>
             </tr>
+            <tr>
+                <td>
+                    <p><code>--clean</code></p>
+                </td>
+                <td>
+                    <p>Perform a `gatsby clean` before building (delete /cache and /public directories) See <a href="https://www.gatsbyjs.org/docs/gatsby-cli/#clean">https://www.gatsbyjs.org/docs/gatsby-cli/#clean</a></p>
+                </td>
+            </tr>            
         </tbody>
     </table>
     <h3><code>gatsby serve</code></h3>

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -118,6 +118,7 @@ At the root of a Gatsby site, compile your application and make it ready for dep
 |       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                       |
 |        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                   |
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
+|          `--clean`           | Perform 'gatsby clean' before building (removes .cache, .public directories)                              |    
 | `--no-color`, `--no-colors`  | Disables colored terminal output                                                                          |
 
 In addition to these build options, there are some optional [build environment variables](/docs/environment-variables/#build-variables) for more advanced configurations that can adjust how a build runs. For example, setting `CI=true` as an environment variable will tailor output for [dumb terminals](https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals).

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -99,6 +99,7 @@ At the root of a Gatsby app run `gatsby build` to do a production build of a sit
 |       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                        | `false` |
 |        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                    | `false` |
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.org/docs/performance-tracing/ |         |
+|          `--clean`           | Perform 'gatsby clean' before building (removes .cache, .public directories)                               | `false` |
 | `--no-color`, `--no-colors`  | Disables colored terminal output                                                                           | `false` |
 
 ### `serve`

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -179,7 +179,7 @@ function buildLocalCommands(cli, isLocalSite) {
           type: `boolean`,
           default: false,
           describe: `Perform 'gatsby clean' (purge .cache and .public dirs) before building`,
-        }),        
+        }),
     handler: handlerP(
       getCommandHandler(`build`, (args, cmd) => {
         process.env.NODE_ENV = `production`

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -174,7 +174,12 @@ function buildLocalCommands(cli, isLocalSite) {
         .option(`open-tracing-config-file`, {
           type: `string`,
           describe: `Tracer configuration file (OpenTracing compatible). See https://gatsby.dev/tracing`,
-        }),
+        })
+        .option(`clean`, {
+          type: `boolean`,
+          default: false,
+          describe: `Perform 'gatsby clean' (purge .cache and .public dirs) before building`,
+        }),        
     handler: handlerP(
       getCommandHandler(`build`, (args, cmd) => {
         process.env.NODE_ENV = `production`

--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -16,6 +16,7 @@ const queryUtil = require(`../query`)
 const appDataUtil = require(`../utils/app-data`)
 const WorkerPool = require(`../utils/worker/pool`)
 const { structureWebpackErrors } = require(`../utils/webpack-error-utils`)
+const cleanCommand = require(`../clean.js`)
 
 type BuildArgs = {
   directory: string,
@@ -23,6 +24,7 @@ type BuildArgs = {
   prefixPaths: boolean,
   noUglify: boolean,
   openTracingConfigFile: string,
+  clean: boolean,
 }
 
 const waitJobsFinished = () =>
@@ -47,6 +49,8 @@ module.exports = async function build(program: BuildArgs) {
   signalExit(exitCode => {
     telemetry.trackCli(`BUILD_END`, { exitCode })
   })
+
+  if (clean) await cleanCommand.clean()
 
   const buildSpan = buildActivity.span
   buildSpan.setTag(`directory`, program.directory)

--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -50,7 +50,7 @@ module.exports = async function build(program: BuildArgs) {
     telemetry.trackCli(`BUILD_END`, { exitCode })
   })
 
-  if (clean) await cleanCommand.clean()
+  if (program.clean) await cleanCommand.clean()
 
   const buildSpan = buildActivity.span
   buildSpan.setTag(`directory`, program.directory)

--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -16,7 +16,7 @@ const queryUtil = require(`../query`)
 const appDataUtil = require(`../utils/app-data`)
 const WorkerPool = require(`../utils/worker/pool`)
 const { structureWebpackErrors } = require(`../utils/webpack-error-utils`)
-const cleanCommand = require(`../clean.js`)
+const cleanCommand = require(`./clean.js`)
 
 type BuildArgs = {
   directory: string,


### PR DESCRIPTION
I previously commented https://github.com/gatsbyjs/gatsby/pull/16887#issuecomment-544351195 that while I don't think `clean` should be part of the default `gatsby build`, it should be an option. This is highly useful on continuous deployment scenarios which offer a single command to run upon each new commit. Thus, `gatsby clean` followed by `gatsby build` is not possible. This PR would make it possible.

To be very clear: THIS PR LIKELY DOES NOT WORK AS-IS. I am a gatsby user, compiling a forked CLI would mess up my main gatsby CLI which I rely upon to keep my live sites updated. I went through the code and edited the CLI command instructions (these probably work) and then the `build.js` file and make a best guess at where the clean command should be inserted, and how to call it. I will not be offended :) if major changes are necessary to the code. I will be disappointed :( if the PR (and the idea behind it) is outright rejected. 

Thank you!

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
