### PR TITLE
fix(docs): fix 404 sidebar link to glossary / nodejs

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -695,7 +695,7 @@
       link: /docs/glossary/
       items:
         - title: Node.js
-          link: /docs/glossary/nodejs
+          link: /docs/glossary/node
         - title: React
           link: /docs/glossary/react
     - title: Gatsby Telemetry


### PR DESCRIPTION

## Description

fixed link from:

`/docs/glossary/nodejs`

to

`/docs/glossary/node`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

#19965 Docs: Encyclopedia: Add entry for Node.js
#19267 Add link check To Gatsby Docs

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
