### PR TITLE
feat(gatsby-plugin-benchmarks): Create benchmark reporting plugin

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/.babelrc
+++ b/packages/gatsby-plugin-benchmark-reporting/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    ["babel-preset-gatsby-package"]
+  ]
+}

--- a/packages/gatsby-plugin-benchmark-reporting/.gitignore
+++ b/packages/gatsby-plugin-benchmark-reporting/.gitignore
@@ -1,0 +1,6 @@
+/lib
+/node_modules
+
+/*.js
+!index.js
+yarn.lock

--- a/packages/gatsby-plugin-benchmark-reporting/.npmignore
+++ b/packages/gatsby-plugin-benchmark-reporting/.npmignore
@@ -1,0 +1,6 @@
+/lib
+/node_modules
+
+/*.js
+!/gatsby-node.js
+yarn.lock

--- a/packages/gatsby-plugin-benchmark-reporting/README.md
+++ b/packages/gatsby-plugin-benchmark-reporting/README.md
@@ -1,0 +1,28 @@
+# gatsby-benchmarks
+
+This plugin is used to send env data / meta information / results when running a benchmark.
+
+The plugin is intended to be used for our internal benchmarking infra.
+
+## Usage
+
+Add the plugin to your gatsby-config.js
+
+```js
+module.exports = {
+  plugins: ["gatsby-plugin-benchmark-reporting"],
+}
+```
+
+The plugin will either logs results to the terminal, or if `BENCHMARK_REPORTING_URL` is set as an environment variable, it will POST a JSON with the results and meta data to given endpoint (url).
+
+By default it logs to terminal.
+
+## Errors
+
+The plugin
+
+- will try to wait for submitted data to complete
+- logs the error message to terminal
+- does not report an error to the remote
+- triggers `exit 1` to signal to the host that an error happened

--- a/packages/gatsby-plugin-benchmark-reporting/index.js
+++ b/packages/gatsby-plugin-benchmark-reporting/index.js
@@ -1,0 +1,1 @@
+// Dummy file to help resolving

--- a/packages/gatsby-plugin-benchmark-reporting/package.json
+++ b/packages/gatsby-plugin-benchmark-reporting/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "gatsby-plugin-benchmark-reporting",
+  "description": "Gatsby Benchmark Reporting",
+  "version": "0.0.0",
+  "author": "Peter van der Zee <pvdz@github>",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-plugin-benchmark-reporting"
+  },
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-benchmark-reporting#readme",
+  "devDependencies": {
+    "babel-preset-gatsby-package": "^0.2.15"
+  },
+  "dependencies": {
+    "fast-glob": "^3.1.1",
+    "node-fetch": "^2.6.0",
+    "uuid": "^3.3.3"
+  },
+  "scripts": {
+    "build": "babel src --out-dir . --ignore **/__tests__",
+    "prepare": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir . --ignore **/__tests__"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  }
+}

--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -1,0 +1,184 @@
+const { performance } = require(`perf_hooks`)
+
+const { sync: glob } = require(`fast-glob`)
+const nodeFetch = require(`node-fetch`)
+const uuidv4 = require(`uuid/v4`)
+
+const bootstrapTime = performance.now()
+
+const BENCHMARK_REPORTING_URL =
+  process.env.BENCHMARK_REPORTING_URL === `cli`
+    ? undefined
+    : process.env.BENCHMARK_REPORTING_URL
+
+// Track the last received `api` because not all events in this plugin will receive one
+let lastApi
+function reportInfo(...args) {
+  ;(lastApi ? lastApi.reporter : console).info(...args)
+}
+function reportError(...args) {
+  ;(lastApi ? lastApi.reporter : console).error(...args)
+}
+
+class BenchMeta {
+  constructor() {
+    this.flushing = undefined // Promise of flushing if that has started
+    this.flushed = false // Completed flushing?
+    this.localTime = new Date().toISOString()
+    this.timestamps = {
+      // TODO: we should also have access to node's timing data and see how long it took before bootstrapping this script
+      bootstrapTime, // Start of this file
+      instantiationTime: performance.now(), // Instantiation time of this class
+      benchmarkStart: 0, // Start of benchmark itself
+      preInit: 0, // Gatsby onPreInit life cycle
+      preBootstrap: 0, // Gatsby onPreBootstrap life cycle
+      preBuild: 0, // Gatsby onPreBuild life cycle
+      postBuild: 0, // Gatsby onPostBuild life cycle
+      benchmarkEnd: 0, // End of benchmark itself
+    }
+    this.started = false
+  }
+
+  getData() {
+    for (const key in this.timestamps) {
+      this.timestamps[key] = Math.floor(this.timestamps[key])
+    }
+
+    const pageCount = glob(`**/**.json`, {
+      cwd: `./public/page-data`,
+      nocase: true,
+    }).length
+
+    return {
+      time: this.localTime,
+      sessionId: uuidv4(),
+      pageCount,
+      timestamps: this.timestamps,
+    }
+  }
+
+  markStart() {
+    if (this.started) {
+      reportError(
+        `gatsby-plugin-benchmark-reporting: `,
+        new Error(`Error: Should not call markStart() more than once`)
+      )
+      process.exit(1)
+    }
+    this.timestamps.benchmarkStart = performance.now()
+    this.started = true
+  }
+
+  markDataPoint(name) {
+    if (BENCHMARK_REPORTING_URL) {
+      if (!(name in this.timestamps)) {
+        reportError(
+          `Attempted to record a timestamp with a name (\`${name}\`) that wasn't expected`
+        )
+        process.exit(1)
+      }
+    }
+    this.timestamps[name] = performance.now()
+  }
+
+  async markEnd() {
+    if (!this.timestamps.benchmarkStart) {
+      reportError(
+        `gatsby-plugin-benchmark-reporting:`,
+        new Error(`Error: Should not call markEnd() before calling markStart()`)
+      )
+      process.exit(1)
+    }
+    this.timestamps.benchmarkEnd = performance.now()
+    return this.flush()
+  }
+
+  async flush() {
+    const data = this.getData()
+    const json = JSON.stringify(data)
+
+    reportInfo(`Submitting data: ` + json)
+
+    if (BENCHMARK_REPORTING_URL) {
+      reportInfo(`Flushing benchmark data to remote server...`)
+
+      let lastStatus = 0
+      this.flushing = nodeFetch(`${BENCHMARK_REPORTING_URL}`, {
+        method: `POST`,
+        headers: {
+          "content-type": `application/json`,
+          // "user-agent": this.getUserAgent(),
+        },
+        body: json,
+      }).then(res => {
+        lastStatus = res.status
+        if (lastStatus === 500) {
+          reportError(
+            `Response error`,
+            new Error(`Server responded with a 500 error`)
+          )
+          process.exit(1)
+        }
+        this.flushed = true
+        // Note: res.text returns a promise
+        return res.text()
+      })
+
+      this.flushing.then(text =>
+        reportInfo(`Server response: ${lastStatus}: ${text}`)
+      )
+
+      return this.flushing
+    }
+
+    // ENV var had no reporting end point
+
+    this.flushed = true
+    return (this.flushing = Promise.resolve())
+  }
+}
+
+process.on(`exit`, () => {
+  if (!benchMeta.flushed) {
+    // This is probably already a non-zero exit as otherwise node should wait for the last promise to complete
+    reportError(
+      `gatsby-plugin-benchmark-reporting error`,
+      new Error(
+        `This is process.exit(); Benchmark plugin has not completely flushed yet`
+      )
+    )
+    process.exit(1)
+  }
+})
+
+const benchMeta = new BenchMeta()
+
+async function onPreInit(api) {
+  lastApi = api
+  // This should be set in the gatsby-config of the site when enabling this plugin
+  reportInfo(
+    `gatsby-plugin-benchmark-reporting: Will post benchmark data to: ${BENCHMARK_REPORTING_URL ||
+      `the CLI`}`
+  )
+
+  benchMeta.markStart()
+  benchMeta.markDataPoint(`preInit`)
+}
+
+async function onPreBootstrap(api) {
+  lastApi = api
+  benchMeta.markDataPoint(`preBootstrap`)
+}
+
+async function onPreBuild(api) {
+  lastApi = api
+  benchMeta.markDataPoint(`preBuild`)
+}
+
+async function onPostBuild(api) {
+  lastApi = api
+  benchMeta.markDataPoint(`postBuild`)
+  return benchMeta.markEnd()
+}
+
+module.exports = { onPreInit, onPreBootstrap, onPreBuild, onPostBuild }


### PR DESCRIPTION
Start of a plugin to report meta data back when running a benchmark (that includes this plugin).

This is different from and unrelated to the telemetry package. 
- For one this benchmark plugin is not automatically enabled, you have to explicitly add it to your site.
- Another reason is the way that stats are reported; this plugin will send everything after the benchmark, assumes no crash will occur.
- Everything is logged at once, rather than incrementally
- And finally this plugin sends a lot of meta data about the state of the repo, code, and state machine. This helps reporting and debugging regressions. We don't have to concern with privacy with this plugin.

This plugin is a shim to get the ball rolling. It will collect some time points and send them as a session id.
Server credentials to be specified in gatsby-config through options when registering the plugin.

The list of options and things to log will expand as time goes on.