### PR TITLE
[docs] Add date to building a theme tutorial

### DIFF
--- a/docs/tutorial/building-a-theme.md
+++ b/docs/tutorial/building-a-theme.md
@@ -1,5 +1,6 @@
 ---
 title: Building a Theme
+date: 2019-07-16
 ---
 
 In this tutorial, you'll learn how to build a theme plugin for Gatsby. This tutorial is meant as a written companion to the [Gatsby Theme Authoring Egghead course](https://egghead.io/courses/gatsby-theme-authoring).


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Incorrect date of Feb 9, 2011 appears in Google SERP. Adding `date` frontmatter to tutorial to last updated date to fix issue.

![image](https://user-images.githubusercontent.com/41944255/68066182-fdaf8580-fcf0-11e9-9e00-5202b794b136.png)


## Related Issues

Part of https://github.com/gatsbyjs/gatsby/issues/18242