### PR TITLE
chore(gatsby): Move duplicate node path check to gatsby-core-utils

### DIFF
--- a/packages/gatsby-cli/src/reporter/errors.js
+++ b/packages/gatsby-cli/src/reporter/errors.js
@@ -3,7 +3,7 @@
 const PrettyError = require(`pretty-error`)
 const prepareStackTrace = require(`./prepare-stack-trace`)
 const _ = require(`lodash`)
-const { isNodePath } = require(`gatsby-core-utils`)
+const { isNodeInternalModulePath } = require(`gatsby-core-utils`)
 
 const packagesToSkip = [`core-js`, `bluebird`, `regenerator-runtime`, `graphql`]
 
@@ -28,7 +28,7 @@ const sanitizeStructuredStackTrace = stack => {
       return false
     }
 
-    if (isNodePath(callSite.fileName)) {
+    if (isNodeInternalModulePath(callSite.fileName)) {
       return false
     }
 

--- a/packages/gatsby-cli/src/reporter/errors.js
+++ b/packages/gatsby-cli/src/reporter/errors.js
@@ -3,62 +3,7 @@
 const PrettyError = require(`pretty-error`)
 const prepareStackTrace = require(`./prepare-stack-trace`)
 const _ = require(`lodash`)
-
-// copied from https://runpkg.com/?pretty-error@2.1.1/lib/nodePaths.js
-// and added `^internal/` test
-const nodePaths = [
-  /^_debugger.js$/,
-  /^_http_agent.js$/,
-  /^_http_client.js$/,
-  /^_http_common.js$/,
-  /^_http_incoming.js$/,
-  /^_http_outgoing.js$/,
-  /^_http_server.js$/,
-  /^_linklist.js$/,
-  /^_stream_duplex.js$/,
-  /^_stream_passthrough.js$/,
-  /^_stream_readable.js$/,
-  /^_stream_transform.js$/,
-  /^_stream_writable.js$/,
-  /^_tls_legacy.js$/,
-  /^_tls_wrap.js$/,
-  /^assert.js$/,
-  /^buffer.js$/,
-  /^child_process.js$/,
-  /^cluster.js$/,
-  /^console.js$/,
-  /^constants.js$/,
-  /^crypto.js$/,
-  /^dgram.js$/,
-  /^dns.js$/,
-  /^domain.js$/,
-  /^events.js$/,
-  /^freelist.js$/,
-  /^fs.js$/,
-  /^http.js$/,
-  /^https.js$/,
-  /^module.js$/,
-  /^net.js$/,
-  /^os.js$/,
-  /^path.js$/,
-  /^punycode.js$/,
-  /^querystring.js$/,
-  /^readline.js$/,
-  /^repl.js$/,
-  /^smalloc.js$/,
-  /^stream.js$/,
-  /^string_decoder.js$/,
-  /^sys.js$/,
-  /^timers.js$/,
-  /^tls.js$/,
-  /^tty.js$/,
-  /^url.js$/,
-  /^util.js$/,
-  /^vm.js$/,
-  /^zlib.js$/,
-  /^node.js$/,
-  /^internal[/\\]/,
-]
+const { isNodePath } = require(`gatsby-core-utils`)
 
 const packagesToSkip = [`core-js`, `bluebird`, `regenerator-runtime`, `graphql`]
 
@@ -83,14 +28,7 @@ const sanitizeStructuredStackTrace = stack => {
       return false
     }
 
-    if (
-      nodePaths.some(regTest => {
-        if (regTest.test(callSite.fileName)) {
-          return true
-        }
-        return false
-      })
-    ) {
+    if (isNodePath(callSite.fileName)) {
       return false
     }
 

--- a/packages/gatsby-core-utils/index.d.ts
+++ b/packages/gatsby-core-utils/index.d.ts
@@ -13,6 +13,12 @@ export declare function createContentDigest(input: any): string
 export declare function joinPath(...paths: string[]): string
 
 /**
+ * Checks if the file name matches a node path
+ * @param {string} fileName File name
+ */
+export declare function isNodePath(fileName: string): boolean
+
+/**
  * Calculate CPU core count
  *
  * @param {boolean} ignoreEnvVar Ignore the 'GATSBY_CPU_COUNT' env var to calculate the requested type of CPU cores

--- a/packages/gatsby-core-utils/index.d.ts
+++ b/packages/gatsby-core-utils/index.d.ts
@@ -16,7 +16,7 @@ export declare function joinPath(...paths: string[]): string
  * Checks if the file name matches a node path
  * @param {string} fileName File name
  */
-export declare function isNodePath(fileName: string): boolean
+export declare function isNodeInternalModulePath(fileName: string): boolean
 
 /**
  * Calculate CPU core count

--- a/packages/gatsby-core-utils/src/__tests__/path.js
+++ b/packages/gatsby-core-utils/src/__tests__/path.js
@@ -1,4 +1,4 @@
-const { joinPath, isNodePath } = require(`../path`)
+const { joinPath, isNodeInternalModulePath } = require(`../path`)
 const os = require(`os`)
 
 describe(`paths`, () => {
@@ -23,9 +23,11 @@ describe(`paths`, () => {
   })
   describe(`isNodePath`, () => {
     it(`Matches common node files`, () => {
-      expect(isNodePath(`console.js`)).toBe(true)
-      expect(isNodePath(`http.js`)).toBe(true)
-      expect(isNodePath(`internal/foo`)).toBe(true)
+      expect(isNodeInternalModulePath(`console.js`)).toBe(true)
+      expect(isNodeInternalModulePath(`http.js`)).toBe(true)
+      expect(isNodeInternalModulePath(`internal/foo`)).toBe(true)
+      const modulePath = `/Users/username/dev/project/node_modules/package-name/index.js`
+      expect(isNodeInternalModulePath(modulePath)).toBe(false)
     })
   })
 })

--- a/packages/gatsby-core-utils/src/__tests__/path.js
+++ b/packages/gatsby-core-utils/src/__tests__/path.js
@@ -1,4 +1,4 @@
-const { joinPath } = require(`../path`)
+const { joinPath, isNodePath } = require(`../path`)
 const os = require(`os`)
 
 describe(`paths`, () => {
@@ -20,5 +20,12 @@ describe(`paths`, () => {
         expect(actual).toBe(expected)
       })
     }
+  })
+  describe(`isNodePath`, () => {
+    it(`Matches common node files`, () => {
+      expect(isNodePath(`console.js`)).toBe(true)
+      expect(isNodePath(`http.js`)).toBe(true)
+      expect(isNodePath(`internal/foo`)).toBe(true)
+    })
   })
 })

--- a/packages/gatsby-core-utils/src/index.js
+++ b/packages/gatsby-core-utils/src/index.js
@@ -1,5 +1,5 @@
 exports.createContentDigest = require(`./create-content-digest`)
 exports.joinPath = require(`./path`).joinPath
-exports.isNodePath = require(`./path`).isNodePath
+exports.isNodeInternalModulePath = require(`./path`).isNodeInternalModulePath
 exports.cpuCoreCount = require(`./cpu-core-count`)
 exports.urlResolve = require(`./url`).resolve

--- a/packages/gatsby-core-utils/src/index.js
+++ b/packages/gatsby-core-utils/src/index.js
@@ -1,4 +1,5 @@
 exports.createContentDigest = require(`./create-content-digest`)
 exports.joinPath = require(`./path`).joinPath
+exports.isNodePath = require(`./path`).isNodePath
 exports.cpuCoreCount = require(`./cpu-core-count`)
 exports.urlResolve = require(`./url`).resolve

--- a/packages/gatsby-core-utils/src/path.js
+++ b/packages/gatsby-core-utils/src/path.js
@@ -12,3 +12,65 @@ export function joinPath(...paths) {
 
   return joinedPath
 }
+
+// copied from https://runpkg.com/?pretty-error@2.1.1/lib/nodePaths.js
+// and added `^internal/` test
+const nodePaths = [
+  /^_debugger.js$/,
+  /^_http_agent.js$/,
+  /^_http_client.js$/,
+  /^_http_common.js$/,
+  /^_http_incoming.js$/,
+  /^_http_outgoing.js$/,
+  /^_http_server.js$/,
+  /^_linklist.js$/,
+  /^_stream_duplex.js$/,
+  /^_stream_passthrough.js$/,
+  /^_stream_readable.js$/,
+  /^_stream_transform.js$/,
+  /^_stream_writable.js$/,
+  /^_tls_legacy.js$/,
+  /^_tls_wrap.js$/,
+  /^assert.js$/,
+  /^buffer.js$/,
+  /^child_process.js$/,
+  /^cluster.js$/,
+  /^console.js$/,
+  /^constants.js$/,
+  /^crypto.js$/,
+  /^dgram.js$/,
+  /^dns.js$/,
+  /^domain.js$/,
+  /^events.js$/,
+  /^freelist.js$/,
+  /^fs.js$/,
+  /^http.js$/,
+  /^https.js$/,
+  /^module.js$/,
+  /^net.js$/,
+  /^os.js$/,
+  /^path.js$/,
+  /^punycode.js$/,
+  /^querystring.js$/,
+  /^readline.js$/,
+  /^repl.js$/,
+  /^smalloc.js$/,
+  /^stream.js$/,
+  /^string_decoder.js$/,
+  /^sys.js$/,
+  /^timers.js$/,
+  /^tls.js$/,
+  /^tty.js$/,
+  /^url.js$/,
+  /^util.js$/,
+  /^vm.js$/,
+  /^zlib.js$/,
+  /^node.js$/,
+  /^internal[/\\]/,
+]
+
+/**
+ * @type {import('../index').isNodePath}
+ */
+export const isNodePath = fileName =>
+  nodePaths.some(regTest => regTest.test(fileName))

--- a/packages/gatsby-core-utils/src/path.js
+++ b/packages/gatsby-core-utils/src/path.js
@@ -70,7 +70,7 @@ const nodePaths = [
 ]
 
 /**
- * @type {import('../index').isNodePath}
+ * @type {import('../index').isNodeInternalModulePath}
  */
-export const isNodePath = fileName =>
+export const isNodeInternalModulePath = fileName =>
   nodePaths.some(regTest => regTest.test(fileName))

--- a/packages/gatsby/src/utils/stack-trace-utils.js
+++ b/packages/gatsby/src/utils/stack-trace-utils.js
@@ -3,62 +3,7 @@ const { codeFrameColumns } = require(`@babel/code-frame`)
 const fs = require(`fs-extra`)
 const path = require(`path`)
 const chalk = require(`chalk`)
-
-// copied from https://runpkg.com/?pretty-error@2.1.1/lib/nodePaths.js
-// and added `^internal/` test
-const nodePaths = [
-  /^_debugger.js$/,
-  /^_http_agent.js$/,
-  /^_http_client.js$/,
-  /^_http_common.js$/,
-  /^_http_incoming.js$/,
-  /^_http_outgoing.js$/,
-  /^_http_server.js$/,
-  /^_linklist.js$/,
-  /^_stream_duplex.js$/,
-  /^_stream_passthrough.js$/,
-  /^_stream_readable.js$/,
-  /^_stream_transform.js$/,
-  /^_stream_writable.js$/,
-  /^_tls_legacy.js$/,
-  /^_tls_wrap.js$/,
-  /^assert.js$/,
-  /^buffer.js$/,
-  /^child_process.js$/,
-  /^cluster.js$/,
-  /^console.js$/,
-  /^constants.js$/,
-  /^crypto.js$/,
-  /^dgram.js$/,
-  /^dns.js$/,
-  /^domain.js$/,
-  /^events.js$/,
-  /^freelist.js$/,
-  /^fs.js$/,
-  /^http.js$/,
-  /^https.js$/,
-  /^module.js$/,
-  /^net.js$/,
-  /^os.js$/,
-  /^path.js$/,
-  /^punycode.js$/,
-  /^querystring.js$/,
-  /^readline.js$/,
-  /^repl.js$/,
-  /^smalloc.js$/,
-  /^stream.js$/,
-  /^string_decoder.js$/,
-  /^sys.js$/,
-  /^timers.js$/,
-  /^tls.js$/,
-  /^tty.js$/,
-  /^url.js$/,
-  /^util.js$/,
-  /^vm.js$/,
-  /^zlib.js$/,
-  /^node.js$/,
-  /^internal[/\\]/,
-]
+const { isNodePath } = require(`gatsby-core-utils`)
 
 const gatsbyLocation = path.dirname(require.resolve(`gatsby/package.json`))
 const reduxThunkLocation = path.dirname(
@@ -76,7 +21,7 @@ const getNonGatsbyCallSite = () =>
         !callSite.getFileName().includes(gatsbyLocation) &&
         !callSite.getFileName().includes(reduxLocation) &&
         !callSite.getFileName().includes(reduxThunkLocation) &&
-        !nodePaths.some(regTest => regTest.test(callSite.getFileName()))
+        !isNodePath(callSite.getFileName())
     )
 
 const getNonGatsbyCodeFrame = ({ highlightCode = true } = {}) => {

--- a/packages/gatsby/src/utils/stack-trace-utils.js
+++ b/packages/gatsby/src/utils/stack-trace-utils.js
@@ -3,7 +3,7 @@ const { codeFrameColumns } = require(`@babel/code-frame`)
 const fs = require(`fs-extra`)
 const path = require(`path`)
 const chalk = require(`chalk`)
-const { isNodePath } = require(`gatsby-core-utils`)
+const { isNodeInternalModulePath } = require(`gatsby-core-utils`)
 
 const gatsbyLocation = path.dirname(require.resolve(`gatsby/package.json`))
 const reduxThunkLocation = path.dirname(
@@ -21,7 +21,7 @@ const getNonGatsbyCallSite = () =>
         !callSite.getFileName().includes(gatsbyLocation) &&
         !callSite.getFileName().includes(reduxLocation) &&
         !callSite.getFileName().includes(reduxThunkLocation) &&
-        !isNodePath(callSite.getFileName())
+        !isNodeInternalModulePath(callSite.getFileName())
     )
 
 const getNonGatsbyCodeFrame = ({ highlightCode = true } = {}) => {


### PR DESCRIPTION
## Description

Moved duplicate code under the gatsby-core-utils.

## Related Issues
Addresses #19010 