### PR TITLE
fix(www): Update share menu title

### DIFF
--- a/www/src/views/starter/meta.js
+++ b/www/src/views/starter/meta.js
@@ -128,7 +128,7 @@ const Meta = ({ starter, repoName, imageSharp, demo }) => (
           </Button>
           <ShareMenu
             url={`https://github.com/${starter.githubFullName}`}
-            title={`Check out ${repoName} on the @Gatsby Starter Showcase!`}
+            title={`Check out ${repoName} on the @gatsbyjs Starter Showcase!`}
             image={imageSharp.childImageSharp.resize.src}
           />
         </div>


### PR DESCRIPTION
## Description

Hi, I think the Gatsby account URL is not correct when people want to share starters!
It is not correct on Twitter. On other social medias, there is no mention option or there is no Gatsby account. 

<img width="740" alt="image" src="https://user-images.githubusercontent.com/25138854/68897800-7677fe00-0743-11ea-91db-e4a2ba23ce0d.png">

