### PR TITLE
docs: make the docz tutorial work

### DIFF
--- a/docs/tutorial/writing-documentation-with-docz.md
+++ b/docs/tutorial/writing-documentation-with-docz.md
@@ -18,7 +18,7 @@ First, if you do not have a Gatsby project set up yet, use the Gatsby CLI to cre
 gatsby new my-gatsby-site-with-docz
 ```
 
-To set up Docz you need to install the Docz Gatsby theme and add some custom configuration. Make sure you are in the root directory of your Gatsby project:
+You'll want to let docz control your pages, so start by deleting the `pages` directory, and all of the files inside of it. Then you need to install the Docz Gatsby theme and add some custom configuration. Make sure you are in the root directory of your Gatsby project:
 
 ```shell
 cd my-gatsby-site-with-docz


### PR DESCRIPTION
## Description

The docz tutorial doesn't really work right now. With the provided installation instructions, you start up docz but the default `index.js` still shows instead of the `docz` ones. By deleting the default `pages` folder, I was able to get it to work though. If there is a better way to make this happen, I would be happy to make the appropriate change.

## Related Issues

No issue. I noticed it didn't work while going through the tutorial.
