### PR TITLE
docs(What-you-dont-need-plugins-for): Grammar change to aid readability 

### DIFF
--- a/docs/docs/what-you-dont-need-plugins-for.md
+++ b/docs/docs/what-you-dont-need-plugins-for.md
@@ -9,4 +9,6 @@ Some examples:
 - Importing JavaScript packages that provide general functionality, such as `lodash` or `axios`
 - Integrating visualization libraries, such as `Highcharts` or `d3`.
 
-As a general rule, you may use _any_ npm package you might use without Gatsby, with Gatsby. What plugins offer is a prepackaged integration into the core Gatsby APIs to save you time and energy, with minimal configuration. In the case of `Styled Components`, you could manually render the `Provider` component near the root of your application, or you could just use `gatsby-plugin-styled-components` which takes care of this step for you in addition to any other difficulties you may run into configuring Styled Components to work with server side rendering.
+As a general rule, any npm package you might use while working on another JavaScript or React application can also be used ,with a Gatsby application. What plugins offer is a prepackaged integration into the core Gatsby APIs to save you time and energy, with minimal configuration.
+
+A good use case would be using `Styled Components`, you could manually render the `Provider` component near the root of your application, or you could use [gatsby-plugin-styled-components ](https://www.gatsbyjs.org/packages/gatsby-plugin-styled-components/) which takes care of this step for you in addition to any other difficulties when configuring Styled Components to work with server-side rendering.


### PR DESCRIPTION
 Also added hyperlink to styled-component

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

While reading through the Doc for plugins, I saw that the introduction statement for the second paragraph could be a bit more detailed 😄
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
https://www.gatsbyjs.org/docs/what-you-dont-need-plugins-for/
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
Related to #19277
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
