### PR TITLE
Provide a semantic error in Gatsby-Image components to non-TypeScript users when `onClick` props are added

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -414,6 +414,11 @@ class Image extends React.Component {
       itemProp,
     }
 
+    if (this.props.onClick)
+      throw new Error(
+        `'onClick' event handlers are not allowed for accessibility reasons.`
+      )
+
     if (fluid) {
       const imageVariants = fluid
       const image = imageVariants[0]

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -414,10 +414,11 @@ class Image extends React.Component {
       itemProp,
     }
 
-    if (this.props.onClick)
+    if (this.props.onClick) {
       throw new Error(
         `'onClick' event handlers are not allowed for accessibility reasons.`
       )
+    }
 
     if (fluid) {
       const imageVariants = fluid


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

This throws an error during the render method of gatsby-image components if someone tries to add an invalid `onClick` prop. `onClick` props were removed in https://github.com/gatsbyjs/gatsby/pull/19458 for accessibility reasons. The version was only incremented for a bug fix, but it should've been at least a minor version change due to it being breaking. 

I would've incremented the version myself, but I think Lerna handles in some fashion so I left it alone.

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/19458 and https://github.com/gatsbyjs/gatsby/issues/18468
