### PR TITLE
fix(showcase): showcase redirects

### DIFF
--- a/.github/actions/gatsby-site-showcase-validator/README.md
+++ b/.github/actions/gatsby-site-showcase-validator/README.md
@@ -1,5 +1,5 @@
 # Gatsby Site Showcase Validator
 
-A simple node script that visits and checks all of the sites in the [Site Showcase](https://www.gatsbyjs.org/showcase/) for Gatsby.
+A simple node script that visits and checks all of the sites in the [Site Showcase](https://www.gatsbyjs.or/showcase/) for Gatsby.
 
 Run locally [using act](https://github.com/nektos/act): `act -a "gatsby-site-showcase-validator"`

--- a/.github/actions/gatsby-site-showcase-validator/README.md
+++ b/.github/actions/gatsby-site-showcase-validator/README.md
@@ -1,5 +1,5 @@
 # Gatsby Site Showcase Validator
 
-A simple node script that visits and checks all of the sites in the [Site Showcase](https://www.gatsbyjs.or/showcase/) for Gatsby.
+A simple node script that visits and checks all of the sites in the [Site Showcase](https://www.gatsbyjs.org/showcase/) for Gatsby.
 
 Run locally [using act](https://github.com/nektos/act): `act -a "gatsby-site-showcase-validator"`

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -408,7 +408,7 @@ const ShowcaseDetails = ({ parent, data, isModal, categories }) => (
                     {categories.map((c, i) => (
                       <Fragment key={c}>
                         <Link
-                          to={`/showcase?${qs.stringify({ filters: [c] })}`}
+                          to={`/showcase/?${qs.stringify({ filters: [c] })}`}
                           state={{ isModal: true }}
                           sx={styles.link}
                         >

--- a/www/src/templates/template-showcase-details.js
+++ b/www/src/templates/template-showcase-details.js
@@ -66,9 +66,9 @@ class ShowcaseTemplate extends React.Component {
       const queryString = qs.stringify({
         filters: this.props.location.state.filters,
       })
-      return `/showcase?${queryString}`
+      return `/showcase/?${queryString}`
     } else {
-      return `/showcase`
+      return `/showcase/`
     }
   }
 

--- a/www/src/views/showcase/featured-sites.js
+++ b/www/src/views/showcase/featured-sites.js
@@ -142,7 +142,7 @@ class FeaturedSites extends Component {
               Want to get featured?
             </div>
             <Button
-              to="https://gatsbyjs.org/contributing/site-showcase-submissions/"
+              to="https://www.gatsbyjs.org/contributing/site-showcase-submissions/"
               tag="href"
               target="_blank"
               rel="noopener noreferrer"

--- a/www/src/views/showcase/showcase-item-categories.js
+++ b/www/src/views/showcase/showcase-item-categories.js
@@ -22,7 +22,7 @@ const ShowcaseItemCategories = ({ categories, onCategoryClick }) => {
             },
           },
         }}
-        to={`/showcase?${qs.stringify({
+        to={`/showcase/?${qs.stringify({
           filters: [c],
         })}`}
         onClick={e => {

--- a/www/src/views/showcase/showcase-list.js
+++ b/www/src/views/showcase/showcase-list.js
@@ -110,7 +110,7 @@ const ShowcaseList = ({ items, count, filters, onCategoryClick }) => {
                         },
                       },
                     }}
-                    to={`/showcase?${qs.stringify({
+                    to={`/showcase/?${qs.stringify({
                       filters: `Featured`,
                     })}`}
                     className="featured-site"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

all showcase links without a trailing slash result in a redirect

example:

```shell
curl -I https://www.gatsbyjs.org/showcase?filters%5B0%5D=WordPress
HTTP/2 301                                                                                                                                                              
location: /showcase/?filters%5B0%5D=WordPress         
```


and 

```shell
curl -I https://gatsbyjs.org/contributing/site-showcase-submissions/
HTTP/2 301                                                                                                                                                              
location: https://www.gatsbyjs.org/contributing/site-showcase-submissions/                                                                                              
```

## Related Issues

n/a