### PR TITLE
fix(webpack-utils): compact user JS only in production builds

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
@@ -32,7 +32,7 @@ Object {
     Object {
       "loader": "<PROJECT_ROOT>/packages/gatsby/src/utils/babel-loader.js",
       "options": Object {
-        "compact": true,
+        "compact": false,
         "configFile": true,
         "stage": "develop",
       },

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -325,7 +325,7 @@ module.exports = async ({
           loaders.js({
             ...options,
             configFile: true,
-            compact: true,
+            compact: PRODUCTION,
           }),
         ],
       }


### PR DESCRIPTION
## Description
This line was preventing debugging while using `gatsby develop`.

By relying on the existing `PRODUCTION` variable, we ignore compacting in a dev environment.

## Related Issues
Fixes [issue #19128](https://github.com/gatsbyjs/gatsby/issues/19128)
