### PR TITLE
Fix 301 redirect to trailing slash when not specified in createPage.path

### DIFF
--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -85,9 +85,18 @@ module.exports = async program => {
   app.use(telemetry.expressMiddleware(`SERVE`))
 
   router.use(compression())
-  router.use(express.static(`public`, { extensions: [`index.html`] }))
+  router.use(express.static(`public`, { redirect: false }))
   const matchPaths = await readMatchPaths(program)
   router.use(matchPathRouter(matchPaths, { root }))
+  router.use((req, res, next) => {
+    if (!/.+\..+$/g.test(req.url) && req.url.slice(-1) !== `/`) {
+      res.sendFile(req.url + `/index.html`, {
+        root,
+      })
+    } else {
+      next()
+    }
+  })
   router.use((req, res, next) => {
     if (req.accepts(`html`)) {
       return res.status(404).sendFile(`404.html`, { root })

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -93,7 +93,7 @@ module.exports = async program => {
     // Express already handles trailing slashes, e.g. /hello/ => /hello/index.html
     if (req.url.slice(-1) !== `/`) {
       res.sendFile(req.url + `/index.html`, {
-        root
+        root,
       })
     } else {
       next()

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -85,7 +85,7 @@ module.exports = async program => {
   app.use(telemetry.expressMiddleware(`SERVE`))
 
   router.use(compression())
-  router.use(express.static(`public`, { redirect: false }))
+  router.use(express.static(`public`, { extensions: [`index.html`] }))
   const matchPaths = await readMatchPaths(program)
   router.use(matchPathRouter(matchPaths, { root }))
   router.use((req, res, next) => {

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -89,9 +89,11 @@ module.exports = async program => {
   const matchPaths = await readMatchPaths(program)
   router.use(matchPathRouter(matchPaths, { root }))
   router.use((req, res, next) => {
-    if (!/.+\..+$/g.test(req.url) && req.url.slice(-1) !== `/`) {
+    // Handle URLs without trailing slashes, e.g. /hello => /hello/index.html
+    // Express already handles trailing slashes, e.g. /hello/ => /hello/index.html
+    if (req.url.slice(-1) !== `/`) {
       res.sendFile(req.url + `/index.html`, {
-        root,
+        root
       })
     } else {
       next()

--- a/packages/gatsby/src/commands/serve.js
+++ b/packages/gatsby/src/commands/serve.js
@@ -85,7 +85,7 @@ module.exports = async program => {
   app.use(telemetry.expressMiddleware(`SERVE`))
 
   router.use(compression())
-  router.use(express.static(`public`))
+  router.use(express.static(`public`, { redirect: false }))
   const matchPaths = await readMatchPaths(program)
   router.use(matchPathRouter(matchPaths, { root }))
   router.use((req, res, next) => {

--- a/packages/gatsby/src/utils/worker/render-html.js
+++ b/packages/gatsby/src/utils/worker/render-html.js
@@ -7,8 +7,7 @@ const generatePathToOutput = outputPath => {
   let outputFileName = outputPath.replace(/^(\/|\\)/, ``) // Remove leading slashes for webpack-dev-server
 
   if (!/\.(html?)$/i.test(outputFileName)) {
-    outputFileName =
-      outputFileName + `${outputFileName.endsWith(`/`) ? `index` : ``}.html`
+    outputFileName = path.join(outputFileName, `index.html`)
   }
 
   return path.join(process.cwd(), `public`, outputFileName)

--- a/packages/gatsby/src/utils/worker/render-html.js
+++ b/packages/gatsby/src/utils/worker/render-html.js
@@ -7,7 +7,8 @@ const generatePathToOutput = outputPath => {
   let outputFileName = outputPath.replace(/^(\/|\\)/, ``) // Remove leading slashes for webpack-dev-server
 
   if (!/\.(html?)$/i.test(outputFileName)) {
-    outputFileName = outputFileName + `.html`
+    outputFileName =
+      outputFileName + `${outputFileName.endsWith(`/`) ? `index` : ``}.html`
   }
 
   return path.join(process.cwd(), `public`, outputFileName)

--- a/packages/gatsby/src/utils/worker/render-html.js
+++ b/packages/gatsby/src/utils/worker/render-html.js
@@ -7,7 +7,7 @@ const generatePathToOutput = outputPath => {
   let outputFileName = outputPath.replace(/^(\/|\\)/, ``) // Remove leading slashes for webpack-dev-server
 
   if (!/\.(html?)$/i.test(outputFileName)) {
-    outputFileName = path.join(outputFileName, `index.html`)
+    outputFileName = outputFileName + `.html`
   }
 
   return path.join(process.cwd(), `public`, outputFileName)


### PR DESCRIPTION
## Description

When using `gatsby serve`, for pages created with `createPage`, for a given path `/hello` there is a 301 redirect to `/hello/` even when `path` does not end with a slash.

The issue can be reproduced on [this repository](https://github.com/adrienharnay/gatsby-simplest-example).

The fix is to keep generating `public/hello/index.html` if `createPage.path === '/hello/'`, but instead to generate `public/hello.html` if `createPage.path === '/hello`.

## Related Issues

Fixes #19543 