### PR TITLE
refactor(gatsby-plugin-netlify-cms) preview styles during development using MiniCssExtractPlugin and HMR

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/cms.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms.js
@@ -19,22 +19,7 @@ if (!CMS_MANUAL_INIT) {
   )
 }
 
-// eslint-disable-next-line no-undef
-if (PRODUCTION) {
-  /**
-   * The stylesheet output from the modules at `modulePath` will be at `cms.css`.
-   */
-  CMS.registerPreviewStyle(`cms.css`)
-} else {
-  /**
-   * In development styles are injected dynamically via the style-loader plugin
-   */
-  window.addEventListener(`DOMContentLoaded`, event => {
-    const list = document.querySelectorAll(`link[rel='stylesheet']`)
-    list.forEach(link => {
-      CMS.registerPreviewStyle(link.href)
-      // remove the preview style from the CMS context
-      link.parentNode.removeChild(link)
-    })
-  })
-}
+/**
+ * The stylesheet output from the modules at `modulePath` will be at `cms.css`.
+ */
+CMS.registerPreviewStyle(`cms.css`)

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -29,7 +29,27 @@ function deepMap(obj, fn) {
   return obj
 }
 
-function replaceRule(value) {
+const cssTests = []
+
+function isCssRule({ test }) {
+  return test instanceof RegExp && cssTests.includes(test.toString())
+}
+
+function replaceStyleLoader(rule) {
+  if (rule.loader.includes(`style-loader`)) {
+    return {
+      ...rule,
+      loader: MiniCssExtractPlugin.loader,
+      options: {
+        hmr: true,
+      },
+    }
+  }
+
+  return rule
+}
+
+function replaceRule(value, stage) {
   // If `value` does not have a `test` property, it isn't a rule object.
   if (!value || !value.test) {
     return value
@@ -47,6 +67,21 @@ function replaceRule(value) {
     )
   ) {
     return null
+  }
+
+  // use MiniCssExtractPlugin.loader in development
+  if (stage === `develop` && value.test && isCssRule(value)) {
+    if (value.use) {
+      return {
+        ...value,
+        use: value.use.map(replaceStyleLoader),
+      }
+    } else if (value.loader) {
+      return {
+        ...value,
+        loader: replaceStyleLoader(value),
+      }
+    }
   }
 
   return value
@@ -94,6 +129,21 @@ exports.onCreateWebpackConfig = (
   if (![`develop`, `build-javascript`].includes(stage)) {
     return Promise.resolve()
   }
+
+  // populate cssTests array later used by isCssRule
+  if (`develop` === stage) {
+    cssTests.push(
+      ...[
+        rules.cssModules().test,
+        rules.css().test,
+        /\.s(a|c)ss$/,
+        /\.module\.s(a|c)ss$/,
+        /\.less$/,
+        /\.module\.less$/,
+      ].map(t => t.toString())
+    )
+  }
+
   const gatsbyConfig = getConfig()
   const { program } = store.getState()
   const publicPathClean = trim(publicPath, `/`)
@@ -144,7 +194,9 @@ exports.onCreateWebpackConfig = (
       path: path.join(program.directory, `public`, publicPathClean),
     },
     module: {
-      rules: deepMap(gatsbyConfig.module.rules, replaceRule).filter(Boolean),
+      rules: deepMap(gatsbyConfig.module.rules, value =>
+        replaceRule(value, stage)
+      ).filter(Boolean),
     },
     plugins: [
       // Remove plugins that either attempt to process the core Netlify CMS
@@ -174,10 +226,9 @@ exports.onCreateWebpackConfig = (
 
       // Use a simple filename with no hash so we can access from source by
       // path.
-      stage !== `develop` &&
-        new MiniCssExtractPlugin({
-          filename: `[name].css`,
-        }),
+      new MiniCssExtractPlugin({
+        filename: `[name].css`,
+      }),
 
       // Auto generate CMS index.html page.
       new HtmlWebpackPlugin({

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -35,20 +35,6 @@ function isCssRule({ test }) {
   return test instanceof RegExp && cssTests.includes(test.toString())
 }
 
-function replaceStyleLoader(rule) {
-  if (rule.loader.includes(`style-loader`)) {
-    return {
-      ...rule,
-      loader: MiniCssExtractPlugin.loader,
-      options: {
-        hmr: true,
-      },
-    }
-  }
-
-  return rule
-}
-
 function replaceRule(value, stage) {
   // If `value` does not have a `test` property, it isn't a rule object.
   if (!value || !value.test) {
@@ -71,6 +57,20 @@ function replaceRule(value, stage) {
 
   // use MiniCssExtractPlugin.loader in development
   if (stage === `develop` && value.test && isCssRule(value)) {
+    function replaceStyleLoader(rule) {
+      if (rule.loader.includes(`style-loader`)) {
+        return {
+          ...rule,
+          loader: MiniCssExtractPlugin.loader,
+          options: {
+            hmr: true,
+          },
+        }
+      }
+
+      return rule
+    }
+
     if (value.use) {
       return {
         ...value,


### PR DESCRIPTION
## Description

This aims to provide more straightforward approach to add preview styles to netlify-cms previews during `develop` without workarounds. Basically this reverts some of the changes introduced in #19575 and enables `MiniCssExtractPlugin.loader` with HMR mode for most of the webpack rules that handle css including `sass` and `less`.

## Related Issues

Related to #19575
Fixes #15126 and #20428
