### PR TITLE
chore(www): [contributing] add note about internal PR label

### DIFF
--- a/docs/contributing/managing-pull-requests.md
+++ b/docs/contributing/managing-pull-requests.md
@@ -144,7 +144,9 @@ These are bad PR titles because they are generic, don't communicate the change p
 
 ### Who can review a PR?
 
-If you're a member of the [gatsbyjs](http://github.com/gatsbyjs) organization on GitHub, you can review a PR.
+If you're a member of the [gatsbyjs](http://github.com/gatsbyjs) organization on GitHub, you can review most PRs.
+
+PRs with [`topic: internal`](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3A+internal%22) or marked as "WIP" (work-in-progress) or "Draft" are reserved for Core and Learning team members as they are typically part of an internal project or hiring process.
 
 > 💡 Not a member yet? Want to [get involved in contributing](/contributing/how-to-contribute/) to open source projects? Make your first contribution and you'll be invited automatically!
 

--- a/docs/contributing/managing-pull-requests.md
+++ b/docs/contributing/managing-pull-requests.md
@@ -144,9 +144,7 @@ These are bad PR titles because they are generic, don't communicate the change p
 
 ### Who can review a PR?
 
-If you're a member of the [gatsbyjs](http://github.com/gatsbyjs) organization on GitHub, you can review most PRs.
-
-PRs with [`topic: internal`](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3A+internal%22) or marked as "WIP" (work-in-progress) or "Draft" are reserved for Core and Learning team members as they are typically part of an internal project or hiring process.
+If you're a member of the [gatsbyjs](http://github.com/gatsbyjs) organization on GitHub, you can review **most** PRs. PRs with [`topic: internal`](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3A+internal%22) are reserved for Core and Learning team members as they are typically part of an internal project or hiring process.
 
 > 💡 Not a member yet? Want to [get involved in contributing](/contributing/how-to-contribute/) to open source projects? Make your first contribution and you'll be invited automatically!
 


### PR DESCRIPTION
## Description

We've started using [topic: internal](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3A+internal%22) to label PRs that are part of an internal project or hiring process, where contributions should be limited to core or learning team members. To make sure this is communicated to the broader community, I've added a note to the contributing docs. Looking forward to hearing what @gatsbyjs/core and @gatsbyjs/learning think about this. 

## Related Issues

N/A