### PR TITLE
test(gatsby-cli): update active NodeJS version

### DIFF
--- a/packages/gatsby-cli/src/__tests__/index.js
+++ b/packages/gatsby-cli/src/__tests__/index.js
@@ -58,7 +58,7 @@ describe(`error handling`, () => {
 
 describe(`normal behavior`, () => {
   it(`does not panic on Node >= 8.0.0`, () => {
-    ;[`8.0.0`, `8.9.0`, `10.0.0`, `12.0.0`].forEach(version => {
+    ;[`8.0.0`, `8.9.0`, `10.0.0`, `12.0.0`, `13.0.0`].forEach(version => {
       const { reporter } = setup(version)
 
       expect(reporter.panic).not.toHaveBeenCalled()

--- a/packages/gatsby-cli/src/__tests__/index.js
+++ b/packages/gatsby-cli/src/__tests__/index.js
@@ -58,7 +58,7 @@ describe(`error handling`, () => {
 
 describe(`normal behavior`, () => {
   it(`does not panic on Node >= 8.0.0`, () => {
-    ;[`8.0.0`, `8.9.0`, `10.0.0`, `11.0.0`, `12.0.0`].forEach(version => {
+    ;[`8.0.0`, `8.9.0`, `10.0.0`, `12.0.0`].forEach(version => {
       const { reporter } = setup(version)
 
       expect(reporter.panic).not.toHaveBeenCalled()


### PR DESCRIPTION
Node.js v11 has been already deprecated and v13 is active now.
Please see https://nodejs.org/en/about/releases/

<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
