### PR TITLE
chore(www): Improve build reliability

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -7,7 +7,7 @@ const slugify = require(`slugify`)
 const url = require(`url`)
 const getpkgjson = require(`get-package-json-from-github`)
 const parseGHUrl = require(`parse-github-url`)
-const { GraphQLClient } = require(`graphql-request`)
+const { GraphQLClient } = require(`@jamo/graphql-request`)
 const moment = require(`moment`)
 const startersRedirects = require(`./starter-redirects.json`)
 const {

--- a/www/package.json
+++ b/www/package.json
@@ -7,6 +7,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
     "@loadable/component": "^5.11.0",
+    "@jamo/graphql-request": "2.0.2",
     "@mdx-js/mdx": "^1.5.1",
     "@mdx-js/react": "^1.5.1",
     "@reach/skip-nav": "^0.6.2",

--- a/www/src/components/homepage/homepage-ecosystem.js
+++ b/www/src/components/homepage/homepage-ecosystem.js
@@ -194,10 +194,12 @@ const HomepageEcosystem = ({ featuredItems }) => (
     <SubTitle>Some of our recent favorites</SubTitle>
     <FeaturedItems className={SCROLLER_CLASSNAME}>
       <FeaturedItemsList>
-        {featuredItems.map(item => {
-          const { slug } = item
-          return <FeaturedItem key={slug} item={item} />
-        })}
+        {featuredItems
+          .filter(e => Boolean(e))
+          .map(item => {
+            const { slug } = item
+            return <FeaturedItem key={slug} item={item} />
+          })}
       </FeaturedItemsList>
     </FeaturedItems>
   </HomepageSection>


### PR DESCRIPTION
This fixes the most frequent issues I've run into when building .org in gatsby cloud build. 

1. Try fixing issues with ```
error Error getting repo data for starter "<any starter name>": request to https://api.github.com/graphql failed, reason: socket hang up```
I've tried this and I haven't seen a single Github API error, but maybe I just had too good of luck...

I'd like to propose using my fork with the fix for a bit and if things work reliably we should try to port to fix to upstream

---

2. fixes some weird errors where we get bad data. I'm happy to leave this out if this isn't the proper fix.


