### PR TITLE
fix(gatsby): Reset graphql runner on certain node events

### DIFF
--- a/packages/gatsby/src/bootstrap/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/graphql-runner.js
@@ -3,8 +3,24 @@ const stackTrace = require(`stack-trace`)
 const GraphQLRunner = require(`../query/graphql-runner`)
 const errorParser = require(`../query/error-parser`).default
 
+const { emitter } = require(`../redux`)
+
 module.exports = (store, reporter) => {
-  const runner = new GraphQLRunner(store)
+  let runner = new GraphQLRunner(store)
+  ;[
+    `DELETE_CACHE`,
+    `CREATE_NODE`,
+    `DELETE_NODE`,
+    `DELETE_NODES`,
+    `SET_SCHEMA_COMPOSER`,
+    `SET_SCHEMA`,
+    `ADD_FIELD_TO_NODE`,
+    `ADD_CHILD_NODE_TO_PARENT_NODE`,
+  ].forEach(eventType => {
+    emitter.on(eventType, event => {
+      runner = new GraphQLRunner(store)
+    })
+  })
   return (query, context) =>
     runner.query(query, context).then(result => {
       if (result.errors) {

--- a/packages/gatsby/src/bootstrap/graphql-runner.js
+++ b/packages/gatsby/src/bootstrap/graphql-runner.js
@@ -6,6 +6,7 @@ const errorParser = require(`../query/error-parser`).default
 const { emitter } = require(`../redux`)
 
 module.exports = (store, reporter) => {
+  // TODO: Move tracking of changed state inside GraphQLRunner itself. https://github.com/gatsbyjs/gatsby/issues/20941
   let runner = new GraphQLRunner(store)
   ;[
     `DELETE_CACHE`,


### PR DESCRIPTION
Hot reloading is broken on certain configurations due to node materialization.
Child objects in the node model are not updated when a node is recreated
This has something to do with the recent materialization update

By resetting the runner on these events the node model is forced to be recreated

See details in issue #18661, this is a dirty fix but allows me to edit files without
gatsby crashing

## Description

Resets the GraphQLRunner in `packages/gatsby/src/bootstrap/graphql-runner.js` on events
* `DELETE_CACHE`,
* `CREATE_NODE`,
* `DELETE_NODE`,
* `DELETE_NODES`,
* `SET_SCHEMA_COMPOSER`,
* `SET_SCHEMA`,
* `ADD_FIELD_TO_NODE`,
* `ADD_CHILD_NODE_TO_PARENT_NODE`,

### Documentation

This is a direct translation of comments by @pieh [here](https://github.com/gatsbyjs/gatsby/issues/18661#issuecomment-546893796)

## Related Issues
Fixes #18661
