### PR TITLE
Updated TypeScript types to add matchPath

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -803,7 +803,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createPage */
   createPage<TContext = Record<string, unknown>>(
-    args: { path: string; component: string; context: TContext },
+    args: { path: string; matchPath?: string; component: string; context: TContext },
     plugin?: ActionPlugin,
     option?: ActionOptions
   ): void


### PR DESCRIPTION
## Description

https://www.gatsbyjs.org/docs/actions/#createPage

`createPage` supports a `matchPath` parameter which is not available in the TypeScript types.

## Related Issues

Didn't bother to create one, went straight to fixing it.
