### PR TITLE
chore(docs): Fix typo in wordpress-source-plugin-tutorial.md

### DIFF
--- a/docs/tutorial/wordpress-source-plugin-tutorial.md
+++ b/docs/tutorial/wordpress-source-plugin-tutorial.md
@@ -223,7 +223,7 @@ Before you can create the blog posts, however, you need to specify a template to
 
 In your `src` directory, create a directory called `templates` and in the newly created `templates` folder, create a filed named `blog-post.js`. In that new file, paste the following:
 
-```jsx:title=src/tempates/blog-post.js
+```jsx:title=src/templates/blog-post.js
 import React from "react"
 import Layout from "../components/layout"
 import { graphql } from "gatsby"


### PR DESCRIPTION
Correct the spelling in the path

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
