### PR TITLE
fix(gatsby-plugin-sharp): hot fix for "Generating image thumbnails" progress bar reporting duplicates that don't do actual processing

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
@@ -904,6 +904,7 @@ exports[`gatsby-plugin-sharp queueImageResizing with createJob file name works w
         "outputDir": "<PROJECT_ROOT>/public/static/1234",
       },
       Object {},
+      undefined,
     ],
   ],
   "results": Array [
@@ -945,6 +946,7 @@ exports[`gatsby-plugin-sharp queueImageResizing with createJob should round heig
         "outputDir": "<PROJECT_ROOT>/public/static/1234",
       },
       Object {},
+      undefined,
     ],
   ],
   "results": Array [

--- a/packages/gatsby-plugin-sharp/src/__tests__/utils.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/utils.js
@@ -1,23 +1,28 @@
 jest.mock(`gatsby-cli/lib/reporter`)
 jest.mock(`progress`)
-const { createProgress } = require(`../utils`)
+const {
+  createGatsbyProgressOrFallbackToExternalProgressBar,
+} = require(`../utils`)
 const reporter = require(`gatsby-cli/lib/reporter`)
 const progress = require(`progress`)
 
-describe(`createProgress`, () => {
+describe(`createGatsbyProgressOrFallbackToExternalProgressBar`, () => {
   beforeEach(() => {
     progress.mockClear()
   })
 
   it(`should use createProgress from gatsby-cli when available`, () => {
-    createProgress(`test`, reporter)
+    createGatsbyProgressOrFallbackToExternalProgressBar(`test`, reporter)
     expect(reporter.createProgress).toBeCalled()
     expect(progress).not.toBeCalled()
   })
 
   it(`should fallback to a local implementation when createProgress does not exists on reporter`, () => {
     reporter.createProgress = null
-    const bar = createProgress(`test`, reporter)
+    const bar = createGatsbyProgressOrFallbackToExternalProgressBar(
+      `test`,
+      reporter
+    )
     expect(progress).toHaveBeenCalledTimes(1)
     expect(bar).toHaveProperty(`start`, expect.any(Function))
     expect(bar).toHaveProperty(`tick`, expect.any(Function))
@@ -26,7 +31,7 @@ describe(`createProgress`, () => {
   })
 
   it(`should fallback to a local implementation when no reporter is present`, () => {
-    const bar = createProgress(`test`)
+    const bar = createGatsbyProgressOrFallbackToExternalProgressBar(`test`)
     expect(progress).toHaveBeenCalledTimes(1)
     expect(bar).toHaveProperty(`start`, expect.any(Function))
     expect(bar).toHaveProperty(`tick`, expect.any(Function))

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -1,9 +1,9 @@
 const {
   setBoundActionCreators,
-  getProgressBar,
   // queue: jobQueue,
   // reportError,
 } = require(`./index`)
+const { getProgressBar, createOrGetProgressBar } = require(`./utils`)
 
 const { setPluginOptions } = require(`./plugin-options`)
 
@@ -63,9 +63,52 @@ const finishProgressBar = () => {
 exports.onPostBuild = () => finishProgressBar()
 exports.onCreateDevServer = () => finishProgressBar()
 
-exports.onPreBootstrap = ({ actions }, pluginOptions) => {
+// TO-DO - figure this out before merging (it can't unconditionally return false),
+// so we don't end up with duplicate progress bars (one from this plugin and one from core)
+const GatsbyCoreVersionManagesProgressBar = () => false
+
+exports.onPreBootstrap = ({ actions, emitter, reporter }, pluginOptions) => {
   setBoundActionCreators(actions)
   setPluginOptions(pluginOptions)
+
+  // below is a hack / hot fix for confusing progress bar behaviour
+  // that doesn't recognize duplicate jobs, as it's now
+  // in gatsby core internals (if `createJobV2` is available)
+  // we should remove this or make this code path not hit
+  // (we should never use emitter in plugins)
+  // as soon as possible (possibly by moving progress bar handling
+  // inside jobs-manager in core)
+
+  // sanity check - in case we remove `emitter` at some point
+  if (!GatsbyCoreVersionManagesProgressBar() && emitter) {
+    // track how many image transformation each job has
+    // END_JOB_V2 doesn't contain that information
+    // so we store it in <JobContentHash, TransformsCount> map
+    // when job is created. Then retrieve that when job finishes
+    // and remove that entry from the map.
+    const imageCountInJobsMap = new Map()
+
+    emitter.on(`CREATE_JOB_V2`, action => {
+      if (action.plugin.name === `gatsby-plugin-sharp`) {
+        const job = action.payload.job
+        const imageCount = job.args.operations.length
+        imageCountInJobsMap.set(job.contentDigest, imageCount)
+        const progress = createOrGetProgressBar(reporter)
+        progress.addImageToProcess(imageCount)
+      }
+    })
+
+    emitter.on(`END_JOB_V2`, action => {
+      if (action.plugin.name === `gatsby-plugin-sharp`) {
+        const jobContentDigest = action.payload.jobContentDigest
+        const imageCount = imageCountInJobsMap.get(jobContentDigest)
+        const progress = createOrGetProgressBar(reporter)
+        progress.tick(imageCount)
+        imageCountInJobsMap.delete(jobContentDigest)
+      }
+    })
+  }
+
   // normalizedOptions = setPluginOptions(pluginOptions)
 }
 

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -75,8 +75,7 @@ exports.onPreBootstrap = ({ actions, emitter, reporter }, pluginOptions) => {
   // as soon as possible (possibly by moving progress bar handling
   // inside jobs-manager in core)
 
-  // only use emitter if `setJobTypeMetadata` action is not available
-  if (!actions.setJobTypeMetadata && emitter) {
+  if (emitter) {
     // track how many image transformation each job has
     // END_JOB_V2 doesn't contain that information
     // so we store it in <JobContentHash, TransformsCount> map

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -63,10 +63,6 @@ const finishProgressBar = () => {
 exports.onPostBuild = () => finishProgressBar()
 exports.onCreateDevServer = () => finishProgressBar()
 
-// TO-DO - figure this out before merging (it can't unconditionally return false),
-// so we don't end up with duplicate progress bars (one from this plugin and one from core)
-const GatsbyCoreVersionManagesProgressBar = () => false
-
 exports.onPreBootstrap = ({ actions, emitter, reporter }, pluginOptions) => {
   setBoundActionCreators(actions)
   setPluginOptions(pluginOptions)
@@ -79,8 +75,8 @@ exports.onPreBootstrap = ({ actions, emitter, reporter }, pluginOptions) => {
   // as soon as possible (possibly by moving progress bar handling
   // inside jobs-manager in core)
 
-  // sanity check - in case we remove `emitter` at some point
-  if (!GatsbyCoreVersionManagesProgressBar() && emitter) {
+  // only use emitter if `setJobTypeMetadata` action is not available
+  if (!actions.setJobTypeMetadata && emitter) {
     // track how many image transformation each job has
     // END_JOB_V2 doesn't contain that information
     // so we store it in <JobContentHash, TransformsCount> map

--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -4,6 +4,7 @@ const fs = require(`fs-extra`)
 const got = require(`got`)
 const { createContentDigest } = require(`gatsby-core-utils`)
 const worker = require(`./gatsby-worker`)
+const { createOrGetProgressBar } = require(`./utils`)
 
 const processImages = async (jobId, job, boundActionCreators) => {
   try {
@@ -16,7 +17,7 @@ const processImages = async (jobId, job, boundActionCreators) => {
 }
 
 const jobsInFlight = new Map()
-const scheduleJob = async (job, boundActionCreators) => {
+const scheduleJob = async (job, boundActionCreators, reporter) => {
   const inputPaths = job.inputPaths.filter(
     inputPath => !fs.existsSync(path.join(job.outputDir, inputPath))
   )
@@ -70,12 +71,16 @@ const scheduleJob = async (job, boundActionCreators) => {
     { name: `gatsby-plugin-sharp` }
   )
 
+  const progressBar = createOrGetProgressBar(reporter)
+  const transformsCount = job.args.operations.length
+  progressBar.addImageToProcess(transformsCount)
+
   const promise = new Promise((resolve, reject) => {
     setImmediate(() => {
-      processImages(jobId, convertedJob, boundActionCreators).then(
-        resolve,
-        reject
-      )
+      processImages(jobId, convertedJob, boundActionCreators).then(result => {
+        progressBar.tick(transformsCount)
+        resolve(result)
+      }, reject)
     })
   })
 

--- a/packages/gatsby-plugin-sharp/src/utils.js
+++ b/packages/gatsby-plugin-sharp/src/utils.js
@@ -1,7 +1,10 @@
 const ProgressBar = require(`progress`)
 
 // TODO remove in V3
-export function createProgress(message, reporter) {
+function createGatsbyProgressOrFallbackToExternalProgressBar(
+  message,
+  reporter
+) {
   if (reporter && reporter.createProgress) {
     return reporter.createProgress(message)
   }
@@ -26,3 +29,56 @@ export function createProgress(message, reporter) {
     },
   }
 }
+
+let progressBar
+let pendingImagesCounter = 0
+let firstPass = true
+const createOrGetProgressBar = reporter => {
+  if (!progressBar) {
+    progressBar = createGatsbyProgressOrFallbackToExternalProgressBar(
+      `Generating image thumbnails`,
+      reporter
+    )
+
+    const originalDoneFn = progressBar.done
+
+    // TODO this logic should be moved to the reporter.
+    // when done is called we remove the progressbar instance and reset all the things
+    // this will be called onPostBuild or when devserver is created
+    progressBar.done = () => {
+      originalDoneFn.call(progressBar)
+      progressBar = null
+      pendingImagesCounter = 0
+    }
+
+    progressBar.addImageToProcess = imageCount => {
+      if (pendingImagesCounter === 0) {
+        progressBar.start()
+      }
+      pendingImagesCounter += imageCount
+      progressBar.total = pendingImagesCounter
+    }
+
+    // when we create a progressBar for the second time so when .done() has been called before
+    // we create a modified tick function that automatically stops the progressbar when total is reached
+    // this is used for development as we're watching for changes
+    if (!firstPass) {
+      let progressBarCurrentValue = 0
+      const originalTickFn = progressBar.tick
+      progressBar.tick = (ticks = 1) => {
+        originalTickFn.call(progressBar, ticks)
+        progressBarCurrentValue += ticks
+
+        if (progressBarCurrentValue === pendingImagesCounter) {
+          progressBar.done()
+        }
+      }
+    }
+    firstPass = false
+  }
+
+  return progressBar
+}
+
+exports.createOrGetProgressBar = createOrGetProgressBar
+exports.getProgressBar = () => progressBar

--- a/packages/gatsby-plugin-sharp/src/utils.js
+++ b/packages/gatsby-plugin-sharp/src/utils.js
@@ -80,5 +80,6 @@ const createOrGetProgressBar = reporter => {
   return progressBar
 }
 
+exports.createGatsbyProgressOrFallbackToExternalProgressBar = createGatsbyProgressOrFallbackToExternalProgressBar
 exports.createOrGetProgressBar = createOrGetProgressBar
 exports.getProgressBar = () => progressBar


### PR DESCRIPTION
Note: This is very hacky - primarly the jobs v2 handling:
plugins right now don't know if they create duplicate jobs - this is internal gatsby core feature that is not exposed to plugins, so plugins potentially would need to implement duplicate jobs tracking themselves (duplicate functionality already built into gatsby). This is not ideal because implementation might not end up 1:1 (or implementations can drift over time)

Instead I listen to internal actions here, which are guaranteed not be emitted for duplicates (for jobs v2 code path). Legacy jobs / jobsv1 don't have any of this and this requires plugins to track things, so we already do that in sharp plugin - I just moved progress bar handling to "better" location so it doesn't display duplicates.

Long/medium term we should have Jobs v2 able to manage progress bar, but currently we are lacking some APIs for this:
 - what should be label of progress bar?
 - how many "ticks" each job should add to totals / increment progress bar when job finishes
 - should a job even show progress bar (i can see some internals using jobs later on that might not be very useful to show to users)? 

fixes #20816

---edited:
we will need new API to provide some metadata for jobs created from same plugin - see https://github.com/gatsbyjs/gatsby/pull/20839#issuecomment-578274773 as general direction

Because of that we don't need to preemptively make any checks, because adding support for progress bar management by jobs API in core won't immediately result in progress bar showing by plugin creating v2 jobs. The check will be added once API is designed and implemented in core, so there shouldn't be any weird regressions like 2 progress bars for same thing or none progress bars