### PR TITLE
chore(www): Change ts codeblock color

### DIFF
--- a/www/src/utils/styles/global.js
+++ b/www/src/utils/styles/global.js
@@ -95,14 +95,17 @@ const gatsbyHighlightLanguageBadges = t => {
     ".gatsby-highlight pre[class='language-typescript']::before": {
       content: `'ts'`,
       background: `#294e80`,
+      color: t.colors.white,
     },
     ".gatsby-highlight pre[class='language-ts']::before": {
       content: `'ts'`,
       background: `#294e80`,
+      color: t.colors.white,
     },
     ".gatsby-highlight pre[class='language-tsx']::before": {
       content: `'tsx'`,
       background: `#294e80`,
+      color: t.colors.white,
     },
     ".gatsby-highlight pre[class='language-graphql']::before": {
       content: `'GraphQL'`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

In the little "ts" label on TypeScript codeblocks, text should be white on blue

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
