### PR TITLE
fix(gatsby-plugin-netlify-cms): Mark relevant dependencies as externals

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -8,8 +8,10 @@
   },
   "dependencies": {
     "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
+    "copy-webpack-plugin": "^5.0.5",
     "html-webpack-exclude-assets-plugin": "^0.0.7",
     "html-webpack-plugin": "^3.2.0",
+    "html-webpack-tags-plugin": "^2.0.17",
     "lodash": "^4.17.15",
     "mini-css-extract-plugin": "^0.8.0",
     "netlify-identity-widget": "^1.5.5",
@@ -35,9 +37,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.101",
-    "netlify-cms-app": "^2.9.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "netlify-cms-app": "^2.9.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -37,7 +37,9 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.101",
-    "netlify-cms-app": "^2.9.0"
+    "netlify-cms-app": "^2.9.0",
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-netlify-cms/src/cms-manual-init.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms-manual-init.js
@@ -1,1 +1,0 @@
-window.CMS_MANUAL_INIT = true

--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -3,11 +3,12 @@ import CMS from "netlify-cms-app"
 /**
  * Load Netlify CMS automatically if `window.CMS_MANUAL_INIT` is set.
  */
-if (!window.CMS_MANUAL_INIT) {
+// eslint-disable-next-line no-undef
+if (!CMS_MANUAL_INIT) {
   CMS.init()
 } else {
   console.log(
-    `\`window.CMS_MANUAL_INIT\` flag set, skipping automatic initialization.'`
+    `\`CMS_MANUAL_INIT\` flag set, skipping automatic initialization.'`
   )
 }
 

--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -12,7 +12,20 @@ if (!CMS_MANUAL_INIT) {
   )
 }
 
-/**
- * The stylesheet output from the modules at `modulePath` will be at `cms.css`.
- */
-CMS.registerPreviewStyle(`cms.css`)
+// eslint-disable-next-line no-undef
+if (PRODUCTION) {
+  /**
+   * The stylesheet output from the modules at `modulePath` will be at `cms.css`.
+   */
+  CMS.registerPreviewStyle(`cms.css`)
+} else {
+  /**
+   * In development styles are injected dynamically via the style-loader plugin
+   */
+  window.addEventListener(`DOMContentLoaded`, event => {
+    const list = document.querySelectorAll(`link[rel='stylesheet']`)
+    list.forEach(({ href }) => {
+      CMS.registerPreviewStyle(href)
+    })
+  })
+}

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -92,7 +92,7 @@ exports.onCreateDevServer = ({ app, store }, { publicPath = `admin` }) => {
 }
 
 exports.onCreateWebpackConfig = (
-  { store, stage, getConfig, plugins, pathPrefix, loaders, rules },
+  { store, stage, getConfig, plugins, pathPrefix, loaders, rules, actions },
   {
     modulePath,
     customizeWebpackConfig,
@@ -259,6 +259,22 @@ exports.onCreateWebpackConfig = (
       plugins,
     })
   }
+
+  // force code splitting for netlify-identity-widget
+  actions.setWebpackConfig({
+    optimization: {
+      splitChunks: {
+        cacheGroups: {
+          "netlify-identity-widget": {
+            test: /[\\/]node_modules[\\/](netlify-identity-widget)[\\/]/,
+            name: `netlify-identity-widget`,
+            chunks: `all`,
+            enforce: true,
+          },
+        },
+      },
+    },
+  })
 
   return new Promise((resolve, reject) => {
     if (stage === `develop`) {

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -147,7 +147,6 @@ exports.onCreateWebpackConfig = (
     ...gatsbyConfig,
     entry: {
       cms: [
-        manualInit && path.join(__dirname, `cms-manual-init.js`),
         path.join(__dirname, `cms.js`),
         enableIdentityWidget && path.join(__dirname, `cms-identity.js`),
       ]
@@ -235,6 +234,10 @@ exports.onCreateWebpackConfig = (
       new HtmlWebpackTagsPlugin({
         tags: externals.map(({ assetName }) => assetName),
         append: false,
+      }),
+
+      new webpack.DefinePlugin({
+        CMS_MANUAL_INIT: JSON.stringify(manualInit),
       }),
     ].filter(p => p),
 

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -49,19 +49,6 @@ function replaceRule(value) {
     return null
   }
 
-  // Manually swap `style-loader` for `MiniCssExtractPlugin.loader`.
-  // `style-loader` is only used in development, and doesn't allow us to pass
-  // the `styles` entry css path to Netlify CMS.
-  if (
-    typeof value.loader === `string` &&
-    value.loader.includes(`style-loader`)
-  ) {
-    return {
-      ...value,
-      loader: MiniCssExtractPlugin.loader,
-    }
-  }
-
   return value
 }
 
@@ -187,9 +174,10 @@ exports.onCreateWebpackConfig = (
 
       // Use a simple filename with no hash so we can access from source by
       // path.
-      new MiniCssExtractPlugin({
-        filename: `[name].css`,
-      }),
+      stage !== `develop` &&
+        new MiniCssExtractPlugin({
+          filename: `[name].css`,
+        }),
 
       // Auto generate CMS index.html page.
       new HtmlWebpackPlugin({
@@ -238,6 +226,7 @@ exports.onCreateWebpackConfig = (
 
       new webpack.DefinePlugin({
         CMS_MANUAL_INIT: JSON.stringify(manualInit),
+        PRODUCTION: JSON.stringify(stage !== `develop`),
       }),
     ].filter(p => p),
 

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -268,18 +268,21 @@ exports.onCreateWebpackConfig = (
 
   actions.setWebpackConfig({
     // force code splitting for netlify-identity-widget
-    optimization: {
-      splitChunks: {
-        cacheGroups: {
-          "netlify-identity-widget": {
-            test: /[\\/]node_modules[\\/](netlify-identity-widget)[\\/]/,
-            name: `netlify-identity-widget`,
-            chunks: `all`,
-            enforce: true,
+    optimization:
+      stage === `develop`
+        ? {}
+        : {
+            splitChunks: {
+              cacheGroups: {
+                "netlify-identity-widget": {
+                  test: /[\\/]node_modules[\\/](netlify-identity-widget)[\\/]/,
+                  name: `netlify-identity-widget`,
+                  chunks: `all`,
+                  enforce: true,
+                },
+              },
+            },
           },
-        },
-      },
-    },
     // ignore netlify-identity-widget when not enabled
     plugins: enableIdentityWidget
       ? []

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -115,18 +115,21 @@ exports.onCreateWebpackConfig = (
     {
       name: `react`,
       global: `React`,
-      tag: `https://unpkg.com/react@16/umd/react.production.min.js`,
+      assetDir: `umd`,
+      assetName: `react.production.min.js`,
     },
     {
       name: `react-dom`,
       global: `ReactDOM`,
-      tag: `https://unpkg.com/react-dom@16/umd/react-dom.production.min.js`,
+      assetDir: `umd`,
+      assetName: `react-dom.production.min.js`,
     },
     {
       name: `netlify-cms-app`,
       global: `NetlifyCmsApp`,
       assetDir: `dist`,
-      tag: `netlify-cms-app.js`,
+      assetName: `netlify-cms-app.js`,
+      sourceMap: `netlify-cms-app.js.map`,
     },
   ]
 
@@ -135,7 +138,8 @@ exports.onCreateWebpackConfig = (
       name: `netlify-identity-widget`,
       global: `netlifyIdentity`,
       assetDir: `build`,
-      tag: `netlify-identity-widget.js`,
+      assetName: `netlify-identity-widget.js`,
+      sourceMap: `netlify-identity-widget.js.map`,
     })
   }
 
@@ -213,23 +217,23 @@ exports.onCreateWebpackConfig = (
       new CopyPlugin(
         [].concat.apply(
           [],
-          externals
-            .filter(({ assetDir }) => assetDir)
-            .map(({ name, assetDir }) => [
+          externals.map(({ name, assetName, sourceMap, assetDir }) =>
+            [
               {
-                from: path.join(`node_modules`, name, assetDir, `${name}.js`),
-                to: `${name}.js`,
+                from: path.join(`node_modules`, name, assetDir, assetName),
+                to: assetName,
               },
-              {
-                from: path.join(`node_modules`, name, assetDir, `${name}.js`),
-                to: `${name}.js.map`,
+              sourceMap && {
+                from: path.join(`node_modules`, name, assetDir, sourceMap),
+                to: sourceMap,
               },
-            ])
+            ].filter(item => item)
+          )
         )
       ),
 
       new HtmlWebpackTagsPlugin({
-        tags: externals.map(({ tag }) => tag),
+        tags: externals.map(({ assetName }) => assetName),
         append: false,
       }),
     ].filter(p => p),

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -260,8 +260,8 @@ exports.onCreateWebpackConfig = (
     })
   }
 
-  // force code splitting for netlify-identity-widget
   actions.setWebpackConfig({
+    // force code splitting for netlify-identity-widget
     optimization: {
       splitChunks: {
         cacheGroups: {
@@ -274,6 +274,14 @@ exports.onCreateWebpackConfig = (
         },
       },
     },
+    // ignore netlify-identity-widget when not enabled
+    plugins: enableIdentityWidget
+      ? []
+      : [
+          new webpack.IgnorePlugin({
+            resourceRegExp: /^netlify-identity-widget$/,
+          }),
+        ],
   })
 
   return new Promise((resolve, reject) => {

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -211,19 +211,21 @@ exports.onCreateWebpackConfig = (
       }),
 
       new CopyPlugin(
-        externals
-          .filter(({ assetDir }) => assetDir)
-          .map(({ name, assetDir }) => [
-            {
-              from: path.join(`node_modules`, name, assetDir, `${name}.js`),
-              to: `${name}.js`,
-            },
-            {
-              from: path.join(`node_modules`, name, assetDir, `${name}.js`),
-              to: `${name}.js.map`,
-            },
-          ])
-          .flat()
+        [].concat.apply(
+          [],
+          externals
+            .filter(({ assetDir }) => assetDir)
+            .map(({ name, assetDir }) => [
+              {
+                from: path.join(`node_modules`, name, assetDir, `${name}.js`),
+                to: `${name}.js`,
+              },
+              {
+                from: path.join(`node_modules`, name, assetDir, `${name}.js`),
+                to: `${name}.js.map`,
+              },
+            ])
+        )
       ),
 
       new HtmlWebpackTagsPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7146,6 +7146,24 @@ copy-webpack-plugin@^5.0.0:
     serialize-javascript "^1.7.0"
     webpack-log "^2.0.0"
 
+copy-webpack-plugin@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.5.tgz#731df6a837a2ef0f8f8e2345bdfe9b7c62a2da68"
+  integrity sha512-7N68eIoQTyudAuxkfPT7HzGoQ+TsmArN/I3HFwG+lVE3FNzqvZKIiaxtYh4o3BIznioxUvx9j26+Rtsc9htQUQ==
+  dependencies:
+    cacache "^12.0.3"
+    find-cache-dir "^2.1.0"
+    glob-parent "^3.1.0"
+    globby "^7.1.1"
+    is-glob "^4.0.1"
+    loader-utils "^1.2.3"
+    minimatch "^3.0.4"
+    normalize-path "^3.0.0"
+    p-limit "^2.2.1"
+    schema-utils "^1.0.0"
+    serialize-javascript "^2.1.0"
+    webpack-log "^2.0.0"
+
 copyfiles@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.1.1.tgz#d430e122d7880f92c45d372208b0af03b0c39db6"
@@ -11551,6 +11569,15 @@ html-webpack-plugin@^3.2.0:
     tapable "^1.0.0"
     toposort "^1.0.0"
     util.promisify "1.0.0"
+
+html-webpack-tags-plugin@^2.0.17:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/html-webpack-tags-plugin/-/html-webpack-tags-plugin-2.0.17.tgz#1143cb41fa895eca6bc45207d3aadd914cee8b55"
+  integrity sha512-TKT8hnumMni6ztKfWZpP+UBeA7+aUn+qQQ4c9wT/p1IGTO/QWoIc19E+ZrxCcToDMjBO1NMYWkUbW4c4NtlGvg==
+  dependencies:
+    glob "^7.1.4"
+    minimatch "^3.0.4"
+    slash "^3.0.0"
 
 htmlparser2@^3.10.0, htmlparser2@^3.9.1:
   version "3.10.1"
@@ -16442,6 +16469,13 @@ p-limit@^2.0.0, p-limit@^2.1.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
+  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -19643,6 +19677,11 @@ serialize-javascript@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
   integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
+
+serialize-javascript@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.0.tgz#9310276819efd0eb128258bb341957f6eb2fc570"
+  integrity sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/18245
Fixes https://github.com/gatsbyjs/gatsby/issues/17568

I can split this into two PRs (one per issue) if needed.

Main changes:

1. Mark `netlify-cms-app` and relevant dependencies as externals to avoid re-build during bundle. `netlify-cms-app`,`netlify-identity-widget`, `react` and `react-dom` are already set up for that since they expose a global variable on the window object which Webpack can reference instead of importing the module.

2. The reason `netlify-identity-widget` was still included in the main app bundle [here](https://github.com/gatsbyjs/gatsby/issues/17568) is that it didn't pass Gatsby's default thresholds for code splitting. Forcing it into its own cache group makes sure it's not in the app bundle.
~~It will still be included in the html as a link tag with a preload attribute, since it is imported as a runtime dependency (though we do know at build time it won't be needed). I actually wrote some code to remove it from the html using a `gatsby-ssr.js` but then realized it will prevent using the widget all together in other contexts than the plugin (not sure such a scenario exists).~~
Along with code splitting the widget when `enableIdentityWidget` is true, when the widget is disabled it will be ignored completely from the build via the `webpack.IgnorePlugin` plugin.

Would love to get some feedback and if there is something I can do to make it easier for other people to test it please let me know (thought about publishing it separately).

Also, I'm not sure how to go about versioning.

Update:
Also fixes https://github.com/gatsbyjs/gatsby/issues/15126