### PR TITLE
fix(docs): use new -v for gatsby-dev-cli

### DIFF
--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -47,7 +47,7 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
   - Make sure you have the Gatsby CLI installed with `gatsby -v`,
   - if not, install globally: `yarn global add gatsby-cli`
 - Install [gatsby-dev-cli](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli):
-  - Make sure you have the Gatsby Dev CLI installed with `gatsby-dev -h`
+  - Make sure you have the Gatsby Dev CLI installed with `gatsby-dev -v`
   - if not, install globally: `yarn global add gatsby-dev-cli`
 - Run `yarn install` in each of the sites you're testing.
 - For each of your Gatsby test sites, run the `gatsby-dev` command inside the test site's directory to copy


### PR DESCRIPTION
## Description

`-v` is implemented now (#19459) in `gatsby-dev-cli` so it can be used same here, the way as with `gatsby -v` in line 47

## Related Issues

#19459 PR: feat(gatsby-dev-cli): Add --version 
#19348 Issue: feature request: add version to gatsby-dev-cli 