### PR TITLE
fix(gatsby): memoize shadowCreatePagePath to fix performance regression

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/index.js
@@ -8,6 +8,12 @@ const pathWithoutExtension = fullPath => {
   return path.join(parsed.dir, parsed.name)
 }
 
+// TO-DO:
+//  - implement ability to add/remove shadowed modules from the webpack chain as file are being created/deleted
+//    ( https://github.com/gatsbyjs/gatsby/issues/11456 ):
+//    - this will also need to add memo invalidation for page template shadowing:
+//      see memoized `shadowCreatePagePath` function used in `createPage` action creator.
+
 module.exports = class GatsbyThemeComponentShadowingResolverPlugin {
   cache = {}
 

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -20,7 +20,14 @@ const { getCommonDir } = require(`../../utils/path`)
 const apiRunnerNode = require(`../../utils/api-runner-node`)
 const { trackCli } = require(`gatsby-telemetry`)
 const { getNonGatsbyCodeFrame } = require(`../../utils/stack-trace-utils`)
-const shadowCreatePagePath = require(`../../internal-plugins/webpack-theme-component-shadowing/create-page`)
+
+/**
+ * Memoize function used to pick shadowed page components to avoid expensive I/O.
+ *
+ */
+const shadowCreatePagePath = _.memoize(
+  require(`../../internal-plugins/webpack-theme-component-shadowing/create-page`)
+)
 
 const actions = {}
 const isWindows = platform() === `win32`

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -23,7 +23,9 @@ const { getNonGatsbyCodeFrame } = require(`../../utils/stack-trace-utils`)
 
 /**
  * Memoize function used to pick shadowed page components to avoid expensive I/O.
- *
+ * Ideally, we should invalidate memoized values if there are any FS operations
+ * on files that are in shadowing chain, but webpack currently doesn't handle
+ * shadowing changes during develop session, so no invalidation is not a deal breaker.
  */
 const shadowCreatePagePath = _.memoize(
   require(`../../internal-plugins/webpack-theme-component-shadowing/create-page`)


### PR DESCRIPTION
This memoize `shadowCreatePagePath` in `actions.createPage` to avoid rerunning it for same inputs.

This is not ideal, because we could have memoized potentially stale output, but webpack part of shadowing doesn't invalidate when there are changes in shadowing chain right now, so it's acceptable.

This will need memo cache busting when webpack part will be looked at