### PR TITLE
fix(blog): remove wrong link

### DIFF
--- a/www/src/data/tags-docs.js
+++ b/www/src/data/tags-docs.js
@@ -93,5 +93,5 @@ export const TAGS_AND_DOCS = new Map([
     `/docs/gatsby-core-philosophy/#construct-new-higher-level-web-building-blocks`,
   ],
   [`wordpress`, `/docs/sourcing-from-wordpress/`],
-  [`100-Days-of-Gatsby`, `/docs/100days/`],
+  [`100-Days-of-Gatsby`, ``],
 ])


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

![Bildschirmfoto 2020-01-17 um 10 32 15](https://user-images.githubusercontent.com/184316/72601020-e73ec080-3914-11ea-9e83-755174666d7b.png)

- for 100days Gatsby i set the link for `Read the documentation` wrong (`/docs/100days` should be `/blog/100days`) in  #20519
- but this is not a documentation - so i remove this link


## Related Issues

bug introduced in #20519 chore(blog): add tags for 100days