### PR TITLE
fix(netlify-cms-plugin): remove preview styles from global context

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -31,8 +31,10 @@ if (PRODUCTION) {
    */
   window.addEventListener(`DOMContentLoaded`, event => {
     const list = document.querySelectorAll(`link[rel='stylesheet']`)
-    list.forEach(({ href }) => {
-      CMS.registerPreviewStyle(href)
+    list.forEach(link => {
+      CMS.registerPreviewStyle(link.href)
+      // remove the preview style from the CMS context
+      link.parentNode.removeChild(link)
     })
   })
 }


### PR DESCRIPTION
## Description
Removes CMS preview styles so they don't collide with the CMS's styles

## Related Issues
Fixes #20428