### PR TITLE
fix(renovate): disable yarn upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "packages/**",
     "www/package.json"
   ],
+  "ignoreDeps": ["yarn"],
   "major": {
     "masterIssueApproval": true
   },

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
     "packages/**",
     "www/package.json"
   ],
-  "ignoreDeps": ["yarn"],
   "major": {
     "masterIssueApproval": true
   },
@@ -24,6 +23,10 @@
     {
       "groupName": "patch updates in packages",
       "updateTypes": ["patch"]
+    },
+    {
+      "depTypeList": ["engines"],
+      "enabled": false
     }
   ],
   "timezone": "GMT",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I added `yarn` to `ignoreDeps` in `renovate.json`. This change will prevent upgrading `yarn`.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Fixes #18980

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
