### PR TITLE
fix failing starter tags

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5025,8 +5025,6 @@
     - Search
     - Styling:Bootstrap
     - RSS
-    - Design
-    - Media
     - SEO
   features:
     - Designed to focus on blog posts with images.
@@ -5055,7 +5053,6 @@
   repo: https://github.com/arshad/gatsby-starter-flex
   description: A Gatsby starter for the Flex theme.
   tags:
-    - Language:JavaScript
     - SEO
     - MDX
     - Styling:CSS-in-JS


### PR DESCRIPTION
Noticed the "Danger" bot for another PR based on a couple starters having incompatible tags. This PR addresses those.
