### PR TITLE
fix(gatsby-plugin-google-analytics): Value typing

### DIFF
--- a/packages/gatsby-plugin-google-analytics/index.d.ts
+++ b/packages/gatsby-plugin-google-analytics/index.d.ts
@@ -13,7 +13,7 @@ export interface CustomEventArgs {
   category: string
   action: string
   label?: string
-  value?: string
+  value?: number
   nonInteraction?: boolean
   transport?: "beacon" | "xhr" | "image"
   hitCallback?: Function


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fix `gatsby-plugin-google-analytics` type definition.

The `value` parameter for `trackCustomEvent` should be a `number` instead of `string`.

### Documentation

Docs of this plugin and [Google Analytics docs](https://developers.google.com/analytics/devguides/collection/analyticsjs/events#event_fields)
