### PR TITLE
chore(gatsby): Drop deprecated (and unused) async describe blocks

### DIFF
--- a/packages/gatsby-plugin-feed/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/__tests__/gatsby-node.js
@@ -8,7 +8,7 @@ global.Date = jest.fn(() => DATE_TO_USE)
 global.Date.UTC = _Date.UTC
 global.Date.now = _Date.now
 
-describe(`Test plugin feed`, async () => {
+describe(`Test plugin feed`, () => {
   beforeEach(() => {
     fs.exists = jest.fn().mockResolvedValue(true)
     fs.writeFile = jest.fn().mockResolvedValue()

--- a/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
@@ -12,7 +12,7 @@ beforeEach(() => {
   global.__PATH_PREFIX__ = ``
 })
 
-describe(`Test plugin sitemap`, async () => {
+describe(`Test plugin sitemap`, () => {
   it(`default settings work properly`, async () => {
     internals.writeFile = jest.fn()
     internals.writeFile.mockResolvedValue(true)


### PR DESCRIPTION
Jest has deprecated `describe(() => async`, so this removes the two instances we had, which weren't even really used.