### PR TITLE
fix(gatsby): Call cwd() when called instead of on import

### DIFF
--- a/packages/gatsby/src/redux/persist.js
+++ b/packages/gatsby/src/redux/persist.js
@@ -1,10 +1,11 @@
 const v8 = require(`v8`)
 const fs = require(`fs-extra`)
 
-const file = `${process.cwd()}/.cache/redux.state`
+const file = () => `${process.cwd()}/.cache/redux.state`
 
-const readFromCache = () => v8.deserialize(fs.readFileSync(file))
+const readFromCache = () => v8.deserialize(fs.readFileSync(file()))
 
-const writeToCache = contents => fs.writeFileSync(file, v8.serialize(contents))
+const writeToCache = contents =>
+  fs.writeFileSync(file(), v8.serialize(contents))
 
 module.exports = { readFromCache, writeToCache }


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
Currently, when redux persists its state, the path to the state file is generated when the file is imported.

https://github.com/gatsbyjs/gatsby/blob/a0094f4325bce73cf8be9aaad3408b8a6a7195d1/packages/gatsby/src/redux/persist.js#L4

It would make some situations easier to handle, if the path to use was calculated when the module is used rather than when imported, so that changes to the current directory are reflected in the path used.

This PR changes the generation of the path to a function, which is called when the redux state is loaded or saved.