### PR TITLE
fix(gatsby-source-drupal): skip jsonapi_schema endpoint

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -57,7 +57,7 @@ exports.sourceNodes = async (
   })
   const allData = await Promise.all(
     _.map(data.data.links, async (url, type) => {
-      if (type === `self`) return
+      if (type === `self` || type === `describedby`) return
       if (!url) return
       if (!type) return
       const getNext = async (url, data = []) => {


### PR DESCRIPTION
## Description

The JSON:API Schema module (https://www.drupal.org/project/jsonapi_schema) adds a `describedby` link to resources. This payload doesn't contain a JSON:API document, but information describing the object's schema. It's not a valid source of content.

After debugging, it is the original cause of #19867

## Related Issues

Related to #19867