### PR TITLE
fix(chore): extract style to const

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -185,19 +185,20 @@ class RouteAnnouncer extends React.Component {
   }
 
   render() {
+    const style = {
+      position: `absolute`,
+      width: 1,
+      height: 1,
+      padding: 0,
+      overflow: `hidden`,
+      clip: `rect(0, 0, 0, 0)`,
+      whiteSpace: `nowrap`,
+      border: 0,
+    }
     return (
       <div
         id="gatsby-announcer"
-        style={{
-          position: `absolute`,
-          width: 1,
-          height: 1,
-          padding: 0,
-          overflow: `hidden`,
-          clip: `rect(0, 0, 0, 0)`,
-          whiteSpace: `nowrap`,
-          border: 0,
-        }}
+        style={style}
         role="alert"
         aria-live="assertive"
         aria-atomic="true"

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -7,6 +7,17 @@ import emitter from "./emitter"
 import { navigate as reachNavigate } from "@reach/router"
 import { parsePath } from "gatsby-link"
 
+const routeAnnouncerStyle = {
+  position: `absolute`,
+  width: 1,
+  height: 1,
+  padding: 0,
+  overflow: `hidden`,
+  clip: `rect(0, 0, 0, 0)`,
+  whiteSpace: `nowrap`,
+  border: 0,
+}
+
 // Convert to a map for faster lookup in maybeRedirect()
 const redirectMap = redirects.reduce((map, redirect) => {
   map[redirect.fromPath] = redirect
@@ -185,20 +196,10 @@ class RouteAnnouncer extends React.Component {
   }
 
   render() {
-    const style = {
-      position: `absolute`,
-      width: 1,
-      height: 1,
-      padding: 0,
-      overflow: `hidden`,
-      clip: `rect(0, 0, 0, 0)`,
-      whiteSpace: `nowrap`,
-      border: 0,
-    }
     return (
       <div
         id="gatsby-announcer"
-        style={style}
+        style={routeAnnouncerStyle}
         role="alert"
         aria-live="assertive"
         aria-atomic="true"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

extract style to const

## Related Issues

#19290 

suggested in https://github.com/gatsbyjs/gatsby/pull/19290/files#r368206484
> please extract object to const outside of class scope, or React.useMemo hook

