### PR TITLE
Fixes bug where `include` directive was not relative to parent document

### DIFF
--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -34,7 +34,10 @@ async function onCreateNode(
   }
 
   // changes the incoming imagesdir option to take the
-  const asciidocOptions = processPluginOptions(pluginOptions, pathPrefix, node)
+  let asciidocOptions = processPluginOptions(pluginOptions, pathPrefix)
+
+  // Add a base_dir key and value, so include works as expected
+  asciidocOptions.base_dir = node.dir
 
   const { createNode, createParentChildLink } = actions
   // Load Asciidoc contents
@@ -106,7 +109,7 @@ async function onCreateNode(
   }
 }
 
-const processPluginOptions = _.memoize((pluginOptions, pathPrefix, node) => {
+const processPluginOptions = _.memoize((pluginOptions, pathPrefix) => {
   const defaultImagesDir = `/images@`
   const currentPathPrefix = pathPrefix || ``
 
@@ -115,9 +118,6 @@ const processPluginOptions = _.memoize((pluginOptions, pathPrefix, node) => {
   if (clonedPluginOptions.attributes === undefined) {
     clonedPluginOptions.attributes = {}
   }
-
-  // Set the base_dir to the current node (i.e. document) path
-  clonedPluginOptions.base_dir = node.dir
 
   clonedPluginOptions.attributes.imagesdir = withPathPrefix(
     currentPathPrefix,

--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -34,7 +34,7 @@ async function onCreateNode(
   }
 
   // changes the incoming imagesdir option to take the
-  const asciidocOptions = processPluginOptions(pluginOptions, pathPrefix)
+  const asciidocOptions = processPluginOptions(pluginOptions, pathPrefix, node)
 
   const { createNode, createParentChildLink } = actions
   // Load Asciidoc contents
@@ -106,7 +106,7 @@ async function onCreateNode(
   }
 }
 
-const processPluginOptions = _.memoize((pluginOptions, pathPrefix) => {
+const processPluginOptions = _.memoize((pluginOptions, pathPrefix, node) => {
   const defaultImagesDir = `/images@`
   const currentPathPrefix = pathPrefix || ``
 
@@ -115,6 +115,9 @@ const processPluginOptions = _.memoize((pluginOptions, pathPrefix) => {
   if (clonedPluginOptions.attributes === undefined) {
     clonedPluginOptions.attributes = {}
   }
+
+  // Set the base_dir to the current node (i.e. document) path
+  clonedPluginOptions.base_dir = node.dir
 
   clonedPluginOptions.attributes.imagesdir = withPathPrefix(
     currentPathPrefix,


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fixes bug where `include` directive was not relative to parent document.

Previously this was relative to the root of the project. 

I believe this was a bug, not a feature _but_ I might have misread the asciidoctor manual (I find it confusing) so I'm happy to make this an opt-in feature if that is the case.

There are also no tests that I can see, so this PR doesn't add any.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

None, as this is a bug fix (see above)

## Related Issues

Fixes #19502 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
