### PR TITLE
fix(gatsby-theme-blog): fix avatar squishing on mobile (#19172)

### DIFF
--- a/packages/gatsby-theme-blog/src/components/bio.js
+++ b/packages/gatsby-theme-blog/src/components/bio.js
@@ -30,6 +30,7 @@ const Bio = () => {
             mr: 2,
             mb: 0,
             width: 48,
+            minWidth: 48,
             borderRadius: 99999,
           })}
         />
@@ -39,6 +40,7 @@ const Bio = () => {
             mr: 2,
             mb: 0,
             width: 48,
+            minWidth: 48,
             borderRadius: 99999,
           })}
           role="presentation"


### PR DESCRIPTION
## Description
Add `minWidth` to Avatar in `gatsby-theme-blog` so it won't squish when space for it is too narrow.

## Related Issues
Fixes #19172
