### PR TITLE
docs(environment-variables.md): use `const` instead of `let` if we are not re-assigning it

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -163,12 +163,12 @@ API_URL="http://foo.bar"
 ```
 
 ```javascript:title=gatsby-config.js
-let activeEnv =
-  process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || "development"
 
+const activeEnv =
+  process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || 'development'
 console.log(`Using environment config: '${activeEnv}'`)
 
-require("dotenv").config({
+require('dotenv').config({
   path: `.env.${activeEnv}`,
 })
 

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -165,6 +165,7 @@ API_URL="http://foo.bar"
 ```javascript:title=gatsby-config.js
 const activeEnv =
   process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || "development"
+
 console.log(`Using environment config: '${activeEnv}'`)
 
 require("dotenv").config({

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -163,12 +163,11 @@ API_URL="http://foo.bar"
 ```
 
 ```javascript:title=gatsby-config.js
-
 const activeEnv =
-  process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || 'development'
+  process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || "development"
 console.log(`Using environment config: '${activeEnv}'`)
 
-require('dotenv').config({
+require("dotenv").config({
   path: `.env.${activeEnv}`,
 })
 


### PR DESCRIPTION
Prettier.js suggests using a constant since `activeEnv` is never reassigned and also use single quotes.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
