### PR TITLE
fix: dont remove query declaration hash, terser will remove it anyway and it can be useful for 3rd party tools

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -5,6 +5,7 @@ exports[`Allow alternative import of useStaticQuery 1`] = `
 import React from 'react';
 import * as Gatsby from 'gatsby';
 export default (() => {
+  const query = \\"2626356014\\";
   const siteTitle = staticQueryData.data;
   return React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"
@@ -82,7 +83,8 @@ import React from 'react';
 export default (() => {
   const data = staticQueryData.data;
   return React.createElement(React.Fragment, null, React.createElement(\\"h1\\", null, data.site.siteMetadata.title), React.createElement(\\"p\\", null, data.site.siteMetadata.description));
-});"
+});
+export const query = \\"2626356014\\";"
 `;
 
 exports[`Transforms only the call expression in useStaticQuery 1`] = `
@@ -103,6 +105,7 @@ exports[`Transforms queries and preserves destructuring in useStaticQuery 1`] = 
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import React from 'react';
 export default (() => {
+  const query = \\"2626356014\\";
   const {
     site
   } = staticQueryData.data;
@@ -114,6 +117,7 @@ exports[`Transforms queries and preserves variable type in useStaticQuery 1`] = 
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import React from 'react';
 export default (() => {
+  const query = \\"2626356014\\";
   let {
     site
   } = staticQueryData.data;
@@ -137,6 +141,7 @@ exports[`Transforms queries defined in own variable in useStaticQuery 1`] = `
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import React from 'react';
 export default (() => {
+  const query = \\"2626356014\\";
   const siteTitle = staticQueryData.data;
   return React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"

--- a/packages/babel-plugin-remove-graphql-queries/src/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.js
@@ -222,11 +222,6 @@ export default function({ types: t }) {
               const shortResultPath = `public/static/d/${this.queryHash}.json`
               const resultPath = nodePath.join(process.cwd(), shortResultPath)
 
-              // Remove query variable since it is useless now
-              if (this.templatePath.parentPath.isVariableDeclarator()) {
-                this.templatePath.parentPath.remove()
-              }
-
               // only remove the import if its like:
               // import { useStaticQuery } from 'gatsby'
               // but not if its like:


### PR DESCRIPTION
I have some generated code (bucklescript/graphql_ppx) whereby the reference of the query is used in another data structure (which is also unused, but it is still referenced). So if this is removed from the code Gatsby won't build. I think removing this shouldn't need to happen in the babel plugin as it will happen anyway in the dead code removal of webpack (I believe).