### PR TITLE
fix(gatsby-plugin-google-analytics): Don't create tracking code without an ID.

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -15,6 +15,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
+        // The property ID; the tracking code won't be generated without it
         trackingId: "YOUR_GOOGLE_ANALYTICS_TRACKING_ID",
         // Defines where to place the tracking script - `true` in the head and `false` in the body
         head: false,

--- a/packages/gatsby-plugin-google-analytics/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/__tests__/gatsby-ssr.js
@@ -29,7 +29,7 @@ describe(`gatsby-plugin-google-analytics`, () => {
           const setHeadComponents = jest.fn()
           const setPostBodyComponents = jest.fn()
 
-          options = Object.assign({}, options)
+          options = Object.assign({ trackingId: `TEST_TRACKING_ID` }, options)
 
           onRenderBody({ setHeadComponents, setPostBodyComponents }, options)
 
@@ -38,6 +38,15 @@ describe(`gatsby-plugin-google-analytics`, () => {
             setPostBodyComponents,
           }
         }
+
+        it(`does not set tracking script when trackingId not given`, () => {
+          const { setHeadComponents, setPostBodyComponents } = setup({
+            trackingId: ``,
+          })
+
+          expect(setHeadComponents).not.toHaveBeenCalled()
+          expect(setPostBodyComponents).not.toHaveBeenCalled()
+        })
 
         it(`sets tracking script`, () => {
           const { setHeadComponents, setPostBodyComponents } = setup()
@@ -56,9 +65,7 @@ describe(`gatsby-plugin-google-analytics`, () => {
         })
 
         it(`sets trackingId`, () => {
-          const { setPostBodyComponents } = setup({
-            trackingId: `TEST_TRACKING_ID`,
-          })
+          const { setPostBodyComponents } = setup()
 
           const result = JSON.stringify(setPostBodyComponents.mock.calls[0][0])
 

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
@@ -1,0 +1,7 @@
+exports.onPreInit = ({ reporter }, options) => {
+  if (!options.trackingId) {
+    reporter.warn(
+      `The Google Analytics plugin requires a tracking ID. Did you mean to add it?`
+    )
+  }
+}

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -27,7 +27,7 @@ export const onRenderBody = (
   { setHeadComponents, setPostBodyComponents },
   pluginOptions
 ) => {
-  if (process.env.NODE_ENV !== `production`) {
+  if (process.env.NODE_ENV !== `production` || !pluginOptions.trackingId) {
     return null
   }
 


### PR DESCRIPTION
Hello, this is my first code-related PR. 

Fixes https://github.com/gatsbyjs/gatsby/issues/19479#issuecomment-555000813

There is no fancy string validation here; this fix just stops the tracking code from being created if (option) "trackingId" is empty or false. It also outputs a warning.

I'm not sure about my changes to tests. With this fix the existing tests now rely on "trackingId" being set, so I've made this the default while adding a new test that tests the opposite condition ("trackingId" is unset). 
