### PR TITLE
feat(gatsby): use embedded remote schemas

### DIFF
--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.7.2",
     "apollo-link": "1.2.13",
     "apollo-link-http": "^1.5.16",
-    "graphql-tools": "^3.1.1",
+    "graphql-tools-fork": "^7.1.4",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",
     "uuid": "^3.3.3"

--- a/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
@@ -1,6 +1,5 @@
-jest.mock(`graphql-tools`, () => {
+jest.mock(`graphql-tools-fork`, () => {
   return {
-    makeRemoteExecutableSchema: jest.fn(),
     transformSchema: jest.fn(),
     introspectSchema: jest.fn(),
     RenameTypes: jest.fn(),

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -1,11 +1,10 @@
 const uuidv4 = require(`uuid/v4`)
 const { buildSchema, printSchema } = require(`gatsby/graphql`)
 const {
-  makeRemoteExecutableSchema,
   transformSchema,
   introspectSchema,
   RenameTypes,
-} = require(`graphql-tools`)
+} = require(`graphql-tools-fork`)
 const { createHttpLink } = require(`apollo-link-http`)
 const fetch = require(`node-fetch`)
 const invariant = require(`invariant`)
@@ -74,11 +73,6 @@ exports.sourceNodes = async (
     await cache.set(cacheKey, sdl)
   }
 
-  const remoteSchema = makeRemoteExecutableSchema({
-    schema: introspectionSchema,
-    link,
-  })
-
   const nodeId = createNodeId(`gatsby-source-graphql-${typeName}`)
   const node = createSchemaNode({
     id: nodeId,
@@ -96,15 +90,21 @@ exports.sourceNodes = async (
     return {}
   }
 
-  const schema = transformSchema(remoteSchema, [
-    new StripNonQueryTransform(),
-    new RenameTypes(name => `${typeName}_${name}`),
-    new NamespaceUnderFieldTransform({
-      typeName,
-      fieldName,
-      resolver,
-    }),
-  ])
+  const schema = transformSchema(
+    {
+      schema: introspectionSchema,
+      link,
+    },
+    [
+      new StripNonQueryTransform(),
+      new RenameTypes(name => `${typeName}_${name}`),
+      new NamespaceUnderFieldTransform({
+        typeName,
+        fieldName,
+        resolver,
+      }),
+    ]
+  )
 
   addThirdPartySchema({ schema })
 

--- a/packages/gatsby-source-graphql/src/transforms.js
+++ b/packages/gatsby-source-graphql/src/transforms.js
@@ -3,14 +3,11 @@ const {
   GraphQLNonNull,
   GraphQLSchema,
 } = require(`gatsby/graphql`)
-const {
-  visitSchema,
-  VisitSchemaKind,
-} = require(`graphql-tools/dist/transforms/visitSchema`)
+const { visitSchema, VisitSchemaKind } = require(`graphql-tools-fork`)
 const {
   createResolveType,
   fieldMapToFieldConfigMap,
-} = require(`graphql-tools/dist/stitching/schemaRecreation`)
+} = require(`graphql-tools-fork`)
 
 class NamespaceUnderFieldTransform {
   constructor({ typeName, fieldName, resolver }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4237,7 +4237,7 @@ apollo-link-http@^1.5.16:
     apollo-link-http-common "^0.2.15"
     tslib "^1.9.3"
 
-apollo-link@1.2.13, apollo-link@^1.2.13, apollo-link@^1.2.2:
+apollo-link@1.2.13, apollo-link@^1.2.13:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
   integrity sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==
@@ -4247,7 +4247,7 @@ apollo-link@1.2.13, apollo-link@^1.2.13, apollo-link@^1.2.2:
     tslib "^1.9.3"
     zen-observable-ts "^0.8.20"
 
-apollo-utilities@^1.0.1, apollo-utilities@^1.3.0:
+apollo-utilities@^1.3.0, apollo-utilities@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.2.tgz#8cbdcf8b012f664cd6cb5767f6130f5aed9115c9"
   integrity sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==
@@ -7699,6 +7699,7 @@ depd@~1.1.2:
 deprecated-decorator@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
+  integrity sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -10641,16 +10642,16 @@ graphql-request@^1.5.0, graphql-request@^1.8.2:
   dependencies:
     cross-fetch "2.2.2"
 
-graphql-tools@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.1.1.tgz#d593358f01e7c8b1671a17b70ddb034dea9dbc50"
-  integrity sha512-yHvPkweUB0+Q/GWH5wIG60bpt8CTwBklCSzQdEHmRUgAdEQKxw+9B7zB3dG7wB3Ym7M7lfrS4Ej+jtDZfA2UXg==
+graphql-tools-fork@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/graphql-tools-fork/-/graphql-tools-fork-7.1.4.tgz#a3a6c2ab06add2a6fdaec0a976237ac49e05c85a"
+  integrity sha512-WabbxnfId5j5HTDFEYPXuelw4OUDqHY4pwRClTT74o1VOtGarilkgK96ubPqAszIpxYKjlYntqe7+0Y889z+zA==
   dependencies:
-    apollo-link "^1.2.2"
-    apollo-utilities "^1.0.1"
+    apollo-link "^1.2.13"
+    apollo-utilities "^1.3.2"
     deprecated-decorator "^0.1.6"
-    iterall "^1.1.3"
-    uuid "^3.1.0"
+    iterall "^1.2.2"
+    uuid "^3.3.3"
 
 graphql-type-json@^0.2.4:
   version "0.2.4"
@@ -12448,7 +12449,7 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-iterall@^1.1.3, iterall@^1.2.2:
+iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
@@ -21036,7 +21037,7 @@ type-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
 
-typedarray-to-buffer@~3.1.5:
+typedarray-to-buffer@^3.1.5, typedarray-to-buffer@~3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
@@ -22423,7 +22424,7 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, write-file-atomic@^2.4.2, write-file-atomic@^3.0.0:
+write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
   integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
@@ -22431,6 +22432,25 @@ write-file-atomic@2.4.1, write-file-atomic@^2.0.0, write-file-atomic@^2.3.0, wri
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-atomic@^2.4.2:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+write-file-atomic@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.1.tgz#558328352e673b5bb192cf86500d60b230667d4b"
+  integrity sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 write-file-stdout@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Avoid additional layer of delegation.

## Description

Switches to graphql-tools-fork, a maintained fork of the original repository with continued support for schema stitching. The fork allows for embedding a remote schema configuration within the call to transform schema, removing an additional layer of delegation within root fields and merging by defaultMergedResolver.