### PR TITLE
fix(gatsby): use correct state in the schema hot reloader

### DIFF
--- a/e2e-tests/development-runtime/src/pages/schema-rebuild.js
+++ b/e2e-tests/development-runtime/src/pages/schema-rebuild.js
@@ -1,0 +1,27 @@
+import React from "react"
+import { graphql } from "gatsby"
+import Layout from "../components/layout"
+import InstrumentPage from "../utils/instrument-page"
+
+const SchemaRebuildPage = ({ data }) => (
+  <Layout>
+    <p>{JSON.stringify(data)}</p>
+  </Layout>
+)
+
+export default InstrumentPage(SchemaRebuildPage)
+
+export const schemaRebuildQuery = graphql`
+  {
+    allMarkdownRemark {
+      edges {
+        node {
+          frontmatter {
+            title
+            # foo
+          }
+        }
+      }
+    }
+  }
+`

--- a/packages/gatsby/src/bootstrap/schema-hot-reloader.js
+++ b/packages/gatsby/src/bootstrap/schema-hot-reloader.js
@@ -6,10 +6,10 @@ const { updateStateAndRunQueries } = require(`../query/query-watcher`)
 const report = require(`gatsby-cli/lib/reporter`)
 
 const inferredTypesChanged = (typeMap, prevTypeMap) =>
-  Object.keys(typeMap).filter(
+  Object.keys(typeMap).some(
     type =>
       typeMap[type].dirty && !haveEqualFields(typeMap[type], prevTypeMap[type])
-  ).length > 0
+  )
 
 const schemaChanged = (schemaCustomization, lastSchemaCustomization) =>
   [`fieldExtensions`, `printConfig`, `thirdPartySchemas`, `types`].some(

--- a/packages/gatsby/src/bootstrap/schema-hot-reloader.js
+++ b/packages/gatsby/src/bootstrap/schema-hot-reloader.js
@@ -5,11 +5,10 @@ const { haveEqualFields } = require(`../schema/infer/inference-metadata`)
 const { updateStateAndRunQueries } = require(`../query/query-watcher`)
 const report = require(`gatsby-cli/lib/reporter`)
 
-const inferredTypesChanged = (inferenceMetadata, prevInferenceMetadata) =>
-  Object.keys(inferenceMetadata).filter(
+const inferredTypesChanged = (typeMap, prevTypeMap) =>
+  Object.keys(typeMap).filter(
     type =>
-      inferenceMetadata[type].dirty &&
-      !haveEqualFields(inferenceMetadata[type], prevInferenceMetadata[type])
+      typeMap[type].dirty && !haveEqualFields(typeMap[type], prevTypeMap[type])
   ).length > 0
 
 const schemaChanged = (schemaCustomization, lastSchemaCustomization) =>
@@ -26,7 +25,7 @@ const maybeRebuildSchema = debounce(async () => {
   const { inferenceMetadata, schemaCustomization } = store.getState()
 
   if (
-    !inferredTypesChanged(inferenceMetadata, lastMetadata) &&
+    !inferredTypesChanged(inferenceMetadata.typeMap, lastMetadata.typeMap) &&
     !schemaChanged(schemaCustomization, lastSchemaCustomization)
   ) {
     return


### PR DESCRIPTION
This PR is a follow up after #19781. It fixes schema hot reloading which was not handled correctly in the previous PR. It also adds a simple e2e test for schema rebuilding to catch such situations in the future.