### PR TITLE
fix: ensure all docjs elements are typed

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -51,7 +51,7 @@ exports.sourceNodes = ({ actions }) => {
       memberof: String
       scope: String
       access: String
-      optiona: Boolean
+      optional: Boolean
       readonly: Boolean
       abstract: Boolean
       generator: Boolean

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -44,13 +44,14 @@ function prepareDescriptionNode(node, markdownStr, name, helpers) {
 
 exports.sourceNodes = ({ actions }) => {
   const { createTypes } = actions
-  const typeDefs = `
+  const typeDefs = /* GraphQL */ `
     type DocumentationJs implements Node {
       name: String
       kind: String
       memberof: String
       scope: String
       access: String
+      optiona: Boolean
       readonly: Boolean
       abstract: Boolean
       generator: Boolean
@@ -65,6 +66,10 @@ exports.sourceNodes = ({ actions }) => {
       lends: String
       type: DoctrineType
       default: JSON
+      description: DocumentationJSComponentDescription
+        @link(from: description___NODE)
+      deprecated: DocumentationJSComponentDescription
+        @link(from: deprecated___NODE)
       augments: [DocumentationJs] @link(from: "augments___NODE")
       examples: [DocumentationJsExample]
       implements: [DocumentationJs] @link(from: "implements___NODE")


### PR DESCRIPTION

## Description

Rounds out the type declaration for docjs for fields that were missed.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
