### PR TITLE
fix(gatsby-source-filesystem): fix add/change text

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -113,7 +113,7 @@ const createFSMachine = (
                     `deletePathNode`,
                     log(
                       (_, { pathType, path }) =>
-                        `${pathType} deleted at ${path}`
+                        deleted `${pathType} at ${path}`
                     ),
                   ],
                 },

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -141,7 +141,7 @@ const createFSMachine = (
           flushPathQueue().then(resolve, reject)
         },
         queueNodeDeleting(_, { path }) {
-          pathQueue.push({ op: `delete `, path })
+          pathQueue.push({ op: `delete`, path })
         },
         queueNodeProcessing(_, { path }) {
           pathQueue.push({ op: `upsert`, path })
@@ -184,7 +184,7 @@ See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
     ignored: [
       `**/*.un~`,
       `**/.DS_Store`,
-      `** /.gitignore`,
+      `**/.gitignore`,
       `**/.npmignore`,
       `**/.babelrc`,
       `**/yarn.lock`,

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -83,15 +83,9 @@ const createFSMachine = (
             NOT_READY: {
               on: {
                 CHOKIDAR_READY: `READY`,
-                CHOKIDAR_ADD: {
-                  actions: `queueNodeProcessing`,
-                },
-                CHOKIDAR_CHANGE: {
-                  actions: `queueNodeProcessing`,
-                },
-                CHOKIDAR_UNLINK: {
-                  actions: `queueNodeDeleting`,
-                },
+                CHOKIDAR_ADD: { actions: `queueNodeProcessing` },
+                CHOKIDAR_CHANGE: { actions: `queueNodeProcessing` },
+                CHOKIDAR_UNLINK: { actions: `queueNodeDeleting` },
               },
               exit: `flushPathQueue`,
             },
@@ -156,14 +150,11 @@ exports.sourceNodes = (api, pluginOptions) => {
   // Validate that the path exists.
   if (!fs.existsSync(pluginOptions.path)) {
     api.reporter.panic(`
-The path passed to gatsby - source - filesystem does not exist on your file system:
-
-                    ${pluginOptions.path}
-
+The path passed to gatsby-source-filesystem does not exist on your file system:
+${pluginOptions.path}
 Please pick a path to an existing directory.
-
 See docs here - https://www.gatsbyjs.org/packages/gatsby-source-filesystem/
-                    `)
+      `)
   }
 
   // Validate that the path is absolute.

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -113,7 +113,7 @@ const createFSMachine = (
                     `deletePathNode`,
                     log(
                       (_, { pathType, path }) =>
-                        deleted `${pathType} at ${path}`
+                        `deleted ${pathType} at ${path}`
                     ),
                   ],
                 },


### PR DESCRIPTION
## Description
Fixes info messages when filesystem detects changes. When a new file is created we use the `add` word, when updating we use the `changed` verb.

This might lead to confusion

## Related Issues
Fixes #17885