### PR TITLE
fix(compontent): fix links with undefined in docs-table-of-contents.js

### DIFF
--- a/www/src/components/docs-table-of-contents.js
+++ b/www/src/components/docs-table-of-contents.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { Link } from "gatsby"
-import { mediaQueries, colors } from "../gatsby-plugin-theme-ui"
+import { colors, mediaQueries } from "../gatsby-plugin-theme-ui"
 
 function isUnderDepthLimit(depth, maxDepth) {
   if (maxDepth === null) {
@@ -17,38 +17,40 @@ function isUnderDepthLimit(depth, maxDepth) {
 function createItems(items, location, depth, maxDepth) {
   return (
     items &&
-    items.map(item => (
+    items.map((item, index) => (
       <li
         sx={{ [mediaQueries.xl]: { fontSize: 1 } }}
-        key={location.pathname + item.url}
+        key={location.pathname + (item.url || depth + `-` + index)}
       >
-        <Link
-          sx={{
-            "&&": {
-              color: `textMuted`,
-              border: 0,
-              transition: t =>
-                `all ${t.transition.speed.fast} ${t.transition.curve.default}`,
-              ":hover": {
-                color: `link.color`,
-                borderBottom: t => `1px solid ${t.colors.link.hoverBorder}`,
+        {item.url && (
+          <Link
+            sx={{
+              "&&": {
+                color: `textMuted`,
+                border: 0,
+                transition: t =>
+                  `all ${t.transition.speed.fast} ${t.transition.curve.default}`,
+                ":hover": {
+                  color: `link.color`,
+                  borderBottom: t => `1px solid ${t.colors.link.hoverBorder}`,
+                },
               },
-            },
-          }}
-          getProps={({ href, location }) =>
-            location && location.href && location.href.includes(href)
-              ? {
-                  style: {
-                    color: colors.link.color,
-                    borderBottom: `1px solid ${colors.link.hoverBorder}`,
-                  },
-                }
-              : null
-          }
-          to={location.pathname + item.url}
-        >
-          {item.title}
-        </Link>
+            }}
+            getProps={({ href, location }) =>
+              location && location.href && location.href.includes(href)
+                ? {
+                    style: {
+                      color: colors.link.color,
+                      borderBottom: `1px solid ${colors.link.hoverBorder}`,
+                    },
+                  }
+                : null
+            }
+            to={location.pathname + item.url}
+          >
+            {item.title}
+          </Link>
+        )}
         {item.items && isUnderDepthLimit(depth, maxDepth) && (
           <ul sx={{ color: `textMuted`, listStyle: `none`, ml: 5 }}>
             {createItems(item.items, location, depth + 1, maxDepth)}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

### Missing header element 

there are some mdx that have left off a header in the tree:

```markdown

## 2. Header

#### 4. Header 
```

### Examples:

- [docs/how-code-splitting-works.md](https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/how-code-splitting-works.md#L84-L92) -> https://www.gatsbyjs.org/docs/how-code-splitting-works/
- [docs/production-app.md](https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/production-app.md#L118-L122) -> https://www.gatsbyjs.org/docs/production-app/

### Current Result

then an element is inserted to the header array with just `items:`:

```javascript
{ 
  url: '#2header', 
  title: '2. Header', 
  items:
    [
      { 
        items: 
	      [ 
		    { 
              url: '#4header', 
              title: '4. Header' 
            }
          ]
      }
    ]
}
```

it creates: 

- then the TOC create empty Links with `undefined` in href: 
```html
<a class="css-1wk9u7" href="/docs/how-code-splitting-works/undefined"></a>
```
- it creates a: 
```html
<link rel="prefetch" href="/page-data/docs/how-code-splitting-works/undefined/page-data.json" crossorigin="anonymous" as="fetch">
```

### Fixed Result

- removed `Link` element when `item.url` is undefined
- changed the `key` for the `li` item 
- prefetch links for the undefined links are not created

## Related Issues

#19267

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
