### PR TITLE
fix(docs): tutorial - part seven - fix spelling

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -427,7 +427,7 @@ And there you go! A working, albeit small, blog!
 
 Try playing more with the site. Try adding some more markdown files. Explore
 querying other data from the `MarkdownRemark` nodes and adding them to the
-frontpage or blog posts pages.
+front page or blog posts pages.
 
 In this part of the tutorial, you've learned the foundations of building with
 Gatsby's data layer. You've learned how to _source_ and _transform_ data using


### PR DESCRIPTION
Corrected some spelling and grammatical error.

## Description

Corrected some spelling error.
Changed "frontpage"  to "front page". Added spacing between words. For the simplicity of the reader.
