### PR TITLE
fix(gatsby-cli): normalize case of windows drive letter

### DIFF
--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -7,12 +7,16 @@ import createCli from "./create-cli"
 import report from "./reporter"
 import pkg from "../package.json"
 import updateNotifier from "update-notifier"
+import normalizeWindowsCwd from "./util/normalize-windows-cwd"
 
 const useJsonLogger = process.argv.slice(2).some(arg => arg.includes(`json`))
 
 if (useJsonLogger) {
   process.env.GATSBY_LOGGER = `json`
 }
+
+// Ensure stable runs on Windows when started from different shells (i.e. c:\dir vs C:\dir)
+normalizeWindowsCwd()
 
 // Check if update is available
 updateNotifier({ pkg }).notify({ isGlobal: true })

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
 import "@babel/polyfill"
+import os from "os"
 import semver from "semver"
 import util from "util"
 import createCli from "./create-cli"
 import report from "./reporter"
 import pkg from "../package.json"
 import updateNotifier from "update-notifier"
-import normalizeWindowsCwd from "./util/normalize-windows-cwd"
+import ensureWindowsDriveLetterIsUppercase from "./util/ensure-windows-drive-letter-is-uppercase"
 
 const useJsonLogger = process.argv.slice(2).some(arg => arg.includes(`json`))
 
@@ -16,7 +17,9 @@ if (useJsonLogger) {
 }
 
 // Ensure stable runs on Windows when started from different shells (i.e. c:\dir vs C:\dir)
-normalizeWindowsCwd()
+if (os.platform() === `win32`) {
+  ensureWindowsDriveLetterIsUppercase()
+}
 
 // Check if update is available
 updateNotifier({ pkg }).notify({ isGlobal: true })

--- a/packages/gatsby-cli/src/util/ensure-windows-drive-letter-is-uppercase.js
+++ b/packages/gatsby-cli/src/util/ensure-windows-drive-letter-is-uppercase.js
@@ -1,4 +1,4 @@
-const { platform, tmpdir } = require(`os`)
+const { tmpdir } = require(`os`)
 const report = require(`../reporter`)
 
 /**
@@ -20,10 +20,7 @@ const report = require(`../reporter`)
  * and then the next one from "C:" shell, you may get a bunch of webpack warnings
  * because it expects module paths to be case-sensitive.
  */
-module.exports = function normalizeWindowsCwd() {
-  if (platform() !== `win32`) {
-    return
-  }
+module.exports = function ensureWindowsDriveLetterIsUppercase() {
   const cwd = process.cwd()
   const normalizedCwd = driveLetterToUpperCase(cwd)
 

--- a/packages/gatsby-cli/src/util/normalize-windows-cwd.js
+++ b/packages/gatsby-cli/src/util/normalize-windows-cwd.js
@@ -1,0 +1,62 @@
+const { platform, tmpdir } = require(`os`)
+const report = require(`../reporter`)
+
+/**
+ * This function ensures that the current working directory on Windows
+ * always has an uppercase drive letter (i.e., C: vs. c:).
+ *
+ * Why?
+ * 1. Different utils like "true-case-path", "normalize-path", "slash" treat Windows
+ * drive letter differently. "true-case-path" will uppercase, others usually don't care.
+ * As a result path normalization produces different results depending on current cwd (c: vs. C:)
+ * which manifests in weird bugs that are very hard to debug.
+ *
+ * We can't control community plugins or site code, so everything should be working
+ * even with a different set of libraries.
+ *
+ * Related: https://github.com/Profiscience/true-case-path/issues/3
+ *
+ * 2. Builds save some paths in a cache. If you run the first build from "c:" shell
+ * and then the next one from "C:" shell, you may get a bunch of webpack warnings
+ * because it expects module paths to be case-sensitive.
+ */
+module.exports = function normalizeWindowsCwd() {
+  if (platform() !== `win32`) {
+    return
+  }
+  const cwd = process.cwd()
+  const normalizedCwd = driveLetterToUpperCase(cwd)
+
+  if (cwd !== normalizedCwd) {
+    try {
+      // When cwd is "c:\dir" then command "cd C:\dir" won't do anything
+      // You have to change the dir twice to actually change the casing of the path
+      process.chdir(tmpdir())
+      process.chdir(normalizedCwd)
+    } catch {
+      // rollback
+      process.chdir(cwd)
+    }
+
+    if (normalizedCwd !== process.cwd()) {
+      report.warn(
+        report.stripIndent(`
+          Your working directory has a lowercase drive letter:
+            "${cwd}".
+          For stable cross-platform builds we recommend switching it to:
+            "${normalizedCwd}".
+        `)
+      )
+    }
+  }
+}
+
+function driveLetterToUpperCase(path) {
+  const segments = path.split(`:\\`)
+  path =
+    segments.length > 1
+      ? segments.shift().toUpperCase() + `:\\` + segments.join(`:\\`)
+      : path
+
+  return path
+}

--- a/packages/gatsby-cli/src/util/normalize-windows-cwd.js
+++ b/packages/gatsby-cli/src/util/normalize-windows-cwd.js
@@ -53,10 +53,7 @@ module.exports = function normalizeWindowsCwd() {
 
 function driveLetterToUpperCase(path) {
   const segments = path.split(`:\\`)
-  path =
-    segments.length > 1
-      ? segments.shift().toUpperCase() + `:\\` + segments.join(`:\\`)
-      : path
-
-  return path
+  return segments.length > 1
+    ? segments.shift().toUpperCase() + `:\\` + segments.join(`:\\`)
+    : path
 }

--- a/packages/gatsby-cli/src/util/normalize-windows-cwd.js
+++ b/packages/gatsby-cli/src/util/normalize-windows-cwd.js
@@ -41,10 +41,13 @@ module.exports = function normalizeWindowsCwd() {
     if (normalizedCwd !== process.cwd()) {
       report.warn(
         report.stripIndent(`
-          Your working directory has a lowercase drive letter:
+          Your working directory has a lower case drive letter:
             "${cwd}".
-          For stable cross-platform builds we recommend switching it to:
-            "${normalizedCwd}".
+          ---^
+          For solid development experience, we recommend switching it to upper case:
+            cd "C:\\"
+            cd "${normalizedCwd}"
+          (Windows requires two directory switches to change the case of the drive letter)
         `)
       )
     }


### PR DESCRIPTION
## Description

This PR ensures that the current working directory on Windows always has an uppercase drive letter (i.e., C: vs. c:).

### Motivation
Different utils like "true-case-path", "normalize-path", "slash" treat Windows drive letter differently. "true-case-path" will [uppercase](https://github.com/Profiscience/true-case-path/issues/3), others usually don't care. As a result path normalization produces different results depending on current cwd (c: vs. C:) which manifests in weird issues that are very hard to debug (see related issues bellow).

Ad-hoc fixes like the one introduced in #17492 address the part of the problem but anytime you want to compare a path that is normalized this way you must remember about it and normalize the other side of the comparison the same way.

This is not maintainable (and is especially annoying for those who do not use Windows as they cannot even test it). Things get even worse because we can't really control community plugins or site code but everything should still be working even with a different set of libraries.

This PR is meant to be a general solution to this problem and (hopefully) fix it for good.

### Documentation
N/A (as this is a bugfix)

## Related Issues
https://github.com/Profiscience/true-case-path/issues/3
#16721
#17811
Fixes #19863 
