### PR TITLE
fix(gatsby): Fix sift query against empty nodes

### DIFF
--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -183,7 +183,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
           mockNodes()[3].id,
         ])
       })
-      it('return empty array in case of empty nodes', async () => {
+      it(`return empty array in case of empty nodes`, async () => {
         const resultSingular = await runSift({
           gqlType,
           queryArgs,

--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -183,6 +183,15 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
           mockNodes()[3].id,
         ])
       })
+      if('return empty array in case of empty nodes', async () => {
+        const resultSingular = await runSift({
+          gqlType,
+          queryArgs,
+          firstOnly: true,
+          nodeTypeNames: [`NonExistentNodeType`],
+        })
+        expect(resultSingular).toEqual([])
+      })
     })
   })
 } else {

--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -183,7 +183,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
           mockNodes()[3].id,
         ])
       })
-      if('return empty array in case of empty nodes', async () => {
+      it('return empty array in case of empty nodes', async () => {
         const resultSingular = await runSift({
           gqlType,
           queryArgs,

--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -184,6 +184,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
         ])
       })
       it(`return empty array in case of empty nodes`, async () => {
+        const queryArgs = {}
         const resultSingular = await runSift({
           gqlType,
           queryArgs,

--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -184,7 +184,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
         ])
       })
       it(`return empty array in case of empty nodes`, async () => {
-        const queryArgs = {}
+        const queryArgs = { filter: {}, sort: {} }
         const resultSingular = await runSift({
           gqlType,
           queryArgs,

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -64,7 +64,8 @@ function handleFirst(siftArgs, nodes) {
       )
 
   if (index !== -1) {
-    return [nodes[index]]
+    const result  = nodes[index];
+    return result ? [result] : [];
   } else {
     return []
   }

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -55,6 +55,10 @@ function isEqId(firstOnly, siftArgs) {
 }
 
 function handleFirst(siftArgs, nodes) {
+  if (nodes.length === 0) {
+    return []
+  }
+
   const index = _.isEmpty(siftArgs)
     ? 0
     : nodes.findIndex(
@@ -64,8 +68,7 @@ function handleFirst(siftArgs, nodes) {
       )
 
   if (index !== -1) {
-    const result  = nodes[index];
-    return result ? [result] : [];
+    return [nodes[index]]
   } else {
     return []
   }


### PR DESCRIPTION
## Description

For [Kentico Kontent source plugin] - there is a schema definition implemented (https://github.com/Kentico/gatsby-source-kontent/pull/95 - still in progress).

During testing, when I try to load a node that has a definition, but **does not have the data provided** - no node is created:

So then this query:
```gql
{
  kontentItemTextContentTypeWithNoItem {
    id
  }
}
```

I am getting this error:

```json
{
      "message": "Cannot read property 'id' of undefined",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "kontentItemTextContentTypeWithNoItem"
      ],
      "stack": [
        "TypeError: Cannot read property 'id' of undefined",
        "    at LocalNodeModel.trackInlineObjectsInRootNode (C:\\projects\\gatsby-content-type-not-in-schema\\node_modules\\gatsby\\dist\\schema\\node-model.js:281:42)",
        "    at LocalNodeModel.runQuery (C:\\projects\\gatsby-content-type-not-in-schema\\node_modules\\gatsby\\dist\\schema\\node-model.js:190:14)",
        "    at runMicrotasks (<anonymous>)",
        "    at processTicksAndRejections (internal/process/task_queues.js:93:5)",
        "    at async Promise.all (index 0)"
      ]
    }
```

After some digging, I have found out that in `~\gatsby\dist\schema\node-model.js - runQuery` the `queryResult` results to an array with the only item - `undefined` (`[undefined]`).

Error is caused in `~\gatsby\dist\redux\run-sift.js - handleFirst` get the empty array of nodes (expected, because there is no node yet) but the return statement is:
```js
    return [nodes[index]];
```
Which in case of empty `nodes` array leads to the array with one item undefined, instead of returning empty array as the upcoming code expect in my opinion.

So the error is then raised:
`~\gatsby\dist\schema\node-model.js - trackInlineObjectsInRootNode` where undefined is passed (the value of the result).


### Documentation

This is what I have found just by debugging - if there is any other  way, how to handle failing query when no node is placed - I am more then welcome to implement it in the source plugin.

## Related Issues

https://github.com/Kentico/gatsby-source-kontent/issues/92
