### PR TITLE
blog: Update link to shadowing documentation

### DIFF
--- a/docs/blog/2019-04-29-component-shadowing/index.md
+++ b/docs/blog/2019-04-29-component-shadowing/index.md
@@ -142,5 +142,5 @@ Gatsby Themes and is currently being used in production.
 
 ## Further reading
 
-- [Component Shadowing Documentation](/docs/themes/api-reference/#component-shadowing)
+- [Component Shadowing Documentation](/docs/themes/shadowing/)
 - [Latent Component Shadowing](https://johno.com/latent-component-shadowing)


### PR DESCRIPTION
## Description

The link to the documentation on component shadowing in this blog post was broken. I replaced the link with what I believe it should be pointing to now.

## Related Issues

No ticket. Just saw this while I was trying to understand how component shadowing works.
