### PR TITLE
Remove 'shortcut' link type before 'icon'

### DIFF
--- a/docs/docs/building-with-components.md
+++ b/docs/docs/building-with-components.md
@@ -157,7 +157,7 @@ function HTML(props) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         {props.headComponents}
-        <link rel="shortcut icon" href={favicon} />
+        <link rel="icon" href={favicon} />
         {css}
       </head>
       <body>

--- a/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
@@ -31,8 +31,8 @@ describe(`assetPrefix`, () => {
         .and(`not.matches`, assetPrefixExpression)
     })
 
-    it(`prefixes shortcut icon`, () => {
-      assetPrefixMatcher(cy.get(`head link[rel="shortcut icon"]`))
+    it(`prefixes icon`, () => {
+      assetPrefixMatcher(cy.get(`head link[rel="icon"]`))
     })
 
     it(`prefixes manifest icons`, () => {

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -238,7 +238,7 @@ module.exports = {
 
 #### Disable favicon
 
-Excludes `<link rel="shortcut icon" href="/favicon.png" />` link tag to html output. You can set `include_favicon` plugin option to `false` to opt-out of this behavior.
+Excludes `<link rel="icon" href="/favicon.png" />` link tag to html output. You can set `include_favicon` plugin option to `false` to opt-out of this behavior.
 
 ```js
 // in gatsby-config.js

--- a/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-manifest/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -33,7 +33,7 @@ exports[`gatsby-plugin-manifest Cache Busting Does file name cache busting if "c
 Array [
   <link
     href="/icons/icon-48x48-contentDigest.png"
-    rel="shortcut icon"
+    rel="icon"
   />,
   <link
     href="/manifest.webmanifest"
@@ -86,7 +86,7 @@ exports[`gatsby-plugin-manifest Cache Busting Does query cache busting if "cache
 Array [
   <link
     href="/icons/icon-48x48.png?v=contentDigest"
-    rel="shortcut icon"
+    rel="icon"
   />,
   <link
     href="/manifest.webmanifest"
@@ -139,7 +139,7 @@ exports[`gatsby-plugin-manifest Cache Busting Does query cache busting if "cache
 Array [
   <link
     href="/icons/icon-48x48.png?v=contentDigest"
-    rel="shortcut icon"
+    rel="icon"
   />,
   <link
     href="/manifest.webmanifest"
@@ -192,7 +192,7 @@ exports[`gatsby-plugin-manifest Cache Busting doesn't add cache busting if "cach
 Array [
   <link
     href="/icons/icon-48x48.png"
-    rel="shortcut icon"
+    rel="icon"
   />,
   <link
     href="/manifest.webmanifest"
@@ -264,7 +264,7 @@ exports[`gatsby-plugin-manifest Favicon Adds link favicon tag if "include_favico
 Array [
   <link
     href="/icons/icon-48x48.png"
-    rel="shortcut icon"
+    rel="icon"
   />,
   <link
     href="/manifest.webmanifest"
@@ -422,11 +422,11 @@ Array [
 ]
 `;
 
-exports[`gatsby-plugin-manifest Manifest Link Generation Adds "shortcut icon" and "manifest" links and "theme_color" meta tag to head 1`] = `
+exports[`gatsby-plugin-manifest Manifest Link Generation Adds "icon" and "manifest" links and "theme_color" meta tag to head 1`] = `
 Array [
   <link
     href="/icons/icon-48x48.png?v=contentDigest"
-    rel="shortcut icon"
+    rel="icon"
   />,
   <link
     href="/manifest.webmanifest"

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -87,7 +87,7 @@ describe(`gatsby-plugin-manifest`, () => {
       expect(headComponents).toMatchSnapshot()
     })
 
-    it(`Adds "shortcut icon" and "manifest" links and "theme_color" meta tag to head`, () => {
+    it(`Adds "icon" and "manifest" links and "theme_color" meta tag to head`, () => {
       onRenderBody(ssrArgs, {
         icon: true,
         theme_color: `#000000`,

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -45,7 +45,7 @@ exports.onRenderBody = (
       headComponents.push(
         <link
           key={`gatsby-plugin-manifest-icon-link`}
-          rel="shortcut icon"
+          rel="icon"
           href={withPrefix(addDigestToPath(favicon, iconDigest, cacheBusting))}
         />
       )

--- a/packages/gatsby-plugin-offline/src/__tests__/fixtures/public/index.html
+++ b/packages/gatsby-plugin-offline/src/__tests__/fixtures/public/index.html
@@ -801,7 +801,7 @@
             f.parentNode.insertBefore(j, f);
         })(window, document, 'script', 'dataLayer', 'GTM-KLZLVML');
     </script>
-    <link rel="shortcut icon" href="/icons/icon-48x48.png">
+    <link rel="icon" href="/icons/icon-48x48.png">
     <link rel="manifest" href="/manifest.webmanifest">
     <meta name="theme-color" content="#663399">
     <link rel="preconnect" href="https://sentry.io">


### PR DESCRIPTION
## Description

According to [this MDN page](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types), referring to `<link rel="shortcut icon" ...>`:

>The shortcut link type is often seen before icon, but this link type is non-conforming, ignored and web authors must not use it anymore.

So I've removed it from all files where it was present, resulting in `<link rel="icon" ...>`.
