### PR TITLE
added deploying-to-dokku

### DIFF
--- a/docs/docs/deploying-to-dokku.md
+++ b/docs/docs/deploying-to-dokku.md
@@ -4,14 +4,14 @@ title: Deploying to Dokku
 
 Deploying Gatsby to Dokku is very similar to [Deploying to Heroku](/docs/deploying-to-heroku), with a few minor changes.
 
-As with deploying to Heroku, you will need both the [nodejs](https://github.com/heroku/heroku-buildpack-nodejs.git) and [static](https://github.com/heroku/heroku-buildpack-static) buildpacks.  Unlike for Heroku, this is done with a `.buildpacks` file.  In your project's root directory, create the file with the following contents:
+As with deploying to Heroku, you will need both the [nodejs](https://github.com/heroku/heroku-buildpack-nodejs.git) and [static](https://github.com/heroku/heroku-buildpack-static) buildpacks. Unlike for Heroku, this is done with a `.buildpacks` file. In your project's root directory, create the file with the following contents:
 
 ```text:title=.buildpacks
 https://github.com/heroku/heroku-buildpack-nodejs.git
 https://github.com/heroku/heroku-buildpack-static.git
 ```
 
-The rest of the steps are identical to Heroku's instructions.  In particular, make sure that you have a `build` or `heroku-post-build` so that Dokku builds your site before deploying. See [Customizing the build process](https://devcenter.heroku.com/articles/nodejs-support#customizing-the-build-process) for more details.
+The rest of the steps are identical to Heroku's instructions. In particular, make sure that you have a `build` or `heroku-post-build` so that Dokku builds your site before deploying. See [Customizing the build process](https://devcenter.heroku.com/articles/nodejs-support#customizing-the-build-process) for more details.
 
 ```json:title=package.json
 {
@@ -46,4 +46,3 @@ Similarly, create a `static.json` file in your project's root directory accordin
   "error_page": "404.html"
 }
 ```
-

--- a/docs/docs/deploying-to-dokku.md
+++ b/docs/docs/deploying-to-dokku.md
@@ -1,0 +1,49 @@
+---
+title: Deploying to Dokku
+---
+
+Deploying Gatsby to Dokku is very similar to [Deploying to Heroku](/docs/deploying-to-heroku), with a few minor changes.
+
+As with deploying to Heroku, you will need both the [nodejs](https://github.com/heroku/heroku-buildpack-nodejs.git) and [static](https://github.com/heroku/heroku-buildpack-static) buildpacks.  Unlike for Heroku, this is done with a `.buildpacks` file.  In your project's root directory, create the file with the following contents:
+
+```text:title=.buildpacks
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-static.git
+```
+
+The rest of the steps are identical to Heroku's instructions.  In particular, make sure that you have a `build` or `heroku-post-build` so that Dokku builds your site before deploying. See [Customizing the build process](https://devcenter.heroku.com/articles/nodejs-support#customizing-the-build-process) for more details.
+
+```json:title=package.json
+{
+  "scripts": {
+    "build": "gatsby build"
+  }
+}
+```
+
+Similarly, create a `static.json` file in your project's root directory according to the [heroku-buildpack-static](https://github.com/heroku/heroku-buildpack-static#configuration) configuration documentaion. For example:
+
+```json:title=static.json
+{
+  "root": "public/",
+  "headers": {
+    "/**": {
+      "Cache-Control": "public, max-age=0, must-revalidate"
+    },
+    "/**.css": {
+      "Cache-Control": "public, max-age=31536000, immutable"
+    },
+    "/**.js": {
+      "Cache-Control": "public, max-age=31536000, immutable"
+    },
+    "/static/**": {
+      "Cache-Control": "public, max-age=31536000, immutable"
+    },
+    "/icons/*.png": {
+      "Cache-Control": "public, max-age=31536000, immutable"
+    }
+  },
+  "error_page": "404.html"
+}
+```
+

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -49,6 +49,9 @@
             - title: Deploying to Heroku
               link: /docs/deploying-to-heroku/
               breadcrumbTitle: Heroku
+            - title: Deploying to Dokku
+              link: /docs/deploying-to-dokku/
+              breadcrumbTitle: Dokku
             - title: Deploying to ZEIT Now
               link: /docs/deploying-to-zeit-now/
               breadcrumbTitle: ZEIT Now


### PR DESCRIPTION
## Description

Added a Deploying to Dokku page. ([Dokku](https://github.com/dokku/dokku) is a self-hosted Heroku-like PaaS). It is 80% the same as the Heroku page, with one substantive change regarding the specification of buildpacks.

## Related Issues

I did not file any issues for this.