### PR TITLE
docs: update community event support page

### DIFF
--- a/docs/contributing/organize-a-gatsby-event.md
+++ b/docs/contributing/organize-a-gatsby-event.md
@@ -2,13 +2,13 @@
 title: Organize a Gatsby Event
 ---
 
-Interested in organizing a Gatsby event? We want to help build the Gatsby community in your area. If your event meets a few basic requirements listed below, you’ll be eligible to receive support from Gatsby such as Gatsby stickers, learning resources, up to $300 for event costs, and more. Get started by requesting event support below.
+Interested in organizing a Gatsby event? We want to help build the Gatsby community in your area. If your event meets a few basic requirements listed below, you’ll be eligible to receive support from Gatsby such as Gatsby stickers, learning resources, up to \$300 for event costs, and more. Get started by requesting event support below.
 
 [Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)
 
 ## What constitutes a Gatsby event?
 
-A community-organized Gatsby event can be a local meetup, a small conference, a “lunch and learn” with coworkers, or a larger event - as long as __it includes at least one Gatsby-focused presentation or discussion__. It’s up to you how many people you want to invite and how casual the environment. You can organize an event at your workplace or for the local community. 
+A community-organized Gatsby event can be a local meetup, a small conference, a “lunch and learn” with coworkers, or a larger event - as long as **it includes at least one Gatsby-focused presentation or discussion**. It’s up to you how many people you want to invite and how casual the environment. You can organize an event at your workplace or for the local community.
 
 ## What support does Gatsby provide?
 
@@ -21,14 +21,15 @@ There are several ways Gatsby can support your event:
 - 20% off swag in the [Gatsby Swag Store](https://store.gatsbyjs.org/) for your attendees
 
 ### A note on shipping
-We support US and international Gatsby events, but it’s not uncommon to run into issues with international shipping that can delay orders for weeks. Shipments to non-western countries in particular can often take well over a month to arrive. We’re working on finding international shipping partners, but until that’s sorted out, __if you need stickers shipped internationally, please make sure you’re submitting your event at least 6 weeks in advance__.
+
+We support US and international Gatsby events, but it’s not uncommon to run into issues with international shipping that can delay orders for weeks. Shipments to non-western countries in particular can often take well over a month to arrive. We’re working on finding international shipping partners, but until that’s sorted out, **if you need stickers shipped internationally, please make sure you’re submitting your event at least 6 weeks in advance**.
 
 ## Requirements
 
-- Requests should be made at least 1 month in advance of your event date. (If your event is outside the US and you plan to request stickers, we strongly recommend making your request at least 6 weeks in advance.)  
+- Requests should be made at least 1 month in advance of your event date. (If your event is outside the US and you plan to request stickers, we strongly recommend making your request at least 6 weeks in advance.)
 - The event must have at least one Gatsby-focused presentation or discussion.
 - Please announce Gatsby as a sponsor for the event and/or list us on the event as a sponsor.
-- If you’re requesting the $300 reimbursement, then you must submit a receipt or receipts for event-related expenses.
+- If you’re requesting the \$300 reimbursement, then you must submit a receipt or receipts for event-related expenses.
 - The event must be in harmony with the [Gatsby Code of Conduct](/contributing/code-of-conduct/) and follow the [Gatsby brand guidelines](/guidelines/logo/)
 
 ## How do you qualify for Gatsby support?

--- a/docs/contributing/organize-a-gatsby-event.md
+++ b/docs/contributing/organize-a-gatsby-event.md
@@ -2,30 +2,33 @@
 title: Organize a Gatsby Event
 ---
 
-Interested in organizing a Gatsby event? We want to help build the Gatsby community in your area. If your event meets a few basic requirements listed below, you’ll be eligible to receive support from Gatsby such as Gatsby swag, \$300 for food, learning resources, and more. Get started by requesting event support below.
+Interested in organizing a Gatsby event? We want to help build the Gatsby community in your area. If your event meets a few basic requirements listed below, you’ll be eligible to receive support from Gatsby such as Gatsby stickers, learning resources, up to $300 for event costs, and more. Get started by requesting event support below.
 
 [Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)
 
 ## What constitutes a Gatsby event?
 
-A community organized Gatsby event can be a local meetup, a small conference, a _lunch and learn_ with coworkers, or a larger event. It’s up to you how many people you want to invite and how casual the environment. You can organize an event at your workplace or for the local community.
+A community-organized Gatsby event can be a local meetup, a small conference, a “lunch and learn” with coworkers, or a larger event - as long as __it includes at least one Gatsby-focused presentation or discussion__. It’s up to you how many people you want to invite and how casual the environment. You can organize an event at your workplace or for the local community. 
 
 ## What support does Gatsby provide?
 
-There are several ways Gatsby may support your event:
+There are several ways Gatsby can support your event:
 
 - Promote event on the [Gatsbyjs.org Events Page](/contributing/events/)
-- Promote event via [Gatsby’s Twitter handle](https://twitter.com/gatsbyjs)
-- \$300 off food related expenses
+- Promote event via [Gatsby’s Twitter account](https://twitter.com/gatsbyjs)
+- \$300 off event expenses (food, supplies, space rental, etc.)
 - Free Gatsby stickers from the [Gatsby Swag Store](https://store.gatsbyjs.org/)
 - 20% off swag in the [Gatsby Swag Store](https://store.gatsbyjs.org/) for your attendees
-- Gatsby team member speaker (when available)
+
+### A note on shipping
+We support US and international Gatsby events, but it’s not uncommon to run into issues with international shipping that can delay orders for weeks. Shipments to non-western countries in particular can often take well over a month to arrive. We’re working on finding international shipping partners, but until that’s sorted out, __if you need stickers shipped internationally, please make sure you’re submitting your event at least 6 weeks in advance__.
 
 ## Requirements
 
-- The event must have at least half of the content focused on Gatsby or a Gatsby-related topic (such as JAMstack)
-- Both US and international events qualify for support
-- If you’re requesting the \$300 food credit, then you must submit a receipt for the expense
+- Requests should be made at least 1 month in advance of your event date. (If your event is outside the US and you plan to request stickers, we strongly recommend making your request at least 6 weeks in advance.)  
+- The event must have at least one Gatsby-focused presentation or discussion.
+- Please announce Gatsby as a sponsor for the event and/or list us on the event as a sponsor.
+- If you’re requesting the $300 reimbursement, then you must submit a receipt or receipts for event-related expenses.
 - The event must be in harmony with the [Gatsby Code of Conduct](/contributing/code-of-conduct/) and follow the [Gatsby brand guidelines](/guidelines/logo/)
 
 ## How do you qualify for Gatsby support?
@@ -33,6 +36,9 @@ There are several ways Gatsby may support your event:
 To request support and submit your event to the Gatsby events page, apply at the link below.
 
 [Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)
+
+Events are evaluated on a weekly basis. If your submission is approved, you will receive an email with instructions for receiving event support and other guidance.
+If you have any questions, please send them to events@gatsbyjs.com.
 
 ## Related Links
 


### PR DESCRIPTION
We're making some updates to help clarify and simplify the event support process. This PR includes updates to the page content that are already reflected in the community event form and follow-up emails.

Changes include:
-Clarify the financial support and swag items available
-Include requirement that a Gatsby presentation/discussion be included in the event
-Be clear that reimbursement can be applied to costs besides food
-Warn applicants about difficulties with international shipping 