### PR TITLE
fix: remove 1px line from gatsby-announcer on 100vh pages

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -190,6 +190,7 @@ class RouteAnnouncer extends React.Component {
         id="gatsby-announcer"
         style={{
           position: `absolute`,
+          top: 0,
           width: 1,
           height: 1,
           padding: 0,


### PR DESCRIPTION

## Description
The `1px` height style on the `gatsby-announcer` div adds a `1px` line to the bottom of `100vh` pages. We want the announcer element to be visually hidden on the page, and have followed best practices from [WebAIM](https://webaim.org/techniques/css/invisiblecontent/#offscreen). 

> `width:1px; height:1px; overflow:hidden;` tells the browser to make the element 1px by 1px in size and to visually hide everything that does not fit into these dimensions. While this is a likely a little overkill and can probably be omitted in most circumstances, there are a few instances where positioning may be disabled, but all other styles remain enabled. In this case, the element will remain in its original position, but will only take 1 pixel of space.

To remove the line at the bottom of `100vh` pages, we've added `top: 0` to the list of styles for the announcer element.

## Related Issues
Fixes #20728

