### PR TITLE
chore: bump caches for www build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,9 +290,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1_www_public_dir
+          key: v2_www_public_dir
       - restore_cache:
-          key: v1_www_cache_dir
+          key: v2_www_cache_dir
       - run:
           command: yarn
           working_directory: ~/project/www
@@ -301,11 +301,11 @@ jobs:
           command: GATSBY_CPU_COUNT=8 yarn build
           working_directory: ~/project/www
       - save_cache:
-          key: v1_www_public_dir_{{ epoch }}
+          key: v2_www_public_dir_{{ epoch }}
           paths:
             - ~/project/www/public
       - save_cache:
-          key: v1_www_cache_dir_{{ epoch }}
+          key: v2_www_cache_dir_{{ epoch }}
           paths:
             - ~/project/www/.cache
 
@@ -315,7 +315,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1_www_public_dir
+          key: v2_www_public_dir
       - run:
           command: yarn add netlify-cli
           working_directory: ~/project/www


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Reset the caches for the www build job 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
