### PR TITLE
chore(gatsby-plugin-mdx): stop using "babylon" as parser in test

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
@@ -57,7 +57,7 @@ const fixtures = c
 describe(`mdx-loader`, () => {
   expect.addSnapshotSerializer({
     print(val /*, serialize */) {
-      return prettier.format(val, { parser: `babylon` })
+      return prettier.format(val, { parser: `babel` })
     },
     test() {
       return true


### PR DESCRIPTION
Minor fix. Was seeing the warning while running `yarn jest`, now I don't.

Backstory: The Babel parser used to be called Babylon and you still see this name come back every now and then. In fact, we still have a sub-dependency on the old babylon parser (`yarn why babylon`). But that's not super relevant for us.