### PR TITLE
fix(gatsby): fix circular ref stack overflow checks

### DIFF
--- a/packages/gatsby/src/db/__tests__/__snapshots__/sanitize-node.js.snap
+++ b/packages/gatsby/src/db/__tests__/__snapshots__/sanitize-node.js.snap
@@ -7,7 +7,7 @@ Object {
     "self": [Circular],
   },
   "deep": Object {
-    "deepCircular": Object {
+    "indirectCircular": Object {
       "down1": Object {
         "down2": Object {
           "deepCircular": [Circular],
@@ -30,5 +30,12 @@ Object {
     "type": "Test",
   },
   "parent": null,
+  "repeat": "foo",
+  "repeat2": "bar",
+  "repeat3": Object {
+    "repeat3": Object {
+      "repeat": "bar",
+    },
+  },
 }
 `;

--- a/packages/gatsby/src/db/__tests__/__snapshots__/sanitize-node.js.snap
+++ b/packages/gatsby/src/db/__tests__/__snapshots__/sanitize-node.js.snap
@@ -3,6 +3,18 @@
 exports[`node sanitization Remove not supported fields / values 1`] = `
 Object {
   "children": Array [],
+  "circularReference": Object {
+    "self": [Circular],
+  },
+  "deep": Object {
+    "deepCircular": Object {
+      "down1": Object {
+        "down2": Object {
+          "deepCircular": [Circular],
+        },
+      },
+    },
+  },
   "id": "id1",
   "inlineArray": Array [
     1,

--- a/packages/gatsby/src/db/__tests__/sanitize-node.js
+++ b/packages/gatsby/src/db/__tests__/sanitize-node.js
@@ -2,7 +2,17 @@ const sanitizeNode = require(`../sanitize-node`)
 
 describe(`node sanitization`, () => {
   let testNode
+
   beforeEach(() => {
+    const circularReference = {}
+    circularReference.self = circularReference
+    const indirectCircular = {
+      down1: {
+        down2: {},
+      },
+    }
+    indirectCircular.down1.down2.deepCircular = indirectCircular
+
     testNode = {
       id: `id1`,
       parent: null,
@@ -17,6 +27,10 @@ describe(`node sanitization`, () => {
         type: `Test`,
         contentDigest: `digest1`,
         owner: `test`,
+      },
+      circularReference,
+      deep: {
+        indirectCircular,
       },
     }
   })

--- a/packages/gatsby/src/db/__tests__/sanitize-node.js
+++ b/packages/gatsby/src/db/__tests__/sanitize-node.js
@@ -26,6 +26,7 @@ describe(`node sanitization`, () => {
       repeat2: `bar`,
       repeat3: {
         repeat3: {
+          test: () => {},
           repeat: `bar`,
         },
       },

--- a/packages/gatsby/src/db/__tests__/sanitize-node.js
+++ b/packages/gatsby/src/db/__tests__/sanitize-node.js
@@ -22,6 +22,13 @@ describe(`node sanitization`, () => {
         field: `fieldOfFirstNode`,
         re: /re/,
       },
+      repeat: `foo`,
+      repeat2: `bar`,
+      repeat3: {
+        repeat3: {
+          repeat: `bar`,
+        },
+      },
       inlineArray: [1, 2, 3, Symbol(`test`)],
       internal: {
         type: `Test`,

--- a/packages/gatsby/src/db/sanitize-node.js
+++ b/packages/gatsby/src/db/sanitize-node.js
@@ -10,13 +10,12 @@ const sanitizeNode = (data, isNode = true, path = new Set()) => {
   const isPlainObject = _.isPlainObject(data)
 
   if (isPlainObject || _.isArray(data)) {
+    if (path.has(data)) return data
     path.add(data)
 
     const returnData = isPlainObject ? {} : []
     let anyFieldChanged = false
     _.each(data, (o, key) => {
-      if (path.has(o)) return
-
       if (isNode && key === `internal`) {
         returnData[key] = o
         return
@@ -32,8 +31,6 @@ const sanitizeNode = (data, isNode = true, path = new Set()) => {
       data = omitUndefined(returnData)
     }
 
-    path.add(data)
-
     // arrays and plain objects are supported - no need to to sanitize
     return data
   }
@@ -41,7 +38,6 @@ const sanitizeNode = (data, isNode = true, path = new Set()) => {
   if (!isTypeSupported(data)) {
     return undefined
   } else {
-    path.add(data)
     return data
   }
 }

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -698,6 +698,12 @@ describe(`NodeModel`, () => {
         // This tests whether addRootNodeToInlineObject properly prevents re-traversing the same key-value pair infinitely
         const circular = { i_am: `recursion!` }
         circular.circled = circular
+        const indirectCircular = {
+          down1: {
+            down2: {},
+          },
+        }
+        indirectCircular.down1.down2.deepCircular = indirectCircular
 
         const node = {
           id: `circleId`,
@@ -708,6 +714,9 @@ describe(`NodeModel`, () => {
           },
           inlineArray: [1, 2, 3],
           circular,
+          indirect: {
+            indirectCircular,
+          },
           internal: {
             type: `Test`,
             contentDigest: `digest1`,

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -334,7 +334,13 @@ class LocalNodeModel {
    */
   trackInlineObjectsInRootNode(node) {
     if (!this._trackedRootNodes.has(node.id)) {
-      addRootNodeToInlineObject(this._rootNodeMap, node, node.id, true)
+      addRootNodeToInlineObject(
+        this._rootNodeMap,
+        node,
+        node.id,
+        true,
+        new Set()
+      )
       this._trackedRootNodes.add(node.id)
     }
   }
@@ -703,18 +709,18 @@ const addRootNodeToInlineObject = (
   rootNodeMap,
   data,
   nodeId,
-  isNode = false,
-  path = new Set()
-) => {
-  path.add(data)
-
+  isNode /*: boolean */,
+  path /*: Set<mixed> */
+) /*: void */ => {
   const isPlainObject = _.isPlainObject(data)
 
   if (isPlainObject || _.isArray(data)) {
+    if (path.has(data)) return
+    path.add(data)
+
     _.each(data, (o, key) => {
-      if (path.has(o)) return
       if (!isNode || key !== `internal`) {
-        addRootNodeToInlineObject(rootNodeMap, o, nodeId)
+        addRootNodeToInlineObject(rootNodeMap, o, nodeId, false, path)
       }
     })
 


### PR DESCRIPTION
Due to default parameters being omitted the reference fix in #19802 was insufficient. Cementing it by removing the default args (we don't need them right now) and explicitly passing on the args instead.

Updated tests which now did catch the problem before fixing it.

ht @cameron-martin for pushing for the fix in #11364