### PR TITLE
docs(mdx): add caveat on graphql query export

### DIFF
--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -238,3 +238,9 @@ export const pageQuery = graphql`
   }
 `
 ```
+
+> Note: For now, this only works [if the `.mdx` file exporting the query is placed in
+> `src/pages`](https://github.com/ChristopherBiscardi/gatsby-mdx/issues/187#issuecomment-437161966).
+> Exporting GraphQL queries from `.mdx` files that are used for programmatic page creation in
+> `gatsby-node.js` via `actions.createPage` [is not currently
+> supported](https://github.com/ChristopherBiscardi/gatsby-mdx/issues/187#issuecomment-489005677).


### PR DESCRIPTION
## Description

GraphQL queries can only be exported from `.mdx` files used directly as pages rather than programmatically through `actions.createPage`. This was not clear from the docs.

## Related Issues

- [gatsby-mdx#187](https://github.com/ChristopherBiscardi/gatsby-mdx/issues/187)