### PR TITLE
fix(docs): Sentence fragment in translation docs

### DIFF
--- a/docs/contributing/gatsby-docs-translation-guide.md
+++ b/docs/contributing/gatsby-docs-translation-guide.md
@@ -20,7 +20,7 @@ The Gatsby learning team is in charge of determining priorities for which docs s
 
 ### Use English as the source
 
-The [gatsbyjs.org](https://gatsbyjs.org) website is written first in English and should be considered the source material for all translations (as opposed to starting from another translation). When a repository is created, it will provide a copy of the docs to be translated which you can then update through [pull requests](/contributing/how-to-open-a-pull-request/) against them in the relevant language. A bot will
+The [gatsbyjs.org](https://gatsbyjs.org) website is written first in English and should be considered the source material for all translations (as opposed to starting from another translation). When a repository is created, it will provide a copy of the docs to be translated which you can then update through [pull requests](/contributing/how-to-open-a-pull-request/) against them in the relevant language.
 
 Changes to the meaning of a text or code example should be done in the main [English repo](https://github.com/gatsbyjs/gatsby/), and then translated afterwards to keep the content aligned across languages.
 


### PR DESCRIPTION
## Description

There was a sentence fragment in the translation docs.

## Related Issues

#19046
