### PR TITLE
fix(docs): Fix broken link to Documentation PRs

### DIFF
--- a/docs/contributing/how-to-open-a-pull-request.md
+++ b/docs/contributing/how-to-open-a-pull-request.md
@@ -14,7 +14,7 @@ Gatsby uses the PR process to review and test changes before they’re added to 
 
 When someone wants to contribute to Gatsby, they open a request to _pull_ their code into the repo. Depending on the type of change, PRs are categorized into:
 
-- [Documentation](#documentation)
+- [Documentation](#documentation-prs)
 - [Code](#code-changes)
 - [Starters or Site Showcase](#starters-or-site-showcase)
 - [Blog posts](#blog-posts)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Updated broken link in ``how-to-open-a-pull-request.md``  from ``#documentation`` to ``#documentation-prs``.
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
