### PR TITLE
fix(gatsby): revert #19664 fix duplicate runs in develop mode

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -1,3 +1,4 @@
+const Promise = require(`bluebird`)
 const _ = require(`lodash`)
 const chalk = require(`chalk`)
 const { bindActionCreators } = require(`redux`)
@@ -76,7 +77,7 @@ const getLocalReporter = (activity, reporter) =>
     ? { ...reporter, panicOnBuild: activity.panicOnBuild.bind(activity) }
     : reporter
 
-const runAPI = async (plugin, api, args, activity) => {
+const runAPI = (plugin, api, args, activity) => {
   const gatsbyNode = require(`${plugin.resolve}/gatsby-node`)
   if (gatsbyNode[api]) {
     const parentSpan = args && args.parentSpan
@@ -207,12 +208,11 @@ const runAPI = async (plugin, api, args, activity) => {
     // If the plugin is using a callback use that otherwise
     // expect a Promise to be returned.
     if (gatsbyNode[api].length === 3) {
-      return new Promise((resolve, reject) => {
+      return Promise.fromCallback(callback => {
         const cb = (err, val) => {
           pluginSpan.finish()
+          callback(err, val)
           apiFinished = true
-          if (err) reject(err)
-          else resolve(val)
         }
 
         try {
@@ -225,193 +225,203 @@ const runAPI = async (plugin, api, args, activity) => {
           throw e
         }
       })
+    } else {
+      const result = gatsbyNode[api](...apiCallArgs)
+      pluginSpan.finish()
+      return Promise.resolve(result).then(res => {
+        apiFinished = true
+        return res
+      })
     }
-
-    const result = await gatsbyNode[api](...apiCallArgs)
-    pluginSpan.finish()
-    apiFinished = true
-    return result
   }
 
   return null
 }
 
-let apiRunnersActive = 0
+let apisRunningById = new Map()
 let apisRunningByTraceId = new Map()
 let waitingForCasacadeToFinish = []
 
-module.exports = async (api, args = {}, { pluginSource, activity } = {}) => {
-  let resolve
-  let promise = new Promise(res => (resolve = res)) // This is guaranteed to assign to `resolve` in sync
+module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
+  new Promise(resolve => {
+    const { parentSpan, traceId, traceTags, waitForCascadingActions } = args
+    const apiSpanArgs = parentSpan ? { childOf: parentSpan } : {}
+    const apiSpan = tracer.startSpan(`run-api`, apiSpanArgs)
 
-  const { parentSpan, traceId, traceTags, waitForCascadingActions } = args
-
-  const apiSpanArgs = parentSpan ? { childOf: parentSpan } : {}
-  const apiSpan = tracer.startSpan(`run-api`, apiSpanArgs)
-
-  apiSpan.setTag(`api`, api)
-  _.forEach(traceTags, (value, key) => {
-    apiSpan.setTag(key, value)
-  })
-
-  const plugins = store.getState().flattenedPlugins
-
-  // Get the list of plugins that implement this API.
-  // Also: Break infinite loops. Sometimes a plugin will implement an API and
-  // call an action which will trigger the same API being called.
-  // `onCreatePage` is the only example right now. In these cases, we should
-  // avoid calling the originating plugin again.
-  const implementingPlugins = plugins.filter(
-    plugin => plugin.nodeAPIs.includes(api) && plugin.name !== pluginSource
-  )
-
-  const apiRunInstance = {
-    api,
-    resolve,
-    span: apiSpan,
-    traceId,
-  }
-
-  if (waitForCascadingActions) {
-    waitingForCasacadeToFinish.push(apiRunInstance)
-  }
-
-  if (apiRunnersActive === 0) {
-    emitter.emit(`API_RUNNING_START`)
-  }
-  ++apiRunnersActive
-
-  if (apisRunningByTraceId.has(apiRunInstance.traceId)) {
-    const currentCount = apisRunningByTraceId.get(apiRunInstance.traceId)
-    apisRunningByTraceId.set(apiRunInstance.traceId, currentCount + 1)
-  } else {
-    apisRunningByTraceId.set(apiRunInstance.traceId, 1)
-  }
-
-  let stopQueuedApiRuns = false
-  let onAPIRunComplete = null
-  if (api === `onCreatePage`) {
-    const path = args.page.path
-    const actionHandler = action => {
-      if (action.payload.path === path) {
-        stopQueuedApiRuns = true
-      }
-    }
-    emitter.on(`DELETE_PAGE`, actionHandler)
-    onAPIRunComplete = () => {
-      emitter.off(`DELETE_PAGE`, actionHandler)
-    }
-  }
-
-  let results = []
-  for (const plugin of implementingPlugins) {
-    if (stopQueuedApiRuns) {
-      break
-    }
-    let result = await runPlugin(
-      api,
-      plugin,
-      args,
-      stopQueuedApiRuns,
-      activity,
-      apiSpan
-    )
-    results.push(result)
-  }
-
-  if (onAPIRunComplete) {
-    onAPIRunComplete()
-  }
-  // Remove runner instance
-  const currentCount = apisRunningByTraceId.get(apiRunInstance.traceId)
-  apisRunningByTraceId.set(apiRunInstance.traceId, currentCount - 1)
-
-  --apiRunnersActive
-  if (apiRunnersActive === 0) {
-    emitter.emit(`API_RUNNING_QUEUE_EMPTY`)
-  }
-
-  // Filter empty results
-  apiRunInstance.results = results.filter(result => !_.isEmpty(result))
-
-  // Filter out empty responses and return if the
-  // api caller isn't waiting for cascading actions to finish.
-  if (!waitForCascadingActions) {
-    apiSpan.finish()
-    resolve(apiRunInstance.results)
-  }
-
-  // Check if any of our waiters are done.
-  waitingForCasacadeToFinish = waitingForCasacadeToFinish.filter(instance => {
-    // If none of its trace IDs are running, it's done.
-    const apisByTraceIdCount = apisRunningByTraceId.get(instance.traceId)
-    if (apisByTraceIdCount === 0) {
-      instance.span.finish()
-      instance.resolve(instance.results)
-      return false
-    } else {
-      return true
-    }
-  })
-
-  // This promise will resolve with the results for all the plugin calls for this particular api call.
-  // If args.waitForCascadingActions is true, it will wait for all concurrent calls with the same api to resolve.
-  // If args.waitForCascadingActions is false, it should be resolved by the time the code reaches here
-  return promise
-}
-
-function runPlugin(api, plugin, args, stopQueuedApiRuns, activity, apiSpan) {
-  return new Promise(resolve => {
-    resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }, activity))
-  }).catch(err => {
-    const pluginName =
-      plugin.name === `default-site-plugin` ? `gatsby-node.js` : plugin.name
-
-    decorateEvent(`BUILD_PANIC`, {
-      pluginName: `${plugin.name}@${plugin.version}`,
+    apiSpan.setTag(`api`, api)
+    _.forEach(traceTags, (value, key) => {
+      apiSpan.setTag(key, value)
     })
 
-    const localReporter = getLocalReporter(activity, reporter)
+    const plugins = store.getState().flattenedPlugins
 
-    const file = stackTrace
-      .parse(err)
-      .find(file => /gatsby-node/.test(file.fileName))
+    // Get the list of plugins that implement this API.
+    // Also: Break infinite loops. Sometimes a plugin will implement an API and
+    // call an action which will trigger the same API being called.
+    // `onCreatePage` is the only example right now. In these cases, we should
+    // avoid calling the originating plugin again.
+    const implementingPlugins = plugins.filter(
+      plugin => plugin.nodeAPIs.includes(api) && plugin.name !== pluginSource
+    )
 
-    let codeFrame = ``
-    const structuredError = errorParser({ err })
+    const apiRunInstance = {
+      api,
+      args,
+      pluginSource,
+      resolve,
+      span: apiSpan,
+      startTime: new Date().toJSON(),
+      traceId,
+    }
 
-    if (file) {
-      const { fileName, lineNumber: line, columnNumber: column } = file
+    // Generate IDs for api runs. Most IDs we generate from the args
+    // but some API calls can have very large argument objects so we
+    // have special ways of generating IDs for those to avoid stringifying
+    // large objects.
+    let id
+    if (api === `setFieldsOnGraphQLNodeType`) {
+      id = `${api}${apiRunInstance.startTime}${args.type.name}${traceId}`
+    } else if (api === `onCreateNode`) {
+      id = `${api}${apiRunInstance.startTime}${args.node.internal.contentDigest}${traceId}`
+    } else if (api === `preprocessSource`) {
+      id = `${api}${apiRunInstance.startTime}${args.filename}${traceId}`
+    } else if (api === `onCreatePage`) {
+      id = `${api}${apiRunInstance.startTime}${args.page.path}${traceId}`
+    } else {
+      // When tracing is turned on, the `args` object will have a
+      // `parentSpan` field that can be quite large. So we omit it
+      // before calling stringify
+      const argsJson = JSON.stringify(_.omit(args, `parentSpan`))
+      id = `${api}|${apiRunInstance.startTime}|${apiRunInstance.traceId}|${argsJson}`
+    }
+    apiRunInstance.id = id
 
-      const code = fs.readFileSync(fileName, { encoding: `utf-8` })
-      codeFrame = codeFrameColumns(
-        code,
-        {
-          start: {
-            line,
-            column,
-          },
-        },
-        {
-          highlightCode: true,
+    if (waitForCascadingActions) {
+      waitingForCasacadeToFinish.push(apiRunInstance)
+    }
+
+    if (apisRunningById.size === 0) {
+      emitter.emit(`API_RUNNING_START`)
+    }
+
+    apisRunningById.set(apiRunInstance.id, apiRunInstance)
+    if (apisRunningByTraceId.has(apiRunInstance.traceId)) {
+      const currentCount = apisRunningByTraceId.get(apiRunInstance.traceId)
+      apisRunningByTraceId.set(apiRunInstance.traceId, currentCount + 1)
+    } else {
+      apisRunningByTraceId.set(apiRunInstance.traceId, 1)
+    }
+
+    let stopQueuedApiRuns = false
+    let onAPIRunComplete = null
+    if (api === `onCreatePage`) {
+      const path = args.page.path
+      const actionHandler = action => {
+        if (action.payload.path === path) {
+          stopQueuedApiRuns = true
+        }
+      }
+      emitter.on(`DELETE_PAGE`, actionHandler)
+      onAPIRunComplete = () => {
+        emitter.off(`DELETE_PAGE`, actionHandler)
+      }
+    }
+
+    Promise.mapSeries(implementingPlugins, plugin => {
+      if (stopQueuedApiRuns) {
+        return null
+      }
+
+      let pluginName =
+        plugin.name === `default-site-plugin` ? `gatsby-node.js` : plugin.name
+
+      return new Promise(resolve => {
+        resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }, activity))
+      }).catch(err => {
+        decorateEvent(`BUILD_PANIC`, {
+          pluginName: `${plugin.name}@${plugin.version}`,
+        })
+
+        let localReporter = getLocalReporter(activity, reporter)
+
+        const file = stackTrace
+          .parse(err)
+          .find(file => /gatsby-node/.test(file.fileName))
+
+        let codeFrame = ``
+        const structuredError = errorParser({ err })
+
+        if (file) {
+          const { fileName, lineNumber: line, columnNumber: column } = file
+
+          const code = fs.readFileSync(fileName, { encoding: `utf-8` })
+          codeFrame = codeFrameColumns(
+            code,
+            {
+              start: {
+                line,
+                column,
+              },
+            },
+            {
+              highlightCode: true,
+            }
+          )
+
+          structuredError.location = {
+            start: { line: line, column: column },
+          }
+          structuredError.filePath = fileName
+        }
+
+        structuredError.context = {
+          ...structuredError.context,
+          pluginName,
+          api,
+          codeFrame,
+        }
+
+        localReporter.panicOnBuild(structuredError)
+
+        return null
+      })
+    }).then(results => {
+      if (onAPIRunComplete) {
+        onAPIRunComplete()
+      }
+      // Remove runner instance
+      apisRunningById.delete(apiRunInstance.id)
+      const currentCount = apisRunningByTraceId.get(apiRunInstance.traceId)
+      apisRunningByTraceId.set(apiRunInstance.traceId, currentCount - 1)
+
+      if (apisRunningById.size === 0) {
+        emitter.emit(`API_RUNNING_QUEUE_EMPTY`)
+      }
+
+      // Filter empty results
+      apiRunInstance.results = results.filter(result => !_.isEmpty(result))
+
+      // Filter out empty responses and return if the
+      // api caller isn't waiting for cascading actions to finish.
+      if (!waitForCascadingActions) {
+        apiSpan.finish()
+        resolve(apiRunInstance.results)
+      }
+
+      // Check if any of our waiters are done.
+      waitingForCasacadeToFinish = waitingForCasacadeToFinish.filter(
+        instance => {
+          // If none of its trace IDs are running, it's done.
+          const apisByTraceIdCount = apisRunningByTraceId.get(instance.traceId)
+          if (apisByTraceIdCount === 0) {
+            instance.span.finish()
+            instance.resolve(instance.results)
+            return false
+          } else {
+            return true
+          }
         }
       )
-
-      structuredError.location = {
-        start: { line: line, column: column },
-      }
-      structuredError.filePath = fileName
-    }
-
-    structuredError.context = {
-      ...structuredError.context,
-      pluginName,
-      api,
-      codeFrame,
-    }
-
-    localReporter.panicOnBuild(structuredError)
-
-    return null
+      return
+    })
   })
-}


### PR DESCRIPTION
Reverts #19664 because it exposed a timing problem in promises ultimately leading to `gatsby develop` triggering a number of redundant rebuilds.

At the core to this is listening to the api queue drain event, `API_RUNNING_QUEUE_EMPTY`, which before would only fire once. After this change, that event fires three times for the same sequence of events (a file changing).

The reason seems to relate to the difference in how BlueBird resolves its promise vs doing it natively. In this case, changing the promise led to the queue draining before the next api call had a chance to fill it up again. And again. So each of these calls would now see an empty queue, fill it, completely run (in pseudo sync time), and drain the queue again. Each call would lead to announcing the start and drain of the api queue.

Over in `gatsby develop` we were listening for the drain event as a way of debouncing a refresh-in-progress.

We've triaged this and tried to come up with a better solution without having to do a revert but ultimately there's not a trivial way of getting what we want. We need to consider a proper state machine model, where api calls fall within a higher level task description, to be able to "wait" for a current update to finish. Right now such structure does not exist and we can't wait for anything because we can't know what's semantically going on within the gatsby machinery right now.

Resolved the merge conflicts together with @sidharthachatterjee . Despite the age of the commit, luckily this file doesn't see many updates, so it's mostly about keeping @LekoArts's changes. Which I think we've done.