### PR TITLE
fix(www): fix background on gatsby version indicator in showcase

### DIFF
--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -102,7 +102,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                     >
                       {owner} /
                     </span>
-                    <span css={{ display: `flex` }}>
+                    <span css={{ display: `flex`, maxHeight: '1rem' }}>
                       {gatsbyMajorVersion &&
                         gatsbyMajorVersion[0] &&
                         gatsbyMajorVersion[0][1] === `2` && (

--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -89,7 +89,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                 />
                 <div sx={meta}>
                   <div
-                    css={{ display: `flex`, justifyContent: `space-between` }}
+                    css={{ display: `flex`, justifyContent: `space-between`, alignItems: `start` }}
                   >
                     <span
                       sx={{
@@ -102,7 +102,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                     >
                       {owner} /
                     </span>
-                    <span css={{ display: `flex`, maxHeight: '1rem' }}>
+                    <span css={{ display: `flex` }}>
                       {gatsbyMajorVersion &&
                         gatsbyMajorVersion[0] &&
                         gatsbyMajorVersion[0][1] === `2` && (


### PR DESCRIPTION
Resolves #20686

Also ensures the version and stars are always pinned to the top most
corner instead of sometimes floating based on the length of the author's
name

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
