### PR TITLE
Fix - Broken link & syntax highlighting on Recipes: Sourcing from WordPress

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1002,7 +1002,7 @@ npm install gatsby-source-wordpress --save
 
 2. Configure the plugin by modifying the `gatsby-config.js` file such that it includes the following:
 
-```JS:title=gatsby-config.js
+```javascript:title=gatsby-config.js
 module.exports = {
   ...
   plugins: [
@@ -1026,7 +1026,7 @@ module.exports = {
 
 3. Create a template component such as `src/templates/post.js` with the following code in it:
 
-```JS:title=post.js
+```javascript:title=post.js
 import React, { Component } from "react"
 import { graphql } from "gatsby"
 import PropTypes from "prop-types"
@@ -1063,7 +1063,7 @@ export const pageQuery = graphql`
 
 4. Create dynamic pages for your Wordpress posts by pasting the following sample code in `gatsby-node.js`:
 
-```JS:title=gatsby-node.js
+```javascript:title=gatsby-node.js
 const path = require(`path`)
 const slash = require(`slash`)
 

--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -1111,7 +1111,7 @@ The dynamic pages created above in `gatsby-node.js` have unique paths for naviga
 
 - [Getting Started with WordPress and Gatsby](/blog/2019-04-26-how-to-build-a-blog-with-wordpress-and-gatsby-part-1/)
 - More on [Sourcing from WordPress](/docs/sourcing-from-wordpress/)
-- [Live example on Sourcing from WordPress](/examples/gatsby-sourcing-wordpress/)
+- [Live example on Sourcing from WordPress](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-wordpress)
 
 ### Sourcing data from Contentful
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
On recipes.md, Sourcing from WordPress section has a broken link and the syntax highlighting doesn't work.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
