### PR TITLE
[docs] Refactoring Using Gatsby Themes, how to install a theme directly

### DIFF
--- a/docs/docs/themes/getting-started.md
+++ b/docs/docs/themes/getting-started.md
@@ -1,0 +1,72 @@
+---
+title: Getting Started
+---
+
+The quickest way to get started using a Gatsby theme is to use a starter that's configured to use the theme.
+
+For example, `gatsby-starter-blog-theme` is a theme starter for the `gatsby-theme-blog` package.
+
+A **regular Gatsby starter** creates a new Gatsby site that is preconfigured for a particular use case. The resulting site effectively forks off the starter — after it’s created, the site maintains no connection to the starter.
+
+A **Gatsby theme starter** creates a new Gatsby site that installs and configures one or more Gatsby themes. When a starter installs a theme, it maintains the connection to that theme as a standalone npm package.
+
+Installing the Gatsby blog theme starter is the same process as a regular Gatsby starter:
+
+```shell
+gatsby new my-blog https://github.com/gatsbyjs/gatsby-starter-blog-theme
+```
+
+## What does a theme starter do?
+
+The starter for the official Gatsby blog theme does the following:
+
+### 1. The starter installs the theme and configures it
+
+When you use a starter that's built with a theme, you will often see that you're initially presented with a lighter weight `gatsby-config.js`. Themes start doing their magic when installed via the `plugins` array:
+
+```javascript:title=gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: "gatsby-theme-blog",
+      options: {},
+    },
+  ],
+  // Customize your site metadata:
+  siteMetadata: {
+    title: "My Blog Title",
+    author: "My Name",
+    description: "My site description...",
+    siteUrl: "https://www.gatsbyjs.org/",
+    social: [
+      {
+        name: "twitter",
+        url: "https://twitter.com/gatsbyjs",
+      },
+      {
+        name: "github",
+        url: "https://github.com/gatsbyjs",
+      },
+    ],
+  },
+}
+```
+
+### 2. The starter scaffolds out example blog posts.
+
+```md:title=/content/posts/hello-world.mdx
+---
+title: Hello, world!
+path: /hello-world
+---
+
+I'm an example post!
+```
+
+Once you've made some edits, run `gatsby develop` to start a development server and view your changes in a browser.
+
+## Updating a theme
+
+To pull in the latest updates of your theme you can update the `gatsby-theme-blog` version in your site's `package.json`.
+
+You can do this by running the install of the theme package again: `npm install --save gatsby-theme-blog`.

--- a/docs/docs/themes/getting-started.md
+++ b/docs/docs/themes/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started
+title: Getting Started with Gatsby Themes
 ---
 
 The quickest way to get started using a Gatsby theme is to use a starter that's configured to use the theme.

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -20,7 +20,7 @@ npm install --save gatsby-theme-blog
 
 Depending on the theme, there may be theme options that can be configured via `gatsby-config.js`.
 
-For example, `gatsby-theme-blog` can take in 4 potential options: `basePath`, `contentPath`, `assetPath`, and `mdx`.
+For example, `gatsby-theme-blog` can take in 4 potential options: `basePath`, `contentPath`, `assetPath`, and `mdx`. These options are also documented in the [theme's README](/packages/gatsby-theme-blog/) file.
 
 ```js
 // gatsby-config.js

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -22,8 +22,7 @@ Depending on the theme, there may be theme options that can be configured via `g
 
 For example, `gatsby-theme-blog` can take in 4 potential options: `basePath`, `contentPath`, `assetPath`, and `mdx`. These options are also documented in the [theme's README](/packages/gatsby-theme-blog/) file.
 
-```js
-// gatsby-config.js
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [
     {

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -16,7 +16,7 @@ To install it, run in the root of your site:
 npm install --save gatsby-theme-blog
 ```
 
-## Theme Options
+## Theme options
 
 Depending on the theme, there may be theme options that can be configured via `gatsby-config.js`.
 

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -48,7 +48,7 @@ To learn how to further customize a theme, check out the docs on [Gatsby theme s
 
 ## Published Themes
 
-Public Gatsby themes are published on npm for anyone to use. You can also publish private themes for use by your organization. Examples of private npm package hosting include [npm registry](https://docs.npmjs.com/about-private-packages) and [GitHub Package Registry](https://help.github.com/en/github/managing-packages-with-github-package-registry/about-github-package-registry).
+Public Gatsby themes are published on npm for anyone to use. You can also publish private themes for use by your organization. Examples of private theme package hosting include the [npm registry](https://docs.npmjs.com/about-private-packages) and [GitHub Package Registry](https://help.github.com/en/github/managing-packages-with-github-package-registry/about-github-package-registry).
 
 ## Using Yarn Workspaces
 

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -52,4 +52,4 @@ Public Gatsby themes are published on npm for anyone to use. You can also publis
 
 ## Using Yarn Workspaces
 
-If you would like to work with unpublished themes, consider [setting up Yarn Workspaces for theme development](/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/#reach-skip-nav).
+If you would like to work with unpublished themes, consider [setting up Yarn Workspaces for theme development](/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/) and [using Yarn](/docs/gatsby-cli/#how-to-change-your-default-package-manager-for-your-next-project) instead of npm.

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -2,7 +2,7 @@
 title: Using a Gatsby Theme
 ---
 
-While you can [get started quickly with a Gatsby theme starter](/docs/themes/getting-started/), you can also install a Gatsby theme directly to an existing Gatsby site. Gatsby themes are plugins, so we [use them just like any other Gatsby plugin](/docs/using-a-plugin-in-your-site/).
+While you can [get started quickly with a Gatsby theme starter](/docs/themes/getting-started/), you can also install a Gatsby theme directly to an existing Gatsby site. Gatsby themes are plugins, so you can [install and use them like any other Gatsby plugin](/docs/using-a-plugin-in-your-site/).
 
 ## Installing a Theme
 

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -6,7 +6,7 @@ While you can [get started quickly with a Gatsby theme starter](/docs/themes/get
 
 ## Installing a Theme
 
-Like any Gatsby plugin, Gatsby themes are Node.js packages, so you can install them like other packages in node using npm.
+Like any Gatsby plugin, Gatsby themes are Node.js packages, so you can install them like other published packages in Node using npm or [yarn, including local workspaces](#using-yarn-workspaces).
 
 For example, `gatsby-theme-blog` is the official Gatsby theme for creating a blog.
 

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -2,71 +2,55 @@
 title: Using a Gatsby Theme
 ---
 
-The quickest way to get started using a Gatsby theme is to use a starter that's configured to use the theme.
+While you can [get started quickly with a Gatsby theme starter](/docs/themes/getting-started/), you can also install a Gatsby theme directly to an existing Gatsby site. Gatsby themes are plugins, so we [use them just like any other Gatsby plugin](/docs/using-a-plugin-in-your-site/).
 
-For example, `gatsby-starter-blog-theme` is a theme starter for the `gatsby-theme-blog` package.
+## Installing a Theme
 
-A **regular Gatsby starter** creates a new Gatsby site that is preconfigured for a particular use case. The resulting site effectively forks off the starter — after it’s created, the site maintains no connection to the starter.
+Like any Gatsby plugin, Gatsby themes are Node.js packages, so you can install them like other packages in node using npm.
 
-A **Gatsby theme starter** creates a new Gatsby site that installs and configures one or more Gatsby themes. When a starter installs a theme, it maintains the connection to that theme as a standalone npm package.
+For example, `gatsby-theme-blog` is the official Gatsby theme for creating a blog.
 
-Installing the Gatsby blog theme starter is the same process as a regular Gatsby starter:
+To install it, in the root of you site, run
 
-```shell
-gatsby new my-blog https://github.com/gatsbyjs/gatsby-starter-blog-theme
+```js
+npm install --save gatsby-theme-blog
 ```
 
-## What does a theme starter do?
+## Theme Options
 
-The starter for the official Gatsby blog theme does the following:
+Depending on the theme, there may be theme options that can be configured via `gatsby-config.js`.
 
-### 1. The starter installs the theme and configures it
+For example, `gatsby-theme-blog` can take in 4 potential options: `basePath`, `contentPath`, `assetPath`, and `mdx`.
 
-When you use a starter that's built with a theme, you will often see that you're initially presented with a lighter weight `gatsby-config.js`. Themes start doing their magic when installed via the `plugins` array:
-
-```javascript:title=gatsby-config.js
+```js
+// gatsby-config.js
 module.exports = {
   plugins: [
     {
-      resolve: "gatsby-theme-blog",
-      options: {},
+      resolve: `gatsby-theme-blog`,
+      options: {
+        /*
+        - basePath defaults to `/`
+        - contentPath defaults to `content/posts`
+        - assetPath defaults to `content/assets`
+        - mdx defaults to `true`
+        */
+        basePath: `/blog`,
+        contentPath: `content/blogPosts`,
+        assetPath: `content/blogAssets`,
+        mdx: false,
+      },
     },
   ],
-  // Customize your site metadata:
-  siteMetadata: {
-    title: "My Blog Title",
-    author: "My Name",
-    description: "My site description...",
-    siteUrl: "https://www.gatsbyjs.org/",
-    social: [
-      {
-        name: "twitter",
-        url: "https://twitter.com/gatsbyjs",
-      },
-      {
-        name: "github",
-        url: "https://github.com/gatsbyjs",
-      },
-    ],
-  },
 }
 ```
 
-### 2. The starter scaffolds out example blog posts.
+To further customize a theme, see [Gatsby theme shadowing](/docs/themes/shadowing/).
 
-```md:title=/content/posts/hello-world.mdx
----
-title: Hello, world!
-path: /hello-world
----
+## Published Themes
 
-I'm an example post!
-```
+Public Gatsby themes are published on npm for anyone to use. You can also publish private themes for use by your organization. Examples of private npm package hosting include [npm registry](https://docs.npmjs.com/about-private-packages) and [GitHub Package Registry](https://help.github.com/en/github/managing-packages-with-github-package-registry/about-github-package-registry).
 
-Once you've made some edits, run `gatsby develop` to start a development server and view your changes in a browser.
+## Using Yarn Workspaces
 
-## Updating a theme
-
-To pull in the latest updates of your theme you can update the `gatsby-theme-blog` version in your site's `package.json`.
-
-You can do this by running the install of the theme package again: `npm install --save gatsby-theme-blog`.
+If you would like to work with unpublished themes, consider [setting up Yarn Workspaces for theme development](/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/#reach-skip-nav).

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -44,7 +44,7 @@ module.exports = {
 }
 ```
 
-To further customize a theme, see [Gatsby theme shadowing](/docs/themes/shadowing/).
+To learn how to further customize a theme, check out the docs on [Gatsby theme shadowing](/docs/themes/shadowing/).
 
 ## Published Themes
 

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -10,7 +10,7 @@ Like any Gatsby plugin, Gatsby themes are Node.js packages, so you can install t
 
 For example, `gatsby-theme-blog` is the official Gatsby theme for creating a blog.
 
-To install it, in the root of you site, run
+To install it, run in the root of your site:
 
 ```js
 npm install --save gatsby-theme-blog

--- a/docs/docs/themes/using-multiple-gatsby-themes.md
+++ b/docs/docs/themes/using-multiple-gatsby-themes.md
@@ -4,13 +4,13 @@ title: Using Multiple Gatsby Themes
 
 Gatsby themes are intended to be composable. This means you can install multiple themes alongside each other.
 
-The `gatsby-starter-theme` composes two Gatsby themes: `gatsby-theme-blog` and `gatsby-theme-notes`
+For example, `gatsby-starter-theme` composes two Gatsby themes: `gatsby-theme-blog` and `gatsby-theme-notes`
 
 ```shell
 gatsby new my-notes-blog https://github.com/gatsbyjs/gatsby-starter-theme
 ```
 
-The starter includes both theme packages (`gatsby-theme-blog` and `gatsby-theme-notes`) in the starter's `gatsby-config.js` file.
+You can include multiple theme packages in your `gatsby-config.js`. `gatsby-starter-theme` includes both theme packages: `gatsby-theme-blog` and `gatsby-theme-notes`.
 
 ```javascript:title=gatsby-config.js
 module.exports = {

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -248,6 +248,8 @@
           items:
             - title: What are Gatsby Themes?
               link: /docs/themes/what-are-gatsby-themes/
+            - title: Getting Started
+              link: /docs/themes/getting-started/
             - title: Using a Gatsby Theme
               link: /docs/themes/using-a-gatsby-theme/
             - title: Using Multiple Gatsby Themes


### PR DESCRIPTION
## Description

> The information on Using a Gatsby Theme provides a lot of cognitive overhead by telling people how to install a starter to use a theme. What if there isn't a starter for the theme someone wants to use: how do they install it?

This PR introduces a new reference guide for Themes to provide instructions on how to install a theme directly with references to installing a Gatsby plugin, theme options, customizing further with shadowing, published themes and Yarn workspaces. The original guide was renamed to "Getting Started" to reflect the use of `gatsby-starter-blog-theme`. The structure of the main Themes doc is also updated.

## Related Issues

Part of #18242
