### PR TITLE
Include gatsby-remark-images in RootConfig.Plugins array of code-copy section in docs.

### DIFF
--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -19,9 +19,9 @@ yarn add gatsby-plugin-sharp gatsby-remark-images
 If you don't have `gatsby-source-filesystem` installed, also install that.
 
 Then configure the plugins. `gatsby-source-filesystem` needs to be
-pointed at wherever you have your images on disk,
-`gatsby-remark-images` needs to be a sub-plugin of `gatsby-plugin-mdx`, and
-`gatsby-plugin-sharp` can be included on its own.
+pointed at wherever you have your images on disk, `gatsby-remark-images`
+needs to be both a sub-plugin of `gatsby-plugin-mdx`and a string entry in
+the plugins array, and `gatsby-plugin-sharp` can be included on its own.
 
 ```javascript=gatsby-config.js
 module.exports = {

--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -30,6 +30,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
+        plugins: ['gatsby-remark-images'],
         gatsbyRemarkPlugins: [
           {
             resolve: `gatsby-remark-images`,

--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -27,10 +27,10 @@ pointed at wherever you have your images on disk,
 module.exports = {
   plugins: [
     `gatsby-plugin-sharp`,
+    `gatsby-remark-images`,
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
-        plugins: [`gatsby-remark-images`],
         gatsbyRemarkPlugins: [
           {
             resolve: `gatsby-remark-images`,

--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -30,7 +30,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
-        plugins: ['gatsby-remark-images'],
+        plugins: [`gatsby-remark-images`],
         gatsbyRemarkPlugins: [
           {
             resolve: `gatsby-remark-images`,


### PR DESCRIPTION
## Follow up to #19666 

[This repo](https://github.com/MaxwellKendall/gatsby-starter-mdx-basic/tree/bug/inline-imgs) uses the current configuration object from [the documentation's](https://www.gatsbyjs.org/docs/mdx/plugins/) code-copy section. This configuration object used in the basic-mdx gatsby starter results in a bug where in-lined images in markdown (the purpose of the documentation) are duplicated; the duplicate image being a traced SVG version of the image.

The correct configuration object that should exist in this copy-block of the documentation is mentioned in the previous PR, and confirmed in [this repo](https://github.com/MaxwellKendall/gatsby-starter-mdx-basic/tree/bug-solution/inline-imgs-not-duplicated).

This PR updates the documentation with the correct configuration object.

## Steps to reproduce
1. Clone repo above
2. Execute `Yarn && yarn start`
3. Go to `http://localhost:8000/page-2/`

Expected results: Image is not duplicated
Actual results: Image is duplicated
