### PR TITLE
fix(gatsby): Improve warning message about implicit child fields

### DIFF
--- a/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
@@ -176,12 +176,12 @@ describe(`Define parent-child relationships with field extensions`, () => {
     await buildSchema()
     expect(report.warn).toBeCalledTimes(1)
     expect(report.warn).toBeCalledWith(
-      `On types with the \`@dontInfer\` directive, or with the \`infer\` ` +
+      `The type \`Parent\` does not explicitly define the field \`childChild\`.\n` +
+        `On types with the \`@dontInfer\` directive, or with the \`infer\` ` +
         `extension set to \`false\`, automatically adding fields for ` +
         `children types is deprecated.\n` +
         `In Gatsby v3, only children fields explicitly set with the ` +
-        `\`childOf\` extension will be added.\n` +
-        `For example, in Gatsby v3, \`Parent\` will not get a \`childChild\` field.`
+        `\`childOf\` extension will be added.\n`
     )
   })
 

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -967,13 +967,13 @@ const addImplicitConvenienceChildrenFields = ({
           ? fieldNames.convenienceChildren(typeName)
           : fieldNames.convenienceChild(typeName)
         report.warn(
-          `On types with the \`@dontInfer\` directive, or with the \`infer\` ` +
+          `The type \`${parentTypeName}\` does not explicitly define ` +
+            `the field \`${fieldName}\`.\n` +
+            `On types with the \`@dontInfer\` directive, or with the \`infer\` ` +
             `extension set to \`false\`, automatically adding fields for ` +
             `children types is deprecated.\n` +
             `In Gatsby v3, only children fields explicitly set with the ` +
-            `\`childOf\` extension will be added.\n` +
-            `For example, in Gatsby v3, \`${parentTypeName}\` will ` +
-            `not get a \`${fieldName}\` field.`
+            `\`childOf\` extension will be added.\n`
         )
       }
     }


### PR DESCRIPTION
## Description

This PR aims to improve debugging experience with warnings produced by schema customization for implicit child fields created via `createParentChildLink`.

## Related Issues

Fixes #19314 