### PR TITLE
docs: clarify that `loader.js` is a function by calling it in code snippet

### DIFF
--- a/docs/docs/add-custom-webpack-config.md
+++ b/docs/docs/add-custom-webpack-config.md
@@ -108,7 +108,7 @@ exports.onCreateWebpackConfig = ({ actions, loaders, getConfig }) => {
 
     // Recreate it with custom exclude filter
     {
-      // Called without any arguments, `loaders.js` will return an
+      // Called without any arguments, `loaders.js()` will return an
       // object like:
       // {
       //   options: undefined,


### PR DESCRIPTION
### Description
This change makes it a bit more obvious that `loaders.js` is a function and should be called.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->



<!-- Write a brief description of the changes introduced by this PR -->
