### PR TITLE
Use gatsby-theme name convention on getting started

### DIFF
--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -12,7 +12,7 @@ The quickest way to get up and running with a workspace for building themes is t
 To get started, run:
 
 ```shell
-gatsby new my-theme gatsbyjs/gatsby-starter-theme-workspace
+gatsby new gatsby-theme-my-theme gatsbyjs/gatsby-starter-theme-workspace
 ```
 
 This will generate a new project for you. The file tree will look like this:


### PR DESCRIPTION
I think the getting started section should use the **gatsby-theme** naming convention when creating the project. And maybe even link to that section