### PR TITLE
fix(gatsby-transformer-remark): check if laterTextNode is truthy before using it

### DIFF
--- a/packages/gatsby-transformer-remark/src/hast-processing.js
+++ b/packages/gatsby-transformer-remark/src/hast-processing.js
@@ -59,7 +59,7 @@ function findLastTextNode(node, textNode) {
   if (node.children) {
     node.children.forEach(child => {
       const laterTextNode = findLastTextNode(child)
-      if (laterTextNode !== textNode) {
+      if (laterTextNode && laterTextNode !== textNode) {
         textNode = laterTextNode
       }
     })


### PR DESCRIPTION
This just adds "is truthy" check to nodes traversal code to make sure we don't overwrite actual last found node with `null`

Fixes #19511