### PR TITLE
fix(gatsby-source-contentful): limit fixIds recursive call depth

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -53,24 +53,26 @@ const fixId = id => {
 }
 exports.fixId = fixId
 
-const fixIds = object =>
-  _.mapValues(object, (val, key) => {
-    if (key === `sys`) {
-      val = {
-        ...val,
-        id: fixId(val.id),
-        contentful_id: val.id,
-      }
-    }
+const fixIds = (object, depth = 0) =>
+  depth > 10
+    ? object
+    : _.mapValues(object, (val, key) => {
+        if (key === `sys`) {
+          val = {
+            ...val,
+            id: fixId(val.id),
+            contentful_id: val.id,
+          }
+        }
 
-    if (_.isArray(val)) {
-      return _.toArray(fixIds(val))
-    }
-    if (_.isPlainObject(val)) {
-      return fixIds(val)
-    }
-    return val
-  })
+        if (_.isArray(val)) {
+          return _.toArray(fixIds(val, depth + 1))
+        }
+        if (_.isPlainObject(val)) {
+          return fixIds(val, depth + 1)
+        }
+        return val
+      })
 exports.fixIds = fixIds
 
 const makeId = ({ spaceId, id, currentLocale, defaultLocale }) =>


### PR DESCRIPTION
## Description

Small additional fix for the original fixIds change introduced in PR #20258. As I reported in Issue #20279, there could be a Maximum call stack size exceeded error if you have circular references in your content types (which I do).

## Related Issues

Fixes #20279