### PR TITLE
chore(gatsby-theme-notes): Use createContentDigest helper

### DIFF
--- a/packages/gatsby-theme-notes/gatsby-node.js
+++ b/packages/gatsby-theme-notes/gatsby-node.js
@@ -1,9 +1,8 @@
 const fs = require(`fs`)
 const path = require(`path`)
 const mkdirp = require(`mkdirp`)
-const crypto = require(`crypto`)
 const Debug = require(`debug`)
-const { urlResolve } = require(`gatsby-core-utils`)
+const { urlResolve, createContentDigest } = require(`gatsby-core-utils`)
 
 const debug = Debug(`gatsby-theme-notes`)
 
@@ -165,10 +164,7 @@ breadcrumbSeparator: String
     children: [],
     internal: {
       type: `NotesConfig`,
-      contentDigest: crypto
-        .createHash(`md5`)
-        .update(JSON.stringify(notesConfig))
-        .digest(`hex`),
+      contentDigest: createContentDigest(notesConfig),
       content: JSON.stringify(notesConfig),
       description: `Notes Config`,
     },


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

use `createContentDigest`

### Documentation


## Related Issues

#8805 feat: update gatsby plugins to use new createContentDigest helper