### PR TITLE
docs (tutorial):  Improve contrast on dates

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -382,7 +382,7 @@ export default ({ data }) => {
                 {node.frontmatter.title}{" "}
                 <span
                   css={css`
-                    color: #bbb;
+                    color: #767676;
                   `}
                 >
                   — {node.frontmatter.date}


### PR DESCRIPTION
## Description 

The tutorial uses #bbb as the color for the blog post dates. This only has a contrast ratio of 1.92 and fails to reach WCAG level AA.
Reducing the color's lightness to #767676 would achieve a contrast ratio of 4.54, reaching WCAG AA, while keeping the shade of grey similar.
This addresses issue #20694 






