### PR TITLE
fix(gatsby-plugin-preload-fonts): Make sure pathname ends with slash

### DIFF
--- a/packages/gatsby-plugin-preload-fonts/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-preload-fonts/src/gatsby-ssr.js
@@ -19,11 +19,13 @@ exports.onRenderBody = (
   { crossOrigin = `anonymous` } = {}
 ) => {
   const cache = loadCache()
-  if (!cache.assets[pathname]) return
+
+  const pathnameWithSlash = pathname.endsWith(`/`) ? pathname : `${pathname}/`
+  if (!cache.assets[pathnameWithSlash]) return
 
   const props = getLinkProps({ crossOrigin, pathname })
 
-  const assets = Object.keys(cache.assets[pathname])
+  const assets = Object.keys(cache.assets[pathnameWithSlash])
 
   setHeadComponents(
     assets.map(href => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Pathnames in fonts cache ends with slash. This plugin won't work if users remove trailing slashes from pathname e.g. using gatsby-plugin-remove-trailing-slashes.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
