### PR TITLE
docs(glossary): Add several web api entries in the glossary page

### DIFF
--- a/docs/docs/adding-react-components.md
+++ b/docs/docs/adding-react-components.md
@@ -63,7 +63,7 @@ Since Gatsby uses Server-Side Rendering (SSR) to generate your site's pages, the
 
 ### Use of browser globals
 
-Some components or code reference browser globals such as `window`, `document` or `localStorage`. These objects are not available at [build](/docs/glossary#build) time and can result in a webpack error when compiling:
+Some components or code reference browser globals such as [`window`](/docs/glossary#Window), [`document`](/docs/glossary#Document) or [`localStorage`](/docs/glossary#LocalStorage). These objects are not available at [build](/docs/glossary#build) time and can result in a webpack error when compiling:
 
 ```text
 WebpackError: ReferenceError: window is not defined
@@ -73,7 +73,7 @@ To learn more about solutions for supporting SSR and client-side libraries, chec
 
 #### Fixing third-party modules
 
-Some packages expect `window` or another browser global to be defined. These packages will have to be patched.
+Some packages expect [`window`](/docs/glossary#Window) or another browser global to be defined. These packages will have to be patched.
 
 You can learn how to patch these packages on the [Debugging HTML Builds documentation](/docs/debugging-html-builds/#fixing-third-party-modules).
 

--- a/docs/docs/building-a-site-with-authentication.md
+++ b/docs/docs/building-a-site-with-authentication.md
@@ -57,9 +57,9 @@ More specific code examples for this pattern are outlined in the [Client-only Ro
 
 ### Protecting code from accessing browser globals during build
 
-Global objects that are accessible in the browser like `localStorage` aren't available while a Gatsby site is building, because the build runs in a Node.js environment.
+Global objects that are accessible in the browser like [`localStorage`](/docs/glossary#LocalStorage) aren't available while a Gatsby site is building, because the build runs in a Node.js environment.
 
-However, some third party services might try and access `localStorage` or the `window` object with internal methods. To keep those snippets from breaking the build, those invocations should be wrapped in checks or `useEffect` hooks to verify that the code is running in the browser and is skipped during the build process:
+However, some third party services might try and access [`localStorage`](/docs/glossary#LocalStorage) or the [`window`](/docs/glossary#Window) object with internal methods. To keep those snippets from breaking the build, those invocations should be wrapped in checks or `useEffect` hooks to verify that the code is running in the browser and is skipped during the build process:
 
 ```javascript
 import app from "firebase/app"

--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -4,7 +4,7 @@ title: Debugging HTML Builds
 
 Errors while building static HTML files generally happen for one of the following reasons:
 
-1.  Some of your code references "browser globals" like `window` or `document`. If
+1.  Some of your code references "browser globals" like [`window`](/docs/glossary#Window) or [`document`](/docs/glossary#Document). If
     this is your problem you should see an error above like "window is not
     defined". To fix this, find the offending code and either a) check before
     calling the code if window is defined so the code doesn't run while Gatsby is
@@ -12,21 +12,21 @@ Errors while building static HTML files generally happen for one of the followin
     of a React.js component, move that code into a [`componentDidMount` lifecycle](https://reactjs.org/docs/react-component.html#componentdidmount) or into a [`useEffect` hook](https://reactjs.org/docs/hooks-reference.html#useeffect), which
     ensures the code doesn't run unless it's in the browser.
 
-1.  Check that each of your JS files listed in your `pages` directory (and any
+2.  Check that each of your JS files listed in your `pages` directory (and any
     sub-directories) are exporting either a React component or string. Gatsby
     treats any JS file listed under the `pages` dir as a page component, so it must
     have a default export that's a component or string.
 
-1.  You mix up `import` and `require` calls in the same file. This might lead to
+3.  You mix up `import` and `require` calls in the same file. This might lead to
     "WebpackError: Invariant Violation: Minified React error #130" [since Webpack 4
     is stricter than v3](/docs/migrating-from-v1-to-v2/#convert-to-either-pure-commonjs-or-pure-es6).
     The solution is to only use `import`.
 
-1.  Your app is not correctly [hydrated](https://reactjs.org/docs/react-dom.html), which results in gatsby develop and gatsby
+4.  Your app is not correctly [hydrated](https://reactjs.org/docs/react-dom.html), which results in gatsby develop and gatsby
     build being inconsistent. It's possible that a change in a file like `gatsby-ssr` or `gatsby-browser` has a structure that is
     not reflected in the other file, meaning that there is a mismatch between client and server output.
 
-1.  Some other reason :-) #1 is the most common reason building static files
+5.  Some other reason :-) #1 is the most common reason building static files
     fail. If it's another reason, you have to be a bit more creative in figuring
     out the problem.
 
@@ -51,7 +51,7 @@ const module = typeof window !== `undefined` ? require("module") : null
 
 ## Fixing third-party modules
 
-So, the worst has happened and you're using an NPM module that expects `window`
+So, the worst has happened and you're using an NPM module that expects [`window`](/docs/glossary#Window)
 to be defined. You may be able to file an issue and get the module patched, but
 what to do in the mean time?
 
@@ -78,4 +78,4 @@ exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
 }
 ```
 
-Another solution is to use a package like [react-loadable](https://github.com/jamiebuilds/react-loadable). The module that tries to use `window` will be dynamically loaded only on the client side (and not during SSR).
+Another solution is to use a package like [react-loadable](https://github.com/jamiebuilds/react-loadable). The module that tries to use [`window`](/docs/glossary#Window) will be dynamically loaded only on the client side (and not during SSR).

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -102,6 +102,10 @@ The process of [building](#build) your website or app and uploading onto a [host
 
 The [environment](#environment) when you're developing your code. It's accessed through the [CLI](#cli) using `gatsby develop`, and provides extra error reporting and things to help you debug before building for [production](#production-environment).
 
+### Document
+
+A Document Object represents any web page loaded in the browser and serves as an entry point into the web page's content
+
 ### DOM
 
 The Document Object Model, commonly referred to as "the DOM", is a standard browser API that connects web pages to scripts or programming languages by representing the structure of an HTML document in memory. Developers commonly interact with the DOM through [HTML](#html) markup (written in [JSX](#jsx) in Gatsby), as well as both [React](https://reactjs.org/docs/react-dom.html) and [vanilla JavaScript](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction#DOM_and_JavaScript) code. Another important aspect of utilizing the DOM to its full potential is writing [accessible](#accessibility) HTML markup to expose a page's structure to assistive technology.
@@ -192,6 +196,10 @@ JSX is an extension to JavaScript that allows developers to write HTML and custo
 
 Linting is the process of running a program that will analyze code for potential errors. The Gatsby project uses [prettier](https://prettier.io/) to identify and fix common style issues. Another example of a linter commonly used in React projects is [eslint-jsx-plugin-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y), which checks for common [accessibility](#accessibility) issues in development.
 
+### LocalStorage
+
+LocalStorage is the storage that to save key/value pairs in a web browser. The localStorage object stores data with no expiration date. The data will not be deleted when the browser is closed, and will be available the next day, week, or year.
+
 ## M
 
 ### MDX
@@ -203,6 +211,10 @@ Extends [Markdown](#markdown) to support [React](#react) [components](#component
 A way of writing HTML content with plain text, using special characters to denote content types such as hash symbols for [headings](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements), and underscores and asterisks for text emphasis.
 
 ## N
+
+### Navigator
+
+A Navigator object represents information about the browser. You can get the browser's language or user-agent using the Navigator object.
 
 ### NPM
 
@@ -284,6 +296,10 @@ An exact representation of how data is stored in a system, such as tables and fi
 
 The server-side part of the [client-server relationship](https://en.wikipedia.org/wiki/Client%E2%80%93server_model) refers to operations performed by a computer program which manages access to a centralized resource or service in a computer network. Gatsby uses the server-side technology [Node.js](#nodejs) to compile pages at build time, as opposed to serving them at [browser runtime](#runtime) with [client-side](#client-side) JavaScript. See also: [frontend](#frontend) and [backend](#backend).
 
+### SessionStorage
+
+SessionStorage is the storage that to save key/value pairs in a web browser. The sessionStorage object stores data for only one session (the data is deleted when the browser tab is closed).
+
 ### Source Code
 
 Source code is your code that lives in `/src/` folder and makes up the unique aspects of your website or app. It is made up of [JavaScript](#javascript) and sometimes [CSS](#css) and other files.
@@ -327,6 +343,10 @@ A UI refers to a User Interface. In the field of human-computer interaction, a U
 ## V
 
 ## W
+
+### Window 
+
+A window object represents an open window in a browser. The window object is available in javascript of all browsers.
 
 ### [webpack](/docs/glossary/webpack)
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -52,7 +52,7 @@ Gatsby has two command line interfaces. One, [`gatsby`](/docs/gatsby-cli/), for 
 
 ### Client-side
 
-Client-side refers to operations that are performed by the user's browser in a [client–server relationship](https://en.wikipedia.org/wiki/Client%E2%80%93server_model) in a computer network. In Gatsby, this is important when [working with packages](/docs/using-client-side-only-packages/) that rely on objects in the [browser DOM](#dom), such as `window` or `navigator`. See also: [server-side](#server-side), [frontend](#frontend), and [backend](#backend).
+Client-side refers to operations that are performed by the user's browser in a [client–server relationship](https://en.wikipedia.org/wiki/Client%E2%80%93server_model) in a computer network. In Gatsby, this is important when [working with packages](/docs/using-client-side-only-packages/) that rely on objects in the [browser DOM](#dom), such as [`window`](#Window) or [`navigator`](#Navigator). See also: [server-side](#server-side), [frontend](#frontend), and [backend](#backend).
 
 ### CMS
 
@@ -166,7 +166,7 @@ A feature in use when you run `gatsby develop` that live updates your site on sa
 
 ### Hydration
 
-Once a site has been [built](#build) by Gatsby and loaded in a web browser, [client-side](#client-side) JavaScript assets will download and turn the site into a full React application that can manipulate the [DOM](#dom). This process is often called re-hydration as it runs some of the same JavaScript code used to generate Gatsby pages, but this time with browser DOM APIs like `window` available.
+Once a site has been [built](#build) by Gatsby and loaded in a web browser, [client-side](#client-side) JavaScript assets will download and turn the site into a full React application that can manipulate the [DOM](#dom). This process is often called re-hydration as it runs some of the same JavaScript code used to generate Gatsby pages, but this time with browser DOM APIs like [`window`](#Window) available.
 
 ## I
 
@@ -344,7 +344,7 @@ A UI refers to a User Interface. In the field of human-computer interaction, a U
 
 ## W
 
-### Window 
+### Window
 
 A window object represents an open window in a browser. The window object is available in javascript of all browsers.
 

--- a/docs/docs/overview-of-the-gatsby-build-process.md
+++ b/docs/docs/overview-of-the-gatsby-build-process.md
@@ -19,7 +19,7 @@ A common confusion with the generation of [static](/docs/glossary#static) assets
 
 Processes that happen in a web browser that you click through and interact with can be referred to as a _browser runtime_. JavaScript code can interact with the browser and take advantage of APIs it offers, such as `window.location` to get information from a page's URL, using AJAX to submit a form, or injecting markup dynamically into the [DOM](/docs/glossary#dom). [Gatsby creates a JavaScript runtime](/docs/production-app) that takes over in the browser once the initial HTML has loaded.
 
-_Build time_, in contrast, refers to the process of using a server process to compile the site into files that can be delivered to a web browser later, so Browser APIs like `window` aren't available at that time.
+_Build time_, in contrast, refers to the process of using a server process to compile the site into files that can be delivered to a web browser later, so Browser APIs like [`window`](/docs/glossary#Window) aren't available at that time.
 
 The `gatsby develop` command doesn't perform some of the production build steps that the `gatsby build` command does. Instead, it starts up a development server that you can use to preview your site in the browser -- like a runtime. When you run `gatsby build` (build time) there won't be a browser available, so your site needs to be capable of protecting calls to browser based APIs.
 

--- a/docs/docs/porting-from-create-react-app-to-gatsby.md
+++ b/docs/docs/porting-from-create-react-app-to-gatsby.md
@@ -119,11 +119,11 @@ The `gatsby build` command also won't be able to use browser APIs, so some code 
 
 Some common globals that would need to be protected are:
 
-- `window`
-- `localStorage`
-- `sessionStorage`
-- `navigator`
-- `document`
+- [`window`](/docs/glossary#Window)
+- [`localStorage`](/docs/glossary#LocalStorage)
+- [`sessionStorage`](/docs/glossary#SessionStorage)
+- [`navigator`](/docs/glossary#Navigator)
+- [`document`](/docs/glossary#Document)
 
 Additionally, some packages that depend on globals existing (e.g. `react-router-dom`) may need to be [patched](/docs/debugging-html-builds/#fixing-third-party-modules) or migrated to other packages.
 

--- a/docs/docs/production-app.md
+++ b/docs/docs/production-app.md
@@ -72,7 +72,7 @@ This is the entry point to webpack that outputs `app-[contenthash].js` bundle. I
 
 ### First load
 
-To show how `production-app` works, let's imagine that you've just refreshed the browser on your site's `/blog/2` page. The HTML loads immediately, painting your page quickly. It includes a CDATA section which injects page information into the `window` object so it's available in your JavaScript code (inserted during [Page HTML Generation](/docs/html-generation/#6-inject-page-info-to-cdata)).
+To show how `production-app` works, let's imagine that you've just refreshed the browser on your site's `/blog/2` page. The HTML loads immediately, painting your page quickly. It includes a CDATA section which injects page information into the [`window`](/docs/glossary#Window) object so it's available in your JavaScript code (inserted during [Page HTML Generation](/docs/html-generation/#6-inject-page-info-to-cdata)).
 
 ```html
 /*
@@ -117,7 +117,7 @@ This occurs in [loader.js](https://github.com/gatsbyjs/gatsby/blob/master/packag
 
 ### `window` variables
 
-Gatsby attaches global state to the `window` object via `window.___somevar` variables so they can be used by plugins (though this is technically unsupported). Here are a few:
+Gatsby attaches global state to the [`window`](/docs/glossary#Window) object via `window.___somevar` variables so they can be used by plugins (though this is technically unsupported). Here are a few:
 
 ##### `___loader`
 

--- a/docs/docs/troubleshooting-common-errors.md
+++ b/docs/docs/troubleshooting-common-errors.md
@@ -205,7 +205,7 @@ For more information on common problems while building your site, refer to the [
 
 ### Error: ReferenceError: window is not defined when running `gatsby build`
 
-You may encounter an error like `Error: ReferenceError: window is not defined` that you didn't see in development if you reference browser globals like `window` or `document` in your code. Because the build is not running in a browser, it will not have access to a browser, which is why objects like `window` will not be defined.
+You may encounter an error like `Error: ReferenceError: window is not defined` that you didn't see in development if you reference browser globals like [`window`](/docs/glossary#Window) or [`document`](/docs/glossary#Document) in your code. Because the build is not running in a browser, it will not have access to a browser, which is why objects like [`window`](/docs/glossary#Window) will not be defined.
 
 Exact steps for fixing this issue can be found on in the Debugging HTML Builds guide in the section on [checking if `window` is defined](/docs/debugging-html-builds/#how-to-check-if-window-is-defined).
 

--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -103,7 +103,7 @@ exclude the `gatsby` module.
   and which some components need.
 
 - You need to set `testURL` to a valid URL, because some DOM APIs such as
-  `localStorage` are unhappy with the default (`about:blank`).
+  [`localStorage`](/docs/glossary#LocalStorage) are unhappy with the default (`about:blank`).
 
 > Note: if you're using Jest 23.5.0 or later, `testURL` will default to `http://localhost` so you can skip this setting.
 


### PR DESCRIPTION
## Description

~~I added the mdn docs link to web apis(ex: localStorage, window, etc...) to make it easier for anyone who doesn't know about the web api~~
I added several web api entries in the glossary page

### Documentation

- https://www.gatsbyjs.org/docs/adding-react-components
- https://www.gatsbyjs.org/docs/debugging-html-builds
- https://www.gatsbyjs.org/docs/building-a-site-with-authentication
- https://www.gatsbyjs.org/docs/glossary
- https://www.gatsbyjs.org/docs/overview-of-the-gatsby-build-process
- https://www.gatsbyjs.org/docs/porting-from-create-react-app-to-gatsby
- https://www.gatsbyjs.org/docs/production-app
- https://www.gatsbyjs.org/docs/troubleshooting-common-errors
- https://www.gatsbyjs.org/docs/unit-testing


## Related Issues

 Related to #20678
