### PR TITLE
chore(gatsby): cleanup api runner promises

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -221,12 +221,12 @@ const runAPI = async (plugin, api, args, activity) => {
           throw e
         }
       })
-    } else {
-      const result = await gatsbyNode[api](...apiCallArgs)
-      pluginSpan.finish()
-      apiFinished = true
-      return result
     }
+
+    const result = await gatsbyNode[api](...apiCallArgs)
+    pluginSpan.finish()
+    apiFinished = true
+    return result
   }
 
   return null

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -73,7 +73,7 @@ const getLocalReporter = (activity, reporter) =>
     ? { ...reporter, panicOnBuild: activity.panicOnBuild.bind(activity) }
     : reporter
 
-const runAPI = (plugin, api, args, activity) => {
+const runAPI = async (plugin, api, args, activity) => {
   const gatsbyNode = require(`${plugin.resolve}/gatsby-node`)
   if (gatsbyNode[api]) {
     const parentSpan = args && args.parentSpan
@@ -222,12 +222,10 @@ const runAPI = (plugin, api, args, activity) => {
         }
       })
     } else {
-      const result = gatsbyNode[api](...apiCallArgs)
+      const result = await gatsbyNode[api](...apiCallArgs)
       pluginSpan.finish()
-      return Promise.resolve(result).then(res => {
-        apiFinished = true
-        return res
-      })
+      apiFinished = true
+      return result
     }
   }
 

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -1,4 +1,4 @@
-const Promise = require(`bluebird`)
+const BlueBirdPromise = require(`bluebird`)
 const _ = require(`lodash`)
 const chalk = require(`chalk`)
 const { bindActionCreators } = require(`redux`)
@@ -204,7 +204,7 @@ const runAPI = async (plugin, api, args, activity) => {
     // If the plugin is using a callback use that otherwise
     // expect a Promise to be returned.
     if (gatsbyNode[api].length === 3) {
-      return Promise.fromCallback(callback => {
+      return BlueBirdPromise.fromCallback(callback => {
         const cb = (err, val) => {
           pluginSpan.finish()
           callback(err, val)
@@ -301,7 +301,7 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
       }
     }
 
-    Promise.mapSeries(implementingPlugins, plugin =>
+    BlueBirdPromise.mapSeries(implementingPlugins, plugin =>
       runPlugin(api, plugin, args, stopQueuedApiRuns, activity, apiSpan)
     ).then(results =>
       afterPlugin(

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -253,15 +253,10 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) => {
 
   const apiRunInstance = {
     api,
-    args,
-    pluginSource,
     resolve,
     span: apiSpan,
-    startTime: new Date().toJSON(),
     traceId: args.traceId,
   }
-
-  apiRunInstance.id = getApiId(api, apiRunInstance, args)
 
   if (args.waitForCascadingActions) {
     waitingForCasacadeToFinish.push(apiRunInstance)
@@ -388,28 +383,4 @@ function afterPlugin(
       return true
     }
   })
-}
-
-function getApiId(api, apiRunInstance, args) {
-  // Generate IDs for api runs. Most IDs we generate from the args
-  // but some API calls can have very large argument objects so we
-  // have special ways of generating IDs for those to avoid stringifying
-  // large objects.
-  if (api === `setFieldsOnGraphQLNodeType`) {
-    return `${api}${apiRunInstance.startTime}${args.type.name}${args.traceId}`
-  }
-  if (api === `onCreateNode`) {
-    return `${api}${apiRunInstance.startTime}${args.node.internal.contentDigest}${args.traceId}`
-  }
-  if (api === `preprocessSource`) {
-    return `${api}${apiRunInstance.startTime}${args.filename}${args.traceId}`
-  }
-  if (api === `onCreatePage`) {
-    return `${api}${apiRunInstance.startTime}${args.page.path}${args.traceId}`
-  }
-  // When tracing is turned on, the `args` object will have a
-  // `parentSpan` field that can be quite large. So we omit it
-  // before calling stringify
-  const argsJson = JSON.stringify(_.omit(args, `parentSpan`))
-  return `${api}|${apiRunInstance.startTime}|${apiRunInstance.traceId}|${argsJson}`
 }

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -348,12 +348,12 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) => {
 }
 
 function runPlugin(api, plugin, args, stopQueuedApiRuns, activity, apiSpan) {
-  let pluginName =
-    plugin.name === `default-site-plugin` ? `gatsby-node.js` : plugin.name
-
   return new Promise(resolve => {
     resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }, activity))
   }).catch(err => {
+    let pluginName =
+      plugin.name === `default-site-plugin` ? `gatsby-node.js` : plugin.name
+
     decorateEvent(`BUILD_PANIC`, {
       pluginName: `${plugin.name}@${plugin.version}`,
     })

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -223,7 +223,7 @@ const runAPI = async (plugin, api, args, activity) => {
   return null
 }
 
-let apisRunningById = new Map()
+let apiRunnersActive = 0
 let apisRunningByTraceId = new Map()
 let waitingForCasacadeToFinish = []
 
@@ -267,11 +267,11 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) => {
     waitingForCasacadeToFinish.push(apiRunInstance)
   }
 
-  if (apisRunningById.size === 0) {
+  if (apiRunnersActive === 0) {
     emitter.emit(`API_RUNNING_START`)
   }
+  ++apiRunnersActive
 
-  apisRunningById.set(apiRunInstance.id, apiRunInstance)
   if (apisRunningByTraceId.has(apiRunInstance.traceId)) {
     const currentCount = apisRunningByTraceId.get(apiRunInstance.traceId)
     apisRunningByTraceId.set(apiRunInstance.traceId, currentCount + 1)
@@ -358,11 +358,11 @@ function afterPlugin(
     onAPIRunComplete()
   }
   // Remove runner instance
-  apisRunningById.delete(apiRunInstance.id)
   const currentCount = apisRunningByTraceId.get(apiRunInstance.traceId)
   apisRunningByTraceId.set(apiRunInstance.traceId, currentCount - 1)
 
-  if (apisRunningById.size === 0) {
+  --apiRunnersActive
+  if (apiRunnersActive === 0) {
     emitter.emit(`API_RUNNING_QUEUE_EMPTY`)
   }
 

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -231,12 +231,13 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) => {
   let resolve
   let promise = new Promise(res => (resolve = res)) // This is guaranteed to assign to `resolve` in sync
 
-  const { parentSpan } = args
+  const { parentSpan, traceId, traceTags, waitForCascadingActions } = args
+
   const apiSpanArgs = parentSpan ? { childOf: parentSpan } : {}
   const apiSpan = tracer.startSpan(`run-api`, apiSpanArgs)
 
   apiSpan.setTag(`api`, api)
-  _.forEach(args.traceTags, (value, key) => {
+  _.forEach(traceTags, (value, key) => {
     apiSpan.setTag(key, value)
   })
 
@@ -255,10 +256,10 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) => {
     api,
     resolve,
     span: apiSpan,
-    traceId: args.traceId,
+    traceId,
   }
 
-  if (args.waitForCascadingActions) {
+  if (waitForCascadingActions) {
     waitingForCasacadeToFinish.push(apiRunInstance)
   }
 
@@ -322,7 +323,7 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) => {
 
   // Filter out empty responses and return if the
   // api caller isn't waiting for cascading actions to finish.
-  if (!args.waitForCascadingActions) {
+  if (!waitForCascadingActions) {
     apiSpan.finish()
     resolve(apiRunInstance.results)
   }


### PR DESCRIPTION
This attempts to remove a bunch of BlueBird promises from the api runner, in favor of native Promises.

It also cleans up the core of the api-runner by eliminating a bunch of controls that would never really be used due to how promises get resolved and non-blocking works.
