### PR TITLE
Update creating-and-modifying-pages.md

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -156,6 +156,8 @@ exports.onCreatePage = ({ page, actions }) => {
 }
 ```
 
+Note that because Gatsby core automatically turns components in `src/pages` into pages, if you want to pass custom context you'll need to specify a different directory.
+
 On your pages and templates, you can access your context via the prop `pageContext` like this:
 
 ```jsx


### PR DESCRIPTION
## Description
A fair number of people, myself included, have been tripped up by trying to pass context into pages located inside /src/pages/. Because Gatsby automatically generates pages for this directory, custom context isn't received even when pages appear to be created in gatsby-node.js successfully. This results in context appearing to be passed properly, but empty context in the template in /src/pages/

I've simply clarified that for custom context to work, users will need to specify a template directory other that /src/pages/

## Related Issues
Lengthy thread here:
https://github.com/gatsbyjs/gatsby/issues/10742

