### PR TITLE
fix(blog): add code fences to not create a link from example

### DIFF
--- a/docs/blog/2019-07-23-google-sheets-gatsby-acroyoga-video-explorer/index.md
+++ b/docs/blog/2019-07-23-google-sheets-gatsby-acroyoga-video-explorer/index.md
@@ -336,7 +336,7 @@ This was such a clear and easy 'aha!' moment. I hadn't optimized my images and w
 
 I dug into my normal gatsby-image workflow but I quickly hit a snag. My previous use of Gatsby-image had been for local images whilst I was now trying to use remote images (cloud storage image links). Thankfully, with just a bit more searching, I found the right plugin to solve this: [gatsby-plugin-remote-images](/packages/gatsby-plugin-remote-images/).
 
-Gatsby-plugin-remote-images fetches image URL links (e.g. http://super-image.png) and prepares them in a way that gatsby-image can use them. To make my cards load faster, I'd need to optimize both the video thumbnail as well as the small instructor image. It makes no sense at all to load a 300+ pixel image of an instructor when all you really need are maybe 40 pixels max.
+Gatsby-plugin-remote-images fetches image URL links (e.g. `http://super-image.png`) and prepares them in a way that gatsby-image can use them. To make my cards load faster, I'd need to optimize both the video thumbnail as well as the small instructor image. It makes no sense at all to load a 300+ pixel image of an instructor when all you really need are maybe 40 pixels max.
 
 ![Acroyoga Card with Optimized Images](./images/word-image-4.png)
 


### PR DESCRIPTION
## Description

add code fences to not create a clickable link from an example link

## notes

should it not be more like a full link like:

`https://domain.tld/path/super-image.png`

## Related Issues

#19267 Add link check To Gatsby Docs

