### PR TITLE
fix(gatsby): do not cause stack overflow over circular refs

### DIFF
--- a/packages/gatsby/src/db/sanitize-node.js
+++ b/packages/gatsby/src/db/sanitize-node.js
@@ -9,9 +9,9 @@ const _ = require(`lodash`)
 const sanitizeNode = (data, isNode = true, path = new Set()) => {
   const isPlainObject = _.isPlainObject(data)
 
-  path.add(data)
-
   if (isPlainObject || _.isArray(data)) {
+    path.add(data)
+
     const returnData = isPlainObject ? {} : []
     let anyFieldChanged = false
     _.each(data, (o, key) => {

--- a/packages/gatsby/src/db/sanitize-node.js
+++ b/packages/gatsby/src/db/sanitize-node.js
@@ -3,19 +3,25 @@ const _ = require(`lodash`)
 /**
  * Make data serializable
  * @param {(Object|Array)} data to sanitize
+ * @param {boolean} isNode = true
+ * @param {Set<string>} path = new Set
  */
-const sanitizeNode = (data, isNode = true) => {
+const sanitizeNode = (data, isNode = true, path = new Set()) => {
   const isPlainObject = _.isPlainObject(data)
+
+  path.add(data)
 
   if (isPlainObject || _.isArray(data)) {
     const returnData = isPlainObject ? {} : []
     let anyFieldChanged = false
     _.each(data, (o, key) => {
+      if (path.has(o)) return
+
       if (isNode && key === `internal`) {
         returnData[key] = o
         return
       }
-      returnData[key] = sanitizeNode(o, false)
+      returnData[key] = sanitizeNode(o, false, path)
 
       if (returnData[key] !== o) {
         anyFieldChanged = true
@@ -26,6 +32,8 @@ const sanitizeNode = (data, isNode = true) => {
       data = omitUndefined(returnData)
     }
 
+    path.add(data)
+
     // arrays and plain objects are supported - no need to to sanitize
     return data
   }
@@ -33,6 +41,7 @@ const sanitizeNode = (data, isNode = true) => {
   if (!isTypeSupported(data)) {
     return undefined
   } else {
+    path.add(data)
     return data
   }
 }

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -691,4 +691,97 @@ describe(`NodeModel`, () => {
       })
     })
   })
+
+  describe(`circular references`, () => {
+    describe(`directly on a node`, () => {
+      beforeEach(async () => {
+        // This tests whether addRootNodeToInlineObject properly prevents re-traversing the same key-value pair infinitely
+        const circular = { i_am: `recursion!` }
+        circular.circled = circular
+
+        const node = {
+          id: `circleId`,
+          parent: null,
+          children: [],
+          inlineObject: {
+            field: `fieldOfFirstNode`,
+          },
+          inlineArray: [1, 2, 3],
+          circular,
+          internal: {
+            type: `Test`,
+            contentDigest: `digest1`,
+          },
+        }
+        actions.createNode(node, { name: `test` })(store.dispatch)
+
+        await build({})
+        const {
+          schemaCustomization: { composer: schemaComposer },
+        } = store.getState()
+        schema = store.getState().schema
+
+        nodeModel = new LocalNodeModel({
+          schema,
+          schemaComposer,
+          nodeStore,
+          createPageDependency,
+        })
+      })
+
+      it(`trackInlineObjectsInRootNode should not infinitely loop on a circular reference`, () => {
+        const node = nodeModel.getAllNodes({ type: `Test` })[0]
+        const copiedInlineObject = { ...node.inlineObject }
+        nodeModel.trackInlineObjectsInRootNode(copiedInlineObject)
+
+        expect(nodeModel._trackedRootNodes instanceof Set).toBe(true)
+        expect(nodeModel._trackedRootNodes.has(node.id)).toEqual(true)
+      })
+    })
+    describe(`not directly on a node`, () => {
+      beforeEach(async () => {
+        // This tests whether addRootNodeToInlineObject properly prevents re-traversing the same key-value pair infinitely
+        const circular = { i_am: `recursion!` }
+        circular.circled = { bar: { circular } }
+
+        const node = {
+          id: `circleId`,
+          parent: null,
+          children: [],
+          inlineObject: {
+            field: `fieldOfFirstNode`,
+          },
+          inlineArray: [1, 2, 3],
+          foo: { circular },
+          internal: {
+            type: `Test`,
+            contentDigest: `digest1`,
+          },
+        }
+        actions.createNode(node, { name: `test` })(store.dispatch)
+
+        await build({})
+        const {
+          schemaCustomization: { composer: schemaComposer },
+        } = store.getState()
+        schema = store.getState().schema
+
+        nodeModel = new LocalNodeModel({
+          schema,
+          schemaComposer,
+          nodeStore,
+          createPageDependency,
+        })
+      })
+
+      it(`trackInlineObjectsInRootNode should not infinitely loop on a circular reference`, () => {
+        const node = nodeModel.getAllNodes({ type: `Test` })[0]
+        const copiedInlineObject = { ...node.inlineObject }
+        nodeModel.trackInlineObjectsInRootNode(copiedInlineObject)
+
+        expect(nodeModel._trackedRootNodes instanceof Set).toBe(true)
+        expect(nodeModel._trackedRootNodes.has(node.id)).toEqual(true)
+      })
+    })
+  })
 })

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -113,19 +113,47 @@ const getType = (value, key) => {
   }
 }
 
-const updateValueDescriptor = ({
-  nodeId,
-  key,
-  value,
-  operation = `add`,
-  descriptor = {},
-}) => {
+const updateValueDescriptor = (
+  { nodeId, key, value, operation = `add` /*: add | del*/, descriptor = {} },
+  path = []
+) => {
+  // The object may be traversed multiple times from root.
+  // Each time it does it should not revisit the same node twice
+  if (path.includes(value)) {
+    return [descriptor, false]
+  }
+
   const typeName = getType(value, key)
 
   if (typeName === `null`) {
     return [descriptor, false]
   }
 
+  path.push(value)
+
+  const ret = _updateValueDescriptor(
+    nodeId,
+    key,
+    value,
+    operation,
+    descriptor,
+    path,
+    typeName
+  )
+
+  path.pop()
+
+  return ret
+}
+const _updateValueDescriptor = (
+  nodeId,
+  key,
+  value,
+  operation,
+  descriptor,
+  path,
+  typeName
+) => {
   const delta = operation === `del` ? -1 : 1
   const typeInfo = descriptor[typeName] || { total: 0 }
   typeInfo.total += delta
@@ -150,13 +178,18 @@ const updateValueDescriptor = ({
     case `object`: {
       const { props = {} } = typeInfo
       Object.keys(value).forEach(key => {
-        const [propDescriptor, propDirty] = updateValueDescriptor({
-          nodeId,
-          key,
-          value: value[key],
-          operation,
-          descriptor: props[key],
-        })
+        const v = value[key]
+
+        const [propDescriptor, propDirty] = updateValueDescriptor(
+          {
+            nodeId,
+            key,
+            value: v,
+            operation,
+            descriptor: props[key],
+          },
+          path
+        )
         props[key] = propDescriptor
         dirty = dirty || propDirty
       })
@@ -165,13 +198,17 @@ const updateValueDescriptor = ({
     }
     case `array`: {
       value.forEach(item => {
-        const [itemDescriptor, itemDirty] = updateValueDescriptor({
-          nodeId,
-          descriptor: typeInfo.item,
-          operation,
-          value: item,
-          key,
-        })
+        const [itemDescriptor, itemDirty] = updateValueDescriptor(
+          {
+            nodeId,
+            descriptor: typeInfo.item,
+            operation,
+            value: item,
+            key,
+          },
+          path
+        )
+
         typeInfo.item = itemDescriptor
         dirty = dirty || itemDirty
       })

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -166,12 +166,13 @@ const _updateValueDescriptor = (
   // Keeping track of the first node for this type. Only used for better conflict reporting.
   // (see Caveats section in the header comments)
   if (operation === `add`) {
-    typeInfo.first = typeInfo.first || nodeId
+    if (!typeInfo.first) {
+      typeInfo.first = nodeId
+    }
   } else if (operation === `del`) {
-    typeInfo.first =
-      typeInfo.first === nodeId || typeInfo.total === 0
-        ? undefined
-        : typeInfo.first
+    if (typeInfo.first === nodeId || typeInfo.total === 0) {
+      typeInfo.first = undefined
+    }
   }
 
   switch (typeName) {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -703,16 +703,21 @@ const addRootNodeToInlineObject = (
   rootNodeMap,
   data,
   nodeId,
-  isNode = false
+  isNode = false,
+  path = new Set()
 ) => {
+  path.add(data)
+
   const isPlainObject = _.isPlainObject(data)
 
   if (isPlainObject || _.isArray(data)) {
     _.each(data, (o, key) => {
+      if (path.has(o)) return
       if (!isNode || key !== `internal`) {
         addRootNodeToInlineObject(rootNodeMap, o, nodeId)
       }
     })
+
     // don't need to track node itself
     if (!isNode) {
       rootNodeMap.set(data, nodeId)


### PR DESCRIPTION
This allows nodes to have a circular dependency without causing stack overflow exceptions when traversing the graph.

Fixes #11364 (hopefully). Will have to confirm this after publishing an update.

Causes somewhere between 0 and 1% perf regression for our 25k page benchmark site. But it's within variance of benchmarking, not even sure if there's a noticable regression at all. See this table:

The first two columns are on master (at the time of writing), the third and fourth column are after this change. (The `(govbook)` lines are printed from within the benchmark site). Shrug.

```
    master:                |      branch:                  |
------------------------------------------------------------------------------------------------------
     0.025s        0.026s  |       0.026s         0.030s   |   success open and validate gatsby-configs 
     0.365s        0.361s  |       0.333s         0.362s   |   success load plugins 
     0.004s        0.004s  |       0.005s         0.005s   |   success onPreInit 
     0.012s        0.011s  |       0.011s         0.011s   |   success delete html and css files from previous builds 
     0.008s        0.008s  |       0.008s         0.008s   |   success initialize cache 
     0.025s        0.021s  |       0.018s         0.027s   |   success copy gatsby files 
     1.420s        1.530s  |       1.432s         1.655s   |   success onPreBootstrap 
     0.003s        0.004s  |       0.007s         0.006s   |   success createSchemaCustomization 
    11.587s       12.116s  |      12.048s        13.105s   |   success source and transform nodes 
     0.431s        0.491s  |       0.304s         0.332s   |   success building schema 
  560.858ms     591.782ms  |    617.005ms      668.053ms   |   (govbook) initial graphql query
    25.176s       27.344s  |      24.406s        27.665s   |   success govbook/gatsby-node.js 
25198.194ms   27369.563ms  |  24429.250ms    27689.333ms   |   (govbook) created pages
    5.316ms       5.221ms  |      5.142ms        5.059ms   |   (govbook) _wrapGraphql
   35.774ms      32.683ms  |     31.356ms       34.587ms   |   (govbook) _graphql
    2.906ms       3.225ms  |      2.761ms        3.011ms   |   (govbook) _createMarkdownPages
25819.979ms   28018.942ms  |  25102.183ms    28422.466ms   |   (govbook) total exports.createPages
   104.950s      110.702s  |     105.509s       112.224s   |   success createPages 
     0.399s        0.175s  |       0.383s         0.387s   |   success createPagesStatefully 
     0.002s        0.002s  |       0.002s         0.002s   |   success onPreExtractQueries 
     0.316s        0.181s  |       0.356s         0.306s   |   success update schema 
     0.340s        0.146s  |       0.359s         0.319s   |   success extract queries from components 
     0.831s        0.545s  |       0.951s         0.825s   |   success write out requires 
     0.002s        0.002s  |       0.002s         0.002s   |   success write out redirect data 
     0.124s        0.095s  |       0.125s         0.119s   |   success Build manifest and related icons 
     2.233s        1.516s  |       2.303s         2.193s   |   success onPostBootstrap 
   125.512s      130.371s  |     126.555s       134.379s   |   info bootstrap finished 
    13.429s       12.381s  |      14.701s        12.956s   |   success Building production JavaScript and CSS bundles 
     0.005s        0.005s  |       0.008s         0.008s   |   success Rewriting compilation hashes 
    85.845s       95.184s  |         30/s        91.392s   |   success run queries 
    24.421s       27.864s  |      25.243s        25.466s   |   success Building static HTML for pages 
   237.088s      254.554s  |      245.77s       252.497s   |   info Done building 
```
