### PR TITLE
chore(gatsby): Fix case where the error parser receives an array

### DIFF
--- a/packages/gatsby/src/utils/api-runner-error-parser.js
+++ b/packages/gatsby/src/utils/api-runner-error-parser.js
@@ -25,7 +25,10 @@ const errorParser = ({ err }) => {
   let structured
 
   for (const { regex, cb } of handlers) {
-    const matched = err.message.match(regex)
+    if (Array.isArray(err)) {
+      err = err[0]
+    }
+    const matched = err.message?.match(regex)
     if (matched) {
       structured = {
         ...cb(matched),


### PR DESCRIPTION
The repro was too big to wrap in a test, but I did debug this to a point where I've verified and observed in the devtools that this value was an array. As such I'm adding a check and taking the first element of that array.

Technically there could be multiple errors in that array and perhaps we should do something with that. As it stands, printing an error is better than printing "cannot call match on undefined" :)