### PR TITLE
feat(site-showcase-validator): Add user-agent for HTTP requests

### DIFF
--- a/.github/actions/gatsby-site-showcase-validator/index.js
+++ b/.github/actions/gatsby-site-showcase-validator/index.js
@@ -12,7 +12,12 @@ async function run() {
   let yamlStr
 
   try {
-    yamlStr = await fetch(url).then(resp => resp.text())
+    yamlStr = await fetch(url, {
+      headers: {
+        "User-Agent":
+          "gatsby-site-showcase-validator/1.0 (+https://github.com/gatsbyjs/gatsby/tree/master/.github/actions/gatsby-site-showcase-validator)",
+      },
+    }).then(resp => resp.text())
   } catch (err) {
     console.log(`[Err]: ${err.message}`)
     process.exit(1)
@@ -35,7 +40,12 @@ async function run() {
 
     // Fetch site
     try {
-      siteHtml = await fetch(siteUrl).then(resp => resp.text())
+      siteHtml = await fetch(siteUrl, {
+        headers: {
+          "User-Agent":
+            "gatsby-site-showcase-validator/1.0 (+https://github.com/gatsbyjs/gatsby/tree/master/.github/actions/gatsby-site-showcase-validator)",
+        },
+      }).then(resp => resp.text())
     } catch (err) {
       console.log(
         `${chalk.red(`[Err]`)}: ${site.title} (${siteUrl}) ran into an error: ${
@@ -65,7 +75,12 @@ async function run() {
 
     // Check if provided repository is public
     if (sourceUrl) {
-      const status = await fetch(sourceUrl).then(({ status }) => status)
+      const status = await fetch(sourceUrl, {
+        headers: {
+          "User-Agent":
+            "gatsby-site-showcase-validator/1.0 (+https://github.com/gatsbyjs/gatsby/tree/master/.github/actions/gatsby-site-showcase-validator)",
+        },
+      }).then(({ status }) => status)
 
       if (status !== 200) {
         console.log(

--- a/.github/actions/gatsby-site-showcase-validator/index.js
+++ b/.github/actions/gatsby-site-showcase-validator/index.js
@@ -4,6 +4,15 @@ const yaml = require("js-yaml")
 const cheerio = require("cheerio")
 const chalk = require("chalk")
 
+async function fetchAsSiteValidator(url) {
+  return fetch(url, {
+    headers: {
+      "User-Agent":
+        "gatsby-site-showcase-validator/1.0 (+https://github.com/gatsbyjs/gatsby/tree/master/.github/actions/gatsby-site-showcase-validator)",
+    },
+  })
+}
+
 async function run() {
   // Grab down sites.yml
   const url =
@@ -12,12 +21,7 @@ async function run() {
   let yamlStr
 
   try {
-    yamlStr = await fetch(url, {
-      headers: {
-        "User-Agent":
-          "gatsby-site-showcase-validator/1.0 (+https://github.com/gatsbyjs/gatsby/tree/master/.github/actions/gatsby-site-showcase-validator)",
-      },
-    }).then(resp => resp.text())
+    yamlStr = await fetchAsSiteValidator(url).then(resp => resp.text())
   } catch (err) {
     console.log(`[Err]: ${err.message}`)
     process.exit(1)
@@ -40,12 +44,7 @@ async function run() {
 
     // Fetch site
     try {
-      siteHtml = await fetch(siteUrl, {
-        headers: {
-          "User-Agent":
-            "gatsby-site-showcase-validator/1.0 (+https://github.com/gatsbyjs/gatsby/tree/master/.github/actions/gatsby-site-showcase-validator)",
-        },
-      }).then(resp => resp.text())
+      siteHtml = await fetchAsSiteValidator(siteUrl).then(resp => resp.text())
     } catch (err) {
       console.log(
         `${chalk.red(`[Err]`)}: ${site.title} (${siteUrl}) ran into an error: ${
@@ -75,12 +74,9 @@ async function run() {
 
     // Check if provided repository is public
     if (sourceUrl) {
-      const status = await fetch(sourceUrl, {
-        headers: {
-          "User-Agent":
-            "gatsby-site-showcase-validator/1.0 (+https://github.com/gatsbyjs/gatsby/tree/master/.github/actions/gatsby-site-showcase-validator)",
-        },
-      }).then(({ status }) => status)
+      const status = await fetchAsSiteValidator(sourceUrl).then(
+        ({ status }) => status
+      )
 
       if (status !== 200) {
         console.log(


### PR DESCRIPTION
## Description

Just to make things a little more cleaner when hitting the various hundreds of links we ping, I am adding a custom user agent so if the site admin goes into the logs and sees a daily ping around the same time of day, they can know what it is coming from.

## Related Issues

N/A