### PR TITLE
fix(gatsby-transformer-remark): pass current textNode into recursive call to maintain reference

### DIFF
--- a/packages/gatsby-transformer-remark/src/hast-processing.js
+++ b/packages/gatsby-transformer-remark/src/hast-processing.js
@@ -58,7 +58,7 @@ function findLastTextNode(node, textNode) {
   }
   if (node.children) {
     node.children.forEach(child => {
-      const laterTextNode = findLastTextNode(child)
+      const laterTextNode = findLastTextNode(child, textNode)
       if (laterTextNode !== textNode) {
         textNode = laterTextNode
       }


### PR DESCRIPTION
## Description

Passes the currently assigned textNode into a recursive call to ensure that if a textNode is assigned in a node, we do not exit without one. 

This might still leave the possibility open for an error of `undefined` if the node has _no_ text nodes, however, if there is at least one, this check should be sufficient to ensure a clean exit of the method. 

Additional discussion on this approach can be found here: https://github.com/gatsbyjs/gatsby/pull/19519#pullrequestreview-317388430

## Related Issues
Fixes #19511