### PR TITLE
fix(image-processing-example): use same image for all `crop` examples

### DIFF
--- a/examples/image-processing/src/pages/index.js
+++ b/examples/image-processing/src/pages/index.js
@@ -476,7 +476,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    cropBottomLeft: file(relativePath: { regex: "/nyancat/" }) {
+    cropBottomLeft: file(relativePath: { regex: "/gatsby.jpg/" }) {
       childImageSharp {
         resize(width: 180, height: 180, cropFocus: SOUTHWEST) {
           src


### PR DESCRIPTION
## Description

Fixes the source image for `cropBottomLeft` described in [issue 20851](https://github.com/gatsbyjs/gatsby/issues/20851).

## Related Issues

Fixes #20851
