### PR TITLE
Update Kentico Kontent starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1207,11 +1207,13 @@
     - Ready to deploy to GitHub Pages
     - Automatic RSS generation
     - Automatic Sitemap generation
-- url: https://gatsby-starter-kentico-cloud.netlify.com/
-  repo: https://github.com/Kentico/gatsby-starter-kentico-cloud
-  description: Gatsby starter site with Kentico Cloud
+- url: https://gatsby-starter-kontent.netlify.com
+  repo: https://github.com/Kentico/gatsby-starter-kontent
+  description: Gatsby starter site with Kentico Kontent
   tags:
     - CMS:Headless
+    - CMS:Kontent
+    - Netlify
   features:
     - Gatsby v2 support
     - Content item <-> content type relationships


### PR DESCRIPTION
## Description

As a part of rebranding [Kentico Cloud to Kentico Kontent](https://kontent.ai/blog/moving-to-caas-with-kentico-kontent) official Kentico starter was [renamed](https://github.com/Kentico/gatsby-starter-kontent/pull/42) as well.

This pull request is adjusting the information about Kentico Kontent starter.

## Related Issues

#19114