### PR TITLE
fix(gatsby): support union types for one-to-one ___NODE relations

### DIFF
--- a/packages/gatsby/src/schema/__tests__/rebuild-schema.js
+++ b/packages/gatsby/src/schema/__tests__/rebuild-schema.js
@@ -374,8 +374,7 @@ describe(`build and update individual types`, () => {
     expect(String(field.type)).toEqual(`[Foo]`)
   })
 
-  it(`doesn't change ___NODE relations (defined as string)`, async () => {
-    // FIXME: this behavior seems a bit inconsistent, we should possibly reconsider it
+  it(`changes ___NODE relations (defined as string) from object type to union and back`, async () => {
     const node = {
       id: `Bar1`,
       internal: { type: `Bar`, contentDigest: `0` },
@@ -392,9 +391,9 @@ describe(`build and update individual types`, () => {
     }
     newSchema = await addNodeAndRebuild(node2)
     field = newSchema.getType(`Bar`).getFields().related
-    expect(String(field.type)).toEqual(`Foo`)
+    expect(String(field.type)).toEqual(`FooNestedUnion`)
 
-    newSchema = await deleteNodeAndRebuild(node)
+    newSchema = await deleteNodeAndRebuild(node2)
     field = newSchema.getType(`Bar`).getFields().related
     expect(String(field.type)).toEqual(`Foo`)
   })

--- a/packages/gatsby/src/schema/infer/__tests__/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/__tests__/inference-metadata.js
@@ -680,7 +680,10 @@ describe(`Get example value for type inference`, () => {
         ],
         typeConflictReporter,
       })
-      expect(example.related___NODE).toBe(`foo`)
+      expect(example.related___NODE).toEqual({
+        multiple: false,
+        linkedNodes: [`foo`, `bar`, `baz`],
+      })
     })
 
     it(`aggregates array of related node ids`, () => {
@@ -692,7 +695,10 @@ describe(`Get example value for type inference`, () => {
         ],
         typeConflictReporter,
       })
-      expect(example.related___NODE).toEqual([`foo`, `bar`, `baz`])
+      expect(example.related___NODE).toEqual({
+        multiple: true,
+        linkedNodes: [`foo`, `bar`, `baz`],
+      })
     })
 
     it(`skips nullish values and empty arrays/objects`, () => {
@@ -1033,8 +1039,8 @@ describe(`Type change detection`, () => {
     { object: { foo: `foo`, bar: `bar` } },
     { list: [`item`], bar: `bar` },
     { listOfObjects: [{ foo: `foo`, bar: `bar` }] },
-    { union___NODE: `foo` },
-    { listOfUnion___NODE: [`foo`] },
+    { relatedNode___NODE: `foo` },
+    { relatedNodeList___NODE: [`foo`] },
   ]
 
   const addOne = (node, metadata = initialMetadata) =>
@@ -1125,39 +1131,38 @@ describe(`Type change detection`, () => {
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
   })
 
-  // TODO
-  it.skip(`detects on any change of the union field`, () => {
+  it(`detects on any change of the relatedNode field`, () => {
     // We do not know a type of the node being added hence consider and
     // add/delete to such fields as mutations
-    let metadata = addOne({ union___NODE: `added` })
+    let metadata = addOne({ relatedNode___NODE: `added` })
     expect(metadata.dirty).toEqual(true)
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
     metadata.dirty = false
 
-    metadata = deleteOne({ union___NODE: `added` }, metadata)
+    metadata = deleteOne({ relatedNode___NODE: `added` }, metadata)
     expect(metadata.dirty).toEqual(true)
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
   })
 
-  it.skip(`does not detect when the same node added to the union field`, () => {
-    const metadata = addOne({ union___NODE: `foo` })
+  it(`does not detect when the same node added to the relatedNode field`, () => {
+    const metadata = addOne({ relatedNode___NODE: `foo` })
     expect(metadata.dirty).toEqual(false)
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
   })
 
-  it(`detects on any change of the listOfUnion field`, () => {
-    let metadata = addOne({ listOfUnion___NODE: [`added`] })
+  it(`detects on any change of the relatedNodeList field`, () => {
+    let metadata = addOne({ relatedNodeList___NODE: [`added`] })
     expect(metadata.dirty).toEqual(true)
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
     metadata.dirty = false
 
-    metadata = deleteOne({ listOfUnion___NODE: [`added`] }, metadata)
+    metadata = deleteOne({ relatedNodeList___NODE: [`added`] }, metadata)
     expect(metadata.dirty).toEqual(true)
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
   })
 
-  it(`does not detect when the same node added to the listOfUnion field`, () => {
-    const metadata = addOne({ listOfUnion___NODE: [`foo`] })
+  it(`does not detect when the same node added to the relatedNodeList field`, () => {
+    const metadata = addOne({ relatedNodeList___NODE: [`foo`] })
     expect(metadata.dirty).toEqual(false)
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
   })

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -169,6 +169,7 @@ const getFieldConfig = ({
       value: exampleValue,
       key: unsanitizedKey,
     })
+    arrays = arrays + (value.multiple ? 1 : 0)
   } else {
     fieldConfig = getSimpleFieldConfig({
       schemaComposer,
@@ -255,9 +256,7 @@ const getFieldConfigFromFieldNameConvention = ({
       ? nodeStore.getNodes().find(node => _.get(node, foreignKey) === value)
       : nodeStore.getNode(value)
 
-  const linkedNodes = Array.isArray(value)
-    ? value.map(getNodeBy)
-    : [getNodeBy(value)]
+  const linkedNodes = value.linkedNodes.map(getNodeBy)
 
   const linkedTypes = _.uniq(
     linkedNodes.filter(Boolean).map(node => node.internal.type)
@@ -266,7 +265,7 @@ const getFieldConfigFromFieldNameConvention = ({
   invariant(
     linkedTypes.length,
     `Encountered an error trying to infer a GraphQL type for: \`${key}\`. ` +
-      `There is no corresponding node with the \`id\` field matching: "${value}".`
+      `There is no corresponding node with the \`id\` field matching: "${value.linkedNodes}".`
   )
 
   let type


### PR DESCRIPTION
## Description

This PR should make the processing of `___NODE` convenience fields consistent for `one-to-one` and `one-to-many` relations (currently `one-to-many` works as expected while `one-to-one` doesn't). 

Take this example with `one-to-one` relation:
```
createNode({
  internal: { type: `MyType` },
  related___NODE: `FooTypeNode1`,
})
createNode({
  internal: { type: `MyType` },
  related___NODE: `BarTypeNode1`,
})
```

The expected inference result is a union type:
```
type MyType {
  related: FooBar
}

union FooBar = Foo | Bar
```

The actual result is a first registered object type:
```
type MyType {
  related: Foo
}
```

The same example for `one-to-many` relation produces an expected result:
```
createNode({
  internal: { type: `MyType` },
  related___NODE: [`FooTypeNode1`],
})
createNode({
  internal: { type: `MyType` },
  related___NODE: [`BarTypeNode1`],
})
```

Results in:
```
type MyType {
  related: [FooBar]
}

union FooBar = Foo | Bar
```

## Related Issues
Fixes #10090
