### PR TITLE
Update second code block to include title field which is missing

### DIFF
--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -60,6 +60,7 @@ export const useSiteMetadata = () => {
       query SiteMetaData {
         site {
           siteMetadata {
+            title
             siteUrl
             headline
             description


### PR DESCRIPTION
**title** field is missing from the second block within documentation which makes the code confusing when final code block is printing the _title_ within H1 but title is not included in fields queried via GraphQL statement above.
