### PR TITLE
fix(gatsby-transformer-javascript-frontmatter): use typescript parser instead of flow parser for typescript files

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
+++ b/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
@@ -37,7 +37,7 @@ async function onCreateNode({
       `functionBind`,
       `functionSent`,
       `dynamicImport`,
-      `flow`,
+      _.includes([`ts`, `tsx`], node.extension) ? `typescript` : `flow`,
     ],
   }
 


### PR DESCRIPTION
## Description

This updates **gatsby-transformer-javascript-frontmatter** with support for typescript files while parsing.

## Related Issues

Fixes #19253
