### PR TITLE
Add note about disabling frontend inclusion of netlify-identity-widget

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -237,6 +237,24 @@ plugins: [
 ]
 ```
 
+## Disable widget on site
+
+To completely disable the widget (and not the CMS) if you're not using Netlify Identity within your site, add the following to `gatsby-node.js`:
+
+```javascript
+const webpack = require(`webpack`)
+
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    plugins: [
+      new webpack.IgnorePlugin({
+        resourceRegExp: /^netlify-identity-widget$/,
+      }),
+    ],
+  })
+}
+```
+
 ## Support
 
 For help with integrating Netlify CMS with Gatsby, check out the community

--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -239,7 +239,7 @@ plugins: [
 
 ## Disable widget on site
 
-To completely disable the widget (and not the CMS) if you're not using Netlify Identity within your site, add the following to `gatsby-node.js`:
+If you're not using Netlify Identity within your site you have the option to completely disable the widget (and not the CMS). To do so, add the following to `gatsby-node.js`:
 
 ```javascript
 const webpack = require(`webpack`)


### PR DESCRIPTION
## Description

Includes note on `gatsby-plugin-netlify-cms` for disabling widget JS within frontend. cc @erezrokah

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/17568#issuecomment-573771892