### PR TITLE
chore(gatsby): add keyword gatsby-plugin to package.json

### DIFF
--- a/packages/gatsby-cypress/package.json
+++ b/packages/gatsby-cypress/package.json
@@ -25,6 +25,7 @@
   },
   "keywords": [
     "gatsby",
+    "gatsby-plugin",
     "cypress",
     "cypress.io",
     "integration"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

add keyword `gatsby-plugin` to `package.json`

i don't know if this is 

## Related Issues

fixes #20773 chore(packages): 404 on `gatsby-cypress` 

## follow up steps

the package need to be published to get updated on npm https://www.npmjs.com/package/gatsby-cypress