### PR TITLE
fix(gatsby): clear cache before refresh

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -106,7 +106,7 @@ const navigate = (to, options = {}) => {
           navigator.serviceWorker.controller.state === `activated`
         ) {
           navigator.serviceWorker.controller.postMessage({
-            gatsbyApi: `resetWhitelist`,
+            gatsbyApi: `clearPathResources`,
           })
         }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

When loading an app and detecting a newer build on the server, it attempts to clear cached paths by the service worker and refresh the browser.

However, with the latest version of gatsby-plugin-offline, the method `resetWhitelist` is no longer on the MessageAPI object, so this fails. On subsequent load it tries to do the same thing and ends up refreshing in a loop.

https://github.com/gatsbyjs/gatsby/blob/589c599f9e4c494e6aa867ded162650805327c95/packages/gatsby-plugin-offline/src/sw-append.js#L40-L56

## Related Issues

Related to #18531 

This is my first pull request ever so sorry for any missing information or if my assumptions here are totally wrong.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
