### PR TITLE
[docs] Organizing themes tutorials and walkthroughs

### DIFF
--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -11,6 +11,5 @@ This means that the configuration and functionality isn’t directly written int
 
 ## Other resources
 
+- [Gatsby theme tutorials](/tutorial/theme-tutorials/)
 - [Gatsby blog posts on themes](/blog/tags/themes)
-- [Jason Lengstorf and Brent Jackson livestream building a theme](https://www.youtube.com/watch?v=6Z4p-qjnKCQ)
-- [Jason Lengstorf and Emma Wedekind livestream building a theme](https://www.youtube.com/watch?v=W2uTfay3doo)

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -109,7 +109,3 @@ Check out how some existing themes are built:
 - The official [Gatsby blog theme](https://github.com/gatsbyjs/gatsby-starter-blog-theme)
 - The official [Gatsby notes theme](https://github.com/gatsbyjs/gatsby-starter-notes-theme)
 - The [Apollo themes](https://github.com/apollographql/gatsby-theme-apollo/tree/master/packages). (_You might also be interested in the [Apollo case study on themes](https://www.gatsbyjs.org/blog/2019-07-03-using-themes-for-distributed-docs/) on the blog._)
-
-### Tutorial
-
-- [Building a theme tutorial](/tutorial/building-a-theme/)

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -109,3 +109,7 @@ Check out how some existing themes are built:
 - The official [Gatsby blog theme](https://github.com/gatsbyjs/gatsby-starter-blog-theme)
 - The official [Gatsby notes theme](https://github.com/gatsbyjs/gatsby-starter-notes-theme)
 - The [Apollo themes](https://github.com/apollographql/gatsby-theme-apollo/tree/master/packages). (_You might also be interested in the [Apollo case study on themes](https://www.gatsbyjs.org/blog/2019-07-03-using-themes-for-distributed-docs/) on the blog._)
+
+### Tutorial
+
+- [Building a theme tutorial](/tutorial/building-a-theme/)

--- a/docs/docs/themes/converting-a-starter.md
+++ b/docs/docs/themes/converting-a-starter.md
@@ -90,3 +90,7 @@ Once you've published, you can install the theme in your starter.
 ```shell
 npm install --save gatsby-theme-NAME
 ```
+
+## Walkthrough
+
+- [Jason Lengstorg converts an existing Gatsby site to a theme](https://www.youtube.com/watch?v=NkW06HK9-aY)

--- a/docs/docs/themes/converting-a-starter.md
+++ b/docs/docs/themes/converting-a-starter.md
@@ -93,4 +93,4 @@ npm install --save gatsby-theme-NAME
 
 ## Walkthrough
 
-- [Jason Lengstorg converts an existing Gatsby site to a theme](https://www.youtube.com/watch?v=NkW06HK9-aY)
+- [Jason Lengstorf converts an existing Gatsby site to a theme](https://www.youtube.com/watch?v=NkW06HK9-aY)

--- a/docs/tutorial/building-a-theme.md
+++ b/docs/tutorial/building-a-theme.md
@@ -1548,4 +1548,11 @@ Congratulations! You've set up, built, and customized your first Gatsby theme!
 - Check out the [Gatsby themes docs](/docs/themes/) to keep learning.
 - Have an idea for a theme you'd like to build? Get a headstart on a local theme development workspace using the [Theme Workspace starter](https://github.com/gatsbyjs/gatsby/tree/master/themes/gatsby-starter-theme-workspace).
 - Have you built a Gatsby starter before? Perhaps [convert that starter to a theme](/docs/themes/converting-a-starter).
-- All through the month of July 2019, Jason Lengstorf will be live-streaming building themes with community members. Follow [his Twitch channel](https://twitch.tv/jlengstorf) for updates, or check out [recordings from previous streams](https://jason.af/lwj-youtube).
+
+### Livestreams
+
+- [Jason Lengstorf and Brent Jackson livestream building a theme](https://www.youtube.com/watch?v=6Z4p-qjnKCQ)
+- [Jason Lengstorf and Emma Wedekind livestream building a theme](https://www.youtube.com/watch?v=W2uTfay3doo)
+- [Jason Lengstorf and Henry Zhu livestream building a theme](https://www.youtube.com/watch?v=z4ETLpujcqo)
+- [Jason Lengstorf and Henry Zhu livestream building a theme](https://www.youtube.com/watch?v=z4ETLpujcqo)
+- [Jason Lengstorf and John Otander livestream building a theme](https://www.youtube.com/watch?v=PS2784YfPpw)

--- a/docs/tutorial/building-a-theme.md
+++ b/docs/tutorial/building-a-theme.md
@@ -1554,5 +1554,4 @@ Congratulations! You've set up, built, and customized your first Gatsby theme!
 - [Jason Lengstorf and Brent Jackson livestream building a theme](https://www.youtube.com/watch?v=6Z4p-qjnKCQ)
 - [Jason Lengstorf and Emma Wedekind livestream building a theme](https://www.youtube.com/watch?v=W2uTfay3doo)
 - [Jason Lengstorf and Henry Zhu livestream building a theme](https://www.youtube.com/watch?v=z4ETLpujcqo)
-- [Jason Lengstorf and Henry Zhu livestream building a theme](https://www.youtube.com/watch?v=z4ETLpujcqo)
 - [Jason Lengstorf and John Otander livestream building a theme](https://www.youtube.com/watch?v=PS2784YfPpw)


### PR DESCRIPTION
## Description

This PR adds Theme Tutorials to main Themes page and move Jason's building themes livestreams to Building Themes tutorial. Added Jason's walkthrough for converting a theme to bottom of "Converting a Theme." This aims to organize and properly link external resources in themes documentation.

## Related Issues

Part of #18242
