### PR TITLE
chore(www): Add clean command (#19642) 

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -113,6 +113,7 @@
     "develop": "cross-env GATSBY_GRAPHQL_IDE=playground gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
+    "clean": "gatsby clean",
     "test": "jest",
     "scrapeStarters": "cd src/data/StarterShowcase && node scraper.js",
     "stylelint": "stylelint './src/**/*.js'",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Similar to the #19584 commit i also miss in `www` the [`gatsby clean`](https://www.gatsbyjs.org/docs/build-caching/#clearing-cache) command. With `clean` command in `package.json` i can run the command from IntelliJ's list of available commands.

## Related Issues

#19584