### PR TITLE
fix(gatsby): Re-use plugin resolution logic for theme dir resolution

### DIFF
--- a/docs/docs/files-gatsby-looks-for-in-a-plugin.md
+++ b/docs/docs/files-gatsby-looks-for-in-a-plugin.md
@@ -11,7 +11,7 @@ All files are optional unless specifically marked as required.
     - if `name` isn’t set, the folder name for the plugin is used
   - `main` is the [name of the file that will be loaded when your module is required by another application](https://docs.npmjs.com/creating-node-js-modules#create-the-file-that-will-be-loaded-when-your-module-is-required-by-another-application)
     - if `main` isn’t set, a default name of `index.js` will be used
-    - if `main` isn't set, it is recommended to create an empty index.js file with the contents `//no-op` (short for no-operation), as seen in this [example plugin](https://github.com/gatsbyjs/gatsby/tree/817a6c14543c73ea8f56c9f93d401b03adb44e9d/packages/gatsby-source-wikipedia)
+    - if `main` isn't set, it is recommended (but not required) to create an empty index.js file with the contents `//no-op` (short for no-operation), as seen in this [example plugin](https://github.com/gatsbyjs/gatsby/tree/817a6c14543c73ea8f56c9f93d401b03adb44e9d/packages/gatsby-source-wikipedia)
   - `version` is used to manage the cache — if it changes, the cache is cleared
     - if `version` isn’t set, an MD5 hash of the `gatsby-*` file contents is used to invalidate the cache
     - omitting the `version` field is recommended for local plugins

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -130,6 +130,7 @@ module.exports = async (args: BootstrapArgs) => {
     const themes = await loadThemes(config, {
       useLegacyThemes: true,
       configFilePath,
+      rootDir: program.directory,
     })
     config = themes.config
 
@@ -141,6 +142,7 @@ module.exports = async (args: BootstrapArgs) => {
     const plugins = await loadThemes(config, {
       useLegacyThemes: false,
       configFilePath,
+      rootDir: program.directory,
     })
     config = plugins.config
   }

--- a/packages/gatsby/src/bootstrap/load-plugins/index.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.js
@@ -4,7 +4,7 @@ const { store } = require(`../../redux`)
 const nodeAPIs = require(`../../utils/api-node-docs`)
 const browserAPIs = require(`../../utils/api-browser-docs`)
 const ssrAPIs = require(`../../../cache-dir/api-ssr-docs`)
-const loadPlugins = require(`./load`)
+const { loadPlugins } = require(`./load`)
 const {
   collatePluginAPIs,
   handleBadExports,

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -108,7 +108,7 @@ function resolvePlugin(pluginName, rootDir) {
   }
 }
 
-module.exports = (config = {}, rootDir = null) => {
+const loadPlugins = (config = {}, rootDir = null) => {
   // Instantiate plugins.
   const plugins = []
 
@@ -240,4 +240,9 @@ module.exports = (config = {}, rootDir = null) => {
   )
 
   return plugins
+}
+
+module.exports = {
+  loadPlugins,
+  resolvePlugin,
 }


### PR DESCRIPTION
## Description

This PR aligns plugin and theme dir resolution logic to avoid acidental breaks for plugins which are not themes. Also fixes the breaking change introduced in gatsby 2.17.7

## Related Issues

Fixes #19150 
