### PR TITLE
perf(gatsby): Eliminate generator

### DIFF
--- a/packages/gatsby/src/redux/nodes.js
+++ b/packages/gatsby/src/redux/nodes.js
@@ -105,24 +105,21 @@ exports.saveResolvedNodes = async (nodeTypeNames, resolver) => {
 
 const getNodesAndResolvedNodes = typeName => {
   const { nodesByType, resolvedNodesCache } = store.getState()
-  const nodes = nodesByType.get(typeName)
-  if (nodes) {
-    const resolvedNodes = resolvedNodesCache.get(typeName)
-    if (resolvedNodes) {
-      return Array.from(resolvedNodesIterator(nodes, resolvedNodes))
-    } else {
-      return Array.from(nodes.values())
-    }
-  } else {
-    return []
-  }
-}
+  const nodes /*: Map<mixed> */ = nodesByType.get(typeName)
+  let arr = []
 
-function* resolvedNodesIterator(nodes, resolvedNodes) {
-  for (const node of nodes.values()) {
-    node.__gatsby_resolved = resolvedNodes.get(node.id)
-    yield node
-  }
+  if (!nodes) return arr
+
+  const resolvedNodes = resolvedNodesCache.get(typeName)
+
+  nodes.forEach(node => {
+    if (resolvedNodes) {
+      node.__gatsby_resolved = resolvedNodes.get(node.id)
+    }
+    arr.push(node)
+  })
+
+  return arr
 }
 
 exports.getNodesAndResolvedNodes = getNodesAndResolvedNodes

--- a/packages/gatsby/src/redux/nodes.js
+++ b/packages/gatsby/src/redux/nodes.js
@@ -103,12 +103,11 @@ exports.saveResolvedNodes = async (nodeTypeNames, resolver) => {
   }
 }
 
-const getNodesAndResolvedNodes = typeName => {
+const addResolvedNodes = (typeName, arr) => {
   const { nodesByType, resolvedNodesCache } = store.getState()
   const nodes /*: Map<mixed> */ = nodesByType.get(typeName)
-  let arr = []
 
-  if (!nodes) return arr
+  if (!nodes) return
 
   const resolvedNodes = resolvedNodesCache.get(typeName)
 
@@ -118,8 +117,6 @@ const getNodesAndResolvedNodes = typeName => {
     }
     arr.push(node)
   })
-
-  return arr
 }
 
-exports.getNodesAndResolvedNodes = getNodesAndResolvedNodes
+exports.addResolvedNodes = addResolvedNodes

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -119,20 +119,13 @@ function handleMany(siftArgs, nodes, sort, resolvedFields) {
  *   if `firstOnly` is true
  */
 const runSift = (args: Object) => {
-  const { getNode, getNodesAndResolvedNodes } = require(`./nodes`)
+  const { getNode, addResolvedNodes } = require(`./nodes`)
 
   const { nodeTypeNames } = args
 
-  let nodes
+  let nodes = []
 
-  if (nodeTypeNames.length > 1) {
-    nodes = nodeTypeNames.reduce((acc, typeName) => {
-      acc.push(...getNodesAndResolvedNodes(typeName))
-      return acc
-    }, [])
-  } else {
-    nodes = getNodesAndResolvedNodes(nodeTypeNames[0])
-  }
+  nodeTypeNames.forEach(typeName => addResolvedNodes(typeName, nodes))
 
   return runSiftOnNodes(nodes, args, getNode)
 }


### PR DESCRIPTION
The generator eliminated by this commit was working fine but felt a little redundant. And since it was ranking at the top of the perf chart, I changed it to a plain `forEach` loop, which dropped it from the benchmark chart.

Additionally dropped two `Array.from` because they were redundant.

This seems to improve a simple MD site with 5000 pages that built in about 98s by one or two seconds.

### Screenshots of perf traces

Before:
![image](https://user-images.githubusercontent.com/209817/70723230-dc32b800-1cf8-11ea-98a5-e7e98d79870c.png)

After:
![image](https://user-images.githubusercontent.com/209817/70723273-ea80d400-1cf8-11ea-9af6-f7e9b030e1cb.png)
