### PR TITLE
Revert "feat(gatsby): use embedded remote schemas (#19504)"

### DIFF
--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.7.6",
     "apollo-link": "1.2.13",
     "apollo-link-http": "^1.5.16",
-    "graphql-tools-fork": "^7.2.2",
+    "graphql-tools": "^3.1.1",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",
     "uuid": "^3.3.3"

--- a/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
@@ -1,5 +1,6 @@
-jest.mock(`graphql-tools-fork`, () => {
+jest.mock(`graphql-tools`, () => {
   return {
+    makeRemoteExecutableSchema: jest.fn(),
     transformSchema: jest.fn(),
     introspectSchema: jest.fn(),
     RenameTypes: jest.fn(),

--- a/packages/gatsby-source-graphql/src/transforms.js
+++ b/packages/gatsby-source-graphql/src/transforms.js
@@ -3,11 +3,14 @@ const {
   GraphQLNonNull,
   GraphQLSchema,
 } = require(`gatsby/graphql`)
-const { visitSchema, VisitSchemaKind } = require(`graphql-tools-fork`)
+const {
+  visitSchema,
+  VisitSchemaKind,
+} = require(`graphql-tools/dist/transforms/visitSchema`)
 const {
   createResolveType,
   fieldMapToFieldConfigMap,
-} = require(`graphql-tools-fork`)
+} = require(`graphql-tools/dist/stitching/schemaRecreation`)
 
 class NamespaceUnderFieldTransform {
   constructor({ typeName, fieldName, resolver }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4586,7 +4586,7 @@ apollo-link-http@^1.5.16:
     apollo-link-http-common "^0.2.15"
     tslib "^1.9.3"
 
-apollo-link@1.2.13, apollo-link@^1.2.13:
+apollo-link@1.2.13, apollo-link@^1.2.13, apollo-link@^1.2.2:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
   integrity sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==
@@ -4596,7 +4596,7 @@ apollo-link@1.2.13, apollo-link@^1.2.13:
     tslib "^1.9.3"
     zen-observable-ts "^0.8.20"
 
-apollo-utilities@^1.3.0, apollo-utilities@^1.3.2:
+apollo-utilities@^1.0.1, apollo-utilities@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.2.tgz#8cbdcf8b012f664cd6cb5767f6130f5aed9115c9"
   integrity sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==
@@ -8101,7 +8101,6 @@ depd@~1.1.2:
 deprecated-decorator@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
-  integrity sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -11058,16 +11057,16 @@ graphql-request@^1.5.0, graphql-request@^1.8.2:
   dependencies:
     cross-fetch "2.2.2"
 
-graphql-tools-fork@^7.2.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/graphql-tools-fork/-/graphql-tools-fork-7.2.2.tgz#c5bb6da969759ce137f5803fb1383edb77231cf1"
-  integrity sha512-Nx1pTzDcNLeF1WtEJHMzKw9CpHoj5p2rdTSLF7y1LwIuDvCkWRVALYHESKGkZVSFmOkWUVZvlzl4gRIBMDdrQg==
+graphql-tools@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.1.1.tgz#d593358f01e7c8b1671a17b70ddb034dea9dbc50"
+  integrity sha512-yHvPkweUB0+Q/GWH5wIG60bpt8CTwBklCSzQdEHmRUgAdEQKxw+9B7zB3dG7wB3Ym7M7lfrS4Ej+jtDZfA2UXg==
   dependencies:
-    apollo-link "^1.2.13"
-    apollo-utilities "^1.3.2"
+    apollo-link "^1.2.2"
+    apollo-utilities "^1.0.1"
     deprecated-decorator "^0.1.6"
-    iterall "^1.2.2"
-    uuid "^3.3.3"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
 
 graphql-type-json@^0.2.4:
   version "0.2.4"
@@ -12931,7 +12930,7 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-iterall@^1.2.2:
+iterall@^1.1.3, iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 


### PR DESCRIPTION
This reverts commit 588eaf78f438a21864d1e78c8b16f71dac843eb0.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
