### PR TITLE
[docs] Add link to publishing theme and update instructions with gatsby-theme keyword

### DIFF
--- a/docs/contributing/submit-to-plugin-library.md
+++ b/docs/contributing/submit-to-plugin-library.md
@@ -6,8 +6,8 @@ title: Submit to Plugin Library
 
 In order to add your plugin to the [Plugin Library](/plugins/), you need to:
 
-1.  Publish a package to npm (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages))
-2.  Include the [required files](/docs/files-gatsby-looks-for-in-a-plugin/) in your plugin code
+1.  Publish a package to npm (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages)).
+2.  Include the [required files](/docs/files-gatsby-looks-for-in-a-plugin/) in your plugin code.
 3.  **Include a `keywords` field** in your plugin's `package.json`, containing `gatsby` and `gatsby-plugin`. If your plugin is a theme, please also include `gatsby-theme`.
 4.  Document your plugin with a README, there is a [plugin template](/contributing/docs-templates/#plugin-readme-template) available to be used as reference.
 

--- a/docs/contributing/submit-to-plugin-library.md
+++ b/docs/contributing/submit-to-plugin-library.md
@@ -6,7 +6,7 @@ title: Submit to Plugin Library
 
 In order to add your plugin to the [Plugin Library](/plugins/), you need to:
 
-1.  Publish a package to npm (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages)).
+1.  Publish a package to npm (learn how on the [npm docs](https://docs.npmjs.com/getting-started/publishing-npm-packages)).
 2.  Include the [required files](/docs/files-gatsby-looks-for-in-a-plugin/) in your plugin code.
 3.  **Include a `keywords` field** in your plugin's `package.json`, containing `gatsby` and `gatsby-plugin`. If your plugin is a theme, please also include `gatsby-theme`.
 4.  Document your plugin with a README, there is a [plugin template](/contributing/docs-templates/#plugin-readme-template) available to be used as reference.

--- a/docs/contributing/submit-to-plugin-library.md
+++ b/docs/contributing/submit-to-plugin-library.md
@@ -6,10 +6,10 @@ title: Submit to Plugin Library
 
 In order to add your plugin to the [Plugin Library](/plugins/), you need to:
 
-1.  publish a package to npm (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages)),
-2.  include the [required files](/docs/files-gatsby-looks-for-in-a-plugin/) in your plugin code,
-3.  **include a `keywords` field** in your plugin's `package.json`, containing `gatsby` and `gatsby-plugin`,
-4.  and document your plugin with a README, there are [plugin templates](/contributing/docs-templates/#plugin-readme-template) available to be used as reference.
+1.  Publish a package to npm (learn how [here](https://docs.npmjs.com/getting-started/publishing-npm-packages))
+2.  Include the [required files](/docs/files-gatsby-looks-for-in-a-plugin/) in your plugin code
+3.  **Include a `keywords` field** in your plugin's `package.json`, containing `gatsby` and `gatsby-plugin`. If your plugin is a theme, please also include `gatsby-theme`.
+4.  Document your plugin with a README, there is a [plugin template](/contributing/docs-templates/#plugin-readme-template) available to be used as reference.
 
 After doing so, Algolia will take up to 12 hours to add it to the library search index (the exact time necessary is still unknown), and wait for the daily rebuild of https://gatsbyjs.org to automatically include your plugin page to the website. Then, all you have to do is share your wonderful plugin with the community!
 

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -84,6 +84,10 @@ Inside it you'll find:
 - `gatsby-config.js`: Specifies which theme to use and any other one-off configuration a site might need.
 - `/src`: Contains source code such as custom pages or components that might live in a user's site.
 
+## Publishing a Theme
+
+After building your theme, you may want to publish it for the Gatsby community. To do so, please [publish your theme plugin to the plugin library](/contributing/submit-to-plugin-library/#publishing-a-plugin-to-the-library).
+
 ## Further resources
 
 ### Gatsby Theme Authoring (Video course)


### PR DESCRIPTION
## Description

This PR adds a link to how to publish a plugin from the "Building Themes" reference guide. Also added a change to step 3 of instructions to include a note about adding `gatsby-theme` keyword if publishing a theme plugin 

## Related Issues

Part of #18242
