### PR TITLE
chore: Add stale workflow

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -1,0 +1,52 @@
+on:
+  schedule:
+    - cron: "0 */12 * * *"
+name: Stale Bot workflow
+jobs:
+  build:
+    name: stale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: stale
+        id: stale
+        uses: gatsbyjs/stale@gatsby-refactoring
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAYS_BEFORE_STALE: 20
+          DAYS_BEFORE_CLOSE: 10
+          DRY_RUN: true
+          STALE_ISSUE_MESSAGE: |
+            Hiya!
+            
+            This issue has gone quiet. Spooky quiet. 👻
+
+            We get a lot of issues, so we currently close issues after 30 days of inactivity. It’s been at least 20 days since the last update here.
+            If we missed this issue or if you want to keep it open, please reply here. You can also add the label "not stale" to keep this issue open!
+            As a friendly reminder: the best way to see this issue, or any other, fixed is to open a Pull Request. Check out [gatsby.dev/contribute](https://www.gatsbyjs.org/contributing/how-to-contribute/) for more information about opening PRs, triaging issues, and contributing!
+
+            Thanks for being a part of the Gatsby community! 💪💜
+          CLOSE_MESSAGE: |
+            Hey again!
+
+            It’s been 30 days since anything happened on this issue, so our friendly neighborhood robot (that’s me!) is going to close it.
+            Please keep in mind that I’m only a robot, so if I’ve closed this issue in error, I’m `HUMAN_EMOTION_SORRY`. Please feel free to reopen this issue or create a new one if you need anything else.
+            As a friendly reminder: the best way to see this issue, or any other, fixed is to open a Pull Request. Check out [gatsby.dev/contribute](https://www.gatsbyjs.org/contributing/how-to-contribute/) for more information about opening PRs, triaging issues, and contributing!
+
+            Thanks again for being part of the Gatsby community! 💪💜
+          EXEMPT_ISSUE_LABELS: |
+            not stale
+            important
+            Epic
+            good first issue
+            help wanted
+            Hacktoberfest
+            no triage
+            status: confirmed
+            type: feature or enhancement
+      - name: Post slack report
+        uses: pullreminders/slack-action@v1.0.7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        with:
+          args: '{\"channel\": \"${{ secrets.SLACK_STALE_CHANNEL_ID }}\", \"text\": \"\", \"blocks\": ${{ steps.stale.outputs.blocks }} }'

--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: stale
         id: stale
-        uses: gatsbyjs/stale@gatsby-refactoring
+        uses: gatsbyjs/stale@gatsby-repo-test
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DAYS_BEFORE_STALE: 20

--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -7,7 +7,6 @@ jobs:
     name: stale
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
       - name: stale
         id: stale
         uses: gatsbyjs/stale@gatsby-refactoring

--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -17,7 +17,7 @@ jobs:
           DRY_RUN: true
           STALE_ISSUE_MESSAGE: |
             Hiya!
-            
+
             This issue has gone quiet. Spooky quiet. 👻
 
             We get a lot of issues, so we currently close issues after 30 days of inactivity. It’s been at least 20 days since the last update here.


### PR DESCRIPTION
Adding our [stale action fork](https://github.com/gatsbyjs/stale/tree/gatsby-refactoring) as a workflow but first in `DRY_RUN` mode. So no actions will be taken, only logging.

To see the logging the secret `ACTIONS_STEP_DEBUG` was temporarily added. When deactivating the DRY_RUN this secret should be deleted.

A channel ID for SLACK_STALE_CHANNEL_ID was also added to the secrets

The workflow will run every 12 hours.

I've also added a bunch of labels to the exempt, we'd need to discuss which ones in more detail.