### PR TITLE
perf(gatsby): Shortcut trivial queries by id, potential huge win

### DIFF
--- a/packages/gatsby/src/redux/nodes.js
+++ b/packages/gatsby/src/redux/nodes.js
@@ -103,11 +103,45 @@ exports.saveResolvedNodes = async (nodeTypeNames, resolver) => {
   }
 }
 
+/**
+ * Get node and save path dependency.
+ *
+ * @param {string} typeName
+ * @param {string} id
+ * @returns {Object|void} node
+ */
+const getResolvedNode = (typeName, id) => {
+  const { nodesByType, resolvedNodesCache } = store.getState()
+  const nodes /*: Map<mixed> */ = nodesByType.get(typeName)
+
+  if (!nodes) {
+    return null
+  }
+
+  let node = nodes.get(id)
+
+  if (!node) {
+    return null
+  }
+
+  const resolvedNodes = resolvedNodesCache.get(typeName)
+
+  if (resolvedNodes) {
+    node.__gatsby_resolved = resolvedNodes.get(id)
+  }
+
+  return node
+}
+
+exports.getResolvedNode = getResolvedNode
+
 const addResolvedNodes = (typeName, arr) => {
   const { nodesByType, resolvedNodesCache } = store.getState()
   const nodes /*: Map<mixed> */ = nodesByType.get(typeName)
 
-  if (!nodes) return
+  if (!nodes) {
+    return
+  }
 
   const resolvedNodes = resolvedNodesCache.get(typeName)
 


### PR DESCRIPTION
While there is a check for queries by `id`, this one circumvents a few more steps. It prevents having to build up an array based on type. Instead, if it sees a query by `id`, it will immediately just fetch that node directly.

This makes many large sites that use plain queries by id a helluvalot faster. One site that made me look into this problem with 145k pages went down from 4.5 hours to about 5 minutes (that is not a typo).
