### PR TITLE
docs: Update Reference to src/layouts/index.js

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -40,9 +40,9 @@ plugins: [
             // bash highlighter.
             aliases: {},
             // This toggles the display of line numbers globally alongside the code.
-            // To use it, add the following line in src/layouts/index.js
+            // To use it, add the following line in gatsby-browser.js
             // right after importing the prism color scheme:
-            //  `require("prismjs/plugins/line-numbers/prism-line-numbers.css");`
+            //  require("prismjs/plugins/line-numbers/prism-line-numbers.css")
             // Defaults to false.
             // If you wish to only show line numbers on certain code blocks,
             // leave false and use the {numberLines: true} syntax below


### PR DESCRIPTION
In the the code comments for "showLineNumbers: false", the instruction reference src/layouts/index.js which appears to be left over from Gatsby version 1. The line number instructions further down the page reference gatsby-browser.js instead of src/layouts/index.js. This PR updates the instructions in the code comments to point to gatsby-browser.js.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
