### PR TITLE
docs(pair-programming): Require issue or PR and remove getting started sessions

### DIFF
--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -6,12 +6,12 @@ The best part of open source is the community, and every community is stronger w
 
 ## How community pair programming sessions work
 
-1.  Select or create [an issue](https://github.com/gatsbyjs/gatsby/issues) you would like to work on and work on it yourself.
-2.  Create a [Pull Request](https://github.com/gatsbyjs/gatsby/compare) when you encounter any problem.
+1.  Select or create [an issue](https://github.com/gatsbyjs/gatsby/issues) you would like to work on and work on it yourself
+2.  [Create a pull request](https://www.gatsbyjs.org/contributing/how-to-open-a-pull-request/) when you encounter any problem
 3.  Sign up for any available slot on [the open pairing calendar][cal]
-4.  You’ll be paired with one of the Gatsby Inkteam
-5.  Join the video meeting during your time slot (we are using Zoom)
-6.  We'll help you with your PR or Issue!
+4.  You’ll be paired with a Gatsby team member
+5.  Join the video meeting during your time slot (we use [Zoom](https://zoom.us) for meetings)
+6.  We'll help you with your pull request or issue!
 
 ### What we expect in pair programming sessions
 
@@ -21,7 +21,7 @@ If you're interested in support for a commercial Gatsby project, please [get in 
 
 We also expect the following from pair programming participants:
 
-- These sessions tend to work best when you have a specific goal for the session. Preferably you have already selected an issue or have started work and created a work-in-progress pull request.
+- These sessions work best when you have a specific goal for the session. You should choose an issue or pull request that you'd like to work on.
 - If you're new to building with Gatsby we recommend [working through the tutorial](https://www.gatsbyjs.org/tutorial/) before your session. If you get stuck part way through that's a great time to book a pairing session.
 - If you're new to contributing to open source we recommend following the ["Setting Up Your Local Dev Environment" guide](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/) before your session.
 - All participants are expected to adhere to [Gatsby’s code of conduct](/contributing/code-of-conduct/)

--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -6,25 +6,22 @@ The best part of open source is the community, and every community is stronger w
 
 ## How community pair programming sessions work
 
-1.  Sign up for any available slot on [the open pairing calendar][cal]
-2.  You’ll be paired with one of the Gatsby Inkteam
-3.  Join the video meeting during your time slot
-4.  Build, learn, or discuss your Gatsby or other OSS project!
+1.  Select or create [an issue](https://github.com/gatsbyjs/gatsby/issues) you would like to work on and work on it yourself.
+2.  Create a [Pull Request](https://github.com/gatsbyjs/gatsby/compare) when you encounter any problem.
+3.  Sign up for any available slot on [the open pairing calendar][cal]
+4.  You’ll be paired with one of the Gatsby Inkteam
+5.  Join the video meeting during your time slot (we are using Zoom)
+6.  We'll help you with your PR or Issue!
 
 ### What we expect in pair programming sessions
 
-These sessions are intended for people who:
-
-- would like to get started with Gatsby, or
-- would like to get started with contributing to open source software, or
-- would like to work on an issue or pull request related to Gatsby, or
-- are using Gatsby for a personal, open source, charity or education project
+These sessions are intended for people who would like to contribute to Gatsby. We will pair program together to solve an issue or pull request related to Gatsby.
 
 If you're interested in support for a commercial Gatsby project, please [get in touch via the contact page](https://www.gatsbyjs.com/contact-us/).
 
 We also expect the following from pair programming participants:
 
-- These sessions tend to work best when you have a specific goal for the session.
+- These sessions tend to work best when you have a specific goal for the session. Preferably you have already selected and worked on an issue and have created a Pull Request with your work.
 - If you're new to building with Gatsby we recommend [working through the tutorial](https://www.gatsbyjs.org/tutorial/) before your session. If you get stuck part way through that's a great time to book a pairing session.
 - If you're new to contributing to open source we recommend following the ["Setting Up Your Local Dev Environment" guide](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/) before your session.
 - All participants are expected to adhere to [Gatsby’s code of conduct](/contributing/code-of-conduct/)

--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -2,7 +2,7 @@
 title: Open Community Pair Programming Sessions
 ---
 
-The best part of open source is the community, and every community is stronger when it works together. To help build the strongest community possible, Gatsby is offering free [one-hour pair programming sessions][cal] to anyone and everyone in the open source community.
+The best part of open source is the community, and every community is stronger when it works together. To help build the strongest community possible, Gatsby is offering free [45 minute pair programming sessions][cal] to anyone and everyone in the open source community.
 
 ## How community pair programming sessions work
 

--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -21,7 +21,7 @@ If you're interested in support for a commercial Gatsby project, please [get in 
 
 We also expect the following from pair programming participants:
 
-- These sessions tend to work best when you have a specific goal for the session. Preferably you have already selected and worked on an issue and have created a Pull Request with your work.
+- These sessions tend to work best when you have a specific goal for the session. Preferably you have already selected an issue or have started work and created a work-in-progress pull request.
 - If you're new to building with Gatsby we recommend [working through the tutorial](https://www.gatsbyjs.org/tutorial/) before your session. If you get stuck part way through that's a great time to book a pairing session.
 - If you're new to contributing to open source we recommend following the ["Setting Up Your Local Dev Environment" guide](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/) before your session.
 - All participants are expected to adhere to [Gatsby’s code of conduct](/contributing/code-of-conduct/)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

Require an issue or PR selected when arranging pair programming calls.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->
