### PR TITLE
feat(benchmarks): add circleci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,8 +402,27 @@ jobs:
           paths:
             - "*"
 
+  run_benchmarks:
+    docker:
+      - image: circleci/node:12
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ./scripts/build-benchmark.sh
+
 workflows:
   version: 2
+
+  run_benchmarks:
+    jobs: [run_benchmarks]
+    triggers:
+      - schedule:
+          cron: "12 3 * * *" # every day at 03:12
+          filters:
+            branches:
+              only:
+                - master
+
   nightly-react-next:
     triggers:
       - schedule:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,24 @@
+# Benchmarks
+
+Example sites for benchmarking `gatsby`.
+
+## Interface
+
+The standard interface for running a benchmark is:
+
+```
+cd {benchmark directory}
+export NUM_PAGES={n}
+npm install
+gatsby build
+```
+
+If a specific benchmark needs to perform some code generation (e.g. `markdown_id`),
+that generation shall happen in a `postinstall` script.
+Any `postinstall` script must ensure that previous benchmark runs do not interfere with the current run.
+
+For example:
+
+```
+"postinstall": "del-cli ./generated && gatsby clean && npm run generate"
+```

--- a/benchmarks/markdown_id/package.json
+++ b/benchmarks/markdown_id/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "author": "PvdZ <pvdz@github>",
   "dependencies": {
+    "del-cli": "^3.0.0",
     "gatsby": "*",
     "gatsby-image": "*",
     "gatsby-plugin-feed": "*",
@@ -51,6 +52,6 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
     "bench": "rm -r markdown-pages; NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js; gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "benchnb": "gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
-    "postinstall": "NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js"
+    "postinstall": "del-cli markdown-pages && gatsby clean && NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js"
   }
 }

--- a/benchmarks/markdown_slug/package.json
+++ b/benchmarks/markdown_slug/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "author": "PvdZ <pvdz@github>",
   "dependencies": {
+    "del-cli": "^3.0.0",
     "gatsby": "*",
     "gatsby-image": "*",
     "gatsby-plugin-feed": "*",
@@ -51,6 +52,6 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
     "bench": "rm -r markdown-pages; NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js; gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "benchnb": "gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
-    "postinstall": "NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js"
+    "postinstall": "del-cli markdown-pages && gatsby clean && NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js"
   }
 }

--- a/scripts/build-benchmark.sh
+++ b/scripts/build-benchmark.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eux
+
+set -e
+set -u
+set -x
+
+BENCHMARKS=(
+  # create-pages
+  # image-processing
+  markdown_id
+  markdown_slug
+  markdown_table
+  # plugin-manifest
+  # query
+)
+
+SIZES=(
+    1000
+    5000
+   10000
+   25000
+  # 100000
+)
+
+cd benchmarks
+for benchmark in "${BENCHMARKS[@]}"; do
+    cd "${benchmark}"
+    for num in "${SIZES[@]}"; do
+      NUM_PAGES=${num} npm install
+      NUM_PAGES=${num} ./node_modules/.bin/gatsby build
+    done
+    cd ..
+done


### PR DESCRIPTION
# Description

Run each benchmark in CircleCI.
One run for each value of NUM_PAGES

Each benchmark needs to ensure that any generated files are cleaned before the build starts (specifically it needs to clean during the postinstall script).

Co-authored-by: Dustin Schau <dustinschau@gmail.com>