### PR TITLE
fix(gatsby-source-filesystem): Retry stalled remote file downloads

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -14,7 +14,7 @@
     "file-type": "^12.4.0",
     "fs-extra": "^8.1.0",
     "gatsby-core-utils": "^1.0.27",
-    "got": "^9.6.0",
+    "got": "^8.3.2",
     "md5-file": "^3.2.3",
     "mime": "^2.4.4",
     "pretty-bytes": "^5.3.0",

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -14,7 +14,7 @@
     "file-type": "^12.4.0",
     "fs-extra": "^8.1.0",
     "gatsby-core-utils": "^1.0.27",
-    "got": "^7.1.0",
+    "got": "^9.6.0",
     "md5-file": "^3.2.3",
     "mime": "^2.4.4",
     "pretty-bytes": "^5.3.0",

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -61,6 +61,8 @@ let totalJobs = 0
 
 const CACHE_DIR = `.cache`
 const FS_PLUGIN_DIR = `gatsby-source-filesystem`
+const RETRY_LIMIT = 3
+const STALL_TIMEOUT = 30000
 
 /********************
  * Queue Management *
@@ -124,31 +126,65 @@ async function pushToQueue(task, cb) {
  * @param  {Headers}  headers
  * @param  {String}   tmpFilename
  * @param  {Object}   httpOpts
+ * @param  {number}   attempt
  * @return {Promise<Object>}  Resolves with the [http Result Object]{@link https://nodejs.org/api/http.html#http_class_http_serverresponse}
  */
-const requestRemoteNode = (url, headers, tmpFilename, httpOpts) =>
+const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
   new Promise((resolve, reject) => {
-    const opts = Object.assign({}, { timeout: 30000, retries: 5 }, httpOpts)
+    let timeout
+
+    // Called if we stall for 30s without receiving any data
+    const handleTimeout = () => {
+      fsWriteStream.close()
+      fs.removeSync(tmpFilename)
+      if (attempt < RETRY_LIMIT) {
+        // Retry by calling ourself recursively
+        resolve(
+          requestRemoteNode(url, headers, tmpFilename, httpOpts, attempt + 1)
+        )
+      } else {
+        reject(`Failed to download ${url} after ${RETRY_LIMIT} attempts`)
+      }
+    }
+
+    const resetTimeout = () => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      timeout = setTimeout(handleTimeout, STALL_TIMEOUT)
+    }
+
     const responseStream = got.stream(url, {
       headers,
-      ...opts,
+      ...httpOpts,
     })
     const fsWriteStream = fs.createWriteStream(tmpFilename)
     responseStream.pipe(fsWriteStream)
-    responseStream.on(`downloadProgress`, pro => console.log(pro))
+
+    // As long as we're receiving data, we'll reset the timeout
+    responseStream.on(`downloadProgress`, resetTimeout)
 
     // If there's a 400/500 response or other error.
-    responseStream.on(`error`, (error, body, response) => {
+    responseStream.on(`error`, error => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
       fs.removeSync(tmpFilename)
       reject(error)
     })
 
     fsWriteStream.on(`error`, error => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
       reject(error)
     })
 
     responseStream.on(`response`, response => {
       fsWriteStream.on(`finish`, () => {
+        if (timeout) {
+          clearTimeout(timeout)
+        }
         resolve(response)
       })
     })

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -159,16 +159,12 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
       }
       timeout = setTimeout(handleTimeout, STALL_TIMEOUT)
     }
-    resetTimeout()
     const responseStream = got.stream(url, {
       headers,
       ...httpOpts,
     })
     const fsWriteStream = fs.createWriteStream(tmpFilename)
     responseStream.pipe(fsWriteStream)
-
-    // As long as we're receiving data, we'll reset the timeout
-    responseStream.on(`downloadProgress`, resetTimeout)
 
     // If there's a 400/500 response or other error.
     responseStream.on(`error`, error => {
@@ -187,6 +183,8 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
     })
 
     responseStream.on(`response`, response => {
+      resetTimeout()
+
       fsWriteStream.on(`finish`, () => {
         if (timeout) {
           clearTimeout(timeout)

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -134,13 +134,19 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
     let timeout
 
     // Called if we stall for 30s without receiving any data
-    const handleTimeout = () => {
+    const handleTimeout = async () => {
       fsWriteStream.close()
       fs.removeSync(tmpFilename)
       if (attempt < RETRY_LIMIT) {
         // Retry by calling ourself recursively
         resolve(
-          requestRemoteNode(url, headers, tmpFilename, httpOpts, attempt + 1)
+          await requestRemoteNode(
+            url,
+            headers,
+            tmpFilename,
+            httpOpts,
+            attempt + 1
+          )
         )
       } else {
         reject(`Failed to download ${url} after ${RETRY_LIMIT} attempts`)
@@ -153,7 +159,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
       }
       timeout = setTimeout(handleTimeout, STALL_TIMEOUT)
     }
-
+    resetTimeout()
     const responseStream = got.stream(url, {
       headers,
       ...httpOpts,

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -140,13 +140,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
       if (attempt < RETRY_LIMIT) {
         // Retry by calling ourself recursively
         resolve(
-          await requestRemoteNode(
-            url,
-            headers,
-            tmpFilename,
-            httpOpts,
-            attempt + 1
-          )
+          requestRemoteNode(url, headers, tmpFilename, httpOpts, attempt + 1)
         )
       } else {
         reject(`Failed to download ${url} after ${RETRY_LIMIT} attempts`)

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -161,6 +161,8 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
     }
     const responseStream = got.stream(url, {
       headers,
+      timeout: 30000,
+      retries: 5,
       ...httpOpts,
     })
     const fsWriteStream = fs.createWriteStream(tmpFilename)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11219,7 +11219,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-got@^7.0.0, got@^7.1.0:
+got@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"
   dependencies:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

gatsby-source-filesystem has a problem where downloads would stall and never timeout or error. Eventually all the concurrent downloads were stalled, preventing any more starting. This was causing builds to stall indefinitely. 

This PR adds a timeout in `createRemoteFileNode`. If no `data` events are received in the download stream for 30 seconds then the download is cancelled and retried up to three times. In tests this unblocks the downloads on the first attempt.

WIP while I'm writing unit tests.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
