### PR TITLE
fix(gatsby): Add early return in link resolver for empty arrays

### DIFF
--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -157,6 +157,12 @@ const link = (options = {}, fieldConfig) => async (
   const oneOf = value => {
     return { in: value }
   }
+
+  // Return early if fieldValue is [] since { in: [] } doesn't make sense
+  if (Array.isArray(fieldValue) && fieldValue.length === 0) {
+    return fieldValue
+  }
+
   const operator = Array.isArray(fieldValue) ? oneOf : equals
   args.filter = options.by.split(`.`).reduceRight((acc, key, i, { length }) => {
     return {


### PR DESCRIPTION
## Why 

Consider a schema like, 

```
type Item {
  name: String
}

type Collection {
  items: [Item]! @link(by: "id", from: "items___NODE")
}
```

And a query like, 

```
allCollection {
  nodes {
    items {
      name
    }
  }
}
```

If a collection has no items, this currently returns `items` set to `null` as opposed to `[]` (even if it is non nullable as shown in the schema above). 

## Why 

This happens because the link resolver sets the `{ in: value }` operator in case the field value is an array. This however doesn't make sense for an empty array. 

This PR adds an early return to fix this 🙂 

## Todo

- [ ] I'd like to add a test for this but unsure where a test for this should go? 

## Related issues 

@Simply007 discovered this issue when building `gatsby-source-kentico`. You can find a reproduction at https://github.com/Simply007/gatsby-null-instead-of-array