### PR TITLE
[docs] Add bullet about themes to What are Plugins

### DIFF
--- a/docs/docs/what-is-a-plugin.md
+++ b/docs/docs/what-is-a-plugin.md
@@ -11,4 +11,5 @@ Of the many possibilities, plugins can:
 - add external data or content (e.g. your CMS, static files, a REST API) to your Gatsby GraphQL data
 - transform data from other formats (e.g. Markdown, YAML, CSV) to JSON objects
 - add third-party services (e.g. Google Analytics, Instagram) to your site
+- add bundled, pre-configured functionality with [themes](/docs/themes/)
 - do anything you can dream up!


### PR DESCRIPTION
## Description

Themes are not linked in Plugins documentation. This PR adds a bullet to the "What are Plugins" page to link to the Themes documentation. This may help improve understanding of themes as being a type of Gatsby plugin.

## Related Issues

Part of #18242