### PR TITLE
Makes the ESLint configuration work regardless of the hoisting

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.js
+++ b/packages/gatsby/src/utils/eslint-config.js
@@ -10,7 +10,7 @@ module.exports = schema => {
         __PATH_PREFIX__: true,
         __BASE_PATH__: true, // this will rarely, if ever, be used by consumers
       },
-      extends: [require.resolve(`react-app`)],
+      extends: [require.resolve(`eslint-config-react-app`)],
       plugins: [`graphql`],
       rules: {
         "import/no-webpack-loader-syntax": [0],

--- a/packages/gatsby/src/utils/eslint-config.js
+++ b/packages/gatsby/src/utils/eslint-config.js
@@ -3,13 +3,14 @@ import { printSchema } from "graphql"
 module.exports = schema => {
   return {
     useEslintrc: false,
+    resolvePluginsRelativeTo: __dirname,
     baseConfig: {
       globals: {
         graphql: true,
         __PATH_PREFIX__: true,
         __BASE_PATH__: true, // this will rarely, if ever, be used by consumers
       },
-      extends: [`react-app`],
+      extends: [require.resolve(`react-app`)],
       plugins: [`graphql`],
       rules: {
         "import/no-webpack-loader-syntax": [0],


### PR DESCRIPTION
## Description

The current implementation loads the shared config by sending the name to ESLint, which doesn't know from where to resolve it. As a result, it resolves it from the cwd (so the project directory), which is wrong: it should be resolved from Gatsby itself.

Similarly, the `resolvePluginsRelativeTo` option need to be set for ESLint to know that the `graphql` plugin is meant to be loaded from Gatsby rather than the cwd.

### Documentation

- cf [`resolvePluginsRelativeTo`](https://eslint.org/docs/developer-guide/nodejs-api#cliengine)
