### PR TITLE
Use webpack watchOptions config for webpack-dev-middleware

### DIFF
--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -230,6 +230,7 @@ async function startServer(program) {
     require(`webpack-dev-middleware`)(compiler, {
       logLevel: `silent`,
       publicPath: devConfig.output.publicPath,
+      watchOptions: devConfig.devServer ? devConfig.devServer.watchOptions : null,
       stats: `errors-only`,
     })
   )

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -230,7 +230,9 @@ async function startServer(program) {
     require(`webpack-dev-middleware`)(compiler, {
       logLevel: `silent`,
       publicPath: devConfig.output.publicPath,
-      watchOptions: devConfig.devServer ? devConfig.devServer.watchOptions : null,
+      watchOptions: devConfig.devServer
+        ? devConfig.devServer.watchOptions
+        : null,
       stats: `errors-only`,
     })
   )


### PR DESCRIPTION
## Description

When running node in Docker for Windows, polling needs to be used for any kind of hot reloading to work. 
There is a webpack setting to enable polling, but it is currently not being passed to `webpack-dev-middleware`. 
This solves the issue by passing the webpack `devServer.watchOptions` to the middleware. 

## Related Issues

Addresses #9625