### PR TITLE
swap  broken link

### DIFF
--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -28,7 +28,7 @@ date: 2019-01-29
 # Hello, world!
 ```
 
-Which can then be [queried with GraphQL](/docs/querying-with-graphql/):
+Which can then be [queried with GraphQL](/docs/page-query/):
 
 ```graphql
 query {

--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -28,7 +28,7 @@ date: 2019-01-29
 # Hello, world!
 ```
 
-Which can then be [queried with GraphQL](/docs/page-query/):
+Which can then be [queried with GraphQL](/docs/graphql-concepts/):
 
 ```graphql
 query {


### PR DESCRIPTION
## Description
- The link on this page for 'queried with GraphQL' was returning a Page Not Found.
- From the DOM "\<a href="/docs/querying-with-graphql/" class="css-0">queried with GraphQL</a>"
- In the mdx file I swapped the link from `/docs/querying-with-graphql/` to this working link `/docs/page-query/` 

<!--
- I am a first time contributor. I read the docs and I hope this is the right way to do this. If I can/should do something differently please let me know. Thank you and thank you for Gatsby!
-->
