### PR TITLE
chore(actions): Run the site showcase validator only on the base repo

### DIFF
--- a/.github/workflows/schedule-site-showcase-validator-workflow.yml
+++ b/.github/workflows/schedule-site-showcase-validator-workflow.yml
@@ -7,7 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - id: base_check
+        name: Check if repo is gatsbyjs/gatsby
+        run: |
+          if [ "$GITHUB_REPOSITORY" = "gatsbyjs/gatsby" ]; then
+            echo "::set-output name=base::true"
+          fi
       - name: gatsby-site-showcase-validator
+        if: steps.base_check.outputs.base == 'true'
         uses: ./.github/actions/gatsby-site-showcase-validator
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

@pieh and I discussed how it would be possible to reduce the amount of notifications of failures from the Site Showcase Validator for forks of the repo. I modified the workflow so it will check if the repo is `gatsbyjs/gatsby` and if it is not, it will skip the run of the action. This doesn't disable the workflow on other forks, but this will reduce the notification spam for forks as it never actually runs the validator.