### PR TITLE
chore: fixes clear-package-dir script for windows

### DIFF
--- a/scripts/clear-package-dir.js
+++ b/scripts/clear-package-dir.js
@@ -115,7 +115,9 @@ const run = async () => {
   try {
     const changed = JSON.parse(
       execSync(
-        `node_modules/.bin/lerna changed --json --loglevel=silent`
+        `${path.resolve(
+          `node_modules/.bin/lerna`
+        )} changed --json --loglevel=silent`
       ).toString()
     )
     const filesToDelete = _.flatten(changed.map(getListOfFilesToClear))


### PR DESCRIPTION

## Description

When publishing I always got this message:
`'node_modules' is not recognized as an internal or external 
command,`

This fixes that script to make it work on windows. Please test it on linux/macOs as well. You can by running `node scripts/clear-package-dir.js`.