### PR TITLE
fix(gatsby-source-contentful): fix crash when downloading asset with a file that doesn't have a url

### DIFF
--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -49,6 +49,12 @@ const downloadContentfulAssets = async gatsbyFunctions => {
         reporter.warn(`The asset with id: ${id}, contains no file.`)
         return Promise.resolve()
       }
+      if (!node.file.url) {
+        reporter.warn(
+          `The asset with id: ${id} has a file but the file contains no url.`
+        )
+        return Promise.resolve()
+      }
       const url = `http://${node.file.url.slice(2)}`
 
       // Avoid downloading the asset again if it's been cached


### PR DESCRIPTION
## Description

Prevents build process error when a gatsby asset has a file but not a url

## Related Issues

Fixes #19217 
