### PR TITLE
docs(writing-documentation-with-docz): Update guide to fix dependencies

### DIFF
--- a/docs/tutorial/writing-documentation-with-docz.md
+++ b/docs/tutorial/writing-documentation-with-docz.md
@@ -27,7 +27,7 @@ cd my-gatsby-site-with-docz
 And install required packages:
 
 ```shell
-npm install --save gatsby-theme-docz@latest
+npm install --save gatsby-theme-docz
 ```
 
 Add `gatsby-theme-docz` under `plugins` in `gatsby-config.js`:

--- a/docs/tutorial/writing-documentation-with-docz.md
+++ b/docs/tutorial/writing-documentation-with-docz.md
@@ -24,10 +24,10 @@ To set up Docz you need to install the Docz Gatsby theme and add some custom con
 cd my-gatsby-site-with-docz
 ```
 
-And install the `gatsby-theme-docz` package:
+And install some required packages:
 
 ```shell
-npm install --save gatsby-theme-docz@next
+npm install --save docz@latest gatsby-theme-docz@latest
 ```
 
 Add `gatsby-theme-docz` under `plugins` in `gatsby-config.js`:

--- a/docs/tutorial/writing-documentation-with-docz.md
+++ b/docs/tutorial/writing-documentation-with-docz.md
@@ -24,10 +24,10 @@ To set up Docz you need to install the Docz Gatsby theme and add some custom con
 cd my-gatsby-site-with-docz
 ```
 
-And install some required packages:
+And install required packages:
 
 ```shell
-npm install --save docz@latest gatsby-theme-docz@latest
+npm install --save gatsby-theme-docz@latest
 ```
 
 Add `gatsby-theme-docz` under `plugins` in `gatsby-config.js`:


### PR DESCRIPTION
The documentation to install `docz` is outdated and will not install the core `docz` if you follow the documentation.

Additionally, as it currently stands, we are pulling in the alpha versions of packages. This is risky. We should update this to pull in the `latest` stable version of the package instead of `next`.

Changing the docs to `npm install --save docz@latest gatsby-theme-docz@latest` would better suit this guide and allow for a working install.

Fixes #20386 


