### PR TITLE
fix(blog): fixes for the export drupal to gatsby post

### DIFF
--- a/docs/blog/2018-10-26-export-a-drupal-site-to-gatsby/index.md
+++ b/docs/blog/2018-10-26-export-a-drupal-site-to-gatsby/index.md
@@ -21,12 +21,13 @@ To do this yourself, you'll build a simple blog using the excellent [gatsby-star
 ```
 gatsby new gatsby-blog https://github.com/gatsbyjs/gatsby-starter-blog
 git init # so you can keep track of the changes
-npm i --save-dev better-sqlite3
+npm i # to install regular gastby requirements
+npm i --save-dev better-sqlite3 # to add an sqlite javascript client
 ```
 
 The useful commands on an sqlite3 command line to explore are `.tables` to see all tables :) and `.schema table_name` to see information about a specific table. Oh! and `.help` to know more.
 
-Next, you will be creating a new file on your project at `src/scripts/migrate.js`. Initially, what you want is to iterate through all your posts and export basic data like title, created date, body and status (published or draft). All of that data is in two tables, the _node_ table and the _field_data_body_. Initially, your script will look like this:
+Next, you will be creating a new file on your project at `src/scripts/import.js`. Initially, what you want is to iterate through all your posts and export basic data like title, created date, body and status (published or draft). All of that data is in two tables, the _node_ table and the _field_data_body_. Initially, your script will look like this:
 
 ```javascript
 const Database = require('better-sqlite3');
@@ -58,6 +59,15 @@ const tags = db
   )
   .pluck()
   .all(row.nid)
+```
+
+To avoid 404 in case you created some url aliases you can query the `url_alias` table and create an aliases frontmatter property and later (depending on your hosting platform) use a plugin like [gatsby-plugin-meta-redirect](https://github.com/nsresulta/gatsby-plugin-meta-redirect) to use the gatsby [createRedirect](https://www.gatsbyjs.org/docs/actions/#createRedirect) function:
+
+```javascript
+const aliases = db.prepare(`SELECT alias FROM url_alias
+    WHERE source = ? AND alias != ?`)
+    .pluck()
+    .all('node/' + row.nid, slug);
 ```
 
 For the image, you will retrieve only the URL of the image, so you can download it and store it locally. And you will replace `public://` for the URL path of the images folder on your old site:

--- a/docs/blog/2018-10-26-export-a-drupal-site-to-gatsby/index.md
+++ b/docs/blog/2018-10-26-export-a-drupal-site-to-gatsby/index.md
@@ -64,10 +64,13 @@ const tags = db
 To avoid 404 in case you created some url aliases you can query the `url_alias` table and create an aliases frontmatter property and later (depending on your hosting platform) use a plugin like [gatsby-plugin-meta-redirect](https://github.com/nsresulta/gatsby-plugin-meta-redirect) to use the gatsby [createRedirect](https://www.gatsbyjs.org/docs/actions/#createRedirect) function:
 
 ```javascript
-const aliases = db.prepare(`SELECT alias FROM url_alias
-    WHERE source = ? AND alias != ?`)
-    .pluck()
-    .all('node/' + row.nid, slug);
+const aliases = db
+  .prepare(
+    `SELECT alias FROM url_alias
+    WHERE source = ? AND alias != ?`
+  )
+  .pluck()
+  .all("node/" + row.nid, slug)
 ```
 
 For the image, you will retrieve only the URL of the image, so you can download it and store it locally. And you will replace `public://` for the URL path of the images folder on your old site:


### PR DESCRIPTION
Thanks to https://www.drupal.org/u/klokie who sent some fixes and suggestions via email for this blog post:

1. After `git init`, the next step should be `npm install` and then `npm i
--save-dev better-sqlite3`.
2. You mention that you named the script `src/scripts/migrate.js`, but refer
to it afterward as `src/scripts/import.js`, so it should probably be named
`src/scripts/import.js`.
3. `aliases` is never defined - what should it be?

<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
