### PR TITLE
fix(gatsby-source-drupal): sanity check before accessing field

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -93,7 +93,7 @@ exports.sourceNodes = async (
           }
         }
         data = data.concat(d.data.data)
-        if (d.data.links.next) {
+        if (d.data.links && d.data.links.next) {
           data = await getNext(d.data.links.next, data)
         }
 


### PR DESCRIPTION
## Description

I do not know why, but https://d2.api.demo.centarro.io/jsonapi/action/action returned the following error when trying to build a project w/ gatsby-source-drupal

```
 ERROR #11321  PLUGIN
"gatsby-source-drupal" threw an error while running the sourceNodes lifecycle:
Cannot read property 'next' of undefined
  TypeError: Cannot read property 'next' of undefined
  - gatsby-node.js:109 getNext
    [gatsbyjs_commerce_demo]/[gatsby-source-drupal]/gatsby-node.js:109:24
```

when unauthenticated. There is a links object. But it is acting like it is null


