### PR TITLE
fix(gatsby-source-contentful): LongText fields require markdown transformer

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -237,7 +237,7 @@ You might query for a **single** node inside a component in your `src/components
 
 #### A note about LongText fields
 
-On Contentful, a "Long text" field uses Markdown by default. The field is exposed as an object, while the raw Markdown is exposed as a child node. 
+On Contentful, a "Long text" field uses Markdown by default. The field is exposed as an object, while the raw Markdown is exposed as a child node.
 
 ```graphql
 {
@@ -248,6 +248,7 @@ On Contentful, a "Long text" field uses Markdown by default. The field is expose
   }
 }
 ```
+
 Unless the text is Markdown-free, you cannot use the returned value directly. In order to handle the Markdown content, you must use a transformer plugin such as [gatsby-transformer-remark](https://www.gatsbyjs.org/packages/gatsby-transformer-remark/). The transformer will create a childMarkdownRemark on the "Long text" field and expose the generated html as a child node:
 
 ```graphql

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -273,6 +273,7 @@ You can then insert the HTML inline in your JSX:
      }}
    />
 ```
+While this solution is not ideal, you can alternatively use "Rich text" fields instead of "Long text" in order to avoid the inline html (see below).
 
 #### Duplicated entries
 

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -237,7 +237,7 @@ You might query for a **single** node inside a component in your `src/components
 
 #### A note about LongText fields
 
-On Contentful, a "Long text" field uses Markdown by default. The field is exposed as an object, while the raw Markdown is exposed as a child node. Except if the content is Markdown-free, you cannot use it as is:
+On Contentful, a "Long text" field uses Markdown by default. The field is exposed as an object, while the raw Markdown is exposed as a child node. 
 
 ```graphql
 {
@@ -248,8 +248,7 @@ On Contentful, a "Long text" field uses Markdown by default. The field is expose
   }
 }
 ```
-
-In order to handle the Markdown content, you must use a transformer plugin such as [gatsby-transformer-remark](https://www.gatsbyjs.org/packages/gatsby-transformer-remark/). The transformer will create a childMarkdownRemark on the "Long text" field and expose the generated html as a child node:
+Unless the text is Markdown-free, you cannot use the returned value directly. In order to handle the Markdown content, you must use a transformer plugin such as [gatsby-transformer-remark](https://www.gatsbyjs.org/packages/gatsby-transformer-remark/). The transformer will create a childMarkdownRemark on the "Long text" field and expose the generated html as a child node:
 
 ```graphql
 {
@@ -263,7 +262,7 @@ In order to handle the Markdown content, you must use a transformer plugin such 
 }
 ```
 
-You can then insert the HTML inline in your JSX:
+You can then insert the returned HTML inline in your JSX:
 
 ```
   <div
@@ -273,8 +272,6 @@ You can then insert the HTML inline in your JSX:
      }}
    />
 ```
-
-While this solution is not ideal, you can alternatively use "Rich text" fields instead of "Long text" in order to avoid the inline html (see below).
 
 #### Duplicated entries
 

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -237,11 +237,11 @@ You might query for a **single** node inside a component in your `src/components
 
 #### A note about LongText fields
 
-If you include fields with a `LongText` type in your Contentful `ContentType`, their returned value will be **an object not a string**. This is because Contentful LongText fields are Markdown by default. In order to handle the Markdown content properly, this field type is created as a child node so Gatsby can transform it to HTML.
+If you include fields with a `LongText` type in your Contentful `ContentType`, their returned value will be **an object not a string**. This is because Contentful LongText fields are Markdown by default. In order to handle the Markdown content properly, this field type is created as a child node so that a transformer plugin such as gatsby-transformer-remark can transform it to HTML.
 
 `ShortText` type fields will be returned as strings.
 
-Querying a **single** `CaseStudy` node with the ShortText properties `title` and `subtitle` and LongText property `body` requires formatting the LongText fields as an object with the _child node containing the exact same field name as the parent_:
+Querying a **single** `CaseStudy` node with the ShortText properties `title` and `subtitle` and LongText property `body` requires formatting the LongText fields as an object with the _child node being the childMarkodwnRemark generated automatically by the gatsby-trasnformer-remark:
 
 ```graphql
 {
@@ -249,11 +249,22 @@ Querying a **single** `CaseStudy` node with the ShortText properties `title` and
     title
     subtitle
     body {
-      body
+      childMarkdownRemark {
+        html
+      }
     }
   }
 }
 ```
+You can then use the LongText html by setting the inner HTML:
+
+```
+  <div dangerouslySetInnerHTML={{
+       __html: data.contentfulCaseStudy.body.childMarkdownRemark.html,
+     }}
+   />
+```
+
 
 #### Duplicated entries
 

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -237,17 +237,23 @@ You might query for a **single** node inside a component in your `src/components
 
 #### A note about LongText fields
 
-If you include fields with a `LongText` type in your Contentful `ContentType`, their returned value will be **an object not a string**. This is because Contentful LongText fields are Markdown by default. In order to handle the Markdown content properly, this field type is created as a child node so that a transformer plugin such as [gatsby-transformer-remark](https://www.gatsbyjs.org/packages/gatsby-transformer-remark/), can transform it to HTML.
-
-`ShortText` type fields will be returned as strings.
-
-Querying a **single** `CaseStudy` node with the ShortText properties `title` and `subtitle` and LongText property `body` requires formatting the LongText fields as an object with the _child node being the childMarkodwnRemark generated automatically by gatsby-transformer-remark:
+On Contentful, a "Long text" field uses Markdown by default. The field is exposed as an object, while the raw Markdown is exposed as a child node. Except if the content is Markdown-free, you cannot use it as is:
 
 ```graphql
 {
   contentfulCaseStudy {
-    title
-    subtitle
+    body {
+      body
+    }
+  }
+}
+```
+
+In order to handle the Markdown content, you must use a transformer plugin such as [gatsby-transformer-remark](https://www.gatsbyjs.org/packages/gatsby-transformer-remark/). The transformer will create a childMarkdownRemark on the "Long text" field and expose the generated html as a child node:
+
+```graphql
+{
+  contentfulCaseStudy {
     body {
       childMarkdownRemark {
         html
@@ -256,15 +262,19 @@ Querying a **single** `CaseStudy` node with the ShortText properties `title` and
   }
 }
 ```
-You can then use the LongText html by setting the inner HTML:
+
+You can then insert the HTML inline in your JSX:
 
 ```
-  <div dangerouslySetInnerHTML={{
+  <div 
+  className="body"
+  dangerouslySetInnerHTML={{
        __html: data.contentfulCaseStudy.body.childMarkdownRemark.html,
      }}
    />
 ```
 
+"Long text" fields can 
 
 #### Duplicated entries
 

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -274,8 +274,6 @@ You can then insert the HTML inline in your JSX:
    />
 ```
 
-"Long text" fields can 
-
 #### Duplicated entries
 
 When Contentful pulls the data, all localizations will be pulled. Therefore, if you have a localization active, it will duplicate the entries. Narrow the search by filtering the query with `node_locale` filter:

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -237,11 +237,11 @@ You might query for a **single** node inside a component in your `src/components
 
 #### A note about LongText fields
 
-If you include fields with a `LongText` type in your Contentful `ContentType`, their returned value will be **an object not a string**. This is because Contentful LongText fields are Markdown by default. In order to handle the Markdown content properly, this field type is created as a child node so that a transformer plugin such as gatsby-transformer-remark can transform it to HTML.
+If you include fields with a `LongText` type in your Contentful `ContentType`, their returned value will be **an object not a string**. This is because Contentful LongText fields are Markdown by default. In order to handle the Markdown content properly, this field type is created as a child node so that a transformer plugin such as gatsby-transformer-remark or react-markdown, can transform it to HTML.
 
 `ShortText` type fields will be returned as strings.
 
-Querying a **single** `CaseStudy` node with the ShortText properties `title` and `subtitle` and LongText property `body` requires formatting the LongText fields as an object with the _child node being the childMarkodwnRemark generated automatically by the gatsby-trasnformer-remark:
+Querying a **single** `CaseStudy` node with the ShortText properties `title` and `subtitle` and LongText property `body` requires formatting the LongText fields as an object with the _child node being the childMarkodwnRemark generated automatically by gatsby-transformer-remark:
 
 ```graphql
 {

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -266,13 +266,14 @@ In order to handle the Markdown content, you must use a transformer plugin such 
 You can then insert the HTML inline in your JSX:
 
 ```
-  <div 
+  <div
   className="body"
   dangerouslySetInnerHTML={{
        __html: data.contentfulCaseStudy.body.childMarkdownRemark.html,
      }}
    />
 ```
+
 While this solution is not ideal, you can alternatively use "Rich text" fields instead of "Long text" in order to avoid the inline html (see below).
 
 #### Duplicated entries

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -237,7 +237,7 @@ You might query for a **single** node inside a component in your `src/components
 
 #### A note about LongText fields
 
-If you include fields with a `LongText` type in your Contentful `ContentType`, their returned value will be **an object not a string**. This is because Contentful LongText fields are Markdown by default. In order to handle the Markdown content properly, this field type is created as a child node so that a transformer plugin such as gatsby-transformer-remark or react-markdown, can transform it to HTML.
+If you include fields with a `LongText` type in your Contentful `ContentType`, their returned value will be **an object not a string**. This is because Contentful LongText fields are Markdown by default. In order to handle the Markdown content properly, this field type is created as a child node so that a transformer plugin such as [gatsby-transformer-remark](https://www.gatsbyjs.org/packages/gatsby-transformer-remark/), can transform it to HTML.
 
 `ShortText` type fields will be returned as strings.
 


### PR DESCRIPTION
**TLDR: The main problem is that if you follow the current documentation, you end up with raw markdown in your pages instead of the expected formatted content**

As shown here: https://github.com/gatsbyjs/gatsby/issues/3205#issuecomment-351603320

> The source plugins still exposes the raw markdown but generally you'd want to use the transformed HTML as in the above code sample.

this means doing the following will return raw markdown instead of html.
```{
body{
  body
  }
}
```
You have to use a transformer plugin to transform the markdown into html.
The doc was misleading since it suggested that using LongText can be used without a transformer, and said that the markdown was transformed by Gatsby (incorrect). As a result, if someone were to follow the example, he would get raw markdown displaying in the webpage, as opposed to the expected result.

<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
