### PR TITLE
docs: fix React terminology

### DIFF
--- a/docs/docs/sourcing-content-from-json-or-yaml.md
+++ b/docs/docs/sourcing-content-from-json-or-yaml.md
@@ -65,7 +65,7 @@ const YAMLbuildtime = () => (
 export default YAMLbuildtime
 ```
 
-The above code imports YAML source data as an array, iterates over it with the `Array.map` method, and renders the data-filled markup through a functional stateless React component.
+The above code imports YAML source data as an array, iterates over it with the `Array.map` method, and renders the data-filled markup through a functional React component.
 
 ## Directly import data with JSON
 


### PR DESCRIPTION
## Description

The name stateless functional component seems to be deprecated now.
Changed the term to "functional component"

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Related to: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30364
Related to: https://github.com/gatsbyjs/gatsby-ja/pull/112