### PR TITLE
fix(gatsby-plugin-mdx): display better error message for MDX `html` field in development

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -184,7 +184,8 @@ module.exports = (
             return html
           } catch (e) {
             reporter.error(
-              `Error querying the \`html\` field. This field is intended for use with RSS feed generation.
+              `gatsby-plugin-mdx: Error querying the \`html\` field.
+This field is intended for use with RSS feed generation.
 If you're trying to use it in application-level code, try querying for \`Mdx.body\` instead.
 Original error:
 ${e}`

--- a/packages/gatsby-plugin-mdx/utils/render-html.js
+++ b/packages/gatsby-plugin-mdx/utils/render-html.js
@@ -155,9 +155,8 @@ exports.mdxHTMLLoader = ({ cache, reporter, store }) =>
                 keys.map(({ body }) =>
                   renderMdxBody
                     ? renderMdxBody(body)
-                    : reporter.error(
-                        `gatsby-plugin-mdx: renderMdxBody was unavailable when rendering html.
->> This is a bug.`
+                    : new Error(
+                        `renderMdxBody was unavailable when rendering html.`
                       )
                 )
               )


### PR DESCRIPTION
## Description

This fixes a cryptic error message when a user requests MDX `html` field. There were several issues about it and I also faced it while playing with md files. 

We already have a proper message in the `catch` block, all we need is to throw vs reporting directly to console. Should improve DX a bit.

Fixes #17210 

## Related Issues
Also reported in:
#16706
#17592
#17592
#17175
