### PR TITLE
Edited regex in config.yml to bypass CI on pull requests limited to docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ aliases:
     filters:
       branches:
         ignore:
-          - /docs.+/
+          - /.+docs.+/
           - /blog.+/
 
   test_template: &test_template
@@ -65,7 +65,7 @@ aliases:
       branches:
         ignore:
           - master
-          - /docs.+/
+          - /.+docs.+/
           - /blog.+/
     requires:
       - lint


### PR DESCRIPTION
## Description

This PR is intended to address CI not bypassing checks in the instance of forked branches.

## Related Issues

The motivation for this is discussed in [#19725](https://github.com/gatsbyjs/gatsby/issues/19725)
