### PR TITLE
fix: npm permissions check

### DIFF
--- a/scripts/check-publish-access/index.js
+++ b/scripts/check-publish-access/index.js
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 const getUnownedPackages = require(`../get-unowned-packages`)
 
-getUnownedPackages().then(({ packages, user }) => {
-  if (packages.length > 0) {
-    console.warn(
-      `The following packages will fail to publish, please add access for ${user}:`
-    )
-    console.warn(packages.map(pkg => ` - ${pkg.name}`).join(`\n`))
+getUnownedPackages()
+  .then(({ packages, user }) => {
+    if (packages.length > 0) {
+      console.warn(
+        `The following packages will fail to publish, please add access for ${user}:`
+      )
+      console.warn(packages.map(pkg => ` - ${pkg.name}`).join(`\n`))
+      process.exit(1)
+    }
+  })
+  .catch(err => {
+    console.error(err)
     process.exit(1)
-  }
-})
+  })

--- a/scripts/get-unowned-packages/index.js
+++ b/scripts/get-unowned-packages/index.js
@@ -26,9 +26,13 @@ module.exports = async function getUnownedPackages({
   // infer user from npm whoami
   // set registry because yarn run hijacks registry
   if (!user) {
-    user = await execP(`npm whoami --registry https://registry.npmjs.org`)
+    user = await execP(
+      `npm_config_username="" npm whoami --registry https://registry.npmjs.org`
+    )
       .then(({ stdout }) => stdout.trim())
-      .catch(() => process.exit(1))
+      .catch(() => {
+        throw new Error(`You are not logged-in`)
+      })
   }
 
   return getPackages(rootPath).then(async packages => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The publish script was failing to recognise if the user was not logged-in to npm if they _were_ logged-in to yarn. This prevents Yarn being clever.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
