### PR TITLE
docs: Update gatsby-cli ReadMe for develop PORT env var

### DIFF
--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -78,9 +78,9 @@ development server.
 
 #### Options
 
-|     Option      | Description                                     | Default              |
+|     Option      | Description                                     |       Default        |
 | :-------------: | ----------------------------------------------- | :------------------: |
-| `-H`, `--host`  | Set host.                                       | `localhost`          |
+| `-H`, `--host`  | Set host.                                       |     `localhost`      |
 | `-p`, `--port`  | Set port.                                       | `env.PORT` or `8000` |
 | `-o`, `--open`  | Open the site in your (default) browser for you |                      |
 | `-S`, `--https` | Use HTTPS                                       |                      |

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -78,12 +78,12 @@ development server.
 
 #### Options
 
-|     Option      | Description                                     |   Default   |
-| :-------------: | ----------------------------------------------- | :---------: |
-| `-H`, `--host`  | Set host.                                       | `localhost` |
-| `-p`, `--port`  | Set port.                                       |   `8000`    |
-| `-o`, `--open`  | Open the site in your (default) browser for you |             |
-| `-S`, `--https` | Use HTTPS                                       |             |
+|     Option      | Description                                     | Default              |
+| :-------------: | ----------------------------------------------- | :------------------: |
+| `-H`, `--host`  | Set host.                                       | `localhost`          |
+| `-p`, `--port`  | Set port.                                       | `env.PORT` or `8000` |
+| `-o`, `--open`  | Open the site in your (default) browser for you |                      |
+| `-S`, `--https` | Use HTTPS                                       |                      |
 
 Follow the [Local HTTPS guide](https://www.gatsbyjs.org/docs/local-https/)
 to find out how you can set up an HTTPS development server using Gatsby.


### PR DESCRIPTION
## Description

Updates defaults in gatsby-cli ReadMe to note the fallback to `env.PORT` if it is provided.

## Related Issues

Updates reference not caught in #20250 and thus fixes #20214.