### PR TITLE
Bump css-loader

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -47,7 +47,7 @@
     "copyfiles": "^2.2.0",
     "core-js": "^2.6.11",
     "cors": "^2.8.5",
-    "css-loader": "^1.0.1",
+    "css-loader": "^3.4.2",
     "date-fns": "^2.11.0",
     "debug": "^3.2.6",
     "del": "^5.1.0",

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -194,14 +194,15 @@ export const createWebpackUtils = (
 
     css: (options = {}) => {
       return {
-        loader: isSSR
-          ? require.resolve(`css-loader/locals`)
-          : require.resolve(`css-loader`),
+        loader: require.resolve(`css-loader`),
         options: {
           sourceMap: !PRODUCTION,
-          camelCase: `dashesOnly`,
-          // https://github.com/webpack-contrib/css-loader/issues/406
-          localIdentName: `[name]--[local]--[hash:base64:5]`,
+          localsConvention: `dashesOnly`,
+          modules: {
+            mode: false,
+            // https://github.com/webpack-contrib/css-loader/issues/406
+            localIdentName: `[name]--[local]--[hash:base64:5]`,
+          },
           ...options,
         },
       }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This PR bump version of css-loader of gatsby for fix broken escaping and spaces in css

### Documentation


nothing, just bump css-loader and change configration for newer version
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

* fix #20310
* related to https://github.com/webpack-contrib/css-loader/issues/578
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
