### PR TITLE
fix(gatsby-plugin-sharp): fix "Cannot set property 'multipassCount' of undefined" error

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -24,7 +24,7 @@
     "progress": "^2.0.3",
     "semver": "^5.7.1",
     "sharp": "^0.23.2",
-    "svgo": "^1.3.0",
+    "svgo": "1.3.0",
     "uuid": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
There seems to be bug in recent release of `svgo` ( https://github.com/svg/svgo/issues/1174 ). So pinning this dependency to fix errors when using `tracedSVG`