### PR TITLE
chore(gatsby): Refactor schema/infer/inference-metadata.js

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -51,8 +51,10 @@ async function queryResult(
   } = require(`../../../gatsby/src/schema/infer/add-inferred-fields`)
   const {
     addNodes,
-    getExampleObject,
   } = require(`../../../gatsby/src/schema/infer/inference-metadata`)
+  const {
+    getExampleObject,
+  } = require(`../../../gatsby/src/schema/infer/build-example-data`)
 
   const typeName = `MarkdownRemark`
   const sc = createSchemaComposer()

--- a/packages/gatsby-transformer-remark/src/__tests__/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/on-node-create.js
@@ -128,8 +128,10 @@ yadda yadda
       } = require(`../../../gatsby/src/schema/infer/add-inferred-fields`)
       const {
         addNodes,
-        getExampleObject,
       } = require(`../../../gatsby/src/schema/infer/inference-metadata`)
+      const {
+        getExampleObject,
+      } = require(`../../../gatsby/src/schema/infer/build-example-data`)
 
       const sc = createSchemaComposer()
       const typeName = `MarkdownRemark`

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -138,7 +138,8 @@ const makeNodes = () => [
 function makeGqlType(nodes) {
   const { createSchemaComposer } = require(`../../schema/schema-composer`)
   const { addInferredFields } = require(`../infer/add-inferred-fields`)
-  const { addNodes, getExampleObject } = require(`../infer/inference-metadata`)
+  const { addNodes } = require(`../infer/inference-metadata`)
+  const { getExampleObject } = require(`../infer/build-example-data`)
 
   const sc = createSchemaComposer()
   const typeName = `Test`

--- a/packages/gatsby/src/schema/infer/__tests__/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/__tests__/inference-metadata.js
@@ -2,12 +2,13 @@
 const _ = require(`lodash`)
 
 const {
-  getExampleObject,
   addNode,
   deleteNode,
   addNodes,
   haveEqualFields,
 } = require(`../inference-metadata`)
+const { getExampleObject } = require(`../build-example-data`)
+
 const { TypeConflictReporter } = require(`../type-conflict-reporter`)
 
 const INVALID_VALUE = undefined

--- a/packages/gatsby/src/schema/infer/build-example-data.js
+++ b/packages/gatsby/src/schema/infer/build-example-data.js
@@ -1,0 +1,177 @@
+const { groupBy } = require(`lodash`)
+
+// See gatsby/src/schema/infer/inference-metadata.js for the ValueDescriptor structs (-> typeInfo)
+
+const getExampleObject = ({ fieldMap = {}, typeName, typeConflictReporter }) =>
+  Object.keys(fieldMap).reduce((acc, key) => {
+    const value = buildExampleValue({
+      path: `${typeName}.${key}`,
+      descriptor: fieldMap[key],
+      typeConflictReporter,
+    })
+    if (key && value !== null) {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+
+const buildExampleValue = ({
+  descriptor,
+  typeConflictReporter,
+  isArrayItem = false,
+  path = ``,
+}) => {
+  const [type, conflicts = false] = resolveWinnerType(descriptor)
+
+  if (conflicts && typeConflictReporter) {
+    typeConflictReporter.addConflict(
+      path,
+      prepareConflictExamples(descriptor, isArrayItem)
+    )
+  }
+
+  const typeInfo = descriptor[type]
+
+  switch (type) {
+    case `null`:
+      return null
+
+    case `date`:
+    case `string`: {
+      if (isMixOfDateAndString(descriptor)) {
+        return hasOnlyEmptyStrings(descriptor) ? `1978-09-26` : `String`
+      }
+      return typeInfo.example
+    }
+
+    case `array`: {
+      const { item } = typeInfo
+      const exampleItemValue = item
+        ? buildExampleValue({
+            descriptor: item,
+            isArrayItem: true,
+            typeConflictReporter,
+            path,
+          })
+        : null
+      return exampleItemValue === null ? null : [exampleItemValue]
+    }
+
+    case `relatedNode`:
+    case `relatedNodeList`: {
+      const { nodes = {} } = typeInfo
+      return {
+        multiple: type === `relatedNodeList`,
+        linkedNodes: Object.keys(nodes).filter(key => nodes[key] > 0),
+      }
+    }
+
+    case `object`: {
+      const { props } = typeInfo
+      let hasKeys = false
+      const result = {}
+      Object.keys(props).forEach(prop => {
+        const value = buildExampleValue({
+          descriptor: typeInfo.props[prop],
+          typeConflictReporter,
+          path: `${path}.${prop}`,
+        })
+        if (value !== null) {
+          hasKeys = true
+          result[prop] = value
+        }
+      }, {})
+      return hasKeys ? result : null
+    }
+
+    default:
+      return typeInfo.example
+  }
+}
+
+const resolveWinnerType = descriptor => {
+  const candidates = possibleTypes(descriptor)
+  if (candidates.length === 1) {
+    return [candidates[0]]
+  }
+  if (candidates.length === 2 && isMixedNumber(descriptor)) {
+    return [`float`]
+  }
+  if (candidates.length === 2 && isMixOfDateAndString(descriptor)) {
+    return [hasOnlyEmptyStrings(descriptor) ? `date` : `string`]
+  }
+  if (candidates.length > 1) {
+    return [`null`, true]
+  }
+  return [`null`]
+}
+
+const prepareConflictExamples = (descriptor, isArrayItem) => {
+  const typeNameMapper = typeName => {
+    if (typeName === `relatedNode`) {
+      return `string`
+    }
+    if (typeName === `relatedNodeList`) {
+      return `[string]`
+    }
+    return [`float`, `int`].includes(typeName) ? `number` : typeName
+  }
+  const reportedValueMapper = typeName => {
+    if (typeName === `relatedNode`) {
+      const { nodes } = descriptor.relatedNode
+      return Object.keys(nodes).find(key => nodes[key] > 0)
+    }
+    if (typeName === `relatedNodeList`) {
+      const { nodes } = descriptor.relatedNodeList
+      return Object.keys(nodes).filter(key => nodes[key] > 0)
+    }
+    if (typeName === `object`) {
+      return getExampleObject({ typeName, fieldMap: descriptor.object.props })
+    }
+    if (typeName === `array`) {
+      const itemValue = buildExampleValue({
+        descriptor: descriptor.array.item,
+        isArrayItem: true,
+      })
+      return itemValue === null || itemValue === undefined ? [] : [itemValue]
+    }
+    return descriptor[typeName].example
+  }
+  const conflictingTypes = possibleTypes(descriptor)
+
+  if (isArrayItem) {
+    // Differentiate conflict examples by node they were first seen in.
+    // See Caveats section in the header of this file
+    const groups = groupBy(
+      conflictingTypes,
+      type => descriptor[type].first || ``
+    )
+    return Object.keys(groups).map(nodeId => {
+      return {
+        type: `[${groups[nodeId].map(typeNameMapper).join(`,`)}]`,
+        value: groups[nodeId].map(reportedValueMapper),
+      }
+    })
+  }
+
+  return conflictingTypes.map(type => {
+    return {
+      type: typeNameMapper(type),
+      value: reportedValueMapper(type),
+    }
+  })
+}
+
+const isMixedNumber = ({ float, int }) =>
+  float && float.total > 0 && int && int.total > 0
+
+const isMixOfDateAndString = ({ date, string }) =>
+  date && date.total > 0 && string && string.total > 0
+
+const hasOnlyEmptyStrings = ({ string }) =>
+  string && string.empty === string.total
+
+const possibleTypes = (descriptor = {}) =>
+  Object.keys(descriptor).filter(type => descriptor[type].total > 0)
+
+export { getExampleObject }

--- a/packages/gatsby/src/schema/infer/build-example-data.js
+++ b/packages/gatsby/src/schema/infer/build-example-data.js
@@ -67,12 +67,12 @@ const buildExampleValue = ({
     }
 
     case `object`: {
-      const { props } = typeInfo
+      const { dprops } = typeInfo
       let hasKeys = false
       const result = {}
-      Object.keys(props).forEach(prop => {
+      Object.keys(dprops).forEach(prop => {
         const value = buildExampleValue({
-          descriptor: typeInfo.props[prop],
+          descriptor: dprops[prop],
           typeConflictReporter,
           path: `${path}.${prop}`,
         })
@@ -80,7 +80,7 @@ const buildExampleValue = ({
           hasKeys = true
           result[prop] = value
         }
-      }, {})
+      })
       return hasKeys ? result : null
     }
 
@@ -126,7 +126,7 @@ const prepareConflictExamples = (descriptor, isArrayItem) => {
       return Object.keys(nodes).filter(key => nodes[key] > 0)
     }
     if (typeName === `object`) {
-      return getExampleObject({ typeName, fieldMap: descriptor.object.props })
+      return getExampleObject({ typeName, fieldMap: descriptor.object.dprops })
     }
     if (typeName === `array`) {
       const itemValue = buildExampleValue({

--- a/packages/gatsby/src/schema/infer/index.js
+++ b/packages/gatsby/src/schema/infer/index.js
@@ -1,6 +1,7 @@
 const report = require(`gatsby-cli/lib/reporter`)
 const { ObjectTypeComposer } = require(`graphql-compose`)
-const { getExampleObject, hasNodes } = require(`./inference-metadata`)
+const { hasNodes } = require(`./inference-metadata`)
+const { getExampleObject } = require(`./build-example-data`)
 const { addNodeInterface } = require(`../types/node-interface`)
 const { addInferredFields } = require(`./add-inferred-fields`)
 

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -331,10 +331,14 @@ const _updateValueDescriptor = (
       return dirty
     }
     case `relatedNode`:
-      updateValueRelNodes([value], delta, operation, typeInfo)
+      if (updateValueRelNodes([value], delta, operation, typeInfo)) {
+        dirty = true
+      }
       return dirty
     case `relatedNodeList`: {
-      updateValueRelNodes(value, delta, operation, typeInfo)
+      if (updateValueRelNodes(value, delta, operation, typeInfo)) {
+        dirty = true
+      }
       return dirty
     }
     case `string`: {

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -247,10 +247,9 @@ const updateValueDescriptorArray = (
 
   return dirty
 }
-const updateValueRelNodes = (value, delta, operation, typeInfo) => {
+const updateValueRelNodes = (listOfNodeIds, delta, operation, typeInfo) => {
   const { nodes = {} } = typeInfo
   typeInfo.nodes = nodes
-  const listOfNodeIds = Array.isArray(value) ? value : [value]
   let dirty = false
   listOfNodeIds.forEach(nodeId => {
     nodes[nodeId] = (nodes[nodeId] || 0) + delta

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -97,7 +97,7 @@ type TypeInfoBoolean = {
 }
 
 type TypeInfoObject = TypeInfo & {
-  props?: {[name]: Descriptor},
+  dprops?: {[name]: Descriptor},
 }
 
 type TypeInfoArray = TypeInfo & {
@@ -163,15 +163,15 @@ const updateValueDescriptorObject = (
 ) => {
   path.push(value)
 
-  const { props = {} } = typeInfo
-  typeInfo.props = props
+  const { dprops = {} } = typeInfo
+  typeInfo.dprops = dprops
 
   Object.keys(value).forEach(key => {
     const v = value[key]
 
-    let descriptor = props[key]
+    let descriptor = dprops[key]
     if (descriptor === undefined) {
-      props[key] = descriptor = {}
+      dprops[key] = descriptor = {}
     }
 
     updateValueDescriptor(nodeId, key, v, operation, descriptor, metadata, path)
@@ -333,10 +333,10 @@ const updateValueDescriptor = (
     typeof typeInfo.example !== `undefined` ? typeInfo.example : value
 }
 
-const mergeObjectKeys = (obj, other) => {
-  const props = Object.keys(obj)
-  const otherProps = Object.keys(other)
-  return [...new Set(props.concat(otherProps))]
+const mergeObjectKeys = (dpropsKeysA, dpropsKeysB) => {
+  const dprops = Object.keys(dpropsKeysA)
+  const otherProps = Object.keys(dpropsKeysB)
+  return [...new Set(dprops.concat(otherProps))]
 }
 
 const descriptorsAreEqual = (descriptor, otherDescriptor) => {
@@ -359,14 +359,14 @@ const descriptorsAreEqual = (descriptor, otherDescriptor) => {
         otherDescriptor.array.item
       )
     case `object`: {
-      const props = mergeObjectKeys(
-        descriptor.object.props,
-        otherDescriptor.object.props
+      const dpropsKeys = mergeObjectKeys(
+        descriptor.object.dprops,
+        otherDescriptor.object.dprops
       )
-      return props.every(prop =>
+      return dpropsKeys.every(prop =>
         descriptorsAreEqual(
-          descriptor.object.props[prop],
-          otherDescriptor.object.props[prop]
+          descriptor.object.dprops[prop],
+          otherDescriptor.object.dprops[prop]
         )
       )
     }

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -282,7 +282,7 @@ const updateValueDescriptor = (
     if (typeInfo.first === nodeId || typeInfo.total === 0) {
       typeInfo.first = undefined
     }
-  } // return function calls for TCO
+  }
 
   switch (typeName) {
     // I want to return the func call to use TCO, eslint ignores that case :(

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -158,8 +158,8 @@ const updateValueDescriptor = (
   key,
   value,
   operation = `add` /* add | del */,
-  descriptor = {},
-  path = []
+  descriptor,
+  path
 ) => {
   // The object may be traversed multiple times from root.
   // Each time it does it should not revisit the same node twice
@@ -426,7 +426,8 @@ const updateTypeMetadata = (metadata = initialMetadata(), operation, node) => {
       field,
       node[field],
       operation,
-      descriptor
+      descriptor,
+      []
     )
     structureChanged = structureChanged || valueStructureChanged
   })

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -153,42 +153,6 @@ const getType = (value, key) => {
   }
 }
 
-const updateValueDescriptor = (
-  nodeId,
-  key,
-  value,
-  operation = `add` /* add | del */,
-  descriptor,
-  path
-) => {
-  // The object may be traversed multiple times from root.
-  // Each time it does it should not revisit the same node twice
-  if (path.includes(value)) {
-    return false
-  }
-
-  const typeName = getType(value, key)
-
-  if (typeName === `null`) {
-    return false
-  }
-
-  path.push(value)
-
-  const ret = _updateValueDescriptor(
-    nodeId,
-    key,
-    value,
-    operation,
-    descriptor,
-    path,
-    typeName
-  )
-
-  path.pop()
-
-  return ret
-}
 const updateValueDescriptorObject = (
   value,
   typeInfo,
@@ -196,6 +160,8 @@ const updateValueDescriptorObject = (
   operation,
   path
 ) => {
+  path.push(value)
+
   const { props = {} } = typeInfo
   typeInfo.props = props
   let dirty = false
@@ -217,6 +183,8 @@ const updateValueDescriptorObject = (
     )
     dirty = dirty || propDirty
   })
+
+  path.pop()
   return dirty
 }
 const updateValueDescriptorArray = (
@@ -273,15 +241,26 @@ const updateValueString = (value, delta, typeInfo) => {
   typeInfo.example =
     typeof typeInfo.example !== `undefined` ? typeInfo.example : value
 }
-const _updateValueDescriptor = (
+const updateValueDescriptor = (
   nodeId,
   key,
   value,
-  operation,
+  operation = `add` /* add | del */,
   descriptor,
-  path,
-  typeName
+  path
 ) => {
+  // The object may be traversed multiple times from root.
+  // Each time it does it should not revisit the same node twice
+  if (path.includes(value)) {
+    return false
+  }
+
+  const typeName = getType(value, key)
+
+  if (typeName === `null`) {
+    return false
+  }
+
   const delta = operation === `del` ? -1 : 1
   let typeInfo = descriptor[typeName]
   if (typeInfo === undefined) {

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -154,7 +154,11 @@ const getType = (value, key) => {
 }
 
 const updateValueDescriptor = (
-  { nodeId, key, value, operation = `add` /* add | del */, descriptor = {} },
+  nodeId,
+  key,
+  value,
+  operation = `add` /* add | del */,
+  descriptor = {},
   path = []
 ) => {
   // The object may be traversed multiple times from root.
@@ -204,13 +208,11 @@ const updateValueDescriptorObject = (
     }
 
     const propDirty = updateValueDescriptor(
-      {
-        nodeId,
-        key,
-        value: v,
-        operation,
-        descriptor,
-      },
+      nodeId,
+      key,
+      v,
+      operation,
+      descriptor,
       path
     )
     dirty = dirty || propDirty
@@ -233,13 +235,11 @@ const updateValueDescriptorArray = (
     }
 
     const itemDirty = updateValueDescriptor(
-      {
-        nodeId,
-        descriptor,
-        operation,
-        value: item,
-        key,
-      },
+      nodeId,
+      key,
+      item,
+      operation,
+      descriptor,
       path
     )
     dirty = dirty || itemDirty
@@ -417,13 +417,13 @@ const updateTypeMetadata = (metadata = initialMetadata(), operation, node) => {
       fieldMap[field] = descriptor = {}
     }
 
-    const valueStructureChanged = updateValueDescriptor({
-      nodeId: node.id,
-      key: field,
-      value: node[field],
+    const valueStructureChanged = updateValueDescriptor(
+      node.id,
+      field,
+      node[field],
       operation,
-      descriptor,
-    })
+      descriptor
+    )
     structureChanged = structureChanged || valueStructureChanged
   })
   metadata.fieldMap = fieldMap


### PR DESCRIPTION
While trying to investigate objects vs maps I ended up refactoring the inference-metadata bits

- Move example builder to its own file
- Drop some destructuring juggling, both upward and downwards
- Drop the juggling down of `dirty` in favor of passing on the object that contains the flag to be set if dirty
- Drop some destructuring
- Renamed `typeInfo.props` to `typeInfo.dprops` for easier greppability

The end should be simpler and (very slightly) more performant.

I've tried to make `typeInfo.dprops` a Map but my experiments did not yield a win so I did not commit that. We may try again in the future as it may be caused by other complexities / conversions.