### PR TITLE
fix(www): Fix styling of active links in the sidebar for localizations

### DIFF
--- a/www/src/utils/i18n.js
+++ b/www/src/utils/i18n.js
@@ -1,4 +1,7 @@
+const langs = require("../../i18n.json")
 const defaultLang = "en"
+
+const langCodes = langs.map(lang => lang.code)
 
 function isDefaultLang(locale) {
   return locale === defaultLang
@@ -16,4 +19,12 @@ function localizedPath(locale, path) {
   return isLocalized ? `${locale}${isIndex ? `` : `${path}`}` : path
 }
 
-module.exports = { defaultLang, localizedPath }
+function getLocaleAndBasePath(path) {
+  const [, code, ...rest] = path.split("/")
+  if (langCodes.includes(code)) {
+    return { locale: code, basePath: `/${rest.join("/")}` }
+  }
+  return { locale: defaultLang, basePath: path }
+}
+
+module.exports = { defaultLang, localizedPath, getLocaleAndBasePath }

--- a/www/src/utils/i18n.js
+++ b/www/src/utils/i18n.js
@@ -3,22 +3,51 @@ const defaultLang = "en"
 
 const langCodes = langs.map(lang => lang.code)
 
+const localizedSections = ["tutorial"]
+
 function isDefaultLang(locale) {
   return locale === defaultLang
 }
 
+/**
+ * Get the path prefixed with the locale
+ * @param {*} locale the locale to prefix with
+ * @param {*} path the path to prefix
+ */
 function localizedPath(locale, path) {
   const isIndex = path === `/`
 
-  // TODO generalize this to other paths
-  const isLocalized = !isDefaultLang(locale) && path.startsWith("/tutorial/")
-  // If it's the default language, don't do anything
+  // Our default language isn't prefixed for back-compat
+  if (isDefaultLang(locale)) {
+    return path
+  }
+
+  const [, base] = path.split("/")
+
+  // If for whatever reason we receive an already localized path
+  // (e.g. if the path was made with location.pathname)
+  // just return it as-is.
+  if (langCodes.includes(base)) {
+    return path
+  }
+
+  // Only localize paths for localized sections
+  if (!localizedSections.includes(base)) {
+    return path
+  }
+
   // If it's another language, add the "path"
   // However, if the homepage/index page is linked don't add the "to"
   // Because otherwise this would add a trailing slash
-  return isLocalized ? `${locale}${isIndex ? `` : `${path}`}` : path
+  return `${locale}${isIndex ? `` : `${path}`}`
 }
 
+/**
+ * Split a path into its locale and base path.
+ *
+ * e.g. /es/tutorial/ -> { locale: "es", basePath: "/tutorial/"}
+ * @param {string} path the path to extract locale information from
+ */
 function getLocaleAndBasePath(path) {
   const [, code, ...rest] = path.split("/")
   if (langCodes.includes(code)) {

--- a/www/src/utils/sidebar/get-active-item.js
+++ b/www/src/utils/sidebar/get-active-item.js
@@ -1,7 +1,10 @@
+import { getLocaleAndBasePath } from "../i18n"
+
 const isItemActive = (location, item, activeItemHash) => {
-  const linkMatchesPathname = item.link === location.pathname
+  const { basePath } = getLocaleAndBasePath(location.pathname)
+  const linkMatchesPathname = item.link === basePath
   const linkWithoutHashMatchesPathname =
-    item.link.replace(/#.*/, ``) === location.pathname
+    item.link.replace(/#.*/, ``) === basePath
   const activeItemHashFalsy = !activeItemHash || activeItemHash === `NONE`
 
   if (activeItemHash) {
@@ -9,7 +12,7 @@ const isItemActive = (location, item, activeItemHash) => {
       return item
     }
 
-    if (item.link === `${location.pathname}#${activeItemHash}`) {
+    if (item.link === `${basePath}#${activeItemHash}`) {
       return item
     }
   }
@@ -18,7 +21,7 @@ const isItemActive = (location, item, activeItemHash) => {
     return item
   }
 
-  if (item.link === `${location.pathname}${location.hash}` && !activeItemHash) {
+  if (item.link === `${basePath}${location.hash}` && !activeItemHash) {
     return item
   }
 


### PR DESCRIPTION
## Description

Fix styling of active links in the sidebar for localized versions of the gatsby site. Also update the `getLocalizedPath` to be more robust.

## Related Issues
Fixes: #20796 