### PR TITLE
docs(gatsby): html.js docs for themes

### DIFF
--- a/docs/docs/custom-html.md
+++ b/docs/docs/custom-html.md
@@ -2,6 +2,9 @@
 title: Customizing html.js
 ---
 
+> Customizing `html.js` is a workaround solution for when the use of the appropriate APIs is not available in `gatsby-ssr.js`. Consider using [`onRenderBody`](https://www.gatsbyjs.org/docs/ssr-apis/#onRenderBody) or [`onPreRenderHTML`](https://www.gatsbyjs.org/docs/ssr-apis/#onPreRenderHTML) instead.
+> As a further consideration, customizing `html.js` will not work when used within a Gatsby Theme. Use the API methods mentioned instead.
+
 Gatsby uses a React component to server render the `<head>` and other parts of
 the HTML outside of the core Gatsby application. Gatsby also sets a default value for the `<noscript>` tag there.
 

--- a/docs/docs/custom-html.md
+++ b/docs/docs/custom-html.md
@@ -2,9 +2,6 @@
 title: Customizing html.js
 ---
 
-> Customizing `html.js` is a workaround solution for when the use of the appropriate APIs is not available in `gatsby-ssr.js`. Consider using [`onRenderBody`](https://www.gatsbyjs.org/docs/ssr-apis/#onRenderBody) or [`onPreRenderHTML`](https://www.gatsbyjs.org/docs/ssr-apis/#onPreRenderHTML) instead.
-> As a further consideration, customizing `html.js` will not work when used within a Gatsby Theme. Use the API methods mentioned instead.
-
 Gatsby uses a React component to server render the `<head>` and other parts of
 the HTML outside of the core Gatsby application. Gatsby also sets a default value for the `<noscript>` tag there.
 
@@ -19,6 +16,9 @@ cp .cache/default-html.js src/html.js
 And then make modifications as needed.
 
 If you need to insert custom html into the `<head>` or `<footer>` of each page on your site, you can use `html.js`.
+
+> Customizing `html.js` is a workaround solution for when the use of the appropriate APIs is not available in `gatsby-ssr.js`. Consider using [`onRenderBody`](https://www.gatsbyjs.org/docs/ssr-apis/#onRenderBody) or [`onPreRenderHTML`](https://www.gatsbyjs.org/docs/ssr-apis/#onPreRenderHTML) instead of the method above.
+> As a further consideration, customizing `html.js` is not supported within a Gatsby Theme. Use the API methods mentioned instead.
 
 ## Required props
 

--- a/docs/docs/custom-html.md
+++ b/docs/docs/custom-html.md
@@ -17,7 +17,7 @@ And then make modifications as needed.
 
 If you need to insert custom html into the `<head>` or `<footer>` of each page on your site, you can use `html.js`.
 
-> Customizing `html.js` is a workaround solution for when the use of the appropriate APIs is not available in `gatsby-ssr.js`. Consider using [`onRenderBody`](https://www.gatsbyjs.org/docs/ssr-apis/#onRenderBody) or [`onPreRenderHTML`](https://www.gatsbyjs.org/docs/ssr-apis/#onPreRenderHTML) instead of the method above.
+> Customizing `html.js` is a workaround solution for when the use of the appropriate APIs is not available in `gatsby-ssr.js`. Consider using [`onRenderBody`](/docs/ssr-apis/#onRenderBody) or [`onPreRenderHTML`](/docs/ssr-apis/#onPreRenderHTML) instead of the method above.
 > As a further consideration, customizing `html.js` is not supported within a Gatsby Theme. Use the API methods mentioned instead.
 
 ## Required props


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Clarifies usage of `html.js` within normal sites and specifically within Gatsby Themes.
Main content taken from this comment on a related issue https://github.com/gatsbyjs/gatsby/issues/19181#issuecomment-548729019

## Related Issues
Related to #19181

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
