### PR TITLE
fix(gatsby-transformer-sharp): add base64 field as non-null in schema

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -318,7 +318,7 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
       name: name,
       fields: {
         base64: {
-          type: GraphQLString,
+          type: new GraphQLNonNull(GraphQLString),
           resolve(imageProps) {
             return getBase64Image(imageProps)
           },
@@ -415,7 +415,7 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
       name: name,
       fields: {
         base64: {
-          type: GraphQLString,
+          type: new GraphQLNonNull(GraphQLString),
           resolve(imageProps) {
             return getBase64Image(imageProps)
           },

--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -63,7 +63,7 @@ const fixedNodeType = ({
     type: new GraphQLObjectType({
       name: name,
       fields: {
-        base64: { type: GraphQLString },
+        base64: { type: new GraphQLNonNull(GraphQLString) },
         tracedSVG: {
           type: GraphQLString,
           resolve: parent =>
@@ -220,7 +220,7 @@ const fluidNodeType = ({
     type: new GraphQLObjectType({
       name: name,
       fields: {
-        base64: { type: GraphQLString },
+        base64: { type: new GraphQLNonNull(GraphQLString) },
         tracedSVG: {
           type: GraphQLString,
           resolve: parent =>


### PR DESCRIPTION
## Description

Follow up of https://github.com/gatsbyjs/gatsby/pull/20314, I added the `base64` field because the fragment [defines it](https://github.com/gatsbyjs/gatsby/blob/119c345bd4cb8f45649fe547bdfcbdf38a56e8e1/packages/gatsby-transformer-sharp/src/fragments.js#L22) and it avoids TS errors.
