### PR TITLE
style(gatsby): reword "changed plugin -> stale data" message to avoid widowed word

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -231,8 +231,7 @@ module.exports = async (args: BootstrapArgs) => {
   if (oldPluginsHash && pluginsHash !== oldPluginsHash) {
     report.info(report.stripIndent`
       One or more of your plugins have changed since the last time you ran Gatsby. As
-      a precaution, we're deleting your site's cache to ensure there's not any stale
-      data
+      a precaution, we're deleting your site's cache to ensure there's no stale data.
     `)
   }
   const cacheDirectory = `${program.directory}/.cache`


### PR DESCRIPTION
Looks nicer now.

Before:

![image](https://user-images.githubusercontent.com/33569/68352924-f663ef80-00d5-11ea-88f2-4e9339a95c6a.png)
