### PR TITLE
chore(github): Disable blank issues and link to Discord and AskGatsbyJS

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Gatsby Discord
+    url: http://gatsby.dev/discord
+    about: Ask questions, get help and discuss new things you're building with the Gatsby community.
+  - name: AskGatsbyJS Twitter
+    url: https://twitter.com/AskGatsbyJS
+    about: The official Twitter account to ask questions and get help with Gatsby.


### PR DESCRIPTION
See docs for this at https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository