### PR TITLE
chore(starters): add gatsby-starter-resume-cms

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -4831,7 +4831,7 @@
     - ✔️ CI with GitHub Actions
     - ⚡ CD with Netlify
 - url: https://gatsby-resume-starter.netlify.com/
-  repo: https://github.com/barancezayirli/gatsby-resume-tailwind
+  repo: https://github.com/barancezayirli/gatsby-starter-resume-cms
   description: Resume starter styled using Tailwind with Netlify CMS as headless CMS.
   tags:
     - CMS:Headless

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -4830,3 +4830,21 @@
     - 📓 Visual testing with Storybook
     - ✔️ CI with GitHub Actions
     - ⚡ CD with Netlify
+- url: https://gatsby-resume-starter.netlify.com/
+  repo: https://github.com/barancezayirli/gatsby-resume-tailwind
+  description: Resume starter styled using Tailwind with Netlify CMS as headless CMS.
+  tags:
+    - CMS:Headless
+    - SEO
+    - PWA
+    - Portfolio
+  features:
+    - One-page resume/CV
+    - PWA
+    - Multiple Netlify CMS widgets
+    - Netlify CMS as Headless CMS
+    - Tailwind for styling with theming
+    - Optimized build process (purge css)
+    - Basic SEO, site metadata
+    - Prettier
+    - Social media links


### PR DESCRIPTION
<!-- Gatsby OSS team is on holiday, expect a delayed response -->

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

It is a resume/CV starter with Netlify CMS as the headless CMS for editing content.
