### PR TITLE
chore(gatsby-transformer-sharp): remove fragment copying from plugins

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.33"
+    "gatsby": "^2.12.1"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -262,11 +262,4 @@ exports.onPreExtractQueries = async ({ store, getNodesByType }) => {
   if (gatsbyImageDoesNotExist) {
     return
   }
-
-  // We have both gatsby-image installed as well as ImageSharp nodes so let's
-  // add our fragments to .cache/fragments.
-  await fs.copy(
-    require.resolve(`gatsby-source-contentful/src/fragments.js`),
-    `${program.directory}/.cache/fragments/contentful-asset-fragments.js`
-  )
 }

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -246,20 +246,4 @@ exports.onPreExtractQueries = async ({ store, getNodesByType }) => {
     `${program.directory}/.cache/contentful/assets/`
   )
   await fs.ensureDir(CACHE_DIR)
-
-  if (getNodesByType(`ContentfulAsset`).length == 0) {
-    return
-  }
-
-  let gatsbyImageDoesNotExist = true
-  try {
-    require.resolve(`gatsby-image`)
-    gatsbyImageDoesNotExist = false
-  } catch (e) {
-    // Ignore
-  }
-
-  if (gatsbyImageDoesNotExist) {
-    return
-  }
 }

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.12.0",
+    "gatsby": "^2.12.1",
     "gatsby-plugin-sharp": "^2.0.0-beta.3"
   },
   "repository": {

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -1,14 +1,2 @@
-const fs = require(`fs-extra`)
-
 exports.onCreateNode = require(`./on-node-create`)
 exports.createSchemaCustomization = require(`./customize-schema`)
-
-exports.onPreExtractQueries = async ({ store }) => {
-  const program = store.getState().program
-
-  // Add fragments for ImageSharp to .cache/fragments.
-  await fs.copy(
-    require.resolve(`gatsby-transformer-sharp/src/fragments.js`),
-    `${program.directory}/.cache/fragments/image-sharp-fragments.js`
-  )
-}


### PR DESCRIPTION
## Description

Since https://github.com/gatsbyjs/gatsby/pull/15284, fragments no longer need to be copied over to the `.cache` directory because gatsby looks through `node_modules`

This PR removes that copying mechanism from `gatsby-transformer-sharp` and `gatsby-source-contentful` and updates its peer dependencies to `"gatsby": "^2.12.1"`
