### PR TITLE
chore(showcase): Add 8fit.com to sites.yml

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -8901,3 +8901,13 @@
     - Open Source
   built_by: Bearer
   featured: false
+- title: 8fit.com
+  url: https://8fit.com/
+  main_url: https://8fit.com/
+  description: >
+    Get personalized workouts, custom meal plans, and nutrition guidance, right in the palm of your hand. Prioritize progress over perfection with the 8fit app!
+  categories:
+    - App
+    - Food
+    - Sports
+  featured: false


### PR DESCRIPTION
## Description

This adds an entry about 8fit.com to Gatsby's showcase.
8fit.com was rebuilt entirely over the course of the last year using a JAM stack setup with Gatsby at its core.