### PR TITLE
fix(gatsby-cli): only emit endActivity events for activity that is not finished yet

### DIFF
--- a/packages/gatsby-cli/src/reporter/redux/actions.js
+++ b/packages/gatsby-cli/src/reporter/redux/actions.js
@@ -227,43 +227,43 @@ const actions = {
           name: activity.text,
           duration: Math.round(durationMS),
         })
-      }
 
-      const durationS = durationMS / 1000
-      if (activity.errored) {
-        status = ActivityStatuses.Failed
-      }
-      actionsToEmit.push({
-        type: Actions.EndActivity,
-        payload: {
-          uuid: activity.uuid,
-          id,
-          status,
-          duration: durationS,
-          type: activity.type,
-        },
-      })
-
-      if (activity.type !== ActivityTypes.Hidden) {
-        actionsToEmit.push(
-          actions.createLog({
-            text: activity.text,
-            level: ActivityStatusToLogLevel[status],
+        const durationS = durationMS / 1000
+        if (activity.errored) {
+          status = ActivityStatuses.Failed
+        }
+        actionsToEmit.push({
+          type: Actions.EndActivity,
+          payload: {
+            uuid: activity.uuid,
+            id,
+            status,
             duration: durationS,
-            statusText:
-              activity.statusText ||
-              (status === ActivityStatuses.Success &&
-              activity.type === ActivityTypes.Progress
-                ? `${activity.current}/${activity.total} ${(
-                    activity.total / durationS
-                  ).toFixed(2)}/s`
-                : undefined),
-            activity_uuid: activity.uuid,
-            activity_current: activity.current,
-            activity_total: activity.total,
-            activity_type: activity.type,
-          })
-        )
+            type: activity.type,
+          },
+        })
+
+        if (activity.type !== ActivityTypes.Hidden) {
+          actionsToEmit.push(
+            actions.createLog({
+              text: activity.text,
+              level: ActivityStatusToLogLevel[status],
+              duration: durationS,
+              statusText:
+                activity.statusText ||
+                (status === ActivityStatuses.Success &&
+                activity.type === ActivityTypes.Progress
+                  ? `${activity.current}/${activity.total} ${(
+                      activity.total / durationS
+                    ).toFixed(2)}/s`
+                  : undefined),
+              activity_uuid: activity.uuid,
+              activity_current: activity.current,
+              activity_total: activity.total,
+              activity_type: activity.type,
+            })
+          )
+        }
       }
     }
 


### PR DESCRIPTION
This will cause to emit `ACTIVITY_END` and accompanying `LOG` events only if activity was in progress.

This fixes duplicated `run queries` success messages in gatsby develop where second has `Infinity/s` rate:

```
success run queries - 0.084s - 2/2 23.77/s
success run queries - 2/2 Infinity/s
``` 