### PR TITLE
chore(showcase): Remove Smoopit

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -6848,17 +6848,6 @@
   built_by: Kyle Kitlinski
   built_by_url: http://github.com/k-kit
   featured: false
-- title: Smoopit
-  main_url: https://smoopit.com
-  url: https://smoopit.com/
-  description: >
-    Smoopit helps you schedule meetings without the extra effort of checking your availability or back-and-forth emails.
-  categories:
-    - Business
-    - Productivity
-  built_by: Chandra Bhushan
-  built_by_url: https://github.com/chandu2304
-  featured: false
 - title: Mill3 Studio
   main_url: https://mill3.studio/en/
   url: https://mill3.studio/en/


### PR DESCRIPTION
## Description

The site moved to a new domain (https://www.canumeet.com/) and is no longer a Gatsby site