### PR TITLE
docs: remove TODOs from Static vs Normal Queries to focus more on internals

### DIFF
--- a/docs/docs/query-execution.md
+++ b/docs/docs/query-execution.md
@@ -95,7 +95,7 @@ In `develop` mode, every time a node is created, or is updated (e.g. via editing
 
 ### Queue Queries for Execution
 
-There is now a list of all pages that need to be executed (linked to their Query information). Gatsby will queue them for execution (for realz this time). A call to [runQueriesForPathnames](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js#L127) kicks off this step. For each page or static query, Gatsby creates a Query Job that looks something like:
+There is now a list of all pages that need to be executed (linked to their Query information). Gatsby will queue them for execution (for real this time). A call to [runQueriesForPathnames](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/internal-plugins/query-runner/page-query-runner.js#L127) kicks off this step. For each page or static query, Gatsby creates a Query Job that looks something like:
 
 ```javascript
 {

--- a/docs/docs/static-vs-normal-queries.md
+++ b/docs/docs/static-vs-normal-queries.md
@@ -6,9 +6,9 @@ Gatsby handles 3 varieties of GraphQL queries: Page queries (sometimes for simpl
 
 ## Differences between varieties of GraphQL queries
 
-Static queries differ from Gatsby page queries in a number of ways. Gatsby is capable of handling queries with variables for pages because of its awareness of page context while generating them, and **page queries can only be made in top-level page components**.
+Static queries differ from Gatsby page queries in a number of ways. For pages, Gatsby is capable of handling queries with variables because of its awareness of page context. However, **page queries can only be made in top-level page components**.
 
-Doing the same for queries inside of specific components lower in the component tree is not yet possible, which is where static queries are used. Data fetched with a static query won't be dynamic (i.e. **they can't use variables**, hence the name "static" query), but they can be called at any level in the component tree.
+In contrast, static queries do not take variables. This is because static queries are used inside specific components, and can appear lower in the component tree. Data fetched with a static query won't be dynamic (i.e. **they can't use variables**, hence the name "static" query), but they can be called at any level in the component tree.
 
 _For more information on the practical differences in usage between static and normal queries, refer to the guide on [static query](/docs/static-query/#how-staticquery-differs-from-page-query). This guide discusses the differences in how they are handled internally by Gatsby_
 
@@ -37,11 +37,11 @@ The `staticQueryComponents` Redux namespace watches for updates to queries while
 
 ## Replacing queries with JSON imports
 
-With the final build, there isn't a GraphQL server running to query for data. Gatsby has already [extracted](/docs/query-extraction/) and [run](/docs/query-execution/) the queries, [storing](/docs/query-execution/#save-query-results-to-redux-and-disk) them in files based on hashes in `/public/static/d/<hash>.json`. It can now remove code for GraphQL queries, because there isn't a server it can query against and the data is already available.
+With the final build, there isn't a GraphQL server running to query for data. Gatsby has already [extracted](/docs/query-extraction/) and [run](/docs/query-execution/) the queries, [storing](/docs/query-execution/#save-query-results-to-redux-and-disk) them in files based on hashes in `/public/static/d/<hash>.json`. It can now remove code for GraphQL queries, because the data is already available.
 
 ### Distinguishing between static and normal queries
 
-Babel traverses all of your source code looking for queries during query extraction, in order for Gatsby to handle static and normal queries differently, it looks for 3 specific cases in [`babel-plugin-remove-graphql-queries`](https://github.com/gatsbyjs/gatsby/blob/master/packages/babel-plugin-remove-graphql-queries/src/index.js):
+Babel traverses all of your source code looking for queries during query extraction. In order for Gatsby to handle static and normal queries differently, it looks for 3 specific cases in [`babel-plugin-remove-graphql-queries`](https://github.com/gatsbyjs/gatsby/blob/master/packages/babel-plugin-remove-graphql-queries/src/index.js):
 
 1. JSX nodes with the name `StaticQuery`
 2. Calls to functions with the name `useStaticQuery`
@@ -49,9 +49,9 @@ Babel traverses all of your source code looking for queries during query extract
 
 ### Adding imports for page data
 
-Code specific for querying with GraphQL is no longer relevant and can be swapped out.
+Code that is specific for querying the GraphQL server set up during build time is no longer relevant, and can be swapped out in exchange for the JSON data that has been extracted for each query.
 
-A static query written in a component with the `useStaticQuery` hook like this:
+The imports related to GraphQL and query declarations are changed to imports for the JSON that correspond to the query result that Gatsby found when it ran the query. Consider the following component with with a static query written using the `useStaticQuery` hook:
 
 ```jsx
 import { useStaticQuery, graphql } from "gatsby"
@@ -72,7 +72,7 @@ export () => {
 }
 ```
 
-Will have the query string removed and replaced with an import for the JSON file created and named with its specific hash. The Redux stores tracking the queries link the correct data to the page they correspond to.
+This component will have the query string removed and replaced with an import for the JSON file created and named with its specific hash. The Redux stores tracking the queries link the correct data to the page they correspond to.
 
 The above component is rewritten like this:
 

--- a/docs/docs/static-vs-normal-queries.md
+++ b/docs/docs/static-vs-normal-queries.md
@@ -51,7 +51,7 @@ Babel traverses all of your source code looking for queries during query extract
 
 Code specific for querying with GraphQL is no longer relevant and can be swapped out.
 
-A query written in a component like this:
+A static query written in a component with the `useStaticQuery` hook like this:
 
 ```jsx
 import { useStaticQuery, graphql } from "gatsby"
@@ -65,9 +65,9 @@ export () => {
       }
   `)
   return (
-    <div>
+    <h1>
         {data.siteMetadata.site.title}
-    </div>
+    </h1>
   )
 }
 ```
@@ -91,11 +91,37 @@ export () => {
 + const data = dataJson
 
   return (
-    <div>
+    <h1>
         {data.siteMetadata.site.title}
-    </div>
-)
+    </h1>
+  )
 }
 ```
 
-Gatsby will remove unnecessary imports for `useStaticQuery` and `graphql` from Gatsby along with the string containing the query as well.
+A page query would be updated in a similar fashion. Alhough the exact specifics of what has to change are different, the idea is the same:
+
+```diff
+- import { graphql } from "gatsby"
++ import dataJson from `/d/<hash>.json`
+
+- export const query = graphql`
+-   query HomePageQuery {
+-     site {
+-       siteMetadata {
+-         description
+-       }
+-     }
+-   }
+- `
+
+- export ({ data }) => {
++ export ({ data = dataJson }) => {
+    return (
+      <h1>
+          {data.siteMetadata.site.title}
+      </h1>
+    )
+  }
+```
+
+Gatsby will remove unnecessary imports like `useStaticQuery` and `graphql` from your pages along with the strings containing queries as well.

--- a/docs/docs/static-vs-normal-queries.md
+++ b/docs/docs/static-vs-normal-queries.md
@@ -2,7 +2,7 @@
 title: Static vs Normal Queries
 ---
 
-Gatsby handles 3 varieties of GraphQL queries: Page queries (sometimes for simplicity referred to as "normal queries"), static queries using the `<StaticQuery />` component, and static queries using the `useStaticQuery` hook.
+Gatsby handles three varieties of GraphQL queries: Page queries (sometimes for simplicity referred to as "normal queries"), static queries using the `<StaticQuery />` component, and static queries using the `useStaticQuery` hook.
 
 ## Differences between varieties of GraphQL queries
 

--- a/docs/docs/static-vs-normal-queries.md
+++ b/docs/docs/static-vs-normal-queries.md
@@ -10,15 +10,15 @@ title: Static vs Normal Queries
 >
 > You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
 
-Static queries differ from the normal Gatsby page queries in a number of ways. One example is that Gatsby is capable of handling queries with variables for pages because of it's awareness of pages while generating them. Doing the same for queries inside of specific components is not yet possible, which is where static queries are used. That means data fetched won't be dynamic (hence the name "static" query).
+Static queries differ from Gatsby page queries in a number of ways. One example is that Gatsby is capable of handling queries with variables for pages because of its awareness of page context while generating them. Doing the same for queries inside of specific components is not yet possible, which is where static queries are used. That means data fetched won't be dynamic (hence the name "static" query).
 
-_For more information on the practical differences in usage between static and normal queries, refer to the guide on [static query](/docs/static-query/#how-staticquery-differs-from-page-query), this guide discusses the differences in how they are handled internally by Gatsby_
+_For more information on the practical differences in usage between static and normal queries, refer to the guide on [static query](/docs/static-query/#how-staticquery-differs-from-page-query). This guide discusses the implementation differences in how they are handled internally by Gatsby_
 
-## The `staticQueryComponents` and `components` redux stores
+## The `staticQueryComponents` and `components` Redux stores
 
 Gatsby stores the queries from your site in Redux stores called `components` and `staticQueryComponents`. This process and a flowchart illustrating it are explained in the [query extraction](/docs/query-extraction/#store-queries-in-redux) guide.
 
-The redux `staticQueryComponents` is a `Map` from component `jsonName` to `StaticQueryObject`. An example entry in that data structure looks like this:
+In Redux, `staticQueryComponents` is a `Map` from component `jsonName` to `StaticQueryObject`. An example entry in that data structure looks like this:
 
 ```javascript
 {
@@ -35,10 +35,10 @@ The redux `staticQueryComponents` is a `Map` from component `jsonName` to `Stati
 
 In the example above, `blog-2018-07-17-announcing-gatsby-preview-995` is the key, with the object as its value in the `Map`.
 
-The `staticQueryComponents` redux namespace is owned by the `static-query-components.js` reducer which reacts to `REPLACE_STATIC_QUERY` actions. It is created in `query-watcher.js` and is called in [`websocket-manager.js`](https://github.com/gatsbyjs/gatsby/blob/610b5812a815f9ecff422e9087c851cd103c8e7e/packages/gatsby/src/utils/websocket-manager.js#L85) to watch for updates to querys while you are developing, and add new data to your cache when queries change.
+The `staticQueryComponents` Redux namespace is owned by the `static-query-components.js` reducer which reacts to `REPLACE_STATIC_QUERY` actions. It is created in `query-watcher.js` and called in [`websocket-manager.js`](https://github.com/gatsbyjs/gatsby/blob/610b5812a815f9ecff422e9087c851cd103c8e7e/packages/gatsby/src/utils/websocket-manager.js#L85) to watch for updates to queries while you are developing, and add new data to your cache when queries change.
 
-## Other related internal methods used static queries
+## Other related internal methods using static queries
 
 The `getQueriesSnapshot` function returns a `Map` with a snapshot of both the `staticQueryComponents` and `components` that holds all queries from Redux to watch.
 
-The `handleComponentsWithRemovedQueries` function removes static queries from Redux when they no longer have a query associated with them, which is derived from any staticQueryComponent which doesn't have a `componentPath` on it.
+The `handleComponentsWithRemovedQueries` function removes static queries from Redux when they no longer have a query associated with them. This derives from any staticQueryComponent which doesn't have a `componentPath` on it.

--- a/docs/docs/static-vs-normal-queries.md
+++ b/docs/docs/static-vs-normal-queries.md
@@ -16,9 +16,9 @@ _For more information on the practical differences in usage between static and n
 
 ## The `staticQueryComponents` and `components` redux stores
 
-Gatsby stores the queries from your site in redux stores called `components` and `staticQueryComponents`. This process and a flowchart illustrating it are explained in the [query extraction](/docs/query-extraction/#store-queries-in-redux) guide.
+Gatsby stores the queries from your site in Redux stores called `components` and `staticQueryComponents`. This process and a flowchart illustrating it are explained in the [query extraction](/docs/query-extraction/#store-queries-in-redux) guide.
 
-The redux `staticQueryComponents` is a `Map` from component jsonName to StaticQueryObject. An example entry in that data structure looks like this:
+The redux `staticQueryComponents` is a `Map` from component `jsonName` to `StaticQueryObject`. An example entry in that data structure looks like this:
 
 ```javascript
 {


### PR DESCRIPTION
## Description

This doc had several TODO's hanging around, there was redundant information around the differences in usage between this doc and the using static query components doc, so I removed it from this section and tried to refocus it more on Gatsby  internals.

I answered what I felt I could discern from reading code in the query-watcher, query-runner, and query-compilation files, but if someone from the Core team has more context and can help realign something it would be very appreciated 😬 

## Related Issues

Closes #15157
