### PR TITLE
docs: Add documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,50 @@
+---
+name: Documentation 📝
+about: Suggest better docs coverage for a particular tool or process.
+---
+
+<!-- Gatsby OSS team is on holiday, expect a delayed response -->
+
+<!--
+  To make it easier for us to help you, please include as much useful information as possible.
+
+  Useful Links:
+  - Documentation: https://www.gatsbyjs.org/docs/
+  - Contributing: https://www.gatsbyjs.org/contributing/
+
+  Gatsby has several community support channels, try asking your question on:
+
+  - Discord: https://gatsby.dev/discord
+  - Spectrum: https://spectrum.chat/gatsby-js
+  - Twitter: https://twitter.com/gatsbyjs
+
+  Before opening a new issue, please search existing issues https://github.com/gatsbyjs/gatsby/issues
+-->
+
+## Summary
+
+What problem(s) did you run into that caused you to request additional documentation? What questions do you think we should answer? What, if any, existing documenation relates to this proposal?
+
+Some recommended topics to cover:
+
+- List the topics you think should be here.
+- This list does not need to be exhaustive!
+
+### Motivation
+
+Why should we document this and who will benefit from it?
+
+## Steps to resolve this issue
+
+<!-- Your suggestion may require additional steps. Remember to add any relevant labels. Note that you'll need to fill in the link to a similar article as well as the correct section. Don't worry if you're not yet sure about these, especially if this is a brand new topic! -->
+
+### Draft the doc
+
+- [ ] Write the doc, following the format listed in these resources:
+  - [Overview on contributing to documentation](https://www.gatsbyjs.org/contributing/docs-contributions/)
+  - [Docs Templates](https://www.gatsbyjs.org/contributing/docs-templates/)
+  - [Example of a similar article]()
+- [ ] Add the article to the [docs sidebar](https://github.com/gatsbyjs/gatsby/blob/master/www/src/data/sidebars/doc-links.yaml) under the [parent doc] section.
+
+### Open a pull request
+- [ ] Open a pull request with your work including the words "closes #[this issue's number]" in the pull request description

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -47,4 +47,5 @@ Why should we document this and who will benefit from it?
 - [ ] Add the article to the [docs sidebar](https://github.com/gatsbyjs/gatsby/blob/master/www/src/data/sidebars/doc-links.yaml) under the [parent doc] section.
 
 ### Open a pull request
+
 - [ ] Open a pull request with your work including the words "closes #[this issue's number]" in the pull request description


### PR DESCRIPTION
###  Description

Especially now that the Learning team has grown significantly, it seems likely that we'll be writing lots of issues related to documentation. I think it would be helpful to incorporate an issue template specific to suggestions for _new_ documentation. The goal here is to help streamline the process of requesting new docs for both Gatsby team members and members of the community. A similar strategy seems to have worked well in preparation for past Hacktoberfests. I'm open to suggestions on how to make this better but I don't expect feedback til the new year!