### PR TITLE
 fix(www): Making prev and next navigation well aligned vertically 

### DIFF
--- a/www/src/components/prev-and-next.js
+++ b/www/src/components/prev-and-next.js
@@ -51,6 +51,8 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
                 [mediaQueries.md]: {
                   marginLeft: t => `-${t.space[4]}`,
                 },
+                display: 'inline-flex',
+                alignItems: 'center'
               }}
             >
               <ArrowBackIcon sx={{ verticalAlign: `sub` }} />
@@ -74,6 +76,8 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
                 [mediaQueries.md]: {
                   marginRight: t => `-${t.space[4]}`,
                 },
+                display: 'inline-flex',
+                alignItems: 'center'
               }}
             >
               {next.title}

--- a/www/src/components/prev-and-next.js
+++ b/www/src/components/prev-and-next.js
@@ -51,8 +51,8 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
                 [mediaQueries.md]: {
                   marginLeft: t => `-${t.space[4]}`,
                 },
-                display: 'inline-flex',
-                alignItems: 'center'
+                display: `inline-flex`,
+                alignItems: `center`
               }}
             >
               <ArrowBackIcon sx={{ verticalAlign: `sub` }} />
@@ -76,8 +76,8 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
                 [mediaQueries.md]: {
                   marginRight: t => `-${t.space[4]}`,
                 },
-                display: 'inline-flex',
-                alignItems: 'center'
+                display: `inline-flex`,
+                alignItems: `center`
               }}
             >
               {next.title}

--- a/www/src/components/prev-and-next.js
+++ b/www/src/components/prev-and-next.js
@@ -52,7 +52,7 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
                   marginLeft: t => `-${t.space[4]}`,
                 },
                 display: `inline-flex`,
-                alignItems: `center`
+                alignItems: `center`,
               }}
             >
               <ArrowBackIcon sx={{ verticalAlign: `sub` }} />
@@ -77,7 +77,7 @@ const PrevAndNext = ({ prev = null, next = null, ...props }) => {
                   marginRight: t => `-${t.space[4]}`,
                 },
                 display: `inline-flex`,
-                alignItems: `center`
+                alignItems: `center`,
               }}
             >
               {next.title}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I found misaligned prev - next navigation. (Between text and arrow)
**Before change**
![Not vertically aligned](https://i.imgur.com/y3Rz1bL.png)

**After change**
![vertically aligned](https://i.imgur.com/xjI7vYJ.png)

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
I don't submit any issue, because I'm not sure this is listed on the category.

ps: This is my very first PR. Sorry if make any mistake.
*This is my second PR, I closed the first one because I got some errors #19232 