### PR TITLE
chore(starters): add gatsby-starter-darkmode

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -4807,3 +4807,14 @@
     - 📓 Visual testing with Storybook
     - ✔️ CI with GitHub Actions
     - ⚡ CD with Netlify
+- url: https://gatsby-starter-darkmode.now.sh
+  repo: https://github.com/someshkar/gatsby-starter-darkmode
+  description: Gatsby Default Starter with a dark mode using styled-components
+  tags:
+    - Landing Page
+    - Styling:CSS-in-JS
+  features:
+    - Build a landing page with a super simple to configure dark mode
+    - Customizable dark/other themes using the styled-components ThemeProvider
+    - localStorage based retention of user theme selection across reloads
+    - Change the button which toggles themes easily


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR adds my darkmode Gatsby starter to the `starters.yml` file.