### PR TITLE
docs: added newly created Shopify guide and E-commerce overview to doc sidebar

### DIFF
--- a/docs/docs/building-an-e-commerce-site.md
+++ b/docs/docs/building-an-e-commerce-site.md
@@ -2,7 +2,10 @@
 title: Building an E-commerce Site
 ---
 
-This is a stub. Help our community expand it.
+The speed and performance of sites built with Gatsby make it a great tool for building E-commerce sites. There are existing plugins for connecting services like [Shopify](/packages/gatsby-source-shopify/) and [Snipcart](/packages/gatsby-plugin-snipcart/) to Gatsby, and this section contains reference guides to help get things setup.
 
-Please use the [Gatsby Style Guide](/contributing/gatsby-style-guide/) to ensure your
-pull request gets accepted.
+To see examples of E-commerce sites built with Gatsby, check out the [showcase](/showcase/?filters%5B0%5D=eCommerce).
+
+<GuideList slug={props.slug} />
+
+_You can also check out the ["Making an E-commerce Site with Stripe" tutorial](/tutorial/ecommerce-tutorial/) for more information._

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -419,6 +419,11 @@
               link: /docs/client-data-fetching/
             - title: Using Client-Side Only Packages
               link: /docs/using-client-side-only-packages/
+            - title: Building an E-commerce Site
+              link: /docs/building-an-e-commerce-site/
+              items:
+                - title: Building an E-commerce Site with Shopify
+                  link: /docs/building-an-ecommerce-site-with-shopify/
         - title: Improving Performance
           link: /docs/performance/
           items:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

With a newly created guide on Shopify merged (#17793), I think it makes sense to add this into the sidebar and remove the stub for the Building an E-commerce doc that has been sitting around. We have a tutorial in the additional tutorials section that sort of covers this too (hooking up a site to Stripe), but it's hard to find this info in the docs section without adding this to the sidebar somewhere (like this PR aims to fix).

## Screenshot

<details>
<summary>Details</summary>

<img width="1337" alt="Screen Shot 2019-10-24 at 11 15 36 AM" src="https://user-images.githubusercontent.com/21114044/67509412-2cbe5b00-f650-11e9-820c-ca0aa5d6f0b6.png">

</details>

## Related Issues

Related to #17793 and an upcoming workflow evaluation on Building E-commerce from #13708 
