### PR TITLE
fix(gatsby-plugin-sharp): add output file cache back for non job api

### DIFF
--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -61,6 +61,18 @@ const scheduleJob = async (job, boundActionCreators, reporter) => {
     return cloudJob
   }
 
+  // If output file already exists don't re-run image processing
+  // this has been in here from the beginning, job api v2 does this correct
+  // to not break existing behahaviour we put this in here too.
+  job.args.operations = job.args.operations.filter(
+    operation => !fs.existsSync(path.join(job.outputDir, operation.outputPath))
+  )
+
+  if (!job.args.operations.length) {
+    jobsInFlight.set(jobDigest, Promise.resolve())
+    return jobsInFlight.get(jobDigest)
+  }
+
   const jobId = uuidv4()
   boundActionCreators.createJob(
     {


### PR DESCRIPTION
## Description
When testing @pieh's progress bar fix for image-sharp I noticed that we still rebuild some images on the old gatsby versions. I removed it from my refactor as I think it's bad behavior of the plugin to only check if it exists and not the hash of the file content.

This brings it back to have the same behavior as before. If people want better caching they'll need to upgrade gatsby.
<!-- Write a brief description of the changes introduced by this PR -->
