### PR TITLE
fix(gatsby-starter-default): Removes extraneous paddingTop

### DIFF
--- a/starters/default/src/components/layout.js
+++ b/starters/default/src/components/layout.js
@@ -30,8 +30,7 @@ const Layout = ({ children }) => {
         style={{
           margin: `0 auto`,
           maxWidth: 960,
-          padding: `0px 1.0875rem 1.45rem`,
-          paddingTop: 0,
+          padding: `0 1.0875rem 1.45rem`,
         }}
       >
         <main>{children}</main>


### PR DESCRIPTION
## Description

Makes a small tweak to the inline CSS from the default starter layout. I noticed as I was playing with it that it had a `paddingTop` call immediately after a `padding` shorthand that set the value of padding-top to the same value. When I removed the `paddingTop` property, it broke the `padding` shorthand up into long-form for everything but Top, potentially causing issues.

The fix for the secondary issue was to change the shorthand's top value to `0` instead of `0px`.
