### PR TITLE
chore(gatsby-theme-notes): Adjust directory-list margin

### DIFF
--- a/packages/gatsby-theme-notes/src/components/directory-list.js
+++ b/packages/gatsby-theme-notes/src/components/directory-list.js
@@ -19,8 +19,8 @@ export default ({ directories }) =>
                 alignItems: `center`,
               }}
             >
-              <Folder style={{ marginRight: `10px` }} />
-              <span>{key}</span>
+              <Folder style={{ marginRight: `5px` }} />
+              <span style={{ marginRight: `15px` }}>{key}</span>
             </Box>
           </Styled.a>
         ))}

--- a/packages/gatsby-theme-notes/src/components/directory-list.js
+++ b/packages/gatsby-theme-notes/src/components/directory-list.js
@@ -9,17 +9,19 @@ export default ({ directories }) =>
     <>
       <Box py={3} style={{ display: `flex`, flexWrap: `wrap` }}>
         {Object.entries(directories).map(([key, value]) => (
-          <Styled.a
-            as={Link}
-            key={key}
-            to={value[0].pagePath}
-            style={{
-              display: `flex`,
-              alignItems: `center`,
-            }}
-          >
-            <Folder style={{ marginRight: `5px` }} />
-            <span style={{ marginRight: `15px` }}>{key}</span>
+          <Styled.a as={Link} key={key} to={value[0].pagePath}>
+            <Box
+              w={[1, 2, 2]}
+              p={3}
+              key={key}
+              style={{
+                display: `flex`,
+                alignItems: `center`,
+              }}
+            >
+              <Folder style={{ marginRight: `5px` }} />
+              <span style={{ marginRight: `15px` }}>{key}</span>
+            </Box>
           </Styled.a>
         ))}
       </Box>

--- a/packages/gatsby-theme-notes/src/components/directory-list.js
+++ b/packages/gatsby-theme-notes/src/components/directory-list.js
@@ -9,7 +9,12 @@ export default ({ directories }) =>
     <>
       <Box py={3} style={{ display: `flex`, flexWrap: `wrap` }}>
         {Object.entries(directories).map(([key, value]) => (
-          <Styled.a as={Link} key={key} to={value[0].pagePath}>
+          <Styled.a
+            as={Link}
+            key={key}
+            to={value[0].pagePath}
+            style={{ marginRight: `15px` }}
+          >
             <Box
               w={[1, 2, 2]}
               p={3}
@@ -20,7 +25,7 @@ export default ({ directories }) =>
               }}
             >
               <Folder style={{ marginRight: `5px` }} />
-              <span style={{ marginRight: `15px` }}>{key}</span>
+              <span>{key}</span>
             </Box>
           </Styled.a>
         ))}

--- a/packages/gatsby-theme-notes/src/components/directory-list.js
+++ b/packages/gatsby-theme-notes/src/components/directory-list.js
@@ -9,19 +9,17 @@ export default ({ directories }) =>
     <>
       <Box py={3} style={{ display: `flex`, flexWrap: `wrap` }}>
         {Object.entries(directories).map(([key, value]) => (
-          <Styled.a as={Link} key={key} to={value[0].pagePath}>
-            <Box
-              w={[1, 2, 2]}
-              p={3}
-              key={key}
-              style={{
-                display: `flex`,
-                alignItems: `center`,
-              }}
-            >
-              <Folder style={{ marginRight: `5px` }} />
-              <span style={{ marginRight: `15px` }}>{key}</span>
-            </Box>
+          <Styled.a
+            as={Link}
+            key={key}
+            to={value[0].pagePath}
+            style={{
+              display: `flex`,
+              alignItems: `center`,
+            }}
+          >
+            <Folder style={{ marginRight: `5px` }} />
+            <span style={{ marginRight: `15px` }}>{key}</span>
           </Styled.a>
         ))}
       </Box>


### PR DESCRIPTION
## Description

Minor improvement of look of directory list in /notes page of gatsby-theme-notes 

Made the label and associated folder stay closer to each other and separated them from other folders - see images below.

Current:
![Screenshot 2019-11-24 at 1 21 34 PM](https://user-images.githubusercontent.com/44570539/69494592-ddbd4d00-0ebd-11ea-8957-7d4038a33ec0.jpg)

After adjustment:
![Screenshot 2019-11-24 at 1 21 09 PM](https://user-images.githubusercontent.com/44570539/69494594-e01fa700-0ebd-11ea-977a-d8445149f8a3.jpg)
