### PR TITLE
perf(gatsby): cache parsing and validation results in graphql-runner

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/__tests__/graphql-runner.js
@@ -1,7 +1,12 @@
 jest.mock(`graphql`)
 
 const createGraphqlRunner = require(`../graphql-runner`)
-const { graphql } = require(`graphql`)
+const { execute, validate, parse } = require(`graphql`)
+
+parse.mockImplementation(() => {
+  return {}
+})
+validate.mockImplementation(() => [])
 
 const createStore = (schema = {}) => {
   return {
@@ -33,9 +38,9 @@ describe(`grapqhl-runner`, () => {
         gatsby: `is awesome`,
       },
     }
-    graphql.mockImplementation(() => Promise.resolve(expectation))
+    execute.mockImplementation(() => Promise.resolve(expectation))
 
-    const result = await graphqlRunner({}, {})
+    const result = await graphqlRunner(``, {})
     expect(reporter.panicOnBuild).not.toHaveBeenCalled()
     expect(result).toBe(expectation)
   })
@@ -51,9 +56,9 @@ describe(`grapqhl-runner`, () => {
         },
       ],
     }
-    graphql.mockImplementation(() => Promise.resolve(expectation))
+    execute.mockImplementation(() => Promise.resolve(expectation))
 
-    const result = await graphqlRunner({}, {})
+    const result = await graphqlRunner(``, {})
     expect(reporter.panicOnBuild).not.toHaveBeenCalled()
     expect(result).toBe(expectation)
   })
@@ -68,13 +73,13 @@ describe(`grapqhl-runner`, () => {
       message: `Cannot query field boyhowdy on RootQueryType`,
     }
 
-    graphql.mockImplementation(() =>
+    execute.mockImplementation(() =>
       Promise.resolve({
         errors: [errorObject],
       })
     )
 
-    await graphqlRunner({}, {})
+    await graphqlRunner(``, {})
     expect(reporter.panicOnBuild).toHaveBeenCalled()
     expect(reporter.panicOnBuild).toMatchSnapshot()
   })

--- a/packages/gatsby/src/query/graphql-runner.js
+++ b/packages/gatsby/src/query/graphql-runner.js
@@ -1,4 +1,5 @@
-const { graphql } = require(`graphql`)
+const { parse, validate, execute } = require(`graphql`)
+const { debounce } = require(`lodash`)
 
 const withResolverContext = require(`../schema/context`)
 const { LocalNodeModel } = require(`../schema/node-model`)
@@ -16,24 +17,68 @@ class GraphQLRunner {
       schemaComposer: schemaCustomization.composer,
       createPageDependency,
     })
+    this.schema = schema
+    this.parseCache = new Map()
+    this.validDocuments = new WeakSet()
+    this.scheduleClearCache = debounce(this.clearCache.bind(this), 5000)
+  }
+
+  clearCache() {
+    this.parseCache.clear()
+    this.validDocuments = new WeakSet()
+  }
+
+  parse(query) {
+    if (!this.parseCache.has(query)) {
+      this.parseCache.set(query, parse(query))
+    }
+    return this.parseCache.get(query)
+  }
+
+  validate(schema, document) {
+    if (!this.validDocuments.has(document)) {
+      const errors = validate(schema, document)
+      if (!errors.length) {
+        this.validDocuments.add(document)
+      }
+      return errors
+    }
+    return []
   }
 
   query(query, context) {
     const { schema, schemaCustomization } = this.store.getState()
 
-    return graphql(
-      schema,
-      query,
-      context,
-      withResolverContext({
-        schema,
-        schemaComposer: schemaCustomization.composer,
-        context,
-        customContext: schemaCustomization.context,
-        nodeModel: this.nodeModel,
-      }),
-      context
-    )
+    if (this.schema !== schema) {
+      this.schema = schema
+      this.clearCache()
+    }
+
+    const document = this.parse(query)
+    const errors = this.validate(schema, document)
+
+    const result =
+      errors.length > 0
+        ? { errors }
+        : execute({
+            schema,
+            document,
+            rootValue: context,
+            contextValue: withResolverContext({
+              schema,
+              schemaComposer: schemaCustomization.composer,
+              context,
+              customContext: schemaCustomization.context,
+              nodeModel: this.nodeModel,
+            }),
+            variableValues: context,
+          })
+
+    // Queries are usually executed in batch. But after the batch is finished
+    // cache just wastes memory without much benefits.
+    // TODO: consider a better strategy for cache purging/invalidation
+    this.scheduleClearCache()
+    return result
   }
 }
 


### PR DESCRIPTION
## Description

This PR introduces a cache for GraphQL parsing and validation steps in the `graphql-runner`, which
improves the performance of query running for about 18% on our synthetic [`benchmarks/query`][1] site.

It is inspired by an [experiment][2] of @pieh with `graphql-jit`. We saw positive numbers from the
`graphql-jit` branch, but it turns out most benefits came from avoiding re-parsing and re-validating
the same query.

Here are some numbers on my laptop (queries per second, higher is better):

Node 10.17.0:

|                 | graphql-js     | graphql-jit |
| --------------- | -------------- | ----------- |
| without caching | 460 (baseline) | 422 (-8.2%) |
| with caching    | 543 (+18%)     | 561 (+22%)  |

Node 13.1.0 (surprisingly slower in general in this benchmark):

|                 | graphql-js     | graphql-jit  |
| --------------- | -------------- | ------------ |
| without caching | 433 (baseline) | 381 (-12%)   |
| with caching    | 510 (+17.8%)   | 514 (+18.7%) |

For each test, I ran the build 7 times using `NUM_PAGES=20000 gatsby build`, ignored the first two
results (warm-up), and averaged the remaining 5. The number in the table is from the "run queries"
steps (queries per second).

### Typical scenario
Say you have 1000 pages with the same template component. Then the `graphql-runner` executes
GraphQL query of this template 1000 times (with different variables).

But GraphQL query execution involves 3 steps:
1. Parsing GraphQL query string to AST
2. Validation of this AST document against GraphQL schema
3. Execution of the AST document (using different variables, context, etc.)

Those steps occur inside the `graphql` function call (which is a facade for those steps).

Before this PR `graphql-runner` was using this `graphql` facade and for the example above
it would have run each step 1000 times (for the same query).

In this PR it runs `parsing` and `validation` only once per query and still runs `execute`
1000 times (with different variables/context).

In general, it should improve the performance of sites executing the same query
many times during the build.

## Thoughts about graphql-jit

Without cache, `graphql-jit` has additional overhead for query compilation. But it performs great
when the query is cached.

In the real-world projects though execution time itself is small comparing to GraphQL resolvers
time (which we see even in this benchmark) but we can get back to `graphql-jit` when we need
to squeeze the last millisecond from query running.

The project is also in a too early stage, but we should definitely keep an eye on it
(it is very promising).

[1]: https://github.com/gatsbyjs/gatsby/tree/master/benchmarks/query
[2]: https://github.com/gatsbyjs/gatsby/compare/graphql-jit
