### PR TITLE
chore(www): Remove blank component

### DIFF
--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -16,7 +16,6 @@ import HomepageFeatures from "../components/homepage/homepage-features"
 import HomepageEcosystem from "../components/homepage/homepage-ecosystem"
 import HomepageBlog from "../components/homepage/homepage-blog"
 import HomepageNewsletter from "../components/homepage/homepage-newsletter"
-import HomepageSection from "../components/homepage/homepage-section"
 import FooterLinks from "../components/shared/footer-links"
 import {
   setupScrollersObserver,

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -141,13 +141,6 @@ class IndexRoute extends React.Component {
           <HomepageBlog posts={posts} />
 
           <HomepageNewsletter />
-
-          <HomepageSection
-            css={{
-              paddingTop: `0 !important`,
-              paddingBottom: `0 !important`,
-            }}
-          />
         </main>
         <FooterLinks />
       </Layout>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This component didn't seem to be doing anything. However, it was triggering an error in the browser console:

```
Warning: Failed prop type: The prop `children` is marked as required in `HomepageSection`, but its value is `undefined`.
```

For reference, here is where HomepageSection is defined: https://github.com/gatsbyjs/gatsby/blob/master/www/src/components/homepage/homepage-section.js

### Documentation

n/a

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
n/a
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
