### PR TITLE
fix(gatsby-cli): progress reset unflushedProgress

### DIFF
--- a/packages/gatsby-cli/src/reporter/index.js
+++ b/packages/gatsby-cli/src/reporter/index.js
@@ -412,6 +412,7 @@ const reporter: Reporter = {
       },
       set total(value) {
         unflushedTotal = value
+        unflushedProgress = 0
         updateProgress()
       },
       span,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

- the update of progress bar is throttled since #19866
- when a update is possible then at first `unflushedTotal` is set and afterwards it is incremented by `unflushedProgress` 
- when the `unflushedTotal` is set to a new value then current `unflushedProgress` counts should be set to `0` otherwise it goes out of sync on the next `updateProgress`

## Related Issues

#19866

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
