### PR TITLE
fix(gatsby-theme-blog) Align header's children elements center

### DIFF
--- a/packages/gatsby-theme-blog/src/components/header.js
+++ b/packages/gatsby-theme-blog/src/components/header.js
@@ -103,7 +103,7 @@ export default ({ children, title, ...props }) => {
           css={css({
             display: `flex`,
             justifyContent: `space-between`,
-            alignItems: `baseline`,
+            alignItems: `center`,
             mb: 4,
           })}
         >


### PR DESCRIPTION
## Description

Changing header.js children alignment - see the screenshots and issue #19606

Current state:
![Screenshot 2019-11-18 at 11 14 43 PM](https://user-images.githubusercontent.com/44570539/69101384-c74b6780-0a5f-11ea-98f5-ec65b1abef67.jpg)
![Screenshot 2019-11-18 at 11 16 01 PM](https://user-images.githubusercontent.com/44570539/69101557-32953980-0a60-11ea-9f81-753a43cca076.jpg)


After merge:
![Screenshot 2019-11-18 at 11 17 41 PM](https://user-images.githubusercontent.com/44570539/69101399-cd414880-0a5f-11ea-953c-8d3a90ec4fa6.jpg)
![Screenshot 2019-11-18 at 11 16 56 PM](https://user-images.githubusercontent.com/44570539/69101406-d3372980-0a5f-11ea-992e-2043c4a2fd6e.jpg)


