### PR TITLE
docs: fix incorrect filename

### DIFF
--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -70,9 +70,9 @@ To use cypress-axe you have to install `cypress-axe` and [axe-core](https://gith
 npm install --save-dev cypress-axe axe-core @testing-library/cypress
 ```
 
-Then you add the `cypress-axe` and `@testing-library/cypress` commands in `cypress/support/commands.js`:
+Then you add the `cypress-axe` and `@testing-library/cypress` commands in `cypress/support/index.js`:
 
-```js:title=cypress/support/commands.js
+```js:title=cypress/support/index.js
 import "./commands"
 //highlight-start
 import "cypress-axe"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

`import "./commands"` is actually found in `cypress/support/index.js` . I think this either changed recently by Cypress or was an error. 

This PR proposes changing filename from `cypress/support/commands.js` to `cypress/support/index.js` where `import "./commands"` is now found.

