### PR TITLE
chore(docs): fix mistake in 'gatsby new' examples

### DIFF
--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -45,7 +45,7 @@ gatsby new [<site-name> [<starter-url>]]
 
 #### Examples
 
-- Create a Gatsby site named `my-awesome-blog-site`, using [gatsby-starter-blog](https://www.gatsbyjs.org/starters/gatsbyjs/gatsby-starter-blog/):
+- Create a Gatsby site named `my-awesome-site`, using the [default starter](https://github.com/gatsbyjs/gatsby-starter-default):
 
 ```bash
 gatsby new my-awesome-site


### PR DESCRIPTION
## Description

There was a small mistake in the examples of `gatsby new` command. Default command was described as if it were to create a site with `gatsby-starter-blog` starter.


