### PR TITLE
perf(gatsby-source-contentful): remove recursion in fixIds

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -183,6 +183,69 @@ describe(`Fix contentful IDs`, () => {
   it(`left pads ids that start with a number of a "c"`, () => {
     expect(normalize.fixId(`123`)).toEqual(`c123`)
   })
+  it(`does not change entries that are null/undefined`, () => {
+    const a = null
+    normalize.fixIds(a)
+    expect(a).toBeNull()
+  })
+  it(`does not change entries that are not object/array`, () => {
+    const a = 123
+    const expected = 123
+    normalize.fixIds(a)
+    expect(a).toEqual(expected)
+  })
+
+  it(`does not check/change falsy values in arrays`, () => {
+    const a = {
+      b: [
+        {
+          sys: {
+            id: 500,
+          },
+        },
+        null,
+        {},
+      ],
+    }
+
+    const expected = {
+      b: [
+        {
+          sys: {
+            contentful_id: 500,
+            id: `c500`,
+          },
+        },
+        null,
+        {},
+      ],
+    }
+    normalize.fixIds(a)
+    expect(a).toEqual(expected)
+  })
+
+  it(`does not check/change falsy values in objects`, () => {
+    const a = {
+      b: {
+        sys: {
+          id: 500,
+        },
+        value: null,
+      },
+    }
+
+    const expected = {
+      b: {
+        sys: {
+          contentful_id: 500,
+          id: `c500`,
+        },
+        value: null,
+      },
+    }
+    normalize.fixIds(a)
+    expect(a).toEqual(expected)
+  })
 
   describe(`cycles`, () => {
     it(`should return undefined`, () => {

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -67,7 +67,7 @@ const _fixIds = (object, front = new Set()) => {
     }
 
     if (Array.isArray(current)) {
-      current.forEach(v => objectsToProcess.push(v))
+      objectsToProcess.push(...current)
       continue
     }
 

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -60,8 +60,8 @@ const fixIds = object => _fixIds(object)
 // The `front` tracks which objects have been visited to prevent infinite
 // recursion on cyclic structures.
 const _fixIds = object => {
-  const alreadyWalkedObjectRefs = new Set()
   const objectsToProcess = [object]
+  const alreadyWalkedObjectRefs = new Set(objectsToProcess)
 
   while (objectsToProcess.length !== 0) {
     const current = objectsToProcess.pop()

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -51,39 +51,46 @@ exports.fixId = fixId
 
 const fixIds = object => _fixIds(object)
 
-// Recursively walk the object model and find any property named `sys`. If it
+// Walk the object model and find any property named `sys`. If it
 // contains an `id` then make sure the id is a string and if it starts with a
 // number, prefix it with (an arbitrarily chosen) `c`, for "contentful".
 // The `front` tracks which objects have been visited to prevent infinite
 // recursion on cyclic structures.
 const _fixIds = (object, front = new Set()) => {
-  if (!object || typeof object !== `object`) {
-    return
-  }
+  const objectsToProcess = [object]
 
-  if (Array.isArray(object)) {
-    object.forEach(v => _fixIds(v, front))
-    return
-  }
+  while (objectsToProcess.length !== 0) {
+    const current = objectsToProcess.pop()
 
-  if (front.has(object)) {
-    return
-  }
-
-  front.add(object)
-  Object.getOwnPropertyNames(object).forEach(key => {
-    // The `contentful_id` is ours and we want to make sure we don't visit the
-    // same node twice (this is possible if the same node appears in two
-    // separate branches while sharing a common ancestor). This check makes
-    // sure we keep the original `id` preserved in `contentful_id`.
-    if (key === `sys` && !object.sys.contentful_id) {
-      object.sys.contentful_id = object.sys.id
-      object.sys.id = fixId(object.sys.id)
+    if (!current || typeof current !== `object`) {
+      continue
     }
 
-    _fixIds(object[key], front)
-  })
-  front.delete(object) // Memory vs efficiency
+    if (Array.isArray(current)) {
+      current.forEach(v => objectsToProcess.push(v))
+      continue
+    }
+
+    if (front.has(current)) {
+      continue
+    }
+
+    front.add(current)
+    Object.getOwnPropertyNames(current).forEach(key => {
+      // The `contentful_id` is ours and we want to make sure we don't visit the
+      // same node twice (this is possible if the same node appears in two
+      // separate branches while sharing a common ancestor). This check makes
+      // sure we keep the original `id` preserved in `contentful_id`.
+      if (key === `sys` && !current.sys.contentful_id) {
+        current.sys.contentful_id = current.sys.id
+        current.sys.id = fixId(current.sys.id)
+      }
+
+      if (!front.has(current[key])) {
+        objectsToProcess.push(current[key])
+      }
+    })
+  }
 }
 exports.fixIds = fixIds
 

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -56,7 +56,8 @@ const fixIds = object => _fixIds(object)
 // number, prefix it with (an arbitrarily chosen) `c`, for "contentful".
 // The `front` tracks which objects have been visited to prevent infinite
 // recursion on cyclic structures.
-const _fixIds = (object, front = new Set()) => {
+const _fixIds = object => {
+  const alreadyWalkedObjectRefs = new Set()
   const objectsToProcess = [object]
 
   while (objectsToProcess.length !== 0) {
@@ -71,11 +72,11 @@ const _fixIds = (object, front = new Set()) => {
       continue
     }
 
-    if (front.has(current)) {
+    if (alreadyWalkedObjectRefs.has(current)) {
       continue
     }
 
-    front.add(current)
+    alreadyWalkedObjectRefs.add(current)
     Object.keys(current).forEach(key => {
       // The `contentful_id` is ours and we want to make sure we don't visit the
       // same node twice (this is possible if the same node appears in two
@@ -86,7 +87,11 @@ const _fixIds = (object, front = new Set()) => {
         current.sys.id = fixId(current.sys.id)
       }
 
-      if (!front.has(current[key])) {
+      if (
+        current[key] &&
+        typeof current[key] === `object` &&
+        !alreadyWalkedObjectRefs.has(current[key])
+      ) {
         objectsToProcess.push(current[key])
       }
     })

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -76,7 +76,7 @@ const _fixIds = (object, front = new Set()) => {
     }
 
     front.add(current)
-    Object.getOwnPropertyNames(current).forEach(key => {
+    Object.keys(current).forEach(key => {
       // The `contentful_id` is ours and we want to make sure we don't visit the
       // same node twice (this is possible if the same node appears in two
       // separate branches while sharing a common ancestor). This check makes


### PR DESCRIPTION
## Description

Currently recursion is used to walk the content models in `normalize/fixIds`. This results in quite a big overhead when run on big models (long call stack). Our app has entries that have 70k+ keys in them (entries that are linked to a lot of other entries) so call stack becomes quite big when using recursion.

This change removes the usage of recursion in favour of plain `while` loop and array of objects to fixIds in.

I tested it on our app with following content stats:
```
contentTypes fetched 47
Updated entries 6802
Deleted entries 0
Updated assets 2805
Deleted assets 0
```

I also replaced `Object.getOwnPropertyNames` with `Object.keys` since we don't care about non-enumerable keys in this scenario. This change shaves off ~5s in my tests.

### Documentation
No change needed.
