### PR TITLE
feat(gatsby): Allow alternative import syntax for useStaticQuery

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Allow alternative import of useStaticQuery 1`] = `
+"import staticQueryData from \\"public/static/d/2626356014.json\\";
+import React from 'react';
+import * as Gatsby from 'gatsby';
+export default (() => {
+  const siteTitle = staticQueryData.data;
+  return React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
+});"
+`;
+
 exports[`Doesn't add data import for non static queries 1`] = `
 "import staticQueryData from \\"public/static/d/4279313589.json\\";
 import React from 'react';

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
@@ -43,7 +43,7 @@ it(`Transforms queries in useStaticQuery`, () => {
 
   export default () => {
     const siteTitle = useStaticQuery(graphql\`{site { siteMetadata { title }}}\`)
-    
+
     return (
       <h1>{siteTitle.site.siteMetadata.title}</h1>
     )
@@ -79,7 +79,7 @@ it(`Transforms queries defined in own variable in useStaticQuery`, () => {
   export default () => {
     const query = graphql\`{site { siteMetadata { title }}}\`
     const siteTitle = useStaticQuery(query)
-    
+
     return (
       <h1>{siteTitle.site.siteMetadata.title}</h1>
     )
@@ -95,7 +95,7 @@ it(`Transforms queries and preserves destructuring in useStaticQuery`, () => {
   export default () => {
     const query = graphql\`{site { siteMetadata { title }}}\`
     const { site } = useStaticQuery(query)
-    
+
     return (
       <h1>{site.siteMetadata.title}</h1>
     )
@@ -111,7 +111,7 @@ it(`Transforms queries and preserves variable type in useStaticQuery`, () => {
   export default () => {
     const query = graphql\`{site { siteMetadata { title }}}\`
     let { site } = useStaticQuery(query)
-    
+
     return (
       <h1>{site.siteMetadata.title}</h1>
     )
@@ -142,18 +142,18 @@ it(`Transforms only the call expression in useStaticQuery`, () => {
   matchesSnapshot(`
   import React from "react"
   import { graphql, useStaticQuery } from "gatsby"
-  
+
   const useSiteMetadata = () => {
     return useStaticQuery(
       graphql\`{site { siteMetadata { title }}}\`
     ).site.siteMetadata
   }
-  
+
   export default () => {
     const siteMetadata = useSiteMetadata()
-  
+
     return <h1>{siteMetadata.title}</h1>
-  }    
+  }
   `)
 })
 
@@ -165,7 +165,23 @@ it(`Only runs transforms if useStaticQuery is imported from gatsby`, () => {
   export default () => {
     const query = graphql\`{site { siteMetadata { title }}}\`
     const siteTitle = useStaticQuery(query)
-    
+
+    return (
+      <h1>{siteTitle.site.siteMetadata.title}</h1>
+    )
+  }
+  `)
+})
+
+it(`Allow alternative import of useStaticQuery`, () => {
+  matchesSnapshot(`
+  import React from 'react'
+  import * as Gatsby from 'gatsby'
+
+  export default () => {
+    const query = Gatsby.graphql\`{site { siteMetadata { title }}}\`
+    const siteTitle = Gatsby.useStaticQuery(query)
+
     return (
       <h1>{siteTitle.site.siteMetadata.title}</h1>
     )
@@ -270,7 +286,6 @@ it(`distinguishes between the right tags`, () => {
       animation-timing-function: ease-out;
     }
   \`;
-
 
   export const query = graphql\`
      {

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -86,6 +86,160 @@ query PageQueryName {
           "directives": Array [],
           "kind": "OperationDefinition",
           "loc": Object {
+            "end": 34,
+            "start": 1,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 24,
+              "start": 7,
+            },
+            "value": "PageQueryIndirect",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 34,
+              "start": 25,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 32,
+                  "start": 29,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 32,
+                    "start": 29,
+                  },
+                  "value": "foo",
+                },
+                "selectionSet": undefined,
+              },
+            ],
+          },
+          "variableDefinitions": Array [],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 35,
+        "start": 0,
+      },
+    },
+    "filePath": "page-query-indirect.js",
+    "hash": 1041797972,
+    "isHook": false,
+    "isStaticQuery": false,
+    "templateLoc": SourceLocation {
+      "end": Position {
+        "column": 0,
+        "line": 6,
+      },
+      "filename": true,
+      "start": Position {
+        "column": 26,
+        "line": 2,
+      },
+    },
+    "text": "
+query PageQueryIndirect {
+  foo
+}
+",
+  },
+  Object {
+    "doc": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "loc": Object {
+            "end": 35,
+            "start": 1,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 25,
+              "start": 7,
+            },
+            "value": "PageQueryIndirect2",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 35,
+              "start": 26,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 33,
+                  "start": 30,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 33,
+                    "start": 30,
+                  },
+                  "value": "foo",
+                },
+                "selectionSet": undefined,
+              },
+            ],
+          },
+          "variableDefinitions": Array [],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 36,
+        "start": 0,
+      },
+    },
+    "filePath": "page-query-indirect-2.js",
+    "hash": 934529778,
+    "isHook": false,
+    "isStaticQuery": false,
+    "templateLoc": SourceLocation {
+      "end": Position {
+        "column": 0,
+        "line": 6,
+      },
+      "filename": true,
+      "start": Position {
+        "column": 26,
+        "line": 2,
+      },
+    },
+    "text": "
+query PageQueryIndirect2 {
+  foo
+}
+",
+  },
+  Object {
+    "doc": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "loc": Object {
             "end": 16,
             "start": 1,
           },

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -1384,6 +1384,79 @@ query {
         "start": 0,
       },
     },
+    "filePath": "static-query-hooks-alternative-import.js",
+    "hash": 407706182,
+    "isHook": true,
+    "isStaticQuery": true,
+    "templateLoc": SourceLocation {
+      "end": Position {
+        "column": 81,
+        "line": 3,
+      },
+      "filename": true,
+      "start": Position {
+        "column": 52,
+        "line": 3,
+      },
+    },
+    "text": "query StaticQueryName { foo }",
+  },
+  Object {
+    "doc": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "loc": Object {
+            "end": 29,
+            "start": 0,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 21,
+              "start": 6,
+            },
+            "value": "StaticQueryName",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 29,
+              "start": 22,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 27,
+                  "start": 24,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 27,
+                    "start": 24,
+                  },
+                  "value": "foo",
+                },
+                "selectionSet": undefined,
+              },
+            ],
+          },
+          "variableDefinitions": Array [],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 29,
+        "start": 0,
+      },
+    },
     "filePath": "static-query-hooks-with-type-parameter.ts",
     "hash": 407706182,
     "isHook": true,

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -150,6 +150,11 @@ export default () => {
   const data = useStaticQuery(graphql\`query StaticQueryName { foo }\`);
   return <div>{data.doo}</div>;
 }`,
+    "static-query-hooks-alternative-import.js": `import * as Gatsby from 'gatsby'
+export default () => {
+  const data = Gatsby.useStaticQuery(Gatsby.graphql\`query StaticQueryName { foo }\`);
+  return <div>{data.doo}</div>;
+}`,
     "static-query-hooks-with-type-parameter.ts": `import { graphql, useStaticQuery } from 'gatsby'
 export default () => {
   const data = useStaticQuery<HomepageQuery>(graphql\`query StaticQueryName { foo }\`);

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -23,6 +23,23 @@ query PageQueryName {
   foo
 }
 \``,
+    "page-query-indirect.js": `import { graphql } from 'gatsby'
+    const query = graphql\`
+query PageQueryIndirect {
+  foo
+}
+\`
+export { query }
+`,
+    "page-query-indirect-2.js": `import { graphql } from 'gatsby'
+    const query = graphql\`
+query PageQueryIndirect2 {
+  foo
+}
+\`
+const query2 = query;
+export { query2 }
+`,
     "page-query-no-name.js": `import { graphql } from 'gatsby'
   export const query = graphql\`
 query {


### PR DESCRIPTION
## Description

Currently useStaticQuery can only be imported like this to work:

```js
import { useStaticQuery } from 'gatsby'
```

I'm in process of writing bindings to Gatsby for ReasonML/Bucklescript. Currently it compiles every ES6 import like this

```js
import * as Gatsby from 'gatsby'
...
Gatsby.useStaticQuery(...)
```

With this syntax the static query is not extracted in the babel plugin. This PR fixes that.

### Documentation

I don't think this needs to be a documented feature. It is nice though that it works for people that prefer this syntax for various reasons, but it shouldn't be the sanctioned way to import useStaticQuery.
