### PR TITLE
Add note how to enable eslint-loader with custom config

### DIFF
--- a/docs/docs/eslint.md
+++ b/docs/docs/eslint.md
@@ -38,4 +38,6 @@ module.exports = {
 }
 ```
 
+Note: If you provide a custom `.eslintrc.js` file, Gatsby gives you full control about the ESLint configuration. This means that it will disable the built-in `eslint-loader` and you need to enable it yourself. One way to do so is to use the Community plugin [`gatsby-eslint-plugin`](/packages/gatsby-plugin-eslint/).
+
 If you want to disable ESLint completely, create an empty `.eslintrc` file.


### PR DESCRIPTION
## Description

This adds a little section in the ESLint config documentation explaining how to enable the `eslint-loader` again when providing a custom ESLint config.

## Related Issues

* Fixes #18796
* Relates to #19171 