### PR TITLE
docs(gatsby-plugin-mdx): consistent backticks

### DIFF
--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -1,6 +1,6 @@
 ![Logo](./img/gatsby-mdx.png)
 
-> gatsby-plugin-mdx is the official integration for using [MDX](https://mdxjs.com)
+> `gatsby-plugin-mdx` is the official integration for using [MDX](https://mdxjs.com)
 > with [Gatsby](https://www.gatsbyjs.org/).
 
 # What’s MDX?
@@ -55,7 +55,7 @@ yarn add gatsby-plugin-mdx @mdx-js/mdx @mdx-js/react
 
 ## Usage
 
-After installing gatsby-plugin-mdx you can add it to your plugins list in your
+After installing `gatsby-plugin-mdx` you can add it to your plugins list in your
 `gatsby-config.js`.
 
 ```js
@@ -77,7 +77,7 @@ By default, this configuration will allow you to automatically create pages
 with `.mdx` files in `src/pages` and will process any Gatsby nodes
 with Markdown media types into MDX content.
 
-Note that gatsby-plugin-mdx requires gatsby-source-filesystem to be present
+Note that `gatsby-plugin-mdx` requires gatsby-source-filesystem to be present
 and configured to process local markdown files in order to
 generate the resulting Gatsby nodes.
 
@@ -107,18 +107,18 @@ module.exports = {
 
 ### Configuration
 
-gatsby-plugin-mdx exposes a configuration API that can be used similarly to
+`gatsby-plugin-mdx` exposes a configuration API that can be used similarly to
 any other Gatsby plugin. You can define MDX extensions, layouts, global
 scope, and more.
 
-| Key                                             | Default                                | Description                                                       |
-| ----------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------- |
-| [`extensions`](#extensions)                     | `[".mdx"]`                             | Configure the file extensions that gatsby-plugin-mdx will process |
-| [`defaultLayouts`](#default-layouts)            | `{}`                                   | Set the layout components for MDX source types                    |
-| [`gatsbyRemarkPlugins`](#gatsby-remark-plugins) | `[]`                                   | Use Gatsby-specific remark plugins                                |
-| [`remarkPlugins`](#remark-plugins)              | `[]`                                   | Specify remark plugins                                            |
-| [`rehypePlugins`](#rehype-plugins)              | `[]`                                   | Specify rehype plugins                                            |
-| [`mediaTypes`](#media-types)                    | `["text/markdown", "text/x-markdown"]` | Determine which media types are processed by MDX                  |
+| Key                                             | Default                                | Description                                                         |
+| ----------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------- |
+| [`extensions`](#extensions)                     | `[".mdx"]`                             | Configure the file extensions that `gatsby-plugin-mdx` will process |
+| [`defaultLayouts`](#default-layouts)            | `{}`                                   | Set the layout components for MDX source types                      |
+| [`gatsbyRemarkPlugins`](#gatsby-remark-plugins) | `[]`                                   | Use Gatsby-specific remark plugins                                  |
+| [`remarkPlugins`](#remark-plugins)              | `[]`                                   | Specify remark plugins                                              |
+| [`rehypePlugins`](#rehype-plugins)              | `[]`                                   | Specify rehype plugins                                              |
+| [`mediaTypes`](#media-types)                    | `["text/markdown", "text/x-markdown"]` | Determine which media types are processed by MDX                    |
 
 #### Extensions
 
@@ -392,7 +392,7 @@ module.exports = {
 
 #### Media types
 
-Deciding what content gets processed by gatsby-plugin-mdx. This is an
+Deciding what content gets processed by `gatsby-plugin-mdx`. This is an
 advanced option that is useful for dealing with specialized generated
 content. It is not intended to be configured for most users.
 
@@ -419,7 +419,7 @@ choose which nodes to process by looking at the media type.
 
 ### Components
 
-MDX and gatsby-plugin-mdx use components for different things like rendering
+MDX and `gatsby-plugin-mdx` use components for different things like rendering
 and component mappings.
 
 #### MDXProvider


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In the README for `gatsby-plugin-mdx`, the name of the plugin was sometimes in plain text ("gatsby-plugin-mdx") and was sometimes in code backticks (`gatsby-plugin-mdx`). This simply updates all references to use code backticks for consistency.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

n/a

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

n/a