### PR TITLE
fix(gatsby-source-drupal): allow specifying disallowed link types

### DIFF
--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -162,6 +162,26 @@ module.exports = {
 }
 ```
 
+## Disallowed Link Types
+
+You can use the `disallowedLinkTypes` option to skip link types found in JSON:API documents. By default it skips the `self` and `describedby` links, which do not provide data that can be sourced. You may override the setting to add additional link types to be skipped.
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-drupal`,
+      options: {
+        baseUrl: `https://live-contentacms.pantheonsite.io/`,
+        // skip the action--action resource type.
+        disallowedLinkTypes: [`self`, `describedby`, `action--action`],
+      },
+    },
+  ],
+}
+```
+
 ## Gatsby Preview (experimental)
 
 You will need to have the Drupal module installed, more information on that here: https://www.drupal.org/project/gatsby

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
@@ -6,6 +6,9 @@
     "node--article": "http://fixture/jsonapi/node/article",
     "taxonomy_term--tags": {
       "href": "http://fixture/jsonapi/taxonomy_term/tags"
+    },
+    "describedby": {
+      "href":"http://fixture/jsonapi/schema"
     }
   }
 }

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/schema.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/schema.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https:\/\/json-schema.org\/draft\/2019-09\/hyper-schema",
+    "$id": "http:\/\/fixture\/jsonapi\/schema",
+    "allOf": [
+        {
+            "$ref": "https:\/\/jsonapi.org\/schema#\/definitions\/success"
+        },
+        {
+            "type": "object",
+            "links": [
+                {
+                    "href": "{instanceHref}",
+                    "rel": "related",
+                    "title": "Article",
+                    "targetMediaType": "application\/vnd.api+json",
+                    "targetSchema": "http:\/\/fixture\/jsonapi\/node\/article\/collection\/schema",
+                    "templatePointers": {
+                        "instanceHref": "\/links\/node--article\/href"
+                    },
+                    "templateRequired": [
+                        "instanceHref"
+                    ]
+                },
+                {
+                    "href": "{instanceHref}",
+                    "rel": "related",
+                    "title": "Files",
+                    "targetMediaType": "application\/vnd.api+json",
+                    "targetSchema": "http:\/\/fixture\/jsonapi\/file\/file\/collection\/schema",
+                    "templatePointers": {
+                        "instanceHref": "\/links\/file--file\/href"
+                    },
+                    "templateRequired": [
+                        "instanceHref"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -249,4 +249,19 @@ describe(`gatsby-source-drupal`, () => {
       })
     })
   })
+
+  it(`Control disallowed link types`, async () => {
+    // Reset nodes and test new disallowed link type.
+    Object.keys(nodes).forEach(key => delete nodes[key])
+    const disallowedLinkTypes = [`self`, `describedby`, `taxonomy_term--tags`]
+    await sourceNodes(args, { baseUrl, disallowedLinkTypes })
+    expect(Object.keys(nodes).length).not.toEqual(0)
+    expect(nodes[createNodeId(`file-1`)]).toBeDefined()
+    expect(nodes[createNodeId(`file-2`)]).toBeDefined()
+    expect(nodes[createNodeId(`tag-1`)]).toBeUndefined()
+    expect(nodes[createNodeId(`tag-2`)]).toBeUndefined()
+    expect(nodes[createNodeId(`article-1`)]).toBeDefined()
+    expect(nodes[createNodeId(`article-2`)]).toBeDefined()
+    expect(nodes[createNodeId(`article-3`)]).toBeDefined()
+  })
 })

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -19,12 +19,16 @@ exports.sourceNodes = async (
     headers,
     params,
     concurrentFileRequests,
+    disallowedLinkTypes,
   } = pluginOptions
   const { createNode } = actions
   const drupalFetchActivity = reporter.activityTimer(`Fetch data from Drupal`)
 
   // Default apiBase to `jsonapi`
   apiBase = apiBase || `jsonapi`
+
+  // Default disallowedLinkTypes to self, describedby.
+  disallowedLinkTypes = disallowedLinkTypes || [`self`, `describedby`]
 
   // Default concurrentFileRequests to `20`
   concurrentFileRequests = concurrentFileRequests || 20
@@ -57,7 +61,7 @@ exports.sourceNodes = async (
   })
   const allData = await Promise.all(
     _.map(data.data.links, async (url, type) => {
-      if (type === `self` || type === `describedby`) return
+      if (disallowedLinkTypes.includes(type)) return
       if (!url) return
       if (!type) return
       const getNext = async (url, data = []) => {


### PR DESCRIPTION
## Description

Adds a `disallowedLinkTypes` setting that allows you to exclude specific link types.

By default it excludes `self` and `describedby`, meeting the current state. This allows skipping link types on `/jsonapi`. This way someone could exclude certain resource links from being crawled, so it actually allows someone to add performance enhancements when building.

I've added a test fixture and test.

## Related Issues

Fixes #19921
Relates  #19867
Relates #19879