### PR TITLE
chore(gatsby-plugin-no-sourcemaps): Add install header to Readme

### DIFF
--- a/packages/gatsby-plugin-no-sourcemaps/README.md
+++ b/packages/gatsby-plugin-no-sourcemaps/README.md
@@ -2,6 +2,12 @@
 
 For the times when your JavaScript sourcemaps are just too big to upload to your hosting provider.
 
+## Install
+
+```shell
+npm install --save gatsby-plugin-no-sourcemaps
+```
+
 ## Usage
 
 ```js


### PR DESCRIPTION
Added an install heading to instruct users to install the plugin.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
