### PR TITLE
fix(gatsby-theme-blog): Fix home-footer in Night mode

### DIFF
--- a/packages/gatsby-theme-blog/src/components/home-footer.js
+++ b/packages/gatsby-theme-blog/src/components/home-footer.js
@@ -10,7 +10,7 @@ const Footer = ({ socialLinks }) => (
   >
     © {new Date().getFullYear()}, Powered by
     {` `}
-    <a href="https://www.gatsbyjs.org">Gatsby</a>
+    <Styled.a href="https://www.gatsbyjs.org">Gatsby</Styled.a>
     {` `}&bull;{` `}
     {socialLinks.map((platform, i, arr) => (
       <Fragment key={platform.url}>


### PR DESCRIPTION
## Description

This PR fixes the issue #19976 

## Related Issues

Fix for #19976