### PR TITLE
Make babel-gatsby-preset nested presets configurable

### DIFF
--- a/packages/babel-preset-gatsby/src/index.js
+++ b/packages/babel-preset-gatsby/src/index.js
@@ -58,6 +58,7 @@ module.exports = function preset(_, options = {}) {
           targets,
           // Exclude transforms that make all code slower (https://github.com/facebook/create-react-app/pull/5278)
           exclude: [`transform-typeof-symbol`],
+          ...options['@babel/preset-env'],
         },
       ],
       [
@@ -66,6 +67,7 @@ module.exports = function preset(_, options = {}) {
           useBuiltIns: true,
           pragma: `React.createElement`,
           development: stage === `develop`,
+          ...options['@babel/preset-react'],
         },
       ],
     ],
@@ -74,10 +76,21 @@ module.exports = function preset(_, options = {}) {
         resolve(`@babel/plugin-proposal-class-properties`),
         {
           loose: true,
+          ...options[`@babel/plugin-proposal-class-properties`],
         },
       ],
-      resolve(`babel-plugin-macros`),
-      resolve(`@babel/plugin-syntax-dynamic-import`),
+      [
+        resolve(`babel-plugin-macros`),
+        {
+          ...options[`babel-plugin-macros`],
+        }
+      ],
+      [
+        resolve(`@babel/plugin-syntax-dynamic-import`),
+        {
+          ...options[`@babel/plugin-syntax-dynamic-import`],
+        }
+      ],
       [
         resolve(`@babel/plugin-transform-runtime`),
         {
@@ -86,20 +99,28 @@ module.exports = function preset(_, options = {}) {
           regenerator: true,
           useESModules: stage !== `test`,
           absoluteRuntimePath,
+          ...options[`@babel/plugin-transform-runtime`],
         },
       ],
       [
         resolve(`@babel/plugin-transform-spread`),
         {
           loose: false, // Fixes #14848
+          ...options[`@babel/plugin-transform-spread`],
         },
       ],
-      IS_TEST && resolve(`babel-plugin-dynamic-import-node`),
+      IS_TEST && [
+        resolve(`babel-plugin-dynamic-import-node`),
+        {
+          ...options[`babel-plugin-dynamic-import-node`],
+        }
+      ],
       stage === `build-javascript` && [
         // Remove PropTypes from production build
         resolve(`babel-plugin-transform-react-remove-prop-types`),
         {
           removeImport: true,
+          ...options[`babel-plugin-transform-react-remove-prop-types`],
         },
       ],
     ].filter(Boolean),


### PR DESCRIPTION
Hi there, 

at the moment it's not possible to configure the nested presets or plugins in the gatsby babel preset. Whenever we need to adjust a nested preset like @babel/preset-react we need to build a copied babelrc of the standard config. With this PR it's possible to put "suboptions" into the options object ex: { "@babel/preset-react": { "useBuiltIns": false } }. This way we can also use setBabelPreset action to adjust the config easily from a plugin.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
