### PR TITLE
chore(www): add info about `.env.production`

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -27,6 +27,8 @@ To develop on the starter library, you'll need to supply a GitHub personal acces
 GITHUB_API_TOKEN=YOUR_TOKEN_HERE
 ```
 
+_Note:_ for `gatsby build` you need also a `.env.production` file with the `GITHUB_API_TOKEN`
+
 ### Enabling guess.js
 
 Guess.js is disabled by default and can be enabled by setting `ANALYTICS_SERVICE_ACCOUNT` and `ANALYTICS_SERVICE_ACCOUNT_KEY` env variables. These variables need to have access to the gatsbyjs.org analytics.

--- a/www/README.md
+++ b/www/README.md
@@ -27,7 +27,7 @@ To develop on the starter library, you'll need to supply a GitHub personal acces
 GITHUB_API_TOKEN=YOUR_TOKEN_HERE
 ```
 
-_Note:_ for `gatsby build` you need also a `.env.production` file with the `GITHUB_API_TOKEN`
+_Note:_ For `gatsby build` to be able to run you also need a `.env.production` file with the same contents
 
 ### Enabling guess.js
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add info about `.env.production` for the `GITHUB_API_TOKEN` to the `README.md`. 

When i run `gatsby build` i get the error `A GitHub token is required to build the site. Check the README.` but there is no info about the `.env.production` in readme.


https://github.com/gatsbyjs/gatsby/blob/e5a01a0625ad044bc281e23a7a6644ce2001589d/www/gatsby-node.js#L29-L36


i am open for better wordings of the text.

## Related Issues

n/a

