### PR TITLE
fix(gatsby-source-contentful): Bypass schema validation for null nodes for fixed/fluid media assets

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -397,6 +397,8 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
     },
     resolve: (image, options, context) =>
       Promise.resolve(resolveFixed(image, options)).then(node => {
+        if (!node) return null
+
         return {
           ...node,
           image,
@@ -494,6 +496,8 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
     },
     resolve: (image, options, context) =>
       Promise.resolve(resolveFluid(image, options)).then(node => {
+        if (!node) return null
+
         return {
           ...node,
           image,


### PR DESCRIPTION
## Description

Fix Contentful schema validation for `null` nodes for `fixed` or `fluid` media assets.

### Documentation

N/A

## Related Issues

#20696
