### PR TITLE
Update PR template with docs prompt

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,18 @@
 
 <!-- Write a brief description of the changes introduced by this PR -->
 
+### Documentation
+
+<!--
+  Where is this feature or API documented?
+
+  - If docs exist:
+    - Search the docs to find references and update them if relevant. This includes Guides and Gatsby Internals docs.
+  - If no docs exist:
+    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
+  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
+-->
+
 ## Related Issues
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
   Where is this feature or API documented?
 
   - If docs exist:
-    - Search the docs to find references and update them if relevant. This includes Guides and Gatsby Internals docs.
+    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
   - If no docs exist:
     - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
   - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation


### PR DESCRIPTION
## Description

Updating the PR template to include a docs prompt, to get changes written down while they're fresh and minimize docs debt from being shipped. Information provided in initial PRs will be helpful to all teams, but particularly Learning and Marketing. Feedback welcome. CC @m-allanson and @laurieontech per our discussion.

## Related Issues

N/A