### PR TITLE
fix(gatsby-source-graphql): filter unused variables

### DIFF
--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.7.6",
     "apollo-link": "1.2.13",
     "apollo-link-http": "^1.5.16",
-    "graphql-tools-fork": "^7.2.3",
+    "graphql-tools-fork": "^8.0.1",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",
     "uuid": "^3.3.3"


### PR DESCRIPTION
Updates graphql-tools-fork to v8.0.1 which addresses #20280.