### PR TITLE
fix(gatsby): Improve perf of stale node detection

### DIFF
--- a/packages/gatsby/src/redux/__tests__/nodes.js
+++ b/packages/gatsby/src/redux/__tests__/nodes.js
@@ -113,7 +113,10 @@ describe(`Create and update nodes`, () => {
     const action = dispatch.mock.calls[0][0]
 
     let state = nodeTouchedReducer(undefined, action)
-    expect(state[`hi`]).toBe(true)
+
+    expect(state instanceof Set).toBe(true)
+
+    expect(state.has(`hi`)).toBe(true)
   })
 
   it(`allows adding fields to nodes`, () => {

--- a/packages/gatsby/src/redux/reducers/index.js
+++ b/packages/gatsby/src/redux/reducers/index.js
@@ -37,6 +37,9 @@ function getNodesByTypeReducer() {
   return nodesReducer
 }
 
+/**
+ * @property exports.nodesTouched Set<string>
+ */
 module.exports = {
   program: require(`./program`),
   nodes: getNodesReducer(),

--- a/packages/gatsby/src/redux/reducers/nodes-touched.js
+++ b/packages/gatsby/src/redux/reducers/nodes-touched.js
@@ -1,11 +1,11 @@
-module.exports = (state = {}, action) => {
+module.exports = (state = new Set(), action) => {
   switch (action.type) {
     case `CREATE_NODE`:
-      state[action.payload.id] = true
+      state.add(action.payload.id)
       return state
 
     case `TOUCH_NODE`:
-      state[action.payload] = true
+      state.add(action.payload)
       return state
 
     default:

--- a/packages/gatsby/src/utils/source-nodes.js
+++ b/packages/gatsby/src/utils/source-nodes.js
@@ -50,9 +50,7 @@ module.exports = async ({ webhookBody = {}, parentSpan } = {}) => {
   )
 
   // Garbage collect stale data nodes
-  const touchedNodes = Object.keys(state.nodesTouched)
-  const staleNodes = Array.from(getNodes()).filter(node => {
-    // Find the root node.
+  const staleNodes = getNodes().filter(node => {
     let rootNode = node
     let whileCount = 0
     while (
@@ -70,7 +68,8 @@ module.exports = async ({ webhookBody = {}, parentSpan } = {}) => {
       }
     }
 
-    return !_.includes(touchedNodes, rootNode.id)
+    // `nodesTouched[id]` will be `true` if touched, `undefined` otherwise
+    return !state.nodesTouched[rootNode.id]
   })
 
   if (staleNodes.length > 0) {

--- a/packages/gatsby/src/utils/source-nodes.js
+++ b/packages/gatsby/src/utils/source-nodes.js
@@ -68,8 +68,7 @@ module.exports = async ({ webhookBody = {}, parentSpan } = {}) => {
       }
     }
 
-    // `nodesTouched[id]` will be `true` if touched, `undefined` otherwise
-    return !state.nodesTouched[rootNode.id]
+    return !state.nodesTouched.has(rootNode.id)
   })
 
   if (staleNodes.length > 0) {


### PR DESCRIPTION
Small surface but significant relative win. With large sites the cost of this step adds up and this change almost eliminates time taken to a constant factor.

The problem is that `Object.keys` was called on an object that would be large for large sites (there was also an `_.includes` but that was probably not so relevant).

Since the object was used as a Set I changed it to a Set.

On a 24k page site before / after:
![image](https://user-images.githubusercontent.com/209817/69069857-7f105300-0a27-11ea-97e6-07105147f542.png)
