### PR TITLE
Use git clone --depth-1 instead of --single-branch to clone starters

### DIFF
--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -166,13 +166,9 @@ const clone = async (hostInfo: any, rootPath: string) => {
 
   report.info(`Creating new site from git: ${url}`)
 
-  const args = [
-    `clone`,
-    ...branch,
-    url,
-    rootPath,
-    `--single-branch`,
-  ].filter(arg => Boolean(arg))
+  const args = [`clone`, ...branch, url, rootPath, `--depth=1`].filter(arg =>
+    Boolean(arg)
+  )
 
   await spawnWithArgs(`git`, args)
 


### PR DESCRIPTION
## Description

Re-implements #729/#730.

I'm having trouble figuring out where the change from #730 was removed, but it looks like it was originally added to `packages/gatsby/lib/utils/init-starter.js` in 35b971be55f7cafc19bc04ac33fe2f98e09bf456/#899, then copied over to `packages/gatsby-cli/src/init-starter.js` d737cd3b0185d0d110e21d30614f03832c8cbe70.

Using `--depth=1` instead of `--single-branch` shaved a couple seconds off of `gatsby new gatsby-starter-blog https://github.com/gatsbyjs/gatsby-starter-blog`.

## Related Issues

Related to #729/#730

