### PR TITLE
[docs] Fix 404 link to Shopify starter

### DIFF
--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -193,4 +193,4 @@ exports.createPages = async ({ graphql, actions }) => {
 
 ## Additional Resources
 
-- [Gatsby Shopify Starter](/starters/AlexanderProd/gatsby-shopify-starter/)
+- [Gatsby Shopify Starter](https://github.com/AlexanderProd/gatsby-shopify-starter)


### PR DESCRIPTION
## Description

The current link to the Shopify Starter 404's. Updating the link to point at the right URL.

## Related Issues

I could not find a related issue!