### PR TITLE
Rename Routing Doc and remove duplicate stub

### DIFF
--- a/docs/docs/creating-dynamic-navigation.md
+++ b/docs/docs/creating-dynamic-navigation.md
@@ -1,8 +1,6 @@
 ---
-title: Centralizing Your Site's Navigation
+title: Creating Dynamic Navigation in Gatsby
 ---
-
-## Creating dynamic navigation in Gatsby
 
 At times you will want to be able to edit your website's navigation in response to a _change in requirements_. To achieve this, you can use Gatsby to dynamically generate your navigation. Where you store the data for your navigation can be anywhere - a backend API, CMS, headless CMS or even the filesystem.
 

--- a/docs/docs/rendering-sidebar-navigation-dynamically.md
+++ b/docs/docs/rendering-sidebar-navigation-dynamically.md
@@ -1,9 +1,0 @@
----
-title: Rendering Sidebar Navigation Dynamically
-issue: https://github.com/gatsbyjs/gatsby/issues/9779
----
-
-This is a stub. Help our community expand it.
-
-Please use the [Gatsby Style Guide](/contributing/gatsby-style-guide/) to ensure your
-pull request gets accepted.

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -413,6 +413,12 @@ exports.createPages = ({ graphql, actions, reporter }) => {
     isPermanent: true,
   })
 
+  createRedirect({
+    fromPath: `/docs/centralizing-your-sites-navigation/`,
+    toPath: `/docs/creating-dynamic-navigation/`,
+    isPermanent: true,
+  })
+
   Object.entries(startersRedirects).forEach(([fromSlug, toSlug]) => {
     createRedirect({
       fromPath: `/starters${fromSlug}`,

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -418,8 +418,8 @@
                   link: /docs/linking-and-prefetching-with-gatsby/
                 - title: Location Data from Props
                   link: /docs/location-data-from-props/
-                - title: Centralizing Your Site's Navigation
-                  link: /docs/centralizing-your-sites-navigation/
+                - title: Creating Dynamic Navigation
+                  link: /docs/creating-dynamic-navigation/
                 - title: Rendering Sidebar Navigation Dynamically*
                   link: /docs/rendering-sidebar-navigation-dynamically/
                 - title: Client-only Routes & User Authentication


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
This existing page can be more appropriately named to match its content. It's first header "Creating Dynamic Navigation in Gatsby" should be the page title, and the now redundant stub for "Rendering Sidebar Navigation Dynamically" can be removed. 
<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Addresses #18993