### PR TITLE
docs(gatsby-source-mongodb): fix mapping configuration example

### DIFF
--- a/packages/gatsby-source-mongodb/README.md
+++ b/packages/gatsby-source-mongodb/README.md
@@ -73,10 +73,10 @@ module.exports = {
       resolve: `gatsby-source-mongodb`,
       options: {
         dbName: `local`,
-        collection: `documents`
+        collection: `documents`,
         // highlight-start
         map: {
-          {documents: {body: `text/markdown`}
+          documents: {body: `text/markdown`}
         },
         // highlight-end
       },

--- a/packages/gatsby-source-mongodb/README.md
+++ b/packages/gatsby-source-mongodb/README.md
@@ -76,11 +76,11 @@ module.exports = {
         collection: `documents`,
         // highlight-start
         map: {
-          documents: {body: `text/markdown`}
+          documents: { body: `text/markdown` },
         },
         // highlight-end
       },
-    }
+    },
   ],
 }
 ```


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Map Object example in the `gatsby-source-mongodb` had an extra bracket which wasted half an hour of my time. 

I wouldn't let this happen to anyone else. 

<!-- Write a brief description of the changes introduced by this PR -->

Removed extra bracket and added missing comma from the example

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
