### PR TITLE
fix(docs): Update end-to-end testing documentation

### DIFF
--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -97,10 +97,9 @@ You'll use the `beforeEach` hook to run some commands before each test. After cy
 /// <reference types="Cypress" />
 
 describe("Accessibility checks", () => {
-  beforeEach(() => {
+  before(() => {
     cy.visit("/")
     cy.injectAxe()
-    cy.wait(500)
   })
   it("Has no detectable a11y violations on load", () => {
     cy.checkA11y()
@@ -120,10 +119,9 @@ The following test is for the [gatsby-default-starter](https://github.com/gatsby
 /// <reference types="Cypress" />
 
 describe("Accessibility checks", () => {
-  beforeEach(() => {
+  before(() => {
     cy.visit("/")
     cy.injectAxe()
-    cy.wait(500)
   })
   it("Has no detectable a11y violations on load", () => {
     cy.checkA11y()
@@ -146,10 +144,9 @@ In `gatsby-default-starter` homepage you can write another test that focuses on 
 /// <reference types="Cypress" />
 
 describe("Accessibility checks", () => {
-  beforeEach(() => {
+  before(() => {
     cy.visit("/")
     cy.injectAxe()
-    cy.wait(500)
   })
   it("Has no detectable a11y violations on load", () => {
     cy.checkA11y()

--- a/docs/docs/end-to-end-testing.md
+++ b/docs/docs/end-to-end-testing.md
@@ -99,6 +99,7 @@ You'll use the `beforeEach` hook to run some commands before each test. After cy
 describe("Accessibility checks", () => {
   before(() => {
     cy.visit("/")
+    cy.wait(500)
     cy.injectAxe()
   })
   it("Has no detectable a11y violations on load", () => {
@@ -121,6 +122,7 @@ The following test is for the [gatsby-default-starter](https://github.com/gatsby
 describe("Accessibility checks", () => {
   before(() => {
     cy.visit("/")
+    cy.wait(500)
     cy.injectAxe()
   })
   it("Has no detectable a11y violations on load", () => {
@@ -146,6 +148,7 @@ In `gatsby-default-starter` homepage you can write another test that focuses on 
 describe("Accessibility checks", () => {
   before(() => {
     cy.visit("/")
+    cy.wait(500)
     cy.injectAxe()
   })
   it("Has no detectable a11y violations on load", () => {


### PR DESCRIPTION
Changes in this PR:

- ~`cy.wait()` removed, since Cypress waits for the page to load already (https://docs.cypress.io/guides/references/best-practices.html#Unnecessary-Waiting)~ not true, having tested my own application more, it didn't work properly unless I waited.
- Used `before()` instead of `beforeEach()`, since someone would typically want to visit this url before _all_ of the tests, not before each test (https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Hooks)