### PR TITLE
chore: update a few reference guide overview pages

### DIFF
--- a/docs/docs/porting-to-gatsby.md
+++ b/docs/docs/porting-to-gatsby.md
@@ -1,5 +1,10 @@
 ---
 title: Porting to Gatsby
+disableTableOfContents: true
 ---
+
+Many times when you want to build a Gatsby project, you'll already have a website in some form. Depending on the technology and setup of your older website, the approach for porting it to Gatsby may vary.
+
+These guides cover the various scenarios in which you may want to convert a web project to Gatsby. There are other possibilities as well: [file an issue](/contributing/how-to-file-an-issue/) to recommend a guide that the Gatsby community would find helpful.
 
 <GuideList slug={props.slug} />

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,7 +1,12 @@
 ---
-title: Testing
+title: Adding Testing
 overview: true
+disableTableOfContents: true
 ---
+
+One of the benefits of building a Gatsby project is the ability to add automated tests for your components, APIs, pages, and more. With Gatsby, you can employ modern tooling like Jest, Cypress, Testing Library, Storybook, Enzyme, and any other JavaScript testing tool to build a robust React web application.
+
+In these guides, you can learn the common tools and setup instructions for adding testing functionality to your Gatsby project. There are likely more possibilities than what are listed here: search the [open issues on GitHub](https://github.com/gatsbyjs/gatsby/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+testing) to chime in about your desired testing use case, or [file an issue](/contributing/how-to-file-an-issue/) of your own.
 
 <GuideList slug={props.slug} />
 

--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -1,6 +1,7 @@
 ---
 title: Themes
 overview: true
+disableTableOfContents: true
 ---
 
 Using a Gatsby theme, all of your default configuration (shared functionality, data sourcing, design) is abstracted out of your site, and into an installable package.


### PR DESCRIPTION
## Description

In looking at https://github.com/gatsbyjs/gatsby/pull/19214 with @gillkyle and talking about Table of Contents for overview pages, I noticed a few that were light on intro text and had unnecessary TOC components. This PR makes a few of those changes, including text to better introduce the Adding Testing and Porting to Gatsby sections of the docs.

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/19291
https://github.com/gatsbyjs/gatsby/pull/18609
