### PR TITLE
feat(gatsby-source-hacker-news): use schema customization API

### DIFF
--- a/packages/gatsby-source-hacker-news/README.md
+++ b/packages/gatsby-source-hacker-news/README.md
@@ -32,7 +32,7 @@ query {
         by
         descendants
         timeISO(fromNow: true)
-        children {
+        childrenHnComment {
           id
           text
           timeISO(fromNow: true)

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.15"
+    "gatsby": "^2.13.28"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-hacker-news/src/gatsby-node.js
+++ b/packages/gatsby-source-hacker-news/src/gatsby-node.js
@@ -7,6 +7,30 @@ const get = query =>
     `https://www.graphqlhub.com/graphql?query=${encodeURIComponent(query)}`
   )
 
+exports.createSchemaCustomization = async ({ actions }) => {
+  const typeDefs = `
+    type HNComment implements Node @childOf(types: ["HNStory", "HNComment"], many: true) {
+      text: String
+      timeISO: Date @dateformat
+      by: String
+      order: Int
+    }
+
+    type HNStory implements Node {
+      title: String
+      score: Int
+      timeISO: Date @dateformat
+      url: String
+      by: String
+      descendants: Int
+      content: String
+      domain: String
+      order: Int
+    }
+  `
+  actions.createTypes(typeDefs)
+}
+
 exports.sourceNodes = async ({
   actions,
   getNode,

--- a/packages/gatsby-source-hacker-news/src/gatsby-node.js
+++ b/packages/gatsby-source-hacker-news/src/gatsby-node.js
@@ -11,21 +11,21 @@ exports.createSchemaCustomization = async ({ actions }) => {
   const typeDefs = `
     type HNComment implements Node @childOf(types: ["HNStory", "HNComment"], many: true) {
       text: String
-      timeISO: Date @dateformat
-      by: String
-      order: Int
+      timeISO: Date! @dateformat
+      by: String!
+      order: Int!
     }
 
     type HNStory implements Node {
       title: String
       score: Int
-      timeISO: Date @dateformat
+      timeISO: Date! @dateformat
       url: String
-      by: String
+      by: String!
       descendants: Int
-      content: String
+      content: String!
       domain: String
-      order: Int
+      order: Int!
     }
   `
   actions.createTypes(typeDefs)
@@ -122,7 +122,7 @@ fragment commentsFragment on HackerNewsItem {
       kids.kids = []
     }
     const kidLessStory = _.omit(story, `kids`)
-    const childIds = kids.kids.map(k => createNodeId(k.id))
+    const childIds = kids.kids.filter(Boolean).map(k => createNodeId(k.id))
 
     const storyNode = {
       ...kidLessStory,
@@ -148,6 +148,9 @@ fragment commentsFragment on HackerNewsItem {
     // Recursively create comment nodes.
     const createCommentNodes = (comments, parent, depth = 0) => {
       comments.forEach((comment, i) => {
+        if (!comment) {
+          return
+        }
         if (!comment.kids) {
           comment.kids = []
         }


### PR DESCRIPTION
## Description

Start using [schema customization API](https://www.gatsbyjs.org/docs/schema-customization/) for `gatsby-source-hacker-news`

### Documentation
N/A. Will be probably a separate PR with recipes after #20069

## Related Issues
Part of #20069
