### PR TITLE
chore(docs): Add new language in transalation list

### DIFF
--- a/docs/contributing/gatsby-docs-translation-guide.md
+++ b/docs/contributing/gatsby-docs-translation-guide.md
@@ -41,6 +41,9 @@ The first step for starting a new translation is to check what exists. So far, t
 - [Russian](https://github.com/gatsbyjs/gatsby-ru)
 - [Turkish](https://github.com/gatsbyjs/gatsby-tr)
 - [Simplified Chinese](https://github.com/gatsbyjs/gatsby-zh-Hans)
+- [Gujarati](https://github.com/gatsbyjs/gatsby-gu)
+- [French](https://github.com/gatsbyjs/gatsby-fr)
+- [Mongolian](https://github.com/gatsbyjs/gatsby-mn)
 
 > Note: Once a new translation repository is created, feel free to add it here in a PR!
 

--- a/docs/contributing/gatsby-docs-translation-guide.md
+++ b/docs/contributing/gatsby-docs-translation-guide.md
@@ -31,19 +31,19 @@ The first step for starting a new translation is to check what exists. So far, t
 - [Arabic](https://github.com/gatsbyjs/gatsby-ar)
 - [German](https://github.com/gatsbyjs/gatsby-de)
 - [Spanish](https://github.com/gatsbyjs/gatsby-es)
+- [French](https://github.com/gatsbyjs/gatsby-fr)
+- [Gujarati](https://github.com/gatsbyjs/gatsby-gu)
 - [Hindi](https://github.com/gatsbyjs/gatsby-hi)
 - [Indonesian](https://github.com/gatsbyjs/gatsby-id)
 - [Italian](https://github.com/gatsbyjs/gatsby-it)
 - [Korean](https://github.com/gatsbyjs/gatsby-ko)
+- [Mongolian](https://github.com/gatsbyjs/gatsby-mn)
 - [Dutch](https://github.com/gatsbyjs/gatsby-nl)
 - [Polish](https://github.com/gatsbyjs/gatsby-pl)
 - [Brazilian Portuguese](https://github.com/gatsbyjs/gatsby-pt-BR)
 - [Russian](https://github.com/gatsbyjs/gatsby-ru)
 - [Turkish](https://github.com/gatsbyjs/gatsby-tr)
 - [Simplified Chinese](https://github.com/gatsbyjs/gatsby-zh-Hans)
-- [Gujarati](https://github.com/gatsbyjs/gatsby-gu)
-- [French](https://github.com/gatsbyjs/gatsby-fr)
-- [Mongolian](https://github.com/gatsbyjs/gatsby-mn)
 
 > Note: Once a new translation repository is created, feel free to add it here in a PR!
 


### PR DESCRIPTION
I have added the following new language in the `Process for starting a new translation` section.
Doc Page :- `https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/`
- Gujarati
- French
- Mongolian
