### PR TITLE
Improve comment for when we auto-close a PR in a starter repo

### DIFF
--- a/peril/rules/pull-request-on-starter.ts
+++ b/peril/rules/pull-request-on-starter.ts
@@ -6,7 +6,13 @@ Hey, @${username}
 
 Thank you for your pull request!
 
- We've moved all our starters over to https://github.com/gatsbyjs/gatsby. Please reopen this there. 
+This repo is now a read-only repo that's synced from the main Gatsby monorepo at https://github.com/gatsbyjs/gatsby/.
+
+We've moved all our starters to https://github.com/gatsbyjs/gatsby/tree/master/starters so changes to starters are made there.
+
+Please checkout our contribution docs & recreate your PR against the starter directory in monorepo.
+
+https://www.gatsbyjs.org/contributing/how-to-open-a-pull-request/
 
 Thanks again!
 `


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
