### PR TITLE
fix(docs): remove space from markdown links / image captions

### DIFF
--- a/docs/blog/100days/gatsby-image/index.md
+++ b/docs/blog/100days/gatsby-image/index.md
@@ -25,7 +25,7 @@ But what good is a blog without beautiful images? We want you to use the resourc
 
 #### Part 2
 
-Now it’s time to get direct experience using the `Img`React component provided by [`gatsby-image` ](/packages/gatsby-image/)! Create an about page using JSX, then use the gatsby-image API to transform a normal selfie into a square, black-and-white image.
+Now it’s time to get direct experience using the `Img`React component provided by [`gatsby-image`](/packages/gatsby-image/)! Create an about page using JSX, then use the gatsby-image API to transform a normal selfie into a square, black-and-white image.
 
 Bonus: Take note of the build times for your site before and after you add images to your project. Also, record the performance of specific pages with images, using [a tool like Lighthouse](/docs/audit-with-lighthouse/). As a Gatsby Developer you should be aware of how images affect your site’s production and user experience.
 

--- a/docs/blog/2018-1-18-strapi-and-gatsby/index.md
+++ b/docs/blog/2018-1-18-strapi-and-gatsby/index.md
@@ -8,7 +8,7 @@ tags: ["blogs", "cms", "headless-cms", "getting-started"]
 
 (Article updated on 20 March 2019. This updates the tutorial code examples. We added videos with additional explanations to each section.)
 
-![Showing the idea of using Gatsby with Strapi ](gatsby-strapi.png)
+![Showing the idea of using Gatsby with Strapi](gatsby-strapi.png)
 
 A static website contains Web pages with fixed content. Technically, it is a simple list of HTML files, which displays the same information to every visitor. Unlike dynamic websites, they do not require any backend programming or database. Publishing a static website is easy: the files are uploaded on a simple Web server or storage provider. The two main advantages of static websites are security and speed: there is no database so it can not be hacked and there is no need to render a page for each request, which makes Web browsing faster.
 

--- a/docs/contributing/index.mdx
+++ b/docs/contributing/index.mdx
@@ -11,8 +11,8 @@ Below you'll find guides on the Gatsby.js community, code of conduct, and how to
 
 - [Community](/contributing/community/): Learn why you should contribute to Gatsby.js, the most effective ways to do so, and all about the benefits (did we mention the free swag?)
 - [Code of Conduct](/contributing/code-of-conduct/): Read about what we expect from everyone participating in Gatsby.js to make it the most friendly and welcoming community
-- [Gatsby Style Guide ](/contributing/gatsby-style-guide/): The art of contributing to Gatsby, a.k.a. the detailed requirements that will make it more likely your contribution is accepted with minimal changes
-- [How to Contribute ](/contributing/how-to-contribute/): How to get the most out of your Gatsby.js contributing experience, including GitHub management tips, setup instructions for docs and code contributions, and more
+- [Gatsby Style Guide](/contributing/gatsby-style-guide/): The art of contributing to Gatsby, a.k.a. the detailed requirements that will make it more likely your contribution is accepted with minimal changes
+- [How to Contribute](/contributing/how-to-contribute/): How to get the most out of your Gatsby.js contributing experience, including GitHub management tips, setup instructions for docs and code contributions, and more
 - [RFC process](/contributing/rfc-process): Learn how the Gatsby.js team manages bigger changes, by way of a “Request-for-comment” process on GitHub
 
 <EmailCaptureForm signupMessage="Want to keep up with the latest tips &amp; tricks? Subscribe to our newsletter!" />

--- a/docs/docs/creating-a-starter.md
+++ b/docs/docs/creating-a-starter.md
@@ -71,6 +71,5 @@ To make sure your starter is easily discoverable, you are welcome (but not requi
 
 ## Further reading:
 
-- [How to create a Gatsby Starter
-  ](https://medium.com/@emasuriano/how-to-create-a-gatsby-starter-e7d53083a880) by Emanuel Suriano
+- [How to create a Gatsby Starter](https://medium.com/@emasuriano/how-to-create-a-gatsby-starter-e7d53083a880) by Emanuel Suriano
 - [Introducing Gatsby Themes](/blog/2018-11-11-introducing-gatsby-themes/) (including info on starters)


### PR DESCRIPTION
## Description

remove space from markdown links / image captions

## Related Issues

similar to #20541