### PR TITLE
respect DO_NOT_TRACK env var per consoledonottrack.com

### DIFF
--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -42,7 +42,7 @@ module.exports = class EventStorage {
     this.store = new Store(baseDir)
     this.verbose = isTruthy(process.env.GATSBY_TELEMETRY_VERBOSE)
     this.debugEvents = isTruthy(process.env.GATSBY_TELEMETRY_DEBUG)
-    this.disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED)
+    this.disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED) || isTruthy(process.env.DO_NOT_TRACK)
   }
 
   isTrackingDisabled() {

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -42,8 +42,14 @@ module.exports = class EventStorage {
     this.store = new Store(baseDir)
     this.verbose = isTruthy(process.env.GATSBY_TELEMETRY_VERBOSE)
     this.debugEvents = isTruthy(process.env.GATSBY_TELEMETRY_DEBUG)
+
+    // disable telemetry reporting if the user has specifically disabled
+    // gatsby telemetry via GATSBY_TELEMETRY_DISABLED or if they have
+    // opted out via standardized DO_NOT_TRACK environment variable per
+    // consoledonottrack.com
     this.disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED) ||
      isTruthy(process.env.DO_NOT_TRACK)
+
   }
 
   isTrackingDisabled() {

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -42,7 +42,8 @@ module.exports = class EventStorage {
     this.store = new Store(baseDir)
     this.verbose = isTruthy(process.env.GATSBY_TELEMETRY_VERBOSE)
     this.debugEvents = isTruthy(process.env.GATSBY_TELEMETRY_DEBUG)
-    this.disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED) || isTruthy(process.env.DO_NOT_TRACK)
+    this.disabled = isTruthy(process.env.GATSBY_TELEMETRY_DISABLED) ||
+     isTruthy(process.env.DO_NOT_TRACK)
   }
 
   isTrackingDisabled() {


### PR DESCRIPTION
## Description

https://consoledonottrack.com

This introduces a check for the `DO_NOT_TRACK` environment variable standard for users to express clear lack of consent to telemetry tracking.