### PR TITLE
fix(docs): 404 on image and links in recipes

### DIFF
--- a/docs/docs/recipes/querying-data.md
+++ b/docs/docs/recipes/querying-data.md
@@ -426,7 +426,7 @@ Fragments can be nested inside other fragments, and multiple fragments can be us
 
 ### Additional resources
 
-- [Simple example repo using fragments](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-graphql-fragments)
+- [Simple example repo using fragments](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-fragments)
 - [Gatsby GraphQL reference for fragments](/docs/graphql-reference/#fragments)
 - [Gatsby image fragments](/docs/gatsby-image/#image-query-fragments)
 - [Example repo with co-located data](https://github.com/gatsbyjs/gatsby/tree/master/examples/gatsbygram)

--- a/docs/docs/recipes/sourcing-data.md
+++ b/docs/docs/recipes/sourcing-data.md
@@ -402,7 +402,7 @@ plugins: [
 
 8. Query data with the [GraphiQL editor](/docs/introducing-graphiql/) at <https://localhost:8000/___graphql>. The Contentful plugin adds several new node types to your site, including every content type in your Contentful website. Your example space with a "Blog Post" content type produces a `allContentfulBlogPost` node type in GraphQL.
 
-![the graphql interface, with a sample query outlined below](./images/recipe-sourcing-contentful-graphql.png)
+![the graphql interface, with a sample query outlined below](../images/recipe-sourcing-contentful-graphql.png)
 
 To query for Blog Post titles from Contentful, use the following GraphQL query:
 


### PR DESCRIPTION

## Description

- fix 404 on image in recipes
- fix 404 on link to repo

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

#19267 Add link check To Gatsby Docs
#20113 [docs] move recipes to individual pages