### PR TITLE
Update core-js

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -20,7 +20,7 @@
     "common-tags": "^1.8.0",
     "configstore": "^5.0.0",
     "convert-hrtime": "^3.0.0",
-    "core-js": "^2.6.11",
+    "core-js": "^3.6.4",
     "envinfo": "^7.5.0",
     "execa": "^3.4.0",
     "fs-exists-cached": "^1.0.0",


### PR DESCRIPTION
core-js@<3 is no longer maintained


```npm WARN deprecated core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.```