### PR TITLE
fix(gatsby-image): Added aria-hidden attribute to layout elements

### DIFF
--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -7,11 +7,13 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
+      aria-hidden="true"
       style="background-color: lightgray; width: 100px; opacity: 1; height: 100px; transition-delay: 1000ms;"
       title="Title for the image"
     />
     <img
       alt=""
+      aria-hidden="true"
       class="placeholder"
       itemprop="item-prop-for-the-image"
       src="string_of_base64"
@@ -54,11 +56,13 @@ exports[`<Image /> should render fixed size images 1`] = `
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
+      aria-hidden="true"
       style="background-color: lightgray; width: 100px; opacity: 1; height: 100px; transition-delay: 500ms;"
       title="Title for the image"
     />
     <img
       alt=""
+      aria-hidden="true"
       class="placeholder"
       itemprop="item-prop-for-the-image"
       src="string_of_base64"
@@ -101,14 +105,17 @@ exports[`<Image /> should render fluid images 1`] = `
     style="position: relative; overflow: hidden; display: inline;"
   >
     <div
+      aria-hidden="true"
       style="width: 100%; padding-bottom: 66.66666666666667%;"
     />
     <div
+      aria-hidden="true"
       style="background-color: lightgray; position: absolute; top: 0px; bottom: 0px; opacity: 1; right: 0px; left: 0px; transition-delay: 500ms;"
       title="Title for the image"
     />
     <img
       alt=""
+      aria-hidden="true"
       class="placeholder"
       itemprop="item-prop-for-the-image"
       src="string_of_base64"
@@ -152,6 +159,7 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
+      aria-hidden="true"
       style="background-color: lightgray; width: 100px; opacity: 1; height: 100px; transition-delay: 500ms;"
       title="Title for the image"
     />
@@ -165,6 +173,7 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
       />
       <img
         alt=""
+        aria-hidden="true"
         class="placeholder"
         itemprop="item-prop-for-the-image"
         src="other_string_of_base64"
@@ -216,9 +225,11 @@ exports[`<Image /> should render multiple fluid image variants 1`] = `
     style="position: relative; overflow: hidden; display: inline;"
   >
     <div
+      aria-hidden="true"
       style="width: 100%; padding-bottom: 50%;"
     />
     <div
+      aria-hidden="true"
       style="background-color: lightgray; position: absolute; top: 0px; bottom: 0px; opacity: 1; right: 0px; left: 0px; transition-delay: 500ms;"
       title="Title for the image"
     />
@@ -232,6 +243,7 @@ exports[`<Image /> should render multiple fluid image variants 1`] = `
       />
       <img
         alt=""
+        aria-hidden="true"
         class="placeholder"
         itemprop="item-prop-for-the-image"
         src="string_of_base64"

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -293,23 +293,28 @@ describe(`<Image />`, () => {
     expect(onErrorMock).toHaveBeenCalledTimes(1)
   })
 
-  it(`should an element for fluid has "aria-hidden" attribute`, () => {
+  it(`should have an "aria-hidden" attribute on the fluid element`, () => {
     const divTag = setup(true).querySelector(`.gatsby-image-wrapper > div`)
     expect(divTag.getAttribute(`aria-hidden`)).toBe(`true`)
   })
 
-  it(`should BgElement for fluid has "aria-hidden" attribute`, () => {
+  it(`should have an "aria-hidden" attribute on the background element`, () => {
     const BgTag = setup(true).querySelector(`.gatsby-image-wrapper > div + div`)
     expect(BgTag.getAttribute(`aria-hidden`)).toBe(`true`)
   })
 
-  it(`should placeholderImage on fluid has "aria-hidden" attribute`, () => {
+  it(`should have an "aria-hidden" attribute on the Placeholder component when fluid`, () => {
     const placeholderImageTag = setup(true).querySelector(`img`)
     expect(placeholderImageTag.getAttribute(`aria-hidden`)).toBe(`true`)
   })
 
-  it(`should placeholderImage on fixed has "aria-hidden" attribute`, () => {
+  it(`should have an "aria-hidden" attribute on the Placeholder component when fixed`, () => {
     const placeholderImageTag = setup().querySelector(`img`)
     expect(placeholderImageTag.getAttribute(`aria-hidden`)).toBe(`true`)
+  })
+
+  it(`should not have an "aria-hidden" attribute on the Image`, () => {
+    const placeholderImageTag = setup().querySelector(`picture img`)
+    expect(placeholderImageTag.getAttribute(`aria-hidden`)).toBe(null)
   })
 })

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -292,4 +292,24 @@ describe(`<Image />`, () => {
     expect(onLoadMock).toHaveBeenCalledTimes(1)
     expect(onErrorMock).toHaveBeenCalledTimes(1)
   })
+
+  it(`should an element for fluid has "aria-hidden" attribute`, () => {
+    const divTag = setup(true).querySelector(`.gatsby-image-wrapper > div`)
+    expect(divTag.getAttribute(`aria-hidden`)).toBe(`true`)
+  })
+
+  it(`should BgElement for fluid has "aria-hidden" attribute`, () => {
+    const BgTag = setup(true).querySelector(`.gatsby-image-wrapper > div + div`)
+    expect(BgTag.getAttribute(`aria-hidden`)).toBe(`true`)
+  })
+
+  it(`should placeholderImage on fluid has "aria-hidden" attribute`, () => {
+    const placeholderImageTag = setup(true).querySelector(`img`)
+    expect(placeholderImageTag.getAttribute(`aria-hidden`)).toBe(`true`)
+  })
+
+  it(`should placeholderImage on fixed has "aria-hidden" attribute`, () => {
+    const placeholderImageTag = setup().querySelector(`img`)
+    expect(placeholderImageTag.getAttribute(`aria-hidden`)).toBe(`true`)
+  })
 })

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -259,9 +259,9 @@ const Placeholder = ({
   imageVariants,
   generateSources,
   spreadProps,
-  [`aria-hidden`]: ariaHidden,
+  ariaHidden,
 }) => {
-  const baseImage = <Img src={src} {...spreadProps} aria-hidden={ariaHidden} />
+  const baseImage = <Img src={src} {...spreadProps} ariaHidden={ariaHidden} />
 
   return imageVariants.length > 1 ? (
     <picture>
@@ -284,7 +284,7 @@ const Img = React.forwardRef((props, ref) => {
     loading,
     draggable,
     // `ariaHidden`props is used to exclude placeholders from the accessibility tree.
-    [`aria-hidden`]: ariaHidden,
+    ariaHidden,
     ...otherProps
   } = props
 
@@ -504,7 +504,7 @@ class Image extends React.Component {
           {/* Show the blurry base64 image. */}
           {image.base64 && (
             <Placeholder
-              aria-hidden
+              ariaHidden
               src={image.base64}
               spreadProps={placeholderImageProps}
               imageVariants={imageVariants}
@@ -515,7 +515,7 @@ class Image extends React.Component {
           {/* Show the traced SVG image. */}
           {image.tracedSVG && (
             <Placeholder
-              aria-hidden
+              ariaHidden
               src={image.tracedSVG}
               spreadProps={placeholderImageProps}
               imageVariants={imageVariants}
@@ -605,7 +605,7 @@ class Image extends React.Component {
           {/* Show the blurry base64 image. */}
           {image.base64 && (
             <Placeholder
-              aria-hidden
+              ariaHidden
               src={image.base64}
               spreadProps={placeholderImageProps}
               imageVariants={imageVariants}
@@ -616,7 +616,7 @@ class Image extends React.Component {
           {/* Show the traced SVG image. */}
           {image.tracedSVG && (
             <Placeholder
-              aria-hidden
+              ariaHidden
               src={image.tracedSVG}
               spreadProps={placeholderImageProps}
               imageVariants={imageVariants}

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -254,8 +254,14 @@ const noscriptImg = props => {
 // Earlier versions of gatsby-image during the 2.x cycle did not wrap
 // the `Img` component in a `picture` element. This maintains compatibility
 // until a breaking change can be introduced in the next major release
-const Placeholder = ({ src, imageVariants, generateSources, spreadProps }) => {
-  const baseImage = <Img src={src} {...spreadProps} />
+const Placeholder = ({
+  src,
+  imageVariants,
+  generateSources,
+  spreadProps,
+  [`aria-hidden`]: ariaHidden,
+}) => {
+  const baseImage = <Img src={src} {...spreadProps} aria-hidden={ariaHidden} />
 
   return imageVariants.length > 1 ? (
     <picture>
@@ -277,11 +283,14 @@ const Img = React.forwardRef((props, ref) => {
     onError,
     loading,
     draggable,
+    // `ariaHidden`props is used to exclude placeholders from the accessibility tree.
+    [`aria-hidden`]: ariaHidden,
     ...otherProps
   } = props
 
   return (
     <img
+      aria-hidden={ariaHidden}
       sizes={sizes}
       srcSet={srcSet}
       src={src}
@@ -467,6 +476,7 @@ class Image extends React.Component {
         >
           {/* Preserve the aspect ratio. */}
           <Tag
+            aria-hidden
             style={{
               width: `100%`,
               paddingBottom: `${100 / image.aspectRatio}%`,
@@ -476,6 +486,7 @@ class Image extends React.Component {
           {/* Show a solid background color. */}
           {bgColor && (
             <Tag
+              aria-hidden
               title={title}
               style={{
                 backgroundColor: bgColor,
@@ -493,6 +504,7 @@ class Image extends React.Component {
           {/* Show the blurry base64 image. */}
           {image.base64 && (
             <Placeholder
+              aria-hidden
               src={image.base64}
               spreadProps={placeholderImageProps}
               imageVariants={imageVariants}
@@ -503,6 +515,7 @@ class Image extends React.Component {
           {/* Show the traced SVG image. */}
           {image.tracedSVG && (
             <Placeholder
+              aria-hidden
               src={image.tracedSVG}
               spreadProps={placeholderImageProps}
               imageVariants={imageVariants}
@@ -577,6 +590,7 @@ class Image extends React.Component {
           {/* Show a solid background color. */}
           {bgColor && (
             <Tag
+              aria-hidden
               title={title}
               style={{
                 backgroundColor: bgColor,
@@ -591,6 +605,7 @@ class Image extends React.Component {
           {/* Show the blurry base64 image. */}
           {image.base64 && (
             <Placeholder
+              aria-hidden
               src={image.base64}
               spreadProps={placeholderImageProps}
               imageVariants={imageVariants}
@@ -601,6 +616,7 @@ class Image extends React.Component {
           {/* Show the traced SVG image. */}
           {image.tracedSVG && (
             <Placeholder
+              aria-hidden
               src={image.tracedSVG}
               spreadProps={placeholderImageProps}
               imageVariants={imageVariants}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This PR is for the `gatsby-image` plugin.
Placeholders and layout-adjusting elements are unnecessary in the accessibility tree, so I have removed them using the `aria-hidden` attribute.

This prevents assistive technologies from recognizing blank elements.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->
https://www.gatsbyjs.org/packages/gatsby-image/#fixed-queries
https://www.gatsbyjs.org/packages/gatsby-image/#fluid-queries

## Related Issues
Fixes #20181
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
