### PR TITLE
fix(scripts): removed `use-drupal` site from site-up-checker script

### DIFF
--- a/scripts/site-up-checker/index.js
+++ b/scripts/site-up-checker/index.js
@@ -48,7 +48,6 @@ const main = () => {
   const websites = [
     `https://www.gatsbyjs.org`,
     `https://gatsbygram.gatsbyjs.org`,
-    `https://using-drupal.gatsbyjs.org`,
   ]
 
   // Run immediately.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Seems like https://using-drupal.gatsbyjs.org is not available so i removed it. 

Alternative link: https://www.gatsbyjs.com/guides/drupal/

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
