### PR TITLE
fix(ci): don't reuse same job names for experimental react nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
       - notify-status:
           condition: << parameters.postStatus >>
 
-  e2e_tests_production_runtime-in-normal-mode:
+  e2e_tests_production_runtime:
     <<: *e2e_tests_production_runtime_alias
 
   e2e_tests_production_runtime-with-experimental-react:
@@ -459,7 +459,7 @@ workflows:
           <<: *e2e-test-workflow
       - e2e_tests_development_runtime:
           <<: *e2e-test-workflow
-      - e2e_tests_production_runtime-in-normal-mode:
+      - e2e_tests_production_runtime:
           <<: *e2e-test-workflow
       - themes_e2e_tests_production_runtime:
           <<: *e2e-test-workflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,36 @@ aliases:
       - notify-status:
           condition: << parameters.postStatus >>
 
+  e2e_tests_development_runtime_alias: &e2e_tests_development_runtime_alias
+    <<: *e2e-executor
+    parameters:
+      postStatus:
+        type: boolean
+        default: false
+    environment:
+      CYPRESS_PROJECT_ID: s3j3qj
+      CYPRESS_RECORD_KEY: 3904ca0c-bc98-47d9-8371-b68c5e81fb9b
+    steps:
+      - e2e-test:
+          test_path: e2e-tests/development-runtime
+      - notify-status:
+          condition: << parameters.postStatus >>
+
+  e2e_tests_gatsby-image_alias: &e2e_tests_gatsby-image_alias
+    <<: *e2e-executor
+    parameters:
+      postStatus:
+        type: boolean
+        default: false
+    environment:
+      CYPRESS_PROJECT_ID: ave32k
+      CYPRESS_RECORD_KEY: fb3cb6e0-a0f9-48b2-aa9a-95e8ef150a85
+    steps:
+      - e2e-test:
+          test_path: e2e-tests/gatsby-image
+      - notify-status:
+          condition: << parameters.postStatus >>
+
 commands:
   notify-status:
     parameters:
@@ -204,42 +234,30 @@ jobs:
           test_path: e2e-tests/path-prefix
 
   e2e_tests_gatsby-image:
-    <<: *e2e-executor
-    parameters:
-      postStatus:
-        type: boolean
-        default: false
-    environment:
-      CYPRESS_PROJECT_ID: ave32k
-      CYPRESS_RECORD_KEY: fb3cb6e0-a0f9-48b2-aa9a-95e8ef150a85
-    steps:
-      - e2e-test:
-          test_path: e2e-tests/gatsby-image
-      - notify-status:
-          condition: << parameters.postStatus >>
+    <<: *e2e_tests_gatsby-image_alias
+
+  e2e_tests_gatsby-image_with_experimental_react:
+    <<: *e2e_tests_gatsby-image_alias
+
+  e2e_tests_gatsby-image_with_next_react:
+    <<: *e2e_tests_gatsby-image_alias
 
   e2e_tests_development_runtime:
-    <<: *e2e-executor
-    parameters:
-      postStatus:
-        type: boolean
-        default: false
-    environment:
-      CYPRESS_PROJECT_ID: s3j3qj
-      CYPRESS_RECORD_KEY: 3904ca0c-bc98-47d9-8371-b68c5e81fb9b
-    steps:
-      - e2e-test:
-          test_path: e2e-tests/development-runtime
-      - notify-status:
-          condition: << parameters.postStatus >>
+    <<: *e2e_tests_development_runtime_alias
+
+  e2e_tests_development_runtime_with_experimental_react:
+    <<: *e2e_tests_development_runtime_alias
+
+  e2e_tests_development_runtime_with_next_react:
+    <<: *e2e_tests_development_runtime_alias
 
   e2e_tests_production_runtime:
     <<: *e2e_tests_production_runtime_alias
 
-  e2e_tests_production_runtime-with-experimental-react:
+  e2e_tests_production_runtime_with_experimental_react:
     <<: *e2e_tests_production_runtime_alias
 
-  e2e_tests_production_runtime-with-next-react:
+  e2e_tests_production_runtime_with_next_react:
     <<: *e2e_tests_production_runtime_alias
 
   themes_e2e_tests_development_runtime:
@@ -386,15 +404,15 @@ workflows:
     jobs:
       - bootstrap-with-experimental-react:
           version: "next"
-      - e2e_tests_gatsby-image:
+      - e2e_tests_gatsby-image_with_next_react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
-      - e2e_tests_development_runtime:
+      - e2e_tests_development_runtime_with_next_react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
-      - e2e_tests_production_runtime-with-next-react:
+      - e2e_tests_production_runtime_with_next_react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
@@ -409,15 +427,15 @@ workflows:
     jobs:
       - bootstrap-with-experimental-react:
           version: "experimental"
-      - e2e_tests_gatsby-image:
+      - e2e_tests_gatsby-image_with_experimental_react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
-      - e2e_tests_development_runtime:
+      - e2e_tests_development_runtime_with_experimental_react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
-      - e2e_tests_production_runtime-with-experimental-react:
+      - e2e_tests_production_runtime_with_experimental_react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,10 +233,13 @@ jobs:
       - notify-status:
           condition: << parameters.postStatus >>
 
-  e2e_tests_production_runtime:
+  e2e_tests_production_runtime-in-normal-mode:
     <<: *e2e_tests_production_runtime_alias
 
   e2e_tests_production_runtime-with-experimental-react:
+    <<: *e2e_tests_production_runtime_alias
+
+  e2e_tests_production_runtime-with-next-react:
     <<: *e2e_tests_production_runtime_alias
 
   themes_e2e_tests_development_runtime:
@@ -391,7 +394,7 @@ workflows:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
-      - e2e_tests_production_runtime-with-experimental-react:
+      - e2e_tests_production_runtime-with-next-react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
@@ -414,7 +417,7 @@ workflows:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
-      - e2e_tests_production_runtime:
+      - e2e_tests_production_runtime-with-experimental-react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
@@ -456,7 +459,7 @@ workflows:
           <<: *e2e-test-workflow
       - e2e_tests_development_runtime:
           <<: *e2e-test-workflow
-      - e2e_tests_production_runtime:
+      - e2e_tests_production_runtime-in-normal-mode:
           <<: *e2e-test-workflow
       - themes_e2e_tests_production_runtime:
           <<: *e2e-test-workflow

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,19 @@ aliases:
       - lint
       - unit_tests_node8
 
+  e2e_tests_production_runtime_alias: &e2e_tests_production_runtime_alias
+    <<: *e2e-executor
+    parameters:
+      postStatus:
+        type: boolean
+        default: false
+    steps:
+      - e2e-test:
+          test_path: e2e-tests/production-runtime
+          test_command: CYPRESS_PROJECT_ID=is8aoq CYPRESS_RECORD_KEY=cb4708d2-1578-4665-9a07-c59f8db28d91 yarn test && CYPRESS_PROJECT_ID=htpvkv CYPRESS_RECORD_KEY=0d734841-c613-41d2-86e5-df0b5968f93f yarn test:offline
+      - notify-status:
+          condition: << parameters.postStatus >>
+
 commands:
   notify-status:
     parameters:
@@ -221,17 +234,10 @@ jobs:
           condition: << parameters.postStatus >>
 
   e2e_tests_production_runtime:
-    <<: *e2e-executor
-    parameters:
-      postStatus:
-        type: boolean
-        default: false
-    steps:
-      - e2e-test:
-          test_path: e2e-tests/production-runtime
-          test_command: CYPRESS_PROJECT_ID=is8aoq CYPRESS_RECORD_KEY=cb4708d2-1578-4665-9a07-c59f8db28d91 yarn test && CYPRESS_PROJECT_ID=htpvkv CYPRESS_RECORD_KEY=0d734841-c613-41d2-86e5-df0b5968f93f yarn test:offline
-      - notify-status:
-          condition: << parameters.postStatus >>
+    <<: *e2e_tests_production_runtime_alias
+
+  e2e_tests_production_runtime-with-experimental-react:
+    <<: *e2e_tests_production_runtime_alias
 
   themes_e2e_tests_development_runtime:
     <<: *e2e-executor
@@ -385,7 +391,7 @@ workflows:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react
-      - e2e_tests_production_runtime:
+      - e2e_tests_production_runtime-with-experimental-react:
           postStatus: true
           requires:
             - bootstrap-with-experimental-react


### PR DESCRIPTION
Attempt in adjusting circleCi config to not use 2 jobs with same name