### PR TITLE
Fix grammatical error in preparing-for-deployment

### DIFF
--- a/docs/docs/preparing-for-deployment.md
+++ b/docs/docs/preparing-for-deployment.md
@@ -35,7 +35,7 @@ Then in the `public` directory will be files to copy to the server.
 
 ## Adding a path prefix
 
-If you want to specific Path Prefix, for example `example.com/blog/` instead of `example.com/` read [adding a path prefix](/docs/path-prefix)
+If you want a specific Path Prefix, for example `example.com/blog/` instead of `example.com/` read [adding a path prefix](/docs/path-prefix)
 
 ## Specific deploy
 


### PR DESCRIPTION
## Description

Found a slight grammatical error in the Deploying & Hosting section of the docs. This PR fixes it.