### PR TITLE
Fix and clarify Ghost sourcing page

### DIFF
--- a/docs/docs/sourcing-from-ghost.md
+++ b/docs/docs/sourcing-from-ghost.md
@@ -57,7 +57,7 @@ module.exports = {
 
 ## Generating pages
 
-Once the source plugin is set up, you can use the [`createPages` API](/docs/node-apis/#createPages) in `gatsby-node.js` to create queries on your Ghost data with GraphQL. In this example, Gatsby iterates over each post returned by the Ghost API and generates a new page with that data, using the `post.js` template file.
+Once the source plugin is set up, you can use the [`createPages` API](/docs/node-apis/#createPages) in `gatsby-node.js` to run queries against your Ghost data with GraphQL. In this example, Gatsby iterates over each post returned by the Ghost API and generates a new page with that data, using the `post.js` template file.
 
 There are several ways to structure queries depending on how you prefer to work, but here's a very minimal example:
 

--- a/docs/docs/sourcing-from-ghost.md
+++ b/docs/docs/sourcing-from-ghost.md
@@ -57,7 +57,7 @@ module.exports = {
 
 ## Generating pages
 
-Once the source plugin is set up, you can use the `createPages` API in `gatsby-node.js` to create queries on your Ghost data with GraphQL. In this example, Gatsby iterates over each post returned by the Ghost API and generates a new page with that data, using the `post.js` template file.
+Once the source plugin is set up, you can use the [`createPages` API](/docs/node-apis/#createPages) in `gatsby-node.js` to create queries on your Ghost data with GraphQL. In this example, Gatsby iterates over each post returned by the Ghost API and generates a new page with that data, using the `post.js` template file.
 
 There are several ways to structure queries depending on how you prefer to work, but here's a very minimal example:
 
@@ -113,6 +113,8 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 
 ## Outputting data
 
+The code above will create pages in the root of the site at `/`, with the path being the slug of the post.
+
 Then, within the `post.js` template, you can determine exactly how and where you want to output data on each page. Again, you'll use GraphQL to query individual fields, so a simple example looks something like this:
 
 ```javascript:title=templates/post.js
@@ -139,10 +141,10 @@ export default Post
 export const postQuery = graphql`
   query($slug: String!) {
     ghostPost(slug: { eq: $slug }) {
-      id
       title
       slug
       feature_image
+      html
     }
   }
 `


### PR DESCRIPTION
The Ghost sourcing page did not actually output any HTML. This PR fixes that, and attempts to clarify the process.

I still don't understand how `postQuery` is used. That symbol can be named whatever, and the posts are still rendered. Anyone?

It would also be useful to explain (or point to)
* how to [generate links to posts](https://github.com/gatsbyjs/gatsby/issues/3186#issuecomment-552296938)
* how to trigger rebuilds on new posts (an [FAQ on gatsby-source-wordpress](https://github.com/gatsbyjs/gatsby/issues/2753))