### PR TITLE
perf(gatsby): perf problem for match-page search in large sites

### DIFF
--- a/packages/gatsby/src/bootstrap/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/requires-writer.js
@@ -80,6 +80,7 @@ const getMatchPaths = pages => {
   // More info in https://github.com/gatsbyjs/gatsby/issues/16097
   // small speedup: don't bother traversing when no matchPaths found.
   if (matchPathPages.length) {
+    const newMatches = []
     pages.forEach((page, index) => {
       const isInsideMatchPath = !!matchPathPages.find(
         pageWithMatchPath =>
@@ -87,7 +88,7 @@ const getMatchPaths = pages => {
       )
 
       if (isInsideMatchPath) {
-        matchPathPages.push(
+        newMatches.push(
           createMatchPathEntry(
             {
               ...page,
@@ -98,6 +99,8 @@ const getMatchPaths = pages => {
         )
       }
     })
+    // Add afterwards because the new matches are not relevant for the existing search
+    matchPathPages.push(...newMatches)
   }
 
   return matchPathPages


### PR DESCRIPTION
This was found while profiling a site of 25k pages.

The particular search in this diff started with `pages.length == 25599` and `matchPathPages.length == 2` but because `matchPathPages` was being pushed onto inside the loop, the array grew and grew. Ultimately the inner `find` was calling its callback 72 million (!) times, causing massive build delays (this was taking 2/3rds of the total build time for this site).

In contrast, this `forEach` took 390s (seconds!) before and with this diff it takes 0.47s on my machine.

This problem is caused by inefficient routing that is sometimes necessary for proper 404 handling. This becomes a big problem as the site grows and the match-path.json grows. There are some user-land improvements we can suggest to work around other problems, but at least this one we can resolve.

Thanks to @eads for offering a real-world site in #19512 so we could profile this, and @pieh for helping with the debugging.

Note that this won't affect most sites and smaller sites probably won't notice it either way. But big sites with a similar setup might be impacted positively :)
