### PR TITLE
fix(gatsby-plugin-sharp): honor `stripMetadata` setting for webp output images

### DIFF
--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -233,7 +233,10 @@ const compressWebP = (pipeline, outputPath, options) =>
     imagemin
       .buffer(sharpBuffer, {
         plugins: [
-          imageminWebp({ quality: options.webpQuality || options.quality }),
+          imageminWebp({
+            quality: options.webpQuality || options.quality,
+            metadata: options.stripMetadata ? `none` : `all`,
+          }),
         ],
       })
       .then(imageminBuffer => fs.writeFile(outputPath, imageminBuffer))


### PR DESCRIPTION
Fixes #20709 
