### PR TITLE
Readd missing id field in refactored Index query

### DIFF
--- a/docs/docs/graphql-concepts.md
+++ b/docs/docs/graphql-concepts.md
@@ -353,6 +353,7 @@ export const query = graphql`
       totalCount
       edges {
         node {
+          id
           ...IndexPostFragment
         }
       }


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add the `id` field back to the query in the snippet named `src/pages/index.jsx`. I proposed this since `node.id` is still referenced in the anonymous component in `index.jsx`, but the `id` field does not appear in the query there nor in the query fragment in `src/components/IndexPost.jsx`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
