### PR TITLE
docs: consistent terminology for hydration

### DIFF
--- a/docs/docs/react-hydration.md
+++ b/docs/docs/react-hydration.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding React Rehydration
+title: Understanding React Hydration
 ---
 
 One of the central ideas of Gatsby is that HTML content is statically generated using React DOM server-side APIs. Another key feature is that this static HTML content can then be _enhanced_ with client-side JavaScript via React hydration, which allows for [app-like features](/docs/adding-app-and-website-functionality/) in Gatsby sites.

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -540,8 +540,8 @@
           link: /docs/building-with-components/
         - title: Lifecycle APIs
           link: /docs/gatsby-lifecycle-apis/
-        - title: React Rehydration
-          link: /docs/react-rehydration
+        - title: React Hydration
+          link: /docs/react-hydration
         - title: PRPL Pattern
           link: /docs/prpl-pattern/
         - title: GraphQL Concepts


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I noticed a broken link on the building apps overview linking to the doc at `/docs/react-hydration` which is actually at `/docs/react-rehydration`.

Considering we refer to it as hydration instead of rehydration in every other place this is mentioned in the docs I think adjusting the name makes sense and this is a brand new doc.

## Related Issues

_None, but found a broken link_