### PR TITLE
Fix links to CHANGELOG.md

### DIFF
--- a/docs/docs/v1-release-notes.md
+++ b/docs/docs/v1-release-notes.md
@@ -5,5 +5,5 @@ title: v1 Release Notes
 Check out the following useful links for Gatsby version 1:
 
 - [v1 documentation](https://v1.gatsbyjs.org/)
-- [v1 changelog](https://github.com/gatsbyjs/gatsby/blob/master/CHANGELOG.md#100---2017-07-06)
+- [v1 changelog](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/CHANGELOG.md#100---2017-07-06)
 - [v1 release announcement](/blog/gatsby-v1/)

--- a/docs/docs/v2-release-notes.md
+++ b/docs/docs/v2-release-notes.md
@@ -7,4 +7,4 @@ Check out the following useful links for Gatsby v2:
 - [v2 release announcement](/blog/2018-09-17-gatsby-v2/)
 - [Migrating from v1 to v2](/docs/migrating-from-v1-to-v2/)
 - [v2 documentation](/docs/)
-- [v2 changelog](https://github.com/gatsbyjs/gatsby/blob/master/CHANGELOG.md#200---2018-09-13)
+- [v2 changelog](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/CHANGELOG.md#200-2018-09-17)


### PR DESCRIPTION
## Description

Fixed links to `CHANGELOG.md`.

### Documentation

This is the change in the documentation.

## Related Issues

Not found.
