### PR TITLE
feat(gatsby-plugin-google-analytics) Pass additional props to the <OutboundLink>

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/index.js
+++ b/packages/gatsby-plugin-google-analytics/src/index.js
@@ -67,6 +67,7 @@ OutboundLink.propTypes = {
   eventCategory: PropTypes.string,
   eventAction: PropTypes.string,
   eventLabel: PropTypes.string,
+  eventValue: PropTypes.number,
   onClick: PropTypes.func,
 }
 

--- a/packages/gatsby-plugin-google-analytics/src/index.js
+++ b/packages/gatsby-plugin-google-analytics/src/index.js
@@ -37,9 +37,9 @@ function OutboundLink(props) {
         }
         if (window.ga) {
           window.ga(`send`, `event`, {
-            eventCategory: `Outbound Link`,
-            eventAction: `click`,
-            eventLabel: props.href,
+            eventCategory: props.eventCategory || `Outbound Link`,
+            eventAction: props.eventAction || `click`,
+            eventLabel: props.eventLabel || props.href,
             transport: redirect ? `beacon` : ``,
             hitCallback: function() {
               if (redirect) {
@@ -62,6 +62,9 @@ function OutboundLink(props) {
 OutboundLink.propTypes = {
   href: PropTypes.string,
   target: PropTypes.string,
+  eventCategory: PropTypes.string,
+  eventAction: PropTypes.string,
+  eventLabel: PropTypes.string,
   onClick: PropTypes.func,
 }
 

--- a/packages/gatsby-plugin-google-analytics/src/index.js
+++ b/packages/gatsby-plugin-google-analytics/src/index.js
@@ -14,9 +14,10 @@ const createFunctionWithTimeout = (callback, opt_timeout = 1000) => {
 }
 
 function OutboundLink(props) {
+  const { eventCategory, eventAction, eventLabel, eventValue, ...rest } = props
   return (
     <a
-      {...props}
+      {...rest}
       onClick={e => {
         if (typeof props.onClick === `function`) {
           props.onClick(e)
@@ -37,9 +38,10 @@ function OutboundLink(props) {
         }
         if (window.ga) {
           window.ga(`send`, `event`, {
-            eventCategory: props.eventCategory || `Outbound Link`,
-            eventAction: props.eventAction || `click`,
-            eventLabel: props.eventLabel || props.href,
+            eventCategory: eventCategory || `Outbound Link`,
+            eventAction: eventAction || `click`,
+            eventLabel: eventLabel || props.href,
+            eventValue,
             transport: redirect ? `beacon` : ``,
             hitCallback: function() {
               if (redirect) {


### PR DESCRIPTION
## Description

Add the ability to pass the event category, label, and action as properties to the `<OutboundLink>` component.

## Related Issues

Addresses #20337
