### PR TITLE
feat(gatsby-plugin-offline): Merge workboxConfig and default options more deeply

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -150,11 +150,8 @@ exports.onPostBuild = (
     skipWaiting: true,
     clientsClaim: true,
   }
-
-  const combinedOptions = {
-    ...options,
-    ...workboxConfig,
-  }
+  
+  const combinedOptions = _.merge(options, workboxConfig)
 
   const idbKeyvalFile = `idb-keyval-iife.min.js`
   const idbKeyvalSource = require.resolve(`idb-keyval/dist/${idbKeyvalFile}`)

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -150,7 +150,7 @@ exports.onPostBuild = (
     skipWaiting: true,
     clientsClaim: true,
   }
-  
+
   const combinedOptions = _.merge(options, workboxConfig)
 
   const idbKeyvalFile = `idb-keyval-iife.min.js`


### PR DESCRIPTION
Since we're already spreading the workboxConfig options into the defaults, it might make sense to use `_.merge` to more deeply merge the properties and array items together. This would mean that users don't need to copy over all of the default `runtimeCaching` array items if they only want to add another caching rule to the list.