### PR TITLE
fix(gatsby): Respect `@dontInfer` directive on `SitePage` type

### DIFF
--- a/packages/gatsby/src/redux/reducers/inference-metadata.js
+++ b/packages/gatsby/src/redux/reducers/inference-metadata.js
@@ -86,7 +86,9 @@ const incrementalReducer = (state = {}, action) => {
     case `BUILD_TYPE_METADATA`: {
       // Overwrites existing metadata
       const { nodes, typeName } = action.payload
-      state[typeName] = addNodes(initialTypeMetadata(), nodes)
+      if (!state[typeName]?.ignored) {
+        state[typeName] = addNodes(initialTypeMetadata(), nodes)
+      }
       return state
     }
 

--- a/packages/gatsby/src/schema/__tests__/rebuild-sitepage-type.js
+++ b/packages/gatsby/src/schema/__tests__/rebuild-sitepage-type.js
@@ -146,4 +146,20 @@ describe(`build and update schema for SitePage`, () => {
     expect(fieldsEnum.includes(`fields___oldKey`)).toBeTruthy()
     expect(fieldsEnum.includes(`fields___key`)).toBeTruthy()
   })
+
+  it(`respects @dontInfer on SitePage`, async () => {
+    const typeDefs = `
+      type SitePage implements Node @dontInfer {
+        keep: String!
+        fields: SitePageFields
+      }
+    `
+    store.dispatch({ type: `CREATE_TYPES`, payload: typeDefs })
+    store.dispatch({ type: `CREATE_NODE`, payload: secondPage() })
+
+    await rebuildWithSitePage({})
+    schema = store.getState().schema
+    expect(schema.getType(`SitePage`).getFields().context).not.toBeDefined()
+    expect(schema.getType(`SitePageFields`).getFields().key).not.toBeDefined()
+  })
 })


### PR DESCRIPTION
## Description

Looks like PR #19781 broke the ability to disable type inference on `SitePage`. So the following adjustment didn't work anymore:

```js
// gatsby-node.js
exports.createSchemaCustomization = ({ actions }) => {
  actions.createTypes(`
    type SitePage implements Node @dontInfer {
      path: String!
    }
  `)
}
```

This PR fixes it. So it should be working as advertised again.

### Documentation

[Scaling Issues](https://www.gatsbyjs.org/docs/scaling-issues/#switch-off-type-inference-for-sitepagecontext) (was not working before this fix, works after)

## Related Issues

Fixes #20395 
