### PR TITLE
fix(gatsby): use slash from gatsby-core-utils

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -122,7 +122,6 @@
     "shallow-compare": "^1.2.2",
     "sift": "^5.1.0",
     "signal-exit": "^3.0.2",
-    "slash": "^3.0.0",
     "slugify": "^1.3.6",
     "socket.io": "^2.3.0",
     "stack-trace": "^0.0.10",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -122,6 +122,7 @@
     "shallow-compare": "^1.2.2",
     "sift": "^5.1.0",
     "signal-exit": "^3.0.2",
+    "slash": "^3.0.0",
     "slugify": "^1.3.6",
     "socket.io": "^2.3.0",
     "stack-trace": "^0.0.10",

--- a/packages/gatsby/src/utils/__tests__/jobs-manager.js
+++ b/packages/gatsby/src/utils/__tests__/jobs-manager.js
@@ -1,6 +1,6 @@
 const path = require(`path`)
 const _ = require(`lodash`)
-const slash = require(`slash`)
+const { slash } = require(`gatsby-core-utils`)
 let jobManager = null
 
 // I need a mock to spy on

--- a/packages/gatsby/src/utils/jobs-manager.js
+++ b/packages/gatsby/src/utils/jobs-manager.js
@@ -3,9 +3,8 @@ const path = require(`path`)
 const hasha = require(`hasha`)
 const fs = require(`fs-extra`)
 const pDefer = require(`p-defer`)
-const slash = require(`slash`)
 const _ = require(`lodash`)
-const { createContentDigest } = require(`gatsby-core-utils`)
+const { createContentDigest, slash } = require(`gatsby-core-utils`)
 const reporter = require(`gatsby-cli/lib/reporter`)
 
 let activityForJobs = null


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Seems like slash isn't a dependency in gatsby. I could have sworn we used it on multiple places but it seems like it didn't.

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/20740