### PR TITLE
fix(gatsby): support file inference for any field name (not just [a-zA-Z0-9_])

### DIFF
--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -1053,6 +1053,31 @@ Object {
         slash(path.resolve(dir, `file_2.txt`))
       )
     })
+
+    it(`Links to file node from non-standard field name`, async () => {
+      const nodes = [
+        {
+          id: `1`,
+          "file-dashed": `./file_1.jpg`,
+          parent: `parent`,
+          internal: { type: `Test` },
+        },
+      ].concat(getFileNodes())
+
+      const result = await getQueryResult(
+        nodes,
+        `
+          file_dashed {
+            absolutePath
+          }
+        `
+      )
+
+      expect(result.errors).not.toBeDefined()
+      expect(
+        result.data.allTest.edges[0].node.file_dashed.absolutePath
+      ).toEqual(slash(path.resolve(dir, `file_1.jpg`)))
+    })
   })
 
   describe(`Linked inference by __NODE convention`, () => {

--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -1055,10 +1055,12 @@ Object {
     })
 
     it(`Links to file node from non-standard field name`, async () => {
+      const fieldWithSpecialChars = `file-ж-ä-!@#$%^&*()_-=+:;'"?,~\``
       const nodes = [
         {
           id: `1`,
           "file-dashed": `./file_1.jpg`,
+          [fieldWithSpecialChars]: `./file_1.jpg`,
           parent: `parent`,
           internal: { type: `Test` },
         },
@@ -1070,13 +1072,19 @@ Object {
           file_dashed {
             absolutePath
           }
+          file___________________________ {
+            absolutePath
+          }
         `
       )
 
       expect(result.errors).not.toBeDefined()
-      expect(
-        result.data.allTest.edges[0].node.file_dashed.absolutePath
-      ).toEqual(slash(path.resolve(dir, `file_1.jpg`)))
+      const node = result.data.allTest.edges[0].node
+      const expectedFilePath = slash(path.resolve(dir, `file_1.jpg`))
+      expect(node.file_dashed.absolutePath).toEqual(expectedFilePath)
+      expect(node.file___________________________.absolutePath).toEqual(
+        expectedFilePath
+      )
     })
   })
 

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -32,6 +32,7 @@ const addInferredFields = ({
     nodeStore,
     exampleObject: exampleValue,
     prefix: typeComposer.getTypeName(),
+    unsanitizedFieldPath: [typeComposer.getTypeName()],
     typeMapping,
     config,
   })
@@ -48,6 +49,7 @@ const addInferredFieldsImpl = ({
   exampleObject,
   typeMapping,
   prefix,
+  unsanitizedFieldPath,
   config,
 }) => {
   const fields = []
@@ -84,6 +86,7 @@ const addInferredFieldsImpl = ({
       typeComposer,
       nodeStore,
       prefix,
+      unsanitizedFieldPath,
       typeMapping,
       config,
     })
@@ -145,10 +148,12 @@ const getFieldConfig = ({
   exampleValue,
   key,
   unsanitizedKey,
+  unsanitizedFieldPath,
   typeMapping,
   config,
 }) => {
   const selector = `${prefix}.${key}`
+  unsanitizedFieldPath.push(unsanitizedKey)
 
   let arrays = 0
   let value = exampleValue
@@ -178,12 +183,14 @@ const getFieldConfig = ({
       key,
       value,
       selector,
+      unsanitizedFieldPath,
       typeMapping,
       config,
       arrays,
     })
   }
 
+  unsanitizedFieldPath.pop()
   if (!fieldConfig) return null
 
   // Proxy resolver to unsanitized fieldName in case it contained invalid characters
@@ -299,6 +306,7 @@ const getSimpleFieldConfig = ({
   key,
   value,
   selector,
+  unsanitizedFieldPath,
   typeMapping,
   config,
   arrays,
@@ -312,7 +320,7 @@ const getSimpleFieldConfig = ({
       if (isDate(value)) {
         return { type: `Date`, extensions: { dateformat: {} } }
       }
-      if (isFile(nodeStore, selector, value)) {
+      if (isFile(nodeStore, unsanitizedFieldPath, value)) {
         // NOTE: For arrays of files, where not every path references
         // a File node in the db, it is semi-random if the field is
         // inferred as File or String, since the exampleValue only has
@@ -387,6 +395,7 @@ const getSimpleFieldConfig = ({
             exampleObject: value,
             typeMapping,
             prefix: selector,
+            unsanitizedFieldPath,
             config: inferenceConfig,
           }),
         }

--- a/packages/gatsby/src/schema/infer/is-file.js
+++ b/packages/gatsby/src/schema/infer/is-file.js
@@ -5,8 +5,8 @@ const isRelative = require(`is-relative`)
 const isRelativeUrl = require(`is-relative-url`)
 const { getValueAt } = require(`../../utils/get-value-at`)
 
-const isFile = (nodeStore, field, relativePath) => {
-  const filePath = getFilePath(nodeStore, field, relativePath)
+const isFile = (nodeStore, fieldPath, relativePath) => {
+  const filePath = getFilePath(nodeStore, fieldPath, relativePath)
   if (!filePath) return false
   const filePathExists = nodeStore
     .getNodesByType(`File`)
@@ -26,8 +26,10 @@ const getFirstValueAt = (node, selector) => {
   return value
 }
 
-const getFilePath = (nodeStore, field, relativePath) => {
-  const [typeName, ...selector] = field.split(`.`)
+const getFilePath = (nodeStore, fieldPath, relativePath) => {
+  const [typeName, ...selector] = Array.isArray(fieldPath)
+    ? fieldPath
+    : fieldPath.split(`.`)
 
   if (typeName === `File`) return null
 


### PR DESCRIPTION
## Description

This PR fixes file inference on fields other than `[a-zA-Z0-9_]` which was broken before. Take an example:

```js
  createNode({
    id: `1`,
    "file-here": `./file_1.jpg`,
    parent: null,
    children: [],
    internal: { type: `Test` },
  })
```

Before this PR, `file-here` was always inferred as `String` not `File`. But if you were to change the field name to `file_here` it correctly inferred it as `File`.

After this PR both `file-here` and `file_here` are inferred as `File` (and any field with special characters in general).

### Documentation
N/A

## Related Issues
Fixes #20151
