### PR TITLE
docs(gatsby): add note to solve debugging build process on windows

### DIFF
--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -72,6 +72,10 @@ If you use VS Code and its integrated terminal, you can configure it to automati
 
 2.  Using VS Code's integrated terminal run `node --nolazy --inspect-brk node_modules/.bin/gatsby develop` instead of `gatsby develop`
 
+> **Note:** On machines running on Windows you may get an error such as 
+> `basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')") SyntaxError: missing ) after argument list`
+> A workaround is to run `node --nolazy --inspect-brk node_modules/gatsby/dist/bin/gatsby develop`.
+
 3.  Set breakpoints and debug!
 
 > **Note:** If the breakpoint is not being hit on `const value = createFilePath({ node, getNode })`

--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -70,11 +70,7 @@ If you use VS Code and its integrated terminal, you can configure it to automati
 1.  Press `Ctrl + ,` or `⌘ + ,` to open your preferences. Type `node debug` into the search bar. Make sure the `Auto Attach` option is set to `on`.
     ![Search for on debug and set attach to enable](./images/set-node-attach-to-on.png)
 
-2.  Using VS Code's integrated terminal run `node --nolazy --inspect-brk node_modules/.bin/gatsby develop` instead of `gatsby develop`
-
-> **Note:** On machines running on Windows you may get an error such as 
-> `basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')") SyntaxError: missing ) after argument list`
-> A workaround is to run `node --nolazy --inspect-brk node_modules/gatsby/dist/bin/gatsby develop`.
+2.  Using VS Code's integrated terminal run `node --nolazy --inspect-brk node_modules/gatsby/dist/bin/gatsby develop` instead of `gatsby develop`
 
 3.  Set breakpoints and debug!
 


### PR DESCRIPTION
## Description

When trying to debug the build process using the VS Code Debugger on a Windows machine using the `node --nolazy --inspect-brk node_modules/.bin/gatsby develop` command mentioned in the [docs](https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/debugging-the-build-process.md#vs-code-debugger-auto-config), I get the following error:

```
$ node --nolazy --inspect-brk node_modules/.bin/gatsby develop
Debugger listening on ws://127.0.0.1:9229/2dab2d65-35db-4539-bb00-2f32bd25bd50
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
E:\Workspaces\hello-world\node_modules\.bin\gatsby:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at Module._compile (internal/modules/cjs/loader.js:721:23)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:829:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
Waiting for the debugger to disconnect...
```
This error seems to appear only on Windows machines and can be resolved with the following command instead
`node --nolazy --inspect-brk node_modules/gatsby/dist/bin/gatsby develop`