### PR TITLE
chore: lint all shell scripts

### DIFF
--- a/benchmarks/query/bin/runQueryTiming.sh
+++ b/benchmarks/query/bin/runQueryTiming.sh
@@ -1,8 +1,9 @@
+#!/bin/bash
+
 # Run the build (after purging .cache) and output the amount of time
 # taken by the query execution phase
 #
 # run with `bin/runQueryTiming.sh`
 
 output=$(rm -rf .cache && gatsby build | grep "run graphql queries")
-echo $output | cut -d' ' -f 6
-
+echo "$output" | cut -d' ' -f 6

--- a/packages/gatsby-transformer-screenshot/chrome/buildChrome.sh
+++ b/packages/gatsby-transformer-screenshot/chrome/buildChrome.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+# shellcheck disable=SC2129,SC1090
+
 # build headless chrome on EC2
 # https://github.com/adieuadieu/serverless-chrome/blob/master/chrome/README.md
 
@@ -5,15 +9,15 @@
 
 yum install -y git redhat-lsb python bzip2 tar pkgconfig atk-devel alsa-lib-devel bison binutils brlapi-devel bluez-libs-devel bzip2-devel cairo-devel cups-devel dbus-devel dbus-glib-devel expat-devel fontconfig-devel freetype-devel gcc-c++ GConf2-devel glib2-devel glibc.i686 gperf glib2-devel gtk2-devel gtk3-devel java-1.*.0-openjdk-devel libatomic libcap-devel libffi-devel libgcc.i686 libgnome-keyring-devel libjpeg-devel libstdc++.i686 libX11-devel libXScrnSaver-devel libXtst-devel libxkbcommon-x11-devel ncurses-compat-libs nspr-devel nss-devel pam-devel pango-devel pciutils-devel pulseaudio-libs-devel zlib.i686 httpd mod_ssl php php-cli python-psutil wdiff --enablerepo=epel
 
-cd ~
+cd ~ || exit
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 echo "export PATH=$PATH:$HOME/depot_tools" >> ~/.bash_profile
 source ~/.bash_profile
 
 mkdir Chromium
-cd Chromium
+cd Chromium || exit
 fetch --no-history chromium
-cd src
+cd src || exit
 
 # use /tmp instead of /dev/shm
 # https://groups.google.com/a/chromium.org/forum/#!msg/headless-dev/qqbZVZ2IwEw/CPInd55OBgAJ
@@ -29,7 +33,7 @@ echo 'enable_nacl = false' >> out/Headless/args.gn
 gn gen out/Headless
 ninja -C out/Headless headless_shell
 
-cd out/Headless
-tar -zcvf /home/ec2-user/headless_shell.tar.gz headless_shell 
+cd out/Headless || exit
+tar -zcvf /home/ec2-user/headless_shell.tar.gz headless_shell
 
 # scp ec2-user@xxx.amazonaws.com:~/headless_shell.tar.gz .

--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 GREP_PATTERN=$1
 
-FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r $CIRCLE_BRANCH origin/master | grep -E "$GREP_PATTERN" | wc -l)"
+FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r "$CIRCLE_BRANCH" origin/master | grep -E "$GREP_PATTERN" -c)"
 
-if [ $FILES_COUNT -eq 0 ]; then
+if [ "$FILES_COUNT" -eq 0 ]; then
   echo "0 files matching '$GREP_PATTERN'; exiting and marking successful."
   circleci step halt || exit 1
 else

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -7,8 +7,8 @@ GATSBY_PATH="${CIRCLE_WORKING_DIRECTORY:-../../}"
 command -v sudo && sudo npm install -g gatsby-dev-cli || npm install -g gatsby-dev-cli &&
 
 # setting up child integration test link to gatsby packages
-cd $SRC_PATH &&
-gatsby-dev --set-path-to-repo $GATSBY_PATH &&
+cd "$SRC_PATH" &&
+gatsby-dev --set-path-to-repo "$GATSBY_PATH" &&
 gatsby-dev --scan-once --quiet && # copies _all_ files in gatsby/packages
 chmod +x ./node_modules/.bin/gatsby && # this is sometimes necessary to ensure executable
 sh -c "$CUSTOM_COMMAND" &&

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 npm test
 npm run build

--- a/scripts/publish-canary.sh
+++ b/scripts/publish-canary.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 yarn add --global yarn@latest
 lerna run build
 lerna publish --canary

--- a/scripts/publish-site-from-npm.sh
+++ b/scripts/publish-site-from-npm.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 echo "=== Installing the website dependencies"
-cd $1
+cd "$1" || exit
 yarn
 echo "=== Building website"
 NODE_ENV=production ./node_modules/.bin/gatsby build

--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -11,20 +11,20 @@ fi
 
 for folder in $GLOB; do
   [ -d "$folder" ] || continue # only directories
-  cd $BASE
+  cd "$BASE"
 
-  NAME=$(jq -r '.name' $folder/package.json)
-  IS_WORKSPACE=$(jq -r '.workspaces' $folder/package.json)
+  NAME=$(jq -r '.name' "$folder/package.json")
+  IS_WORKSPACE=$(jq -r '.workspaces' "$folder/package.json")
   CLONE_DIR="__${NAME}__clone__"
-  
+
   # sync to read-only clones
   # clone, delete files in the clone, and copy (new) files over
   # this handles file deletions, additions, and changes seamlessly
   # note: redirect output to dev/null to avoid any possibility of leaking token
-  git clone --quiet --depth 1 https://$GITHUB_API_TOKEN@github.com/gatsbyjs/$NAME.git $CLONE_DIR > /dev/null
-  cd $CLONE_DIR
-  find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
-  cp -r $BASE/$folder/. .
+  git clone --quiet --depth 1 "https://$GITHUB_API_TOKEN@github.com/gatsbyjs/$NAME.git" "$CLONE_DIR" > /dev/null
+  cd "$CLONE_DIR"
+  find . | grep -v ".git" | grep -v "^\\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
+  cp -r "$BASE/$folder/." .
 
   if [ "$IS_WORKSPACE" = null ]; then
     rm -rf yarn.lock
@@ -37,5 +37,5 @@ for folder in $GLOB; do
     git push origin master
   fi
 
-  cd $BASE
+  cd "$BASE"
 done

--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -23,7 +23,7 @@ for folder in $GLOB; do
   # note: redirect output to dev/null to avoid any possibility of leaking token
   git clone --quiet --depth 1 "https://$GITHUB_API_TOKEN@github.com/gatsbyjs/$NAME.git" "$CLONE_DIR" > /dev/null
   cd "$CLONE_DIR"
-  find . | grep -v ".git" | grep -v "^\\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
+  find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   cp -r "$BASE/$folder/." .
 
   if [ "$IS_WORKSPACE" = null ]; then

--- a/scripts/validate-starters.sh
+++ b/scripts/validate-starters.sh
@@ -9,10 +9,10 @@ fi
 
 for folder in $GLOB; do
   [ -d "$folder" ] || continue # only directories
-  cd $BASE
-  
+  cd "$BASE" || exit
+
   # validate
-  cd $folder
+  cd "$folder" || exit
   npm audit &&
   npm install &&
   # check both npm and yarn, sometimes yarn registry lags behind
@@ -21,5 +21,5 @@ for folder in $GLOB; do
   npm run build ||
   exit 1
 
-  cd $BASE
+  cd "$BASE" || exit
 done


### PR DESCRIPTION
## Description

Fix linting in shell scripts to conform to [ShellCheck](https://github.com/koalaman/shellcheck) standards. ShellCheck is a static analysis tool that offers suggestions to catch potential warnings and errors.

Specifically, the following rules have been fixed: [SC1090](https://github.com/koalaman/shellcheck/wiki/SC1090), [SC1117](https://github.com/koalaman/shellcheck/wiki/SC1117), [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086), [SC2129](https://github.com/koalaman/shellcheck/wiki/SC2129), [SC2148](https://github.com/koalaman/shellcheck/wiki/SC2148) and [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164)

### Documentation

N/A

## Related Issues

N/A