### PR TITLE
fix(blog-starter): remove unused query field from blog-post template

### DIFF
--- a/starters/blog/src/templates/blog-post.js
+++ b/starters/blog/src/templates/blog-post.js
@@ -87,7 +87,6 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
-        author
       }
     }
     markdownRemark(fields: { slug: { eq: $slug } }) {


### PR DESCRIPTION
query for `author` has been there since alpha days, never used.

an alternative commit could put `author` to use