### PR TITLE
chore(gatsby-remark-katex): Change to new URL and avoid redirect

### DIFF
--- a/packages/gatsby-remark-katex/README.md
+++ b/packages/gatsby-remark-katex/README.md
@@ -60,5 +60,5 @@ $$
 
 [1]: https://www.gatsbyjs.org/packages/gatsby-remark-katex/
 [2]: https://github.com/Rokt33r/remark-math
-[3]: https://github.com/Khan/KaTeX
+[3]: https://github.com/KaTeX/KaTeX
 [4]: https://github.com/gatsbyjs/gatsby/blob/master/examples/using-remark/src/templates/template-blog-post.js


### PR DESCRIPTION
## Description

Updated katex repo URL to current one, that is (https://github.com/KaTeX/KaTeX).
Previously, it was (https://github.com/Khan/KaTeX) and it is now a redirect.