### PR TITLE
fix(gatsby-react-router-scroll): Compare location pathname (#18758)

### DIFF
--- a/packages/gatsby-react-router-scroll/src/ScrollBehaviorContext.js
+++ b/packages/gatsby-react-router-scroll/src/ScrollBehaviorContext.js
@@ -37,7 +37,7 @@ class ScrollContext extends React.Component {
     const { location } = this.props
     const prevLocation = prevProps.location
 
-    if (location === prevLocation) {
+    if (location.pathname === prevLocation.pathname) {
       return
     }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Gatsby React Router Scroll currently does a comparison check against the current location against the previous location. If they are unchanged, the scroll is not updated.

However, because of javascript, we cannot compare objects directly. So the scroll is updated, even when remaining on the same path.

This PR enforces checking against the pathname to determine if scroll should update.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #18758 