### PR TITLE
chore(starters): add gatsby-starter-webcomic

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5000,3 +5000,27 @@
     - Transform links to bitly links automatically
     - Codesyntax
     - Code syntax highlighting
+- url: https://gatsby-starter-webcomic.netlify.com
+  repo: https://github.com/JLDevOps/gatsby-starter-webcomic
+  description: Gatsby blog starter that focuses on webcomics and art with a minimalistic UI.
+  tags:
+    - Markdown
+    - MDX
+    - Netlify
+    - Pagination
+    - Search
+    - Styling:Bootstrap
+    - RSS
+    - Blog
+    - Design
+    - Portfolio
+    - Media
+    - SEO
+  features:
+    - Designed to focus on blog posts with images.
+    - Search capability on blog posts
+    - Displays the latest posts
+    - Displays all the tags from the site
+    - Pagination between blog posts
+    - Has a "archive" page that categorizes and displays all the blog posts by date
+    - Mobile friendly

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5011,9 +5011,7 @@
     - Search
     - Styling:Bootstrap
     - RSS
-    - Blog
     - Design
-    - Portfolio
     - Media
     - SEO
   features:


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Adding my starter template to the starter.yml.

This is a blog boilerplate that focuses on displaying webcomics and art.  The layout is inspired by webcomics such as Magical Game Time and Dakota McFadzean.

The associated template can be found here: https://github.com/JLDevOps/gatsby-starter-webcomic

A demo can be found here: https://gatsby-starter-webcomic.netlify.com/

### Documentation
You can more information about the starter on the README- https://github.com/JLDevOps/gatsby-starter-webcomic

## Related Issues
N/A