### PR TITLE
fix(www): Support dark mode in the feedback widget on mobile devices

### DIFF
--- a/www/src/components/feedback-widget/buttons.js
+++ b/www/src/components/feedback-widget/buttons.js
@@ -91,10 +91,10 @@ export const ToggleButtonLabel = styled(`span`)`
   transition: 0.5s;
   white-space: nowrap;
   width: 100%;
-  z-index: 1;
 
   ${mediaQueries.lg} {
     width: auto;
+    z-index: 1;
   }
 `
 

--- a/www/src/components/feedback-widget/buttons.js
+++ b/www/src/components/feedback-widget/buttons.js
@@ -86,7 +86,8 @@ export const ToggleButtonLabel = styled(`span`)`
   padding: 0 ${p => p.theme.space[9]} 0 ${p => p.theme.space[3]};
   background: ${p => p.theme.colors.widget.background};
   color: ${p => p.theme.colors.text};
-  box-shadow: ${p => p.theme.shadows.floating};
+  box-shadow: ${p => p.theme.shadows.floating},
+    inset 0 0 0 1px ${p => p.theme.colors.widget.border};
   transition: 0.5s;
   white-space: nowrap;
   width: 100%;

--- a/www/src/components/feedback-widget/buttons.js
+++ b/www/src/components/feedback-widget/buttons.js
@@ -80,23 +80,20 @@ export const CloseButton = styled(`button`)`
 
 export const ToggleButtonLabel = styled(`span`)`
   align-items: center;
-  border: 1px solid ${p => p.theme.colors.blue[10]};
-  background: ${p => p.theme.colors.blue[5]};
   border-radius: ${p => p.theme.radii[2]}px;
   display: flex;
   height: 2.5rem;
   padding: 0 ${p => p.theme.space[9]} 0 ${p => p.theme.space[3]};
+  background: ${p => p.theme.colors.widget.background};
+  color: ${p => p.theme.colors.text};
+  box-shadow: ${p => p.theme.shadows.floating};
   transition: 0.5s;
   white-space: nowrap;
   width: 100%;
+  z-index: 1;
 
   ${mediaQueries.lg} {
-    background: ${p => p.theme.colors.widget.background};
-    color: ${p => p.theme.colors.text};
-    border-color: ${p => p.theme.colors.widget.border};
-    box-shadow: ${p => p.theme.shadows.floating};
     width: auto;
-    z-index: 1;
   }
 `
 

--- a/www/src/gatsby-plugin-theme-ui/index.js
+++ b/www/src/gatsby-plugin-theme-ui/index.js
@@ -190,6 +190,7 @@ const col = {
     placeholder: c.grey[60],
   },
   widget: {
+    border: c.grey[10],
     background: c.white,
     color: c.text.primary,
   },


### PR DESCRIPTION
## Description

The purpose of this PR is to support dark mode in the feedback form component on mobile devices.
Currently, the feedback widget on the desktop works properly in a dark mode. However, on mobile devices, it looks the same as in the light mode - has light blue bg color.

<img width="435" alt="Gatsby js Tutorials | GatsbyJS 2019-10-26 20-32-15" src="https://user-images.githubusercontent.com/16977412/67624972-3c989380-f838-11e9-8caa-a283bcbf3a68.png">
<img width="1429" alt="Gatsby js Tutorials | GatsbyJS 2019-10-26 20-31-38" src="https://user-images.githubusercontent.com/16977412/67624973-3c989380-f838-11e9-8a96-252e307ca7ff.png">


With the changes from PR, the feedback widget looks properly on mobile devices in both light and dark modes.
I tested it on different devices in chrome devtools and on real IphoneX device.
![IMG_5874](https://user-images.githubusercontent.com/16977412/67624945-e592be80-f837-11e9-8e78-0ec0c8710dba.PNG)
![IMG_5875](https://user-images.githubusercontent.com/16977412/67624946-e592be80-f837-11e9-9e2d-927670f05a54.PNG)
