### PR TITLE
docs: Add `verbose` method documentation for the `reporter`

### DIFF
--- a/packages/gatsby/src/utils/api-node-helpers-docs.js
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.js
@@ -49,6 +49,15 @@ const GatsbyReporter = {
    * reporter.panicOnBuild(`text`, new Error('something'))
    */
   panicOnBuild: true,
+
+  /**
+   * Note that this method only works if the --verbose option has
+   * been passed to the CLI
+   * @type {GatsbyReporterFn}
+   * @example
+   * reporter.verbose(`text`)
+   */
+  verbose: true,
 };
 
 /** */


### PR DESCRIPTION
## Description

The `verbose` method for the reporter was previously undocumented. This PR adds documentation for that method.

## Related Issues

#16519 
