### PR TITLE
fix(gatsby-source-shopify): allShopifyPage node creation issue #18249 fix

### DIFF
--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -192,7 +192,12 @@ const createPageNodes = async (
 
   if (verbose) console.time(msg)
   await forEach(
-    await queryAll(client, [endpoint], query, paginationSize),
+    await queryAll(
+      client,
+      [NODE_TO_ENDPOINT_MAPPING[endpoint]],
+      query,
+      paginationSize
+    ),
     async entity => {
       const node = await nodeFactory(entity)
       createNode(node)


### PR DESCRIPTION
This is https://github.com/gatsbyjs/gatsby/issues/18249 issue fix.
Issue replication repo: https://github.com/paveli/gatsbyjs-issue-18249

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Wrong object path was passing to queryAll thus page nodes were not creating.
Changed object path to meet the format requirements.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

 Fixes https://github.com/gatsbyjs/gatsby/issues/18249 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
