### PR TITLE
fix(gatsby-remark-autolink-headers): Scroll to document top

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
@@ -5,9 +5,15 @@ const getTargetOffset = hash => {
   if (id !== ``) {
     const element = document.getElementById(id)
     if (element) {
-      let scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
-      let clientTop = document.documentElement.clientTop || document.body.clientTop || 0;
-      return element.getBoundingClientRect().top +  scrollTop - clientTop - offsetY;
+      let scrollTop =
+        window.pageYOffset ||
+        document.documentElement.scrollTop ||
+        document.body.scrollTop
+      let clientTop =
+        document.documentElement.clientTop || document.body.clientTop || 0
+      return (
+        element.getBoundingClientRect().top + scrollTop - clientTop - offsetY
+      )
     }
   }
   return null

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
@@ -5,7 +5,9 @@ const getTargetOffset = hash => {
   if (id !== ``) {
     const element = document.getElementById(id)
     if (element) {
-      return element.offsetTop - offsetY
+      let scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
+      let clientTop = document.documentElement.clientTop || document.body.clientTop || 0;
+      return element.getBoundingClientRect().top +  scrollTop - clientTop - offsetY;
     }
   }
   return null

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -54,7 +54,9 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
       if (hash !== '') {
         var element = document.getElementById(hash)
         if (element) {
-          var offset = element.offsetTop
+          let scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop
+          let clientTop = document.documentElement.clientTop || document.body.clientTop || 0
+          var offset = element.getBoundingClientRect().top + scrollTop - clientTop
           // Wait for the browser to finish rendering before scrolling.
           setTimeout((function() {
             window.scrollTo(0, offset - ${offsetY})


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Calculates scroll position in autolink-headers relative to document top instead of closest relative parent

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #20362 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
