### PR TITLE
Update URL for development dot env file

### DIFF
--- a/docs/blog/2019-01-01-publish-multiple-gatsby-sites/index.md
+++ b/docs/blog/2019-01-01-publish-multiple-gatsby-sites/index.md
@@ -335,7 +335,7 @@ This adds the `dotenv` module to only the blog and shop packages, this way we do
 
 Create a new file in your shop package called `.env.development` and `.env.production`. Inside the former, add the following line:
 
-`BLOG_URL=https://localhost:8000`
+`BLOG_URL=http://localhost:8000`
 
 Leave the production file alone for now and repeat for blog package, just change the name of the variable to `SHOP_URL` and the port to `8001`.
 


### PR DESCRIPTION
Updated URL since there was an issue using the URL pointing to the blog since it should not be https (no SSL when using local gatsby develop, at least with default configurations). Of course, the production env file will be different and HTTPS would be recommended on the production one.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
