### PR TITLE
chore(gatsby): print step duration to the left, aligned

### DIFF
--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/messages.js
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/messages.js
@@ -33,10 +33,12 @@ const getLabel = level => {
 }
 
 export const Message = ({ level, text, duration, statusText }) => {
-  let message = text
+  let message = ``
   if (duration) {
-    message += ` - ${duration.toFixed(3)}s`
+    // Anticipate hundreds of seconds (300s = 5min) but ignore >999s
+    message += `- ${duration.toFixed(3).padStart(10, ` `)}s - `
   }
+  message += text
   if (statusText) {
     message += ` - ${statusText}`
   }


### PR DESCRIPTION
Prints the time for each step in the cli to the left if the result-status, rather than the right of the (arbitrary) message. This allows the durations to line up and give you a faster overview of which steps took longer.

Before:
![image](https://user-images.githubusercontent.com/209817/69955343-bab61d00-14fd-11ea-9158-5394ecae56e0.png)

After:
![image](https://user-images.githubusercontent.com/209817/69955358-c30e5800-14fd-11ea-9c97-c0ffb644f4bd.png)
