### PR TITLE
fix(gatsby-source-wordpress): Cannot read property of undefined error with polylang

### DIFF
--- a/packages/gatsby-source-wordpress/src/normalize.js
+++ b/packages/gatsby-source-wordpress/src/normalize.js
@@ -312,12 +312,19 @@ exports.mapPolylangTranslations = entities =>
   entities.map(entity => {
     if (entity.polylang_translations) {
       entity.polylang_translations___NODE = entity.polylang_translations.map(
-        translation =>
-          entities.find(
+        translation => {
+          const post = entities.find(
             t =>
               t.wordpress_id === translation.wordpress_id &&
               entity.__type === t.__type
-          ).id
+          )
+
+          if (!post) {
+            return null
+          }
+
+          return post.id
+        }
       )
 
       delete entity.polylang_translations


### PR DESCRIPTION
## Description

This patch makes a simple check before returning the `id` key, which sometimes fails because it's sometime null. 

Published a forked package here: https://www.npmjs.com/package/@splitmedialabs/gatsby-source-wordpress for our own project, and it works =) 

## Related Issues

Fixes #19285 

Previous PR #19329 was closed because my amateur mistakes (forgot to pull latest version, and used an already declared `entity` var)