### PR TITLE
docs: update Jest option setupFilesAfterEnv

### DIFF
--- a/docs/docs/testing-css-in-js.md
+++ b/docs/docs/testing-css-in-js.md
@@ -44,7 +44,7 @@ Lastly you need to tell Jest where to find this file. Open your `package.json` a
 
 ```json:title=package.json
 "jest": {
-  "setupFilesAfterEnv": "<rootDir>/setup-test-env.js"
+  "setupFilesAfterEnv": [`<rootDir>/setup-test-env.js`]
 }
 ```
 

--- a/docs/docs/testing-css-in-js.md
+++ b/docs/docs/testing-css-in-js.md
@@ -44,7 +44,7 @@ Lastly you need to tell Jest where to find this file. Open your `package.json` a
 
 ```json:title=package.json
 "jest": {
-  "setupTestFrameworkScriptFile": "<rootDir>/setup-test-env.js"
+  "setupFilesAfterEnv": "<rootDir>/setup-test-env.js"
 }
 ```
 


### PR DESCRIPTION


<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The Jest option `setupTestFrameworkScriptFile` has been renamed to `setupFilesAfterEnv`. The legacy name is deprecated.
 
Source: https://jestjs.io/docs/en/configuration#setupfilesafterenv-array

This PR updates the option in the `Testing CSS-in-JS` guide.

### Documentation

// noop
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
None.