### PR TITLE
fix(gatsby): Ensure inferred types do not conflict with types created via schema customization

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -989,6 +989,43 @@ describe(`Build schema`, () => {
     })
   })
 
+  it(`allows renaming and merging nested types`, async () => {
+    createTypes(`
+      type Nested implements Node {
+        nested: SomeNewNameForNested
+      }
+
+      type SomeNewNameForNested {
+        foo: String
+      }
+    `)
+    const node = {
+      id: `nested1`,
+      parent: null,
+      children: [],
+      internal: { type: `Nested`, contentDigest: `0` },
+      name: `nested1`,
+      nested: {
+        foo: {
+          bar: `str`,
+          baz: 5,
+        },
+        bar: `str`,
+      },
+    }
+    store.dispatch(actions.createNode(node, { name: `test` }))
+    const schema = await buildSchema()
+    const print = type => printType(schema.getType(type))
+
+    expect(print(`SomeNewNameForNested`)).toMatchInlineSnapshot(`
+      "type SomeNewNameForNested {
+        foo: String
+        bar: String
+      }"
+    `)
+    expect(schema.getType(`NestedNested`)).not.toBeDefined()
+  })
+
   describe(`createResolvers`, () => {
     it(`allows adding resolver to field`, async () => {
       createTypes(`

--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -5,6 +5,7 @@ const {
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLBoolean,
+  printType,
 } = require(`graphql`)
 const { SchemaComposer } = require(`graphql-compose`)
 jest.mock(`../../utils/api-runner-node`)
@@ -935,6 +936,56 @@ describe(`Build schema`, () => {
       expect(nestedFields[`published`].type.toString()).toEqual(`Boolean!`)
       expect(nestedFields[`date`].type.toString()).toEqual(`Date`)
       expect(nestedFields[`newField`].type.toString()).toEqual(`String`)
+    })
+
+    it(`allows modifying deeply nested inferred types`, async () => {
+      createTypes(`
+        type Nested implements Node @infer {
+          name: String
+        }
+
+        type NestedNestedFoo {
+          bar: Int
+        }
+      `)
+      const node = {
+        id: `nested1`,
+        parent: null,
+        children: [],
+        internal: { type: `Nested`, contentDigest: `0` },
+        name: `nested1`,
+        nested: {
+          foo: {
+            bar: `str`,
+            baz: 5,
+          },
+        },
+      }
+      store.dispatch(actions.createNode(node, { name: `test` }))
+      const schema = await buildSchema()
+      const print = type => printType(schema.getType(type))
+
+      expect(print(`Nested`)).toMatchInlineSnapshot(`
+        "type Nested implements Node {
+          name: String
+          nested: NestedNested
+          id: ID!
+          parent: Node
+          children: [Node!]!
+          internal: Internal!
+        }"
+      `)
+      expect(print(`NestedNested`)).toMatchInlineSnapshot(`
+        "type NestedNested {
+          foo: NestedNestedFoo
+        }"
+      `)
+      expect(print(`NestedNestedFoo`)).toMatchInlineSnapshot(`
+        "type NestedNestedFoo {
+          bar: Int
+          baz: Int
+        }"
+      `)
     })
   })
 

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -350,15 +350,22 @@ const getSimpleFieldConfig = ({
           // "addDefaultResolvers: true" only makes sense for
           // pre-existing types.
           if (!config.shouldAddFields) return null
-          fieldTypeComposer = ObjectTypeComposer.create(
-            createTypeName(selector),
-            schemaComposer
-          )
-          fieldTypeComposer.setExtension(`createdFrom`, `inference`)
-          fieldTypeComposer.setExtension(
-            `plugin`,
-            typeComposer.getExtension(`plugin`)
-          )
+
+          const typeName = createTypeName(selector)
+          if (schemaComposer.has(typeName)) {
+            // Type could have been already created via schema customization
+            fieldTypeComposer = schemaComposer.getOTC(typeName)
+          } else {
+            fieldTypeComposer = ObjectTypeComposer.create(
+              typeName,
+              schemaComposer
+            )
+            fieldTypeComposer.setExtension(`createdFrom`, `inference`)
+            fieldTypeComposer.setExtension(
+              `plugin`,
+              typeComposer.getExtension(`plugin`)
+            )
+          }
         }
 
         // Inference config options are either explicitly defined on a type


### PR DESCRIPTION
## Description

This fixes the following error during the schema building process:
```
Error: Schema must contain uniquely named types but contains multiple types named "Foo".
```

It happens when overriding deeply nested inferred fields with schema customization. Say you have a node like this:

```js
{
  name: `nested1`,
  internal: { type: `Nested`, contentDigest: `0` },
  nested: {
    foo: {
      bar: `5`,
    },
  },
}
```

and you want to ensure `nested.foo.bar` is always `Int`:

```graphql
type NestedNestedFoo {
  bar: Int
}
```

Before this PR it would throw an error mentioned above. It happens because we create this type twice: once during schema customization call and another time during inference.

## Related Issues

Fixes #18080