### PR TITLE
fix(gatsby-theme-blog): Dark/light mode switch icon is out of place

### DIFF
--- a/packages/gatsby-theme-blog/src/components/header.js
+++ b/packages/gatsby-theme-blog/src/components/header.js
@@ -54,6 +54,13 @@ const Title = ({ children, location }) => {
   }
 }
 
+const iconCss = [
+  css({
+    pointerEvents: `none`,
+  }),
+  { margin: 4 }, // Explicitly leave margin out of theme-ui, this positioning should not change based on theme
+]
+
 const checkedIcon = (
   <img
     alt="moon indicating dark mode"
@@ -61,10 +68,7 @@ const checkedIcon = (
     width="16"
     height="16"
     role="presentation"
-    css={css({
-      pointerEvents: `none`,
-      margin: 4,
-    })}
+    css={iconCss}
   />
 )
 
@@ -75,10 +79,7 @@ const uncheckedIcon = (
     width="16"
     height="16"
     role="presentation"
-    css={css({
-      pointerEvents: `none`,
-      margin: 4,
-    })}
+    css={iconCss}
   />
 )
 


### PR DESCRIPTION
## Description
This change fixes the position of the moon/sun image on the theme toggle. With the changes in #19673, this became out of place:

![image](https://user-images.githubusercontent.com/840677/69676851-7a1a5780-1056-11ea-94b0-192123867332.png)

## Related Issues
Related to #19673 
