### PR TITLE
fix(reporter): TypeScript definitions for Reporter

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -956,6 +956,7 @@ export type ProgressActivityTracker = Omit<ActivityTracker, "end"> & {
 
 export type ActivityArgs = {
   parentSpan?: Object,
+  id?: string;
 }
 
 export interface Reporter {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -2,7 +2,7 @@ import * as React from "react"
 import { EventEmitter } from "events"
 import { WindowLocation } from "@reach/router"
 import { createContentDigest } from "gatsby-core-utils"
-import { TemplateTag } from "common-tags";
+import { TemplateTag } from "common-tags"
 
 export {
   default as Link,
@@ -937,13 +937,13 @@ type LogMessageType = (format: string, ...args: any[]) => void
 type LogErrorType = (errorMeta: string | Object, error?: Object) => void
 
 export type PhantomActivityTracker = {
-  start(): () => void,
-  end(): () => void,
-  span: Object,
+  start(): () => void
+  end(): () => void
+  span: Object
 }
 
 export type ActivityTracker = PhantomActivityTracker & {
-  setStatus(status: string): void,
+  setStatus(status: string): void
   panic: LogErrorType
   panicOnBuild: LogErrorType
 }
@@ -955,8 +955,8 @@ export type ProgressActivityTracker = Omit<ActivityTracker, "end"> & {
 }
 
 export type ActivityArgs = {
-  parentSpan?: Object,
-  id?: string;
+  parentSpan?: Object
+  id?: string
 }
 
 export interface Reporter {
@@ -975,8 +975,16 @@ export interface Reporter {
   log: LogMessageType
   completeActivity(id: string, status?: string): void
   activityTimer(name: string, activityArgs?: ActivityArgs): ActivityTracker
-  createProgress(text: string, total?: number, start?: number, activityArgs?: ActivityArgs): ProgressActivityTracker
-  phantomActivity(text: string, activityArgs?: ActivityArgs): PhantomActivityTracker
+  createProgress(
+    text: string,
+    total?: number,
+    start?: number,
+    activityArgs?: ActivityArgs
+  ): ProgressActivityTracker
+  phantomActivity(
+    text: string,
+    activityArgs?: ActivityArgs
+  ): PhantomActivityTracker
 }
 
 export interface Cache {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -2,6 +2,7 @@ import * as React from "react"
 import { EventEmitter } from "events"
 import { WindowLocation } from "@reach/router"
 import { createContentDigest } from "gatsby-core-utils"
+import { TemplateTag } from "common-tags";
 
 export {
   default as Link,
@@ -932,32 +933,49 @@ export interface Store {
   replaceReducer: Function
 }
 
-type logMessageType = (format: string, ...args: any[]) => void
-type logErrorType = (message: string, error?: Error) => void
+type LogMessageType = (format: string, ...args: any[]) => void
+type LogErrorType = (errorMeta: string | Object, error?: Object) => void
+
+export type PhantomActivityTracker = {
+  start(): () => void,
+  end(): () => void,
+  span: Object,
+}
+
+export type ActivityTracker = PhantomActivityTracker & {
+  setStatus(status: string): void,
+  panic: LogErrorType
+  panicOnBuild: LogErrorType
+}
+
+export type ProgressActivityTracker = Omit<ActivityTracker, "end"> & {
+  tick(increment?: number): void
+  done(): void
+  total: number
+}
+
+export type ActivityArgs = {
+  parentSpan?: Object,
+}
 
 export interface Reporter {
-  stripIndent: Function
+  stripIndent: TemplateTag
   format: object
-  setVerbose(isVerbose: boolean): void
-  setNoColor(isNoColor: boolean): void
-  panic: logErrorType
-  panicOnBuild: logErrorType
-  error: logErrorType
+  setVerbose(isVerbose?: boolean): void
+  setNoColor(isNoColor?: boolean): void
+  panic: LogErrorType
+  panicOnBuild: LogErrorType
+  error: LogErrorType
   uptime(prefix: string): void
-  success: logMessageType
-  verbose: logMessageType
-  info: logMessageType
-  warn: logMessageType
-  log: logMessageType
-  activityTimer(
-    name: string,
-    activityArgs: { parentSpan: object }
-  ): {
-    start: () => void
-    status(status: string): void
-    end: () => void
-    span: object
-  }
+  success: LogMessageType
+  verbose: LogMessageType
+  info: LogMessageType
+  warn: LogMessageType
+  log: LogMessageType
+  completeActivity(id: string, status?: string): void
+  activityTimer(name: string, activityArgs?: ActivityArgs): ActivityTracker
+  createProgress(text: string, total?: number, start?: number, activityArgs?: ActivityArgs): ProgressActivityTracker
+  phantomActivity(text: string, activityArgs?: ActivityArgs): PhantomActivityTracker
 }
 
 export interface Cache {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -2,7 +2,6 @@ import * as React from "react"
 import { EventEmitter } from "events"
 import { WindowLocation } from "@reach/router"
 import { createContentDigest } from "gatsby-core-utils"
-import { TemplateTag } from "common-tags"
 
 export {
   default as Link,
@@ -933,16 +932,13 @@ export interface Store {
   replaceReducer: Function
 }
 
-type LogMessageType = (format: string, ...args: any[]) => void
+type LogMessageType = (format: string) => void
 type LogErrorType = (errorMeta: string | Object, error?: Object) => void
 
-export type PhantomActivityTracker = {
+export type ActivityTracker = {
   start(): () => void
   end(): () => void
   span: Object
-}
-
-export type ActivityTracker = PhantomActivityTracker & {
   setStatus(status: string): void
   panic: LogErrorType
   panicOnBuild: LogErrorType
@@ -960,7 +956,7 @@ export type ActivityArgs = {
 }
 
 export interface Reporter {
-  stripIndent: TemplateTag
+  stripIndent: (input: string) => string
   format: object
   setVerbose(isVerbose?: boolean): void
   setNoColor(isNoColor?: boolean): void
@@ -973,7 +969,6 @@ export interface Reporter {
   info: LogMessageType
   warn: LogMessageType
   log: LogMessageType
-  completeActivity(id: string, status?: string): void
   activityTimer(name: string, activityArgs?: ActivityArgs): ActivityTracker
   createProgress(
     text: string,
@@ -981,10 +976,6 @@ export interface Reporter {
     start?: number,
     activityArgs?: ActivityArgs
   ): ProgressActivityTracker
-  phantomActivity(
-    text: string,
-    activityArgs?: ActivityArgs
-  ): PhantomActivityTracker
 }
 
 export interface Cache {


### PR DESCRIPTION
## Description

update gatsby type definitions for reporter. This fixes some incorrect property types and adds missing method types.

On a separate note, ideally reporter would be a separate package, which would probably also contain the reporter type defs. See https://github.com/gatsbyjs/gatsby/issues/18672#issuecomment-543384184 for a comment to that effect. I haven't addressed that here as it was a large change beyond the scope of this issue, hence just the update to the existing type defs.

## Related Issues

fixes issue #19025 
