### PR TITLE
chore(gatsby): Fix bootstrap CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "@babel/core": "^7.7.7",
     "@babel/node": "^7.7.7",
+    "@babel/plugin-transform-typescript": "^7.7.4",
     "@babel/runtime": "^7.7.7",
     "@lerna/prompt": "3.18.5",
     "@types/express": "^4.17.2",

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
@@ -7,7 +7,7 @@ Object {
   "type": "javascript/auto",
   "use": Array [
     Object {
-      "loader": "<PROJECT_ROOT>/node_modules/babel-loader/lib/index.js",
+      "loader": "<PROJECT_ROOT>/packages/gatsby/node_modules/babel-loader/lib/index.js",
       "options": Object {
         "babelrc": false,
         "cacheIdentifier": "develop---gatsby-dependencies@1.0.0",


### PR DESCRIPTION
This fixes the bootstrap issue we are seeing in CI. Not sure when or why this was removed but we need it to compile the typescripts