### PR TITLE
Docs: Update shadowing other themes

### DIFF
--- a/docs/docs/themes/shadowing.md
+++ b/docs/docs/themes/shadowing.md
@@ -71,15 +71,18 @@ user-site
 
 Some themes, including `gatsby-theme-blog`, install other themes. `gatsby-theme-blog` uses `gatsby-plugin-theme-ui`. If you want to customize the implementation of any theme you can do so with shadowing.
 
-For example, to shadow `index.js` from `gatsby-plugin-theme-ui`, create a file named `user-site/src/gatsby-theme-blog/gatsby-plugin-theme-ui/index.js`.
+For example, to shadow `index.js` from `gatsby-plugin-theme-ui`, create a file named `user-site/src/gatsby-plugin-theme-ui/index.js`.
 
-```js:title=src/gatsby-theme-blog/gatsby-plugin-theme-ui/index.js
+```js:title=src/gatsby-plugin-theme-ui/index.js
+import baseTheme from "gatsby-theme-blog/src/gatsby-plugin-theme-ui/index"
+
 export default {
+  ...baseTheme,
   fontSizes: [12, 14, 16, 24, 32, 48, 64, 96, 128],
   space: [0, 4, 8, 16, 32, 64, 128, 256],
   colors: {
-    blue: `blue`,
-    red: `tomato`,
+    ...baseTheme.colors,
+    primary: `tomato`,
   },
 }
 ```
@@ -89,9 +92,8 @@ Which will result in the following directory tree:
 ```text
 user-site
 └── src
-    └── gatsby-theme-blog
-        └── gatsby-plugin-theme-ui
-            └──index.js // highlight-line
+    └── gatsby-plugin-theme-ui
+        └──index.js // highlight-line
 ```
 
 ## Any source file is shadowable


### PR DESCRIPTION
## Description

In [Shadowing other themes](https://www.gatsbyjs.org/docs/themes/shadowing/#shadowing-other-themes), it says that If we want to change the theme from `gatsby-plugin-theme-ui` while using the  `gatsby-theme-blog`, we have to create a file at: `user-site/src/gatsby-theme-blog/gatsby-plugin-theme-ui/index.js`. This doesn't work right now. 

Instead, as [Chris Biscardi suggests](https://www.christopherbiscardi.com/post/component-shadowing-in-gatsby-child-themes/), we have to create a file at `user-site/src/gatsby-plugin-theme-ui/index.js`. I changed the docs to reflect that. 

For a reproduction: 

- Use the `gatsby-starter-blog-theme` starter: `gatsby new my-themed-blog https://github.com/gatsbyjs/gatsby-starter-blog-theme`
- Then try to shadow the `gatsby-plugin-theme-ui/index.js` file.

## Related Issues

Related to #15456
