### PR TITLE
chore(docs): updates for old maintainer meeting 

### DIFF
--- a/docs/contributing/code-contributions.md
+++ b/docs/contributing/code-contributions.md
@@ -121,4 +121,4 @@ Check [Debugging the build process](/docs/debugging-the-build-process/) page to 
 
 ## Feedback
 
-At any point during the contributing process, the Gatsby Core team would love to help! We hold a weekly [Core Maintainer's meeting](/contributing/community#core-maintainers-meeting) where you can share your creation(s) and receive advice and feedback directly from the team!
+At any point during the contributing process the Gatsby team would love to help! For help with a specific problem you can [open an issue on GitHub](/contributing/how-to-file-an-issue/). Or drop in to [our Discord server](https://gatsby.dev/discord) for general community discussion and support.

--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -45,14 +45,6 @@ Sign up for the Gatsby newsletter to keep up with the latest from the Gatsby com
 For the latest news about Gatsby,
 [follow **@gatsbyjs** on Twitter](https://twitter.com/gatsbyjs).
 
-### Community Maintainers Meeting
-
-The Gatsby Core team (official Gatsby employees who are working on Gatsby open-source) holds a weekly meeting where we encourage community members to share their projects, struggles, and successes directly with the Gatsby Core team. Additionally the Core team shares pertinent info and plans that are applicable to the community!
-
-This event is held on a recurring basis, every Wednesday at 8:30 AM Pacific Standard Time (PST).
-
-[Add the recurring calendar invite here](https://gatsby.dev/core-maintainers)
-
 ## Where to get support
 
 ### Stack Overflow


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This meeting doesn't happen any more, so I've updated the docs. 

## Related Issues

See [the related announcement in the Maintainers group](https://github.com/orgs/gatsbyjs/teams/maintainers/discussions/72).
