### PR TITLE
add gatsby installation instructions for environment setup

### DIFF
--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -89,7 +89,7 @@ After going through the [development setup instructions](/contributing/setting-u
 - Change directories into the docs site folder: `cd www`
 - Install dependencies with Yarn: `yarn install`
 - Add the following env variable to an `.env.development` file inside the `www` directory to [enable image placeholders](https://github.com/gatsbyjs/gatsby/tree/master/www#running-slow-build-screenshots-placeholder): `GATSBY_SCREENSHOT_PLACEHOLDER=true`. This will speed up building the docs site significantly!
-- Make sure you have the Gatsby CLI installed with `gatsby -v`, if not run `npm install -g gatsby-cli`
+- Make sure you have the Gatsby CLI installed with `gatsby -v`, if not run `yarn global add gatsby-cli`
 - Start a build of `www` with `gatsby develop`.
 - Edit Markdown files in the [docs](https://github.com/gatsbyjs/gatsby/tree/master/docs) and [contributing](https://github.com/gatsbyjs/gatsby/tree/master/docs/contributing) folders, as well as the [YAML sidebar files](https://github.com/gatsbyjs/gatsby/tree/master/www/src/data/sidebars).
 - View the changes in your browser at `http://localhost:8000`.

--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -89,7 +89,7 @@ After going through the [development setup instructions](/contributing/setting-u
 - Change directories into the docs site folder: `cd www`
 - Install dependencies with Yarn: `yarn install`
 - Add the following env variable to an `.env.development` file inside the `www` directory to [enable image placeholders](https://github.com/gatsbyjs/gatsby/tree/master/www#running-slow-build-screenshots-placeholder): `GATSBY_SCREENSHOT_PLACEHOLDER=true`. This will speed up building the docs site significantly!
-- Make sure you have gatsby installed with `gatsby -v`, if not run `npm install -g gatsby-cli`
+- Make sure you have the Gatsby CLI installed with `gatsby -v`, if not run `npm install -g gatsby-cli`
 - Start a build of `www` with `gatsby develop`.
 - Edit Markdown files in the [docs](https://github.com/gatsbyjs/gatsby/tree/master/docs) and [contributing](https://github.com/gatsbyjs/gatsby/tree/master/docs/contributing) folders, as well as the [YAML sidebar files](https://github.com/gatsbyjs/gatsby/tree/master/www/src/data/sidebars).
 - View the changes in your browser at `http://localhost:8000`.

--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -89,6 +89,7 @@ After going through the [development setup instructions](/contributing/setting-u
 - Change directories into the docs site folder: `cd www`
 - Install dependencies with Yarn: `yarn install`
 - Add the following env variable to an `.env.development` file inside the `www` directory to [enable image placeholders](https://github.com/gatsbyjs/gatsby/tree/master/www#running-slow-build-screenshots-placeholder): `GATSBY_SCREENSHOT_PLACEHOLDER=true`. This will speed up building the docs site significantly!
+- Make sure you have gatsby installed with `gatsby -v`, if not run `npm install -g gatsby-cli`
 - Start a build of `www` with `gatsby develop`.
 - Edit Markdown files in the [docs](https://github.com/gatsbyjs/gatsby/tree/master/docs) and [contributing](https://github.com/gatsbyjs/gatsby/tree/master/docs/contributing) folders, as well as the [YAML sidebar files](https://github.com/gatsbyjs/gatsby/tree/master/www/src/data/sidebars).
 - View the changes in your browser at `http://localhost:8000`.

--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -33,6 +33,7 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
   - To watch just one package, run `yarn run watch --scope=gatsby`.
 - Install [gatsby-dev-cli](https://www.npmjs.com/package/gatsby-dev-cli) globally: `yarn global add gatsby-dev-cli`
 - Run `yarn install` in each of the sites you're testing.
+- Make sure you have gatsby installed with `gatsby -v`, if not run `npm install -g gatsby-cli`
 - For each of your Gatsby test sites, run the `gatsby-dev` command inside the test site's directory to copy
   the built files from your cloned copy of Gatsby. It'll watch for your changes
   to Gatsby packages and copy them into the site. For more detailed instructions

--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -33,7 +33,7 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
   - To watch just one package, run `yarn run watch --scope=gatsby`.
 - Install [gatsby-dev-cli](https://www.npmjs.com/package/gatsby-dev-cli) globally: `yarn global add gatsby-dev-cli`
 - Run `yarn install` in each of the sites you're testing.
-- Make sure you have gatsby installed with `gatsby -v`, if not run `npm install -g gatsby-cli`
+- Make sure you have the Gatsby CLI installed with `gatsby -v`, if not run `npm install -g gatsby-cli`
 - For each of your Gatsby test sites, run the `gatsby-dev` command inside the test site's directory to copy
   the built files from your cloned copy of Gatsby. It'll watch for your changes
   to Gatsby packages and copy them into the site. For more detailed instructions

--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -33,7 +33,7 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
   - To watch just one package, run `yarn run watch --scope=gatsby`.
 - Install [gatsby-dev-cli](https://www.npmjs.com/package/gatsby-dev-cli) globally: `yarn global add gatsby-dev-cli`
 - Run `yarn install` in each of the sites you're testing.
-- Make sure you have the Gatsby CLI installed with `gatsby -v`, if not run `npm install -g gatsby-cli`
+- Make sure you have the Gatsby CLI installed with `gatsby -v`, if not run `yarn global add gatsby-cli`
 - For each of your Gatsby test sites, run the `gatsby-dev` command inside the test site's directory to copy
   the built files from your cloned copy of Gatsby. It'll watch for your changes
   to Gatsby packages and copy them into the site. For more detailed instructions


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Currently, the setup instructions call for running a gatsby command without ever having a step to install gatsby globally. The user will see an error that the gatsby keyword is not found.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
