### PR TITLE
Remove misleading configuration from gatsby themes example

### DIFF
--- a/docs/docs/recipes/working-with-themes.md
+++ b/docs/docs/recipes/working-with-themes.md
@@ -48,9 +48,6 @@ module.exports = {
         - mdx defaults to `true`
         */
         basePath: `/blog`,
-        contentPath: `content/blogPosts`,
-        assetPath: `content/blogAssets`,
-        mdx: false,
       },
     },
   ],


### PR DESCRIPTION
The current recipe includes an example of configuration that will cause problems for gatsby blog theme users.

The issue is `mdx: false`, this is only meant to be used when another plugin configures mdx for you. In this example, it causes the blog posts not to appear.

I'm also removing the changes to directory paths. There isn't a reason to override them without knowing the users context and the comment is great at explaining the default behavior.