### PR TITLE
feat(gatsby-source-shopify): add metafields to each product variant node

### DIFF
--- a/packages/gatsby-source-shopify/src/constants.js
+++ b/packages/gatsby-source-shopify/src/constants.js
@@ -10,6 +10,7 @@ export const PRODUCT = `Product`
 export const PRODUCT_OPTION = `ProductOption`
 export const PRODUCT_VARIANT = `ProductVariant`
 export const PRODUCT_METAFIELD = `ProductMetafield`
+export const PRODUCT_VARIANT_METAFIELD = `ProductVariantMetafield`
 export const SHOP_POLICY = `ShopPolicy`
 export const PAGE = `Page`
 export const SHOP = `shop`

--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -13,6 +13,7 @@ import {
   ProductOptionNode,
   ProductVariantNode,
   ProductMetafieldNode,
+  ProductVariantMetafieldNode,
   ShopPolicyNode,
   PageNode,
 } from "./nodes"
@@ -85,9 +86,16 @@ export const sourceNodes = async (
         createNodes(COLLECTION, COLLECTIONS_QUERY, CollectionNode, args),
         createNodes(PRODUCT, PRODUCTS_QUERY, ProductNode, args, async x => {
           if (x.variants)
-            await forEach(x.variants.edges, async edge =>
-              createNode(await ProductVariantNode(imageArgs)(edge.node))
-            )
+            await forEach(x.variants.edges, async edge => {
+              const v = edge.node
+              if (v.metafields)
+                await forEach(v.metafields.edges, async edge =>
+                  createNode(
+                    await ProductVariantMetafieldNode(imageArgs)(edge.node)
+                  )
+                )
+              return createNode(await ProductVariantNode(imageArgs)(edge.node))
+            })
 
           if (x.metafields)
             await forEach(x.metafields.edges, async edge =>

--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -12,6 +12,7 @@ import {
   PRODUCT_OPTION,
   PRODUCT_VARIANT,
   PRODUCT_METAFIELD,
+  PRODUCT_VARIANT_METAFIELD,
   SHOP_POLICY,
   PAGE,
 } from "./constants"
@@ -146,6 +147,15 @@ export const ProductOptionNode = _imageArgs => createNodeFactory(PRODUCT_OPTION)
 
 export const ProductVariantNode = imageArgs =>
   createNodeFactory(PRODUCT_VARIANT, async node => {
+    if (node.metafields) {
+      const metafields = node.metafields.edges.map(edge => edge.node)
+
+      node.metafields___NODE = metafields.map(metafield =>
+        generateNodeId(PRODUCT_VARIANT_METAFIELD, metafield.id)
+      )
+      delete node.metafields
+    }
+
     if (node.image)
       node.image.localFile___NODE = await downloadImageAndCreateFileNode(
         {
@@ -157,6 +167,9 @@ export const ProductVariantNode = imageArgs =>
 
     return node
   })
+
+export const ProductVariantMetafieldNode = _imageArgs =>
+  createNodeFactory(PRODUCT_VARIANT_METAFIELD)
 
 export const ShopPolicyNode = createNodeFactory(SHOP_POLICY)
 

--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -180,6 +180,18 @@ export const PRODUCTS_QUERY = `
                     id
                     originalSrc
                   }
+                  metafields(first: 250) {
+                    edges {
+                      node {
+                        description
+                        id
+                        key
+                        namespace
+                        value
+                        valueType
+                      }
+                    }
+                  }
                   price
                   selectedOptions {
                     name


### PR DESCRIPTION
## Description
Following the implementation of adding metafields to Product Nodes ([PR #16312](https://github.com/gatsbyjs/gatsby/pull/16312)), this PR adds metafields to the Variant Nodes as well. Shopify Supports metafields on almost all entities, but Product/Variants are _usually_ the ones that are used the most, as a way to extend data on product entities.

## Related Issues
N/A

Thanks!