### PR TITLE
Importing the Link component is missing

### DIFF
--- a/docs/docs/recipes.md
+++ b/docs/docs/recipes.md
@@ -156,6 +156,7 @@ export default ({ children }) => (
 
 ```jsx:title=src/pages/index.js
 import React from "react"
+import { Link } from "gatsby"
 import Layout from "../components/layout"
 
 export default () => (


### PR DESCRIPTION
## Description

I noticed that importing the Link component is missing from the code example. This PR fixes it.