### PR TITLE
chore(showcase): Add Figma Config to site showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -8525,3 +8525,16 @@
     - Productivity
     - Technology
   featured: false
+- title: Figma Config
+  url: https://config.figma.com/
+  main_url: https://config.figma.com/
+  description: A one-day conference where Figma users come together to learn from each other.
+  categories:
+    - Conference
+    - Design
+    - Event
+    - Community
+    - Learning
+  built_by: Corey Ward
+  built_by_url: "http://www.coreyward.me/"
+  featured: false


### PR DESCRIPTION
Adds the new [Figma Config Conference Website](https://config.figma.com/) to the site showcase.