### PR TITLE
feat(redirects): allow multiple redirects from same path when they have different options

### DIFF
--- a/packages/gatsby/src/redux/reducers/__tests__/redirects.js
+++ b/packages/gatsby/src/redux/reducers/__tests__/redirects.js
@@ -71,4 +71,62 @@ describe(`redirects`, () => {
       ])
     })
   })
+
+  it(`prevents duplicate redirects`, () => {
+    function createRedirect(fromPath, toPath) {
+      return {
+        type: `CREATE_REDIRECT`,
+        payload: { fromPath, toPath },
+      }
+    }
+
+    let state = reducer(undefined, createRedirect(`/page`, `/other-page`))
+    state = reducer(state, createRedirect(`/page`, `/other-page`))
+
+    expect(state).toEqual([
+      {
+        fromPath: `/page`,
+        toPath: `/other-page`,
+      },
+    ])
+  })
+
+  it(`allows multiple redirects with same "fromPath" but different options`, () => {
+    function createRedirect(redirect) {
+      return {
+        type: `CREATE_REDIRECT`,
+        payload: redirect,
+      }
+    }
+
+    let state = reducer(
+      undefined,
+      createRedirect({
+        fromPath: `/page`,
+        toPath: `/en/page`,
+        Language: `en`,
+      })
+    )
+    state = reducer(
+      state,
+      createRedirect({
+        fromPath: `/page`,
+        toPath: `/pt/page`,
+        Language: `pt`,
+      })
+    )
+
+    expect(state).toEqual([
+      {
+        fromPath: `/page`,
+        toPath: `/en/page`,
+        Language: `en`,
+      },
+      {
+        fromPath: `/page`,
+        toPath: `/pt/page`,
+        Language: `pt`,
+      },
+    ])
+  })
 })

--- a/packages/gatsby/src/redux/reducers/redirects.js
+++ b/packages/gatsby/src/redux/reducers/redirects.js
@@ -1,15 +1,38 @@
-const fromPaths = new Set()
+const _ = require(`lodash`)
+
+const redirects = new Map()
+
+function exists(newRedirect) {
+  if (!redirects.has(newRedirect.fromPath)) {
+    return false
+  }
+
+  return redirects
+    .get(newRedirect.fromPath)
+    .some(redirect => _.isEqual(redirect, newRedirect))
+}
+
+function add(redirect) {
+  let samePathRedirects = redirects.get(redirect.fromPath)
+
+  if (!samePathRedirects) {
+    samePathRedirects = []
+    redirects.set(redirect.fromPath, samePathRedirects)
+  }
+
+  samePathRedirects.push(redirect)
+}
 
 module.exports = (state = [], action) => {
   switch (action.type) {
     case `CREATE_REDIRECT`: {
-      const { fromPath } = action.payload
+      const redirect = action.payload
 
       // Add redirect only if it wasn't yet added to prevent duplicates
-      if (!fromPaths.has(fromPath)) {
-        fromPaths.add(fromPath)
+      if (!exists(redirect)) {
+        add(redirect)
 
-        state.push(action.payload)
+        state.push(redirect)
       }
 
       return state


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR updates how the redirects reducer prevents duplicates so that it allows redirects with the same `fromPath` when the other options are different.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #18220
