### PR TITLE
feat(gatsby): support nullish coalescing operator in gatsby

### DIFF
--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -61,6 +61,7 @@ Array [
 exports[`babel-preset-gatsby-package in browser mode specifies the proper plugins 1`] = `
 Array [
   "@babel/plugin-proposal-class-properties",
+  "@babel/plugin-proposal-nullish-coalescing-operator",
   "@babel/plugin-proposal-optional-chaining",
   "@babel/plugin-transform-runtime",
   "@babel/plugin-syntax-dynamic-import",
@@ -123,6 +124,7 @@ Array [
 exports[`babel-preset-gatsby-package in node mode specifies the proper plugins 1`] = `
 Array [
   "@babel/plugin-proposal-class-properties",
+  "@babel/plugin-proposal-nullish-coalescing-operator",
   "@babel/plugin-proposal-optional-chaining",
   "@babel/plugin-transform-runtime",
   "@babel/plugin-syntax-dynamic-import",

--- a/packages/babel-preset-gatsby-package/index.js
+++ b/packages/babel-preset-gatsby-package/index.js
@@ -43,6 +43,7 @@ function preset(context, options = {}) {
     ],
     plugins: [
       r(`@babel/plugin-proposal-class-properties`),
+      r(`@babel/plugin-proposal-nullish-coalescing-operator`),
       r(`@babel/plugin-proposal-optional-chaining`),
       r(`@babel/plugin-transform-runtime`),
       r(`@babel/plugin-syntax-dynamic-import`),

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby-package#readme",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.7.4",
+    "@babel/plugin-proposal-nullish-coalescing-operator":  "^7.7.4",
     "@babel/plugin-proposal-optional-chaining": "^7.7.4",
     "@babel/plugin-syntax-dynamic-import": "^7.7.4",
     "@babel/plugin-transform-runtime": "^7.7.4",


### PR DESCRIPTION
This means we can do `a ?? b` in node now (this should not affect output of, say, webpack).

Note that the `??` operator (together with the `?.` operator, which we already added earlier) have been accepted to be added to the JS spec. For all intentions and purposes; that means it's now part of JS.
