### PR TITLE
chore(gatsby): Add yarn shortcuts for running tests with devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "hooks:uninstall": "node node_modules/husky/husky.js uninstall",
     "hooks:install": "node node_modules/husky/husky.js install",
     "jest": "jest",
+    "jest:inspect": "node --inspect node_modules/.bin/jest --runInBand",
+    "jest:inspect-brk": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "jest:loki": "cross-env GATSBY_DB_NODES=loki jest",
     "lerna": "lerna",
     "lerna-prepare": "lerna run prepare",


### PR DESCRIPTION
Adds two `yarn`/`npm run` aliases;
- `yarn jest:inspect` will run jest through `node --inspect`
- `yarn jest:inspect-brk` will run jest through `node --inspect-brk`

The difference is that one (`--inspect-brk`) will wait for the devtools to connect and pause at the start. This one requires you to explicitly press the start button before the code starts running (once hooked up). The other one (`--inspect`) will start running immediately after connecting to devtools.

(For anyone looking at this; The way you use this is to go to chrome/chromium and open the pseudo-url `about:inspect`. In there click the "open dedicated window for node" link (see screencap). Once that window is open, `node --inspect` and `node --inspect-brk` will automatically start debug sessions in that devtools popup. To debug a Gatsby test you would run `yarn jest:inspect some/feat.js -t "test case"`. )

![image](https://user-images.githubusercontent.com/209817/73057794-a9044c80-3e92-11ea-803a-17154efbf6ad.png)
