### PR TITLE
chore(www): Add labels on TypeScript and TSX code blocks

### DIFF
--- a/www/src/utils/styles/global.js
+++ b/www/src/utils/styles/global.js
@@ -92,6 +92,18 @@ const gatsbyHighlightLanguageBadges = t => {
       content: `'jsx'`,
       background: `#61dafb`,
     },
+    ".gatsby-highlight pre[class='language-typescript']::before": {
+      content: `'ts'`,
+      background: `#294e80`,
+    },
+    ".gatsby-highlight pre[class='language-ts']::before": {
+      content: `'ts'`,
+      background: `#294e80`,
+    },
+    ".gatsby-highlight pre[class='language-tsx']::before": {
+      content: `'tsx'`,
+      background: `#294e80`,
+    },
     ".gatsby-highlight pre[class='language-graphql']::before": {
       content: `'GraphQL'`,
       background: `#E10098`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Adds the little "ts" or "tsx" label onto TypeScript codeblocks

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
