### PR TITLE
test(e2e-tests): add regression test for resolution conflicts of local plugins and themes

### DIFF
--- a/e2e-tests/themes/production-runtime/gatsby-config.js
+++ b/e2e-tests/themes/production-runtime/gatsby-config.js
@@ -5,5 +5,5 @@ module.exports = {
       twitter: `chatsidhartha`,
     },
   },
-  plugins: [`gatsby-theme-about`, `gatsby-theme-local`],
+  plugins: [`gatsby-theme-about`, `gatsby-theme-local`, `gatsby-plugin-local`],
 }

--- a/e2e-tests/themes/production-runtime/plugins/gatsby-plugin-local/package.json
+++ b/e2e-tests/themes/production-runtime/plugins/gatsby-plugin-local/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "gatsby-plugin-local",
+  "description": "Minimum viable plugin structure. See https://github.com/gatsbyjs/gatsby/issues/19150"
+}


### PR DESCRIPTION
## Description

This is a quick follow up for #19470. It adds a missing regression test. This test fails before the fix and works after it.