### PR TITLE
Simplify syntax of adding a fixed className

### DIFF
--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -150,7 +150,7 @@ const Section = styled.section`
 `
 
 export default ({ children }) => (
-  <Section className={`container`}>{children}</Section>
+  <Section className="container">{children}</Section>
 )
 ```
 


### PR DESCRIPTION
## Description

There is no need to add curly braces and a template string if the value is just a string, right?
I used double quotes here since they are also used in the imports in this example.

