### PR TITLE
Allow gatsby-remark plugins to use ES spec conforming default funcs (e.g. TS emitted JS)

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -214,8 +214,15 @@ module.exports = (
       // Use Bluebird's Promise function "each" to run remark plugins serially.
       await Promise.each(pluginOptions.plugins, plugin => {
         const requiredPlugin = require(plugin.resolve)
-        if (_.isFunction(requiredPlugin)) {
-          return requiredPlugin(
+        // Allow both exports = function(), and exports.default = function()
+        const defaultFunction = _.isFunction(requiredPlugin)
+          ? requiredPlugin
+          : _.isFunction(requiredPlugin.default)
+          ? requiredPlugin.default
+          : undefined
+
+        if (defaultFunction) {
+          return defaultFunction(
             {
               markdownAST,
               markdownNode,


### PR DESCRIPTION
TypeScript and the ES module spec say that a module exports always has to be an object, (5 years later this is still a bit pain https://github.com/Microsoft/TypeScript/issues/2719 ) 

This means that TS emits an object with a `default` function when doing `export default function` - so when running through the plugins, want to guess which one of these was transpiled by typescript?

```
// Plugins: 

[Function]
[Function]
[AsyncFunction]
[Function]
[Function]
{ default: [Function: remarkShiki],
  remarkShiki: [Function: remarkShiki] }
[Function]
[Function]
{ [Function] visitor: [Function: visitor] }
{ [Function] visitor: [Function: visitor] }
[Function]
[Function]
```

In user-land code, this can be worked around using `"esModuleInterop": true,` - but this code isn't in user-land and so this PR adds the ability for the plugin resolver to add a look to see if the `default` prop is a function.