### PR TITLE
fix(gatsby-telemetry): only report unique plugins

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -165,7 +165,9 @@ module.exports = async (args: BootstrapArgs) => {
   const flattenedPlugins = await loadPlugins(config, program.directory)
   activity.end()
 
-  const pluginsStr = flattenedPlugins.map(p => `${p.name}@${p.version}`)
+  // Multiple occurrences of the same name-version-pair can occur,
+  // so we report an array of unique pairs
+  const pluginsStr = _.uniq(flattenedPlugins.map(p => `${p.name}@${p.version}`))
   telemetry.decorateEvent(`BUILD_END`, {
     plugins: pluginsStr,
   })


### PR DESCRIPTION
The analytics data currently often contains many copies of some plugin name-version-pairs. Only sending in unique pairs keeps the data a little cleaner.