### PR TITLE
fix(babel-preset-gatsby-package): remove node-env check as it's alway…

### DIFF
--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -21,9 +21,6 @@ Array [
   ],
   Array [
     "@babel/preset-react",
-    Object {
-      "development": true,
-    },
   ],
   "@babel/preset-flow",
 ]
@@ -50,9 +47,6 @@ Array [
   ],
   Array [
     "@babel/preset-react",
-    Object {
-      "development": true,
-    },
   ],
   "@babel/preset-flow",
 ]
@@ -80,16 +74,13 @@ Array [
       "modules": "commonjs",
       "shippedProposals": true,
       "targets": Object {
-        "node": "current",
+        "node": "8.0",
       },
       "useBuiltIns": "entry",
     },
   ],
   Array [
     "@babel/preset-react",
-    Object {
-      "development": true,
-    },
   ],
   "@babel/preset-flow",
 ]
@@ -106,16 +97,13 @@ Array [
       "modules": "commonjs",
       "shippedProposals": true,
       "targets": Object {
-        "node": "current",
+        "node": "8.0",
       },
       "useBuiltIns": "entry",
     },
   ],
   Array [
     "@babel/preset-react",
-    Object {
-      "development": true,
-    },
   ],
   "@babel/preset-flow",
 ]
@@ -129,60 +117,5 @@ Array [
   "@babel/plugin-transform-runtime",
   "@babel/plugin-syntax-dynamic-import",
   "babel-plugin-dynamic-import-node",
-]
-`;
-
-exports[`babel-preset-gatsby-package in production mode specifies proper presets for browser mode 1`] = `
-Array [
-  Array [
-    "@babel/preset-env",
-    Object {
-      "debug": false,
-      "loose": true,
-      "modules": "commonjs",
-      "shippedProposals": true,
-      "targets": Object {
-        "browsers": Array [
-          "last 4 versions",
-          "safari >= 7",
-          "ie >= 9",
-        ],
-      },
-      "useBuiltIns": false,
-    },
-  ],
-  Array [
-    "@babel/preset-react",
-    Object {
-      "development": false,
-    },
-  ],
-  "@babel/preset-flow",
-]
-`;
-
-exports[`babel-preset-gatsby-package in production mode specifies proper presets for node mode 1`] = `
-Array [
-  Array [
-    "@babel/preset-env",
-    Object {
-      "corejs": 2,
-      "debug": false,
-      "loose": true,
-      "modules": "commonjs",
-      "shippedProposals": true,
-      "targets": Object {
-        "node": "8.0",
-      },
-      "useBuiltIns": "entry",
-    },
-  ],
-  Array [
-    "@babel/preset-react",
-    Object {
-      "development": false,
-    },
-  ],
-  "@babel/preset-flow",
 ]
 `;

--- a/packages/babel-preset-gatsby-package/__tests__/index.js
+++ b/packages/babel-preset-gatsby-package/__tests__/index.js
@@ -24,8 +24,6 @@ describe(`babel-preset-gatsby-package`, () => {
     })
 
     it(`can pass custom nodeVersion target`, () => {
-      process.env.BABEL_ENV = `production`
-
       const nodeVersion = `6.0`
       const { presets } = preset(null, {
         nodeVersion,
@@ -52,22 +50,6 @@ describe(`babel-preset-gatsby-package`, () => {
 
     it(`specifies proper presets for debugging`, () => {
       const { presets } = preset(null, { browser: true, debug: true })
-      expect(presets).toMatchSnapshot()
-    })
-  })
-
-  describe(`in production mode`, () => {
-    beforeEach(() => {
-      process.env.BABEL_ENV = `production`
-    })
-
-    it(`specifies proper presets for node mode`, () => {
-      const { presets } = preset(null)
-      expect(presets).toMatchSnapshot()
-    })
-
-    it(`specifies proper presets for browser mode`, () => {
-      const { presets } = preset(null, { browser: true })
       expect(presets).toMatchSnapshot()
     })
   })

--- a/packages/babel-preset-gatsby-package/index.js
+++ b/packages/babel-preset-gatsby-package/index.js
@@ -4,15 +4,12 @@ function preset(context, options = {}) {
   const { browser = false, debug = false, nodeVersion = `8.0` } = options
   const { NODE_ENV, BABEL_ENV } = process.env
 
-  const IS_PRODUCTION = (BABEL_ENV || NODE_ENV) === `production`
   const IS_TEST  = (BABEL_ENV || NODE_ENV) === `test`
 
   const browserConfig = {
     useBuiltIns: false,
     targets: {
-      browsers: IS_PRODUCTION
-        ? [`last 4 versions`, `safari >= 7`, `ie >= 9`]
-        : [`last 2 versions`, `not ie <= 11`, `not android 4.4.3`],
+      browsers: [`last 2 versions`, `not ie <= 11`, `not android 4.4.3`],
     },
   }
 
@@ -20,7 +17,7 @@ function preset(context, options = {}) {
     corejs: 2,
     useBuiltIns: `entry`,
     targets: {
-      node: IS_PRODUCTION ? nodeVersion : `current`,
+      node: nodeVersion,
     },
   }
 
@@ -38,7 +35,7 @@ function preset(context, options = {}) {
           browser ? browserConfig : nodeConfig
         ),
       ],
-      [r(`@babel/preset-react`), { development: !IS_PRODUCTION }],
+      [r(`@babel/preset-react`)],
       r(`@babel/preset-flow`),
     ],
     plugins: [


### PR DESCRIPTION
…s false

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I've been upgrading reactjs.org to the latest gatsby version (see https://github.com/reactjs/reactjs.org/pull/2137). Everything worked fine except when I run it using nvmrc (which is set to node 8) it breaks on bad syntax.

Our babel preset has been wrong for a while. Whenever we publish we don't have NODE_ENV or BABEL_ENV set so we publish telling babel to use the current version instead of node 8. :scream:

This fixes that 👍 