### PR TITLE
fix(blog): use gatsby.dev link

### DIFF
--- a/docs/blog/100days/index.md
+++ b/docs/blog/100days/index.md
@@ -21,7 +21,7 @@ Register below to join the #100daysofGatsby coding challenge!
 
 ## Use #100DaysOfGatsby on Social Media
 
-As you work on your Gatsby project, connect with the community by using #100DaysOfGatsby in your tweets or posts on social media. If you need help with a challenge, or want to share a tool or technique that was useful, visit our [Gatsby communities](/contributing/community/#where-to-get-support) on [Discord](https://discordapp.com/invite/gatsby), [Spectrum](https://spectrum.chat/gatsby-js), [Dev](https://dev.to/t/gatsby), and [Reddit](https://www.reddit.com/r/gatsbyjs/).
+As you work on your Gatsby project, connect with the community by using #100DaysOfGatsby in your tweets or posts on social media. If you need help with a challenge, or want to share a tool or technique that was useful, visit our [Gatsby communities](/contributing/community/#where-to-get-support) on [Discord](https://gatsby.dev/discord), [Spectrum](https://spectrum.chat/gatsby-js), [Dev](https://dev.to/t/gatsby), and [Reddit](https://www.reddit.com/r/gatsbyjs/).
 
 ## 👉🏽 New to React or Web Development?
 


### PR DESCRIPTION
## Description

replace the direct link with the https://gatsby.dev/discord link which is used on all other places in doc 

## Related Issues

#20261

## questions

BTW: 
the redirect from `https://gatsby.dev/discord` 
is set to `https://discordapp.com/invite/br9rbUE` 
and not to `https://discordapp.com/invite/gatsby`