### PR TITLE
Material-UI and Ant Design requires a plugin

### DIFF
--- a/docs/docs/what-you-dont-need-plugins-for.md
+++ b/docs/docs/what-you-dont-need-plugins-for.md
@@ -9,5 +9,4 @@ Some examples:
 - Importing JavaScript packages that provide general functionality, such as `lodash` or `axios`
 - Integrating visualization libraries, such as `Highcharts` or `d3`.
 
-
 As a general rule, you may use _any_ npm package you might use without Gatsby, with Gatsby. What plugins offer is a prepackaged integration into the core Gatsby APIs to save you time and energy, with minimal configuration. In the case of `Styled Components`, you could manually render the `Provider` component near the root of your application, or you could just use `gatsby-plugin-styled-components` which takes care of this step for you in addition to any other difficulties you may run into configuring Styled Components to work with server side rendering.

--- a/docs/docs/what-you-dont-need-plugins-for.md
+++ b/docs/docs/what-you-dont-need-plugins-for.md
@@ -7,7 +7,7 @@ Most third-party functionality you want to add to your website will follow stand
 Some examples:
 
 - Importing JavaScript packages that provide general functionality, such as `lodash` or `axios`
-- Using React components or component libraries you want to include in your UI or the typeahead from your component library. ⚠️ You need a plugin for [Material-UI](https://github.com/hupe1980/gatsby-plugin-material-ui) or [Ant Design](https://github.com/bskimball/gatsby-plugin-antd).
 - Integrating visualization libraries, such as `Highcharts` or `d3`.
+
 
 As a general rule, you may use _any_ npm package you might use without Gatsby, with Gatsby. What plugins offer is a prepackaged integration into the core Gatsby APIs to save you time and energy, with minimal configuration. In the case of `Styled Components`, you could manually render the `Provider` component near the root of your application, or you could just use `gatsby-plugin-styled-components` which takes care of this step for you in addition to any other difficulties you may run into configuring Styled Components to work with server side rendering.

--- a/docs/docs/what-you-dont-need-plugins-for.md
+++ b/docs/docs/what-you-dont-need-plugins-for.md
@@ -7,7 +7,7 @@ Most third-party functionality you want to add to your website will follow stand
 Some examples:
 
 - Importing JavaScript packages that provide general functionality, such as `lodash` or `axios`
-- Using React components or component libraries you want to include in your UI, such as `Ant Design`, `Material UI`, or the typeahead from your component library.
+- Using React components or component libraries you want to include in your UI or the typeahead from your component library. ⚠️ You need a plugin for [Material-UI](https://github.com/hupe1980/gatsby-plugin-material-ui) or [Ant Design](https://github.com/bskimball/gatsby-plugin-antd).
 - Integrating visualization libraries, such as `Highcharts` or `d3`.
 
 As a general rule, you may use _any_ npm package you might use without Gatsby, with Gatsby. What plugins offer is a prepackaged integration into the core Gatsby APIs to save you time and energy, with minimal configuration. In the case of `Styled Components`, you could manually render the `Provider` component near the root of your application, or you could just use `gatsby-plugin-styled-components` which takes care of this step for you in addition to any other difficulties you may run into configuring Styled Components to work with server side rendering.


### PR DESCRIPTION
- Ant Design needs a plugin to handle tree shaking and to import the styles.
- Material-UI needs a plugin to handler server-side style sheets, with JSS. In the future, we will rely on gatsby-plugin-styled-components.

The problem was reported at https://github.com/mui-org/material-ui/issues/18197. It was introduced in #6099.

*You might have noticed that I have switch the order between the two libs, of course, it's not biased, happy to follow the alphabetical ASC order if you prefer 🙃*
