### PR TITLE
fix(gatsby): Address npm audit that blocked CI

### DIFF
--- a/starters/blog/package-lock.json
+++ b/starters/blog/package-lock.json
@@ -320,6 +320,15 @@
         "@babel/plugin-syntax-json-strings": "^7.7.4"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
@@ -336,6 +345,15 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -379,6 +397,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -391,6 +417,14 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
       "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1408,11 +1442,11 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-      "integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
+      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1420,30 +1454,30 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
-      "integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
+      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
-      "integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
+      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.11.0",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
+      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -1866,12 +1900,32 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+      "integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "array-iterate": {
@@ -1905,13 +1959,32 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
-      "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "arraybuffer.slice": {
@@ -2208,9 +2281,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.7.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.17.tgz",
-      "integrity": "sha512-zPAq5DEtucSMppt4U2zB1i9SiGMLOYtjNGoOo5PLw8f5jlihLTYYaPG3Sg2S4+tiB9k+tiWMa07FKXb6lV+rRA=="
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+      "integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -2232,20 +2305,32 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.23.tgz",
-      "integrity": "sha512-IuhRMH6TCbTbJ4NFnHg2UQUZv24t3mRc9ow6qMeyL9mklI8vbXSi/bFVO6ES4xy3k5qmUdElXAK5RSpw8/1hbw==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+      "integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.7.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.7.5",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-        "@babel/plugin-transform-runtime": "^7.7.4",
+        "@babel/plugin-transform-runtime": "^7.7.6",
         "@babel/plugin-transform-spread": "^7.7.4",
-        "@babel/preset-env": "^7.7.4",
+        "@babel/preset-env": "^7.7.6",
         "@babel/preset-react": "^7.7.4",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-macros": "^2.7.1",
+        "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "babel-runtime": {
@@ -2617,6 +2702,15 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "3.0.0",
@@ -3194,9 +3288,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001015",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-      "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+      "version": "1.0.30001016",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
+      "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -3987,9 +4081,9 @@
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-js-compat": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.8.tgz",
-      "integrity": "sha512-l3WTmnXHV2Sfu5VuD7EHE2w7y+K68+kULKt5RJg8ZJk3YhHF1qLD4O8v8AmNq+8vbOwnPFFDvds25/AoEvMqlQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.5.0.tgz",
+      "integrity": "sha512-E7iJB72svRjJTnm9HDvujzNVMCm3ZcDYEedkJ/sDTNsy/0yooCd9Cg7GSzE7b4e0LfIkjijdB1tqg0pGwxWeWg==",
       "requires": {
         "browserslist": "^4.8.2",
         "semver": "^6.3.0"
@@ -4013,9 +4107,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.8.tgz",
-      "integrity": "sha512-K9iPNbLDZ0Epojwd8J3lhodmrLHYvxb07H3DaFme1ne4TIlFq/ufiyPC40rc3OX6NCaVa0zaSu+VV6BVDR2wiA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+      "integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4410,9 +4504,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -6411,6 +6505,12 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
       "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -6664,13 +6764,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -6712,7 +6813,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -6737,7 +6838,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6760,11 +6861,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -6788,7 +6889,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6814,7 +6915,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6831,7 +6932,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -6867,7 +6968,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6876,11 +6977,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -6892,22 +6993,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6920,7 +7021,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -6933,12 +7034,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7000,7 +7109,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -7037,7 +7146,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7060,7 +7169,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -7106,17 +7215,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -7138,7 +7247,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -7155,35 +7264,35 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.8.tgz",
-      "integrity": "sha512-44Cf+IJGyHT7ZKNE6xICG8QqA5Ava2nHXybTrQhPY3n6T7+dsdfbm6+WntT2yVtlfLfLFGute7Udx7HyFfsvSQ==",
+      "version": "2.18.12",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.12.tgz",
+      "integrity": "sha512-EmgSDZcedoUttw/ETEWWgRT0B7GUulsi3h8HwRDqNSMtHMJtk8SH9Vb5MWfQQZlZ2pteV9g8P4kv/bffCYKIbw==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/core": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
         "@babel/polyfill": "^7.7.0",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@babel/traverse": "^7.7.4",
         "@hapi/joi": "^15.1.1",
         "@mikaelkristiansson/domready": "^1.0.9",
         "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
         "@reach/router": "^1.2.1",
-        "@typescript-eslint/eslint-plugin": "^2.9.0",
-        "@typescript-eslint/parser": "^2.9.0",
+        "@typescript-eslint/eslint-plugin": "^2.11.0",
+        "@typescript-eslint/parser": "^2.11.0",
         "address": "1.1.2",
-        "autoprefixer": "^9.7.2",
+        "autoprefixer": "^9.7.3",
         "axios": "^0.19.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^10.0.3",
         "babel-loader": "^8.0.6",
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-remove-graphql-queries": "^2.7.17",
-        "babel-preset-gatsby": "^0.2.23",
+        "babel-plugin-remove-graphql-queries": "^2.7.19",
+        "babel-preset-gatsby": "^0.2.26",
         "better-opn": "1.0.0",
         "better-queue": "^3.8.10",
-        "bluebird": "^3.7.1",
+        "bluebird": "^3.7.2",
         "browserslist": "3.2.8",
         "cache-manager": "^2.10.1",
         "cache-manager-fs-hash": "^0.0.7",
@@ -7193,7 +7302,7 @@
         "compression": "^1.7.4",
         "convert-hrtime": "^3.0.0",
         "copyfiles": "^2.1.1",
-        "core-js": "^2.6.10",
+        "core-js": "^2.6.11",
         "cors": "^2.8.5",
         "css-loader": "^1.0.1",
         "debug": "^3.2.6",
@@ -7201,16 +7310,16 @@
         "detect-port": "^1.3.0",
         "devcert-san": "^0.3.3",
         "dotenv": "^8.2.0",
-        "eslint": "^6.7.1",
-        "eslint-config-react-app": "^5.0.2",
+        "eslint": "^6.7.2",
+        "eslint-config-react-app": "^5.1.0",
         "eslint-loader": "^2.2.1",
         "eslint-plugin-flowtype": "^3.13.0",
         "eslint-plugin-graphql": "^3.1.0",
-        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-import": "^2.19.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.16.0",
+        "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^1.7.0",
-        "event-source-polyfill": "^1.0.9",
+        "event-source-polyfill": "^1.0.11",
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fast-levenshtein": "^2.0.6",
@@ -7218,13 +7327,13 @@
         "flat": "^4.1.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.8.16",
-        "gatsby-core-utils": "^1.0.22",
-        "gatsby-graphiql-explorer": "^0.2.29",
-        "gatsby-link": "^2.2.25",
-        "gatsby-plugin-page-creator": "^2.1.34",
-        "gatsby-react-router-scroll": "^2.1.17",
-        "gatsby-telemetry": "^1.1.42",
+        "gatsby-cli": "^2.8.19",
+        "gatsby-core-utils": "^1.0.24",
+        "gatsby-graphiql-explorer": "^0.2.31",
+        "gatsby-link": "^2.2.27",
+        "gatsby-plugin-page-creator": "^2.1.36",
+        "gatsby-react-router-scroll": "^2.1.19",
+        "gatsby-telemetry": "^1.1.44",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.5.8",
@@ -7274,7 +7383,7 @@
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "style-loader": "^0.23.1",
-        "terser-webpack-plugin": "1.4.1",
+        "terser-webpack-plugin": "^1.4.2",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^1.1.2",
@@ -7287,10 +7396,18 @@
         "webpack-hot-middleware": "^2.25.0",
         "webpack-merge": "^4.2.2",
         "webpack-stats-plugin": "^0.3.0",
-        "xstate": "^4.6.7",
+        "xstate": "^4.7.2",
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -7348,29 +7465,29 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.8.16",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.16.tgz",
-          "integrity": "sha512-hjsK+xu00gg61CuS6z9jJrV6bHmI58YG3nd8B+goibM3vt/Wajg60til3hxaS9EGwHND+SatQUBTjTxdyOhplw==",
+          "version": "2.8.19",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.19.tgz",
+          "integrity": "sha512-cINizncxPBxL3tJAQVrVFCGrf/dFOFEk5o1uYr427zyLuC+jqaAtocE2AcT1P9ayXOEjyH4mP/INwaNfCbYkJg==",
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/runtime": "^7.7.4",
+            "@babel/runtime": "^7.7.6",
             "@hapi/joi": "^15.1.1",
             "better-opn": "^1.0.0",
-            "bluebird": "^3.7.1",
+            "bluebird": "^3.7.2",
             "chalk": "^2.4.2",
             "clipboardy": "^2.1.0",
             "common-tags": "^1.8.0",
             "configstore": "^5.0.0",
             "convert-hrtime": "^3.0.0",
-            "core-js": "^2.6.10",
+            "core-js": "^2.6.11",
             "envinfo": "^7.5.0",
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.0.22",
-            "gatsby-telemetry": "^1.1.42",
+            "gatsby-core-utils": "^1.0.24",
+            "gatsby-telemetry": "^1.1.44",
             "hosted-git-info": "^3.0.2",
-            "ink": "^2.5.0",
+            "ink": "^2.6.0",
             "ink-spinner": "^3.0.1",
             "is-valid-path": "^0.1.1",
             "lodash": "^4.17.15",
@@ -7400,6 +7517,15 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "get-caller-file": {
@@ -7582,11 +7708,21 @@
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.29.tgz",
-      "integrity": "sha512-qKnG1h/BSBkdPX5eUcFRVvHb0BA7WLnqeJ8NMH2AOv5VSK8YEwUdJVimZHz8M/59MKBtFAQyDCRU258sc1oWrQ==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+      "integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
       "requires": {
-        "@babel/runtime": "^7.7.4"
+        "@babel/runtime": "^7.7.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "gatsby-image": {
@@ -7600,30 +7736,57 @@
       }
     },
     "gatsby-link": {
-      "version": "2.2.25",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.25.tgz",
-      "integrity": "sha512-P3Gt5ryW1bFBjAuKoJQsGSZcyEG7vFliHelnOLlAakkJ+wLQz4Wq2o4BAb6lB4wPzO7HzXRJD6RuxQrd9tmkPg==",
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+      "integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@types/reach__router": "^1.2.6",
         "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "gatsby-page-utils": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.33.tgz",
-      "integrity": "sha512-0FweVMQc5JklMwPPbwcXRo5N3ydRKrNI+YZzr6731kON1tvCKB7EbbrwMvZLEedv4BNP+XUe33FuT7LsAaUE3g==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+      "integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "chokidar": "3.3.0",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -7684,19 +7847,27 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.34.tgz",
-      "integrity": "sha512-w315rYA1KS48jVo4Zg/1Uxm5Y6h48rW8Bf0520uOh8SkSr0qXFC6ivFmw2Uq4WFH02+qN7QTqGd3sHX1wwlf+g==",
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+      "integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.0.33",
+        "gatsby-page-utils": "^0.0.35",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -7768,13 +7939,23 @@
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.17.tgz",
-      "integrity": "sha512-5enc2qvcZwD4Omdr78gUfqH/4uOPW7UJE6d3EQAbGyaO6cD0dpjAGsLHHXkcjSTRIult2w6cvru7fI5suJnZtg==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+      "integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "scroll-behavior": "^0.9.10",
         "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "gatsby-remark-copy-linked-files": {
@@ -7961,18 +8142,18 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.42.tgz",
-      "integrity": "sha512-N/P8w8sVB1JDWn9Wm3hiB2NOrfIDioccot5h6jX8IVC4aUjXXROZPM+HSy3f1PHg2EoZuCGG5yH50XnayXupLQ==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+      "integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
-        "boxen": "^4.1.0",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
+        "boxen": "^4.2.0",
         "configstore": "^5.0.0",
         "envinfo": "^7.5.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
         "lodash": "^4.17.15",
@@ -7984,6 +8165,14 @@
         "uuid": "3.3.3"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
         "configstore": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.0.tgz",
@@ -8008,6 +8197,15 @@
           "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "is-obj": {
@@ -9461,9 +9659,9 @@
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -9474,7 +9672,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -11685,9 +11883,9 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -11719,25 +11917,65 @@
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.fromentries": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -14000,11 +14238,32 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "regexpp": {
@@ -14048,9 +14307,9 @@
       "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
     },
     "regjsparser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.1.tgz",
+      "integrity": "sha512-7LutE94sz/NKSYegK+/4E77+8DipxF+Qn2Tmu362AcmsF2NYq/wx3+ObvU90TKEhjf7hQoFXo23ajjrXP7eUgg==",
       "requires": {
         "jsesc": "~0.5.0"
       },
@@ -14671,9 +14930,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -15549,9 +15808,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -15990,15 +16249,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -17046,9 +17305,9 @@
       "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
     },
     "webpack": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-      "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
+      "version": "4.41.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
+      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -17070,7 +17329,7 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
+        "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },
@@ -17781,12 +18040,9 @@
       }
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/starters/blog/package.json
+++ b/starters/blog/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
-    "gatsby": "^2.18.8",
+    "gatsby": "^2.18.12",
     "gatsby-image": "^2.2.34",
     "gatsby-plugin-feed": "^2.3.23",
     "gatsby-plugin-google-analytics": "^2.1.29",

--- a/starters/default/package-lock.json
+++ b/starters/default/package-lock.json
@@ -320,6 +320,15 @@
         "@babel/plugin-syntax-json-strings": "^7.7.4"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
@@ -336,6 +345,15 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -379,6 +397,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -391,6 +417,14 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
       "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1385,11 +1419,11 @@
       "integrity": "sha1-DTyzECL4Qn6ljACK8yuA2hJspOM="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-      "integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
+      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1397,30 +1431,30 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
-      "integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
+      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
-      "integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
+      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.11.0",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
+      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -1843,12 +1877,32 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+      "integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "array-map": {
@@ -1877,13 +1931,32 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
-      "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "arraybuffer.slice": {
@@ -2180,9 +2253,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.7.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.17.tgz",
-      "integrity": "sha512-zPAq5DEtucSMppt4U2zB1i9SiGMLOYtjNGoOo5PLw8f5jlihLTYYaPG3Sg2S4+tiB9k+tiWMa07FKXb6lV+rRA=="
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+      "integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -2204,20 +2277,32 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.23.tgz",
-      "integrity": "sha512-IuhRMH6TCbTbJ4NFnHg2UQUZv24t3mRc9ow6qMeyL9mklI8vbXSi/bFVO6ES4xy3k5qmUdElXAK5RSpw8/1hbw==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+      "integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.7.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.7.5",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-        "@babel/plugin-transform-runtime": "^7.7.4",
+        "@babel/plugin-transform-runtime": "^7.7.6",
         "@babel/plugin-transform-spread": "^7.7.4",
-        "@babel/preset-env": "^7.7.4",
+        "@babel/preset-env": "^7.7.6",
         "@babel/preset-react": "^7.7.4",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-macros": "^2.7.1",
+        "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "babel-runtime": {
@@ -2584,6 +2669,15 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "3.0.0",
@@ -3161,9 +3255,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001015",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-      "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+      "version": "1.0.30001016",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
+      "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -3884,9 +3978,9 @@
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-js-compat": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.8.tgz",
-      "integrity": "sha512-l3WTmnXHV2Sfu5VuD7EHE2w7y+K68+kULKt5RJg8ZJk3YhHF1qLD4O8v8AmNq+8vbOwnPFFDvds25/AoEvMqlQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.5.0.tgz",
+      "integrity": "sha512-E7iJB72svRjJTnm9HDvujzNVMCm3ZcDYEedkJ/sDTNsy/0yooCd9Cg7GSzE7b4e0LfIkjijdB1tqg0pGwxWeWg==",
       "requires": {
         "browserslist": "^4.8.2",
         "semver": "^6.3.0"
@@ -3910,9 +4004,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.8.tgz",
-      "integrity": "sha512-K9iPNbLDZ0Epojwd8J3lhodmrLHYvxb07H3DaFme1ne4TIlFq/ufiyPC40rc3OX6NCaVa0zaSu+VV6BVDR2wiA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+      "integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4302,9 +4396,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -6282,6 +6376,12 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
       "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -6535,13 +6635,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -6583,7 +6684,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -6608,7 +6709,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6631,11 +6732,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -6659,7 +6760,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6685,7 +6786,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6702,7 +6803,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -6738,7 +6839,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6747,11 +6848,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -6763,22 +6864,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6791,7 +6892,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -6804,12 +6905,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6871,7 +6980,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -6908,7 +7017,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6931,7 +7040,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -6977,17 +7086,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -7009,7 +7118,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -7026,35 +7135,35 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.8.tgz",
-      "integrity": "sha512-44Cf+IJGyHT7ZKNE6xICG8QqA5Ava2nHXybTrQhPY3n6T7+dsdfbm6+WntT2yVtlfLfLFGute7Udx7HyFfsvSQ==",
+      "version": "2.18.12",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.12.tgz",
+      "integrity": "sha512-EmgSDZcedoUttw/ETEWWgRT0B7GUulsi3h8HwRDqNSMtHMJtk8SH9Vb5MWfQQZlZ2pteV9g8P4kv/bffCYKIbw==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/core": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
         "@babel/polyfill": "^7.7.0",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@babel/traverse": "^7.7.4",
         "@hapi/joi": "^15.1.1",
         "@mikaelkristiansson/domready": "^1.0.9",
         "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
         "@reach/router": "^1.2.1",
-        "@typescript-eslint/eslint-plugin": "^2.9.0",
-        "@typescript-eslint/parser": "^2.9.0",
+        "@typescript-eslint/eslint-plugin": "^2.11.0",
+        "@typescript-eslint/parser": "^2.11.0",
         "address": "1.1.2",
-        "autoprefixer": "^9.7.2",
+        "autoprefixer": "^9.7.3",
         "axios": "^0.19.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^10.0.3",
         "babel-loader": "^8.0.6",
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-remove-graphql-queries": "^2.7.17",
-        "babel-preset-gatsby": "^0.2.23",
+        "babel-plugin-remove-graphql-queries": "^2.7.19",
+        "babel-preset-gatsby": "^0.2.26",
         "better-opn": "1.0.0",
         "better-queue": "^3.8.10",
-        "bluebird": "^3.7.1",
+        "bluebird": "^3.7.2",
         "browserslist": "3.2.8",
         "cache-manager": "^2.10.1",
         "cache-manager-fs-hash": "^0.0.7",
@@ -7064,7 +7173,7 @@
         "compression": "^1.7.4",
         "convert-hrtime": "^3.0.0",
         "copyfiles": "^2.1.1",
-        "core-js": "^2.6.10",
+        "core-js": "^2.6.11",
         "cors": "^2.8.5",
         "css-loader": "^1.0.1",
         "debug": "^3.2.6",
@@ -7072,16 +7181,16 @@
         "detect-port": "^1.3.0",
         "devcert-san": "^0.3.3",
         "dotenv": "^8.2.0",
-        "eslint": "^6.7.1",
-        "eslint-config-react-app": "^5.0.2",
+        "eslint": "^6.7.2",
+        "eslint-config-react-app": "^5.1.0",
         "eslint-loader": "^2.2.1",
         "eslint-plugin-flowtype": "^3.13.0",
         "eslint-plugin-graphql": "^3.1.0",
-        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-import": "^2.19.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.16.0",
+        "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^1.7.0",
-        "event-source-polyfill": "^1.0.9",
+        "event-source-polyfill": "^1.0.11",
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fast-levenshtein": "^2.0.6",
@@ -7089,13 +7198,13 @@
         "flat": "^4.1.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.8.16",
-        "gatsby-core-utils": "^1.0.22",
-        "gatsby-graphiql-explorer": "^0.2.29",
-        "gatsby-link": "^2.2.25",
-        "gatsby-plugin-page-creator": "^2.1.34",
-        "gatsby-react-router-scroll": "^2.1.17",
-        "gatsby-telemetry": "^1.1.42",
+        "gatsby-cli": "^2.8.19",
+        "gatsby-core-utils": "^1.0.24",
+        "gatsby-graphiql-explorer": "^0.2.31",
+        "gatsby-link": "^2.2.27",
+        "gatsby-plugin-page-creator": "^2.1.36",
+        "gatsby-react-router-scroll": "^2.1.19",
+        "gatsby-telemetry": "^1.1.44",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.5.8",
@@ -7145,7 +7254,7 @@
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "style-loader": "^0.23.1",
-        "terser-webpack-plugin": "1.4.1",
+        "terser-webpack-plugin": "^1.4.2",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^1.1.2",
@@ -7158,10 +7267,18 @@
         "webpack-hot-middleware": "^2.25.0",
         "webpack-merge": "^4.2.2",
         "webpack-stats-plugin": "^0.3.0",
-        "xstate": "^4.6.7",
+        "xstate": "^4.7.2",
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -7219,29 +7336,29 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.8.16",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.16.tgz",
-          "integrity": "sha512-hjsK+xu00gg61CuS6z9jJrV6bHmI58YG3nd8B+goibM3vt/Wajg60til3hxaS9EGwHND+SatQUBTjTxdyOhplw==",
+          "version": "2.8.19",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.19.tgz",
+          "integrity": "sha512-cINizncxPBxL3tJAQVrVFCGrf/dFOFEk5o1uYr427zyLuC+jqaAtocE2AcT1P9ayXOEjyH4mP/INwaNfCbYkJg==",
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/runtime": "^7.7.4",
+            "@babel/runtime": "^7.7.6",
             "@hapi/joi": "^15.1.1",
             "better-opn": "^1.0.0",
-            "bluebird": "^3.7.1",
+            "bluebird": "^3.7.2",
             "chalk": "^2.4.2",
             "clipboardy": "^2.1.0",
             "common-tags": "^1.8.0",
             "configstore": "^5.0.0",
             "convert-hrtime": "^3.0.0",
-            "core-js": "^2.6.10",
+            "core-js": "^2.6.11",
             "envinfo": "^7.5.0",
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.0.22",
-            "gatsby-telemetry": "^1.1.42",
+            "gatsby-core-utils": "^1.0.24",
+            "gatsby-telemetry": "^1.1.44",
             "hosted-git-info": "^3.0.2",
-            "ink": "^2.5.0",
+            "ink": "^2.6.0",
             "ink-spinner": "^3.0.1",
             "is-valid-path": "^0.1.1",
             "lodash": "^4.17.15",
@@ -7271,6 +7388,15 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "get-caller-file": {
@@ -7448,11 +7574,21 @@
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.29.tgz",
-      "integrity": "sha512-qKnG1h/BSBkdPX5eUcFRVvHb0BA7WLnqeJ8NMH2AOv5VSK8YEwUdJVimZHz8M/59MKBtFAQyDCRU258sc1oWrQ==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+      "integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
       "requires": {
-        "@babel/runtime": "^7.7.4"
+        "@babel/runtime": "^7.7.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "gatsby-image": {
@@ -7466,28 +7602,57 @@
       }
     },
     "gatsby-link": {
-      "version": "2.2.25",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.25.tgz",
-      "integrity": "sha512-P3Gt5ryW1bFBjAuKoJQsGSZcyEG7vFliHelnOLlAakkJ+wLQz4Wq2o4BAb6lB4wPzO7HzXRJD6RuxQrd9tmkPg==",
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+      "integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@types/reach__router": "^1.2.6",
         "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "gatsby-page-utils": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.33.tgz",
-      "integrity": "sha512-0FweVMQc5JklMwPPbwcXRo5N3ydRKrNI+YZzr6731kON1tvCKB7EbbrwMvZLEedv4BNP+XUe33FuT7LsAaUE3g==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+      "integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "chokidar": "3.3.0",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
+          }
+        }
       }
     },
     "gatsby-plugin-manifest": {
@@ -7516,17 +7681,27 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.34.tgz",
-      "integrity": "sha512-w315rYA1KS48jVo4Zg/1Uxm5Y6h48rW8Bf0520uOh8SkSr0qXFC6ivFmw2Uq4WFH02+qN7QTqGd3sHX1wwlf+g==",
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+      "integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.0.33",
+        "gatsby-page-utils": "^0.0.35",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "gatsby-plugin-react-helmet": {
@@ -7580,13 +7755,23 @@
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.17.tgz",
-      "integrity": "sha512-5enc2qvcZwD4Omdr78gUfqH/4uOPW7UJE6d3EQAbGyaO6cD0dpjAGsLHHXkcjSTRIult2w6cvru7fI5suJnZtg==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+      "integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "scroll-behavior": "^0.9.10",
         "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "gatsby-source-filesystem": {
@@ -7671,18 +7856,18 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.42.tgz",
-      "integrity": "sha512-N/P8w8sVB1JDWn9Wm3hiB2NOrfIDioccot5h6jX8IVC4aUjXXROZPM+HSy3f1PHg2EoZuCGG5yH50XnayXupLQ==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+      "integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
-        "boxen": "^4.1.0",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
+        "boxen": "^4.2.0",
         "configstore": "^5.0.0",
         "envinfo": "^7.5.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
         "lodash": "^4.17.15",
@@ -7694,6 +7879,14 @@
         "uuid": "3.3.3"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+          "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
         "configstore": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.0.tgz",
@@ -7718,6 +7911,15 @@
           "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "is-obj": {
@@ -8965,9 +9167,9 @@
       }
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -8978,7 +9180,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -11017,9 +11219,9 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -11051,25 +11253,65 @@
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.fromentries": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -11702,9 +11944,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-      "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
+      "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -13267,11 +13509,32 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "regexpp": {
@@ -13315,9 +13578,9 @@
       "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
     },
     "regjsparser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.1.tgz",
+      "integrity": "sha512-7LutE94sz/NKSYegK+/4E77+8DipxF+Qn2Tmu362AcmsF2NYq/wx3+ObvU90TKEhjf7hQoFXo23ajjrXP7eUgg==",
       "requires": {
         "jsesc": "~0.5.0"
       },
@@ -13717,9 +13980,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -14571,9 +14834,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -14988,15 +15251,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -15818,9 +16081,9 @@
       }
     },
     "webpack": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-      "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
+      "version": "4.41.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
+      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -15842,7 +16105,7 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
+        "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },
@@ -16546,12 +16809,9 @@
       }
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/starters/default/package.json
+++ b/starters/default/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
-    "gatsby": "^2.18.8",
+    "gatsby": "^2.18.12",
     "gatsby-image": "^2.2.34",
     "gatsby-plugin-manifest": "^2.2.31",
     "gatsby-plugin-offline": "^3.0.27",

--- a/starters/gatsby-starter-blog-theme-core/package-lock.json
+++ b/starters/gatsby-starter-blog-theme-core/package-lock.json
@@ -320,6 +320,15 @@
         "@babel/plugin-syntax-json-strings": "^7.7.4"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
@@ -336,6 +345,15 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -379,6 +397,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -391,6 +417,14 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
       "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1490,11 +1524,11 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-      "integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
+      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1502,30 +1536,30 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
-      "integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
+      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
-      "integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
+      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.11.0",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
+      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -1948,12 +1982,32 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+      "integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "array-iterate": {
@@ -1987,13 +2041,32 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
-      "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "arraybuffer.slice": {
@@ -2299,9 +2372,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.7.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.17.tgz",
-      "integrity": "sha512-zPAq5DEtucSMppt4U2zB1i9SiGMLOYtjNGoOo5PLw8f5jlihLTYYaPG3Sg2S4+tiB9k+tiWMa07FKXb6lV+rRA=="
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+      "integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -2309,19 +2382,21 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.23.tgz",
-      "integrity": "sha512-IuhRMH6TCbTbJ4NFnHg2UQUZv24t3mRc9ow6qMeyL9mklI8vbXSi/bFVO6ES4xy3k5qmUdElXAK5RSpw8/1hbw==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+      "integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.7.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.7.5",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-        "@babel/plugin-transform-runtime": "^7.7.4",
+        "@babel/plugin-transform-runtime": "^7.7.6",
         "@babel/plugin-transform-spread": "^7.7.4",
-        "@babel/preset-env": "^7.7.4",
+        "@babel/preset-env": "^7.7.6",
         "@babel/preset-react": "^7.7.4",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-macros": "^2.7.1",
+        "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
@@ -2689,6 +2764,15 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.2.2",
@@ -4097,9 +4181,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.8.tgz",
-      "integrity": "sha512-K9iPNbLDZ0Epojwd8J3lhodmrLHYvxb07H3DaFme1ne4TIlFq/ufiyPC40rc3OX6NCaVa0zaSu+VV6BVDR2wiA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+      "integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4494,9 +4578,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -6475,6 +6559,12 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
       "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -6728,13 +6818,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -6776,7 +6867,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -6801,7 +6892,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6824,11 +6915,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -6852,7 +6943,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6878,7 +6969,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6895,7 +6986,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -6931,7 +7022,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6940,11 +7031,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -6956,22 +7047,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6984,7 +7075,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -6997,12 +7088,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7064,7 +7163,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -7101,7 +7200,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7124,7 +7223,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -7170,17 +7269,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -7202,7 +7301,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -7219,35 +7318,35 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.8.tgz",
-      "integrity": "sha512-44Cf+IJGyHT7ZKNE6xICG8QqA5Ava2nHXybTrQhPY3n6T7+dsdfbm6+WntT2yVtlfLfLFGute7Udx7HyFfsvSQ==",
+      "version": "2.18.12",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.12.tgz",
+      "integrity": "sha512-EmgSDZcedoUttw/ETEWWgRT0B7GUulsi3h8HwRDqNSMtHMJtk8SH9Vb5MWfQQZlZ2pteV9g8P4kv/bffCYKIbw==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/core": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
         "@babel/polyfill": "^7.7.0",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@babel/traverse": "^7.7.4",
         "@hapi/joi": "^15.1.1",
         "@mikaelkristiansson/domready": "^1.0.9",
         "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
         "@reach/router": "^1.2.1",
-        "@typescript-eslint/eslint-plugin": "^2.9.0",
-        "@typescript-eslint/parser": "^2.9.0",
+        "@typescript-eslint/eslint-plugin": "^2.11.0",
+        "@typescript-eslint/parser": "^2.11.0",
         "address": "1.1.2",
-        "autoprefixer": "^9.7.2",
+        "autoprefixer": "^9.7.3",
         "axios": "^0.19.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^10.0.3",
         "babel-loader": "^8.0.6",
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-remove-graphql-queries": "^2.7.17",
-        "babel-preset-gatsby": "^0.2.23",
+        "babel-plugin-remove-graphql-queries": "^2.7.19",
+        "babel-preset-gatsby": "^0.2.26",
         "better-opn": "1.0.0",
         "better-queue": "^3.8.10",
-        "bluebird": "^3.7.1",
+        "bluebird": "^3.7.2",
         "browserslist": "3.2.8",
         "cache-manager": "^2.10.1",
         "cache-manager-fs-hash": "^0.0.7",
@@ -7257,7 +7356,7 @@
         "compression": "^1.7.4",
         "convert-hrtime": "^3.0.0",
         "copyfiles": "^2.1.1",
-        "core-js": "^2.6.10",
+        "core-js": "^2.6.11",
         "cors": "^2.8.5",
         "css-loader": "^1.0.1",
         "debug": "^3.2.6",
@@ -7265,16 +7364,16 @@
         "detect-port": "^1.3.0",
         "devcert-san": "^0.3.3",
         "dotenv": "^8.2.0",
-        "eslint": "^6.7.1",
-        "eslint-config-react-app": "^5.0.2",
+        "eslint": "^6.7.2",
+        "eslint-config-react-app": "^5.1.0",
         "eslint-loader": "^2.2.1",
         "eslint-plugin-flowtype": "^3.13.0",
         "eslint-plugin-graphql": "^3.1.0",
-        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-import": "^2.19.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.16.0",
+        "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^1.7.0",
-        "event-source-polyfill": "^1.0.9",
+        "event-source-polyfill": "^1.0.11",
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fast-levenshtein": "^2.0.6",
@@ -7282,13 +7381,13 @@
         "flat": "^4.1.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.8.16",
-        "gatsby-core-utils": "^1.0.22",
-        "gatsby-graphiql-explorer": "^0.2.29",
-        "gatsby-link": "^2.2.25",
-        "gatsby-plugin-page-creator": "^2.1.34",
-        "gatsby-react-router-scroll": "^2.1.17",
-        "gatsby-telemetry": "^1.1.42",
+        "gatsby-cli": "^2.8.19",
+        "gatsby-core-utils": "^1.0.24",
+        "gatsby-graphiql-explorer": "^0.2.31",
+        "gatsby-link": "^2.2.27",
+        "gatsby-plugin-page-creator": "^2.1.36",
+        "gatsby-react-router-scroll": "^2.1.19",
+        "gatsby-telemetry": "^1.1.44",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.5.8",
@@ -7338,7 +7437,7 @@
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "style-loader": "^0.23.1",
-        "terser-webpack-plugin": "1.4.1",
+        "terser-webpack-plugin": "^1.4.2",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^1.1.2",
@@ -7351,7 +7450,7 @@
         "webpack-hot-middleware": "^2.25.0",
         "webpack-merge": "^4.2.2",
         "webpack-stats-plugin": "^0.3.0",
-        "xstate": "^4.6.7",
+        "xstate": "^4.7.2",
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
@@ -7412,29 +7511,29 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.8.16",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.16.tgz",
-          "integrity": "sha512-hjsK+xu00gg61CuS6z9jJrV6bHmI58YG3nd8B+goibM3vt/Wajg60til3hxaS9EGwHND+SatQUBTjTxdyOhplw==",
+          "version": "2.8.19",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.19.tgz",
+          "integrity": "sha512-cINizncxPBxL3tJAQVrVFCGrf/dFOFEk5o1uYr427zyLuC+jqaAtocE2AcT1P9ayXOEjyH4mP/INwaNfCbYkJg==",
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/runtime": "^7.7.4",
+            "@babel/runtime": "^7.7.6",
             "@hapi/joi": "^15.1.1",
             "better-opn": "^1.0.0",
-            "bluebird": "^3.7.1",
+            "bluebird": "^3.7.2",
             "chalk": "^2.4.2",
             "clipboardy": "^2.1.0",
             "common-tags": "^1.8.0",
             "configstore": "^5.0.0",
             "convert-hrtime": "^3.0.0",
-            "core-js": "^2.6.10",
+            "core-js": "^2.6.11",
             "envinfo": "^7.5.0",
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.0.22",
-            "gatsby-telemetry": "^1.1.42",
+            "gatsby-core-utils": "^1.0.24",
+            "gatsby-telemetry": "^1.1.44",
             "hosted-git-info": "^3.0.2",
-            "ink": "^2.5.0",
+            "ink": "^2.6.0",
             "ink-spinner": "^3.0.1",
             "is-valid-path": "^0.1.1",
             "lodash": "^4.17.15",
@@ -7464,6 +7563,15 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "get-caller-file": {
@@ -7641,36 +7749,47 @@
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.29.tgz",
-      "integrity": "sha512-qKnG1h/BSBkdPX5eUcFRVvHb0BA7WLnqeJ8NMH2AOv5VSK8YEwUdJVimZHz8M/59MKBtFAQyDCRU258sc1oWrQ==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+      "integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
       "requires": {
-        "@babel/runtime": "^7.7.4"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "gatsby-link": {
-      "version": "2.2.25",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.25.tgz",
-      "integrity": "sha512-P3Gt5ryW1bFBjAuKoJQsGSZcyEG7vFliHelnOLlAakkJ+wLQz4Wq2o4BAb6lB4wPzO7HzXRJD6RuxQrd9tmkPg==",
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+      "integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@types/reach__router": "^1.2.6",
         "prop-types": "^15.7.2"
       }
     },
     "gatsby-page-utils": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.33.tgz",
-      "integrity": "sha512-0FweVMQc5JklMwPPbwcXRo5N3ydRKrNI+YZzr6731kON1tvCKB7EbbrwMvZLEedv4BNP+XUe33FuT7LsAaUE3g==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+      "integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "chokidar": "3.3.0",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
+          }
+        }
       }
     },
     "gatsby-plugin-mdx": {
@@ -7759,14 +7878,14 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.34.tgz",
-      "integrity": "sha512-w315rYA1KS48jVo4Zg/1Uxm5Y6h48rW8Bf0520uOh8SkSr0qXFC6ivFmw2Uq4WFH02+qN7QTqGd3sHX1wwlf+g==",
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+      "integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.0.33",
+        "gatsby-page-utils": "^0.0.35",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
@@ -7815,11 +7934,11 @@
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.17.tgz",
-      "integrity": "sha512-5enc2qvcZwD4Omdr78gUfqH/4uOPW7UJE6d3EQAbGyaO6cD0dpjAGsLHHXkcjSTRIult2w6cvru7fI5suJnZtg==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+      "integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "scroll-behavior": "^0.9.10",
         "warning": "^3.0.0"
       }
@@ -8057,18 +8176,18 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.42.tgz",
-      "integrity": "sha512-N/P8w8sVB1JDWn9Wm3hiB2NOrfIDioccot5h6jX8IVC4aUjXXROZPM+HSy3f1PHg2EoZuCGG5yH50XnayXupLQ==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+      "integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
-        "boxen": "^4.1.0",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
+        "boxen": "^4.2.0",
         "configstore": "^5.0.0",
         "envinfo": "^7.5.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
         "lodash": "^4.17.15",
@@ -8104,6 +8223,15 @@
           "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "is-obj": {
@@ -9470,9 +9598,9 @@
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -9483,7 +9611,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -11755,9 +11883,9 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -11789,25 +11917,65 @@
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.fromentries": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -12511,9 +12679,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-      "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
+      "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -14053,11 +14221,32 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "regexpp": {
@@ -14850,9 +15039,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -15755,9 +15944,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -16208,15 +16397,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -17285,9 +17474,9 @@
       "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
     },
     "webpack": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-      "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
+      "version": "4.41.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
+      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -17309,7 +17498,7 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
+        "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },
@@ -17862,12 +18051,9 @@
       }
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/starters/gatsby-starter-blog-theme-core/package.json
+++ b/starters/gatsby-starter-blog-theme-core/package.json
@@ -9,7 +9,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "gatsby": "^2.18.8",
+    "gatsby": "^2.18.12",
     "gatsby-theme-blog-core": "^1.0.35",
     "@mdx-js/react": "^1.5.1",
     "react": "^16.12.0",

--- a/starters/gatsby-starter-blog-theme/package-lock.json
+++ b/starters/gatsby-starter-blog-theme/package-lock.json
@@ -320,6 +320,15 @@
         "@babel/plugin-syntax-json-strings": "^7.7.4"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
@@ -336,6 +345,15 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -379,6 +397,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -391,6 +417,14 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
       "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1621,11 +1655,11 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-      "integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
+      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1633,30 +1667,30 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
-      "integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
+      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
-      "integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
+      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.11.0",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
+      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -2079,12 +2113,32 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+      "integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "array-iterate": {
@@ -2118,13 +2172,32 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
-      "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "arraybuffer.slice": {
@@ -2447,9 +2520,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.7.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.17.tgz",
-      "integrity": "sha512-zPAq5DEtucSMppt4U2zB1i9SiGMLOYtjNGoOo5PLw8f5jlihLTYYaPG3Sg2S4+tiB9k+tiWMa07FKXb6lV+rRA=="
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+      "integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
@@ -2462,19 +2535,21 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.23.tgz",
-      "integrity": "sha512-IuhRMH6TCbTbJ4NFnHg2UQUZv24t3mRc9ow6qMeyL9mklI8vbXSi/bFVO6ES4xy3k5qmUdElXAK5RSpw8/1hbw==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+      "integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.7.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.7.5",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-        "@babel/plugin-transform-runtime": "^7.7.4",
+        "@babel/plugin-transform-runtime": "^7.7.6",
         "@babel/plugin-transform-spread": "^7.7.4",
-        "@babel/preset-env": "^7.7.4",
+        "@babel/preset-env": "^7.7.6",
         "@babel/preset-react": "^7.7.4",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-macros": "^2.7.1",
+        "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
@@ -2842,6 +2917,15 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.2.2",
@@ -4274,9 +4358,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.8.tgz",
-      "integrity": "sha512-K9iPNbLDZ0Epojwd8J3lhodmrLHYvxb07H3DaFme1ne4TIlFq/ufiyPC40rc3OX6NCaVa0zaSu+VV6BVDR2wiA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+      "integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6652,6 +6736,12 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
       "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -6910,13 +7000,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -6958,7 +7049,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -6983,7 +7074,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7006,11 +7097,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -7034,7 +7125,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7060,7 +7151,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7077,7 +7168,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -7113,7 +7204,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7122,11 +7213,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -7138,22 +7229,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7166,7 +7257,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -7179,12 +7270,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7246,7 +7345,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -7283,7 +7382,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7306,7 +7405,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -7352,17 +7451,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -7384,7 +7483,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -7401,35 +7500,35 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.8.tgz",
-      "integrity": "sha512-44Cf+IJGyHT7ZKNE6xICG8QqA5Ava2nHXybTrQhPY3n6T7+dsdfbm6+WntT2yVtlfLfLFGute7Udx7HyFfsvSQ==",
+      "version": "2.18.12",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.12.tgz",
+      "integrity": "sha512-EmgSDZcedoUttw/ETEWWgRT0B7GUulsi3h8HwRDqNSMtHMJtk8SH9Vb5MWfQQZlZ2pteV9g8P4kv/bffCYKIbw==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/core": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
         "@babel/polyfill": "^7.7.0",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@babel/traverse": "^7.7.4",
         "@hapi/joi": "^15.1.1",
         "@mikaelkristiansson/domready": "^1.0.9",
         "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
         "@reach/router": "^1.2.1",
-        "@typescript-eslint/eslint-plugin": "^2.9.0",
-        "@typescript-eslint/parser": "^2.9.0",
+        "@typescript-eslint/eslint-plugin": "^2.11.0",
+        "@typescript-eslint/parser": "^2.11.0",
         "address": "1.1.2",
-        "autoprefixer": "^9.7.2",
+        "autoprefixer": "^9.7.3",
         "axios": "^0.19.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^10.0.3",
         "babel-loader": "^8.0.6",
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-remove-graphql-queries": "^2.7.17",
-        "babel-preset-gatsby": "^0.2.23",
+        "babel-plugin-remove-graphql-queries": "^2.7.19",
+        "babel-preset-gatsby": "^0.2.26",
         "better-opn": "1.0.0",
         "better-queue": "^3.8.10",
-        "bluebird": "^3.7.1",
+        "bluebird": "^3.7.2",
         "browserslist": "3.2.8",
         "cache-manager": "^2.10.1",
         "cache-manager-fs-hash": "^0.0.7",
@@ -7439,7 +7538,7 @@
         "compression": "^1.7.4",
         "convert-hrtime": "^3.0.0",
         "copyfiles": "^2.1.1",
-        "core-js": "^2.6.10",
+        "core-js": "^2.6.11",
         "cors": "^2.8.5",
         "css-loader": "^1.0.1",
         "debug": "^3.2.6",
@@ -7447,16 +7546,16 @@
         "detect-port": "^1.3.0",
         "devcert-san": "^0.3.3",
         "dotenv": "^8.2.0",
-        "eslint": "^6.7.1",
-        "eslint-config-react-app": "^5.0.2",
+        "eslint": "^6.7.2",
+        "eslint-config-react-app": "^5.1.0",
         "eslint-loader": "^2.2.1",
         "eslint-plugin-flowtype": "^3.13.0",
         "eslint-plugin-graphql": "^3.1.0",
-        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-import": "^2.19.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.16.0",
+        "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^1.7.0",
-        "event-source-polyfill": "^1.0.9",
+        "event-source-polyfill": "^1.0.11",
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fast-levenshtein": "^2.0.6",
@@ -7464,13 +7563,13 @@
         "flat": "^4.1.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.8.16",
-        "gatsby-core-utils": "^1.0.22",
-        "gatsby-graphiql-explorer": "^0.2.29",
-        "gatsby-link": "^2.2.25",
-        "gatsby-plugin-page-creator": "^2.1.34",
-        "gatsby-react-router-scroll": "^2.1.17",
-        "gatsby-telemetry": "^1.1.42",
+        "gatsby-cli": "^2.8.19",
+        "gatsby-core-utils": "^1.0.24",
+        "gatsby-graphiql-explorer": "^0.2.31",
+        "gatsby-link": "^2.2.27",
+        "gatsby-plugin-page-creator": "^2.1.36",
+        "gatsby-react-router-scroll": "^2.1.19",
+        "gatsby-telemetry": "^1.1.44",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.5.8",
@@ -7520,7 +7619,7 @@
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "style-loader": "^0.23.1",
-        "terser-webpack-plugin": "1.4.1",
+        "terser-webpack-plugin": "^1.4.2",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^1.1.2",
@@ -7533,7 +7632,7 @@
         "webpack-hot-middleware": "^2.25.0",
         "webpack-merge": "^4.2.2",
         "webpack-stats-plugin": "^0.3.0",
-        "xstate": "^4.6.7",
+        "xstate": "^4.7.2",
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
@@ -7594,29 +7693,29 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.8.16",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.16.tgz",
-          "integrity": "sha512-hjsK+xu00gg61CuS6z9jJrV6bHmI58YG3nd8B+goibM3vt/Wajg60til3hxaS9EGwHND+SatQUBTjTxdyOhplw==",
+          "version": "2.8.19",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.19.tgz",
+          "integrity": "sha512-cINizncxPBxL3tJAQVrVFCGrf/dFOFEk5o1uYr427zyLuC+jqaAtocE2AcT1P9ayXOEjyH4mP/INwaNfCbYkJg==",
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/runtime": "^7.7.4",
+            "@babel/runtime": "^7.7.6",
             "@hapi/joi": "^15.1.1",
             "better-opn": "^1.0.0",
-            "bluebird": "^3.7.1",
+            "bluebird": "^3.7.2",
             "chalk": "^2.4.2",
             "clipboardy": "^2.1.0",
             "common-tags": "^1.8.0",
             "configstore": "^5.0.0",
             "convert-hrtime": "^3.0.0",
-            "core-js": "^2.6.10",
+            "core-js": "^2.6.11",
             "envinfo": "^7.5.0",
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.0.22",
-            "gatsby-telemetry": "^1.1.42",
+            "gatsby-core-utils": "^1.0.24",
+            "gatsby-telemetry": "^1.1.44",
             "hosted-git-info": "^3.0.2",
-            "ink": "^2.5.0",
+            "ink": "^2.6.0",
             "ink-spinner": "^3.0.1",
             "is-valid-path": "^0.1.1",
             "lodash": "^4.17.15",
@@ -7646,6 +7745,15 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "get-caller-file": {
@@ -7823,11 +7931,11 @@
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.29.tgz",
-      "integrity": "sha512-qKnG1h/BSBkdPX5eUcFRVvHb0BA7WLnqeJ8NMH2AOv5VSK8YEwUdJVimZHz8M/59MKBtFAQyDCRU258sc1oWrQ==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+      "integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
       "requires": {
-        "@babel/runtime": "^7.7.4"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "gatsby-image": {
@@ -7841,28 +7949,39 @@
       }
     },
     "gatsby-link": {
-      "version": "2.2.25",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.25.tgz",
-      "integrity": "sha512-P3Gt5ryW1bFBjAuKoJQsGSZcyEG7vFliHelnOLlAakkJ+wLQz4Wq2o4BAb6lB4wPzO7HzXRJD6RuxQrd9tmkPg==",
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+      "integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@types/reach__router": "^1.2.6",
         "prop-types": "^15.7.2"
       }
     },
     "gatsby-page-utils": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.33.tgz",
-      "integrity": "sha512-0FweVMQc5JklMwPPbwcXRo5N3ydRKrNI+YZzr6731kON1tvCKB7EbbrwMvZLEedv4BNP+XUe33FuT7LsAaUE3g==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+      "integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "chokidar": "3.3.0",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
+          }
+        }
       }
     },
     "gatsby-plugin-emotion": {
@@ -7972,14 +8091,14 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.34.tgz",
-      "integrity": "sha512-w315rYA1KS48jVo4Zg/1Uxm5Y6h48rW8Bf0520uOh8SkSr0qXFC6ivFmw2Uq4WFH02+qN7QTqGd3sHX1wwlf+g==",
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+      "integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.0.33",
+        "gatsby-page-utils": "^0.0.35",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
@@ -8049,11 +8168,11 @@
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.17.tgz",
-      "integrity": "sha512-5enc2qvcZwD4Omdr78gUfqH/4uOPW7UJE6d3EQAbGyaO6cD0dpjAGsLHHXkcjSTRIult2w6cvru7fI5suJnZtg==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+      "integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "scroll-behavior": "^0.9.10",
         "warning": "^3.0.0"
       }
@@ -8291,18 +8410,18 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.42.tgz",
-      "integrity": "sha512-N/P8w8sVB1JDWn9Wm3hiB2NOrfIDioccot5h6jX8IVC4aUjXXROZPM+HSy3f1PHg2EoZuCGG5yH50XnayXupLQ==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+      "integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
-        "boxen": "^4.1.0",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
+        "boxen": "^4.2.0",
         "configstore": "^5.0.0",
         "envinfo": "^7.5.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
         "lodash": "^4.17.15",
@@ -8338,6 +8457,15 @@
           "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "is-obj": {
@@ -9735,9 +9863,9 @@
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -9748,7 +9876,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -12043,9 +12171,9 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -12077,25 +12205,65 @@
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.fromentries": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -12804,9 +12972,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-      "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
+      "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -14383,11 +14551,32 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "regexpp": {
@@ -15204,9 +15393,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -16109,9 +16298,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -16562,15 +16751,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -17673,9 +17862,9 @@
       "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
     },
     "webpack": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-      "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
+      "version": "4.41.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
+      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -17697,7 +17886,7 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
+        "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },
@@ -18250,12 +18439,9 @@
       }
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/starters/gatsby-starter-blog-theme/package.json
+++ b/starters/gatsby-starter-blog-theme/package.json
@@ -9,7 +9,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "gatsby": "^2.18.8",
+    "gatsby": "^2.18.12",
     "gatsby-theme-blog": "^1.2.7",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/starters/gatsby-starter-notes-theme/package-lock.json
+++ b/starters/gatsby-starter-notes-theme/package-lock.json
@@ -320,6 +320,15 @@
         "@babel/plugin-syntax-json-strings": "^7.7.4"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
@@ -336,6 +345,15 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -379,6 +397,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -391,6 +417,14 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
       "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1598,11 +1632,11 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-      "integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
+      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1610,30 +1644,30 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
-      "integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
+      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
-      "integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
+      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.11.0",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
+      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -2027,12 +2061,32 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+      "integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "array-iterate": {
@@ -2066,13 +2120,32 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
-      "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "arraybuffer.slice": {
@@ -2367,9 +2440,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.7.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.17.tgz",
-      "integrity": "sha512-zPAq5DEtucSMppt4U2zB1i9SiGMLOYtjNGoOo5PLw8f5jlihLTYYaPG3Sg2S4+tiB9k+tiWMa07FKXb6lV+rRA=="
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+      "integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
@@ -2382,19 +2455,21 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.23.tgz",
-      "integrity": "sha512-IuhRMH6TCbTbJ4NFnHg2UQUZv24t3mRc9ow6qMeyL9mklI8vbXSi/bFVO6ES4xy3k5qmUdElXAK5RSpw8/1hbw==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+      "integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.7.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.7.5",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-        "@babel/plugin-transform-runtime": "^7.7.4",
+        "@babel/plugin-transform-runtime": "^7.7.6",
         "@babel/plugin-transform-spread": "^7.7.4",
-        "@babel/preset-env": "^7.7.4",
+        "@babel/preset-env": "^7.7.6",
         "@babel/preset-react": "^7.7.4",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-macros": "^2.7.1",
+        "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
@@ -2539,6 +2614,15 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "blob": {
       "version": "0.0.5",
@@ -3869,9 +3953,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.8.tgz",
-      "integrity": "sha512-K9iPNbLDZ0Epojwd8J3lhodmrLHYvxb07H3DaFme1ne4TIlFq/ufiyPC40rc3OX6NCaVa0zaSu+VV6BVDR2wiA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+      "integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5787,9 +5871,9 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5872,6 +5956,12 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
       "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "3.5.11",
@@ -6080,13 +6170,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -6128,7 +6219,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -6153,7 +6244,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6176,11 +6267,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -6204,7 +6295,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6230,7 +6321,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6247,7 +6338,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -6283,7 +6374,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6292,11 +6383,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -6308,22 +6399,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6336,7 +6427,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -6349,12 +6440,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6416,7 +6515,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -6453,7 +6552,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -6476,7 +6575,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -6522,17 +6621,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -6554,7 +6653,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -6571,35 +6670,35 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.8.tgz",
-      "integrity": "sha512-44Cf+IJGyHT7ZKNE6xICG8QqA5Ava2nHXybTrQhPY3n6T7+dsdfbm6+WntT2yVtlfLfLFGute7Udx7HyFfsvSQ==",
+      "version": "2.18.12",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.12.tgz",
+      "integrity": "sha512-EmgSDZcedoUttw/ETEWWgRT0B7GUulsi3h8HwRDqNSMtHMJtk8SH9Vb5MWfQQZlZ2pteV9g8P4kv/bffCYKIbw==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/core": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
         "@babel/polyfill": "^7.7.0",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@babel/traverse": "^7.7.4",
         "@hapi/joi": "^15.1.1",
         "@mikaelkristiansson/domready": "^1.0.9",
         "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
         "@reach/router": "^1.2.1",
-        "@typescript-eslint/eslint-plugin": "^2.9.0",
-        "@typescript-eslint/parser": "^2.9.0",
+        "@typescript-eslint/eslint-plugin": "^2.11.0",
+        "@typescript-eslint/parser": "^2.11.0",
         "address": "1.1.2",
-        "autoprefixer": "^9.7.2",
+        "autoprefixer": "^9.7.3",
         "axios": "^0.19.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^10.0.3",
         "babel-loader": "^8.0.6",
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-remove-graphql-queries": "^2.7.17",
-        "babel-preset-gatsby": "^0.2.23",
+        "babel-plugin-remove-graphql-queries": "^2.7.19",
+        "babel-preset-gatsby": "^0.2.26",
         "better-opn": "1.0.0",
         "better-queue": "^3.8.10",
-        "bluebird": "^3.7.1",
+        "bluebird": "^3.7.2",
         "browserslist": "3.2.8",
         "cache-manager": "^2.10.1",
         "cache-manager-fs-hash": "^0.0.7",
@@ -6609,7 +6708,7 @@
         "compression": "^1.7.4",
         "convert-hrtime": "^3.0.0",
         "copyfiles": "^2.1.1",
-        "core-js": "^2.6.10",
+        "core-js": "^2.6.11",
         "cors": "^2.8.5",
         "css-loader": "^1.0.1",
         "debug": "^3.2.6",
@@ -6617,16 +6716,16 @@
         "detect-port": "^1.3.0",
         "devcert-san": "^0.3.3",
         "dotenv": "^8.2.0",
-        "eslint": "^6.7.1",
-        "eslint-config-react-app": "^5.0.2",
+        "eslint": "^6.7.2",
+        "eslint-config-react-app": "^5.1.0",
         "eslint-loader": "^2.2.1",
         "eslint-plugin-flowtype": "^3.13.0",
         "eslint-plugin-graphql": "^3.1.0",
-        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-import": "^2.19.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.16.0",
+        "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^1.7.0",
-        "event-source-polyfill": "^1.0.9",
+        "event-source-polyfill": "^1.0.11",
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fast-levenshtein": "^2.0.6",
@@ -6634,13 +6733,13 @@
         "flat": "^4.1.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.8.16",
-        "gatsby-core-utils": "^1.0.22",
-        "gatsby-graphiql-explorer": "^0.2.29",
-        "gatsby-link": "^2.2.25",
-        "gatsby-plugin-page-creator": "^2.1.34",
-        "gatsby-react-router-scroll": "^2.1.17",
-        "gatsby-telemetry": "^1.1.42",
+        "gatsby-cli": "^2.8.19",
+        "gatsby-core-utils": "^1.0.24",
+        "gatsby-graphiql-explorer": "^0.2.31",
+        "gatsby-link": "^2.2.27",
+        "gatsby-plugin-page-creator": "^2.1.36",
+        "gatsby-react-router-scroll": "^2.1.19",
+        "gatsby-telemetry": "^1.1.44",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.5.8",
@@ -6690,7 +6789,7 @@
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "style-loader": "^0.23.1",
-        "terser-webpack-plugin": "1.4.1",
+        "terser-webpack-plugin": "^1.4.2",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^1.1.2",
@@ -6703,7 +6802,7 @@
         "webpack-hot-middleware": "^2.25.0",
         "webpack-merge": "^4.2.2",
         "webpack-stats-plugin": "^0.3.0",
-        "xstate": "^4.6.7",
+        "xstate": "^4.7.2",
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
@@ -6764,29 +6863,29 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.8.16",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.16.tgz",
-          "integrity": "sha512-hjsK+xu00gg61CuS6z9jJrV6bHmI58YG3nd8B+goibM3vt/Wajg60til3hxaS9EGwHND+SatQUBTjTxdyOhplw==",
+          "version": "2.8.19",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.19.tgz",
+          "integrity": "sha512-cINizncxPBxL3tJAQVrVFCGrf/dFOFEk5o1uYr427zyLuC+jqaAtocE2AcT1P9ayXOEjyH4mP/INwaNfCbYkJg==",
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/runtime": "^7.7.4",
+            "@babel/runtime": "^7.7.6",
             "@hapi/joi": "^15.1.1",
             "better-opn": "^1.0.0",
-            "bluebird": "^3.7.1",
+            "bluebird": "^3.7.2",
             "chalk": "^2.4.2",
             "clipboardy": "^2.1.0",
             "common-tags": "^1.8.0",
             "configstore": "^5.0.0",
             "convert-hrtime": "^3.0.0",
-            "core-js": "^2.6.10",
+            "core-js": "^2.6.11",
             "envinfo": "^7.5.0",
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.0.22",
-            "gatsby-telemetry": "^1.1.42",
+            "gatsby-core-utils": "^1.0.24",
+            "gatsby-telemetry": "^1.1.44",
             "hosted-git-info": "^3.0.2",
-            "ink": "^2.5.0",
+            "ink": "^2.6.0",
             "ink-spinner": "^3.0.1",
             "is-valid-path": "^0.1.1",
             "lodash": "^4.17.15",
@@ -6816,6 +6915,15 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "get-caller-file": {
@@ -6993,36 +7101,47 @@
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.29.tgz",
-      "integrity": "sha512-qKnG1h/BSBkdPX5eUcFRVvHb0BA7WLnqeJ8NMH2AOv5VSK8YEwUdJVimZHz8M/59MKBtFAQyDCRU258sc1oWrQ==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+      "integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
       "requires": {
-        "@babel/runtime": "^7.7.4"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "gatsby-link": {
-      "version": "2.2.25",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.25.tgz",
-      "integrity": "sha512-P3Gt5ryW1bFBjAuKoJQsGSZcyEG7vFliHelnOLlAakkJ+wLQz4Wq2o4BAb6lB4wPzO7HzXRJD6RuxQrd9tmkPg==",
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+      "integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@types/reach__router": "^1.2.6",
         "prop-types": "^15.7.2"
       }
     },
     "gatsby-page-utils": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.33.tgz",
-      "integrity": "sha512-0FweVMQc5JklMwPPbwcXRo5N3ydRKrNI+YZzr6731kON1tvCKB7EbbrwMvZLEedv4BNP+XUe33FuT7LsAaUE3g==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+      "integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "chokidar": "3.3.0",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
+          }
+        }
       }
     },
     "gatsby-plugin-compile-es6-packages": {
@@ -7160,14 +7279,14 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.34.tgz",
-      "integrity": "sha512-w315rYA1KS48jVo4Zg/1Uxm5Y6h48rW8Bf0520uOh8SkSr0qXFC6ivFmw2Uq4WFH02+qN7QTqGd3sHX1wwlf+g==",
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+      "integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.0.33",
+        "gatsby-page-utils": "^0.0.35",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
@@ -7187,11 +7306,11 @@
       "integrity": "sha512-rBQ5vlTSeuUuv929s5k6VUit7k/VXqZOFxd5FlMyR9DCo87zqEJhQ0sobkLrfhAiAo80TUyQEEA0GbLZtrb6pA=="
     },
     "gatsby-react-router-scroll": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.17.tgz",
-      "integrity": "sha512-5enc2qvcZwD4Omdr78gUfqH/4uOPW7UJE6d3EQAbGyaO6cD0dpjAGsLHHXkcjSTRIult2w6cvru7fI5suJnZtg==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+      "integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "scroll-behavior": "^0.9.10",
         "warning": "^3.0.0"
       }
@@ -7278,18 +7397,18 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.42.tgz",
-      "integrity": "sha512-N/P8w8sVB1JDWn9Wm3hiB2NOrfIDioccot5h6jX8IVC4aUjXXROZPM+HSy3f1PHg2EoZuCGG5yH50XnayXupLQ==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+      "integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
-        "boxen": "^4.1.0",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
+        "boxen": "^4.2.0",
         "configstore": "^5.0.0",
         "envinfo": "^7.5.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
         "lodash": "^4.17.15",
@@ -7325,6 +7444,15 @@
           "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "is-obj": {
@@ -8399,9 +8527,9 @@
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -8412,7 +8540,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -10389,9 +10517,9 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -10423,25 +10551,65 @@
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.fromentries": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -10462,14 +10630,34 @@
       }
     },
     "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "obuf": {
@@ -11059,9 +11247,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-      "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
+      "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -12539,11 +12727,32 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "regexpp": {
@@ -13158,9 +13367,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -13914,9 +14123,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -14252,15 +14461,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -15237,9 +15446,9 @@
       "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
     },
     "webpack": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-      "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
+      "version": "4.41.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
+      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -15261,7 +15470,7 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
+        "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },
@@ -15801,12 +16010,9 @@
       }
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/starters/gatsby-starter-notes-theme/package.json
+++ b/starters/gatsby-starter-notes-theme/package.json
@@ -9,7 +9,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "gatsby": "^2.18.8",
+    "gatsby": "^2.18.12",
     "gatsby-theme-notes": "^1.0.31",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/starters/gatsby-starter-theme/package-lock.json
+++ b/starters/gatsby-starter-theme/package-lock.json
@@ -320,6 +320,15 @@
         "@babel/plugin-syntax-json-strings": "^7.7.4"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
@@ -336,6 +345,15 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -379,6 +397,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -391,6 +417,14 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
       "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1630,11 +1664,11 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-      "integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
+      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1642,30 +1676,30 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
-      "integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
+      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
-      "integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
+      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.11.0",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
+      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -2088,12 +2122,32 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+      "integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "array-iterate": {
@@ -2127,13 +2181,32 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
-      "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "arraybuffer.slice": {
@@ -2456,9 +2529,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.7.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.17.tgz",
-      "integrity": "sha512-zPAq5DEtucSMppt4U2zB1i9SiGMLOYtjNGoOo5PLw8f5jlihLTYYaPG3Sg2S4+tiB9k+tiWMa07FKXb6lV+rRA=="
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+      "integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
@@ -2471,19 +2544,21 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.23.tgz",
-      "integrity": "sha512-IuhRMH6TCbTbJ4NFnHg2UQUZv24t3mRc9ow6qMeyL9mklI8vbXSi/bFVO6ES4xy3k5qmUdElXAK5RSpw8/1hbw==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+      "integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.7.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.7.5",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-        "@babel/plugin-transform-runtime": "^7.7.4",
+        "@babel/plugin-transform-runtime": "^7.7.6",
         "@babel/plugin-transform-spread": "^7.7.4",
-        "@babel/preset-env": "^7.7.4",
+        "@babel/preset-env": "^7.7.6",
         "@babel/preset-react": "^7.7.4",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-macros": "^2.7.1",
+        "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
@@ -2851,6 +2926,15 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.2.2",
@@ -4283,9 +4367,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.8.tgz",
-      "integrity": "sha512-K9iPNbLDZ0Epojwd8J3lhodmrLHYvxb07H3DaFme1ne4TIlFq/ufiyPC40rc3OX6NCaVa0zaSu+VV6BVDR2wiA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+      "integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6661,6 +6745,12 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
       "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -6919,13 +7009,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -6967,7 +7058,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -6992,7 +7083,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7015,11 +7106,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -7043,7 +7134,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7069,7 +7160,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7086,7 +7177,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -7122,7 +7213,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7131,11 +7222,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -7147,22 +7238,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7175,7 +7266,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -7188,12 +7279,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7255,7 +7354,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -7292,7 +7391,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -7315,7 +7414,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -7361,17 +7460,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -7393,7 +7492,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -7410,35 +7509,35 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.8.tgz",
-      "integrity": "sha512-44Cf+IJGyHT7ZKNE6xICG8QqA5Ava2nHXybTrQhPY3n6T7+dsdfbm6+WntT2yVtlfLfLFGute7Udx7HyFfsvSQ==",
+      "version": "2.18.12",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.12.tgz",
+      "integrity": "sha512-EmgSDZcedoUttw/ETEWWgRT0B7GUulsi3h8HwRDqNSMtHMJtk8SH9Vb5MWfQQZlZ2pteV9g8P4kv/bffCYKIbw==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/core": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
         "@babel/polyfill": "^7.7.0",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@babel/traverse": "^7.7.4",
         "@hapi/joi": "^15.1.1",
         "@mikaelkristiansson/domready": "^1.0.9",
         "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
         "@reach/router": "^1.2.1",
-        "@typescript-eslint/eslint-plugin": "^2.9.0",
-        "@typescript-eslint/parser": "^2.9.0",
+        "@typescript-eslint/eslint-plugin": "^2.11.0",
+        "@typescript-eslint/parser": "^2.11.0",
         "address": "1.1.2",
-        "autoprefixer": "^9.7.2",
+        "autoprefixer": "^9.7.3",
         "axios": "^0.19.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^10.0.3",
         "babel-loader": "^8.0.6",
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-remove-graphql-queries": "^2.7.17",
-        "babel-preset-gatsby": "^0.2.23",
+        "babel-plugin-remove-graphql-queries": "^2.7.19",
+        "babel-preset-gatsby": "^0.2.26",
         "better-opn": "1.0.0",
         "better-queue": "^3.8.10",
-        "bluebird": "^3.7.1",
+        "bluebird": "^3.7.2",
         "browserslist": "3.2.8",
         "cache-manager": "^2.10.1",
         "cache-manager-fs-hash": "^0.0.7",
@@ -7448,7 +7547,7 @@
         "compression": "^1.7.4",
         "convert-hrtime": "^3.0.0",
         "copyfiles": "^2.1.1",
-        "core-js": "^2.6.10",
+        "core-js": "^2.6.11",
         "cors": "^2.8.5",
         "css-loader": "^1.0.1",
         "debug": "^3.2.6",
@@ -7456,16 +7555,16 @@
         "detect-port": "^1.3.0",
         "devcert-san": "^0.3.3",
         "dotenv": "^8.2.0",
-        "eslint": "^6.7.1",
-        "eslint-config-react-app": "^5.0.2",
+        "eslint": "^6.7.2",
+        "eslint-config-react-app": "^5.1.0",
         "eslint-loader": "^2.2.1",
         "eslint-plugin-flowtype": "^3.13.0",
         "eslint-plugin-graphql": "^3.1.0",
-        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-import": "^2.19.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.16.0",
+        "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^1.7.0",
-        "event-source-polyfill": "^1.0.9",
+        "event-source-polyfill": "^1.0.11",
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fast-levenshtein": "^2.0.6",
@@ -7473,13 +7572,13 @@
         "flat": "^4.1.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.8.16",
-        "gatsby-core-utils": "^1.0.22",
-        "gatsby-graphiql-explorer": "^0.2.29",
-        "gatsby-link": "^2.2.25",
-        "gatsby-plugin-page-creator": "^2.1.34",
-        "gatsby-react-router-scroll": "^2.1.17",
-        "gatsby-telemetry": "^1.1.42",
+        "gatsby-cli": "^2.8.19",
+        "gatsby-core-utils": "^1.0.24",
+        "gatsby-graphiql-explorer": "^0.2.31",
+        "gatsby-link": "^2.2.27",
+        "gatsby-plugin-page-creator": "^2.1.36",
+        "gatsby-react-router-scroll": "^2.1.19",
+        "gatsby-telemetry": "^1.1.44",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.5.8",
@@ -7529,7 +7628,7 @@
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "style-loader": "^0.23.1",
-        "terser-webpack-plugin": "1.4.1",
+        "terser-webpack-plugin": "^1.4.2",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^1.1.2",
@@ -7542,7 +7641,7 @@
         "webpack-hot-middleware": "^2.25.0",
         "webpack-merge": "^4.2.2",
         "webpack-stats-plugin": "^0.3.0",
-        "xstate": "^4.6.7",
+        "xstate": "^4.7.2",
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
@@ -7603,29 +7702,29 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.8.16",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.16.tgz",
-          "integrity": "sha512-hjsK+xu00gg61CuS6z9jJrV6bHmI58YG3nd8B+goibM3vt/Wajg60til3hxaS9EGwHND+SatQUBTjTxdyOhplw==",
+          "version": "2.8.19",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.19.tgz",
+          "integrity": "sha512-cINizncxPBxL3tJAQVrVFCGrf/dFOFEk5o1uYr427zyLuC+jqaAtocE2AcT1P9ayXOEjyH4mP/INwaNfCbYkJg==",
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/runtime": "^7.7.4",
+            "@babel/runtime": "^7.7.6",
             "@hapi/joi": "^15.1.1",
             "better-opn": "^1.0.0",
-            "bluebird": "^3.7.1",
+            "bluebird": "^3.7.2",
             "chalk": "^2.4.2",
             "clipboardy": "^2.1.0",
             "common-tags": "^1.8.0",
             "configstore": "^5.0.0",
             "convert-hrtime": "^3.0.0",
-            "core-js": "^2.6.10",
+            "core-js": "^2.6.11",
             "envinfo": "^7.5.0",
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.0.22",
-            "gatsby-telemetry": "^1.1.42",
+            "gatsby-core-utils": "^1.0.24",
+            "gatsby-telemetry": "^1.1.44",
             "hosted-git-info": "^3.0.2",
-            "ink": "^2.5.0",
+            "ink": "^2.6.0",
             "ink-spinner": "^3.0.1",
             "is-valid-path": "^0.1.1",
             "lodash": "^4.17.15",
@@ -7655,6 +7754,15 @@
               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             }
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "get-caller-file": {
@@ -7832,11 +7940,11 @@
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.29.tgz",
-      "integrity": "sha512-qKnG1h/BSBkdPX5eUcFRVvHb0BA7WLnqeJ8NMH2AOv5VSK8YEwUdJVimZHz8M/59MKBtFAQyDCRU258sc1oWrQ==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+      "integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
       "requires": {
-        "@babel/runtime": "^7.7.4"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "gatsby-image": {
@@ -7850,28 +7958,39 @@
       }
     },
     "gatsby-link": {
-      "version": "2.2.25",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.25.tgz",
-      "integrity": "sha512-P3Gt5ryW1bFBjAuKoJQsGSZcyEG7vFliHelnOLlAakkJ+wLQz4Wq2o4BAb6lB4wPzO7HzXRJD6RuxQrd9tmkPg==",
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+      "integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@types/reach__router": "^1.2.6",
         "prop-types": "^15.7.2"
       }
     },
     "gatsby-page-utils": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.33.tgz",
-      "integrity": "sha512-0FweVMQc5JklMwPPbwcXRo5N3ydRKrNI+YZzr6731kON1tvCKB7EbbrwMvZLEedv4BNP+XUe33FuT7LsAaUE3g==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+      "integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "chokidar": "3.3.0",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
+          }
+        }
       }
     },
     "gatsby-plugin-compile-es6-packages": {
@@ -8021,14 +8140,14 @@
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.34.tgz",
-      "integrity": "sha512-w315rYA1KS48jVo4Zg/1Uxm5Y6h48rW8Bf0520uOh8SkSr0qXFC6ivFmw2Uq4WFH02+qN7QTqGd3sHX1wwlf+g==",
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+      "integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.0.33",
+        "gatsby-page-utils": "^0.0.35",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
@@ -8106,11 +8225,11 @@
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.17.tgz",
-      "integrity": "sha512-5enc2qvcZwD4Omdr78gUfqH/4uOPW7UJE6d3EQAbGyaO6cD0dpjAGsLHHXkcjSTRIult2w6cvru7fI5suJnZtg==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+      "integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "scroll-behavior": "^0.9.10",
         "warning": "^3.0.0"
       }
@@ -8348,18 +8467,18 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.42.tgz",
-      "integrity": "sha512-N/P8w8sVB1JDWn9Wm3hiB2NOrfIDioccot5h6jX8IVC4aUjXXROZPM+HSy3f1PHg2EoZuCGG5yH50XnayXupLQ==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+      "integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
-        "boxen": "^4.1.0",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
+        "boxen": "^4.2.0",
         "configstore": "^5.0.0",
         "envinfo": "^7.5.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
         "lodash": "^4.17.15",
@@ -8395,6 +8514,15 @@
           "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
           "requires": {
             "is-obj": "^2.0.0"
+          }
+        },
+        "gatsby-core-utils": {
+          "version": "1.0.24",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+          "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
+          "requires": {
+            "ci-info": "2.0.0",
+            "node-object-hash": "^2.0.0"
           }
         },
         "is-obj": {
@@ -9814,9 +9942,9 @@
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -9827,7 +9955,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -12154,9 +12282,9 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -12188,25 +12316,65 @@
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.fromentries": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.getownpropertydescriptors": {
@@ -12915,9 +13083,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-      "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
+      "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -14504,11 +14672,32 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "regexpp": {
@@ -15330,9 +15519,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -16235,9 +16424,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -16688,15 +16877,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -17799,9 +17988,9 @@
       "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
     },
     "webpack": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-      "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
+      "version": "4.41.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
+      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -17823,7 +18012,7 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
+        "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },
@@ -18376,12 +18565,9 @@
       }
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/starters/gatsby-starter-theme/package.json
+++ b/starters/gatsby-starter-theme/package.json
@@ -9,7 +9,7 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "gatsby": "^2.18.8",
+    "gatsby": "^2.18.12",
     "gatsby-theme-blog": "^1.2.7",
     "gatsby-theme-notes": "^1.0.31",
     "react": "^16.12.0",

--- a/starters/hello-world/package-lock.json
+++ b/starters/hello-world/package-lock.json
@@ -320,6 +320,15 @@
         "@babel/plugin-syntax-json-strings": "^7.7.4"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
@@ -336,6 +345,15 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -379,6 +397,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -391,6 +417,14 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
       "integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -1038,9 +1072,9 @@
       "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
-      "version": "12.12.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.15.tgz",
-      "integrity": "sha512-Pv+vWicyFd07Hw/SmNnTUguqrHgDfMtjabvD9sQyxeqbpCEg8CmViLBaVPHtNsoBgZECrRf5/pgV6FJIBrGSjw=="
+      "version": "12.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.18.tgz",
+      "integrity": "sha512-DBkZuIMFuAfjJHiunyRc+aNvmXYNwV1IPMgGKGlwCp6zh6MKrVtmvjSWK/axWcD25KJffkXgkfvFra8ndenXAw=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -1081,11 +1115,11 @@
       "integrity": "sha1-DTyzECL4Qn6ljACK8yuA2hJspOM="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-      "integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
+      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1093,30 +1127,30 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
-      "integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
+      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
-      "integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
+      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.11.0",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
+      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -1505,12 +1539,12 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.0.tgz",
+      "integrity": "sha512-ONOEQoKrvXPKk7Su92Co0YMqYO32FfqJTzkKU9u2UpIXyYZIzLSvpdg4AwvSw4mSUW0czu6inK+zby6Oj6gDjQ==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0"
       }
     },
     "array-map": {
@@ -1539,13 +1573,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
-      "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "arraybuffer.slice": {
@@ -1806,9 +1839,9 @@
       }
     },
     "babel-plugin-remove-graphql-queries": {
-      "version": "2.7.17",
-      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.17.tgz",
-      "integrity": "sha512-zPAq5DEtucSMppt4U2zB1i9SiGMLOYtjNGoOo5PLw8f5jlihLTYYaPG3Sg2S4+tiB9k+tiWMa07FKXb6lV+rRA=="
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+      "integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -1816,19 +1849,21 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-gatsby": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.23.tgz",
-      "integrity": "sha512-IuhRMH6TCbTbJ4NFnHg2UQUZv24t3mRc9ow6qMeyL9mklI8vbXSi/bFVO6ES4xy3k5qmUdElXAK5RSpw8/1hbw==",
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+      "integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.7.4",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.7.5",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
-        "@babel/plugin-transform-runtime": "^7.7.4",
+        "@babel/plugin-transform-runtime": "^7.7.6",
         "@babel/plugin-transform-spread": "^7.7.4",
-        "@babel/preset-env": "^7.7.4",
+        "@babel/preset-env": "^7.7.6",
         "@babel/preset-react": "^7.7.4",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-macros": "^2.7.1",
+        "babel-plugin-macros": "^2.8.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
@@ -1968,6 +2003,15 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "blob": {
       "version": "0.0.5",
@@ -2489,9 +2533,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001015",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-      "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ=="
+      "version": "1.0.30001016",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
+      "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -3140,9 +3184,9 @@
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-js-compat": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.8.tgz",
-      "integrity": "sha512-l3WTmnXHV2Sfu5VuD7EHE2w7y+K68+kULKt5RJg8ZJk3YhHF1qLD4O8v8AmNq+8vbOwnPFFDvds25/AoEvMqlQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.5.0.tgz",
+      "integrity": "sha512-E7iJB72svRjJTnm9HDvujzNVMCm3ZcDYEedkJ/sDTNsy/0yooCd9Cg7GSzE7b4e0LfIkjijdB1tqg0pGwxWeWg==",
       "requires": {
         "browserslist": "^4.8.2",
         "semver": "^6.3.0"
@@ -3166,9 +3210,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.8.tgz",
-      "integrity": "sha512-K9iPNbLDZ0Epojwd8J3lhodmrLHYvxb07H3DaFme1ne4TIlFq/ufiyPC40rc3OX6NCaVa0zaSu+VV6BVDR2wiA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+      "integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3558,9 +3602,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4168,9 +4212,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
-      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+      "version": "1.17.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+      "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -4180,6 +4224,7 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
         "string.prototype.trimleft": "^2.1.0",
         "string.prototype.trimright": "^2.1.0"
       }
@@ -5040,9 +5085,9 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5120,6 +5165,12 @@
         "loader-utils": "^1.0.2",
         "schema-utils": "^0.4.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "3.5.11",
@@ -5323,13 +5374,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -5371,7 +5423,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -5396,7 +5448,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -5419,11 +5471,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -5447,7 +5499,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -5473,7 +5525,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -5490,7 +5542,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -5526,7 +5578,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -5535,11 +5587,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -5551,22 +5603,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -5579,7 +5631,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -5592,12 +5644,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -5659,7 +5719,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -5696,7 +5756,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -5719,7 +5779,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -5765,17 +5825,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -5797,7 +5857,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -5814,35 +5874,35 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.18.8",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.8.tgz",
-      "integrity": "sha512-44Cf+IJGyHT7ZKNE6xICG8QqA5Ava2nHXybTrQhPY3n6T7+dsdfbm6+WntT2yVtlfLfLFGute7Udx7HyFfsvSQ==",
+      "version": "2.18.12",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.12.tgz",
+      "integrity": "sha512-EmgSDZcedoUttw/ETEWWgRT0B7GUulsi3h8HwRDqNSMtHMJtk8SH9Vb5MWfQQZlZ2pteV9g8P4kv/bffCYKIbw==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/core": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
         "@babel/polyfill": "^7.7.0",
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@babel/traverse": "^7.7.4",
         "@hapi/joi": "^15.1.1",
         "@mikaelkristiansson/domready": "^1.0.9",
         "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
         "@reach/router": "^1.2.1",
-        "@typescript-eslint/eslint-plugin": "^2.9.0",
-        "@typescript-eslint/parser": "^2.9.0",
+        "@typescript-eslint/eslint-plugin": "^2.11.0",
+        "@typescript-eslint/parser": "^2.11.0",
         "address": "1.1.2",
-        "autoprefixer": "^9.7.2",
+        "autoprefixer": "^9.7.3",
         "axios": "^0.19.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-eslint": "^10.0.3",
         "babel-loader": "^8.0.6",
         "babel-plugin-add-module-exports": "^0.3.3",
         "babel-plugin-dynamic-import-node": "^2.3.0",
-        "babel-plugin-remove-graphql-queries": "^2.7.17",
-        "babel-preset-gatsby": "^0.2.23",
+        "babel-plugin-remove-graphql-queries": "^2.7.19",
+        "babel-preset-gatsby": "^0.2.26",
         "better-opn": "1.0.0",
         "better-queue": "^3.8.10",
-        "bluebird": "^3.7.1",
+        "bluebird": "^3.7.2",
         "browserslist": "3.2.8",
         "cache-manager": "^2.10.1",
         "cache-manager-fs-hash": "^0.0.7",
@@ -5852,7 +5912,7 @@
         "compression": "^1.7.4",
         "convert-hrtime": "^3.0.0",
         "copyfiles": "^2.1.1",
-        "core-js": "^2.6.10",
+        "core-js": "^2.6.11",
         "cors": "^2.8.5",
         "css-loader": "^1.0.1",
         "debug": "^3.2.6",
@@ -5860,16 +5920,16 @@
         "detect-port": "^1.3.0",
         "devcert-san": "^0.3.3",
         "dotenv": "^8.2.0",
-        "eslint": "^6.7.1",
-        "eslint-config-react-app": "^5.0.2",
+        "eslint": "^6.7.2",
+        "eslint-config-react-app": "^5.1.0",
         "eslint-loader": "^2.2.1",
         "eslint-plugin-flowtype": "^3.13.0",
         "eslint-plugin-graphql": "^3.1.0",
-        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-import": "^2.19.1",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.16.0",
+        "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-react-hooks": "^1.7.0",
-        "event-source-polyfill": "^1.0.9",
+        "event-source-polyfill": "^1.0.11",
         "express": "^4.17.1",
         "express-graphql": "^0.9.0",
         "fast-levenshtein": "^2.0.6",
@@ -5877,13 +5937,13 @@
         "flat": "^4.1.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^8.1.0",
-        "gatsby-cli": "^2.8.16",
-        "gatsby-core-utils": "^1.0.22",
-        "gatsby-graphiql-explorer": "^0.2.29",
-        "gatsby-link": "^2.2.25",
-        "gatsby-plugin-page-creator": "^2.1.34",
-        "gatsby-react-router-scroll": "^2.1.17",
-        "gatsby-telemetry": "^1.1.42",
+        "gatsby-cli": "^2.8.19",
+        "gatsby-core-utils": "^1.0.24",
+        "gatsby-graphiql-explorer": "^0.2.31",
+        "gatsby-link": "^2.2.27",
+        "gatsby-plugin-page-creator": "^2.1.36",
+        "gatsby-react-router-scroll": "^2.1.19",
+        "gatsby-telemetry": "^1.1.44",
         "glob": "^7.1.6",
         "got": "8.3.2",
         "graphql": "^14.5.8",
@@ -5933,7 +5993,7 @@
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
         "style-loader": "^0.23.1",
-        "terser-webpack-plugin": "1.4.1",
+        "terser-webpack-plugin": "^1.4.2",
         "true-case-path": "^2.2.1",
         "type-of": "^2.0.1",
         "url-loader": "^1.1.2",
@@ -5946,7 +6006,7 @@
         "webpack-hot-middleware": "^2.25.0",
         "webpack-merge": "^4.2.2",
         "webpack-stats-plugin": "^0.3.0",
-        "xstate": "^4.6.7",
+        "xstate": "^4.7.2",
         "yaml-loader": "^0.5.0"
       },
       "dependencies": {
@@ -6007,29 +6067,29 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.8.16",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.16.tgz",
-          "integrity": "sha512-hjsK+xu00gg61CuS6z9jJrV6bHmI58YG3nd8B+goibM3vt/Wajg60til3hxaS9EGwHND+SatQUBTjTxdyOhplw==",
+          "version": "2.8.19",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.19.tgz",
+          "integrity": "sha512-cINizncxPBxL3tJAQVrVFCGrf/dFOFEk5o1uYr427zyLuC+jqaAtocE2AcT1P9ayXOEjyH4mP/INwaNfCbYkJg==",
           "requires": {
             "@babel/code-frame": "^7.5.5",
-            "@babel/runtime": "^7.7.4",
+            "@babel/runtime": "^7.7.6",
             "@hapi/joi": "^15.1.1",
             "better-opn": "^1.0.0",
-            "bluebird": "^3.7.1",
+            "bluebird": "^3.7.2",
             "chalk": "^2.4.2",
             "clipboardy": "^2.1.0",
             "common-tags": "^1.8.0",
             "configstore": "^5.0.0",
             "convert-hrtime": "^3.0.0",
-            "core-js": "^2.6.10",
+            "core-js": "^2.6.11",
             "envinfo": "^7.5.0",
             "execa": "^3.4.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.0.22",
-            "gatsby-telemetry": "^1.1.42",
+            "gatsby-core-utils": "^1.0.24",
+            "gatsby-telemetry": "^1.1.44",
             "hosted-git-info": "^3.0.2",
-            "ink": "^2.5.0",
+            "ink": "^2.6.0",
             "ink-spinner": "^3.0.1",
             "is-valid-path": "^0.1.1",
             "lodash": "^4.17.15",
@@ -6227,84 +6287,84 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.22.tgz",
-      "integrity": "sha512-38W+lWb7pPiv7AjGxDx/MSWwmgnPtOejNHSxRcMXhrXNSWpiWCDoNTBM6UCXnbky82kUx4DPX5gXgw7u2s+/rA==",
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+      "integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
       "requires": {
         "ci-info": "2.0.0",
         "node-object-hash": "^2.0.0"
       }
     },
     "gatsby-graphiql-explorer": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.29.tgz",
-      "integrity": "sha512-qKnG1h/BSBkdPX5eUcFRVvHb0BA7WLnqeJ8NMH2AOv5VSK8YEwUdJVimZHz8M/59MKBtFAQyDCRU258sc1oWrQ==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+      "integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
       "requires": {
-        "@babel/runtime": "^7.7.4"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "gatsby-link": {
-      "version": "2.2.25",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.25.tgz",
-      "integrity": "sha512-P3Gt5ryW1bFBjAuKoJQsGSZcyEG7vFliHelnOLlAakkJ+wLQz4Wq2o4BAb6lB4wPzO7HzXRJD6RuxQrd9tmkPg==",
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+      "integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "@types/reach__router": "^1.2.6",
         "prop-types": "^15.7.2"
       }
     },
     "gatsby-page-utils": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.33.tgz",
-      "integrity": "sha512-0FweVMQc5JklMwPPbwcXRo5N3ydRKrNI+YZzr6731kON1tvCKB7EbbrwMvZLEedv4BNP+XUe33FuT7LsAaUE3g==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+      "integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "chokidar": "3.3.0",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
       }
     },
     "gatsby-plugin-page-creator": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.34.tgz",
-      "integrity": "sha512-w315rYA1KS48jVo4Zg/1Uxm5Y6h48rW8Bf0520uOh8SkSr0qXFC6ivFmw2Uq4WFH02+qN7QTqGd3sHX1wwlf+g==",
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+      "integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
         "fs-exists-cached": "^1.0.0",
-        "gatsby-page-utils": "^0.0.33",
+        "gatsby-page-utils": "^0.0.35",
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
       }
     },
     "gatsby-react-router-scroll": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.17.tgz",
-      "integrity": "sha512-5enc2qvcZwD4Omdr78gUfqH/4uOPW7UJE6d3EQAbGyaO6cD0dpjAGsLHHXkcjSTRIult2w6cvru7fI5suJnZtg==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+      "integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
       "requires": {
-        "@babel/runtime": "^7.7.4",
+        "@babel/runtime": "^7.7.6",
         "scroll-behavior": "^0.9.10",
         "warning": "^3.0.0"
       }
     },
     "gatsby-telemetry": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.42.tgz",
-      "integrity": "sha512-N/P8w8sVB1JDWn9Wm3hiB2NOrfIDioccot5h6jX8IVC4aUjXXROZPM+HSy3f1PHg2EoZuCGG5yH50XnayXupLQ==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+      "integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/runtime": "^7.7.4",
-        "bluebird": "^3.7.1",
-        "boxen": "^4.1.0",
+        "@babel/runtime": "^7.7.6",
+        "bluebird": "^3.7.2",
+        "boxen": "^4.2.0",
         "configstore": "^5.0.0",
         "envinfo": "^7.5.0",
         "fs-extra": "^8.1.0",
-        "gatsby-core-utils": "^1.0.22",
+        "gatsby-core-utils": "^1.0.24",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
         "lodash": "^4.17.15",
@@ -7279,9 +7339,9 @@
       }
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -7292,7 +7352,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -7693,11 +7753,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-relative": {
@@ -8928,9 +8988,9 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -8962,34 +9022,34 @@
       }
     },
     "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
     },
     "object.fromentries": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.15.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.pick": {
@@ -9001,12 +9061,12 @@
       }
     },
     "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
@@ -9472,9 +9532,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-      "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
+      "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -10926,11 +10986,12 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "regexpp": {
@@ -10974,9 +11035,9 @@
       "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
     },
     "regjsparser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.1.tgz",
+      "integrity": "sha512-7LutE94sz/NKSYegK+/4E77+8DipxF+Qn2Tmu362AcmsF2NYq/wx3+ObvU90TKEhjf7hQoFXo23ajjrXP7eUgg==",
       "requires": {
         "jsesc": "~0.5.0"
       },
@@ -11298,9 +11359,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -12008,9 +12069,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -12313,15 +12374,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
@@ -13043,9 +13104,9 @@
       }
     },
     "webpack": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-      "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
+      "version": "4.41.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
+      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -13067,7 +13128,7 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
+        "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },
@@ -13597,12 +13658,9 @@
       }
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "xdg-basedir": {
       "version": "3.0.0",
@@ -13615,9 +13673,9 @@
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "xstate": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.2.tgz",
-      "integrity": "sha512-vAIEf5CuLPNgH5obVP7WS1U+I91L+vSKLpradVn6AhbyFrccWlNQwFVuYktInafgkvA6z4w9rLkuRKBZ5izkSA=="
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.3.tgz",
+      "integrity": "sha512-+1KyOB2JTv4kQQlZnEiDxSpEaIJnqslMa/479sc1KU3NMRP0caIV3p55Sr27GFS1EXQvnJ+n84bnWx77qplDWg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/starters/hello-world/package.json
+++ b/starters/hello-world/package.json
@@ -14,7 +14,7 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
-    "gatsby": "^2.18.8",
+    "gatsby": "^2.18.12",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },


### PR DESCRIPTION
## Description

The `starters_validate` script was failing in CI because of an npm audit reporting vulnerabilities in versions of webpack. Updating the related gatsby version fixed this.
