### PR TITLE
fix(blog): 404 on blog/2018-03-07-why-we-created-the-plugin-library

### DIFF
--- a/docs/blog/2018-03-07-why-we-created-the-plugin-library/index.md
+++ b/docs/blog/2018-03-07-why-we-created-the-plugin-library/index.md
@@ -5,7 +5,7 @@ author: Shannon Soper
 tags: ["plugins", "documentation"]
 ---
 
-Earlier this week, we launched a [Plugin Library](/packages/) on Gatsbyjs.org and are excited for you to use it! This article explains how UX research drove the design of this library and the accompanying [Plugin Authoring](/docs/creating-plugins/) doc.
+Earlier this week, we launched a [Plugin Library](/plugins/) on Gatsbyjs.org and are excited for you to use it! This article explains how UX research drove the design of this library and the accompanying [Plugin Authoring](/docs/creating-plugins/) doc.
 
 ![Plugin tweet](plugin-tweet.png)
 
@@ -32,7 +32,6 @@ With the empathy map and the interviews as our guide, we learned that most peopl
 
 Next, we analyzed over 10 admirable and/or popular plugin libraries to draw from their strengths and learn from their weaknesses. Examples, in no particular order, include:
 
-- [JS.coach](https://js.coach/)
 - [VIM Awesome](https://vimawesome.com/)
 - [Best of JS](https://bestof.js.org/)
 - [Sketch extension library](https://sketchapp.com/extensions/)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

on blog/2018-03-07-why-we-created-the-plugin-library:
- removed link to js.coach
- apply redirect /packages -> /plugins

## Related Issues

#19267

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
