### PR TITLE
fix(www): Improve accessibility of showcase page

### DIFF
--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -52,8 +52,8 @@ class Collapsible extends Component {
               p: 0,
               letterSpacing: `tracked`,
               textTransform: `uppercase`,
-              background: "none",
-              border: "none",
+              background: `none`,
+              border: `none`,
               "&:hover": {
                 color: `gatsby`,
               },

--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -38,7 +38,7 @@ class Collapsible extends Component {
             width: `100%`,
           }}
         >
-          <h4
+          <button
             sx={{
               alignItems: `center`,
               color: `textMuted`,
@@ -47,14 +47,18 @@ class Collapsible extends Component {
               flexShrink: 0,
               fontWeight: `body`,
               fontSize: 1,
-              mt: 6,
-              mr: 7,
+              my: 6,
+              mr: 4,
+              p: 0,
               letterSpacing: `tracked`,
               textTransform: `uppercase`,
+              background: "none",
+              border: "none",
               "&:hover": {
                 color: `gatsby`,
               },
             }}
+            aria-expanded={!collapsed}
             onClick={this.handleClick}
           >
             {heading}
@@ -62,7 +66,7 @@ class Collapsible extends Component {
             <span sx={{ ml: `auto` }} css={{ display: `flex` }}>
               {collapsed ? <FaAngleDown /> : <FaAngleUp />}
             </span>
-          </h4>
+          </button>
           <div
             css={{
               display: collapsed ? `none` : `block`,

--- a/www/src/views/showcase/showcase-list.js
+++ b/www/src/views/showcase/showcase-list.js
@@ -60,6 +60,7 @@ const ShowcaseList = ({ items, count, filters, onCategoryClick }) => {
                         href={node.source_url}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`Open source code for ${node.title}`}
                       >
                         <GithubIcon style={{ verticalAlign: `text-top` }} />
                       </a>
@@ -71,6 +72,7 @@ const ShowcaseList = ({ items, count, filters, onCategoryClick }) => {
                     href={node.main_url}
                     target="_blank"
                     rel="noopener noreferrer"
+                    aria-label={`Open website for ${node.title}`}
                   >
                     <LaunchSiteIcon style={{ verticalAlign: `text-top` }} />
                   </a>

--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -180,6 +180,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                           ...shortcutIcon,
                           svg: { verticalAlign: `text-top !important` },
                         }}
+                        aria-label={`Open source code for ${name}`}
                       >
                         <GithubIcon />
                       </a>
@@ -192,6 +193,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                           ...shortcutIcon,
                           svg: { verticalAlign: `text-top !important` },
                         }}
+                        aria-label={`Open demo for ${name}`}
                       >
                         <LaunchDemoIcon />
                       </a>


### PR DESCRIPTION
## Description

Hey 👋

Fixing a couple of accessibility issues with the showcase page:
 - Icon links had no text: https://dequeuniversity.com/rules/axe/3.4/link-name?application=AxeChrome
- Category toggle was implemented as an `h4` but was clickable and "toggleable" https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role

Before:
<img src="https://user-images.githubusercontent.com/6424140/71230195-45dd3400-22ae-11ea-8b69-be1d83ff4b4a.gif" height="100"/>

After:
<img src="https://user-images.githubusercontent.com/6424140/71230203-51305f80-22ae-11ea-8e92-a68414fc39c0.gif" height="100"/>
