### PR TITLE
test: pin cypress version in some e2e-tests 

### DIFF
--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@testing-library/cypress": "^4.0.4",
     "cross-env": "^5.2.0",
-    "cypress": "^3.1.3",
+    "cypress": "3.4.1",
     "fs-extra": "^7.0.1",
     "gatsby-cypress": "^0.1.7",
     "is-ci": "^2.0.0",

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
-    "cypress": "^3.1.0",
+    "cypress": "3.4.1",
     "gatsby": "^2.0.118",
     "gatsby-plugin-manifest": "^2.0.17",
     "gatsby-plugin-offline": "^3.0.0",


### PR DESCRIPTION
seems like recent release (~24h ago) has some problems when visiting url that includes unicode chars:

test fail, even tho page can be navigated to
![Screenshot 2019-10-24 at 23 18 41](https://user-images.githubusercontent.com/419821/67526957-1f3bbc00-f6b6-11e9-8519-a86bee90e7bc.png)

there is probably nicer solution, but there is bunch of PR that have failing tests let's do "hot fix"
