### PR TITLE
feat(gatsby-plugin-typescript): add support for numeric separators

### DIFF
--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -11,6 +11,7 @@
   ],
   "dependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
+    "@babel/plugin-proposal-numeric-separator": "^7.2.0",
     "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@babel/preset-typescript": "^7.7.2",
     "@babel/runtime": "^7.7.2",

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -25,7 +25,7 @@ describe(`gatsby-plugin-typescript`, () => {
         name: expect.stringContaining(path.join(`@babel`, `preset-typescript`)),
         options,
       })
-      expect(actions.setBabelPlugin).toHaveBeenCalledTimes(2)
+      expect(actions.setBabelPlugin).toHaveBeenCalledTimes(3)
       expect(actions.setBabelPlugin).toHaveBeenCalledWith({
         name: expect.stringContaining(
           path.join(`@babel`, `plugin-proposal-optional-chaining`)
@@ -34,6 +34,11 @@ describe(`gatsby-plugin-typescript`, () => {
       expect(actions.setBabelPlugin).toHaveBeenCalledWith({
         name: expect.stringContaining(
           path.join(`@babel`, `plugin-proposal-nullish-coalescing-operator`)
+        ),
+      })
+      expect(actions.setBabelPlugin).toHaveBeenCalledWith({
+        name: expect.stringContaining(
+          path.join(`@babel`, `plugin-proposal-numeric-separator`)
         ),
       })
     })

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -11,6 +11,9 @@ function onCreateBabelConfig({ actions }, options) {
   actions.setBabelPlugin({
     name: require.resolve(`@babel/plugin-proposal-nullish-coalescing-operator`),
   })
+  actions.setBabelPlugin({
+    name: require.resolve(`@babel/plugin-proposal-numeric-separator`),
+  })
 }
 
 function onCreateWebpackConfig({ actions, loaders }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,7 +630,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.2.0"
 
-"@babel/plugin-proposal-numeric-separator@^7.0.0":
+"@babel/plugin-proposal-numeric-separator@^7.0.0", "@babel/plugin-proposal-numeric-separator@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.2.0.tgz#646854daf4cd22fd6733f6076013a936310443ac"
   dependencies:


### PR DESCRIPTION
## Description
Similar to https://github.com/gatsbyjs/gatsby/pull/19302, TypeScript has supported numeric separators since v2.7.  As they are a Stage 3 proposal, I believe it's reasonable to add them to the configuration here so that Gatsby TypeScript users aren't surprised when numeric separators don't compile.
