### PR TITLE
[gatsby-source-contentful] Add missing 'sys' properties from Contentful

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/normalize.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/normalize.js.snap
@@ -2851,7 +2851,7 @@ Array [
       "icon___NODE": "uuid-from-gatsby",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "76c34d77182ce784b6a5650528fa36b3",
+        "contentDigest": "294a7f3460d8b6aae632c3b8f1b70730",
         "type": "ContentfulCategory",
       },
       "node_locale": "en-US",
@@ -2862,6 +2862,16 @@ Array [
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "title___NODE": "uuid-from-gatsby",
       "updatedAt": "2017-06-27T09:55:54.077Z",
     },
@@ -2878,7 +2888,7 @@ Array [
       "icon___NODE": "uuid-from-gatsby",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "518002bf2a5eb561827065428446e752",
+        "contentDigest": "16b2abf84b891b2575f0663ac2d823d2",
         "type": "ContentfulCategory",
       },
       "node_locale": "en-US",
@@ -2887,6 +2897,16 @@ Array [
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "title___NODE": "uuid-from-gatsby",
       "updatedAt": "2017-06-27T09:46:43.477Z",
     },
@@ -2973,7 +2993,7 @@ Array [
       "icon___NODE": "uuid-from-gatsby",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "8c8d414ac3004573426870fa43bb9a64",
+        "contentDigest": "87876a667c1b76ecd2ec29e9200fdf7f",
         "type": "ContentfulCategory",
       },
       "node_locale": "de",
@@ -2984,6 +3004,16 @@ Array [
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "title___NODE": "uuid-from-gatsby",
       "updatedAt": "2017-06-27T09:55:54.077Z",
     },
@@ -3000,7 +3030,7 @@ Array [
       "icon___NODE": "uuid-from-gatsby",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "fe8836e9d33f97051efe5e93f9e47d21",
+        "contentDigest": "66dd5c80f7e34614924cff01d8471cb0",
         "type": "ContentfulCategory",
       },
       "node_locale": "de",
@@ -3009,6 +3039,16 @@ Array [
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "title___NODE": "uuid-from-gatsby",
       "updatedAt": "2017-06-27T09:46:43.477Z",
     },
@@ -3096,7 +3136,7 @@ Array [
       "email": "normann@normann-copenhagen.com",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "c34237c7597dc2f72762df0f22b81a3a",
+        "contentDigest": "2ed98f7ac68a23b4950a258882653c90",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "uuid-from-gatsby",
@@ -3110,6 +3150,16 @@ Array [
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "twitter": "https://twitter.com/NormannCPH",
       "updatedAt": "2017-06-27T09:55:16.820Z",
       "website": "http://www.normann-copenhagen.com/",
@@ -3128,7 +3178,7 @@ Array [
       "email": "info@acgears.com",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "126da2cea7f094d667239df5fddd2c46",
+        "contentDigest": "ae20dc9c7fdb22fe529565040beb0e66",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "uuid-from-gatsby",
@@ -3139,6 +3189,16 @@ Array [
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "updatedAt": "2017-06-27T09:51:15.647Z",
       "website": "http://www.lemnos.jp/en/",
     },
@@ -3155,7 +3215,7 @@ Array [
       "createdAt": "2017-06-27T09:35:44.988Z",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "3b7395b84b14c4b1e2b433abb823ee2d",
+        "contentDigest": "d83943c2962d567c69c12fa6628a0ad8",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "uuid-from-gatsby",
@@ -3165,6 +3225,16 @@ Array [
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "updatedAt": "2017-06-27T09:50:36.937Z",
       "website": "http://playsam.com/",
     },
@@ -3300,7 +3370,7 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
       "email": "normann@normann-copenhagen.com",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "165308614ff70400290d6b5780c60d40",
+        "contentDigest": "e75c287a6b2d5ad81721464d379bdb2f",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "uuid-from-gatsby",
@@ -3314,6 +3384,16 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "twitter": "https://twitter.com/NormannCPH",
       "updatedAt": "2017-06-27T09:55:16.820Z",
       "website": "http://www.normann-copenhagen.com/",
@@ -3332,7 +3412,7 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
       "email": "info@acgears.com",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "bc9c8e9f60195d4c4cbaae9a9b68dd40",
+        "contentDigest": "f7454c8210e93fb9e3de8885f9f6e6cb",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "uuid-from-gatsby",
@@ -3343,6 +3423,16 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "updatedAt": "2017-06-27T09:51:15.647Z",
       "website": "http://www.lemnos.jp/en/",
     },
@@ -3359,7 +3449,7 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
       "createdAt": "2017-06-27T09:35:44.988Z",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "b651340bf51e117e8c9d1164e21cafbf",
+        "contentDigest": "b2284761e9b6732fa15d763d622b874f",
         "type": "ContentfulBrand",
       },
       "logo___NODE": "uuid-from-gatsby",
@@ -3369,6 +3459,16 @@ Our Lemnos products are made carefully by our craftsmen finely honed skillful te
         "uuid-from-gatsby",
       ],
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "updatedAt": "2017-06-27T09:50:36.937Z",
       "website": "http://playsam.com/",
     },
@@ -3508,7 +3608,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "uuid-from-gatsby",
       ],
       "internal": Object {
-        "contentDigest": "962824760fd2ab03146d7d23de203a22",
+        "contentDigest": "9240cde2fe79efe90cdf87e752d99674",
         "type": "ContentfulProduct",
       },
       "node_locale": "en-US",
@@ -3521,6 +3621,16 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "sku": "B001R6JUZ2",
       "slug": "playsam-streamliner-classic-car-espresso",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "tags": Array [
         "wood",
         "toy",
@@ -3549,7 +3659,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "uuid-from-gatsby",
       ],
       "internal": Object {
-        "contentDigest": "385a7720f0ddd9b67f001ab4230d0118",
+        "contentDigest": "9d3d36c914d3bff5e1ca891e850cb6d2",
         "type": "ContentfulProduct",
       },
       "node_locale": "en-US",
@@ -3562,6 +3672,16 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "sku": "B00E82D7I8",
       "slug": "hudson-wall-cup",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "tags": Array [
         "vase",
         "flowers",
@@ -3588,7 +3708,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "uuid-from-gatsby",
       ],
       "internal": Object {
-        "contentDigest": "7b16fb6ae2dc59b1aa10c270a6939bb7",
+        "contentDigest": "4021391e85d71f44178b2217615ff238",
         "type": "ContentfulProduct",
       },
       "node_locale": "en-US",
@@ -3601,6 +3721,16 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "sku": "B0081F2CCK",
       "slug": "whisk-beater",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "tags": Array [
         "kitchen",
         "accessories",
@@ -3629,7 +3759,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "uuid-from-gatsby",
       ],
       "internal": Object {
-        "contentDigest": "e1de9327d22a548c7b4b8c9c92fbd45a",
+        "contentDigest": "ae98c5a9c663a1e24697cf9be764b87e",
         "type": "ContentfulProduct",
       },
       "node_locale": "en-US",
@@ -3642,6 +3772,16 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "sku": "B00MG4ULK2",
       "slug": "soso-wall-clock",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "tags": Array [
         "home décor",
         "clocks",
@@ -3796,7 +3936,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "uuid-from-gatsby",
       ],
       "internal": Object {
-        "contentDigest": "94c28fdd93fde260dcf9e1182af47483",
+        "contentDigest": "a15ac275f0fc754c668f654bd5281ecd",
         "type": "ContentfulProduct",
       },
       "node_locale": "de",
@@ -3809,6 +3949,16 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "sku": "B001R6JUZ2",
       "slug": "playsam-streamliner-classic-car-espresso",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "tags": Array [
         "wood",
         "toy",
@@ -3837,7 +3987,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "uuid-from-gatsby",
       ],
       "internal": Object {
-        "contentDigest": "91c1918ffa463242dfb7804b3518530d",
+        "contentDigest": "00b95cfa95e14d334a7e9480965e8491",
         "type": "ContentfulProduct",
       },
       "node_locale": "de",
@@ -3850,6 +4000,16 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "sku": "B00E82D7I8",
       "slug": "hudson-wall-cup",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "tags": Array [
         "vase",
         "flowers",
@@ -3876,7 +4036,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "uuid-from-gatsby",
       ],
       "internal": Object {
-        "contentDigest": "d03938d4fe4c473f2f09420552ecc925",
+        "contentDigest": "c2216fbbf1b5e8b79375bfaed2152a73",
         "type": "ContentfulProduct",
       },
       "node_locale": "de",
@@ -3889,6 +4049,16 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "sku": "B0081F2CCK",
       "slug": "whisk-beater",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "tags": Array [
         "kitchen",
         "accessories",
@@ -3917,7 +4087,7 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
         "uuid-from-gatsby",
       ],
       "internal": Object {
-        "contentDigest": "954686c8abfa7b76a17bc8a8ceb3c491",
+        "contentDigest": "ebab062776dd92bcca87f2cc5886660f",
         "type": "ContentfulProduct",
       },
       "node_locale": "de",
@@ -3930,6 +4100,16 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "sku": "B00MG4ULK2",
       "slug": "soso-wall-clock",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+      },
       "tags": Array [
         "home décor",
         "clocks",
@@ -4104,13 +4284,23 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "createdAt": "2017-11-28T02:16:10.604Z",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "395f3ded6dbaf73c464ee1ab1c80ddd9",
+        "contentDigest": "d0e1ae05e94818aca771afd63285a5e2",
         "type": "ContentfulJsonTest",
       },
       "jsonTest___NODE": "uuid-from-gatsby",
       "node_locale": "en-US",
       "parent": "JSON-test",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "jsonTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 3,
+      },
       "updatedAt": "2018-06-11T14:18:54.392Z",
     },
   ],
@@ -4221,13 +4411,23 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "createdAt": "2017-11-28T02:16:10.604Z",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "b194b25d232347380cb0a6b472fa2f8a",
+        "contentDigest": "93fb002907eaed2a4b14b5e3508f91c5",
         "type": "ContentfulJsonTest",
       },
       "jsonTest___NODE": "uuid-from-gatsby",
       "node_locale": "de",
       "parent": "JSON-test",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "jsonTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 3,
+      },
       "updatedAt": "2018-06-11T14:18:54.392Z",
     },
   ],
@@ -4339,12 +4539,22 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "createdAt": "2018-05-28T08:49:06.230Z",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "f80357297c70db9a936bf3439d355c90",
+        "contentDigest": "e87a0b91174f2b3684d6e457f1e6a23d",
         "type": "ContentfulRemarkTest",
       },
       "node_locale": "en-US",
       "parent": "Remark Test",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "remarkTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 1,
+      },
       "title": "Contentful images inlined in Markdown",
       "updatedAt": "2018-05-28T08:49:06.230Z",
     },
@@ -4431,12 +4641,22 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "createdAt": "2018-05-28T08:49:06.230Z",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "a3ba48a75f1095621ee10a8f6db7dbcd",
+        "contentDigest": "faa644d3fb39213f459997c015d9b8b0",
         "type": "ContentfulRemarkTest",
       },
       "node_locale": "de",
       "parent": "Remark Test",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "remarkTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 1,
+      },
       "title": "Contentful images inlined in Markdown",
       "updatedAt": "2018-05-28T08:49:06.230Z",
     },
@@ -4521,13 +4741,22 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "createdAt": "2019-09-09T06:54:07.673Z",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "081ae04dfb62e226565aa5acf63d8131",
+        "contentDigest": "8a900555fbac43e26e4ddf1db6aca7dd",
         "type": "ContentfulBlogPost",
       },
       "node_locale": "en-US",
       "parent": "Blog Post",
       "slug": "post-one",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "blogPost",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+      },
       "title": "Post one",
       "updatedAt": "2019-09-09T06:58:04.316Z",
     },
@@ -4554,13 +4783,22 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "createdAt": "2019-09-09T06:54:07.673Z",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "bf5ce5bf34bc94610e0971ac70d3d819",
+        "contentDigest": "2d20a94014b68da99d7de9a9f47475dd",
         "type": "ContentfulBlogPost",
       },
       "node_locale": "de",
       "parent": "Blog Post",
       "slug": "post-one",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "blogPost",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+      },
       "title": "Post one",
       "updatedAt": "2019-09-09T06:58:04.316Z",
     },
@@ -4590,13 +4828,22 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "favouritePost___NODE": "uuid-from-gatsby",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "ceaedef3c6d7a480310bbc2d4f560fad",
+        "contentDigest": "baa9dace5e18589b8fdfc53a9ca1936f",
         "type": "ContentfulAuthor",
       },
       "name": "Fred",
       "node_locale": "en-US",
       "parent": "Author",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "author",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+      },
       "updatedAt": "2019-09-09T06:54:38.816Z",
     },
   ],
@@ -4625,13 +4872,22 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
       "favouritePost___NODE": "uuid-from-gatsby",
       "id": "uuid-from-gatsby",
       "internal": Object {
-        "contentDigest": "4e5c5518a4238b7684ddbdeb1e568f4d",
+        "contentDigest": "63dd9c90f9cf9e4e46ff737e82e27004",
         "type": "ContentfulAuthor",
       },
       "name": "Fred",
       "node_locale": "de",
       "parent": "Author",
       "spaceId": "x2t9il8x6p",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "id": "author",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+      },
       "updatedAt": "2019-09-09T06:54:38.816Z",
     },
   ],

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -380,6 +380,17 @@ exports.createContentTypeNodes = ({
         internal: {
           type: `${makeTypeName(contentTypeItemId)}`,
         },
+        sys: {},
+      }
+
+      // Revision applies to entries, assets, and content types
+      if (entryItem.sys.revision) {
+        entryNode.sys.revision = entryItem.sys.revision
+      }
+
+      // Content type applies to entries only
+      if (entryItem.sys.contentType) {
+        entryNode.sys.contentType = entryItem.sys.contentType
       }
 
       // Use default locale field.


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

This change adds 2 properties from the Contentful API that are not being surfaced by the gatsby-source-contentful plugin. They are as follows:

- Revision: A field from Contentful that specifies the revision number of a piece of content or content model
- Content Type: For entries, references the content type that the entry is an instance of, including the ID value (useful for apps looking to switch on this field for component lookups)

## Related Issues

Fixes #19791
