### PR TITLE
fix(gatsby-plugin-mdx): Pass node API helpers from onCreateNode and sourceNodes to remark plugins

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
@@ -21,6 +21,7 @@ module.exports = async (
     reporter,
     cache,
     pathPrefix,
+    ...helpers
   },
   pluginOptions
 ) => {
@@ -64,6 +65,10 @@ module.exports = async (
       cache,
       pathPrefix,
       options,
+      loadNodeContent,
+      actions,
+      createNodeId,
+      ...helpers,
     },
     { forceDisableCache: true }
   )

--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -52,7 +52,17 @@ async function getCounts({ mdast }) {
 }
 
 module.exports = (
-  { store, pathPrefix, getNode, getNodes, cache, reporter, actions, schema },
+  {
+    store,
+    pathPrefix,
+    getNode,
+    getNodes,
+    cache,
+    reporter,
+    actions,
+    schema,
+    ...helpers
+  },
   pluginOptions
 ) => {
   let mdxHTMLLoader
@@ -105,7 +115,19 @@ module.exports = (
   }
 
   const processMDX = ({ node }) =>
-    genMDX({ node, getNode, getNodes, reporter, cache, pathPrefix, options })
+    genMDX({
+      node,
+      options,
+      store,
+      pathPrefix,
+      getNode,
+      getNodes,
+      cache,
+      reporter,
+      actions,
+      schema,
+      ...helpers,
+    })
 
   // New Code // Schema
   const MdxType = schema.buildObjectType({

--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -40,7 +40,17 @@ const BabelPluginPluckImports = require(`./babel-plugin-pluck-imports`)
  *  */
 
 module.exports = async function genMDX(
-  { isLoader, node, options, getNode, getNodes, reporter, cache, pathPrefix },
+  {
+    isLoader,
+    node,
+    options,
+    getNode,
+    getNodes,
+    reporter,
+    cache,
+    pathPrefix,
+    ...helpers
+  },
   { forceDisableCache = false } = {}
 ) {
   const pathPrefixCacheStr = pathPrefix || ``
@@ -106,6 +116,7 @@ export const _frontmatter = ${JSON.stringify(data)}`
       reporter,
       cache,
       pathPrefix,
+      ...helpers,
     }
   )
 

--- a/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -16,6 +16,7 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
   reporter,
   cache,
   pathPrefix,
+  ...helpers
 }) {
   debug(`getSourcePluginsAsRemarkPlugins`)
   let pathPlugin = undefined
@@ -63,6 +64,7 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
               pathPrefix,
               reporter,
               cache,
+              ...helpers,
             },
             plugin.options || {}
           )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The gatsby-plugin-mdx plugin runs remark plugins almost identically to gatsby-transformer-remark, but omits several of the [node API helpers](https://www.gatsbyjs.org/docs/node-api-helpers/) when calling them. This PR ensures the rest of those helpers are passed all the way through.

Open to adding a test for this, but didn’t see any likely candidates for where it should go.

### Documentation

As far as I can tell, the fact that gatsby-transformer-remark passes all the API helpers to its plugins is undocumented, though extremely helpful. The gatsby-plugin-mdx docs simply say that you can use gatsby-transformer-remark plugins, so calling them with the same inputs should be a given.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Didn’t see any