### PR TITLE
chore(starters): Remove starter that no longer exists in github

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -4001,26 +4001,6 @@
     - htaccess support
     - Typography.js
     - Integration with Social Media
-- url: https://blogerist.netlify.com
-  repo: https://github.com/bvlktech/blogerist
-  description: Starter blog built with GatsbyJS
-  tags:
-    - Blog
-    - Markdown
-    - SEO
-    - PWA
-  features:
-    - A simple landing page with blog functionality built with Netlify CMS
-    - Create Blog posts from Netlify CMS
-    - Uses SCSS for styling
-    - Blazing fast loading times thanks to pre-rendered HTML and automatic chunk loading of JS files
-    - Uses gatbsy-image with Netlify-CMS preview support
-    - Separate components for everything
-    - Netlify deploy configuration
-    - Netlify forms functionality
-    - Discus commenting added to each blog post
-    - Perfect score on Lighthouse for SEO, Accessibility and Performance
-    - ..and more
 - url: https://gatsby-starter-bloomer-db0aaf.netlify.com
   repo: https://github.com/zlutfi/gatsby-starter-bloomer
   description: Barebones starter website with Bloomer React components for Bulma.


### PR DESCRIPTION
This repo has been removed or made private:
```
$ curl https://github.com/bvlktech/blogerist -I
HTTP/1.1 404 Not Found
Date: Tue, 17 Dec 2019 11:59:05 GMT
Content-Type: text/html; charset=utf-8
Server: GitHub.com
Status: 404 Not Found
```