### PR TITLE
chore(starters): add gatsby-eth-dapp-starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -4546,3 +4546,32 @@
     - Styled Components
     - Code syntax highlighting
     - Light/Dark mode
+- url: https://gatsby-eth-dapp-starter.netlify.com
+  repo: https://github.com/robsecord/gatsby-eth-dapp-starter
+  description: Gatsby Starter for Ethereum Dapps using Web3 with Multiple Account Management Integrations
+  tags:
+    - SEO
+    - Netlify
+    - Image Sharp
+    - Web3
+    - Ethereum
+    - Dapp
+    - Coinbase
+    - Fortmatic
+    - Torus
+    - Portis
+    - Uport
+    - Authereum
+    - Bitski
+    - Metamask
+    - SquareLink
+    - WalletConnect
+    - Ledger
+    - Trezor
+    - dFuse
+    - Rimble
+  features:
+    - Ethereum Web3 Authentication - Multiple Integrations
+    - ConsenSys Rimble UI Integration
+    - Styled Components
+    - Client-side App


### PR DESCRIPTION
Gatsby Starter for Ethereum Dapps using Web3 with Multiple Account Management Integrations