### PR TITLE
[docs] Add one liner to top of What are Gatsby Themes?

### DIFF
--- a/docs/docs/themes/what-are-gatsby-themes.md
+++ b/docs/docs/themes/what-are-gatsby-themes.md
@@ -2,11 +2,15 @@
 title: What Are Gatsby Themes?
 ---
 
+**Gatsby Themes** are plugins that include a `gatsby-config.js` file and add pre-configured functionality, data sourcing, and/or UI code to Gatsby sites. You can think of Gatsby Themes as separate Gatsby sites that allow you to split up a larger Gatsby project!
+
+## Introduction
+
 To introduce themes, let's walk through the journey that led to the creation of themes.
 
 If you've ever created a Gatsby site completely from scratch, you know that there are a number of decisions to be made. Take, for example, creating a blog. You need to decide where your data will live, how it's accessed, how it's displayed and styled, etc.
 
-## Gatsby starters
+### Gatsby starters
 
 One existing way to quickly create Gatsby sites with similar functionality is to use "[Gatsby starters](/docs/starters/)". Starters are essentially Gatsby sites with pre-configured functionality for a particular purpose. You download an entire Gatsby site, pre-built for a particular purpose (e.g. blogging, portfolio site, etc) and customize from there.
 
@@ -15,7 +19,7 @@ These traditional starters take a first step toward reducing the level of effort
 - Sites created from a traditional starter have basically been "ejected" from the starter -- They maintain no connection to the starter, and begin to diverge immediately. If the starter is updated later, there's no easy way to pull upstream changes into an existing project.
 - If you created multiple sites using the same starter, and later wanted to make the same update to all of those sites, you'd have to do them individually, site-by-site.
 
-## Gatsby themes
+### Gatsby themes
 
 Enter themes. Gatsby themes allow Gatsby site functionality to be packaged as a standalone product for others (and yourself!) to easily reuse. Using a traditional starter, all of your default configuration lives directly in your site. Using a theme, all of your default configuration lives in an npm package.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

It is not consistent with the purpose of Reference Guides to have to read about the history of them to know what they are. This PR adds a one-liner to the top of [What are Gatsby Themes](https://www.gatsbyjs.org/docs/themes/what-are-gatsby-themes/) to reduce barrier to the definition of themes:

> **Gatsby Themes** are plugins that include a `gatsby-config.js` file and add pre-configured functionality, data sourcing, and/or UI code to Gatsby sites. You can think of Gatsby Themes as separate Gatsby sites that allow you to split up a larger Gatsby project!

## Related Issues

Part of https://github.com/gatsbyjs/gatsby/issues/18242