### PR TITLE
docs: add 'Deploying to Firebase Hosting' tutorial

### DIFF
--- a/docs/docs/deploying-to-firebase.md
+++ b/docs/docs/deploying-to-firebase.md
@@ -1,0 +1,61 @@
+---
+title: Deploying to Firebase Hosting
+---
+
+In this guide, you will learn how to deploy your Gatsby site to Firebase Hosting.
+
+[Firebase Hosting](https://firebase.google.com/docs/hosting) is a free web content hosting for developers. With a single command, you can quickly deploy web apps and serve both static and dynamic content to a global CDN (content delivery network).
+
+## Pre-requisites
+
+1. Make sure you have:
+    - installed [Node.js](https://nodejs.org/en/download/) on your local machine.
+    - a [Firebase Account](https://console.firebase.google.com).
+
+1. This guide assumes that you already have a Gatsby project on your local machine.
+
+## Deployment
+
+1. Install the Firebase CLI with `npm` by running the following command:
+
+    ```shell
+    npm install -g firebase-tools
+    ```
+
+1. Sign into Firebase using your Google account by running the following command:
+
+    ```shell
+    firebase login
+    ```
+    
+    You can test if the CLI is correctly installed by running `firebase projects:list`, which should show you a list of your Firebase Projects.
+    
+1. Navigate into your gatsby project directory and setup firebase:
+
+    ```shell
+    firebase init
+    ```
+    
+    This command will prompt you to:
+    - select the Firebase products you wish to setup. Be sure to select **Firebase Hosting**.
+    - select the Firebase Project you wish to use or create a new one, if you haven't done it previously.
+    
+    When prompted to select your public directory, you can simply press <kbd>enter</kbd> since it defaults to `public`, which is also Gatsby's default public directory.
+    
+1. Prepare your site for deployment by running `gatsby build`. This generates a publishable version of your site in the `public` folder.
+
+1. Deploy your site by running the following command:
+
+    ```shell
+    firebase deploy
+    ```
+    
+All done! Once the deployment concludes, you can access your website using `firebaseProjectId.firebaseapp.com` or `firebaseProjectId.web.app`.
+
+Check the [Firebase Docs](https://firebase.google.com/docs/hosting/full-config) for information about how to customize your deployment further. Remember that each time you wish to redeploy your site, you will need to rerun `gatsby build` first.
+
+## References:
+
+- [Firebase CLI Reference](https://firebase.google.com/docs/cli)
+- [Get Started with Firebase Hosting](https://firebase.google.com/docs/hosting/quickstart)
+- [Connect a custom domain](https://firebase.google.com/docs/hosting/custom-domain)

--- a/docs/docs/deploying-to-firebase.md
+++ b/docs/docs/deploying-to-firebase.md
@@ -9,8 +9,9 @@ In this guide, you will learn how to deploy your Gatsby site to Firebase Hosting
 ## Pre-requisites
 
 1. Make sure you have:
-    - installed [Node.js](https://nodejs.org/en/download/) on your local machine.
-    - a [Firebase Account](https://console.firebase.google.com).
+
+   - installed [Node.js](https://nodejs.org/en/download/) on your local machine.
+   - a [Firebase Account](https://console.firebase.google.com).
 
 1. This guide assumes that you already have a Gatsby project on your local machine.
 
@@ -18,38 +19,39 @@ In this guide, you will learn how to deploy your Gatsby site to Firebase Hosting
 
 1. Install the Firebase CLI with `npm` by running the following command:
 
-    ```shell
-    npm install -g firebase-tools
-    ```
+   ```shell
+   npm install -g firebase-tools
+   ```
 
 1. Sign into Firebase using your Google account by running the following command:
 
-    ```shell
-    firebase login
-    ```
-    
-    You can test if the CLI is correctly installed by running `firebase projects:list`, which should show you a list of your Firebase Projects.
-    
+   ```shell
+   firebase login
+   ```
+
+   You can test if the CLI is correctly installed by running `firebase projects:list`, which should show you a list of your Firebase Projects.
+
 1. Navigate into your gatsby project directory and setup firebase:
 
-    ```shell
-    firebase init
-    ```
-    
-    This command will prompt you to:
-    - select the Firebase products you wish to setup. Be sure to select **Firebase Hosting**.
-    - select the Firebase Project you wish to use or create a new one, if you haven't done it previously.
-    
-    When prompted to select your public directory, you can simply press <kbd>enter</kbd> since it defaults to `public`, which is also Gatsby's default public directory.
-    
+   ```shell
+   firebase init
+   ```
+
+   This command will prompt you to:
+
+   - select the Firebase products you wish to setup. Be sure to select **Firebase Hosting**.
+   - select the Firebase Project you wish to use or create a new one, if you haven't done it previously.
+
+   When prompted to select your public directory, you can simply press <kbd>enter</kbd> since it defaults to `public`, which is also Gatsby's default public directory.
+
 1. Prepare your site for deployment by running `gatsby build`. This generates a publishable version of your site in the `public` folder.
 
 1. Deploy your site by running the following command:
 
-    ```shell
-    firebase deploy
-    ```
-    
+   ```shell
+   firebase deploy
+   ```
+
 All done! Once the deployment concludes, you can access your website using `firebaseProjectId.firebaseapp.com` or `firebaseProjectId.web.app`.
 
 Check the [Firebase Docs](https://firebase.google.com/docs/hosting/full-config) for information about how to customize your deployment further. Remember that each time you wish to redeploy your site, you will need to rerun `gatsby build` first.

--- a/docs/docs/deploying-to-firebase.md
+++ b/docs/docs/deploying-to-firebase.md
@@ -12,6 +12,7 @@ In this guide, you will learn how to deploy your Gatsby site to Firebase Hosting
 
    - installed [Node.js](https://nodejs.org/en/download/) on your local machine.
    - a [Firebase Account](https://console.firebase.google.com).
+   - created a [Firebase Project](https://firebase.google.com/docs/web/setup#create-firebase-project).
 
 1. This guide assumes that you already have a Gatsby project on your local machine.
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -64,6 +64,9 @@
             - title: Deploying to IIS
               link: /docs/deploying-to-iis/
               breadcrumbTitle: IIS
+            - title: Deploying to Firebase Hosting
+              link: /docs/deploying-to-firebase/
+              breadcrumbTitle: Firebase Hosting
             - title: Adding a Path Prefix
               link: /docs/path-prefix/
             - title: How Gatsby Works with GitHub Pages


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR should add a tutorial explaining how to deploy a Gatsby site to [Firebase Hosting](https://firebase.google.com/docs/hosting)

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
