### PR TITLE
[docs/mdx-plugin/gatsby-remark-images] including options.plugins entry in code-copy block section of doc

### DIFF
--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -30,6 +30,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
+        plugins: ['gatsby-remark-images'],
         gatsbyRemarkPlugins: [
           {
             resolve: `gatsby-remark-images`,

--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -30,7 +30,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
-        plugins: ['gatsby-remark-images'],
+        plugins: [`gatsby-remark-images`],
         gatsbyRemarkPlugins: [
           {
             resolve: `gatsby-remark-images`,


### PR DESCRIPTION
## Description
The code sample provided in the `Copy Code` block for the `gatsby-remark-images` plugin integration with the MDX plugin doesn't match the description; specifically, the code block is missing the sub-plugin property in the configuration object.

### Description of Config Object: (Accurate, no changes needed)

Then configure the plugins. gatsby-source-filesystem needs to be pointed at wherever you have your images on disk, _gatsby-remark-images_ needs to be a sub-plugin of gatsby-plugin-mdx, and gatsby-plugin-sharp can be included on its own.

### Inaccurate Config Object in Code Copy Block
```javascript
module.exports = {
  plugins: [
    `gatsby-plugin-sharp`,
    {
      resolve: `gatsby-plugin-mdx`,
      options: {
      // should be a plugins entry here
        gatsbyRemarkPlugins: [
          {
            resolve: `gatsby-remark-images`,
            options: {
              maxWidth: 1035,
              sizeByPixelDensity: true,
            },
          },
        ],
      },
    },
    {
      resolve: `gatsby-source-filesystem`,
      options: {
        path: `${__dirname}/src/pages`,
      },
    },
  ],
}
```

### Accurate Config Object, provided in this PR:
```javascript=gatsby-config.js
module.exports = {
  plugins: [
    `gatsby-plugin-sharp`,
    {
      resolve: `gatsby-plugin-mdx`,
      options: {
        plugins: ['gatsby-remark-images'],
        gatsbyRemarkPlugins: [
          {
            resolve: `gatsby-remark-images`,
            options: {
              maxWidth: 1035,
              sizeByPixelDensity: true,
            },
          },
        ],
      },
    },
    {
      resolve: `gatsby-source-filesystem`,
      options: {
        path: `${__dirname}/src/pages`,
      },
    },
  ],
}
```