### PR TITLE
docs(porting-from-create-react-app-to-gatsby): Add `sessionStorage` to list of common globals

### DIFF
--- a/docs/docs/porting-from-create-react-app-to-gatsby.md
+++ b/docs/docs/porting-from-create-react-app-to-gatsby.md
@@ -121,6 +121,7 @@ Some common globals that would need to be protected are:
 
 - `window`
 - `localStorage`
+- `sessionStorage`
 - `navigator`
 - `document`
 


### PR DESCRIPTION
## Description

Add `sessionStorage` to list of common globals needing protection during `gatsby build` in Server-side rendering and browser APIs section of `porting-from-create-react-app-to-gatsby.mdx`.

I use `sessionStorage` enough that I felt a reminder might be nice if I were starting out with Gatsby or looking to move an existing Create React App website to the framework.

### Documentation

https://www.gatsbyjs.org/docs/porting-from-create-react-app-to-gatsby/#server-side-rendering-and-browser-apis