### PR TITLE
fix(gatsby): Fix createRequireFromPath deprecation warning

### DIFF
--- a/packages/gatsby/src/utils/create-require-from-path.js
+++ b/packages/gatsby/src/utils/create-require-from-path.js
@@ -3,6 +3,7 @@ const path = require(`path`)
 
 // Polyfill Node's `Module.createRequireFromPath` if not present (added in Node v10.12.0)
 module.exports =
+  Module.createRequire ||
   Module.createRequireFromPath ||
   function(filename) {
     const mod = new Module(filename, null)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR addresses the `createRequireFromPath()` deprecation warning.

To remove the warning, we now use `createRequire()` if it is available.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #19634 