### PR TITLE
fix(www): support dark mode in 'Collapse all' btn on hover

### DIFF
--- a/www/src/components/sidebar/button-expand-all.js
+++ b/www/src/components/sidebar/button-expand-all.js
@@ -27,8 +27,8 @@ const ExpandAllButton = ({ onClick, expandAll }) => (
       textAlign: `left`,
       transition: t => `all ${t.transition.speed.fast}`,
       "&:hover": {
-        bg: `purple.10`,
-        color: `gatsby`,
+        bg: `sidebar.itemHoverBackground`,
+        color: `navigation.linkHover`,
       },
     }}
   >


### PR DESCRIPTION
## Description

The purpose of this PR is to support dark-mode in the `Collapse all/Expand all` button (sidebar) on hover. Currently on hover background of this button is the same for both dark and light modes. (like on the screens).

Before changes:

<img width="580" alt="Preparing a Site to Go Live | GatsbyJS 2019-10-27 14-01-58" src="https://user-images.githubusercontent.com/16977412/67635027-a5c4e900-f8c2-11e9-81a0-95baaca05c06.png">
<img width="594" alt="Preparing a Site to Go Live | GatsbyJS 2019-10-27 14-01-13" src="https://user-images.githubusercontent.com/16977412/67635028-a5c4e900-f8c2-11e9-9736-4809b668bfaf.png">
<img width="629" alt="Preparing a Site to Go Live | GatsbyJS 2019-10-27 14-00-29" src="https://user-images.githubusercontent.com/16977412/67635029-a65d7f80-f8c2-11e9-9491-41bd93c238c2.png">
<img width="495" alt="Preparing a Site to Go Live | GatsbyJS 2019-10-27 13-59-52" src="https://user-images.githubusercontent.com/16977412/67635030-a65d7f80-f8c2-11e9-8d51-d56dd7c2e6d5.png">

With changes from PR 'Collapse all' button appearance remain the same in light mode/light mode on hover/dark mode. Only dark mode on hover is improved:

<img width="571" alt="Gatsby js Tutorials | GatsbyJS 2019-10-27 14-02-55" src="https://user-images.githubusercontent.com/16977412/67635038-b2e1d800-f8c2-11e9-8077-84826cbac59d.png">

