### PR TITLE
chore(benchmarks): Increase minimum version of gatsby to meet Cloud requirement

### DIFF
--- a/benchmarks/markdown_id/package.json
+++ b/benchmarks/markdown_id/package.json
@@ -6,7 +6,7 @@
   "author": "PvdZ <pvdz@github>",
   "dependencies": {
     "del-cli": "^3.0.0",
-    "gatsby": "*",
+    "gatsby": ">=2.1.0",
     "gatsby-image": "*",
     "gatsby-plugin-feed": "*",
     "gatsby-plugin-google-analytics": "*",

--- a/benchmarks/markdown_slug/package.json
+++ b/benchmarks/markdown_slug/package.json
@@ -6,7 +6,7 @@
   "author": "PvdZ <pvdz@github>",
   "dependencies": {
     "del-cli": "^3.0.0",
-    "gatsby": "*",
+    "gatsby": ">=2.1.0",
     "gatsby-image": "*",
     "gatsby-plugin-feed": "*",
     "gatsby-plugin-google-analytics": "*",


### PR DESCRIPTION
## Description

Cloud currently requires that the version of `gatsby` be at least `2.1.0`, which is not the same as `*`.

From https://www.npmjs.com/package/semver#x-ranges-12x-1x-12- :
> * := >=0.0.0 (Any version satisfies)

Bump the version so we can test the benchmarks sites in Cloud.