### PR TITLE
fix(gatsby-image): Remove onClick prop

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -413,8 +413,7 @@ While you could achieve a similar effect with plain CSS media queries, `gatsby-i
 | `fluid`                | `object` / `array`  | Data returned from the `fluid` query. When prop is an array it has to be combined with `media` keys, allows for art directing `fluid` images. |
 | `fadeIn`               | `bool`              | Defaults to fading in the image on load                                                                                                       |
 | `durationFadeIn`       | `number`            | fading duration is set up to 500ms by default                                                                                                 |
-| `title`                | `string`            | Passed to the `img` element                                                                                                                   |
-| `onClick`              | `func`              | Passed to the `img` element                                                                                                                   |
+| `title`                | `string`            | Passed to the `img` element                                                                                                                   |  |
 | `alt`                  | `string`            | Passed to the `img` element. Defaults to an empty string `alt=""`                                                                             |
 | `crossOrigin`          | `string`            | Passed to the `img` element                                                                                                                   |
 | `className`            | `string` / `object` | Passed to the wrapper element. Object is needed to support Glamor's css prop                                                                  |

--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -43,7 +43,6 @@ interface GatsbyImageProps {
   backgroundColor?: string | boolean
   onLoad?: () => void
   onError?: (event: any) => void
-  onClick?: () => void
   onStartLoad?: (param: { wasCached: boolean }) => void
   Tag?: string
   itemProp?: string

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -239,7 +239,6 @@ const Img = React.forwardRef((props, ref) => {
     style,
     onLoad,
     onError,
-    onClick,
     loading,
     draggable,
     ...otherProps
@@ -253,7 +252,6 @@ const Img = React.forwardRef((props, ref) => {
       {...otherProps}
       onLoad={onLoad}
       onError={onError}
-      onClick={onClick}
       ref={ref}
       loading={loading}
       draggable={draggable}
@@ -274,7 +272,6 @@ const Img = React.forwardRef((props, ref) => {
 Img.propTypes = {
   style: PropTypes.object,
   onError: PropTypes.func,
-  onClick: PropTypes.func,
   onLoad: PropTypes.func,
 }
 
@@ -492,7 +489,6 @@ class Image extends React.Component {
                 ref={this.imageRef}
                 onLoad={this.handleImageLoaded}
                 onError={this.props.onError}
-                onClick={this.props.onClick}
                 itemProp={itemProp}
                 loading={loading}
                 draggable={draggable}
@@ -593,7 +589,6 @@ class Image extends React.Component {
                 ref={this.imageRef}
                 onLoad={this.handleImageLoaded}
                 onError={this.props.onError}
-                onClick={this.props.onClick}
                 itemProp={itemProp}
                 loading={loading}
                 draggable={draggable}
@@ -680,7 +675,6 @@ Image.propTypes = {
   backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onLoad: PropTypes.func,
   onError: PropTypes.func,
-  onClick: PropTypes.func,
   onStartLoad: PropTypes.func,
   Tag: PropTypes.string,
   itemProp: PropTypes.string,


### PR DESCRIPTION
## Description

This pull request reverts #18465 as discussed in #18468

Quoting @marcysutton: 
> Even with notes about affordances in the docs, encouraging clicking on images has the very real potential to produce inaccessible websites; something that conflicts with our commitment to accessibility.

