### PR TITLE
Add dataLayerName check before push in event.

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-browser.js
@@ -69,4 +69,23 @@ describe(`onRouteUpdate`, () => {
 
     expect(window.dataLayer).toHaveLength(1)
   })
+
+  it(`registers new data layer variable if dataLayerName is specified`, () => {
+    const { onRouteUpdate } = getAPI(() => {
+      process.env.NODE_ENV = `production`
+    })
+    const dataLayerName = `fooBarDataLater`
+    window[dataLayerName] = []
+
+    onRouteUpdate(
+      {},
+      {
+        dataLayerName,
+      }
+    )
+
+    jest.runAllTimers()
+
+    expect(window[dataLayerName]).toHaveLength(1)
+  })
 })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -5,7 +5,11 @@ exports.onRouteUpdate = (_, pluginOptions) => {
   ) {
     // wrap inside a timeout to ensure the title has properly been changed
     setTimeout(() => {
-      window.dataLayer.push({ event: `gatsby-route-change` })
+      let data = pluginOptions.dataLayerName
+        ? window[pluginOptions.dataLayerName]
+        : window.dataLayer
+
+      data.push({ event: `gatsby-route-change` })
     }, 50)
   }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

gatsby-plugin-google-tagmanager is supporting renamed data layer from PR #16304. The later on fixing of "captures incorrect page title #13968" ignores these changes in dataLayerName feature.

This PR is created to address the issue described in issue #20536, by adding dataLayerName check, it falls back to dataLayer if dataLayerName is not defined.

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Fixes #20536
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
