### PR TITLE
webpack glossary/enclyclopedia entry

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -330,7 +330,7 @@ A UI refers to a User Interface. In the field of human-computer interaction, a U
 
 ## W
 
-### [Webpack](/docs/glossary/webpack)
+### [webpack](/docs/glossary/webpack)
 
 A [JavaScript](#javascript) application that Gatsby uses to bundle your website's code up. This happens automatically on [build](#build).
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -330,7 +330,7 @@ A UI refers to a User Interface. In the field of human-computer interaction, a U
 
 ## W
 
-### Webpack
+### [Webpack](/docs/glossary/webpack)
 
 A [JavaScript](#javascript) application that Gatsby uses to bundle your website's code up. This happens automatically on [build](#build).
 

--- a/docs/docs/glossary/webpack.md
+++ b/docs/docs/glossary/webpack.md
@@ -9,9 +9,9 @@ Learn what webpack is, how it works, and how Gatsby uses it to accelerate web si
 
 [webpack](/docs/glossary#webpack) is a <q>static module bundler,</q> or software that collects chunks or modules of JavaScript and compiles them into one or more optimized bundles. webpack is one of the core software packages that underpins Gatsby.
 
-webpack works by creating a _dependency graph_. In other words, webpack determines which modules depend on other modules to make your site work. A module is simply a chunk of code that encapsulates some functionality. It may be as small as a single JavaScript function, or it may be an entire library such as [React](/docs/glossary#react).
+webpack works by creating a _dependency graph_. In other words, webpack determines which modules depend on other modules to make your site work. A _module_ is a chunk of code that encapsulates some functionality. It may be as small as a single JavaScript function, or it may be an entire library such as [React](/docs/glossary#react).
 
-webpack determines dependencies from the contents of `webpack.config.js`. `webpack.config.js` can contain one or more _entry points_, which tells webpack which file or files to use as the starting point (or points) for a dependency graph. A simple example follows.
+webpack determines dependencies from the contents of `webpack.config.js`. `webpack.config.js` can contain one or more _entry points_, which tell webpack which file or files to use as the starting point (or points) for a dependency graph. See the following example.
 
 ```javascript
 module.exports = {
@@ -19,11 +19,11 @@ module.exports = {
 }
 ```
 
-webpack processes JavaScript and JSON files with its default configuration. But you can add support for CSS and media files with additional software and configuration. For example, Gatsby ships with its own [`webpack.config.js`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js) file that supports [global CSS files](/docs/global-css/), [component-scoped CSS modules](/docs/css-modules/), and [CSS-in-JS](/docs/css-in-js/).
+webpack processes JavaScript and JSON files by default, but you can add support for CSS and media files with additional software and configuration. For example, Gatsby ships with its own [`webpack.config.js`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js) file that supports [global CSS files](/docs/global-css/), [component-scoped CSS modules](/docs/css-modules/), and [CSS-in-JS](/docs/css-in-js/).
 
-You can also use webpack to optimize how CSS and JavaScript gets delivered to the browser. webpack supports a feature known as [_code splitting_](https://webpack.js.org/guides/code-splitting/). Code splitting allows you to divide your code across a few bundles that are loaded as needed or as requested. Gatsby is already configured to use this feature. You do not have to do any additional set up to reap the benefits.
+You can also use webpack to optimize how CSS and JavaScript are delivered to the browser. webpack supports a feature known as [_code splitting_](https://webpack.js.org/guides/code-splitting/). Code splitting allows you to divide your code across a few bundles that are loaded as needed or as requested. Gatsby is already configured to use this feature. You do not have to do any additional set up to reap the benefits.
 
-If you want to add support for features such as [Sass/SCSS](/docs/sass/), that Gatsby does not support out of the box, you can also add a [custom](/docs/add-custom-webpack-config/) webpack configuration. Or use one of the [Gatsby plugins](/docs/plugins/) contributed by the community.
+If you want to add support for features such as [Sass/SCSS](/docs/sass/), that Gatsby does not support out of the box, you can also add a [custom](/docs/add-custom-webpack-config/) webpack configuration, or use one of the [Gatsby plugins](/docs/plugins/) contributed by the community.
 
 ### Learn more about webpack
 

--- a/docs/docs/glossary/webpack.md
+++ b/docs/docs/glossary/webpack.md
@@ -1,0 +1,31 @@
+---
+title: webpack
+disableTableOfContents: true
+---
+
+Learn what webpack is, how it works, and how Gatsby uses it to accelerate web site development.
+
+## What is webpack?
+
+[webpack](/docs/glossary#webpack) is a <q>static module bundler,</q> or software that collects chunks or modules of JavaScript and compiles them into one or more optimized bundles. webpack is one of the core software packages that underpins Gatsby.
+
+webpack works by creating a _dependency graph_. In other words, webpack determines which modules depend on other modules to make your site work. A module is simply a chunk of code that encapsulates some functionality. It may be as small as a single JavaScript function, or it may be an entire library such as [React](/docs/glossary#react).
+
+webpack determines dependencies from the contents of `webpack.config.js`. `webpack.config.js` can contain one or more _entry points_, which tells webpack which file or files to use as the starting point (or points) for a dependency graph. A simple example follows.
+
+```javascript
+module.exports = {
+  entry: "/scripts/index.js",
+}
+```
+
+webpack processes JavaScript and JSON files with its default configuration. But you can add support for CSS and media files with additional software and configuration. For example, Gatsby ships with its own [`webpack.config.js`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js) file that supports [global CSS files](/docs/global-css/), [component-scoped CSS modules](/docs/css-modules/), and [CSS-in-JS](/docs/css-in-js/).
+
+You can also use webpack to optimize how CSS and JavaScript gets delivered to the browser. webpack supports a feature known as [_code splitting_](https://webpack.js.org/guides/code-splitting/). Code splitting allows you to divide your code across a few bundles that are loaded as needed or as requested. Gatsby is already configured to use this feature. You do not have to do any additional set up to reap the benefits.
+
+If you want to add support for features such as [Sass/SCSS](/docs/sass/), that Gatsby does not support out of the box, you can also add a [custom](/docs/add-custom-webpack-config/) webpack configuration. Or use one of the [Gatsby plugins](/docs/plugins/) contributed by the community.
+
+### Learn more about webpack
+
+- [webpack](https://webpack.js.org/) official site
+- [Custom Configuration](/docs/customization/) from the Gatsby Docs

--- a/docs/docs/glossary/webpack.md
+++ b/docs/docs/glossary/webpack.md
@@ -23,7 +23,7 @@ webpack processes JavaScript and JSON files by default, but you can add support 
 
 You can also use webpack to optimize how CSS and JavaScript are delivered to the browser. webpack supports a feature known as [_code splitting_](https://webpack.js.org/guides/code-splitting/). Code splitting allows you to divide your code across a few bundles that are loaded as needed or as requested. Gatsby is already configured to use this feature. You do not have to do any additional set up to reap the benefits.
 
-If you want to add support for features such as [Sass/SCSS](/docs/sass/), that Gatsby does not support out of the box, you can also add a [custom](/docs/add-custom-webpack-config/) webpack configuration, or use one of the [Gatsby plugins](/docs/plugins/) contributed by the community.
+If you want to add support for features such as [Sass/SCSS](/docs/sass/), that Gatsby does not support out of the box, you can also [add a custom webpack configuration](/docs/add-custom-webpack-config/), or use one of the [Gatsby plugins](/docs/plugins/) contributed by the community.
 
 ### Learn more about webpack
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -725,6 +725,8 @@
           link: /docs/glossary/node
         - title: React
           link: /docs/glossary/react
+        - title: webpack
+          link: /docs/glossary/webpack
     - title: Gatsby Telemetry
       link: /docs/telemetry/
     - title: Gatsby REPL


### PR DESCRIPTION
## Description

Adds a new documentation page that explains webpack and how Gatsby uses it. Also updates glossary page and sidebar navigation with links to the new page.


