### PR TITLE
feat(gatsby): add plugin data to `gatsby develop` telemetry to match `gatsby build` events

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -165,12 +165,13 @@ module.exports = async (args: BootstrapArgs) => {
   const flattenedPlugins = await loadPlugins(config, program.directory)
   activity.end()
 
+  const pluginsStr = flattenedPlugins.map(p => `${p.name}@${p.version}`)
   telemetry.decorateEvent(`BUILD_END`, {
-    plugins: flattenedPlugins.map(p => `${p.name}@${p.version}`),
+    plugins: pluginsStr,
   })
 
   telemetry.decorateEvent(`DEVELOP_STOP`, {
-    plugins: flattenedPlugins.map(p => `${p.name}@${p.version}`),
+    plugins: pluginsStr,
   })
 
   // onPreInit

--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -169,6 +169,10 @@ module.exports = async (args: BootstrapArgs) => {
     plugins: flattenedPlugins.map(p => `${p.name}@${p.version}`),
   })
 
+  telemetry.decorateEvent(`DEVELOP_STOP`, {
+    plugins: flattenedPlugins.map(p => `${p.name}@${p.version}`),
+  })
+
   // onPreInit
   activity = report.activityTimer(`onPreInit`, {
     parentSpan: bootstrapSpan,


### PR DESCRIPTION
We already send plugin data on `gatsby build`. This PR adds the same functionality to our telemetry for the `gatsby develop` command for more granular data points on how plugins are added to projects or removed from projects during development.

The same bootstrap function is used for both the build and develop command entrypoints, so adding a `DEVELOP_STOP` event decoration with the same metadata as the `BUILD_END` event decoration will make sure we send this data on both commands.