### PR TITLE
chore(gatsby-google-tagmanager): Update README

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -55,7 +55,7 @@ plugins: [
 ]
 ```
 
-This plugin only initiates the tag manager _container_. If you want to use Google Analytics, please also add `gatsby-plugin-google-analytics`. 
+This plugin only initiates the tag manager _container_. If you want to use Google Analytics, please also add `gatsby-plugin-google-analytics`.
 
 If you want to link analytics use with anything inside the container (for example, a cookie consent manager such as OneTrust), you will need to ensure that the tag manager script comes _before_ the analytics script in your `gatsby-config.js`.
 

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -55,6 +55,10 @@ plugins: [
 ]
 ```
 
+This plugin only initiates the tag manager _container_. If you want to use google analytics, please also add gatsby-plugin-google-analytics. 
+
+If you want to link analytics use with anything inside the container (for example, a cookie consent manager such as OneTrust), you will need to ensure that the tag manager script comes _before_ the analytics script in your gatsby-config.js.
+
 #### Tracking routes
 
 This plugin will fire a new event called `gatsby-route-change` whenever a route is changed in your Gatsby application. To record this in Google Tag Manager, we will need to add a trigger to the desired tag to listen for the event:

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -55,9 +55,9 @@ plugins: [
 ]
 ```
 
-This plugin only initiates the tag manager _container_. If you want to use google analytics, please also add gatsby-plugin-google-analytics. 
+This plugin only initiates the tag manager _container_. If you want to use Google Analytics, please also add `gatsby-plugin-google-analytics`. 
 
-If you want to link analytics use with anything inside the container (for example, a cookie consent manager such as OneTrust), you will need to ensure that the tag manager script comes _before_ the analytics script in your gatsby-config.js.
+If you want to link analytics use with anything inside the container (for example, a cookie consent manager such as OneTrust), you will need to ensure that the tag manager script comes _before_ the analytics script in your `gatsby-config.js`.
 
 #### Tracking routes
 


### PR DESCRIPTION
## Description

I just came across this issue where our cookie consent manager was not able to withhold cookies based on consent because it was initiated using our gtm container; by swapping the order of the analytics plugin and gtm plugin in gatsby-config.js, I was able to resolve the issue.