### PR TITLE
docs(plugin-netlify-cms): don't warn about GitLab implicit auth when using identity widget

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -143,9 +143,7 @@ CMS.init({
 
 `enableIdentityWidget` is `true` by default, allowing [Netlify
 Identity](https://www.netlify.com/docs/identity/) to be used without
-configuration, but you may need to disable it in some cases, such as when using
-a Netlify CMS backend that conflicts. This is currently known to be the case
-when using the GitLab backend, but only when using implicit OAuth.
+configuration. Disable it when not using Netlify Identity to reduce bundle size.
 
 ```javascript
 plugins: [


### PR DESCRIPTION
Since https://github.com/netlify/netlify-identity-widget/pull/223 is published I updated the Readme to reflect the fix