### PR TITLE
fix(plugin-netlify-cms): set global window vars required for Gatsby components

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -1,4 +1,11 @@
 import CMS from "netlify-cms-app"
+// set global variables required by Gatsby's components
+// https://github.com/gatsbyjs/gatsby/blob/deb41cdfefbefe0c170b5dd7c10a19ba2b338f6e/docs/docs/production-app.md#window-variables
+// some Gatsby components require these global variables set here:
+// https://github.com/gatsbyjs/gatsby/blob/deb41cdfefbefe0c170b5dd7c10a19ba2b338f6e/packages/gatsby/cache-dir/production-app.js#L28
+import emitter from "gatsby/cache-dir/emitter"
+window.___emitter = emitter
+window.___loader = { enqueue: () => {}, hovering: () => {} }
 
 /**
  * Load Netlify CMS automatically if `window.CMS_MANUAL_INIT` is set.


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/19898

Netlify CMS supports registering Gatsby components as preview templates. Some of these components (`gastby-link` in the issue above) use global window variables set [here](https://github.com/gatsbyjs/gatsby/blob/deb41cdfefbefe0c170b5dd7c10a19ba2b338f6e/packages/gatsby/cache-dir/production-app.js#L28).

The CMS plugin bundles the CMS as a separate React app thus needs to set these manually.
I'm stubbing the `___loader` since preloading is not required for the CMS previews.

Not sure this is the best approach though.