### PR TITLE
fix(gatsby): do not rebuild schema having identical conflicts

### DIFF
--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -343,40 +343,36 @@ const descriptorsAreEqual = (descriptor, otherDescriptor) => {
   const types = possibleTypes(descriptor)
   const otherTypes = possibleTypes(otherDescriptor)
 
-  // Empty are equal
-  if (types.length === 0 && otherTypes.length === 0) {
-    return true
-  }
-  // Conflicting and non-matching types are not equal
-  // TODO: consider descriptors with equal conflicts as equal?
-  if (types.length > 1 || otherTypes.length > 1 || types[0] !== otherTypes[0]) {
-    return false
-  }
-  switch (types[0]) {
-    case `array`:
-      return descriptorsAreEqual(
-        descriptor.array.item,
-        otherDescriptor.array.item
-      )
-    case `object`: {
-      const dpropsKeys = mergeObjectKeys(
-        descriptor.object.dprops,
-        otherDescriptor.object.dprops
-      )
-      return dpropsKeys.every(prop =>
-        descriptorsAreEqual(
-          descriptor.object.dprops[prop],
-          otherDescriptor.object.dprops[prop]
+  const childDescriptorsAreEqual = type => {
+    switch (type) {
+      case `array`:
+        return descriptorsAreEqual(
+          descriptor.array.item,
+          otherDescriptor.array.item
         )
-      )
+      case `object`: {
+        const dpropsKeys = mergeObjectKeys(
+          descriptor.object.dprops,
+          otherDescriptor.object.dprops
+        )
+        return dpropsKeys.every(prop =>
+          descriptorsAreEqual(
+            descriptor.object.dprops[prop],
+            otherDescriptor.object.dprops[prop]
+          )
+        )
+      }
+      case `relatedNode`:
+      case `relatedNodeList`: {
+        return isEqual(descriptor.nodes, otherDescriptor.nodes)
+      }
+      default:
+        return true
     }
-    case `relatedNode`:
-    case `relatedNodeList`: {
-      return isEqual(descriptor.nodes, otherDescriptor.nodes)
-    }
-    default:
-      return true
   }
+
+  // Equal when all possible types are equal (including conflicts)
+  return isEqual(types, otherTypes) && types.every(childDescriptorsAreEqual)
 }
 
 const nodeFields = (node, ignoredFields = new Set()) =>


### PR DESCRIPTION
## Preface

Gatsby uses data inference to build GraphQL types. When sourcing nodes we aggregate meta-information about each node field. There are situations when two or more nodes contain conflicting field types. A simple example:

```js
createNode({ foo: "foo", internal: { type: "Foo" } });
createNode({ foo: 2, internal: { type: "Foo" } });
```

It is impossible to understand the type of the field `foo` from those nodes. We still produce GraphQL type in this case but remove `foo` field from it and also emit a warning.

## The Problem

Before this PR schema would rebuild when the type with conflicts updates. For example, it could rebuild on a new node (e.g. sourced statefully):

```js
createNode({ foo: "bar", internal: { type: "Foo" } });
```

(there are several other conditions to actually trigger the rebuild but I omit them for simplicity)
So this is a false positive because the new schema is exactly the same as the previous one.

After this PR schema won't rebuild if meta-information about conflicts didn't change (i.e. won't rebuild with the example above).

## Related issues:
Noticed this in #20043 (which shouldn't have triggered a rebuild in the first place)