### PR TITLE
fix(gatsby-cli): remove $ for better copy paste

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -237,8 +237,9 @@ type InitOptions = {
 const successMessage = path => {
   report.info(`
 Your new Gatsby site has been successfully bootstrapped. Start developing it by running:
-  $ cd ${path}
-  $ gatsby develop
+
+  cd ${path}
+  gatsby develop
 `)
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

remove the `$` for better copy and paste: 
if i double click in terminal then the whole line is selected with the `$`

## Related Issues

