### PR TITLE
chore(gatsby-cli): Bump target node version to v8.0 for .babelrc

### DIFF
--- a/packages/gatsby-cli/.babelrc
+++ b/packages/gatsby-cli/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     ["babel-preset-gatsby-package", {
-      "nodeVersion": "6.0"
+      "nodeVersion": "8.0"
     }]
   ]
 }


### PR DESCRIPTION
Bump target node version to version 8.0 for Babel compilation. It was still targeting Node 6