### PR TITLE
fix(docs): custom converter example

### DIFF
--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -175,7 +175,7 @@ plugins: [
 In the example below, we will use a custom converter to convert paragraphs but the other nodes will be converted using the built-in HTML5 converter:
 
 ```javascript
-const asciidoc = require(`asciidoctor.js`)()
+const asciidoc = require(`asciidoctor`)()
 
 class TemplateConverter {
   constructor() {


### PR DESCRIPTION
Fixed the gatsby-transformer-asciidoc's custom converter example because it was old.

## Description

`asciidoctor` has latest update than `asciidoctor.js`

https://www.npmjs.com/package/asciidoctor
https://www.npmjs.com/package/asciidoctor.js

The following error occurs when using `asciidoctor.js`
```
 ERROR

Error in "/Users/takuya.tokuyama/Develop/reblitz-env/repos/reblitz-dev-guideline/node_modules/gatsby-transformer-asciidoc/gatsby-node.js": Object prototype may only be an Object or null: undefined



  TypeError: Object prototype may only be an Object or null: undefined

  - setPrototypeOf

  - opal.js:450 Object.Opal.allocate_class
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:450:7

  - opal.js:518 Opal.klass
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:518:18

  - opal.js:4919
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:4919:16

  - opal.js:5072 Opal.modules.corelib/error
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:5072:5

  - opal.js:2311 Object.Opal.load
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:2311:7

  - opal.js:2339 constructor.Opal.require
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:2339:17

  - opal.js:5439 Opal.modules.opal/base
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:5439:8

  - opal.js:2311 Object.Opal.load
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:2311:7

  - opal.js:2339 constructor.Opal.require
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:2339:17

  - opal.js:19939
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:19939:8

  - opal.js:19949 Object.<anonymous>
    [reblitz-dev-guideline]/[asciidoctor-opal-runtime]/src/opal.js:19949:3

  - v8-compile-cache.js:178 Module._compile
    [reblitz-dev-guideline]/[v8-compile-cache]/v8-compile-cache.js:178:30

  - loader.js:973 Object.Module._extensions..js
    internal/modules/cjs/loader.js:973:10

  - loader.js:812 Module.load
    internal/modules/cjs/loader.js:812:32

  - loader.js:724 Function.Module._load
    internal/modules/cjs/loader.js:724:14
```