### PR TITLE
refactor: use includes() instead of indexOf()

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -526,8 +526,8 @@ module.exports = async (program: any) => {
       .sync(`{,!(node_modules|public)/**/}*.js`, { nodir: true })
       .forEach(file => {
         const fileText = fs.readFileSync(file)
-        const matchingApis = deprecatedApis.filter(
-          api => fileText.includes(api)
+        const matchingApis = deprecatedApis.filter(api =>
+          fileText.includes(api)
         )
         matchingApis.forEach(api => deprecatedLocations[api].push(file))
       })

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -527,7 +527,7 @@ module.exports = async (program: any) => {
       .forEach(file => {
         const fileText = fs.readFileSync(file)
         const matchingApis = deprecatedApis.filter(
-          api => fileText.indexOf(api) !== -1
+          api => fileText.includes(api)
         )
         matchingApis.forEach(api => deprecatedLocations[api].push(file))
       })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Use `Array.includes()` to check for existence.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
