### PR TITLE
chore(i18n/update-source): use master over test branch

### DIFF
--- a/scripts/i18n/update-source.js
+++ b/scripts/i18n/update-source.js
@@ -14,8 +14,7 @@ const owner = `gatsbyjs`
 // Repo to be used as basis for translations
 const sourceRepo = `gatsby-i18n-source`
 
-// const branch = `master`
-const branch = `test-update` // test branch
+const branch = `master`
 
 const sourceRepoUrl = `${protocol}${process.env.GITHUB_API_TOKEN}@${host}/${owner}/${sourceRepo}.git`
 


### PR DESCRIPTION
This script was running for quite some time using `test-update` branch in https://github.com/gatsbyjs/gatsby-i18n-source as target. 

Check history for the branch how it syncs docs updates: https://github.com/gatsbyjs/gatsby-i18n-source/commits/test-update

I think we can be confident enough with it to switch it to `master` now

For context - referenced repository is used as source of truth for translation repositories:
 - right now when creating new language repository we use this is a base
 - in future that repo will be used to sync updates from gatsbyjs/gatsby to translation repos