### PR TITLE
fix(gatsby-telemetry): suppress flush if disabled

### DIFF
--- a/packages/gatsby-telemetry/src/flush.js
+++ b/packages/gatsby-telemetry/src/flush.js
@@ -1,7 +1,11 @@
 const { join } = require(`path`)
 const { fork } = require(`child_process`)
 
-module.exports = async () => {
+module.exports = isTrackingEnabled => async () => {
+  if (!isTrackingEnabled) {
+    return
+  }
+
   // Submit events on background w/o blocking the main process
   // nor relying on it's lifecycle
   const forked = fork(join(__dirname, `send.js`), {

--- a/packages/gatsby-telemetry/src/index.js
+++ b/packages/gatsby-telemetry/src/index.js
@@ -1,7 +1,7 @@
 const Telemetry = require(`./telemetry`)
-const flush = require(`./flush`)
-
 const instance = new Telemetry()
+
+const flush = require(`./flush`)(instance.isTrackingEnabled())
 
 process.on(`exit`, flush)
 


### PR DESCRIPTION
Suppressing telemetry flush calls when disabled through env should help with https://github.com/gatsbyjs/gatsby/issues/20125