### PR TITLE
docs(gatsby-theme-blog): Include Blog Post Fields

### DIFF
--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -81,3 +81,18 @@ module.exports = {
   },
 }
 ```
+
+### Blog Post Fields
+
+The following are the defined blog post fields based on the node interface in the schema
+
+| Field    | Type     |
+| -------- | -------- |
+| id       | String   |
+| title    | String   |
+| body     | String   |
+| slug     | String   |
+| date     | Date     |
+| tags     | String[] |
+| keywords | String[] |
+| excerpt  | String   |


### PR DESCRIPTION
Closes #20631

## Description

This adds a table of information describing the fields a blog post has available based on the `gatsby-node` file's node interface in the schema.
