### PR TITLE
fix(gatsby-transformer-sharp): define required image fields as non-null in schema

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -6,6 +6,7 @@ const {
   GraphQLInt,
   GraphQLFloat,
   GraphQLJSON,
+  GraphQLNonNull,
 } = require(`gatsby/graphql`)
 const qs = require(`qs`)
 const base64Img = require(`base64-img`)
@@ -327,10 +328,10 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
           resolve: getTracedSVG,
         },
         aspectRatio: { type: GraphQLFloat },
-        width: { type: GraphQLFloat },
-        height: { type: GraphQLFloat },
-        src: { type: GraphQLString },
-        srcSet: { type: GraphQLString },
+        width: { type: new GraphQLNonNull(GraphQLFloat) },
+        height: { type: new GraphQLNonNull(GraphQLFloat) },
+        src: { type: new GraphQLNonNull(GraphQLString) },
+        srcSet: { type: new GraphQLNonNull(GraphQLString) },
         srcWebp: {
           type: GraphQLString,
           resolve({ image, options, context }) {
@@ -421,9 +422,9 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
           type: GraphQLString,
           resolve: getTracedSVG,
         },
-        aspectRatio: { type: GraphQLFloat },
-        src: { type: GraphQLString },
-        srcSet: { type: GraphQLString },
+        aspectRatio: { type: new GraphQLNonNull(GraphQLFloat) },
+        src: { type: new GraphQLNonNull(GraphQLString) },
+        srcSet: { type: new GraphQLNonNull(GraphQLString) },
         srcWebp: {
           type: GraphQLString,
           resolve({ image, options, context }) {
@@ -458,7 +459,7 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
             return _.get(fluid, `srcSet`)
           },
         },
-        sizes: { type: GraphQLString },
+        sizes: { type: new GraphQLNonNull(GraphQLString) },
       },
     }),
     args: {

--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -75,9 +75,9 @@ const fixedNodeType = ({
         },
         aspectRatio: { type: GraphQLFloat },
         width: { type: new GraphQLNonNull(GraphQLFloat) },
-        height: { type: GraphQLNonNull(GraphQLFloat) },
-        src: { type: GraphQLNonNull(GraphQLString) },
-        srcSet: { type: GraphQLNonNull(GraphQLString) },
+        height: { type: new GraphQLNonNull(GraphQLFloat) },
+        src: { type: new GraphQLNonNull(GraphQLString) },
+        srcSet: { type: new GraphQLNonNull(GraphQLString) },
         srcWebp: {
           type: GraphQLString,
           resolve: ({ file, image, fieldArgs }) => {

--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -6,6 +6,7 @@ const {
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
+  GraphQLNonNull,
 } = require(`gatsby/graphql`)
 const {
   queueImageResizing,
@@ -73,10 +74,10 @@ const fixedNodeType = ({
             }),
         },
         aspectRatio: { type: GraphQLFloat },
-        width: { type: GraphQLFloat },
-        height: { type: GraphQLFloat },
-        src: { type: GraphQLString },
-        srcSet: { type: GraphQLString },
+        width: { type: new GraphQLNonNull(GraphQLFloat) },
+        height: { type: GraphQLNonNull(GraphQLFloat) },
+        src: { type: GraphQLNonNull(GraphQLString) },
+        srcSet: { type: GraphQLNonNull(GraphQLString) },
         srcWebp: {
           type: GraphQLString,
           resolve: ({ file, image, fieldArgs }) => {
@@ -229,9 +230,9 @@ const fluidNodeType = ({
               reporter,
             }),
         },
-        aspectRatio: { type: GraphQLFloat },
-        src: { type: GraphQLString },
-        srcSet: { type: GraphQLString },
+        aspectRatio: { type: new GraphQLNonNull(GraphQLFloat) },
+        src: { type: new GraphQLNonNull(GraphQLString) },
+        srcSet: { type: new GraphQLNonNull(GraphQLString) },
         srcWebp: {
           type: GraphQLString,
           resolve: ({ file, image, fieldArgs }) => {
@@ -266,7 +267,7 @@ const fluidNodeType = ({
             ).then(({ srcSet }) => srcSet)
           },
         },
-        sizes: { type: GraphQLString },
+        sizes: { type: new GraphQLNonNull(GraphQLString) },
         originalImg: { type: GraphQLString },
         originalName: { type: GraphQLString },
         presentationWidth: { type: GraphQLInt },


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
The generated graphql schema have a lot of nullable fields which are required for images (i.e. the src of an image). This makes it incompatible to use it with type generators and TypeScript. 

This PR changes the gatsby-source-contentful and the gatsby-transformer-sharp to be at least compatible with the gatsby-image type definitions. 

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
Docs should exist already. I don't expect that they include such details. 

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
This PR should close #17003.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
