### PR TITLE
fix(gatsby-transformer-sharp): explicitly register enum types

### DIFF
--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -27,6 +27,7 @@ const {
   ImageFormatType,
   ImageCropFocusType,
   DuotoneGradientType,
+  PotraceTurnPolicyType,
   PotraceType,
   ImageFitType,
 } = require(`./types`)
@@ -567,6 +568,14 @@ module.exports = ({
   })
 
   if (createTypes) {
-    createTypes([imageSharpType])
+    createTypes([
+      ImageFormatType,
+      ImageFitType,
+      ImageCropFocusType,
+      DuotoneGradientType,
+      PotraceTurnPolicyType,
+      PotraceType,
+      imageSharpType,
+    ])
   }
 }

--- a/packages/gatsby-transformer-sharp/src/types.js
+++ b/packages/gatsby-transformer-sharp/src/types.js
@@ -57,22 +57,24 @@ const DuotoneGradientType = new GraphQLInputObjectType({
   },
 })
 
+const PotraceTurnPolicyType = new GraphQLEnumType({
+  name: `PotraceTurnPolicy`,
+  values: {
+    TURNPOLICY_BLACK: { value: Potrace.TURNPOLICY_BLACK },
+    TURNPOLICY_WHITE: { value: Potrace.TURNPOLICY_WHITE },
+    TURNPOLICY_LEFT: { value: Potrace.TURNPOLICY_LEFT },
+    TURNPOLICY_RIGHT: { value: Potrace.TURNPOLICY_RIGHT },
+    TURNPOLICY_MINORITY: { value: Potrace.TURNPOLICY_MINORITY },
+    TURNPOLICY_MAJORITY: { value: Potrace.TURNPOLICY_MAJORITY },
+  },
+})
+
 const PotraceType = new GraphQLInputObjectType({
   name: `Potrace`,
   fields: () => {
     return {
       turnPolicy: {
-        type: new GraphQLEnumType({
-          name: `PotraceTurnPolicy`,
-          values: {
-            TURNPOLICY_BLACK: { value: Potrace.TURNPOLICY_BLACK },
-            TURNPOLICY_WHITE: { value: Potrace.TURNPOLICY_WHITE },
-            TURNPOLICY_LEFT: { value: Potrace.TURNPOLICY_LEFT },
-            TURNPOLICY_RIGHT: { value: Potrace.TURNPOLICY_RIGHT },
-            TURNPOLICY_MINORITY: { value: Potrace.TURNPOLICY_MINORITY },
-            TURNPOLICY_MAJORITY: { value: Potrace.TURNPOLICY_MAJORITY },
-          },
-        }),
+        type: PotraceTurnPolicyType,
       },
       turdSize: { type: GraphQLFloat },
       alphaMax: { type: GraphQLFloat },
@@ -91,5 +93,6 @@ module.exports = {
   ImageFitType,
   ImageCropFocusType,
   DuotoneGradientType,
+  PotraceTurnPolicyType,
   PotraceType,
 }


### PR DESCRIPTION
explicitly register transformer-sharp enums -- this is needed for schema snapshoting to work correctly

related: #19210