### PR TITLE
chore: add babel/core to peer dependencies

### DIFF
--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/babel-preset-gatsby-package"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby-package#readme",
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -10,6 +10,7 @@
     "Noah Lange <noahrlange@gmail.com>"
   ],
   "dependencies": {
+    "@babel/core": "^7.7.5",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
     "@babel/plugin-proposal-numeric-separator": "^7.7.4",
     "@babel/plugin-proposal-optional-chaining": "^7.7.5",


### PR DESCRIPTION
## Description

I've got errors when tried to using yarn@berry which doesn't support implicit transitive peer deps anymore.

```
➤ YN0002: │ babel-preset-gatsby-package@npm:0.2.3 doesn't provide @babel/core@^7.0.0-0 requested by @babel/plugin-proposal-class-properties@npm:7.5.5
➤ YN0002: │ babel-preset-gatsby-package@npm:0.2.3 doesn't provide @babel/core@^7.0.0-0 requested by @babel/plugin-proposal-optional-chaining@npm:7.2.0
➤ YN0002: │ babel-preset-gatsby-package@npm:0.2.3 doesn't provide @babel/core@^7.0.0-0 requested by @babel/plugin-syntax-dynamic-import@npm:7.2.0
➤ YN0002: │ babel-preset-gatsby-package@npm:0.2.3 doesn't provide @babel/core@^7.0.0-0 requested by @babel/plugin-transform-runtime@npm:7.5.5
➤ YN0002: │ babel-preset-gatsby-package@npm:0.2.3 doesn't provide @babel/core@^7.0.0-0 requested by @babel/preset-env@npm:7.5.5
➤ YN0002: │ babel-preset-gatsby-package@npm:0.2.3 doesn't provide @babel/core@^7.0.0-0 requested by @babel/preset-flow@npm:7.0.0
➤ YN0002: │ babel-preset-gatsby-package@npm:0.2.3 doesn't provide @babel/core@^7.0.0-0 requested by @babel/preset-react@npm:7.0.0
```

I added missing peer dependencies into the package.json of two packages:

- babel-preset-gatsby-package
- gatsby-plugin-typescript (also has a similar issue, #20900)

## Note

I know @Austaras requested removing `@babel/plugin-proposal-nullish-coalescing-operator` and `@babel/plugin-proposal-optional-chaining` from gatsby-plugin-typescript.

I think it's better to deal with another PR because removing the two plugins requires to raise existing gatsby peer dependency version from 2.0.0 to [at least 2.18.11](https://github.com/gatsbyjs/gatsby/commit/ea6185ce28a8b940322ec670303a46c6b758e464)

## Related Issues

Fixes #20900 
