### PR TITLE
fix(www): handle case when gatsbyMajorVersion is unset in a starter

### DIFF
--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -103,34 +103,36 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                       {owner} /
                     </span>
                     <span css={{ display: `flex` }}>
-                      {gatsbyMajorVersion && gatsbyMajorVersion[0] && gatsbyMajorVersion[0][1] === `2` && (
-                        <span
-                          sx={{
-                            alignItems: `center`,
-                            bg: `muted`,
-                            display: `flex`,
-                            borderRadius: 5,
-                            fontSize: 0,
-                            lineHeight: `solid`,
-                            px: `2px`,
-                            pr: 2,
-                            py: `2px`,
-                            mr: 2,
-                          }}
-                        >
+                      {gatsbyMajorVersion &&
+                        gatsbyMajorVersion[0] &&
+                        gatsbyMajorVersion[0][1] === `2` && (
                           <span
-                            dangerouslySetInnerHTML={{ __html: V2Icon }}
                             sx={{
-                              color: `textMuted`,
-                              mb: 0,
+                              alignItems: `center`,
+                              bg: `muted`,
+                              display: `flex`,
+                              borderRadius: 5,
+                              fontSize: 0,
+                              lineHeight: `solid`,
+                              px: `2px`,
+                              pr: 2,
+                              py: `2px`,
                               mr: 2,
-                              "& svg": { height: 12, width: 12 },
                             }}
-                          />
-                          {` `}
-                          v2
-                        </span>
-                      )}
+                          >
+                            <span
+                              dangerouslySetInnerHTML={{ __html: V2Icon }}
+                              sx={{
+                                color: `textMuted`,
+                                mb: 0,
+                                mr: 2,
+                                "& svg": { height: 12, width: 12 },
+                              }}
+                            />
+                            {` `}
+                            v2
+                          </span>
+                        )}
                       <div
                         sx={{
                           alignItems: `center`,

--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -103,7 +103,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                       {owner} /
                     </span>
                     <span css={{ display: `flex` }}>
-                      {gatsbyMajorVersion[0][1] === `2` && (
+                      {gatsbyMajorVersion && gatsbyMajorVersion[0] && gatsbyMajorVersion[0][1] === `2` && (
                         <span
                           sx={{
                             alignItems: `center`,


### PR DESCRIPTION
Seems to fix:
```
21:36:45 PM: error Building static HTML failed for path "/starters/"
21:36:45 PM: 104 | </span> 105 | <span css={{ display: `flex` }}> > 106 | {gatsbyMajorVersion[0][1] === `2` && ( | ^ 107 | <span 108 | sx={{ 109 | alignItems: `center`, WebpackError: TypeError: Cannot read property '1' of undefined - starter-list.js:106 StartersList.starters.map src/views/starter-library/starter-list.js:106:46 - starter-list.js:63 StartersList src/views/starter-library/starter-list.js:63:19
21:36:46 PM: ERROR Failed to compile: Error: Exited with code 1
```

Not sure if there is a nicer way to fix this in the query 🙈 