### PR TITLE
fix(docs): Fix link on "Using GraphQL Fragments"

### DIFF
--- a/docs/docs/using-graphql-fragments.md
+++ b/docs/docs/using-graphql-fragments.md
@@ -78,5 +78,5 @@ When compiling your site, Gatsby preprocesses all GraphQL queries it finds. Ther
 
 ## Further reading
 
-- [Querying Data with GraphQL - Fragments](/docs/querying-with-graphql/#fragments)
+- [Querying Data with GraphQL - Fragments](/docs/graphql-concepts/#fragments)
 - [GraphQL Docs - Fragments](https://graphql.org/learn/queries/#fragments)


### PR DESCRIPTION
Fix "Querying Data with GraphQL - Fragments" link on "Using GraphQL Fragments" page