### PR TITLE
docs(sourcing-from-netlify-cms): absolute path for public folder

### DIFF
--- a/docs/docs/sourcing-from-netlify-cms.md
+++ b/docs/docs/sourcing-from-netlify-cms.md
@@ -63,7 +63,7 @@ backend:
   name: test-repo
 
 media_folder: static/assets
-public_folder: assets
+public_folder: /assets
 
 collections:
   - name: blog


### PR DESCRIPTION
Disclaimer: I'm new to React and Netlify 

When I created a post using netlify on my demo site images wok OK if the page is in the root directory

But not when I make a page in a subdirectory - I think the public_folder of netlify config should be an absolute path so that images still work for netlify content in subdirectories

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
