### PR TITLE
[gatsby-plugin-netlify-cms] switch to `require.resolve` for modules hoisting

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -207,11 +207,11 @@ exports.onCreateWebpackConfig = (
           externals.map(({ name, assetName, sourceMap, assetDir }) =>
             [
               {
-                from: path.join(`node_modules`, name, assetDir, assetName),
+                from: require.resolve(path.join(name, assetDir, assetName)),
                 to: assetName,
               },
               sourceMap && {
-                from: path.join(`node_modules`, name, assetDir, sourceMap),
+                from: require.resolve(path.join(name, assetDir, sourceMap)),
                 to: sourceMap,
               },
             ].filter(item => item)


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

![image](https://user-images.githubusercontent.com/890063/69808443-74716d00-1222-11ea-9c8e-afc021e48f7b.png)

This fix in mono-repo based project the `node_modules` hoist to project root.
