### PR TITLE
chore: Add package script for shellcheck linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "lerna-prepare": "lerna run prepare",
     "lint": "npm-run-all --continue-on-error -p lint:code lint:other",
     "lint:code": "eslint --ignore-path .gitignore --ignore-path .prettierignore --ext .js,.jsx .",
+    "lint:scripts": "sh scripts/lint-shell-scripts.sh",
     "lint:other": "npm run prettier -- --check",
     "markdown": "md-magic --path \"starters/**/*.md\"",
     "postmarkdown": "prettier --write \"starters/**/*.md\"",

--- a/scripts/lint-shell-scripts.sh
+++ b/scripts/lint-shell-scripts.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+ROOT_DIR="$(realpath "$SCRIPT_DIR"/..)";
+
+if ! [ -x "$(command -v shellcheck)" ]; then
+  echo ''
+  echo 'ShellCheck not found.'
+  echo 'For more info: https://github.com/koalaman/shellcheck#installing"'
+  echo ''
+  exit 1
+fi
+
+shellcheck "$ROOT_DIR"/**/*.sh


### PR DESCRIPTION
## Description

Adds a `lint:scripts` task in package.json to lint all shell scripts using the ShellCheck tool 

### Documentation

N/A

## Related Issues

See: https://github.com/gatsbyjs/gatsby/pull/19991#issuecomment-563440299
