### PR TITLE
Fix link to Carbon Design System in documentation

### DIFF
--- a/docs/docs/component-libraries.md
+++ b/docs/docs/component-libraries.md
@@ -4,7 +4,7 @@ title: Creating Component Libraries
 
 Component libraries are often used in component-based UI systems like React and Vue. They are typically versioned repositories of components.
 
-IBM's [Carbon Design System](http://carbondesignsystem.com/) and Palantir's [Blueprint](https://blueprintjs.com/) are both good examples.
+IBM's [Carbon Design System](https://www.carbondesignsystem.com/) and Palantir's [Blueprint](https://blueprintjs.com/) are both good examples.
 
 ## Why component libraries
 


### PR DESCRIPTION
## Description
Looks like IBM's Carbon design system link doesn't work without the `www` (without it, it redirects to a dreamhost error page. This PR adds that + https for the link