### PR TITLE
feat(gatsby-source-graphql): Allow override fetch

### DIFF
--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -47,6 +47,19 @@ module.exports = {
       },
     },
 
+    // Advanced config, using a custom fetch function
+    {
+      resolve: "gatsby-source-graphql",
+      options: {
+        typeName: "GitHub",
+        fieldName: "github",
+        url: "https://api.github.com/graphql",
+        // A `fetch`-compatible API to use when making requests.
+        fetch: (uri, options = {}) =>
+          fetch(uri, { ...options, headers: sign(options.headers) }),
+      },
+    },
+
     // Complex situations: creating arbitrary Apollo Link
     {
       resolve: "gatsby-source-graphql",
@@ -54,14 +67,15 @@ module.exports = {
         typeName: "GitHub",
         fieldName: "github",
         // Create Apollo Link manually. Can return a Promise.
-        createLink: (pluginOptions) => {
+        createLink: pluginOptions => {
           return createHttpLink({
-            uri: 'https://api.github.com/graphql',
+            uri: "https://api.github.com/graphql",
             headers: {
-              'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+              Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
             },
             fetch,
           })
+        },
       },
     },
   ],

--- a/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
@@ -6,6 +6,12 @@ jest.mock(`graphql-tools`, () => {
     RenameTypes: jest.fn(),
   }
 })
+jest.mock(`apollo-link-http`, () => {
+  return {
+    createHttpLink: jest.fn(),
+  }
+})
+const { createHttpLink } = require(`apollo-link-http`)
 jest.mock(`gatsby/graphql`, () => {
   const graphql = jest.requireActual(`gatsby/graphql`)
   return {
@@ -15,6 +21,7 @@ jest.mock(`gatsby/graphql`, () => {
   }
 })
 const { sourceNodes } = require(`../gatsby-node`)
+const nodeFetch = require(`node-fetch`)
 
 const getInternalGatsbyAPI = () => {
   const actions = {
@@ -65,5 +72,34 @@ describe(`createSchemaNode`, () => {
 
     expect(api.createContentDigest).toHaveBeenCalledWith(expect.any(String))
     expect(api.createContentDigest).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe(`createHttpLink`, () => {
+  it(`used passed in fetch if provided`, async () => {
+    const api = getInternalGatsbyAPI()
+    const mockFetch = jest.fn()
+    await sourceNodes(api, {
+      typeName: `Github foo`,
+      fieldName: `github`,
+      url: `https://github.com`,
+      fetch: mockFetch,
+    })
+
+    expect(createHttpLink).toHaveBeenCalledWith(
+      expect.objectContaining({ fetch: mockFetch })
+    )
+  })
+  it(`use default fetch if not provided`, async () => {
+    const api = getInternalGatsbyAPI()
+    await sourceNodes(api, {
+      typeName: `Github foo`,
+      fieldName: `github`,
+      url: `https://github.com`,
+    })
+
+    expect(createHttpLink).toHaveBeenCalledWith(
+      expect.objectContaining({ fetch: nodeFetch })
+    )
   })
 })

--- a/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
@@ -76,7 +76,7 @@ describe(`createSchemaNode`, () => {
 })
 
 describe(`createHttpLink`, () => {
-  it(`used passed in fetch if provided`, async () => {
+  it(`use passed in fetch if provided`, async () => {
     const api = getInternalGatsbyAPI()
     const mockFetch = jest.fn()
     await sourceNodes(api, {

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -7,7 +7,7 @@ const {
   RenameTypes,
 } = require(`graphql-tools`)
 const { createHttpLink } = require(`apollo-link-http`)
-const fetch = require(`node-fetch`)
+const nodeFetch = require(`node-fetch`)
 const invariant = require(`invariant`)
 
 const {
@@ -25,6 +25,7 @@ exports.sourceNodes = async (
     typeName,
     fieldName,
     headers = {},
+    fetch = nodeFetch,
     fetchOptions = {},
     createLink,
     createSchema,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Allow a custom fetch to be passed to `createHttpLink` instead of overriding the entire link.

Makes it easier to use a graphql behind aws4 signing.

## Related Issues
Fixes #18684
