### PR TITLE
fix(gatsby): ensure `@childOf` adds convenience fields before root field arguments

### DIFF
--- a/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
@@ -872,6 +872,29 @@ describe(`Define parent-child relationships with field extensions`, () => {
     )
     await expect(buildSchema()).resolves.toEqual(expect.any(Object))
   })
+
+  it(`adds root field arguments for searchable child fields (when there are no data nodes)`, async () => {
+    dispatch(
+      createTypes(`
+        type Parent implements Node {
+          id: ID!
+        }
+        type ChildWithoutSourceNodes implements Node @childOf(types: ["Parent"]) {
+          name: String
+        }
+      `)
+    )
+    const { schema } = await buildSchema()
+    const expectedArg = schema
+      .getType(`Query`)
+      .getFields()
+      .parent.args.find(arg => arg.name === `childChildWithoutSourceNodes`)
+    const expectedArgType = schema.getType(`ChildWithoutSourceNodesFilterInput`)
+
+    expect(expectedArg).toBeDefined()
+    expect(expectedArgType).toBeDefined()
+    expect(expectedArg.type).toStrictEqual(expectedArgType)
+  })
 })
 
 const buildSchema = async () => {

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -145,6 +145,10 @@ const updateSchemaComposer = async ({
     nodeStore,
     parentSpan: activity.span,
   })
+  await addConvenienceChildrenFields({
+    schemaComposer,
+    parentSpan: activity.span,
+  })
   await Promise.all(
     Array.from(new Set(schemaComposer.values())).map(typeComposer =>
       processTypeComposer({
@@ -157,10 +161,6 @@ const updateSchemaComposer = async ({
     )
   )
   checkQueryableInterfaces({ schemaComposer, parentSpan: activity.span })
-  await addConvenienceChildrenFields({
-    schemaComposer,
-    parentSpan: activity.span,
-  })
   await addThirdPartySchemas({
     schemaComposer,
     thirdPartySchemas,


### PR DESCRIPTION
# Description

This fixes an edge case situation when `@childOf` directive is applied after root field arguments are created (and thus convenience arguments are missing in the schema).

Since we use a schema composer, changing the ordering of calls seems to be enough. Tests are green and nothing seems to be affected. But I may be easily missing something here.

Fixes #18872
