### PR TITLE
chore: enable eslint-plugin-import to catch unresolvable imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,9 +7,7 @@
     "plugin:react/recommended",
     "prettier",
     "prettier/flowtype",
-    "prettier/react",
-    "plugin:import/errors",
-    "plugin:import/warnings"
+    "prettier/react"
   ],
   "plugins": ["flowtype", "prettier", "react", "filenames", "import"],
   "parserOptions": {
@@ -77,6 +75,12 @@
       "globals": {
         "cy": false,
         "Cypress": false
+      }
+    },
+    {
+      "files": ["packages/**/*"],
+      "rules": {
+        "no-unused-expressions": "error"
       }
     }
   ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,9 +7,11 @@
     "plugin:react/recommended",
     "prettier",
     "prettier/flowtype",
-    "prettier/react"
+    "prettier/react",
+    "plugin:import/errors",
+    "plugin:import/warnings"
   ],
-  "plugins": ["flowtype", "prettier", "react", "filenames"],
+  "plugins": ["flowtype", "prettier", "react", "filenames", "import"],
   "parserOptions": {
     "ecmaVersion": 2016,
     "sourceType": "module",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,7 +81,14 @@
       "files": ["packages/**/*"],
       "rules": {
         "import/no-unresolved": "error",
-        "import/no-extraneous-dependencies": "error"
+        "import/no-extraneous-dependencies": [
+          "error",
+          {
+            "devDependencies": true,
+            "optionalDependencies": true,
+            "peerDependencies": true
+          }
+        ]
       }
     }
   ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,7 +80,8 @@
     {
       "files": ["packages/**/*"],
       "rules": {
-        "no-unused-expressions": "error"
+        "import/no-unresolved": "error",
+        "import/no-extraneous-dependencies": "error"
       }
     }
   ],


### PR DESCRIPTION
This should help us avoid issues like https://github.com/gatsbyjs/gatsby/issues/19088