### PR TITLE
fix(gatsby): don't write out `isCreatedByStatefulCreatePages` to page-data files

### DIFF
--- a/packages/gatsby/src/query/query-runner.js
+++ b/packages/gatsby/src/query/query-runner.js
@@ -72,6 +72,7 @@ ${formatErrorDetails(errorDetails)}`)
     delete result.pageContext.pluginCreatorId
     delete result.pageContext.componentPath
     delete result.pageContext.context
+    delete result.pageContext.isCreatedByStatefulCreatePages
   }
 
   const resultJSON = JSON.stringify(result)


### PR DESCRIPTION
We are writing out internal thing to `page-data` currently that is not needed for actual runtime, so this is waste of user's bandwidth (few bytes, but still) that is not needed:

before / after
```diff
-{"componentChunkName":"component---node-modules-gatsby-plugin-offline-app-shell-js","path":"/offline-plugin-app-shell-fallback/","result":{"pageContext":{"isCreatedByStatefulCreatePages":false}}}
+{"componentChunkName":"component---node-modules-gatsby-plugin-offline-app-shell-js","path":"/offline-plugin-app-shell-fallback/","result":{"pageContext":{}}}
```

This could be moved further and not write out `pageContext` at all if it's empty, but I feel this small change is safe bet that provide value