### PR TITLE
fix(gatsby): use hashes as module identifiers for webpack caching

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -472,6 +472,9 @@ module.exports = async (
       splitChunks: {
         name: false,
         chunks: `all`,
+        // use hashes instead of ids for module identifiers
+        // @see https://webpack.js.org/guides/caching/#module-identifiers
+        moduleIds: `hashed`,
         cacheGroups: {
           default: false,
           vendors: false,


### PR DESCRIPTION
# Description
Use hashes instead of module ids to specify modules. This makes our builds idempotent.

