### PR TITLE
refactor(type-conflict-reporter): use `array.prototype.includes` instead of `array.prototype.indexOf`

### DIFF
--- a/packages/gatsby/src/schema/infer/type-conflict-reporter.js
+++ b/packages/gatsby/src/schema/infer/type-conflict-reporter.js
@@ -51,7 +51,7 @@ const formatValue = value => {
     const usedTypes = []
     value.forEach(item => {
       const type = typeOf(item)
-      if (usedTypes.indexOf(type) !== -1) {
+      if (usedTypes.includes(type)) {
         if (!wasElipsisLast) {
           output.push(`...`)
           wasElipsisLast = true


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Use `Array.includes()` to check for existence.
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
