### PR TITLE
fix: ensure that errorParser always returns something

### DIFF
--- a/packages/gatsby/src/utils/__tests__/api-runner-error-parser.ts
+++ b/packages/gatsby/src/utils/__tests__/api-runner-error-parser.ts
@@ -1,0 +1,52 @@
+import errorParser from "../api-runner-error-parser"
+
+describe(`error matching`, () => {
+  test(`it matches "is not defined" errors`, () => {
+    const match = errorParser({ err: new Error(`foo is not defined`) })
+
+    expect(match).toEqual({
+      id: `11330`,
+      context: { sourceMessage: `foo is not defined`, arg: `foo` },
+    })
+  })
+
+  test(`it has a default when no match are found`, () => {
+    const match = errorParser({ err: new Error(`unknown error`) })
+
+    expect(match).toEqual({
+      id: `11321`,
+      context: { sourceMessage: `unknown error` },
+      error: new Error(`unknown error`),
+    })
+  })
+})
+
+describe(`unkown error parser`, () => {
+  test(`it handles Errors`, () => {
+    const match = errorParser({ err: new Error(`error`) })
+
+    expect(match.context.sourceMessage).toEqual(`error`)
+    expect(match.error).toBeTruthy()
+  })
+
+  test(`it handles Strings`, () => {
+    const match = errorParser({ err: `error` })
+
+    expect(match.context.sourceMessage).toEqual(`error`)
+    expect(match.error).toBeUndefined()
+  })
+
+  test(`it handles arrays of Error`, () => {
+    const match = errorParser({ err: [new Error(`error`)] })
+
+    expect(match.context.sourceMessage).toEqual(`error`)
+    expect(match.error).toBeTruthy()
+  })
+
+  test(`it handles anything else by returning an empty string`, () => {
+    const match = errorParser({ err: new Map() })
+
+    expect(match.context.sourceMessage).toEqual(``)
+    expect(match.error).toBeUndefined()
+  })
+})

--- a/packages/gatsby/src/utils/api-runner-error-parser.ts
+++ b/packages/gatsby/src/utils/api-runner-error-parser.ts
@@ -1,44 +1,50 @@
 import { IMatch } from "../types"
 
-const errorParser = ({ err }): IMatch => {
+const errorParser = ({ err }: { err: unknown }): IMatch => {
   const handlers = [
     {
       regex: /(.+) is not defined/m,
-      cb: (match): IMatch => {
+      cb: (match: RegExpMatchArray): IMatch => {
         return {
           id: `11330`,
           context: { sourceMessage: match[0], arg: match[1] },
         }
       },
     },
-    // Match anything with a generic catch-all error handler
-    {
-      regex: /[\s\S]*/gm,
-      cb: (match): IMatch => {
-        return {
-          id: `11321`,
-          context: { sourceMessage: err instanceof Error ? match[0] : err },
-          error: err instanceof Error ? err : undefined,
-        }
-      },
-    },
   ]
 
-  let structured
+  let structured: IMatch | undefined
+  let errorMessage: string | undefined
+
+  // try to handle as many type of err as possible.
+  // the err might come from a plugin so we don't
+  // know what we are getting
+  if (Array.isArray(err)) {
+    err = err[0]
+  }
+  if (err instanceof Error) {
+    errorMessage = err.message
+  }
+  if (typeof err === 'string') {
+    errorMessage = err
+  }
 
   for (const { regex, cb } of handlers) {
-    if (Array.isArray(err)) {
-      err = err[0]
-    }
-    if (err.message) {
-      err = err.message
-    }
-    const matched = err?.match(regex)
+    const matched = errorMessage?.match(regex)
     if (matched) {
       structured = {
         ...cb(matched),
       }
       break
+    }
+  }
+
+  // if we haven't found any known error
+  if (!structured) {
+    return {
+      id: `11321`,
+      context: { sourceMessage: errorMessage || '' },
+      error: err instanceof Error ? err : undefined,
     }
   }
 

--- a/packages/gatsby/src/utils/api-runner-error-parser.ts
+++ b/packages/gatsby/src/utils/api-runner-error-parser.ts
@@ -25,7 +25,7 @@ const errorParser = ({ err }: { err: unknown }): IMatch => {
   if (err instanceof Error) {
     errorMessage = err.message
   }
-  if (typeof err === 'string') {
+  if (typeof err === `string`) {
     errorMessage = err
   }
 
@@ -43,7 +43,7 @@ const errorParser = ({ err }: { err: unknown }): IMatch => {
   if (!structured) {
     return {
       id: `11321`,
-      context: { sourceMessage: errorMessage || '' },
+      context: { sourceMessage: errorMessage || `` },
       error: err instanceof Error ? err : undefined,
     }
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

- The `api-runner-node` assumes that `api-runner-error-parser` always returns something. (https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/api-runner-node.js#L381-L411)
- That's not the case if the error is a string (as is the case for `gatsby-plugin-manifest`)

This makes `api-runner-error-parser` a bit more robust by returning a default error if we didn't manage to parse it.

I'll fix the `gatsby-plugin-manifest` in another PR
