### PR TITLE
feat(gatsby-source-shopify): Add compareAtPrice to presentment prices

### DIFF
--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -196,6 +196,10 @@ export const PRODUCTS_QUERY = `
                           amount
                           currencyCode
                         }
+                        compareAtPrice {
+                          amount
+                          currencyCode
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
### Description
After adding fields for presentmentPrices to enable a multi currency Gatsby shop, we needed to get **compareAtPrice** fields in different prices as well.
Shopify API supports this field on the ProductVariantPricePair
https://help.shopify.com/en/api/storefront-api/reference/object/productvariant/productvariantpricepair

### Related Issues
N/A

Thank you