### PR TITLE
feat(gatsby-remark-autolink-headers): Allow `after` option to make icon appear after header text

### DIFF
--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -58,7 +58,7 @@ Note: if you are using `gatsby-remark-prismjs`, make sure that it’s listed aft
 - `maintainCase`: Boolean. Maintains the case for markdown header (optional)
 - `removeAccents`: Boolean. Remove accents from generated headings IDs (optional)
 - `enableCustomId`: Boolean. Enable custom header IDs with `{#id}` (optional)
-- `after`: Boolean. Enable the link icon to inline at the end of the header text
+- `isIconAfterH`: Boolean. Enable the anchor icon to be inline at the end of the header text
 
 ```javascript
 // In your gatsby-config.js
@@ -76,7 +76,7 @@ module.exports = {
               className: `custom-class`,
               maintainCase: true,
               removeAccents: true,
-              after: true,
+              isIconAfterH: true,
             },
           },
         ],

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -58,6 +58,7 @@ Note: if you are using `gatsby-remark-prismjs`, make sure that it’s listed aft
 - `maintainCase`: Boolean. Maintains the case for markdown header (optional)
 - `removeAccents`: Boolean. Remove accents from generated headings IDs (optional)
 - `enableCustomId`: Boolean. Enable custom header IDs with `{#id}` (optional)
+- `after`: Boolean. Enable the link icon to inline at the end of the header text
 
 ```javascript
 // In your gatsby-config.js
@@ -75,6 +76,7 @@ module.exports = {
               className: `custom-class`,
               maintainCase: true,
               removeAccents: true,
+              after: true,
             },
           },
         ],

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -58,7 +58,7 @@ Note: if you are using `gatsby-remark-prismjs`, make sure that it’s listed aft
 - `maintainCase`: Boolean. Maintains the case for markdown header (optional)
 - `removeAccents`: Boolean. Remove accents from generated headings IDs (optional)
 - `enableCustomId`: Boolean. Enable custom header IDs with `{#id}` (optional)
-- `isIconAfterHeader`: Boolean. Enable the anchor icon to be inline at the end of the header text
+- `isIconAfterHeader`: Boolean. Enable the anchor icon to be inline at the end of the header text (optional)
 
 ```javascript
 // In your gatsby-config.js

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -58,7 +58,7 @@ Note: if you are using `gatsby-remark-prismjs`, make sure that it’s listed aft
 - `maintainCase`: Boolean. Maintains the case for markdown header (optional)
 - `removeAccents`: Boolean. Remove accents from generated headings IDs (optional)
 - `enableCustomId`: Boolean. Enable custom header IDs with `{#id}` (optional)
-- `isIconAfterH`: Boolean. Enable the anchor icon to be inline at the end of the header text
+- `isIconAfterHeader`: Boolean. Enable the anchor icon to be inline at the end of the header text
 
 ```javascript
 // In your gatsby-config.js
@@ -76,7 +76,7 @@ module.exports = {
               className: `custom-class`,
               maintainCase: true,
               removeAccents: true,
-              isIconAfterH: true,
+              isIconAfterHeader: true,
             },
           },
         ],

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
@@ -250,6 +250,73 @@ Object {
 }
 `;
 
+exports[`gatsby-remark-autolink-headers adds places anchor after header when isIconAfterHeader prop is passed 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-label": "heading uno permalink",
+          "class": "anchor after",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#heading-uno",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "heading-uno",
+      "style": "position:relative;",
+    },
+    "htmlAttributes": Object {
+      "id": "heading-uno",
+    },
+    "id": "heading-uno",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
 exports[`gatsby-remark-autolink-headers maintain case of markdown header for id 1`] = `
 Object {
   "children": Array [

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ Object {
         ],
         "hProperties": Object {
           "aria-label": "heading uno permalink",
-          "class": "anchor",
+          "class": "anchor before",
         },
       },
       "title": null,
@@ -42,6 +42,7 @@ Object {
   "data": Object {
     "hProperties": Object {
       "id": "heading-uno",
+      "style": "position:relative;",
     },
     "htmlAttributes": Object {
       "id": "heading-uno",
@@ -80,7 +81,7 @@ Object {
         ],
         "hProperties": Object {
           "aria-label": "heading uno permalink",
-          "class": "custom-class",
+          "class": "custom-class before",
         },
       },
       "title": null,
@@ -108,6 +109,7 @@ Object {
   "data": Object {
     "hProperties": Object {
       "id": "heading-uno",
+      "style": "position:relative;",
     },
     "htmlAttributes": Object {
       "id": "heading-uno",
@@ -146,7 +148,7 @@ Object {
         ],
         "hProperties": Object {
           "aria-label": "heading uno permalink",
-          "class": "anchor",
+          "class": "anchor before",
         },
       },
       "title": null,
@@ -174,6 +176,7 @@ Object {
   "data": Object {
     "hProperties": Object {
       "id": "heading-uno",
+      "style": "position:relative;",
     },
     "htmlAttributes": Object {
       "id": "heading-uno",
@@ -222,6 +225,7 @@ Object {
   "data": Object {
     "hProperties": Object {
       "id": "heading-uno",
+      "style": "position:relative;",
     },
     "htmlAttributes": Object {
       "id": "heading-uno",
@@ -260,7 +264,7 @@ Object {
         ],
         "hProperties": Object {
           "aria-label": "Heading One permalink",
-          "class": "anchor",
+          "class": "anchor before",
         },
       },
       "title": null,
@@ -288,6 +292,7 @@ Object {
   "data": Object {
     "hProperties": Object {
       "id": "Heading-One",
+      "style": "position:relative;",
     },
     "htmlAttributes": Object {
       "id": "Heading-One",
@@ -326,7 +331,7 @@ Object {
         ],
         "hProperties": Object {
           "aria-label": "Heading Two permalink",
-          "class": "anchor",
+          "class": "anchor before",
         },
       },
       "title": null,
@@ -354,6 +359,7 @@ Object {
   "data": Object {
     "hProperties": Object {
       "id": "Heading-Two",
+      "style": "position:relative;",
     },
     "htmlAttributes": Object {
       "id": "Heading-Two",
@@ -392,7 +398,7 @@ Object {
         ],
         "hProperties": Object {
           "aria-label": "Heading Three permalink",
-          "class": "anchor",
+          "class": "anchor before",
         },
       },
       "title": null,
@@ -420,6 +426,7 @@ Object {
   "data": Object {
     "hProperties": Object {
       "id": "Heading-Three",
+      "style": "position:relative;",
     },
     "htmlAttributes": Object {
       "id": "Heading-Three",

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/index.js
@@ -239,4 +239,18 @@ describe(`gatsby-remark-autolink-headers`, () => {
       },
     ])
   })
+  it(`adds places anchor after header when isIconAfterHeader prop is passed`, () => {
+    const markdownAST = remark.parse(`# Heading Uno`)
+
+    const isIconAfterHeader = true
+    const transformed = plugin({ markdownAST }, { isIconAfterHeader })
+
+    visit(transformed, `heading`, node => {
+      expect(node.data.hProperties.style).toContain(`position:relative`)
+      expect(node.children).toHaveLength(2)
+      expect(node.children[1].data.hProperties.class).toContain(`after`)
+
+      expect(node).toMatchSnapshot()
+    })
+  })
 })

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -13,10 +13,16 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   )
 
   const styles = `
-    .${className} {
-      float: left;
+    .${className}.before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      transform: translateX(-100%);
       padding-right: 4px;
-      margin-left: -20px;
+    }
+    .${className}.after {
+      display: inline-block;
+      padding-left: 4px;
     }
     h1 .${className} svg,
     h2 .${className} svg,

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -21,6 +21,7 @@ module.exports = (
     maintainCase = false,
     removeAccents = false,
     enableCustomId = false,
+    after = true,
   }
 ) => {
   slugs.reset()
@@ -53,10 +54,12 @@ module.exports = (
     patch(data, `hProperties`, {})
     patch(data.htmlAttributes, `id`, id)
     patch(data.hProperties, `id`, id)
+    patch(data.hProperties, `style`, `position:relative;`)
 
     if (icon !== false) {
       const label = id.split(`-`).join(` `)
-      node.children.unshift({
+      const method = after ? `push` : `unshift`
+      node.children[method]({
         type: `link`,
         url: `#${id}`,
         title: null,
@@ -64,7 +67,7 @@ module.exports = (
         data: {
           hProperties: {
             "aria-label": `${label} permalink`,
-            class: className,
+            class: `${className} ${after ? `after` : `before`}`,
           },
           hChildren: [
             {

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -21,7 +21,7 @@ module.exports = (
     maintainCase = false,
     removeAccents = false,
     enableCustomId = false,
-    isIconAfterH = false,
+    isIconAfterHeader = false,
   }
 ) => {
   slugs.reset()
@@ -58,7 +58,7 @@ module.exports = (
 
     if (icon !== false) {
       const label = id.split(`-`).join(` `)
-      const method = after ? `push` : `unshift`
+      const method = isIconAfterHeader ? `push` : `unshift`
       node.children[method]({
         type: `link`,
         url: `#${id}`,
@@ -67,7 +67,7 @@ module.exports = (
         data: {
           hProperties: {
             "aria-label": `${label} permalink`,
-            class: `${className} ${isIconAfterH ? `after` : `before`}`,
+            class: `${className} ${isIconAfterHeader ? `after` : `before`}`,
           },
           hChildren: [
             {

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -21,7 +21,7 @@ module.exports = (
     maintainCase = false,
     removeAccents = false,
     enableCustomId = false,
-    isIconAfterH = true,
+    isIconAfterH = false,
   }
 ) => {
   slugs.reset()

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -21,7 +21,7 @@ module.exports = (
     maintainCase = false,
     removeAccents = false,
     enableCustomId = false,
-    after = true,
+    isIconAfterH = true,
   }
 ) => {
   slugs.reset()
@@ -67,7 +67,7 @@ module.exports = (
         data: {
           hProperties: {
             "aria-label": `${label} permalink`,
-            class: `${className} ${after ? `after` : `before`}`,
+            class: `${className} ${isIconAfterH ? `after` : `before`}`,
           },
           hChildren: [
             {


### PR DESCRIPTION
## Description

Introduce boolean `isIconAfterH` prop in `gatsby-remark-autolink-headers` that will place the icon inline, after the header text. ( Defaults to `before` the title ) 
Also refactor to absolutely position icon relative to the header ( and make the header `position: relative` to make this possible. This removes the need for a float 👍 )
![image](https://user-images.githubusercontent.com/19481150/70119697-c0a41f00-161f-11ea-9d4b-c66f058c33b3.png)