### PR TITLE
fix(www): use UTC timezone to display dates on events page

### DIFF
--- a/www/src/components/events/event.js
+++ b/www/src/components/events/event.js
@@ -8,6 +8,7 @@ const displayDate = date =>
     year: `numeric`,
     month: `long`,
     day: `numeric`,
+    timeZone: `UTC`
   })
 
 const Event = ({

--- a/www/src/components/events/event.js
+++ b/www/src/components/events/event.js
@@ -8,7 +8,7 @@ const displayDate = date =>
     year: `numeric`,
     month: `long`,
     day: `numeric`,
-    timeZone: `UTC`
+    timeZone: `UTC`,
   })
 
 const Event = ({


### PR DESCRIPTION
The source of the dates, Airtable was changed to send dates using UTC timezone. This code change will  correct dates that are currently being displayed as 1 day off.

![localhost_8000_contributing_events_(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/6027587/67434567-76f3fd80-f5b8-11e9-9c05-3e209a313284.png)

