### PR TITLE
fix(scripts/i18n): switch to dotenv

### DIFF
--- a/scripts/i18n/create.js
+++ b/scripts/i18n/create.js
@@ -4,6 +4,8 @@ const shell = require(`shelljs`)
 const { graphql } = require(`@octokit/graphql`)
 const log4js = require(`log4js`)
 
+require(`dotenv`).config()
+
 const { makeProgressIssue } = require(`./make-progress-issue`)
 const { inviteMaintainers } = require(`./invite-maintainers`)
 

--- a/scripts/i18n/package.json
+++ b/scripts/i18n/package.json
@@ -3,15 +3,15 @@
   "version": "1.0.0",
   "description": "Scripts for gatsby internationalization",
   "scripts": {
-    "create": "env-cmd node ./create.js",
-    "update-source": "env-cmd node ./update-source.js"
+    "create": "node ./create.js",
+    "update-source": "node ./update-source.js"
   },
   "author": "Nat Alison",
   "license": "MIT",
   "dependencies": {
     "@octokit/graphql": "^4.2.2",
     "@octokit/rest": "^16.34.0",
-    "env-cmd": "^10.0.1",
+    "dotenv": "^8.2.0",
     "js-yaml": "^3.13.1",
     "log4js": "^5.2.2",
     "shelljs": "^0.8.3"

--- a/scripts/i18n/update-source.js
+++ b/scripts/i18n/update-source.js
@@ -2,6 +2,8 @@ const log4js = require(`log4js`)
 const shell = require(`shelljs`)
 const path = require(`path`)
 
+require(`dotenv`).config()
+
 let logger = log4js.getLogger(`update-source`)
 logger.level = `info`
 


### PR DESCRIPTION
To not fail if `.env` file doesn't exist, but still be able to use it