### PR TITLE
Adjust contributor issue triage with more explicit instructions for o…

### DIFF
--- a/docs/contributing/triaging-github-issues.md
+++ b/docs/contributing/triaging-github-issues.md
@@ -16,7 +16,7 @@ For Gatsby the first line of communication between a user and the team is the is
 
 An opened issue could be:
 
-- a question that can be answered immediately
+- [a question that can be answered immediately](#questions-with-immediate-answers)
 - a bug report
 - a request for a feature
 - or a discussion on a complicated use case
@@ -25,7 +25,7 @@ On the core team, we regularly designate someone to be a first touch maintainer.
 
 First touch maintainers will typically:
 
-- answer questions that can be answered immediately
+- [answer questions by pointing to documentation](#questions-with-immediate-answers)
 - test and reproduce possible bug reports and label them appropriately
 - communicate feature requests to the rest of the team and ensure a valid response
 - enable discussions on complicated use cases, whether themselves or via the rest of team
@@ -62,6 +62,18 @@ Labeling helps group issues into manageable sets and also improves searchability
 It's nice to update labels as the state of an issue changes or if the type of an issue changes, for example if a question becomes a feature request. This means labels are transient in nature and subject to being updated as progress is made on addressing issues.
 
 Check out [the docs on issue labeling for more info](/contributing/how-to-label-an-issue/)
+
+### Questions with immediate answers
+
+If an issue comes in as a question with a known answer it can be tempting to answer it and close the issue. However, the consequence of this approach is that the answer to a question others may have is now buried in a closed issue and may be hard to surface. The preferred solution is to get that answer documented in the main Gatsby documentation.
+
+When a question comes in and it is determined to have a known answer, find the existing documentation that explains it. If that documentation does not exist, is insufficient, or unclear, it is reasonable to provide an answer in a comment in the issue. However, the issue should remain open and be labled as documentation. If you are able, you can open a PR adding the provided answer to the official documentation.
+
+- Point to existing documentation to answer the question
+- If insufficient, do the following:
+  1. Provide an answer
+  2. Label the issue with documentation
+  3. Keep it open until a PR has added the answer to the documentation
 
 ### Resolution flowchart
 

--- a/docs/contributing/triaging-github-issues.md
+++ b/docs/contributing/triaging-github-issues.md
@@ -71,7 +71,7 @@ Check out [the docs on issue labeling for more info](/contributing/how-to-label-
   2. Label the issue with documentation
   3. Keep it open until a PR has added the answer to the documentation, and the issue includes a link to said documentation
 
-If an issue comes in as a question with a known answer it can be tempting to answer it and close the issue. However, the consequence of this approach is that the answer to a question others may have is now buried in a closed issue and may be hard to surface. The preferred solution is to get that answer documented in the main Gatsby documentation.
+If an issue comes in as a question with a known answer it can be tempting to answer it and close the issue. However, the consequence of this approach is that the answer to a question others may have is now buried in a closed issue and may be hard to surface. The preferred solution is to get that answer documented in the main Gatsby documentation and connect the issue to an answer by including a docs link.
 
 When a question comes in and it is determined to have a known answer, find the existing documentation that explains it. If that documentation does not exist, is insufficient, or unclear, it is reasonable to provide an answer in a comment in the issue. However, the issue should remain open and be labled as documentation. If you are able, you can open a PR adding the provided answer to the official documentation.
 

--- a/docs/contributing/triaging-github-issues.md
+++ b/docs/contributing/triaging-github-issues.md
@@ -69,7 +69,7 @@ Check out [the docs on issue labeling for more info](/contributing/how-to-label-
 - If insufficient, do the following:
   1. Provide an answer
   2. Label the issue with documentation
-  3. Keep it open until a PR has added the answer to the documentation
+  3. Keep it open until a PR has added the answer to the documentation, and the issue includes a link to said documentation
 
 If an issue comes in as a question with a known answer it can be tempting to answer it and close the issue. However, the consequence of this approach is that the answer to a question others may have is now buried in a closed issue and may be hard to surface. The preferred solution is to get that answer documented in the main Gatsby documentation.
 

--- a/docs/contributing/triaging-github-issues.md
+++ b/docs/contributing/triaging-github-issues.md
@@ -65,15 +65,15 @@ Check out [the docs on issue labeling for more info](/contributing/how-to-label-
 
 ### Questions with immediate answers
 
-If an issue comes in as a question with a known answer it can be tempting to answer it and close the issue. However, the consequence of this approach is that the answer to a question others may have is now buried in a closed issue and may be hard to surface. The preferred solution is to get that answer documented in the main Gatsby documentation.
-
-When a question comes in and it is determined to have a known answer, find the existing documentation that explains it. If that documentation does not exist, is insufficient, or unclear, it is reasonable to provide an answer in a comment in the issue. However, the issue should remain open and be labled as documentation. If you are able, you can open a PR adding the provided answer to the official documentation.
-
 - Point to existing documentation to answer the question
 - If insufficient, do the following:
   1. Provide an answer
   2. Label the issue with documentation
   3. Keep it open until a PR has added the answer to the documentation
+
+If an issue comes in as a question with a known answer it can be tempting to answer it and close the issue. However, the consequence of this approach is that the answer to a question others may have is now buried in a closed issue and may be hard to surface. The preferred solution is to get that answer documented in the main Gatsby documentation.
+
+When a question comes in and it is determined to have a known answer, find the existing documentation that explains it. If that documentation does not exist, is insufficient, or unclear, it is reasonable to provide an answer in a comment in the issue. However, the issue should remain open and be labled as documentation. If you are able, you can open a PR adding the provided answer to the official documentation.
 
 ### Resolution flowchart
 


### PR DESCRIPTION
…ne off answers without documentation

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adjust the contributing guidelines for triaging issues to prevent one-off answers to questions getting buried in closed issues.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Addresses #19143
