### PR TITLE
fix: wrap `GraphQLRunner.query` return in Promise.resolve

### DIFF
--- a/packages/gatsby/src/query/graphql-runner.js
+++ b/packages/gatsby/src/query/graphql-runner.js
@@ -59,7 +59,7 @@ class GraphQLRunner {
 
     const result =
       errors.length > 0
-        ? { errors }
+        ? Promise.resolve({ errors })
         : execute({
             schema,
             document,

--- a/packages/gatsby/src/query/graphql-runner.js
+++ b/packages/gatsby/src/query/graphql-runner.js
@@ -59,7 +59,7 @@ class GraphQLRunner {
 
     const result =
       errors.length > 0
-        ? Promise.resolve({ errors })
+        ? { errors }
         : execute({
             schema,
             document,
@@ -78,7 +78,7 @@ class GraphQLRunner {
     // cache just wastes memory without much benefits.
     // TODO: consider a better strategy for cache purging/invalidation
     this.scheduleClearCache()
-    return result
+    return Promise.resolve(result)
   }
 }
 


### PR DESCRIPTION
this makes `GraphQLRunner.query` to return promise on validation errors

Before that if there was error in query executed in gatsby-node.js we would see error like this:

```
success building schema - 0.313s

 ERROR #11321  PLUGIN

"gatsby-node.js" threw an error while running the createPages lifecycle:

runner.query(...).then is not a function

   9 | module.exports = (store, reporter) => {
  10 |   const runner = new GraphQLRunner(store);
> 11 |   return (query, context) => runner.query(query, context).then(result => {
     |                                                           ^
  12 |     if (result.errors) {
  13 |       const structuredErrors = result.errors.map(e => {
  14 |         // Find the file where graphql was called.

File: node_modules/gatsby/dist/bootstrap/graphql-runner.js:11:59



  TypeError: runner.query(...).then is not a function
  
  - graphql-runner.js:11 
    [errors-in-gatsby-node-query]/[gatsby]/dist/bootstrap/graphql-runner.js:11:59
  
  - gatsby-node.js:8 Object.exports.createPages
    /Users/misiek/test/errors-in-gatsby-node-query/gatsby-node.js:8:24
  
  - api-runner-node.js:248 runAPI
    [errors-in-gatsby-node-query]/[gatsby]/dist/utils/api-runner-node.js:248:37
  
  - api-runner-node.js:367 resolve
    [errors-in-gatsby-node-query]/[gatsby]/dist/utils/api-runner-node.js:367:15
  
  - debuggability.js:384 Promise._execute
    [errors-in-gatsby-node-query]/[bluebird]/js/release/debuggability.js:384:9
  
  - promise.js:518 Promise._resolveFromExecutor
    [errors-in-gatsby-node-query]/[bluebird]/js/release/promise.js:518:18
  
  - promise.js:103 new Promise
    [errors-in-gatsby-node-query]/[bluebird]/js/release/promise.js:103:10
  
  - api-runner-node.js:366 Promise.mapSeries.plugin
    [errors-in-gatsby-node-query]/[gatsby]/dist/utils/api-runner-node.js:366:12
  
  - util.js:16 tryCatcher
    [errors-in-gatsby-node-query]/[bluebird]/js/release/util.js:16:23
  
  - reduce.js:166 Object.gotValue
    [errors-in-gatsby-node-query]/[bluebird]/js/release/reduce.js:166:18
  
  - reduce.js:155 Object.gotAccum
    [errors-in-gatsby-node-query]/[bluebird]/js/release/reduce.js:155:25
  
  - util.js:16 Object.tryCatcher
    [errors-in-gatsby-node-query]/[bluebird]/js/release/util.js:16:23
  
  - promise.js:547 Promise._settlePromiseFromHandler
    [errors-in-gatsby-node-query]/[bluebird]/js/release/promise.js:547:31
  
  - promise.js:604 Promise._settlePromise
    [errors-in-gatsby-node-query]/[bluebird]/js/release/promise.js:604:18
  
  - promise.js:641 Promise._settlePromiseCtx
    [errors-in-gatsby-node-query]/[bluebird]/js/release/promise.js:641:10
  
  - async.js:97 _drainQueueStep
    [errors-in-gatsby-node-query]/[bluebird]/js/release/async.js:97:12
  

failed createPages - 0.089s
```

With this change we get proper one:

```
success building schema - 0.345s

 ERROR #85923  GRAPHQL

There was an error in your GraphQL query:

Cannot query field "forceQueryParsingOrValidationError" on type "Query".

If you don't expect "forceQueryParsingOrValidationError" to exist on the type "Query" it is most likely a typo.
However, if you expect "forceQueryParsingOrValidationError" to exist there are a couple of solutions to common problems:

- If you added a new data source and/or changed something inside gatsby-node.js/gatsby-config.js, please try a restart of your development server
- The field might be accessible in another subfield, please try your query in GraphiQL and use the GraphiQL explorer to see which fields you can query and what shape they have
- You want to optionally use your field "forceQueryParsingOrValidationError" and right now it is not used anywhere. Therefore Gatsby can't infer the type and add it to the GraphQL schema. A quick fix is to add a least one entry with that field ("dummy content")

It is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for "Query":
https://www.gatsbyjs.org/docs/schema-customization/#creating-type-definitions

File: gatsby-node.js:8:24

not finished createPages - 0.064s
```

https://github.com/pieh/errors-in-gatsby-node-query can be used to quickly reproduce this (blog starter with small change to force query validation error)