### PR TITLE
refactor(gatsby-transformer-excel): use Array.includes

### DIFF
--- a/packages/gatsby-transformer-excel/src/gatsby-node.js
+++ b/packages/gatsby-transformer-excel/src/gatsby-node.js
@@ -17,7 +17,7 @@ async function onCreateNode(
   const extensions = `xls|xlsx|xlsm|xlsb|xml|xlw|xlc|csv|txt|dif|sylk|slk|prn|ods|fods|uos|dbf|wks|123|wq1|qpw|htm|html`.split(
     `|`
   )
-  if (extensions.indexOf((node.extension || ``).toLowerCase()) == -1) {
+  if (!extensions.includes((node.extension || ``).toLowerCase())) {
     return
   }
   // Load binary string


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I think since the `extensions` variable is an array it's a good idea to use Array.includes :recycle:
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
