### PR TITLE
[docs] Add Browse themes section

### DIFF
--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -11,7 +11,7 @@ This means that the configuration and functionality isn’t directly written int
 
 ## Browse themes
 
-- [Themes in Plugin Library](https://www.gatsbyjs.org/plugins/?=gatsby-theme)
+- [Themes in Plugin Library](/plugins/?=gatsby-theme)
 - [Theme Jam Showcase](https://themejam.gatsbyjs.org/showcase)
 
 ## Other resources

--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -11,7 +11,7 @@ This means that the configuration and functionality isn’t directly written int
 
 ## Browse themes
 
-- [Themes in Plugin library](https://www.gatsbyjs.org/plugins/?=gatsby-theme)
+- [Themes in Plugin Library](https://www.gatsbyjs.org/plugins/?=gatsby-theme)
 - [Theme Jam Showcase](https://themejam.gatsbyjs.org/showcase)
 
 ## Other resources

--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -9,6 +9,11 @@ This means that the configuration and functionality isn’t directly written int
 
 <GuideList slug={props.slug} />
 
+## Browse themes
+
+- [Themes in Plugin library](https://www.gatsbyjs.org/plugins/?=gatsby-theme)
+- [Theme Jam Showcase](https://themejam.gatsbyjs.org/showcase)
+
 ## Other resources
 
 - [Gatsby blog posts on themes](/blog/tags/themes)


### PR DESCRIPTION
## Description

Adding a "Browse themes" section to main Themes page with links to the [Plugins page](https://github.com/gatsbyjs/gatsby/issues/18242) tagged with `gatsby theme` and the Theme Jam submissions.

## Related Issues

Part of #18242