### PR TITLE
fix(www): fix links with null in template-contributor-page.js

### DIFF
--- a/www/src/templates/template-contributor-page.js
+++ b/www/src/templates/template-contributor-page.js
@@ -62,10 +62,12 @@ class ContributorPageTemplate extends React.Component {
                 >
                   {contributor.bio}
                 </p>
-                <a href={`https://twitter.com/${contributor.twitter}`}>
-                  {` `}
-                  {contributor.twitter}
-                </a>
+                {contributor.twitter && (
+                  <a href={`https://twitter.com/${contributor.twitter}`}>
+                    {` `}
+                    {contributor.twitter}
+                  </a>
+                )}
               </div>
             </div>
             <div sx={{ py: 7, px: 6 }}>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

in docs/blog/author.yaml some contributors without twitter handle - for example:
- https://www.gatsbyjs.org/contributors/grant-glidewell/
- https://www.gatsbyjs.org/contributors/maddie-wolf/

this creates a empty link to https://twitter.com/null

## Related Issues

#19267

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
