### PR TITLE
fix(gatsby): structured error might be a string

### DIFF
--- a/packages/gatsby/src/utils/api-runner-error-parser.js
+++ b/packages/gatsby/src/utils/api-runner-error-parser.js
@@ -28,7 +28,10 @@ const errorParser = ({ err }) => {
     if (Array.isArray(err)) {
       err = err[0]
     }
-    const matched = err.message?.match(regex)
+    if (err.message) {
+      err = err.message
+    }
+    const matched = err?.match(regex)
     if (matched) {
       structured = {
         ...cb(matched),


### PR DESCRIPTION
Addresses this comment: https://github.com/gatsbyjs/gatsby/pull/20730#issuecomment-578171960

Observed a case where the `err` value is actually a string. This fix should resolve that case too (although to be fair we should always throw an `Error` instance or something similar)