### PR TITLE
fix(gatsby): add ./ prefix to paths in async-requires

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/1-production.js
+++ b/e2e-tests/production-runtime/cypress/integration/1-production.js
@@ -98,6 +98,13 @@ describe(`Production build tests`, () => {
     cy.getTestElement(`process.env.NOT_EXISTING_VAR`).should(`be.empty`)
   })
 
+  it(`should be able to create a page from component located in .cache directory`, () => {
+    cy.visit(`/page-from-cache/`).waitForRouteChange()
+
+    // `bar` is set in gatsby-node createPages
+    cy.getTestElement(`dom-marker`).contains(`[static-page-from-cache]`)
+  })
+
   describe(`Supports unicode characters in urls`, () => {
     it(`Can navigate directly`, () => {
       cy.visit(`/안녕/`, {

--- a/e2e-tests/production-runtime/gatsby-node.js
+++ b/e2e-tests/production-runtime/gatsby-node.js
@@ -1,4 +1,12 @@
 const path = require(`path`)
+const fs = require(`fs-extra`)
+
+exports.onPreBootstrap = () => {
+  fs.copyFileSync(
+    `./src/templates/static-page-from-cache.js`,
+    `./.cache/static-page-from-cache.js`
+  )
+}
 
 exports.createPages = ({ actions: { createPage } }) => {
   createPage({
@@ -82,6 +90,11 @@ exports.createPages = ({ actions: { createPage } }) => {
     context: {
       domMarker: `dynamic-and-wildcard`,
     },
+  })
+
+  createPage({
+    path: `/page-from-cache/`,
+    component: path.resolve(`./.cache/static-page-from-cache.js`),
   })
 }
 

--- a/e2e-tests/production-runtime/src/templates/static-page-from-cache.js
+++ b/e2e-tests/production-runtime/src/templates/static-page-from-cache.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const StaticPage = () => (
+  <pre data-testid="dom-marker">[static-page-from-cache] static-sibling</pre>
+)
+
+export default StaticPage

--- a/packages/gatsby/src/bootstrap/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/requires-writer.js
@@ -173,7 +173,7 @@ const preferDefault = m => m && m.default || m
       )
 
       return `  "${c.componentChunkName}": () => import("${slash(
-        relativeComponentPath
+        `./${relativeComponentPath}`
       )}" /* webpackChunkName: "${c.componentChunkName}" */)`
     })
     .join(`,\n`)}


### PR DESCRIPTION
## Description
Async-requires paths are relative to the file which lives in .cache folder. If a component is inside the .cache folder our import breaks because it's being required from cwd and not the current directory. Prepending ./ cache so it's getting resolved from the current file.

## Related Issues
Fixes #19931