### PR TITLE
chore(gatsby): Prevent eslint from changing type string quotes into backticks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,6 +119,18 @@ module.exports = {
           "error",
           "interface",
         ],
+
+        // Allows us to write unions like `type Foo = "baz" | "bar"`
+        // otherwise eslint will want to switch the strings to backticks,
+        // which then crashes the ts compiler
+        quotes: "off",
+        "@typescript-eslint/quotes": [
+          2,
+          "backtick",
+          {
+            avoidEscape: true,
+          },
+        ],
       },
     },
   ],


### PR DESCRIPTION
This is a quick follow up from #20246 based on @LekoArts's suggestion!