### PR TITLE
fix(www): add dark mode support to the Highlighted Box

### DIFF
--- a/www/src/gatsby-plugin-theme-ui/index.js
+++ b/www/src/gatsby-plugin-theme-ui/index.js
@@ -193,6 +193,10 @@ const col = {
     background: c.white,
     color: c.text.primary,
   },
+  highlightedBox: {
+    background: c.yellow[10],
+    color: c.grey[80],
+  },
   newsletter: {
     background: c.white,
     border: c.grey[10],
@@ -305,6 +309,10 @@ const col = {
       widget: {
         background: darkBackground,
         border: darkBorder,
+        color: c.white,
+      },
+      highlightedBox: {
+        background: c.grey[90],
         color: c.white,
       },
       newsletter: {

--- a/www/src/pages/guidelines/logo.js
+++ b/www/src/pages/guidelines/logo.js
@@ -194,14 +194,14 @@ const Logo = ({ data, location }) => {
               contains everything you need.
             </p>
             <Box
-              bg="yellow.10"
+              bg="highlightedBox.background"
               py={3}
               px={4}
               my={4}
               fontSize={1}
               borderRadius={2}
               maxWidth="30rem"
-              color="grey.80"
+              color="highlightedBox.color"
             >
               Please{` `}
               <a href="https://github.com/gatsbyjs/gatsby/issues">


### PR DESCRIPTION
## Description

The purpose of this PR is to support dark-mode in the Highlighted Box. Currently, this box looks the same for both dark and light modes. (like on the screens).

**Before changes:**
<img width="534" alt="Screenshot 2019-11-02 at 14 59 31" src="https://user-images.githubusercontent.com/16977412/68072086-1b78fb00-fd82-11e9-88b1-e69556625019.png">
<img width="672" alt="Screenshot 2019-11-02 at 14 59 52" src="https://user-images.githubusercontent.com/16977412/68072087-1b78fb00-fd82-11e9-8cf9-ccc9ab06ab0f.png">

**After Changes:**
<img width="808" alt="Logo | Guidelines | GatsbyJS 2019-11-02 14-58-55" src="https://user-images.githubusercontent.com/16977412/68072095-27fd5380-fd82-11e9-9a3c-1bd28b6f4733.png">
<img width="687" alt="Logo | Guidelines | GatsbyJS 2019-11-02 14-58-30" src="https://user-images.githubusercontent.com/16977412/68072096-2895ea00-fd82-11e9-8db6-004825641dc3.png">


