### PR TITLE
Making prev and next navigation well aligned vertically

### DIFF
--- a/www/src/components/prev-and-next.js
+++ b/www/src/components/prev-and-next.js
@@ -51,6 +51,8 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
                 [mediaQueries.md]: {
                   marginLeft: t => `-${t.space[4]}`,
                 },
+                display: 'inline-flex',
+                alignItems: 'center'
               }}
             >
               <ArrowBackIcon sx={{ verticalAlign: `sub` }} />
@@ -74,6 +76,8 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
                 [mediaQueries.md]: {
                   marginRight: t => `-${t.space[4]}`,
                 },
+                display: 'inline-flex',
+                alignItems: 'center'
               }}
             >
               {next.title}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I found misaligned prev - next navigation. (Between text and arrow)
![misaligned](https://i.imgur.com/y3Rz1bL.png/icon48.png)

## Related Issues
I don't submit any issue, because I'm not sure this is listed on the category.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
ps: This is my very first PR. Sorry if make any mistake.
