### PR TITLE
chore(gatsby-theme-blog): center align items in bio

### DIFF
--- a/packages/gatsby-theme-blog/src/components/bio.js
+++ b/packages/gatsby-theme-blog/src/components/bio.js
@@ -21,7 +21,7 @@ const Bio = () => {
   } = data
 
   return (
-    <Flex css={css({ mb: 4 })}>
+    <Flex css={css({ mb: 4, alignItems: `center` })}>
       {avatar ? (
         <Image
           fixed={avatar.childImageSharp.fixed}


### PR DESCRIPTION
## Description

This PR changes bio layout in `gatsby-theme-blog` to align items to center.

## Related Issues

This change was discussed in comment section under #19236 