### PR TITLE
fix headers and add saved replies references

### DIFF
--- a/docs/contributing/triaging-github-issues/index.md
+++ b/docs/contributing/triaging-github-issues/index.md
@@ -67,7 +67,7 @@ Check out [the docs on issue labeling for more info](/contributing/how-to-label-
 
 Issues are categorized into one of five types: question or discussion, bug report, feature request, documentation, or maintenance.
 
-### Questions with immediate answers
+#### Questions with immediate answers
 
 - Point to existing documentation to answer the question
 - If insufficient, do the following:
@@ -89,7 +89,7 @@ If the reproduction is successful, label the issue with `confirmed` and determin
 
 #### Feature Request
 
-Feature Requests are issues that request support for additional functionality not currently covered in the existing codebase. The first step in triaging a feature request is to determine if it's a reasonable request; this is a challenge and if you don't feel comfortable making this determination please label with `inkteam to review`. If it's clear that this isn't a feature it makes sense for Gatsby to implement, provide a comment explaining the decision making and close the issue.
+Feature Requests are issues that request support for additional functionality not currently covered in the existing codebase. The first step in triaging a feature request is to determine if it's a reasonable request; this is a challenge and if you don't feel comfortable making this determination please label with `inkteam to review`. If it's clear that this isn't a feature it makes sense for Gatsby to implement, provide a comment explaining the decision making and close the issue. Review the [saved replies](#saved-replies) to see if there is an appropriate response already available.
 
 If it's determined to be a worthwhile feature, the next decision point is whether the feature should be added to core or upstream. Upstream issues are those that are outside of Gatsby's control and caused by dependencies. Upstream features should be labeled with `upstream` and include comments about the scope.
 
@@ -98,14 +98,16 @@ If it's a core change, is it a breaking change? Breaking changes should be label
 Non-breaking changes can be labeled as `help wanted` and it is often best to ask the creator of the issue if they'd be interested in helping develop the PR.
 ![Flow chart for handling a Feature Request](./FeatureFlow.png)
 
-### Documentation
+#### Documentation
 
 Issues can be filed requesting documentation on a particular topic. Sometimes the documentation already exists, so you can link to it and close the issue.
+
+Alternatively, the issue may be something the team is unable to address. Consider using a [saved reply](#saved-replies) in that circumstance.
 
 Otherwise, label the issue with `documentation` and ask the issuer filer if they'd like to help with a PR.
 ![Flow chart for handling a Documentation Request](./DocumentationFlow.png)
 
-### Maintenance
+#### Maintenance
 
 Maintenance issues are things like bumping a package version. These issues should be labeled with `maintenance`.
 


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
The contributor flow was altered in an earlier PR and a couple outstanding issues remained. This PR fixes header consistency and makes mention of saved replies in a few key places.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Related to #20242