### PR TITLE
feat(gatsby-source-contentful): handle SELF_SIGNED_CERT_IN_CHAIN error.

### DIFF
--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -40,10 +40,10 @@ module.exports = async ({ syncToken, reporter, pluginConfig }) => {
     if (e.code === `ENOTFOUND`) {
       details = `You seem to be offline`
     } else if (e.code === `SELF_SIGNED_CERT_IN_CHAIN`) {
-      details = `Your self signed certificate for SSL communication is failing. 
-                If you are in development environment you might add NODE_TLS_REJECT_UNAUTHORIZED=0 in your .env file.
-                Ref. https://stackoverflow.com/questions/45088006/nodejs-error-self-signed-certificate-in-certificate-chain
-                `
+      reporter.panic(
+        `Your self signed certificate for SSL communication is failing.`,
+        e
+      )
     } else if (e.response) {
       if (e.response.status === 404) {
         // host and space used to generate url

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -39,6 +39,11 @@ module.exports = async ({ syncToken, reporter, pluginConfig }) => {
     let errors
     if (e.code === `ENOTFOUND`) {
       details = `You seem to be offline`
+    } else if (e.code === `SELF_SIGNED_CERT_IN_CHAIN`) {
+      details = `Your self signed certificate for SSL communication is failing. 
+                If you are in development environment you might add NODE_TLS_REJECT_UNAUTHORIZED=0 in your .env file.
+                Ref. https://stackoverflow.com/questions/45088006/nodejs-error-self-signed-certificate-in-certificate-chain
+                `
     } else if (e.response) {
       if (e.response.status === 404) {
         // host and space used to generate url

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -41,7 +41,7 @@ module.exports = async ({ syncToken, reporter, pluginConfig }) => {
       details = `You seem to be offline`
     } else if (e.code === `SELF_SIGNED_CERT_IN_CHAIN`) {
       reporter.panic(
-        `Your self signed certificate for SSL communication is failing.`,
+        `We couldn't make a secure connection to your contentful space. Please check if you have any self-signed SSL certificates installed.`,
         e
       )
     } else if (e.response) {


### PR DESCRIPTION
## Description

I was having troubles with this error working in my local machine. Actually, the error handling doesn't specify why you can't fetch the data.
So, i think it will be helpful adding the cause and a possible solution to this situation.
