### PR TITLE
fix(gatsby-plugin-sitemap): allow paths with trailing slash in `exclude` option

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -33,7 +33,7 @@ The options are as follows:
 - `createLinkInHead` (boolean) Whether to populate the `<head>` of your site with a link to the sitemap.
 - `serialize` (function) Takes the output of the data query and lets you return an array of sitemap entries.
 
-We _ALWAYS_ exclude the following pages: `/dev-404-page/`,`/404` &`/offline-plugin-app-shell-fallback/`, this cannot be changed.
+We _ALWAYS_ exclude the following pages: `/dev-404-page`,`/404` &`/offline-plugin-app-shell-fallback`, this cannot be changed.
 
 Example:
 
@@ -50,7 +50,7 @@ plugins: [
       // Exclude specific pages or groups of pages using glob parameters
       // See: https://github.com/isaacs/minimatch
       // The example below will exclude the single `path/to/page` and all routes beginning with `category`
-      exclude: ["/category/*", `/path/to/page`],
+      exclude: [`/category/*`, `/path/to/page`],
       query: `
         {
           site {

--- a/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
@@ -70,9 +70,17 @@ describe(`results using default settings`, () => {
       ])
     })
 
-    it(`excludes pages`, async () => {
+    it(`excludes pages without trailing slash`, async () => {
       const graphql = () => Promise.resolve(generateQueryResultsMock())
       const queryRecords = await runQuery(graphql, ``, [`/page-2`], pathPrefix)
+      const urls = serialize(queryRecords)
+
+      verifyUrlsExistInResults(urls, [`http://dummy.url${pathPrefix}/page-1`])
+    })
+
+    it(`excludes pages with trailing slash`, async () => {
+      const graphql = () => Promise.resolve(generateQueryResultsMock())
+      const queryRecords = await runQuery(graphql, ``, [`/page-2/`], pathPrefix)
       const urls = serialize(queryRecords)
 
       verifyUrlsExistInResults(urls, [`http://dummy.url${pathPrefix}/page-1`])

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -18,7 +18,10 @@ export const runQuery = (handler, query, excludes, pathPrefix) =>
     r.data.allSitePage.edges = r.data.allSitePage.edges.filter(
       page =>
         !excludes.some(excludedRoute =>
-          minimatch(withoutTrailingSlash(page.node.path), excludedRoute)
+          minimatch(
+            withoutTrailingSlash(page.node.path),
+            withoutTrailingSlash(excludedRoute)
+          )
         )
     )
 


### PR DESCRIPTION
Now `gatsby-plugin-sitemap` treats `/foo/bar/` and `/foo/bar` as the same,
which removes unnecessary confusion when using the `exclude` option,
as previously `gatsby-plugin-sitemap` wouldn't work correctly with trailing slashes in `exclude` option.

Also fixed some inconsistencies in `README.md`