### PR TITLE
fix(gatsby-telemetry): gracefully handle postinstall script permission errors

### DIFF
--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -54,7 +54,7 @@
     "build": "babel src --out-dir lib --ignore \"**/__tests__\",\"**/__mocks__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "jest": "jest",
-    "postinstall": "node src/postinstall.js",
+    "postinstall": "node src/postinstall.js || true",
     "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\",\"**/__mocks__\""
   },
   "yargs": {


### PR DESCRIPTION
This really is a hack for a bug in npm, but some other packages,
including core-js [does this hack](https://github.com/zloirock/core-js/blob/v2.6.10/package.json#L41).

To repro:
```
$ docker run --rm -it ubuntu bash

$ npm install -g gatsby-cli
```
and it will fail with

```
> gatsby-telemetry@1.1.41 postinstall /root/.nvm/versions/node/v10.17.0/lib/node_modules/gatsby-cli/node_modules/gatsby-telemetry
> node src/postinstall.js

sh: 1: node: Permission denied
```

the || true will just make it exit happily, even though we were unable
to run the postinstall script.

