### PR TITLE
docs(gatsby-plugin-typescript): fix plugin instructions

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -17,7 +17,7 @@ Provides drop-in support for TypeScript and TSX.
 ```javascript
 module.exports = {
   // ...,
-  plugins: [...`gatsby-plugin-typescript`],
+  plugins: [`gatsby-plugin-typescript`],
 }
 ```
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The snippet in the README for adding the plugin results in an array of characters. E.g.:

```javascript
[...`gatsby-plugin-typescript`]
// ["g", "a", "t", "s", "b", "y", "-", "p", "l", "u", "g", "i", "n", "-", "t", "y", "p", "e", "s", "c", "r", "i", "p", "t"]
```

This can cause confusing errors for beginners who copy and paste.
