### PR TITLE
fix(docs): update link to using-gatsby-without-graphql example

### DIFF
--- a/examples/using-local-plugins/README.md
+++ b/examples/using-local-plugins/README.md
@@ -6,7 +6,7 @@ You might also be interested in the docs section on [local plugins](/docs/creati
 
 ## Using Gatsby's GraphQL integration layer
 
-This example site is also intended as a direct comparison to the [using-unstructured-data example](../using-unstructured-data), which illustrates how to use an "unstructured data" approach (or, without making use of the GraphQL integration layer).
+This example site is also intended as a direct comparison to the [using-gatsby-without-graphql](../using-gatsby-without-graphql), which illustrates how to use an "unstructured data" approach (or, without making use of the GraphQL integration layer).
 
 ## Sourcing data using a local plugin
 
@@ -16,4 +16,4 @@ This example uses a [local plugin](/docs/loading-plugins-from-your-local-plugins
 2. Process that data into Gatsby's node format
 3. Use the [`createNode` action](/docs/actions/#createNode) to add the data to Gatsby’s GraphQL layer
 
-The [`gatsby-node.js` file](https://github.com/jlengstorf/gatsby-with-unstructured-data/blob/using-gatsby-data-layer/plugins/gatsby-source-pokeapi/gatsby-node.js) of the local plugin includes detailed comments on the process.
+The [`gatsby-node.js` file](./plugins/gatsby-source-pokeapi/gatsby-node.js) of the local plugin includes detailed comments on the process.


### PR DESCRIPTION
## Description

Two of the examples link to each other, and one of them was renamed; this fixes a lingering dead-link.

## Related Issues

Related to #10904, #10782

Thanks!
