### PR TITLE
fix(gatsby-plugin-layout): Add missing HMR for layout component

### DIFF
--- a/packages/gatsby-plugin-layout/src/gatsby-node.js
+++ b/packages/gatsby-plugin-layout/src/gatsby-node.js
@@ -23,8 +23,23 @@ exports.onPreInit = ({ store }, { component }) => {
   absoluteComponentPath = component
 }
 
-exports.onCreateWebpackConfig = ({ actions, plugins }) => {
+exports.onCreateWebpackConfig = ({ stage, actions, plugins }) => {
+  const isDevelop = stage.startsWith(`develop`)
   actions.setWebpackConfig({
+    ...(isDevelop && {
+      module: {
+        rules: [
+          {
+            test: input => input === absoluteComponentPath,
+            use: [
+              {
+                loader: require.resolve(`react-hot-loader-loader`),
+              },
+            ],
+          },
+        ],
+      },
+    }),
     plugins: [
       plugins.define({
         GATSBY_LAYOUT_COMPONENT_PATH: JSON.stringify(absoluteComponentPath),

--- a/packages/gatsby-plugin-layout/src/wrap-page.js
+++ b/packages/gatsby-plugin-layout/src/wrap-page.js
@@ -1,9 +1,10 @@
 const React = require(`react`)
+const { hot } = require(`react-hot-loader/root`)
 
 const preferDefault = m => (m && m.default) || m
 let Layout
 try {
-  Layout = preferDefault(require(GATSBY_LAYOUT_COMPONENT_PATH))
+  Layout = hot(preferDefault(require(GATSBY_LAYOUT_COMPONENT_PATH)))
 } catch (e) {
   if (e.toString().indexOf(`Error: Cannot find module`) !== -1) {
     throw new Error(

--- a/packages/gatsby-plugin-layout/src/wrap-page.js
+++ b/packages/gatsby-plugin-layout/src/wrap-page.js
@@ -1,11 +1,15 @@
 const React = require(`react`)
 
+let hot
+if (process.env.NODE_ENV === `development`) {
+    hot = require(`react-hot-loader/root`).hot
+}
+
 const preferDefault = m => (m && m.default) || m
 let Layout
 try {
   Layout = preferDefault(require(GATSBY_LAYOUT_COMPONENT_PATH))
-  if (process.env.NODE_ENV === `development`) {
-    const { hot } = require(`react-hot-loader/root`)
+  if (hot) {
     Layout = hot(Layout)
   }
 } catch (e) {

--- a/packages/gatsby-plugin-layout/src/wrap-page.js
+++ b/packages/gatsby-plugin-layout/src/wrap-page.js
@@ -4,7 +4,7 @@ const preferDefault = m => (m && m.default) || m
 let Layout
 try {
   Layout = preferDefault(require(GATSBY_LAYOUT_COMPONENT_PATH))
-  if (process.env.NODE_ENV !== `production`) {
+  if (process.env.NODE_ENV === `develeopment`) {
     const { hot } = require(`react-hot-loader/root`)
     Layout = hot(Layout)
   }

--- a/packages/gatsby-plugin-layout/src/wrap-page.js
+++ b/packages/gatsby-plugin-layout/src/wrap-page.js
@@ -4,7 +4,7 @@ const preferDefault = m => (m && m.default) || m
 let Layout
 try {
   Layout = preferDefault(require(GATSBY_LAYOUT_COMPONENT_PATH))
-  if (process.env.NODE_ENV === `develeopment`) {
+  if (process.env.NODE_ENV === `development`) {
     const { hot } = require(`react-hot-loader/root`)
     Layout = hot(Layout)
   }

--- a/packages/gatsby-plugin-layout/src/wrap-page.js
+++ b/packages/gatsby-plugin-layout/src/wrap-page.js
@@ -1,10 +1,13 @@
 const React = require(`react`)
-const { hot } = require(`react-hot-loader/root`)
 
 const preferDefault = m => (m && m.default) || m
 let Layout
 try {
-  Layout = hot(preferDefault(require(GATSBY_LAYOUT_COMPONENT_PATH)))
+  Layout = preferDefault(require(GATSBY_LAYOUT_COMPONENT_PATH))
+  if (process.env.NODE_ENV !== `production`) {
+    const { hot } = require(`react-hot-loader/root`)
+    Layout = hot(Layout)
+  }
 } catch (e) {
   if (e.toString().indexOf(`Error: Cannot find module`) !== -1) {
     throw new Error(

--- a/packages/gatsby-plugin-layout/src/wrap-page.js
+++ b/packages/gatsby-plugin-layout/src/wrap-page.js
@@ -1,17 +1,9 @@
 const React = require(`react`)
 
-let hot
-if (process.env.NODE_ENV === `development`) {
-    hot = require(`react-hot-loader/root`).hot
-}
-
 const preferDefault = m => (m && m.default) || m
 let Layout
 try {
   Layout = preferDefault(require(GATSBY_LAYOUT_COMPONENT_PATH))
-  if (hot) {
-    Layout = hot(Layout)
-  }
 } catch (e) {
   if (e.toString().indexOf(`Error: Cannot find module`) !== -1) {
     throw new Error(


### PR DESCRIPTION
## Description

It seems HMR doesn't work when the layout component changed

I added `hot` wrapper follow this code:

https://github.com/gatsbyjs/gatsby/blob/76ac266a19502c5c038a5fab697dcbfaed5ec664/packages/gatsby/src/bootstrap/requires-writer.js#L128-L142

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
