### PR TITLE
feat(gatsby-transformer-remark, gatsby-plugin-mdx) Make timeToRead configurable

### DIFF
--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -128,6 +128,7 @@ scope, and more.
 | [`rehypePlugins`](#rehype-plugins)                                        | `[]`                                   | Specify rehype plugins                                                |
 | [`mediaTypes`](#media-types)                                              | `["text/markdown", "text/x-markdown"]` | Determine which media types are processed by MDX                      |
 | [`shouldBlockNodeFromTransformation`](#shouldblocknodefromtransformation) | `(node) => false`                      | Disable MDX transformation for nodes where this function returns true |
+| [`timeToRead`](#time-to-read)                                             | `wordCount => wordCount / 265`         | Calculate `timeToRead` from the word count, MDX node, and MDX AST     |
 
 #### Extensions
 
@@ -450,6 +451,27 @@ module.exports = {
               path.parse(node.dir).dir.endsWith(`packages`))
           )
         },
+      },
+    },
+  ],
+}
+```
+
+#### Time to read
+
+Calculating the time to read a Markdown document based on the word
+count or Markdown node. This is useful for customizing the time to
+read a document based on a faster or slower words per minute reading
+rate or by custom heuristics based on the markdown node.
+
+```js
+// gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-mdx`,
+      options: {
+        timeToRead: (wordCount, mdxNode) => wordCount / 42,
       },
     },
   ],

--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -128,7 +128,7 @@ scope, and more.
 | [`rehypePlugins`](#rehype-plugins)                                        | `[]`                                   | Specify rehype plugins                                                |
 | [`mediaTypes`](#media-types)                                              | `["text/markdown", "text/x-markdown"]` | Determine which media types are processed by MDX                      |
 | [`shouldBlockNodeFromTransformation`](#shouldblocknodefromtransformation) | `(node) => false`                      | Disable MDX transformation for nodes where this function returns true |
-| [`timeToRead`](#time-to-read)                                             | `wordCount => wordCount / 265`         | Calculate `timeToRead` from the word count, MDX node, and MDX AST     |
+| [`timeToRead`](#time-to-read)                                             | `wordCount => wordCount / 265`         | Calculate `timeToRead` from the word count, html, and raw MDX content |
 
 #### Extensions
 
@@ -471,7 +471,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
-        timeToRead: (wordCount, mdxNode) => wordCount / 42,
+        timeToRead: (wordCount, html, rawMDX) => wordCount / 42,
       },
     },
   ],

--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -126,6 +126,29 @@ module.exports = (
       ...helpers,
     })
 
+  async function getHTML(mdxNode) {
+    if (mdxNode.html) {
+      return Promise.resolve(mdxNode.html)
+    }
+    const { body } = await processMDX({ node: mdxNode })
+    try {
+      if (!mdxHTMLLoader) {
+        mdxHTMLLoader = loader({ reporter, cache, store })
+      }
+      const html = await mdxHTMLLoader.load({ ...mdxNode, body })
+      return html
+    } catch (e) {
+      reporter.error(
+        `gatsby-plugin-mdx: Error querying the \`html\` field.
+        This field is intended for use with RSS feed generation.
+        If you're trying to use it in application-level code, try querying for \`Mdx.body\` instead.
+        Original error:
+        ${e}`
+      )
+      return undefined
+    }
+  };
+
   // New Code // Schema
   const MdxType = schema.buildObjectType({
     name: `Mdx`,
@@ -202,26 +225,7 @@ module.exports = (
       html: {
         type: `String`,
         async resolve(mdxNode) {
-          if (mdxNode.html) {
-            return Promise.resolve(mdxNode.html)
-          }
-          const { body } = await processMDX({ node: mdxNode })
-          try {
-            if (!mdxHTMLLoader) {
-              mdxHTMLLoader = loader({ reporter, cache, store })
-            }
-            const html = await mdxHTMLLoader.load({ ...mdxNode, body })
-            return html
-          } catch (e) {
-            reporter.error(
-              `gatsby-plugin-mdx: Error querying the \`html\` field.
-This field is intended for use with RSS feed generation.
-If you're trying to use it in application-level code, try querying for \`Mdx.body\` instead.
-Original error:
-${e}`
-            )
-            return undefined
-          }
+          return await getHTML(mdxNode)
         },
       },
       mdxAST: {
@@ -249,7 +253,8 @@ ${e}`
       timeToRead: {
         type: `Int`,
         async resolve(mdxNode) {
-          const { mdast } = await processMDX({ node: mdxNode })
+          const html = await getHTML(mdxNode)
+          const { mdast, body } = await processMDX({ node: mdxNode })
           const { words } = await getCounts({ mdast })
           const { timeToRead } = pluginOptions
           const avgWPM = 265
@@ -257,7 +262,7 @@ ${e}`
             1,
             Math.round(
               _.isFunction(timeToRead)
-                ? timeToRead(words, mdxNode)
+                ? timeToRead(words, html, body)
                 : words / avgWPM
             )
           )

--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -251,13 +251,17 @@ ${e}`
         async resolve(mdxNode) {
           const { mdast } = await processMDX({ node: mdxNode })
           const { words } = await getCounts({ mdast })
-          let timeToRead = 0
+          const { timeToRead } = pluginOptions
           const avgWPM = 265
-          timeToRead = Math.round(words / avgWPM)
-          if (timeToRead === 0) {
-            timeToRead = 1
-          }
-          return timeToRead
+          const timeToReadInMinutes = Math.max(
+            1,
+            Math.round(
+              _.isFunction(timeToRead)
+                ? timeToRead(words, mdxNode)
+                : words / avgWPM
+            )
+          )
+          return timeToReadInMinutes
         },
       },
       wordCount: {

--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -147,7 +147,7 @@ module.exports = (
       )
       return undefined
     }
-  };
+  }
 
   // New Code // Schema
   const MdxType = schema.buildObjectType({

--- a/packages/gatsby-transformer-remark/.gitignore
+++ b/packages/gatsby-transformer-remark/.gitignore
@@ -1,3 +1,2 @@
 /*.js
 !index.js
-utils

--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -22,6 +22,8 @@ plugins: [
       pedantic: true,
       // GitHub Flavored Markdown mode (default: true)
       gfm: true,
+      // Calculate timeToRead in minutes using word count, sanitized html, and/or raw Markdown content. (default: wordCount / 265)
+      timeToRead: (wordCount, html, md) => wordCount / 42
       // Plugins configs
       plugins: [],
     },

--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -22,8 +22,8 @@ plugins: [
       pedantic: true,
       // GitHub Flavored Markdown mode (default: true)
       gfm: true,
-      // Calculate timeToRead in minutes using word count, sanitized html, and/or raw Markdown content. (default: wordCount / 265)
-      timeToRead: (wordCount, html, md) => wordCount / 42
+      // Calculate timeToRead in minutes using word count, sanitized html, and raw Markdown content. (default: wordCount / 265)
+      timeToRead: (wordCount, html, rawMD) => wordCount / 42
       // Plugins configs
       plugins: [],
     },

--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -683,6 +683,15 @@ Object {
 }
 `;
 
+exports[`Wordcount and timeToRead are generated correctly from schema correctly uses a custom value for timeToRead 1`] = `
+Object {
+  "frontmatter": Object {
+    "title": "my little pony",
+  },
+  "timeToRead": 9,
+}
+`;
+
 exports[`Wordcount and timeToRead are generated correctly from schema correctly uses a default value for timeToRead 1`] = `
 Object {
   "frontmatter": Object {

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -916,6 +916,20 @@ date: "2017-09-18T23:19:51.246Z"
       expect(node.timeToRead).toBe(1)
     }
   )
+
+  bootstrapTest(
+    `correctly uses a custom value for timeToRead`,
+    `${content}\nWhere oh where is my little pony?\n`,
+    `timeToRead
+    frontmatter {
+        title
+    }`,
+    node => {
+      expect(node).toMatchSnapshot()
+      expect(node.timeToRead).toBe(9)
+    },
+    { pluginOptions: { timeToRead: wordCount => wordCount / 1 } }
+  )
 })
 
 describe(`Table of contents is generated correctly from schema`, () => {

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -21,7 +21,7 @@ const {
   findLastTextNode,
 } = require(`./hast-processing`)
 const codeHandler = require(`./code-handler`)
-const { timeToRead } = require(`./utils/time-to-read`)
+const { calculateTimeToRead } = require(`./utils/time-to-read`)
 
 let fileNodes
 let pluginsCacheStr = ``
@@ -112,7 +112,7 @@ module.exports = (
         heading: null,
         maxDepth: 6,
       },
-      timeToRead: calcTimeToRead = null,
+      timeToRead = null,
     } = pluginOptions
     const tocOptions = tableOfContents
     const remarkOptions = {
@@ -619,7 +619,7 @@ module.exports = (
         type: `Int`,
         resolve(markdownNode) {
           return getHTML(markdownNode).then(html =>
-            timeToRead(markdownNode, html, calcTimeToRead)
+            calculateTimeToRead(markdownNode, html, timeToRead)
           )
         },
       },

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -1,57 +1,57 @@
-const Remark = require(`remark`);
-const select = require(`unist-util-select`);
-const _ = require(`lodash`);
-const visit = require(`unist-util-visit`);
-const toHAST = require(`mdast-util-to-hast`);
-const hastToHTML = require(`hast-util-to-html`);
-const mdastToToc = require(`mdast-util-toc`);
-const mdastToString = require(`mdast-util-to-string`);
-const Promise = require(`bluebird`);
-const unified = require(`unified`);
-const parse = require(`remark-parse`);
-const stringify = require(`remark-stringify`);
-const english = require(`retext-english`);
-const remark2retext = require(`remark-retext`);
-const stripPosition = require(`unist-util-remove-position`);
-const hastReparseRaw = require(`hast-util-raw`);
-const prune = require(`underscore.string/prune`);
+const Remark = require(`remark`)
+const select = require(`unist-util-select`)
+const _ = require(`lodash`)
+const visit = require(`unist-util-visit`)
+const toHAST = require(`mdast-util-to-hast`)
+const hastToHTML = require(`hast-util-to-html`)
+const mdastToToc = require(`mdast-util-toc`)
+const mdastToString = require(`mdast-util-to-string`)
+const Promise = require(`bluebird`)
+const unified = require(`unified`)
+const parse = require(`remark-parse`)
+const stringify = require(`remark-stringify`)
+const english = require(`retext-english`)
+const remark2retext = require(`remark-retext`)
+const stripPosition = require(`unist-util-remove-position`)
+const hastReparseRaw = require(`hast-util-raw`)
+const prune = require(`underscore.string/prune`)
 const {
   getConcatenatedValue,
   cloneTreeUntil,
   findLastTextNode,
-} = require(`./hast-processing`);
-const codeHandler = require(`./code-handler`);
-const { timeToRead } = require(`./utils/time-to-read`);
+} = require(`./hast-processing`)
+const codeHandler = require(`./code-handler`)
+const { timeToRead } = require(`./utils/time-to-read`)
 
-let fileNodes;
-let pluginsCacheStr = ``;
-let pathPrefixCacheStr = ``;
+let fileNodes
+let pluginsCacheStr = ``
+let pathPrefixCacheStr = ``
 const astCacheKey = node =>
-  `transformer-remark-markdown-ast-${node.internal.contentDigest}-${pluginsCacheStr}-${pathPrefixCacheStr}`;
+  `transformer-remark-markdown-ast-${node.internal.contentDigest}-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const htmlCacheKey = node =>
-  `transformer-remark-markdown-html-${node.internal.contentDigest}-${pluginsCacheStr}-${pathPrefixCacheStr}`;
+  `transformer-remark-markdown-html-${node.internal.contentDigest}-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const htmlAstCacheKey = node =>
-  `transformer-remark-markdown-html-ast-${node.internal.contentDigest}-${pluginsCacheStr}-${pathPrefixCacheStr}`;
+  `transformer-remark-markdown-html-ast-${node.internal.contentDigest}-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const headingsCacheKey = node =>
-  `transformer-remark-markdown-headings-${node.internal.contentDigest}-${pluginsCacheStr}-${pathPrefixCacheStr}`;
+  `transformer-remark-markdown-headings-${node.internal.contentDigest}-${pluginsCacheStr}-${pathPrefixCacheStr}`
 const tableOfContentsCacheKey = (node, appliedTocOptions) =>
   `transformer-remark-markdown-toc-${
-  node.internal.contentDigest
+    node.internal.contentDigest
   }-${pluginsCacheStr}-${JSON.stringify(
     appliedTocOptions
-  )}-${pathPrefixCacheStr}`;
+  )}-${pathPrefixCacheStr}`
 
 // ensure only one `/` in new url
 const withPathPrefix = (url, pathPrefix) =>
-  (pathPrefix + url).replace(/\/\//, `/`);
+  (pathPrefix + url).replace(/\/\//, `/`)
 
 // TODO: remove this check with next major release
 const safeGetCache = ({ getCache, cache }) => id => {
   if (!getCache) {
-    return cache;
+    return cache
   }
-  return getCache(id);
-};
+  return getCache(id)
+}
 
 /**
  * Map that keeps track of generation of AST to not generate it multiple
@@ -59,7 +59,7 @@ const safeGetCache = ({ getCache, cache }) => id => {
  *
  * @type {Map<string,Promise>}
  */
-const ASTPromiseMap = new Map();
+const ASTPromiseMap = new Map()
 
 /**
  * Set of all Markdown node types which, when encountered, generate an extra to
@@ -72,12 +72,12 @@ const SpaceMarkdownNodeTypesSet = new Set([
   `heading`,
   `tableCell`,
   `break`,
-]);
+])
 
 const headingLevels = [...Array(6).keys()].reduce((acc, i) => {
-  acc[`h${i}`] = i;
-  return acc;
-}, {});
+  acc[`h${i}`] = i
+  return acc
+}, {})
 
 module.exports = (
   {
@@ -93,12 +93,12 @@ module.exports = (
   pluginOptions
 ) => {
   if (type.name !== `MarkdownRemark`) {
-    return {};
+    return {}
   }
-  pluginsCacheStr = pluginOptions.plugins.map(p => p.name).join(``);
-  pathPrefixCacheStr = basePath || ``;
+  pluginsCacheStr = pluginOptions.plugins.map(p => p.name).join(``)
+  pathPrefixCacheStr = basePath || ``
 
-  const getCache = safeGetCache({ cache, getCache: possibleGetCache });
+  const getCache = safeGetCache({ cache, getCache: possibleGetCache })
 
   return new Promise((resolve, reject) => {
     // Setup Remark.
@@ -112,57 +112,57 @@ module.exports = (
         heading: null,
         maxDepth: 6,
       },
-      timeToRead = null,
-    } = pluginOptions;
-    const tocOptions = tableOfContents;
+      timeToRead: calcTimeToRead = null,
+    } = pluginOptions
+    const tocOptions = tableOfContents
     const remarkOptions = {
       commonmark,
       footnotes,
       gfm,
       pedantic,
-    };
-    if (_.isArray(blocks)) {
-      remarkOptions.blocks = blocks;
     }
-    let remark = new Remark().data(`settings`, remarkOptions);
+    if (_.isArray(blocks)) {
+      remarkOptions.blocks = blocks
+    }
+    let remark = new Remark().data(`settings`, remarkOptions)
 
     for (let plugin of pluginOptions.plugins) {
-      const requiredPlugin = require(plugin.resolve);
+      const requiredPlugin = require(plugin.resolve)
       if (_.isFunction(requiredPlugin.setParserPlugins)) {
         for (let parserPlugin of requiredPlugin.setParserPlugins(
           plugin.pluginOptions
         )) {
           if (_.isArray(parserPlugin)) {
-            const [parser, options] = parserPlugin;
-            remark = remark.use(parser, options);
+            const [parser, options] = parserPlugin
+            remark = remark.use(parser, options)
           } else {
-            remark = remark.use(parserPlugin);
+            remark = remark.use(parserPlugin)
           }
         }
       }
     }
 
     async function getAST(markdownNode) {
-      const cacheKey = astCacheKey(markdownNode);
-      const cachedAST = await cache.get(cacheKey);
+      const cacheKey = astCacheKey(markdownNode)
+      const cachedAST = await cache.get(cacheKey)
       if (cachedAST) {
-        return cachedAST;
+        return cachedAST
       } else if (ASTPromiseMap.has(cacheKey)) {
         // We are already generating AST, so let's wait for it
-        return await ASTPromiseMap.get(cacheKey);
+        return await ASTPromiseMap.get(cacheKey)
       } else {
-        const ASTGenerationPromise = getMarkdownAST(markdownNode);
+        const ASTGenerationPromise = getMarkdownAST(markdownNode)
         ASTGenerationPromise.then(markdownAST => {
-          ASTPromiseMap.delete(cacheKey);
-          return cache.set(cacheKey, markdownAST);
+          ASTPromiseMap.delete(cacheKey)
+          return cache.set(cacheKey, markdownAST)
         }).catch(err => {
-          ASTPromiseMap.delete(cacheKey);
-          return err;
-        });
+          ASTPromiseMap.delete(cacheKey)
+          return err
+        })
         // Save new AST to cache and return
         // We can now release promise, as we cached result
-        ASTPromiseMap.set(cacheKey, ASTGenerationPromise);
-        return ASTGenerationPromise;
+        ASTPromiseMap.set(cacheKey, ASTGenerationPromise)
+        return ASTGenerationPromise
       }
     }
 
@@ -190,23 +190,23 @@ module.exports = (
             node.url.startsWith(`/`) &&
             !node.url.startsWith(`//`)
           ) {
-            node.url = withPathPrefix(node.url, basePath);
+            node.url = withPathPrefix(node.url, basePath)
           }
-        });
+        })
       }
 
       if (process.env.NODE_ENV !== `production` || !fileNodes) {
-        fileNodes = getNodesByType(`File`);
+        fileNodes = getNodesByType(`File`)
       }
       // Use Bluebird's Promise function "each" to run remark plugins serially.
       await Promise.each(pluginOptions.plugins, plugin => {
-        const requiredPlugin = require(plugin.resolve);
+        const requiredPlugin = require(plugin.resolve)
         // Allow both exports = function(), and exports.default = function()
         const defaultFunction = _.isFunction(requiredPlugin)
           ? requiredPlugin
           : _.isFunction(requiredPlugin.default)
-            ? requiredPlugin.default
-            : undefined;
+          ? requiredPlugin.default
+          : undefined
 
         if (defaultFunction) {
           return defaultFunction(
@@ -223,13 +223,13 @@ module.exports = (
               ...rest,
             },
             plugin.pluginOptions
-          );
+          )
         } else {
-          return Promise.resolve();
+          return Promise.resolve()
         }
-      });
+      })
 
-      return markdownAST;
+      return markdownAST
     }
 
     async function getMarkdownAST(markdownNode) {
@@ -265,37 +265,37 @@ module.exports = (
     }
 
     async function getHeadings(markdownNode) {
-      const cachedHeadings = await cache.get(headingsCacheKey(markdownNode));
+      const cachedHeadings = await cache.get(headingsCacheKey(markdownNode))
       if (cachedHeadings) {
-        return cachedHeadings;
+        return cachedHeadings
       } else {
-        const ast = await getAST(markdownNode);
+        const ast = await getAST(markdownNode)
         const headings = select(ast, `heading`).map(heading => {
           return {
             value: mdastToString(heading),
             depth: heading.depth,
-          };
-        });
+          }
+        })
 
-        cache.set(headingsCacheKey(markdownNode), headings);
-        return headings;
+        cache.set(headingsCacheKey(markdownNode), headings)
+        return headings
       }
     }
 
     async function getTableOfContents(markdownNode, gqlTocOptions) {
       // fetch defaults
-      let appliedTocOptions = { ...tocOptions, ...gqlTocOptions };
+      let appliedTocOptions = { ...tocOptions, ...gqlTocOptions }
       // get cached toc
       const cachedToc = await cache.get(
         tableOfContentsCacheKey(markdownNode, appliedTocOptions)
-      );
+      )
       if (cachedToc) {
-        return cachedToc;
+        return cachedToc
       } else {
-        const ast = await getAST(markdownNode);
-        const tocAst = mdastToToc(ast, appliedTocOptions);
+        const ast = await getAST(markdownNode)
+        const tocAst = mdastToToc(ast, appliedTocOptions)
 
-        let toc;
+        let toc
         if (tocAst.map) {
           const addSlugToUrl = function (node) {
             if (node.url) {
@@ -305,8 +305,8 @@ module.exports = (
               ) {
                 console.warn(
                   `Skipping TableOfContents. Field '${appliedTocOptions.pathToSlugField}' missing from markdown node`
-                );
-                return null;
+                )
+                return null
               }
               node.url = [
                 basePath,
@@ -314,28 +314,28 @@ module.exports = (
                 node.url,
               ]
                 .join(`/`)
-                .replace(/\/\//g, `/`);
+                .replace(/\/\//g, `/`)
             }
             if (node.children) {
               node.children = node.children
                 .map(node => addSlugToUrl(node))
-                .filter(Boolean);
+                .filter(Boolean)
             }
 
-            return node;
-          };
+            return node
+          }
           if (appliedTocOptions.absolute) {
-            tocAst.map = addSlugToUrl(tocAst.map);
+            tocAst.map = addSlugToUrl(tocAst.map)
           }
 
           toc = hastToHTML(toHAST(tocAst.map, { allowDangerousHTML: true }), {
             allowDangerousHTML: true,
-          });
+          })
         } else {
-          toc = ``;
+          toc = ``
         }
-        cache.set(tableOfContentsCacheKey(markdownNode, appliedTocOptions), toc);
-        return toc;
+        cache.set(tableOfContentsCacheKey(markdownNode, appliedTocOptions), toc)
+        return toc
       }
     }
 
@@ -347,34 +347,34 @@ module.exports = (
     }
 
     async function getHTMLAst(markdownNode) {
-      const cachedAst = await cache.get(htmlAstCacheKey(markdownNode));
+      const cachedAst = await cache.get(htmlAstCacheKey(markdownNode))
       if (cachedAst) {
-        return cachedAst;
+        return cachedAst
       } else {
         const ast = await getAST(markdownNode)
         const htmlAst = markdownASTToHTMLAst(ast)
 
         // Save new HTML AST to cache and return
-        cache.set(htmlAstCacheKey(markdownNode), htmlAst);
-        return htmlAst;
+        cache.set(htmlAstCacheKey(markdownNode), htmlAst)
+        return htmlAst
       }
     }
 
     async function getHTML(markdownNode) {
       const cachedHTML = await cache.get(htmlCacheKey(markdownNode))
       if (cachedHTML) {
-        return cachedHTML;
+        return cachedHTML
       } else {
-        const ast = await getHTMLAst(markdownNode);
+        const ast = await getHTMLAst(markdownNode)
         // Save new HTML to cache and return
         const html = hastToHTML(ast, {
           allowDangerousHTML: true,
-        });
+        })
 
         // Save new HTML to cache
         cache.set(htmlCacheKey(markdownNode), html)
 
-        return html;
+        return html
       }
     }
 
@@ -388,41 +388,41 @@ module.exports = (
           fullAST,
           ({ nextNode }) =>
             nextNode.type === `raw` && nextNode.value === excerptSeparator
-        );
+        )
       }
       if (!fullAST.children.length) {
-        return fullAST;
+        return fullAST
       }
 
       const excerptAST = cloneTreeUntil(fullAST, ({ root }) => {
-        const totalExcerptSoFar = getConcatenatedValue(root);
-        return totalExcerptSoFar && totalExcerptSoFar.length > pruneLength;
-      });
-      const unprunedExcerpt = getConcatenatedValue(excerptAST);
+        const totalExcerptSoFar = getConcatenatedValue(root)
+        return totalExcerptSoFar && totalExcerptSoFar.length > pruneLength
+      })
+      const unprunedExcerpt = getConcatenatedValue(excerptAST)
       if (
         !unprunedExcerpt ||
         (pruneLength && unprunedExcerpt.length < pruneLength)
       ) {
-        return excerptAST;
+        return excerptAST
       }
 
-      const lastTextNode = findLastTextNode(excerptAST);
-      const amountToPruneBy = unprunedExcerpt.length - pruneLength;
+      const lastTextNode = findLastTextNode(excerptAST)
+      const amountToPruneBy = unprunedExcerpt.length - pruneLength
       const desiredLengthOfLastNode =
-        lastTextNode.value.length - amountToPruneBy;
+        lastTextNode.value.length - amountToPruneBy
       if (!truncate) {
         lastTextNode.value = prune(
           lastTextNode.value,
           desiredLengthOfLastNode,
           `…`
-        );
+        )
       } else {
         lastTextNode.value = _.truncate(lastTextNode.value, {
           length: pruneLength,
           omission: `…`,
-        });
+        })
       }
-      return excerptAST;
+      return excerptAST
     }
 
     async function getExcerptHtml(
@@ -431,16 +431,16 @@ module.exports = (
       truncate,
       excerptSeparator
     ) {
-      const fullAST = await getHTMLAst(markdownNode);
+      const fullAST = await getHTMLAst(markdownNode)
       const excerptAST = await getExcerptAst(fullAST, markdownNode, {
         pruneLength,
         truncate,
         excerptSeparator,
-      });
+      })
       const html = hastToHTML(excerptAST, {
         allowDangerousHTML: true,
-      });
-      return html;
+      })
+      return html
     }
 
     async function getExcerptMarkdown(
@@ -451,9 +451,9 @@ module.exports = (
     ) {
       // if excerptSeparator in options and excerptSeparator in content then we will get an excerpt from grayMatter that we can use
       if (excerptSeparator && markdownNode.excerpt !== ``) {
-        return markdownNode.excerpt;
+        return markdownNode.excerpt
       }
-      const ast = await getMarkdownAST(markdownNode);
+      const ast = await getMarkdownAST(markdownNode)
       const excerptAST = await getExcerptAst(ast, markdownNode, {
         pruneLength,
         truncate,
@@ -470,39 +470,39 @@ module.exports = (
       excerptSeparator
     ) {
       const text = await getAST(markdownNode).then(ast => {
-        let excerptNodes = [];
-        let isBeforeSeparator = true;
+        let excerptNodes = []
+        let isBeforeSeparator = true
         visit(
           ast,
           node => isBeforeSeparator,
           node => {
             if (excerptSeparator && node.value === excerptSeparator) {
-              isBeforeSeparator = false;
+              isBeforeSeparator = false
             } else if (node.type === `text` || node.type === `inlineCode`) {
-              excerptNodes.push(node.value);
+              excerptNodes.push(node.value)
             } else if (node.type === `image`) {
-              excerptNodes.push(node.alt);
+              excerptNodes.push(node.alt)
             } else if (SpaceMarkdownNodeTypesSet.has(node.type)) {
               // Add a space when encountering one of these node types.
-              excerptNodes.push(` `);
+              excerptNodes.push(` `)
             }
           }
-        );
+        )
 
-        const excerptText = excerptNodes.join(``).trim();
+        const excerptText = excerptNodes.join(``).trim()
 
         if (excerptSeparator && !isBeforeSeparator) {
-          return excerptText;
+          return excerptText
         }
         if (!truncate) {
-          return prune(excerptText, pruneLength, `…`);
+          return prune(excerptText, pruneLength, `…`)
         }
         return _.truncate(excerptText, {
           length: pruneLength,
           omission: `…`,
-        });
-      });
-      return text;
+        })
+      })
+      return text
     }
 
     async function getExcerpt(
@@ -515,37 +515,37 @@ module.exports = (
           pruneLength,
           truncate,
           excerptSeparator
-        );
+        )
       } else if (format === `MARKDOWN`) {
         return getExcerptMarkdown(
           markdownNode,
           pruneLength,
           truncate,
           excerptSeparator
-        );
+        )
       }
       return getExcerptPlain(
         markdownNode,
         pruneLength,
         truncate,
         excerptSeparator
-      );
+      )
     }
 
     return resolve({
       html: {
         type: `String`,
         resolve(markdownNode) {
-          return getHTML(markdownNode);
+          return getHTML(markdownNode)
         },
       },
       htmlAst: {
         type: `JSON`,
         resolve(markdownNode) {
           return getHTMLAst(markdownNode).then(ast => {
-            const strippedAst = stripPosition(_.clone(ast), true);
-            return hastReparseRaw(strippedAst);
-          });
+            const strippedAst = stripPosition(_.clone(ast), true)
+            return hastReparseRaw(strippedAst)
+          })
         },
       },
       excerpt: {
@@ -570,7 +570,7 @@ module.exports = (
             pruneLength,
             truncate,
             excerptSeparator: pluginOptions.excerpt_separator,
-          });
+          })
         },
       },
       excerptAst: {
@@ -595,9 +595,9 @@ module.exports = (
               })
             )
             .then(ast => {
-              const strippedAst = stripPosition(_.clone(ast), true);
-              return hastReparseRaw(strippedAst);
-            });
+              const strippedAst = stripPosition(_.clone(ast), true)
+              return hastReparseRaw(strippedAst)
+            })
         },
       },
       headings: {
@@ -607,38 +607,20 @@ module.exports = (
         },
         resolve(markdownNode, { depth }) {
           return getHeadings(markdownNode).then(headings => {
-            const level = depth && headingLevels[depth];
+            const level = depth && headingLevels[depth]
             if (typeof level === `number`) {
-              headings = headings.filter(heading => heading.depth === level);
+              headings = headings.filter(heading => heading.depth === level)
             }
-            return headings;
-          });
+            return headings
+          })
         },
       },
       timeToRead: {
         type: `Int`,
         resolve(markdownNode) {
-          return getHTML(markdownNode).then(html => {
-            const avgWPM = 265;
-            const pureText = sanitizeHTML(html, { allowTags: [] });
-            const wordCount =
-              _.words(pureText).length +
-              _.words(pureText, /[\p{sc=Katakana}\p{sc=Hiragana}\p{sc=Han}]/gu)
-                .length;
-            const timeToReadInMinutes = Math.max(
-              1,
-              Math.round(
-                _.isFunction(timeToRead)
-                  ? timeToRead(
-                    wordCount,
-                    pureText,
-                    markdownNode.rawMarkdownBody
-                  )
-                  : wordCount / avgWPM
-              )
-            );
-            return timeToReadInMinutes;
-          });
+          return getHTML(markdownNode).then(html =>
+            timeToRead(markdownNode, html, calcTimeToRead)
+          )
         },
       },
       tableOfContents: {
@@ -658,38 +640,38 @@ module.exports = (
           heading: `String`,
         },
         resolve(markdownNode, args) {
-          return getTableOfContents(markdownNode, args);
+          return getTableOfContents(markdownNode, args)
         },
       },
       // TODO add support for non-latin languages https://github.com/wooorm/remark/issues/251#issuecomment-296731071
       wordCount: {
         type: `MarkdownWordCount`,
         resolve(markdownNode) {
-          let counts = {};
+          let counts = {}
 
           unified()
             .use(parse)
             .use(remark2retext, unified().use(english).use(count))
             .use(stringify)
-            .processSync(markdownNode.internal.content);
+            .processSync(markdownNode.internal.content)
 
           return {
             paragraphs: counts.ParagraphNode,
             sentences: counts.SentenceNode,
             words: counts.WordNode,
-          };
+          }
 
           function count() {
-            return counter;
+            return counter
             function counter(tree) {
-              visit(tree, visitor);
+              visit(tree, visitor)
               function visitor(node) {
-                counts[node.type] = (counts[node.type] || 0) + 1;
+                counts[node.type] = (counts[node.type] || 0) + 1
               }
             }
           }
         },
       },
-    });
-  });
-};
+    })
+  })
+}

--- a/packages/gatsby-transformer-remark/src/utils/time-to-read.js
+++ b/packages/gatsby-transformer-remark/src/utils/time-to-read.js
@@ -39,7 +39,7 @@ function isCjChar(char) {
   return cjRanges.some(([from, to]) => charCode >= from && charCode < to)
 }
 
-export const timeToRead = (mdNode, html, calcTimeToRead) => {
+export const calculateTimeToRead = (mdNode, html, calcTimeToRead) => {
   const pureText = sanitizeHTML(html, { allowTags: [] })
   const avgWPM = 265
 

--- a/packages/gatsby-transformer-remark/src/utils/time-to-read.js
+++ b/packages/gatsby-transformer-remark/src/utils/time-to-read.js
@@ -39,8 +39,7 @@ function isCjChar(char) {
   return cjRanges.some(([from, to]) => charCode >= from && charCode < to)
 }
 
-export const timeToRead = html => {
-  let timeToRead = 0
+export const timeToRead = (mdNode, html, calcTimeToRead) => {
   const pureText = sanitizeHTML(html, { allowTags: [] })
   const avgWPM = 265
 
@@ -59,9 +58,13 @@ export const timeToRead = html => {
   // on average one word consists of 2 characters in both Chinese and Japanese
   const wordCount = _.words(latinChars.join(``)).length + cjChars.length * 0.56
 
-  timeToRead = Math.round(wordCount / avgWPM)
-  if (timeToRead === 0) {
-    timeToRead = 1
-  }
-  return timeToRead
+  const timeToReadInMinutes = Math.max(
+    1,
+    Math.round(
+      _.isFunction(calcTimeToRead)
+        ? calcTimeToRead(wordCount, pureText, mdNode.rawMarkdownBody)
+        : wordCount / avgWPM
+    )
+  )
+  return timeToReadInMinutes
 }


### PR DESCRIPTION
I've been wanting this for a while (since not everyone reads at 265 wpm) and had some time to work on it this evening.

## Description

This PR makes `timeToRead` calculation user configurable. I went with the simple solution to start.

```js
{ 
  // Mimics a reading rate of 42 words per minute
  timeToRead: (wordCount, html, md) => wordCount / 42
}
```

### More advanced potential solution

It would make sense to give the user more access to the markdown node for more flexible and precise calculation (e.g. code samples and complex graphs). I was thinking this could look like 

```js
{
  timeToRead: (wordCount, { markdownNode, getAST, getMarkdownAST, getHeadings, getTableOfContents, getHTMLAst, getHTML, getExcerptAst, getExcerpt }) => wordCount / 42
}
```

 It essentially gives access to all of the `markdownNode` field resolvers. `wordCount` would now be based off of `markdownNode.rawMarkdownBody` instead of the sanitized HTML. It's more complicated, but gives the user everything they'd need to calculate `timeToRead` as precisely as they'd want.

## Related Issues

Related to https://github.com/gatsbyjs/gatsby/issues/16760. It would allow users to calculate the value in the they want to vs Gatsby building and maintaining a custom one-size-fits-all solution.

## `gatsby-plugin-mdx`

This plugin also has a `timeToRead` that can be updated with the same simple solution. It doesn't look on first glance that it could be updated to support the more advanced solution above though.

