### PR TITLE
fix(gatsby): Use CWD to get name if not specified in package.json for local SSL certificate when using `--https` flag

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -355,8 +355,12 @@ module.exports = async (program: any) => {
   // Certs are named after `name` inside the project's package.json.
   // Scoped names are converted from @npm/package-name to npm--package-name
   if (program.https) {
+    const name = program.sitePackageJson.name
+      ? program.sitePackageJson.name.replace(`@`, ``).replace(`/`, `--`)
+      : process.cwd().replace(/[^A-Za-z0-9]/g, `-`)
+
     program.ssl = await getSslCert({
-      name: program.sitePackageJson.name.replace(`@`, ``).replace(`/`, `--`),
+      name,
       certFile: program[`cert-file`],
       keyFile: program[`key-file`],
       directory: program.directory,

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -353,7 +353,8 @@ module.exports = async (program: any) => {
 
   // Check if https is enabled, then create or get SSL cert.
   // Certs are named after `name` inside the project's package.json.
-  // Scoped names are converted from @npm/package-name to npm--package-name
+  // Scoped names are converted from @npm/package-name to npm--package-name.
+  // If the name is unavailable, generate one using the current working dir.
   if (program.https) {
     const name = program.sitePackageJson.name
       ? program.sitePackageJson.name.replace(`@`, ``).replace(`/`, `--`)


### PR DESCRIPTION
## Description

When generating an SSL certificate for HTTPS, use the current working directory to get its name if the package name isn't specified in `package.json`

## Related Issues

Fixes #19225