### PR TITLE
chore(gatsby-plugin-sharp): Use createContentDigest helper

### DIFF
--- a/packages/gatsby-plugin-sharp/src/trace-svg.js
+++ b/packages/gatsby-plugin-sharp/src/trace-svg.js
@@ -1,5 +1,4 @@
 const { promisify } = require(`bluebird`)
-const crypto = require(`crypto`)
 const _ = require(`lodash`)
 const tmpDir = require(`os`).tmpdir()
 const sharp = require(`./safe-sharp`)
@@ -7,6 +6,7 @@ const sharp = require(`./safe-sharp`)
 const duotone = require(`./duotone`)
 const { getPluginOptions, healOptions } = require(`./plugin-options`)
 const { reportError } = require(`./report-error`)
+const { createContentDigest } = require(`gatsby-core-utils`)
 
 exports.notMemoizedPrepareTraceSVGInputFile = async ({
   file,
@@ -90,12 +90,9 @@ exports.notMemoizedtraceSVG = async ({ file, args, fileArgs, reporter }) => {
     file.extension
   )
 
-  const tmpFilePath = `${tmpDir}/${file.internal.contentDigest}-${
-    file.name
-  }-${crypto
-    .createHash(`md5`)
-    .update(JSON.stringify(options))
-    .digest(`hex`)}.${file.extension}`
+  const optionsHash = createContentDigest(options)
+
+  const tmpFilePath = `${tmpDir}/${file.internal.contentDigest}-${file.name}-${optionsHash}.${file.extension}`
 
   try {
     await exports.memoizedPrepareTraceSVGInputFile({


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

use `createContentDigest`

### Documentation


## Related Issues

#8805 feat: update gatsby plugins to use new createContentDigest helper