### PR TITLE
fix(docs): Remove superfluous `-- ` from `gatsby develop` cmd

### DIFF
--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -163,7 +163,7 @@ Congrats! This is the beginning of your very first Gatsby site! 🎉
 
 You’ll be able to visit the site locally at [**_http://localhost:8000_**](http://localhost:8000/) for as long as your development server is running. That’s the process you started by running the `gatsby develop` command. To stop running that process (or to “stop running the development server”), go back to your terminal window, hold down the “control” key, and then hit “c” (ctrl-c). To start it again, run `gatsby develop` again!
 
-**Note:** If you are using VM setup like `vagrant` and/or would like to listen on your local IP address, run `gatsby develop -- --host=0.0.0.0`. Now, the development server listens on both 'localhost' and your local IP.
+**Note:** If you are using VM setup like `vagrant` and/or would like to listen on your local IP address, run `gatsby develop --host=0.0.0.0`. Now, the development server listens on both 'localhost' and your local IP.
 
 ## Set up a code editor
 


### PR DESCRIPTION
Command doesn't work as written: `gatsby develop -- --host:0.0.0.0`. Does work with extra `-- ` removed.

<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
