### PR TITLE
feat(gatsby-source-contentful): batch download assets from Contentful

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
@@ -1,4 +1,7 @@
-const { downloadContentfulAssets } = require(`../download-contentful-assets`)
+const {
+  BATCH_SIZE,
+  downloadContentfulAssets,
+} = require(`../download-contentful-assets`)
 
 jest.mock(
   `progress`,
@@ -116,7 +119,7 @@ describe.only(`downloadContentfulAssets`, () => {
     await downloadContentfulAssets({
       actions: { touchNode: jest.fn() },
       getNodes: () =>
-        Array.from({ length: 90 }).fill({
+        Array.from({ length: BATCH_SIZE * 2 + 10 }).fill({
           internal: {
             owner: `gatsby-source-contentful`,
             type: `ContentfulAsset`,
@@ -128,7 +131,7 @@ describe.only(`downloadContentfulAssets`, () => {
       cache,
     })
 
-    expect(global.Promise.all).toHaveBeenCalledTimes(4)
+    expect(global.Promise.all).toHaveBeenCalledTimes(3)
 
     global.Promise.all = originalPromiseAll
   })

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -1,6 +1,8 @@
 const ProgressBar = require(`progress`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
+const BATCH_SIZE = 50
+
 const bar = new ProgressBar(
   `Downloading Contentful Assets [:bar] :current/:total :elapsed secs :percent`,
   {
@@ -104,12 +106,10 @@ const downloadContentfulAssets = async gatsbyFunctions => {
     gatsbyFunctions
   )
 
-  const batchSize = 25
-
-  const batchesNum = Math.ceil(contentfulAssetNodes.length / batchSize)
+  const batchesNum = Math.ceil(contentfulAssetNodes.length / BATCH_SIZE)
 
   const batches = Array.from({ length: batchesNum }, (_, index) =>
-    contentfulAssetNodes.slice(index * batchSize, (index + 1) * batchSize)
+    contentfulAssetNodes.slice(index * BATCH_SIZE, (index + 1) * BATCH_SIZE)
   )
 
   await batches.reduce(async (prevPromise, batch) => {
@@ -119,3 +119,4 @@ const downloadContentfulAssets = async gatsbyFunctions => {
   }, Promise.resolve())
 }
 exports.downloadContentfulAssets = downloadContentfulAssets
+exports.BATCH_SIZE = BATCH_SIZE

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -9,7 +9,76 @@ const bar = new ProgressBar(
   }
 )
 
-let totalJobs = 0
+/**
+ * @name downloadSingleContentfulAsset
+ * @description Downloads one Contentful asset to the local filesystem.
+ * The asset file will be downloaded and cached. Use `localFile` to link to them
+ * @param gatsbyFunctions - Gatsby's internal helper functions
+ */
+const downloadSingleContentfulAsset = gatsbyFunctions => {
+  const {
+    actions: { createNode, touchNode },
+    createNodeId,
+    store,
+    cache,
+    reporter,
+  } = gatsbyFunctions
+
+  return async node => {
+    let fileNodeID
+    const { contentful_id: id, node_locale: locale } = node
+    const remoteDataCacheKey = `contentful-asset-${id}-${locale}`
+    const cacheRemoteData = await cache.get(remoteDataCacheKey)
+    if (!node.file) {
+      reporter.warn(`The asset with id: ${id}, contains no file.`)
+      return Promise.resolve()
+    }
+    if (!node.file.url) {
+      reporter.warn(
+        `The asset with id: ${id} has a file but the file contains no url.`
+      )
+      return Promise.resolve()
+    }
+    const url = `http://${node.file.url.slice(2)}`
+
+    // Avoid downloading the asset again if it's been cached
+    // Note: Contentful Assets do not provide useful metadata
+    // to compare a modified asset to a cached version?
+    if (cacheRemoteData) {
+      fileNodeID = cacheRemoteData.fileNodeID // eslint-disable-line prefer-destructuring
+      touchNode({ nodeId: cacheRemoteData.fileNodeID })
+    }
+
+    // If we don't have cached data, download the file
+    if (!fileNodeID) {
+      try {
+        const fileNode = await createRemoteFileNode({
+          url,
+          store,
+          cache,
+          createNode,
+          createNodeId,
+          reporter,
+        })
+
+        if (fileNode) {
+          bar.tick()
+          fileNodeID = fileNode.id
+
+          await cache.set(remoteDataCacheKey, { fileNodeID })
+        }
+      } catch (err) {
+        // Ignore
+      }
+    }
+
+    if (fileNodeID) {
+      node.localFile___NODE = fileNodeID
+    }
+
+    return node
+  }
+}
 
 /**
  * @name downloadContentfulAssets
@@ -19,14 +88,7 @@ let totalJobs = 0
  */
 
 const downloadContentfulAssets = async gatsbyFunctions => {
-  const {
-    actions: { createNode, touchNode },
-    createNodeId,
-    store,
-    cache,
-    getNodes,
-    reporter,
-  } = gatsbyFunctions
+  const { getNodes } = gatsbyFunctions
 
   // Any ContentfulAsset nodes will be downloaded, cached and copied to public/static
   // regardless of if you use `localFile` to link an asset or not.
@@ -36,64 +98,24 @@ const downloadContentfulAssets = async gatsbyFunctions => {
       n.internal.type === `ContentfulAsset`
   )
 
-  await Promise.all(
-    contentfulAssetNodes.map(async node => {
-      totalJobs += 1
-      bar.total = totalJobs
+  bar.total = contentfulAssetNodes.length
 
-      let fileNodeID
-      const { contentful_id: id, node_locale: locale } = node
-      const remoteDataCacheKey = `contentful-asset-${id}-${locale}`
-      const cacheRemoteData = await cache.get(remoteDataCacheKey)
-      if (!node.file) {
-        reporter.warn(`The asset with id: ${id}, contains no file.`)
-        return Promise.resolve()
-      }
-      if (!node.file.url) {
-        reporter.warn(
-          `The asset with id: ${id} has a file but the file contains no url.`
-        )
-        return Promise.resolve()
-      }
-      const url = `http://${node.file.url.slice(2)}`
-
-      // Avoid downloading the asset again if it's been cached
-      // Note: Contentful Assets do not provide useful metadata
-      // to compare a modified asset to a cached version?
-      if (cacheRemoteData) {
-        fileNodeID = cacheRemoteData.fileNodeID // eslint-disable-line prefer-destructuring
-        touchNode({ nodeId: cacheRemoteData.fileNodeID })
-      }
-
-      // If we don't have cached data, download the file
-      if (!fileNodeID) {
-        try {
-          const fileNode = await createRemoteFileNode({
-            url,
-            store,
-            cache,
-            createNode,
-            createNodeId,
-            reporter,
-          })
-
-          if (fileNode) {
-            bar.tick()
-            fileNodeID = fileNode.id
-
-            await cache.set(remoteDataCacheKey, { fileNodeID })
-          }
-        } catch (err) {
-          // Ignore
-        }
-      }
-
-      if (fileNodeID) {
-        node.localFile___NODE = fileNodeID
-      }
-
-      return node
-    })
+  const boundDownloadSingleContentfulAsset = downloadSingleContentfulAsset(
+    gatsbyFunctions
   )
+
+  const batchSize = 25
+
+  const batchesNum = Math.ceil(contentfulAssetNodes.length / batchSize)
+
+  const batches = Array.from({ length: batchesNum }, (_, index) =>
+    contentfulAssetNodes.slice(index * batchSize, (index + 1) * batchSize)
+  )
+
+  await batches.reduce(async (prevPromise, batch) => {
+    await prevPromise
+
+    return Promise.all(batch.map(boundDownloadSingleContentfulAsset))
+  }, Promise.resolve())
 }
 exports.downloadContentfulAssets = downloadContentfulAssets


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

At my company we're using Gatsby together with Contentful quite extensively. Downloading the assets (> 500) from Contentful for use in our own S3 bucket is quite important. Unfortunately, during dev we often encounter either of two errors on multiple machines and configurations:

- Downloading the assets gets stuck just before finishing (mostly around 97%, mostly macOS)
- Downloading them seems to succeed but may be just a timeout as most assets are missing judging by the infamous `'childImageSharp' of null` error (Linux).

Note that they do not occur in our production env (AWS Amplify) using an Amazon Linux docker container as build environment.

This is an attempt at fixing this by instead of downloading everything at once, the downloads are done in chunks (or batches) of 50 files. This way, I could resolve the above mentioned issues.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
