### PR TITLE
add section on how to change default package manager.

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -233,4 +233,4 @@ In it you’re going to see something like this.
 }
 ```
 
-Edit your `packageManager` value, save and you’re good to go for your next project using `gastby new`.
+Edit your `packageManager` value, save and you’re good to go for your next project using `gatsby new`.

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -208,22 +208,24 @@ For more information, check out the [Gatsby REPL documentation](/docs/gatsby-rep
 
 In addition to the explicit `--no-color` option, the CLI respects the presence of the `NO_COLOR` environment variable (see [no-color.org](https://no-color.org/)).
 
-## How to change your default package manager?
+## How to change your default package manager for your next project?
 When you use `gatsby new` for the first time to create a new project, you are asked to choose your default package manager between yarn and npm. 
 ```shell
 Which package manager would you like to use ? › - Use arrow-keys. Return to submit.
 ❯  yarn
    npm
 ```
-Once you’ve made your choice, the CLI won’t ask for your preference again. 
+Once you’ve made your choice, the CLI won’t ask for your preference again for any subsequent project.  
 
-If you want to change this later you have to edit the config file created automatically by the CLI. 
+If you want to change this for your next project you have to edit the config file created automatically by the CLI. 
 This file is available on your system at: `~/.config/gatsby/config.json` 
 
 In it you’re going to see something like this.
 ```json:title=config.json
-"cli": {
-  "packageManager":"yarn"
+{
+  "cli": {
+    "packageManager": "yarn"
+  }
 }
 ```
-Edit your `packageManager` value, save and you’re good to go for your next gatsby project.
+Edit your `packageManager` value, save and you’re good to go for your next project using `gastby new`.

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -209,18 +209,22 @@ For more information, check out the [Gatsby REPL documentation](/docs/gatsby-rep
 In addition to the explicit `--no-color` option, the CLI respects the presence of the `NO_COLOR` environment variable (see [no-color.org](https://no-color.org/)).
 
 ## How to change your default package manager for your next project?
-When you use `gatsby new` for the first time to create a new project, you are asked to choose your default package manager between yarn and npm. 
+
+When you use `gatsby new` for the first time to create a new project, you are asked to choose your default package manager between yarn and npm.
+
 ```shell
 Which package manager would you like to use ? › - Use arrow-keys. Return to submit.
 ❯  yarn
    npm
 ```
-Once you’ve made your choice, the CLI won’t ask for your preference again for any subsequent project.  
 
-If you want to change this for your next project you have to edit the config file created automatically by the CLI. 
-This file is available on your system at: `~/.config/gatsby/config.json` 
+Once you’ve made your choice, the CLI won’t ask for your preference again for any subsequent project.
+
+If you want to change this for your next project you have to edit the config file created automatically by the CLI.
+This file is available on your system at: `~/.config/gatsby/config.json`
 
 In it you’re going to see something like this.
+
 ```json:title=config.json
 {
   "cli": {
@@ -228,4 +232,5 @@ In it you’re going to see something like this.
   }
 }
 ```
+
 Edit your `packageManager` value, save and you’re good to go for your next project using `gastby new`.

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -207,3 +207,23 @@ For more information, check out the [Gatsby REPL documentation](/docs/gatsby-rep
 ### Disabling colored output
 
 In addition to the explicit `--no-color` option, the CLI respects the presence of the `NO_COLOR` environment variable (see [no-color.org](https://no-color.org/)).
+
+## How to change your default package manager?
+When you use `gatsby new` for the first time to create a new project, you are asked to choose your default package manager between yarn and npm. 
+```shell
+Which package manager would you like to use ? › - Use arrow-keys. Return to submit.
+❯  yarn
+   npm
+```
+Once you’ve made your choice, the CLI won’t ask for your preference again. 
+
+If you want to change this later you have to edit the config file created automatically by the CLI. 
+This file is available on your system at: `~/.config/gatsby/config.json` 
+
+In it you’re going to see something like this.
+```json:title=config.json
+"cli": {
+  "packageManager":"yarn"
+}
+```
+Edit your `packageManager` value, save and you’re good to go for your next gatsby project.


### PR DESCRIPTION
## Description

Changing the default package manager used by `gatsby-cli`can be tricky for newcomers as there is no CLI command for this. I've added some explanation to help those who want to change it by modifying the configstore file.


