### PR TITLE
chore(gatsby-cli): Add notice for Node 8 EOL

### DIFF
--- a/docs/docs/upgrading-node-js.md
+++ b/docs/docs/upgrading-node-js.md
@@ -16,18 +16,18 @@ Run `node -v` in a terminal to see which version of Node.js you have.
 
 ```shell
 node -v
-v10.16.0
+v10.18.0
 ```
 
-This example shows Node.js version 10, specifically v10.16.0.
+This example shows Node.js version 10, specifically v10.18.0.
 
-## Upgrading from Node.js version 6
+## Upgrading from Node.js version 8
 
-Node.js version 6 reached _End-of-life_ status on 30th April 2019. Many of Gatsby's dependencies are updating to Node.js version 8 and above. Gatsby must also update in order to deliver new features and bug fixes more quickly.
+Node.js version 8 reached _End-of-life_ status on December 31, 2019. Many of Gatsby's dependencies are updating to Node.js version 10 and above. Gatsby must also update in order to deliver new features and bug fixes more quickly.
 
-Generally, it's recommended to use [the Node version whose status is _Active LTS_](https://github.com/nodejs/Release#nodejs-release-working-group) (Node 10 at time of writing). However, in this document, you'll learn how to update from Node 6 to Node 8 as this is likely to be the least disruptive upgrade for you.
+Generally, it's recommended to use [the Node version whose status is _Active LTS_](https://github.com/nodejs/Release#nodejs-release-working-group) (Node 10 at time of writing).
 
-> What about Node.js 7? Stable versions of Node.js are evenly numbered releases - Node.js 6, Node.js 8, Node.js 10 etc. Only use uneven release numbers if you'd like to try cutting-edge and experimental features.
+> What about Node.js 9? Stable versions of Node.js are evenly numbered releases - Node.js 6, Node.js 8, Node.js 10 etc. Only use uneven release numbers if you'd like to try cutting-edge and experimental features.
 
 There are multiple ways to update your version of Node.js depending on how you originally installed it. Read on to find the best approach for you.
 
@@ -37,7 +37,7 @@ This is the recommended way to install a newer version of Node.
 
 You will have homebrew installed on your computer if you [followed part zero of the Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-zero/#-install-nodejs-and-npm). Homebrew is a program that allows you to install specific versions of Node.js (and other software).
 
-To update from Node.js 6 to Node.js 8 using Homebrew, open a terminal and run the following commands:
+To update from Node.js 8 to Node.js 10 using Homebrew, open a terminal and run the following commands:
 
 ```shell
 brew search node
@@ -53,10 +53,10 @@ leafnode                         node ✔                           node@8      
 libbitcoin-node                  node-build                       node_exporter                    nodenv
 ```
 
-You're interested in the next stable version of Node.js after Node.js 6, which is Node.js 8. Homebrew makes this available in a package called `node@8`. Run:
+You're interested in the next stable version of Node.js after Node.js 8, which is Node.js 10. Homebrew makes this available in a package called `node@10`. Run:
 
 ```shell
-brew install node@8
+brew install node@10
 ```
 
 Once that's complete, run:
@@ -65,7 +65,7 @@ Once that's complete, run:
 node -v
 ```
 
-to confirm that you've upgraded from Node.js version 6 up to version 8.
+to confirm that you've upgraded from Node.js version 8 up to version 10.
 
 ### Using a Node.js version management package
 
@@ -84,11 +84,11 @@ nvm
 in a terminal to see if nvm is installed on your system. If it's installed, you can run:
 
 ```shell
-nvm install 8
-nvm alias default 8
+nvm install 10
+nvm alias default 10
 ```
 
-to install and use Node.js version 8.
+to install and use Node.js version 10.
 
 [Check nvm's documentation for further instructions](https://github.com/nvm-sh/nvm).
 
@@ -100,7 +100,7 @@ Run:
 n
 ```
 
-in a terminal to see if n is installed on your system. If it's installed, you can run `n 8` to install and use Node.js version 8.
+in a terminal to see if n is installed on your system. If it's installed, you can run `n 10` to install and use Node.js version 10.
 
 [Check n's documentation for further instructions](https://github.com/tj/n).
 
@@ -116,4 +116,4 @@ Gatsby takes backwards compatibility seriously and aims to support older version
 
 Gatsby also relies on a huge ecosystem of JavaScript dependencies. As the ecosystem moves away from older, unsupported Node.js versions we have to keep pace to ensure that bugs can be fixed and new features can be released.
 
-In this document, you learned how you upgrade from Node.js version 6 (which has reached _End of Life_ status) to Node.js version 8 (which has reached _Maintenance_) status.
+In this document, you learned how you upgrade from Node.js version 8 (which has reached _End of Life_ status) to Node.js version 10.

--- a/packages/gatsby-cli/src/__tests__/index.js
+++ b/packages/gatsby-cli/src/__tests__/index.js
@@ -3,6 +3,7 @@ jest.mock(`../reporter`, () => {
     panic: jest.fn(),
     log: jest.fn(),
     stripIndent: jest.fn(str => str),
+    warn: jest.fn(),
   }
 })
 jest.mock(`../create-cli`)
@@ -51,6 +52,16 @@ describe(`error handling`, () => {
     const { reporter } = setup(`v6.0.0`)
 
     expect(reporter.panic).toHaveBeenCalledWith(
+      expect.stringContaining(`https://gatsby.dev/upgrading-node-js`)
+    )
+  })
+})
+
+describe(`deprecation warning`, () => {
+  it(`warns on Node < 10.13.0`, () => {
+    const { reporter } = setup(`v10.12.0`)
+
+    expect(reporter.warn).toHaveBeenCalledWith(
       expect.stringContaining(`https://gatsby.dev/upgrading-node-js`)
     )
   })

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -17,13 +17,25 @@ if (useJsonLogger) {
 // Check if update is available
 updateNotifier({ pkg }).notify({ isGlobal: true })
 
-const MIN_NODE_VERSION = `>=8.0.0`
+const MIN_NODE_VERSION = `8.0.0`
 
-if (!semver.satisfies(process.version, MIN_NODE_VERSION)) {
+if (!semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`)) {
   report.panic(
     report.stripIndent(`
-      Gatsby requires Node.js v8 or higher (you have ${process.version}).
+      Gatsby requires Node.js ${MIN_NODE_VERSION} or higher (you have ${process.version}).
       Upgrade Node to the latest stable release: https://gatsby.dev/upgrading-node-js
+    `)
+  )
+}
+
+const NEXT_MIN_NODE_VERSION = `10.13.0`
+
+if (!semver.satisfies(process.version, NEXT_MIN_NODE_VERSION)) {
+  report.warn(
+    report.stripIndent(`
+      Gatsby will be dropping support for Node.js ${process.version} soon 
+      and will only actively support ${NEXT_MIN_NODE_VERSION} or higher.
+      Please upgrade Node.js to a currently active LTS release: https://gatsby.dev/upgrading-node-js
     `)
   )
 }

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -30,7 +30,7 @@ if (!semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`)) {
 
 const NEXT_MIN_NODE_VERSION = `10.13.0`
 
-if (!semver.satisfies(process.version, NEXT_MIN_NODE_VERSION)) {
+if (!semver.satisfies(process.version, `>=${NEXT_MIN_NODE_VERSION}`)) {
   report.warn(
     report.stripIndent(`
       Gatsby will be dropping support for Node.js ${process.version} soon 

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -32,8 +32,8 @@ if (!semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`)) {
 if (!semver.satisfies(process.version, `>=${NEXT_MIN_NODE_VERSION}`)) {
   report.warn(
     report.stripIndent(`
-      Gatsby will be dropping support for Node.js ${process.version} soon 
-      and will only actively support ${NEXT_MIN_NODE_VERSION} or higher.
+      Node.js ${process.version} has reached End of Life status on 31 December, 2019. 
+      Gatsby will only actively support ${NEXT_MIN_NODE_VERSION} or higher and drop support for Node 8 soon.
       Please upgrade Node.js to a currently active LTS release: https://gatsby.dev/upgrading-node-js
     `)
   )

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -18,6 +18,7 @@ if (useJsonLogger) {
 updateNotifier({ pkg }).notify({ isGlobal: true })
 
 const MIN_NODE_VERSION = `8.0.0`
+const NEXT_MIN_NODE_VERSION = `10.13.0`
 
 if (!semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`)) {
   report.panic(
@@ -27,8 +28,6 @@ if (!semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`)) {
     `)
   )
 }
-
-const NEXT_MIN_NODE_VERSION = `10.13.0`
 
 if (!semver.satisfies(process.version, `>=${NEXT_MIN_NODE_VERSION}`)) {
   report.warn(


### PR DESCRIPTION
Now that Node 8 has hit EOL, we will stop actively supporting it and raise our minimum supported Node version to the next LTS (10.13) as per [support policy](https://www.gatsbyjs.org/docs/upgrading-node-js/#gatsbys-nodejs-support-policy). 

However, we won't stop support _immediately_ because we currently have roughly 6% of our users using Node < 10.13 (based on data over the past month).

<img width="910" alt="Screenshot 2020-01-06 at 3 13 45 PM" src="https://user-images.githubusercontent.com/7701981/71961934-70237100-321e-11ea-82c7-9ea0afea1883.png">

This PR adds a deprecation warning for now and should set the stage for dropping support in a month from now. 