### PR TITLE
perf(gatsby): Drop `firstOnly` requirement for `isEqId` check

### DIFF
--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -44,9 +44,9 @@ const getFilters = filters =>
 // Run Sift
 /////////////////////////////////////////////////////////////////////
 
-function isEqId(firstOnly, siftArgs) {
+function isEqId(siftArgs) {
+  // The `id` of each node is invariably unique. So if a query is doing id $eq(string) it can find only one node tops
   return (
-    firstOnly &&
     siftArgs.length > 0 &&
     siftArgs[0].id &&
     Object.keys(siftArgs[0].id).length === 1 &&
@@ -153,14 +153,15 @@ const runSiftOnNodes = (nodes, args, getNode) => {
 
   // If the the query for single node only has a filter for an "id"
   // using "eq" operator, then we'll just grab that ID and return it.
-  if (isEqId(firstOnly, siftFilter)) {
-    const node = getNode(siftFilter[0].id[`$eq`])
+  if (isEqId(siftFilter)) {
+    const node = getNode(siftFilter[0].id.$eq)
 
     if (
       !node ||
       (node.internal && !nodeTypeNames.includes(node.internal.type))
     ) {
-      return []
+      if (firstOnly) return []
+      return null
     }
 
     return [node]


### PR DESCRIPTION
Noticed a site was going through the slow path even though there was no good reason for it. One of the reasons was that this check failed, even though it should pass.

We use unique `id`s internally for nodes, so if a query finds a node it can't find more than one node. So the check for `firstOnly` is redundant here.

This hopefully leads to a performance improvement for some other sites.
