### PR TITLE
fix(gatsby): Ensure the number of jest-workers respects GATSBY_CPU_COUNT env var

### DIFF
--- a/packages/gatsby/src/utils/worker/pool.js
+++ b/packages/gatsby/src/utils/worker/pool.js
@@ -3,7 +3,7 @@ const { cpuCoreCount } = require(`gatsby-core-utils`)
 
 const create = () =>
   new Worker(require.resolve(`./child`), {
-    numWorkers: cpuCoreCount(true),
+    numWorkers: cpuCoreCount(),
     forkOptions: {
       silent: false,
     },


### PR DESCRIPTION
## Description

As outlined in https://github.com/gatsbyjs/gatsby/issues/19974, the number of `jest-worker` instances created to build the static HTML does not respect the number specified by the environment variable GATSBY_CPU_COUNT. This can result in `ENOMEM` when running in a containerised environment. 

This PR stops forcing the `ignoreEnvVar` argument to `true`. https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-core-utils/src/cpu-core-count.js#L4

As a result of this change, we stopped experiencing ENOMEM issues, but also a bump in page generation speed.

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/19974

## Tests
I'm happy to add any tests for this if required. Sorry if this PR is premature.