### PR TITLE
(docs) Add tip on allowing maintainers to edit PR branches

### DIFF
--- a/docs/contributing/gatsby-docs-translation-guide.md
+++ b/docs/contributing/gatsby-docs-translation-guide.md
@@ -114,7 +114,7 @@ In addition, sometimes a contributor cannot continue a PR for whatever reason. I
 
 #### Check "allow edits from maintainers"
 
-Contributors should check "allow edits from maintainers" when making PRs. This will [allow maintainers to make changes](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) directly to a PR branch created from a fork. Maintainers can add these instructions to a PR template to serve as a reminder to contributors.
+Contributors should check "allow edits from maintainers" when making Pull Requests (PRs). This will [allow maintainers to make changes](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) directly to a PR branch created from a fork. Maintainers can add these instructions to a PR template to serve as a reminder to contributors.
 
 #### Set up a review process
 

--- a/docs/contributing/gatsby-docs-translation-guide.md
+++ b/docs/contributing/gatsby-docs-translation-guide.md
@@ -112,6 +112,10 @@ Some pages are very long and difficult to translate for a single contributor. Fe
 
 In addition, sometimes a contributor cannot continue a PR for whatever reason. It may help to ask them if they need assistance and to bring someone else on to complete the work in a timely fashion.
 
+#### Check "allow edits from maintainers"
+
+Contributors should check "allow edits from maintainers" when making PRs. This will [allow maintainers to make changes](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) directly to a PR branch created from a fork. Maintainers can add these instructions to a PR template to serve as a reminder to contributors.
+
 #### Set up a review process
 
 As codeowners, you have the freedom and responsibility to decide what your review process will be like. You can decide how many reviewers you'd like. If your team is small, one reviewer may be enough. But if you have lots of contributors and enough codeowners, you may want to require two reviewers for additional quality.


### PR DESCRIPTION
## Description

We've had a couple of issues with folks not realizing they can/should [check "allow maintainers to edit"](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) when they make a PR, particularly in the i18n repos. Code owners have tried to make changes or apply suggestions but not had permission to do so. I think it makes sense to add a note to the contributing docs!