### PR TITLE
Update build-caching.md to mention that build outputs are also in public

### DIFF
--- a/docs/docs/build-caching.md
+++ b/docs/docs/build-caching.md
@@ -9,7 +9,7 @@ Caching is already used by Gatsby and plugins for example:
 - any nodes created by source/transformer plugins are cached
 - `gatsby-plugin-sharp` caches built thumbnails
 
-Data is stored in the `.cache` directory relative to your project root.
+Build outputs are stored in the `.cache` and `public` directories relative to your project root.
 
 ## The cache API
 


### PR DESCRIPTION
If you don't persist both .cache & public then there'll be errors when repeatedly building sites along the lines of `Can't resolve '../../public/static/d/856328897.json' in '/zeit/71ceb58f/src/components'`