### PR TITLE
fix(gatsby-plugin-offline): Update incorrect casing for runtimeCachin…

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -143,22 +143,22 @@ const options = {
       // Use cacheFirst since these don't need to be revalidated (same RegExp
       // and same reason as above)
       urlPattern: /(\.js$|\.css$|static\/)/,
-      handler: `CacheFirst`,
+      handler: `cacheOnly`,
     },
     {
       // page-data.json files are not content hashed
       urlPattern: /^https?:.*\page-data\/.*\/page-data\.json/,
-      handler: `NetworkFirst`,
+      handler: `networkFirst`,
     },
     {
       // Add runtime caching of various other page resources
       urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
-      handler: `StaleWhileRevalidate`,
+      handler: `staleWhileRevalidate`,
     },
     {
       // Google Fonts CSS (doesn't end in .css so we need to specify it)
       urlPattern: /^https?:\/\/fonts\.googleapis\.com\/css/,
-      handler: `StaleWhileRevalidate`,
+      handler: `staleWhileRevalidate`,
     },
   ],
   skipWaiting: true,


### PR DESCRIPTION
…g handlers
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Current configuration object with camel case handlers returns:

```
ValidationError: child "runtimeCaching" fails because ["runtimeCaching" at position 0 fails because [child "handler" fails because ["handler" must be a Function, "handler" must be one of [cacheFirst, cacheOnly, networkFirst, networkOnly, staleWhileRevalidate]]]]
```
