### PR TITLE
fix(gatsby): don't rerun static queries if text didn't change

### DIFF
--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -70,7 +70,7 @@ const handleQuery = (
     if (
       isNewQuery ||
       oldQuery.hash !== query.hash ||
-      oldQuery.text !== query.text
+      oldQuery.query !== query.text
     ) {
       boundActionCreators.replaceStaticQuery({
         name: query.name,


### PR DESCRIPTION
`oldQuery` doesn't have `text` property - it has `query` property. This condition was always true so we were replacing and invalidating static queries every time queries were extracted