### PR TITLE
feat(gatsby-source-shopify): Add support for custom domains

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -37,6 +37,9 @@ plugins: [
       // The domain name of your Shopify shop. This is required.
       // Example: 'gatsby-source-shopify-test-shop' if your Shopify address is
       // 'gatsby-source-shopify-test-shop.myshopify.com'.
+      // If you are running your shop on a custom domain, you need to use that
+      // as the shop name, without a trailing slash, for example:
+      // shopName: "gatsby-shop.com",
       shopName: "gatsby-source-shopify-test-shop",
 
       // An API access token to your Shopify shop. This is required.

--- a/packages/gatsby-source-shopify/src/__tests__/create-client.js
+++ b/packages/gatsby-source-shopify/src/__tests__/create-client.js
@@ -1,0 +1,15 @@
+const { createClient } = require(`../create-client`)
+
+describe(`create-client`, () => {
+  it(`Allows a domain as shop name`, () => {
+    expect(createClient(`my-shop.com`, `token`).url).toEqual(
+      expect.not.stringContaining(`myshopify.com`)
+    )
+  })
+
+  it(`Allows a non-domain shop name`, () => {
+    expect(createClient(`my-shop`, `token`).url).toEqual(
+      expect.stringContaining(`myshopify.com`)
+    )
+  })
+})

--- a/packages/gatsby-source-shopify/src/create-client.js
+++ b/packages/gatsby-source-shopify/src/create-client.js
@@ -2,9 +2,17 @@ import { GraphQLClient } from "graphql-request"
 /**
  * Create a Shopify Storefront GraphQL client for the provided name and token.
  */
-export const createClient = (shopName, accessToken) =>
-  new GraphQLClient(`https://${shopName}.myshopify.com/api/graphql`, {
+export const createClient = (shopName, accessToken) => {
+  let url;
+  if (shopName.indexOf("." > -1)) {
+    url = `https://${shopName}/api/graphql`;
+  }
+  else {
+    url = `https://${shopName}.myshopify.com/api/graphql`;
+  }  
+  return new GraphQLClient(url, {
     headers: {
       "X-Shopify-Storefront-Access-Token": accessToken,
     },
   })
+}

--- a/packages/gatsby-source-shopify/src/create-client.js
+++ b/packages/gatsby-source-shopify/src/create-client.js
@@ -3,13 +3,12 @@ import { GraphQLClient } from "graphql-request"
  * Create a Shopify Storefront GraphQL client for the provided name and token.
  */
 export const createClient = (shopName, accessToken) => {
-  let url;
-  if (shopName.indexOf("." > -1)) {
-    url = `https://${shopName}/api/graphql`;
+  let url
+  if (shopName.includes(`.`)) {
+    url = `https://${shopName}/api/graphql`
+  } else {
+    url = `https://${shopName}.myshopify.com/api/graphql`
   }
-  else {
-    url = `https://${shopName}.myshopify.com/api/graphql`;
-  }  
   return new GraphQLClient(url, {
     headers: {
       "X-Shopify-Storefront-Access-Token": accessToken,


### PR DESCRIPTION

## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/19055 and allows the shopify plugin to work with shops that run on a custom domain.

See the ticket for a discussion of the issue.
