### PR TITLE
fix(gatsby-cli): Clean up on unmount in the ink logger

### DIFF
--- a/packages/gatsby-cli/src/reporter/loggers/ink/context.js
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/context.js
@@ -8,9 +8,10 @@ export const StoreStateProvider = ({ children }) => {
   const [state, setState] = useState(getStore().getState())
 
   useEffect(() => {
-    onLogAction(() => {
+    const unsubscribe = onLogAction(() => {
       setState(getStore().getState())
     })
+    return unsubscribe
   }, [])
 
   return (

--- a/packages/gatsby-cli/src/reporter/redux/index.js
+++ b/packages/gatsby-cli/src/reporter/redux/index.js
@@ -11,7 +11,7 @@ let store = Redux.createStore(
 )
 
 const storeSwapListeners = []
-const onLogActionListeners = []
+const onLogActionListeners = new Set()
 
 const isInternalAction = action => {
   if (
@@ -58,15 +58,18 @@ const iface = {
       // deal with actions needed just for internal tracking of status
       return
     }
-    onLogActionListeners.forEach(fn => {
+    for (const fn of onLogActionListeners) {
       fn(action)
-    })
+    }
   },
   onStoreSwap: fn => {
     storeSwapListeners.push(fn)
   },
   onLogAction: fn => {
-    onLogActionListeners.push(fn)
+    onLogActionListeners.add(fn)
+    return () => {
+      onLogActionListeners.delete(fn)
+    }
   },
   setStore: s => {
     s.dispatch({


### PR DESCRIPTION
## Description

This should fix the following warning when gatsby CLI (with ink reporter) exits with an error:
```
Warning: Can't perform a React state update on an unmounted component.
This is a no-op, but it indicates a memory leak in your application.
To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```
