### PR TITLE
fix(gatsby-plugin-offline): Replaced cacheOnly with cacheFirst

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -143,7 +143,7 @@ const options = {
       // Use cacheFirst since these don't need to be revalidated (same RegExp
       // and same reason as above)
       urlPattern: /(\.js$|\.css$|static\/)/,
-      handler: `cacheOnly`,
+      handler: `cacheFirst`,
     },
     {
       // page-data.json files are not content hashed


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Replaced cacheOnly with cacheFirst within the runtimeCaching config for static assets (JS, CSS etc)

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Spotted by @m-allanson inside my [previous pull request ](https://github.com/gatsbyjs/gatsby/pull/19817/commits/eb0b57ef6266fca681f0ebd2f8df2b776b827103)

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
