### PR TITLE
fix(www) - Fix anchor link in tutorial sidebar

### DIFF
--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -10,8 +10,8 @@
       items:
         - title: Familiarize with the command line
           link: /tutorial/part-zero/#familiarize-yourself-with-the-command-line
-        - title: Install Node.js and npm
-          link: /tutorial/part-zero/#-install-nodejs-and-npm
+        - title: Install Node.js
+          link: /tutorial/part-zero/#install-nodejs-for-your-appropriate-operating-system
         - title: Install Git
           link: /tutorial/part-zero/#install-git
         - title: Using the Gatsby CLI

--- a/www/src/data/sidebars/tutorial-links.yaml
+++ b/www/src/data/sidebars/tutorial-links.yaml
@@ -10,7 +10,7 @@
       items:
         - title: Familiarize with the command line
           link: /tutorial/part-zero/#familiarize-yourself-with-the-command-line
-        - title: Install Node.js
+        - title: Install Node.js for your appropriate operating system
           link: /tutorial/part-zero/#install-nodejs-for-your-appropriate-operating-system
         - title: Install Git
           link: /tutorial/part-zero/#install-git


### PR DESCRIPTION
At some point we changed the heading without updating the slugs that link to it, so I'm updating it here now.

What it is now:
https://www.gatsbyjs.org/tutorial/part-zero/#-install-nodejs-and-npm

What it should be:
https://www.gatsbyjs.org/tutorial/part-zero/#install-nodejs-for-your-appropriate-operating-system
