### PR TITLE
chore(doc): Fix variable issue in submit to showcase/starter docs

### DIFF
--- a/docs/contributing/site-showcase-submissions.md
+++ b/docs/contributing/site-showcase-submissions.md
@@ -28,7 +28,7 @@ There are three major steps:
 
   # optional: short paragraph describing the content and/or purpose of the site that will appear in the modal detail view and permalink views for your site
   description: >
-    {titleofthesite} is a shiny new website built with Gatsby v2 that makes important contributions towards a faster web for everyone.
+    This blog is a shiny new website built with Gatsby v2 that makes important contributions towards a faster web for everyone.
 
   # You can list as many categories as you want here. Check list of Categories below in this doc!
   # If you'd like to create a new category, simply list it here.


### PR DESCRIPTION
## Description

As contributor I would like to have a clear understanding of "[submit site to showcase](https://www.gatsbyjs.org/contributing/site-showcase-submissions/)" contribution. The issue I see in this doc is a `{titleofthesite}, {username}` variables misunderstanding. Some of contributors threat it as a real variable which they can put to e.g. `description section` and it will be replaced on built time. But it does not work this way. 

This fix should prevent contributors to use `{titleofthesite}` and `{username}` by making clear that these are not variables.

### Documentation

https://www.gatsbyjs.org/contributing/site-showcase-submissions/
Related to: https://www.gatsbyjs.org/contributing/submit-to-starter-library/

## Related Issues

Related to #20365
Related to #20332 
