### PR TITLE
feat(gatsby-source-lever): use schema customization API (#20069)

### DIFF
--- a/packages/gatsby-source-lever/src/gatsby-node.js
+++ b/packages/gatsby-source-lever/src/gatsby-node.js
@@ -3,6 +3,37 @@ const normalize = require(`./normalize`)
 
 const typePrefix = `lever__`
 
+exports.createSchemaCustomization = async ({ actions }) => {
+  const typeDefs = `
+    type lever implements Node @dontInfer {
+      additional: String
+      additionalPlain: String
+      applyUrl: String
+      createdAt: Date @dateformat
+      description: String
+      descriptionPlain: String
+      hostedUrl: String
+      lever_id: String
+      text: String
+      categories: leverCategories
+      lists: [leverList]
+    }
+
+    type leverCategories {
+      commitment: String
+      level: String
+      location:String
+      team: String
+    }
+
+    type leverList {
+      content: String
+      text: String
+    }
+  `
+  actions.createTypes(typeDefs)
+}
+
 exports.sourceNodes = async (
   { actions, getNode, store, cache, createNodeId, createContentDigest },
   { site, verboseOutput }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Start using [schema customization API](https://www.gatsbyjs.org/docs/schema-customization/) for `gatsby-source-lever`

## Related Issues

Part of #20069 

## Comments

I'm not sure whether I've done this PR correctly, so I could use some help from @vladar