### PR TITLE
[docs] Add local plugins to "Building Themes"

### DIFF
--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -41,7 +41,7 @@ Yarn workspaces are a great way to set up a project for theme development becaus
 
 For Gatsby theme development, that means you can keep multiple themes and example sites together in a single project, and develop them locally.
 
-> 💡 If you prefer, using `yarn link` or `npm link` are viable alternatives. In general, Gatsby recommends the yarn workspaces approach for building themes, and that's what the starter and this guide will reflect.
+> 💡 If you prefer, you can develop themes as [local plugins](https://www.gatsbyjs.org/docs/creating-a-local-plugin/). Using `yarn link` or `npm link` are also viable alternatives. In general, Gatsby recommends the yarn workspaces approach for building themes, and that's what the starter and this guide will reflect.
 
 > 💡 The starter takes care of all of the configuration for developing a theme using yarn workspaces. If you're interested in more detail on this setup, check out [this blog post](/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/).
 


### PR DESCRIPTION
## Description

The "Building Themes" doc focuses on Yarn workspaces, but mentions a tip that `yarn link` and `npm link` as alternatives. This PR adds a note along with the tip that local plugins are an alternative to building themes as well.

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/15856

Tweet: https://twitter.com/gatsbyjs/status/1191814285363699712