### PR TITLE
refactor(gatsby): Avoid re-parsing query by storing AST after extraction

### DIFF
--- a/packages/gatsby/src/query/__tests__/__snapshots__/query-compiler.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/query-compiler.js.snap
@@ -3,6 +3,167 @@
 exports[`actual compiling accepts identical fragment definitions 1`] = `
 Map {
   "mockFile" => Object {
+    "document": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "FragmentDefinition",
+          "loc": Object {
+            "end": 215,
+            "start": 151,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 177,
+              "start": 160,
+            },
+            "value": "PostsJsonFragment",
+          },
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 215,
+              "start": 191,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 205,
+                  "start": 203,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 205,
+                    "start": 203,
+                  },
+                  "value": "id",
+                },
+                "selectionSet": undefined,
+              },
+            ],
+          },
+          "typeCondition": Object {
+            "kind": "NamedType",
+            "loc": Object {
+              "end": 190,
+              "start": 181,
+            },
+            "name": Object {
+              "kind": "Name",
+              "loc": Object {
+                "end": 190,
+                "start": 181,
+              },
+              "value": "PostsJson",
+            },
+          },
+        },
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "loc": Object {
+            "end": 141,
+            "start": 0,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 19,
+              "start": 6,
+            },
+            "value": "mockFileQuery",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 141,
+              "start": 20,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 131,
+                  "start": 33,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 45,
+                    "start": 33,
+                  },
+                  "value": "allPostsJson",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "loc": Object {
+                    "end": 131,
+                    "start": 46,
+                  },
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "loc": Object {
+                        "end": 119,
+                        "start": 61,
+                      },
+                      "name": Object {
+                        "kind": "Name",
+                        "loc": Object {
+                          "end": 66,
+                          "start": 61,
+                        },
+                        "value": "nodes",
+                      },
+                      "selectionSet": Object {
+                        "kind": "SelectionSet",
+                        "loc": Object {
+                          "end": 119,
+                          "start": 67,
+                        },
+                        "selections": Array [
+                          Object {
+                            "directives": Array [],
+                            "kind": "FragmentSpread",
+                            "loc": Object {
+                              "end": 104,
+                              "start": 84,
+                            },
+                            "name": Object {
+                              "kind": "Name",
+                              "loc": Object {
+                                "end": 104,
+                                "start": 87,
+                              },
+                              "value": "PostsJsonFragment",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [],
+        },
+      ],
+      "kind": "Document",
+    },
     "hash": "hash",
     "isHook": false,
     "isStaticQuery": false,
@@ -37,6 +198,167 @@ query mockFileQuery {
 
 exports[`actual compiling adds fragments from different documents 1`] = `
 Object {
+  "document": Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "loc": Object {
+          "end": 69,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 26,
+            "start": 9,
+          },
+          "value": "PostsJsonFragment",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 69,
+            "start": 40,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 57,
+                "start": 55,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 57,
+                  "start": 55,
+                },
+                "value": "id",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "loc": Object {
+            "end": 39,
+            "start": 30,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 39,
+              "start": 30,
+            },
+            "value": "PostsJson",
+          },
+        },
+      },
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 153,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 19,
+            "start": 6,
+          },
+          "value": "mockFileQuery",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 153,
+            "start": 20,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 141,
+                "start": 35,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 47,
+                  "start": 35,
+                },
+                "value": "allPostsJson",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "loc": Object {
+                  "end": 141,
+                  "start": 48,
+                },
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "loc": Object {
+                      "end": 127,
+                      "start": 65,
+                    },
+                    "name": Object {
+                      "kind": "Name",
+                      "loc": Object {
+                        "end": 70,
+                        "start": 65,
+                      },
+                      "value": "nodes",
+                    },
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "loc": Object {
+                        "end": 127,
+                        "start": 71,
+                      },
+                      "selections": Array [
+                        Object {
+                          "directives": Array [],
+                          "kind": "FragmentSpread",
+                          "loc": Object {
+                            "end": 110,
+                            "start": 90,
+                          },
+                          "name": Object {
+                            "kind": "Name",
+                            "loc": Object {
+                              "end": 110,
+                              "start": 93,
+                            },
+                            "value": "PostsJsonFragment",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
   "hash": "hash",
   "isHook": false,
   "isStaticQuery": false,
@@ -66,6 +388,167 @@ query mockFileQuery {
 
 exports[`actual compiling adds fragments from same documents 1`] = `
 Object {
+  "document": Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "loc": Object {
+          "end": 233,
+          "start": 165,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 191,
+            "start": 174,
+          },
+          "value": "PostsJsonFragment",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 233,
+            "start": 205,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 221,
+                "start": 219,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 221,
+                  "start": 219,
+                },
+                "value": "id",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "loc": Object {
+            "end": 204,
+            "start": 195,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 204,
+              "start": 195,
+            },
+            "value": "PostsJson",
+          },
+        },
+      },
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 153,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 19,
+            "start": 6,
+          },
+          "value": "mockFileQuery",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 153,
+            "start": 20,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 141,
+                "start": 35,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 47,
+                  "start": 35,
+                },
+                "value": "allPostsJson",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "loc": Object {
+                  "end": 141,
+                  "start": 48,
+                },
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "loc": Object {
+                      "end": 127,
+                      "start": 65,
+                    },
+                    "name": Object {
+                      "kind": "Name",
+                      "loc": Object {
+                        "end": 70,
+                        "start": 65,
+                      },
+                      "value": "nodes",
+                    },
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "loc": Object {
+                        "end": 127,
+                        "start": 71,
+                      },
+                      "selections": Array [
+                        Object {
+                          "directives": Array [],
+                          "kind": "FragmentSpread",
+                          "loc": Object {
+                            "end": 110,
+                            "start": 90,
+                          },
+                          "name": Object {
+                            "kind": "Name",
+                            "loc": Object {
+                              "end": 110,
+                              "start": 93,
+                            },
+                            "value": "PostsJsonFragment",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
   "hash": "hash",
   "isHook": false,
   "isStaticQuery": false,
@@ -99,6 +582,111 @@ query mockFileQuery {
 
 exports[`actual compiling compiles a query 1`] = `
 Object {
+  "document": Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 135,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 19,
+            "start": 6,
+          },
+          "value": "mockFileQuery",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 135,
+            "start": 20,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 123,
+                "start": 35,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 47,
+                  "start": 35,
+                },
+                "value": "allPostsJson",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "loc": Object {
+                  "end": 123,
+                  "start": 48,
+                },
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "loc": Object {
+                      "end": 109,
+                      "start": 65,
+                    },
+                    "name": Object {
+                      "kind": "Name",
+                      "loc": Object {
+                        "end": 70,
+                        "start": 65,
+                      },
+                      "value": "nodes",
+                    },
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "loc": Object {
+                        "end": 109,
+                        "start": 71,
+                      },
+                      "selections": Array [
+                        Object {
+                          "alias": undefined,
+                          "arguments": Array [],
+                          "directives": Array [],
+                          "kind": "Field",
+                          "loc": Object {
+                            "end": 92,
+                            "start": 90,
+                          },
+                          "name": Object {
+                            "kind": "Name",
+                            "loc": Object {
+                              "end": 92,
+                              "start": 90,
+                            },
+                            "value": "id",
+                          },
+                          "selectionSet": undefined,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
   "hash": "hash",
   "isHook": false,
   "isStaticQuery": false,
@@ -124,6 +712,111 @@ Object {
 
 exports[`actual compiling compiles static query 1`] = `
 Object {
+  "document": Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 135,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 19,
+            "start": 6,
+          },
+          "value": "mockFileQuery",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 135,
+            "start": 20,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 123,
+                "start": 35,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 47,
+                  "start": 35,
+                },
+                "value": "allPostsJson",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "loc": Object {
+                  "end": 123,
+                  "start": 48,
+                },
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "loc": Object {
+                      "end": 109,
+                      "start": 65,
+                    },
+                    "name": Object {
+                      "kind": "Name",
+                      "loc": Object {
+                        "end": 70,
+                        "start": 65,
+                      },
+                      "value": "nodes",
+                    },
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "loc": Object {
+                        "end": 109,
+                        "start": 71,
+                      },
+                      "selections": Array [
+                        Object {
+                          "alias": undefined,
+                          "arguments": Array [],
+                          "directives": Array [],
+                          "kind": "Field",
+                          "loc": Object {
+                            "end": 92,
+                            "start": 90,
+                          },
+                          "name": Object {
+                            "kind": "Name",
+                            "loc": Object {
+                              "end": 92,
+                              "start": 90,
+                            },
+                            "value": "id",
+                          },
+                          "selectionSet": undefined,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
   "hash": "hash",
   "id": Any<String>,
   "isHook": undefined,
@@ -183,6 +876,111 @@ Array [
 exports[`actual compiling errors on double root 2`] = `
 Map {
   "mockFile" => Object {
+    "document": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "loc": Object {
+            "end": 135,
+            "start": 0,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 19,
+              "start": 6,
+            },
+            "value": "mockFileQuery",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 135,
+              "start": 20,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 123,
+                  "start": 35,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 47,
+                    "start": 35,
+                  },
+                  "value": "allPostsJson",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "loc": Object {
+                    "end": 123,
+                    "start": 48,
+                  },
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "loc": Object {
+                        "end": 109,
+                        "start": 65,
+                      },
+                      "name": Object {
+                        "kind": "Name",
+                        "loc": Object {
+                          "end": 70,
+                          "start": 65,
+                        },
+                        "value": "nodes",
+                      },
+                      "selectionSet": Object {
+                        "kind": "SelectionSet",
+                        "loc": Object {
+                          "end": 109,
+                          "start": 71,
+                        },
+                        "selections": Array [
+                          Object {
+                            "alias": undefined,
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "loc": Object {
+                              "end": 92,
+                              "start": 90,
+                            },
+                            "name": Object {
+                              "kind": "Name",
+                              "loc": Object {
+                                "end": 92,
+                                "start": 90,
+                              },
+                              "value": "id",
+                            },
+                            "selectionSet": undefined,
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [],
+        },
+      ],
+      "kind": "Document",
+    },
     "hash": "hash",
     "isHook": false,
     "isStaticQuery": false,
@@ -217,6 +1015,242 @@ Map {
 
 exports[`actual compiling handles fragments that use other fragments 1`] = `
 Object {
+  "document": Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "loc": Object {
+          "end": 110,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 26,
+            "start": 9,
+          },
+          "value": "PostsJsonFragment",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 110,
+            "start": 40,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 57,
+                "start": 55,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 57,
+                  "start": 55,
+                },
+                "value": "id",
+              },
+              "selectionSet": undefined,
+            },
+            Object {
+              "directives": Array [],
+              "kind": "FragmentSpread",
+              "loc": Object {
+                "end": 98,
+                "start": 71,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 98,
+                  "start": 74,
+                },
+                "value": "AnotherPostsJsonFragment",
+              },
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "loc": Object {
+            "end": 39,
+            "start": 30,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 39,
+              "start": 30,
+            },
+            "value": "PostsJson",
+          },
+        },
+      },
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "loc": Object {
+          "end": 199,
+          "start": 122,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 155,
+            "start": 131,
+          },
+          "value": "AnotherPostsJsonFragment",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 199,
+            "start": 169,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 187,
+                "start": 183,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 187,
+                  "start": 183,
+                },
+                "value": "text",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "loc": Object {
+            "end": 168,
+            "start": 159,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 168,
+              "start": 159,
+            },
+            "value": "PostsJson",
+          },
+        },
+      },
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 153,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 19,
+            "start": 6,
+          },
+          "value": "mockFileQuery",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 153,
+            "start": 20,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 141,
+                "start": 35,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 47,
+                  "start": 35,
+                },
+                "value": "allPostsJson",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "loc": Object {
+                  "end": 141,
+                  "start": 48,
+                },
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "loc": Object {
+                      "end": 127,
+                      "start": 65,
+                    },
+                    "name": Object {
+                      "kind": "Name",
+                      "loc": Object {
+                        "end": 70,
+                        "start": 65,
+                      },
+                      "value": "nodes",
+                    },
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "loc": Object {
+                        "end": 127,
+                        "start": 71,
+                      },
+                      "selections": Array [
+                        Object {
+                          "directives": Array [],
+                          "kind": "FragmentSpread",
+                          "loc": Object {
+                            "end": 110,
+                            "start": 90,
+                          },
+                          "name": Object {
+                            "kind": "Name",
+                            "loc": Object {
+                              "end": 110,
+                              "start": 93,
+                            },
+                            "value": "PostsJsonFragment",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
   "hash": "hash",
   "isHook": false,
   "isStaticQuery": false,
@@ -251,6 +1285,167 @@ query mockFileQuery {
 
 exports[`actual compiling removes unused fragments from documents 1`] = `
 Object {
+  "document": Object {
+    "definitions": Array [
+      Object {
+        "directives": Array [],
+        "kind": "FragmentDefinition",
+        "loc": Object {
+          "end": 233,
+          "start": 165,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 191,
+            "start": 174,
+          },
+          "value": "PostsJsonFragment",
+        },
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 233,
+            "start": 205,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 221,
+                "start": 219,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 221,
+                  "start": 219,
+                },
+                "value": "id",
+              },
+              "selectionSet": undefined,
+            },
+          ],
+        },
+        "typeCondition": Object {
+          "kind": "NamedType",
+          "loc": Object {
+            "end": 204,
+            "start": 195,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 204,
+              "start": 195,
+            },
+            "value": "PostsJson",
+          },
+        },
+      },
+      Object {
+        "directives": Array [],
+        "kind": "OperationDefinition",
+        "loc": Object {
+          "end": 153,
+          "start": 0,
+        },
+        "name": Object {
+          "kind": "Name",
+          "loc": Object {
+            "end": 19,
+            "start": 6,
+          },
+          "value": "mockFileQuery",
+        },
+        "operation": "query",
+        "selectionSet": Object {
+          "kind": "SelectionSet",
+          "loc": Object {
+            "end": 153,
+            "start": 20,
+          },
+          "selections": Array [
+            Object {
+              "alias": undefined,
+              "arguments": Array [],
+              "directives": Array [],
+              "kind": "Field",
+              "loc": Object {
+                "end": 141,
+                "start": 35,
+              },
+              "name": Object {
+                "kind": "Name",
+                "loc": Object {
+                  "end": 47,
+                  "start": 35,
+                },
+                "value": "allPostsJson",
+              },
+              "selectionSet": Object {
+                "kind": "SelectionSet",
+                "loc": Object {
+                  "end": 141,
+                  "start": 48,
+                },
+                "selections": Array [
+                  Object {
+                    "alias": undefined,
+                    "arguments": Array [],
+                    "directives": Array [],
+                    "kind": "Field",
+                    "loc": Object {
+                      "end": 127,
+                      "start": 65,
+                    },
+                    "name": Object {
+                      "kind": "Name",
+                      "loc": Object {
+                        "end": 70,
+                        "start": 65,
+                      },
+                      "value": "nodes",
+                    },
+                    "selectionSet": Object {
+                      "kind": "SelectionSet",
+                      "loc": Object {
+                        "end": 127,
+                        "start": 71,
+                      },
+                      "selections": Array [
+                        Object {
+                          "directives": Array [],
+                          "kind": "FragmentSpread",
+                          "loc": Object {
+                            "end": 110,
+                            "start": 90,
+                          },
+                          "name": Object {
+                            "kind": "Name",
+                            "loc": Object {
+                              "end": 110,
+                              "start": 93,
+                            },
+                            "value": "PostsJsonFragment",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "variableDefinitions": Array [],
+      },
+    ],
+    "kind": "Document",
+  },
   "hash": "hash",
   "isHook": false,
   "isStaticQuery": false,

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -169,7 +169,8 @@ const createStaticQueryJob = (state, queryId) => {
   return {
     id: hash,
     hash,
-    query,
+    query: query?.text,
+    document: query?.document,
     componentPath,
     context: { path: id },
   }
@@ -270,7 +271,8 @@ const createPageQueryJob = (state, page) => {
   const { query } = component
   return {
     id: path,
-    query,
+    query: query?.text,
+    document: query?.document,
     isPage: true,
     componentPath,
     context: {

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -388,6 +388,7 @@ const processDefinitions = ({
     const query = {
       name,
       text: print(document),
+      document,
       originalText: originalDefinition.text,
       path: filePath,
       isHook: originalDefinition.isHook,

--- a/packages/gatsby/src/query/query-runner.js
+++ b/packages/gatsby/src/query/query-runner.js
@@ -16,6 +16,7 @@ type QueryJob = {
   id: string,
   hash?: string,
   query: string,
+  document: Object,
   componentPath: string,
   context: Object,
   isPage: Boolean,
@@ -25,16 +26,11 @@ type QueryJob = {
 module.exports = async (graphqlRunner, queryJob: QueryJob) => {
   const { program } = store.getState()
 
-  const graphql = (query, context) => graphqlRunner.query(query, context)
-
   // Run query
-  let result
   // Nothing to do if the query doesn't exist.
-  if (!queryJob.query || queryJob.query === ``) {
-    result = {}
-  } else {
-    result = await graphql(queryJob.query, queryJob.context)
-  }
+  const result = queryJob.document
+    ? await graphqlRunner.query(queryJob.document, queryJob.context)
+    : {}
 
   // If there's a graphql error then log the error. If we're building, also
   // quit.

--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -40,7 +40,7 @@ const handleComponentsWithRemovedQueries = (
   // If a component had static query and it doesn't have it
   // anymore - update the store
   staticQueryComponents.forEach(c => {
-    if (c.query !== `` && !queries.has(c.componentPath)) {
+    if (c.query?.text !== `` && !queries.has(c.componentPath)) {
       debug(`Static query was removed from ${c.componentPath}`)
       store.dispatch({
         type: `REMOVE_STATIC_QUERY`,
@@ -59,7 +59,8 @@ const handleQuery = (
   // If this is a static query
   // Add action / reducer + watch staticquery files
   if (query.isStaticQuery) {
-    const oldQuery = staticQueryComponents.get(query.id)
+    const staticQueryComponent = staticQueryComponents.get(query.id)
+    const oldQuery = staticQueryComponent?.query
     const isNewQuery = !oldQuery
 
     // Compare query text because text is compiled query with any attached
@@ -70,13 +71,13 @@ const handleQuery = (
     if (
       isNewQuery ||
       oldQuery.hash !== query.hash ||
-      oldQuery.query !== query.text
+      oldQuery.text !== query.text
     ) {
       boundActionCreators.replaceStaticQuery({
         name: query.name,
         componentPath: query.path,
         id: query.id,
-        query: query.text,
+        query,
         hash: query.hash,
       })
 
@@ -112,7 +113,7 @@ const updateStateAndRunQueries = (isFirstRun, { parentSpan } = {}) => {
     components.forEach(c =>
       boundActionCreators.queryExtracted({
         componentPath: c.componentPath,
-        query: queries.get(c.componentPath)?.text || ``,
+        query: queries.get(c.componentPath),
       })
     )
 

--- a/packages/gatsby/src/redux/reducers/components.js
+++ b/packages/gatsby/src/redux/reducers/components.js
@@ -23,7 +23,7 @@ module.exports = (state = new Map(), action) => {
       if (!services.has(action.payload.componentPath)) {
         const machine = componentMachine.withContext({
           componentPath: action.payload.componentPath,
-          query: state.get(action.payload.componentPath)?.query || ``,
+          query: state.get(action.payload.componentPath)?.query,
           pages: new Set([action.payload.path]),
           isInBootstrap: programStatus === `BOOTSTRAPPING`,
         })
@@ -52,7 +52,7 @@ module.exports = (state = new Map(), action) => {
         action.payload.componentPath,
         Object.assign(
           {
-            query: ``,
+            query: undefined,
           },
           service.state.context
         )
@@ -69,7 +69,8 @@ module.exports = (state = new Map(), action) => {
       }
 
       // Check if the query has changed or not.
-      if (service.state.context.query === action.payload.query) {
+      const queryText = service.state.context.query?.text
+      if (queryText === action.payload.query.text) {
         service.send(`QUERY_DID_NOT_CHANGE`)
       } else {
         service.send({


### PR DESCRIPTION
## Description

Just an experiment with an attempt to pass query AST from `query-compiler` to `graphql-runner` to avoid re-parsing in the later.

It involves quite a bit of change for the little benefit so likely won't be merged. Not sure if there will be any takeaways, but opening for discussion.

CC @freiksenet 

## Related Issues

A follow up for #20477