### PR TITLE
fix(gatsby): controlled search input component on dev-404-page

### DIFF
--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -104,7 +104,7 @@ class Dev404Page extends React.Component {
                   type="text"
                   id="search"
                   placeholder="Search pages..."
-                  value={this.state.pageSearchTerm}
+                  value={this.state.pagePathSearchTerms}
                   onChange={this.handleSearchTermChange}
                 />
               </label>


### PR DESCRIPTION
## Description

The search field on the dev-404-page references a state variable that does not exist for its `value`, unintentionally making it an [uncontrolled component](https://reactjs.org/docs/uncontrolled-components.html)

The functionality of the search field does work regardless of the search field being a controlled or uncontrolled component.

This is most likely a typo from the initial implementation or from a rewrite, either way this PR fixes the typo making the implementation a proper one.

## Related Issues

None