### PR TITLE
chore(gatsby): Bump `graphql-compose` to ^6.3.7

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -81,7 +81,7 @@
     "glob": "^7.1.5",
     "got": "8.3.2",
     "graphql": "^14.5.8",
-    "graphql-compose": "^6.3.6",
+    "graphql-compose": "^6.3.7",
     "graphql-playground-middleware-express": "^1.7.12",
     "invariant": "^2.2.4",
     "is-relative": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10229,10 +10229,10 @@ graphiql@^0.16.0:
     markdown-it "^8.4.0"
     regenerator-runtime "^0.13.3"
 
-graphql-compose@^6.3.6:
-  version "6.3.6"
-  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-6.3.6.tgz#04787745bac26bcce2a80dde4d6872db2590f4f2"
-  integrity sha512-R+kOLAICndxinZI4dtRAloIyZGJFmXSHOElptO/G0CInKfvLELE2XpD05d7iXNmZk99riTW1CEVQrHZvVK2Pdg==
+graphql-compose@^6.3.7:
+  version "6.3.7"
+  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-6.3.7.tgz#a252076818260d861bc01d5a8d1fcfc90cda3eff"
+  integrity sha512-OxfhSPZS2Uz+P9U6FUllJmGGY2T4jrKhnX0x5XFcyQO4ubjQeoHQbAgRyqKqePhIKGqQWFwm2w40/HJC0tt7rA==
   dependencies:
     graphql-type-json "^0.2.4"
     object-path "^0.11.4"


### PR DESCRIPTION
## Description

This should fix an upstream bug in graphql-compose causing SDL like this to fail:

```js
const { schemaComposer } = require('graphql-compose')

schemaComposer.addTypeDefs(`
  type Image {
    random(format: ImageFormat = JPG): String
  }

  enum ImageFormat {
    JPG
  }
`)
```

## Related Issues

Fixes #19210 