### PR TITLE
chore(starters) add gatsby-starter-robin

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -4789,3 +4789,21 @@
     - MDX for pages and content
     - Code syntax highlighting
     - SEO (OpenGraph and Twitter) out of the box with default settings that make sense (thanks to React Helmet)
+- url: https://gatsby-starter-robin.netlify.com/
+  repo: https://github.com/robinmetral/gatsby-starter-robin
+  description: Gatsby Default Starter with state-of-the-art tooling
+  tags:
+    - MDX
+    - Styling:CSS-in-JS
+    - Linting
+    - Testing
+    - Storybook
+  features:
+    - 📚 Write in MDX
+    - 👩‍🎤 Style with Emotion
+    - 💅 Linting with ESLint and Prettier
+    - 📝 Unit and integration testing with Jest and react-testing-library
+    - 💯 E2E browser testing with Cypress
+    - 📓 Visual testing with Storybook
+    - ✔️ CI with GitHub Actions
+    - ⚡ CD with Netlify


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Adds `gatsby-starter-robin` to Starter Library

### Documentation

None.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

None.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
