### PR TITLE
[WIP] feat(gatsby-link): support @reach/router new back functionality

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -20,7 +20,7 @@ describe(`navigation`, () => {
   it(`can navigate to and from pages`, () => {
     cy.getTestElement(`page-two`).click()
 
-    cy.getTestElement(`back-button`).click()
+    cy.getTestElement(`back-link`).click()
 
     cy.location(`pathname`).should(`equal`, `/`)
   })
@@ -31,6 +31,14 @@ describe(`navigation`, () => {
       .waitForRouteChange()
 
     cy.go(`back`).waitForRouteChange()
+
+    cy.location(`pathname`).should(`equal`, `/`)
+  })
+
+  it(`can navigate back using navigate`, () => {
+    cy.getTestElement(`page-two`).click()
+
+    cy.getTestElement(`back-button`).click()
 
     cy.location(`pathname`).should(`equal`, `/`)
   })

--- a/e2e-tests/development-runtime/src/components/header.js
+++ b/e2e-tests/development-runtime/src/components/header.js
@@ -1,4 +1,4 @@
-import { Link } from "gatsby"
+import { Link, navigate } from "gatsby"
 import PropTypes from "prop-types"
 import React from "react"
 
@@ -27,6 +27,9 @@ const Header = ({ siteTitle }) => (
           {siteTitle}
         </Link>
       </h1>
+      <button data-testid="back-button" onClick={() => navigate(-1)}>
+        BACK
+      </button>
     </div>
   </div>
 )

--- a/e2e-tests/development-runtime/src/pages/page-2.js
+++ b/e2e-tests/development-runtime/src/pages/page-2.js
@@ -9,7 +9,7 @@ const SecondPage = () => (
     <SEO title="Page two" />
     <h1 data-testid="page-2-message">Hi from the second page</h1>
     <p>Welcome to page 2</p>
-    <Link to="/" data-testid="back-button">
+    <Link to="/" data-testid="back-link">
       Go back to the homepage
     </Link>
   </Layout>

--- a/e2e-tests/path-prefix/cypress/integration/navigate.js
+++ b/e2e-tests/path-prefix/cypress/integration/navigate.js
@@ -15,10 +15,19 @@ describe(`navigate`, () => {
       .should(`eq`, withTrailingSlash(`${pathPrefix}/page-2`))
   })
 
-  it(`can navigate back after using`, () => {
+  it(`can navigate back using link after using`, () => {
     cy.getTestElement(`page-2-button-link`)
       .click()
       .getTestElement(`index-link`)
+      .click()
+      .location(`pathname`)
+      .should(`eq`, withTrailingSlash(pathPrefix))
+  })
+
+  it(`can navigate back using navigate function after using`, () => {
+    cy.getTestElement(`page-2-button-link`)
+      .click()
+      .getTestElement(`back-button-page-2`)
       .click()
       .location(`pathname`)
       .should(`eq`, withTrailingSlash(pathPrefix))

--- a/e2e-tests/path-prefix/src/pages/page-2.js
+++ b/e2e-tests/path-prefix/src/pages/page-2.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'gatsby'
+import { Link, navigate } from 'gatsby'
 
 import Layout from '../components/layout'
 
@@ -10,6 +10,9 @@ const SecondPage = () => (
     <Link data-testid="index-link" to="/">
       Go back to the homepage
     </Link>
+    <button data-testid="back-button-page-2" onClick={() => navigate(-1)}>
+      back
+    </button>
   </Layout>
 )
 

--- a/e2e-tests/production-runtime/cypress/integration/1-production.js
+++ b/e2e-tests/production-runtime/cypress/integration/1-production.js
@@ -20,7 +20,7 @@ describe(`Production build tests`, () => {
     })
   }
 
-  it(`should navigate back after a reload`, () => {
+  it(`should navigate back using browser api after a reload`, () => {
     cy.getTestElement(`page2`).click()
 
     cy.waitForRouteChange()
@@ -30,6 +30,25 @@ describe(`Production build tests`, () => {
     cy.reload()
       .waitForRouteChange()
       .go(`back`)
+
+    cy.waitForRouteChange()
+      .getTestElement(`page2`)
+      .should(`exist`)
+      .location(`pathname`)
+      .should(`equal`, `/`)
+  })
+
+  it(`should navigate back using navigate function after a reload`, () => {
+    cy.getTestElement(`page2`).click()
+
+    cy.waitForRouteChange()
+      .location(`pathname`)
+      .should(`equal`, `/page-2/`)
+
+    cy.reload()
+      .waitForRouteChange()
+      .getTestElement(`back-button-page-2`)
+      .click()
 
     cy.waitForRouteChange()
       .getTestElement(`page2`)
@@ -69,7 +88,7 @@ describe(`Production build tests`, () => {
       .should(`exist`)
   })
 
-  it(`should navigate back after a 404 from a direct link entry`, () => {
+  it(`should navigate back using browser api after a 404 from a direct link entry`, () => {
     cy.visit(`/`).waitForRouteChange()
 
     cy.visit(`/non-existent-page/`, {
@@ -78,6 +97,21 @@ describe(`Production build tests`, () => {
 
     cy.waitForRouteChange()
       .go(`back`)
+      .waitForRouteChange()
+      .getTestElement(`index-link`)
+      .should(`exist`)
+  })
+
+  it(`should navigate back using navigate function after a 404 from a direct link entry`, () => {
+    cy.visit(`/`).waitForRouteChange()
+
+    cy.visit(`/non-existent-page/`, {
+      failOnStatusCode: false,
+    })
+
+    cy.waitForRouteChange()
+      .getTestElement(`back-button-not-found`)
+      .click()
       .waitForRouteChange()
       .getTestElement(`index-link`)
       .should(`exist`)

--- a/e2e-tests/production-runtime/cypress/integration/scroll-behavior.js
+++ b/e2e-tests/production-runtime/cypress/integration/scroll-behavior.js
@@ -36,6 +36,25 @@ describe(`Scroll behaviour`, () => {
       expect(win.scrollY).to.eq(0, 0)
     })
 
+    // test same behaviour for navigate(-1)
+    cy.scrollTo(`bottom`)
+
+    // waiting a bit to store scroll position again
+    cy.wait(500)
+
+    cy.getTestElement(`below-the-fold`)
+      .click()
+      .waitForRouteChange()
+
+    // expect navigate behaves the same as browser API
+    cy.getTestElement(`back-button`)
+      .click()
+      .waitForRouteChange()
+
+    cy.window().then(win => {
+      expect(win.scrollY).not.to.eq(0, 0)
+    })
+
     // reset to index page
     cy.getTestElement(`index-link`)
       .click()

--- a/e2e-tests/production-runtime/cypress/integration/scroll-behavior.js
+++ b/e2e-tests/production-runtime/cypress/integration/scroll-behavior.js
@@ -36,6 +36,21 @@ describe(`Scroll behaviour`, () => {
       expect(win.scrollY).to.eq(0, 0)
     })
 
+    // reset to index page
+    cy.getTestElement(`index-link`)
+      .click()
+      .waitForRouteChange()
+  })
+
+  it(`test navigate function`, () => {
+    cy.visit(`/`).waitForRouteChange()
+
+    cy.getTestElement(`long-page`)
+      .click()
+      .waitForRouteChange()
+
+    cy.scrollTo(`bottom`)
+
     // test same behaviour for navigate(-1)
     cy.scrollTo(`bottom`)
 
@@ -50,6 +65,9 @@ describe(`Scroll behaviour`, () => {
     cy.getTestElement(`back-button`)
       .click()
       .waitForRouteChange()
+
+    // @TODO find out why back-button produces very inconsistent scroll behavior in cypress
+    cy.wait(1500)
 
     cy.window().then(win => {
       expect(win.scrollY).not.to.eq(0, 0)

--- a/e2e-tests/production-runtime/src/pages/404.js
+++ b/e2e-tests/production-runtime/src/pages/404.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'gatsby'
+import { Link, navigate } from 'gatsby'
 
 import Layout from '../components/layout'
 
@@ -11,6 +11,9 @@ const NotFoundPage = () => (
     <Link to="/" data-testid="index">
       Go to Index
     </Link>
+    <button data-testid="back-button-not-found" onClick={() => navigate(-1)}>
+      back
+    </button>
   </Layout>
 )
 

--- a/e2e-tests/production-runtime/src/pages/index.js
+++ b/e2e-tests/production-runtime/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'gatsby'
+import { Link, navigate } from 'gatsby'
 
 import Bio from '../components/bio'
 import Layout from '../components/layout'
@@ -60,6 +60,11 @@ const IndexPage = ({ pageContext }) => (
         <Link to="/안녕" data-testid="page-with-unicode-path">
           Go to page with unicode path
         </Link>
+      </li>
+      <li>
+        <button data-testid="back-button" onClick={() => navigate(-1)}>
+          back
+        </button>
       </li>
     </ul>
   </Layout>

--- a/e2e-tests/production-runtime/src/pages/page-2.js
+++ b/e2e-tests/production-runtime/src/pages/page-2.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'gatsby'
+import { Link, navigate } from 'gatsby'
 
 import Layout from '../components/layout'
 import InstrumentPage from '../utils/instrument-page'
@@ -19,6 +19,11 @@ const SecondPage = () => (
         <Link to="/page-3/" data-testid="404">
           To non-existent page
         </Link>
+      </li>
+      <li>
+        <button data-testid="back-button-page-2" onClick={() => navigate(-1)}>
+          back
+        </button>
       </li>
     </ul>
   </Layout>

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "@reach/router": "^1.1.1",
+    "@reach/router": "^1.3.0-beta.0",
     "gatsby": "^2.0.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2"

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -217,6 +217,13 @@ describe(`navigate`, () => {
     expect(global.___navigate).toHaveBeenCalledWith(to, undefined)
   })
 
+  it(`respects back functionality`, () => {
+    const to = -1
+    getNavigate()(to)
+
+    expect(global.___navigate).toHaveBeenCalledWith(to, undefined)
+  })
+
   it(`respects pathPrefix`, () => {
     const to = `/some-path`
     global.__BASE_PATH__ = `/blog`

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -221,7 +221,7 @@ describe(`navigate`, () => {
     const to = -1
     getNavigate()(to)
 
-    expect(global.___navigate).toHaveBeenCalledWith(to, undefined)
+    expect(global.___navigate).not.toBeCalled()
   })
 
   it(`respects pathPrefix`, () => {

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types"
 import React from "react"
-import { Link } from "@reach/router"
+import { Link, navigate as ReachNavigate } from "@reach/router"
 
 import { parsePath } from "./parse-path"
 
@@ -201,7 +201,11 @@ export default React.forwardRef((props, ref) => (
 export const navigate = (to, options) => {
   // @reach/router supports a number for going back
   // or a string for navigation to a path
-  window.___navigate(typeof to === `number` ? to : withPrefix(to), options)
+  if (typeof to === `number`) {
+    ReachNavigate(to, options)
+  } else {
+    window.___navigate(withPrefix(to), options)
+  }
 }
 
 export const push = to => {

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -199,7 +199,9 @@ export default React.forwardRef((props, ref) => (
 ))
 
 export const navigate = (to, options) => {
-  window.___navigate(withPrefix(to), options)
+  // @reach/router supports a number for going back
+  // or a string for navigation to a path
+  window.___navigate(typeof to === `number` ? to : withPrefix(to), options)
 }
 
 export const push = to => {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -20,7 +20,7 @@
     "@hapi/joi": "^15.1.1",
     "@mikaelkristiansson/domready": "^1.0.9",
     "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
-    "@reach/router": "^1.2.1",
+    "@reach/router": "^1.3.0-beta.0",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
     "@typescript-eslint/parser": "^2.7.0",
     "address": "1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,16 +3283,15 @@
     string-width "^2.0.0"
     strip-ansi "^3"
 
-"@reach/router@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
-  integrity sha512-kTaX08X4g27tzIFQGRukaHmNbtMYDS3LEWIS8+l6OayGIw6Oyo1HIF/JzeuR2FoF9z6oV+x/wJSVSq4v8tcUGQ==
+"@reach/router@^1.3.0-beta.0":
+  version "1.3.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.0-beta.0.tgz#a5ed9749ac501f6c79d5ac46ab76d6bacfde7622"
+  integrity sha512-ZBNAyh8TXotBNDlwpA2e6HhYQ93sAAds8DHNgMaHm0coXe3l9zf3N3Vx/Yy2kM8w7JfxMCuQwzw97zHR+Q2NRg==
   dependencies:
-    create-react-context "^0.2.1"
+    create-react-context "0.2.1"
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
-    warning "^3.0.0"
 
 "@rtsao/csstype@2.6.5-forked.0":
   version "2.6.5-forked.0"
@@ -6908,9 +6907,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@^0.2.1:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
+create-react-context@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.1.tgz#425a3d96f4b7690c2fbf20aed5aeae2e2007a959"
+  integrity sha512-dmGgrAJ/nKoQRRcoonkqWWM9uxk6ClzCHUDKZ8zGdc4MxDwvLVG8s/gzIXtWET7lTAoFSXkeCQ113L1p3QSFmw==
   dependencies:
     fbjs "^0.8.0"
     gud "^1.0.0"


### PR DESCRIPTION
## Description

Currently `navigate` from the `gatsby-link` packages assumes a string that it can prepend a slash to, with the latest version of `@reach/router` you can also pass an integer to navigate back (e.g. -1). 

This change doesn't call `withPrefix` if the `to` argument is a number, so the check in `@reach/router` receives an integer and works as expected.

https://github.com/reach/router/blob/master/src/lib/history.js#L49
