### PR TITLE
fix(gatsby): Fix stack overflow on queries with circular fragments

### DIFF
--- a/packages/gatsby/src/query/__tests__/query-compiler.js
+++ b/packages/gatsby/src/query/__tests__/query-compiler.js
@@ -338,6 +338,7 @@ describe(`actual compiling`, () => {
       }
     `
     )
+    expect(result.size).toEqual(0)
   })
 
   it(`removes unused fragments from documents`, async () => {
@@ -607,7 +608,7 @@ describe(`actual compiling`, () => {
          5 |              }
          6 |           }
          7 |         }
-         8 |
+         8 | 
          9 |         fragment PostsJsonFragment on PostsJson {
         10 |           id
         11 |           node
@@ -635,7 +636,7 @@ describe(`actual compiling`, () => {
          5 |              }
          6 |           }
          7 |         }
-         8 |
+         8 | 
       >  9 |         fragment PostsJsonFragment on PostsJson {
            |                  ^^^^^^^^^^^^^^^^^
         10 |           id

--- a/packages/gatsby/src/query/__tests__/query-compiler.js
+++ b/packages/gatsby/src/query/__tests__/query-compiler.js
@@ -276,6 +276,44 @@ describe(`actual compiling`, () => {
     expect(result.get(`mockFile`)).toMatchSnapshot()
   })
 
+  it(`handles circular fragments`, async () => {
+    const nodes = [
+      createGatsbyDoc(
+        `mockFile`,
+        `query mockFileQuery {
+          allDirectory {
+            nodes {
+              ...Foo
+            }
+          }
+        }
+
+        fragment Bar on Directory {
+          parent {
+            ...Foo
+          }
+        }
+
+        fragment Foo on Directory {
+          children {
+            ...Bar
+          }
+        }`
+      ),
+    ]
+
+    const errors = []
+    const result = processQueries({
+      schema,
+      parsedQueries: nodes,
+      addError: e => {
+        errors.push(e)
+      },
+    })
+    expect(errors).toEqual([])
+    expect(result.get(`mockFile`)).toMatchSnapshot()
+  })
+
   it(`removes unused fragments from documents`, async () => {
     const nodes = [
       createGatsbyDoc(
@@ -543,7 +581,7 @@ describe(`actual compiling`, () => {
          5 |              }
          6 |           }
          7 |         }
-         8 | 
+         8 |
          9 |         fragment PostsJsonFragment on PostsJson {
         10 |           id
         11 |           node
@@ -571,7 +609,7 @@ describe(`actual compiling`, () => {
          5 |              }
          6 |           }
          7 |         }
-         8 | 
+         8 |
       >  9 |         fragment PostsJsonFragment on PostsJson {
            |                  ^^^^^^^^^^^^^^^^^
         10 |           id

--- a/packages/gatsby/src/query/__tests__/query-compiler.js
+++ b/packages/gatsby/src/query/__tests__/query-compiler.js
@@ -310,8 +310,34 @@ describe(`actual compiling`, () => {
         errors.push(e)
       },
     })
-    expect(errors).toEqual([])
-    expect(result.get(`mockFile`)).toMatchSnapshot()
+    expect(errors.length).toEqual(1)
+    expect(errors[0]).toMatchInlineSnapshot(
+      {
+        location: expect.any(Object),
+      },
+      `
+      Object {
+        "context": Object {
+          "sourceMessage": "Cannot spread fragment \\"Foo\\" within itself via Bar.
+
+      GraphQL request:17:13
+      16 |           children {
+      17 |             ...Bar
+         |             ^
+      18 |           }
+
+      GraphQL request:11:13
+      10 |           parent {
+      11 |             ...Foo
+         |             ^
+      12 |           }",
+        },
+        "filePath": "mockFile",
+        "id": "85901",
+        "location": Any<Object>,
+      }
+    `
+    )
   })
 
   it(`removes unused fragments from documents`, async () => {

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -430,7 +430,8 @@ const processDefinitions = ({
 const determineUsedFragmentsForDefinition = (
   definition,
   definitionsByName,
-  fragmentsUsedByFragment
+  fragmentsUsedByFragment,
+  visitedFragmentDefinitions = new Set()
 ) => {
   const { def, name, isFragment, filePath } = definition
   const cachedUsedFragments = fragmentsUsedByFragment.get(name)
@@ -443,6 +444,10 @@ const determineUsedFragmentsForDefinition = (
       [Kind.FRAGMENT_SPREAD]: node => {
         const name = node.name.value
         const fragmentDefinition = definitionsByName.get(name)
+        if (visitedFragmentDefinitions.has(fragmentDefinition)) {
+          return undefined
+        }
+        visitedFragmentDefinitions.add(fragmentDefinition)
         if (fragmentDefinition) {
           usedFragments.add(name)
           const {
@@ -451,7 +456,8 @@ const determineUsedFragmentsForDefinition = (
           } = determineUsedFragmentsForDefinition(
             fragmentDefinition,
             definitionsByName,
-            fragmentsUsedByFragment
+            fragmentsUsedByFragment,
+            visitedFragmentDefinitions
           )
           usedFragmentsForFragment.forEach(fragmentName =>
             usedFragments.add(fragmentName)

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -445,7 +445,7 @@ const determineUsedFragmentsForDefinition = (
         const name = node.name.value
         const fragmentDefinition = definitionsByName.get(name)
         if (visitedFragmentDefinitions.has(fragmentDefinition)) {
-          return undefined
+          return
         }
         visitedFragmentDefinitions.add(fragmentDefinition)
         if (fragmentDefinition) {


### PR DESCRIPTION
## Description

This PR fixes stack overflow caused by circular fragments. Stack overflow was first introduced here: https://github.com/gatsbyjs/gatsby/pull/19665 

## Related Issues
Fixes #20826