### PR TITLE
Fix e.g. typos

### DIFF
--- a/benchmarks/query/README.md
+++ b/benchmarks/query/README.md
@@ -2,6 +2,6 @@
 
 Stress tests creating lots of queries.
 
-Defaults to building a site with 5k pages split evenly amongst 10 types. Set the `NUM_PAGES` environment variable to change the number of pages, and `NUM_TYPES` to change the number of types they're split over. E.g to create a site with 5 types, each with 200 pages, do `NUM_TYPES=5 NUM_PAGES=1000 gatsby build`
+Defaults to building a site with 5k pages split evenly amongst 10 types. Set the `NUM_PAGES` environment variable to change the number of pages, and `NUM_TYPES` to change the number of types they're split over. E.g. to create a site with 5 types, each with 200 pages, do `NUM_TYPES=5 NUM_PAGES=1000 gatsby build`
 
 By default it uses simple queries which creates very few data dependencies for each page. If you want to stress test data dependencies tracking use truthy `QUERY_LINKED_NODES` environment variable. E.g. `QUERY_LINKED_NODES=1 gatsby build`

--- a/e2e-tests/production-runtime/cypress/integration/1-production.js
+++ b/e2e-tests/production-runtime/cypress/integration/1-production.js
@@ -3,7 +3,7 @@
 // NOTE: This needs to be run before any other integration tests as it
 // sets up the service worker in offline mode. Therefore, if you want
 // to test an individual integration test, you must run this
-// first. E.g to run `compilation-hash.js` test, run
+// first. E.g. to run `compilation-hash.js` test, run
 //
 // cypress run -s \
 // "cypress/integration/1-production.js,cypress/integration/compilation-hash.js" \

--- a/examples/using-remark/src/pages/2019-02-06---graphviz/index.md
+++ b/examples/using-remark/src/pages/2019-02-06---graphviz/index.md
@@ -141,7 +141,7 @@ digraph graphname {
 
   ## Source Nodes
 
-  dataSource [ label = "data sources. e.g file, contentful", shape = cylinder, fillcolor = gray ];
+  dataSource [ label = "data sources. e.g. file, contentful", shape = cylinder, fillcolor = gray ];
   sourceNodes [ label = "source nodes" URL = "/docs/node-creation/" ];
   nodes [ label = "nodes", shape = box, fillcolor = skyblue, URL = "/docs/node-creation/" ];
   nodesTouched [ label = "touchedNodes", shape = box, fillcolor = skyblue, URL = "/docs/node-creation/#freshstale-nodes" ];
@@ -288,7 +288,7 @@ digraph graphname {
 
   ## Source Nodes
 
-  dataSource [ label = "data sources. e.g file, contentful", shape = cylinder, fillcolor = gray ];
+  dataSource [ label = "data sources. e.g. file, contentful", shape = cylinder, fillcolor = gray ];
   sourceNodes [ label = "source nodes" URL = "/docs/node-creation/" ];
   nodes [ label = "nodes", shape = box, fillcolor = skyblue, URL = "/docs/node-creation/" ];
   nodesTouched [ label = "touchedNodes", shape = box, fillcolor = skyblue, URL = "/docs/node-creation/#freshstale-nodes" ];

--- a/packages/gatsby-remark-code-repls/README.md
+++ b/packages/gatsby-remark-code-repls/README.md
@@ -14,13 +14,13 @@ It currently supports:
 This plug-in was created to solve a couple of problems the React team has faced
 with [reactjs.org](https://github.com/reactjs/reactjs.org):
 
-- Examples were stored separately from documentation (eg in Codepen) which made
+- Examples were stored separately from documentation (e.g. in Codepen) which made
   it more difficult to coordinate updates. (It was easy to forget to update an
   example when an API changes.)
-- Examples (eg Codepens) were owned by a single author, so the community
+- Examples (e.g. Codepens) were owned by a single author, so the community
   couldn't contribute PRs to update them without forking and fragmenting
   ownership.
-- It was easy to create invalid links (eg Babel REPL links that \_don't quite
+- It was easy to create invalid links (e.g. Babel REPL links that \_don't quite
   work).
 
 ## Overview
@@ -131,17 +131,17 @@ specified examples directory. (This will avoid broken links at runtime.)
   options: {
     // Optional default link text.
     // Defaults to "REPL".
-    // eg <a href="...">Click here</a>
+    // e.g. <a href="...">Click here</a>
     defaultText: 'Click here',
 
 
     // Example code links are relative to this dir.
-    // eg examples/path/to/file.js
+    // e.g. examples/path/to/file.js
     directory: `${__dirname}/examples/`,
 
     // Optional link target.
     // Note that if a target is specified, "noreferrer" will also be added.
-    // eg <a href="..." target="_blank" rel="noreferrer">...</a>
+    // e.g. <a href="..." target="_blank" rel="noreferrer">...</a>
     target: '_blank',
 
 
@@ -154,11 +154,11 @@ specified examples directory. (This will avoid broken links at runtime.)
 
       // Optional HTML contents to inject into REPL.
       // Defaults to `<div id="root"></div>`.
-      // eg '<div id="root"></div>'
+      // e.g. '<div id="root"></div>'
       html: '',
 
       // Optional externals to load from a CDN.
-      // eg '//unpkg.com/react/umd/react.development.js'
+      // e.g. '//unpkg.com/react/umd/react.development.js'
       externals: [],
 
       // Include CSS with matching name.
@@ -171,11 +171,11 @@ specified examples directory. (This will avoid broken links at runtime.)
     codesandbox: {
       // Optional HTML contents to inject into REPL.
       // Defaults to `<div id="root"></div>`.
-      // eg '<div id="root"></div>'
+      // e.g. '<div id="root"></div>'
       html: '',
 
       // Optional runtime dependencies to load from NPM.
-      // eg ['react', 'react-dom'] or ['react@15', 'react-dom@15']
+      // e.g. ['react', 'react-dom'] or ['react@15', 'react-dom@15']
       dependencies: [],
     }
   },

--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -20,9 +20,9 @@ plugins: [
           resolve: `gatsby-remark-prismjs`,
           options: {
             // Class prefix for <pre> tags containing syntax highlighting;
-            // defaults to 'language-' (eg <pre class="language-js">).
+            // defaults to 'language-' (e.g. <pre class="language-js">).
             // If your site loads Prism into the browser at runtime,
-            // (eg for use with libraries like react-live),
+            // (e.g. for use with libraries like react-live),
             // you may use this to prevent Prism from re-processing syntax.
             // This is an uncommon use-case though;
             // If you're unsure, it's best to use the default value.

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -94,7 +94,7 @@ graphql`
           ...GatsbyContentfulFluid_withWebp
         }
 
-        # Query for locally stored file(eg An image) - `File` node
+        # Query for locally stored file(e.g. An image) - `File` node
         localFile {
           # Where the asset is downloaded into cache, don't use this
           absolutePath

--- a/packages/gatsby/cache-dir/find-path.js
+++ b/packages/gatsby/cache-dir/find-path.js
@@ -50,7 +50,7 @@ export const findMatchPath = rawPathname => {
 // `#` and query params), or if it matches an entry in
 // `match-paths.json`, its matched path is returned
 //
-// E.g `/foo?bar=far` => `/foo`
+// E.g. `/foo?bar=far` => `/foo`
 //
 // Or if `match-paths.json` contains `{ "/foo*": "/page1", ...}`, then
 // `/foo?bar=far` => `/page1`
@@ -74,7 +74,7 @@ export const findPath = rawPathname => {
 
 /**
  * Clean a url and converts /index.html => /
- * E.g `/foo?bar=far` => `/foo`
+ * E.g. `/foo?bar=far` => `/foo`
  *
  * @param {string} rawPathname A raw pathname
  * @return {string}

--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -22,7 +22,7 @@ function createFileContentHash(root, globPattern) {
 }
 
 /**
- * Make sure key is unique to plugin options. E.g there could
+ * Make sure key is unique to plugin options. E.g. there could
  * be multiple source-filesystem plugins, with different names
  * (docs, blogs).
  * @param {*} name Name of the plugin

--- a/packages/gatsby/src/db/loki/index.js
+++ b/packages/gatsby/src/db/loki/index.js
@@ -21,12 +21,12 @@ loki.Comparators.aeq = customComparators.aeqHelper
 // these collections, and the "meta collections" used to track them.
 //
 // You won't use these directly. They are used by the collection
-// functions in `./nodes.js`. E.g `getTypeCollName()` and
+// functions in `./nodes.js`. E.g. `getTypeCollName()` and
 // `getNodeTypeCollection`
 const colls = {
   // Each object has keys `id` and `typeCollName`. It's a way of
   // quickly looking up the collection that a node is contained in.
-  // E.g { id: `someNodeId`, typeCollName: `gatsby:nodeType:myType` }
+  // E.g. { id: `someNodeId`, typeCollName: `gatsby:nodeType:myType` }
   nodeMeta: {
     name: `gatsby:nodeMeta`,
     options: {
@@ -37,7 +37,7 @@ const colls = {
   // The list of all node type collections. Each object has keys
   // `type` and `collName` so you can quickly look up the collection
   // name for a node type.
-  // e.g { type: `myType`, collName: `gatsby:nodeType:myType` }
+  // e.g. { type: `myType`, collName: `gatsby:nodeType:myType` }
   nodeTypes: {
     name: `gatsby:nodeTypes`,
     options: {

--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -21,9 +21,9 @@ const { getValueAt } = require(`../../utils/get-value-at`)
 const { runSiftOnNodes } = require(`../../redux/run-sift`)
 
 // Takes a raw graphql filter and converts it into a mongo-like args
-// object that can be understood by loki. E.g `eq` becomes
+// object that can be understood by loki. E.g. `eq` becomes
 // `$eq`. gqlFilter should be the raw graphql filter returned from
-// graphql-js. e.g gqlFilter:
+// graphql-js. e.g. gqlFilter:
 //
 // {
 //   internal: {
@@ -73,7 +73,7 @@ function toMongoArgs(gqlFilter, lastFieldType) {
       if (k === `regex`) {
         const re = prepareRegex(v)
         // To ensure that false is returned if a field doesn't
-        // exist. E.g `{nested.field: {$regex: /.*/}}`
+        // exist. E.g. `{nested.field: {$regex: /.*/}}`
         mongoArgs[`$where`] = obj => !_.isUndefined(obj) && re.test(obj)
       } else if (k === `glob`) {
         const Minimatch = require(`minimatch`).Minimatch
@@ -202,7 +202,7 @@ function doesSortFieldsHaveArray(type, sortArgs) {
  *
  * {Object} gqlType: A GraphQL type
  *
- * {Object} queryArgs: The raw graphql query as a js object. E.g `{
+ * {Object} queryArgs: The raw graphql query as a js object. E.g. `{
  * filter: { fields { slug: { eq: "/somepath" } } } }`
  *
  * {Object} context: The context from the QueryJob

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -311,7 +311,7 @@ const runQueuedQueries = () => {
  *
  * 1. A node has changed (but only after the api call has finished
  * running)
- * 2. A component query (e.g by editing a React Component) has
+ * 2. A component query (e.g. by editing a React Component) has
  * changed
  *
  * For what constitutes a dirty query, see `calcQueries`

--- a/packages/gatsby/src/redux/actions/restricted.js
+++ b/packages/gatsby/src/redux/actions/restricted.js
@@ -13,7 +13,7 @@ const actions = {}
  *
  * This schema is going to be merged as-is. This can easily break the main
  * Gatsby schema, so it's user's responsibility to make sure it doesn't happen
- * (by eg namespacing the schema).
+ * (by e.g. namespacing the schema).
  *
  * @availableIn [createSchemaCustomization, sourceNodes]
  *

--- a/packages/gatsby/src/utils/api-node-helpers-docs.js
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.js
@@ -117,7 +117,7 @@ const GatsbyTracing = {
    * exports.sourceNodes = async ({ actions, tracing }) => {
    *   const span = tracing.startSpan(`foo`)
    *
-   *   // Perform any span operations. E.g add a tag to your span
+   *   // Perform any span operations. E.g. add a tag to your span
    *   span.setTag(`bar`, `baz`)
    *
    *   // Rest of your plugin code


### PR DESCRIPTION
[Exempli gratia](https://simple.wikipedia.org/wiki/Exempli_gratia), which means for example or for the sake of example in Latin, should be abbreviated as `e.g.`.

References:

- https://dictionary.cambridge.org/dictionary/english/eg
- https://www.merriam-webster.com/dictionary/e.g.
