### PR TITLE
fix(gatsby): Do not add field `id` to the query when `id` alias exists

### DIFF
--- a/packages/gatsby/src/query/__tests__/__snapshots__/query-compiler.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/query-compiler.js.snap
@@ -549,6 +549,86 @@ query mockFileQuery {
 }
 `;
 
+exports[`Extra fields doesn't add __typename field when alias exists 1`] = `
+Object {
+  "hash": "hash",
+  "isHook": false,
+  "isStaticQuery": false,
+  "name": "mockFileQuery",
+  "originalText": "
+      query mockFileQuery {
+        allDirectory {
+          nodes {
+            __typename: id
+            contents {
+              ... on File {
+                __typename: id
+              }
+            }
+            children {
+              __typename: id
+              ... Node
+            }
+            ... on Directory {
+              children {
+                __typename: id
+              }
+            }
+            ...DirectoryContents
+          }
+        }
+      }
+
+      fragment DirectoryContents on Directory {
+        children {
+          __typename: id
+        }
+      }
+
+      fragment Node on Node {
+        __typename: id
+      }
+    ",
+  "path": "mockFile",
+  "text": "fragment Node on Node {
+  __typename: id
+}
+
+fragment DirectoryContents on Directory {
+  id
+  children {
+    __typename: id
+  }
+}
+
+query mockFileQuery {
+  allDirectory {
+    nodes {
+      __typename: id
+      contents {
+        __typename
+        ... on File {
+          __typename: id
+        }
+      }
+      children {
+        __typename: id
+        ...Node
+      }
+      ... on Directory {
+        id
+        children {
+          __typename: id
+        }
+      }
+      ...DirectoryContents
+    }
+  }
+}
+",
+}
+`;
+
 exports[`Extra fields doesn't add id field twice 1`] = `
 Object {
   "hash": "hash",

--- a/packages/gatsby/src/query/__tests__/__snapshots__/query-compiler.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/query-compiler.js.snap
@@ -657,6 +657,81 @@ query mockFileQuery {
 }
 `;
 
+exports[`Extra fields doesn't add id field when alias for id exists 1`] = `
+Object {
+  "hash": "hash",
+  "isHook": false,
+  "isStaticQuery": false,
+  "name": "mockFileQuery",
+  "originalText": "
+      query mockFileQuery {
+        allDirectory {
+          nodes {
+            contents {
+              ... on File {
+                id: absolutePath
+              }
+              ... on Directory {
+                id: absolutePath
+              }
+            }
+            ... on Directory {
+              id: absolutePath
+            }
+            ...DirectoryContents
+          }
+        }
+      }
+
+      fragment DirectoryContents on Directory {
+        contents {
+          ... on File {
+            id: absolutePath
+          }
+          ... on Directory {
+            id: absolutePath
+          }
+        }
+      }
+    ",
+  "path": "mockFile",
+  "text": "fragment DirectoryContents on Directory {
+  id
+  contents {
+    __typename
+    ... on File {
+      id: absolutePath
+    }
+    ... on Directory {
+      id: absolutePath
+    }
+  }
+}
+
+query mockFileQuery {
+  allDirectory {
+    nodes {
+      id
+      contents {
+        __typename
+        ... on File {
+          id: absolutePath
+        }
+        ... on Directory {
+          id: absolutePath
+        }
+      }
+      ... on Directory {
+        id: absolutePath
+      }
+      ...DirectoryContents
+    }
+  }
+}
+",
+}
+`;
+
 exports[`actual compiling accepts identical fragment definitions 1`] = `
 Map {
   "mockFile" => Object {

--- a/packages/gatsby/src/query/__tests__/query-compiler.js
+++ b/packages/gatsby/src/query/__tests__/query-compiler.js
@@ -1165,6 +1165,42 @@ describe(`Extra fields`, () => {
     expect(errors).toEqual([])
     expect(result.get(`mockFile`)).toMatchSnapshot()
   })
+
+  it(`doesn't add id field when alias for id exists`, async () => {
+    const [result, errors] = transformQuery(`
+      query mockFileQuery {
+        allDirectory {
+          nodes {
+            contents {
+              ... on File {
+                id: absolutePath
+              }
+              ... on Directory {
+                id: absolutePath
+              }
+            }
+            ... on Directory {
+              id: absolutePath
+            }
+            ...DirectoryContents
+          }
+        }
+      }
+
+      fragment DirectoryContents on Directory {
+        contents {
+          ... on File {
+            id: absolutePath
+          }
+          ... on Directory {
+            id: absolutePath
+          }
+        }
+      }
+    `)
+    expect(errors).toEqual([])
+    expect(result.get(`mockFile`)).toMatchSnapshot()
+  })
 })
 
 const createGatsbyDoc = (

--- a/packages/gatsby/src/query/__tests__/query-compiler.js
+++ b/packages/gatsby/src/query/__tests__/query-compiler.js
@@ -1024,6 +1024,45 @@ describe(`Extra fields`, () => {
     expect(result.get(`mockFile`)).toMatchSnapshot()
   })
 
+  it(`doesn't add __typename field when alias exists`, async () => {
+    const [result, errors] = transformQuery(`
+      query mockFileQuery {
+        allDirectory {
+          nodes {
+            __typename: id
+            contents {
+              ... on File {
+                __typename: id
+              }
+            }
+            children {
+              __typename: id
+              ... Node
+            }
+            ... on Directory {
+              children {
+                __typename: id
+              }
+            }
+            ...DirectoryContents
+          }
+        }
+      }
+
+      fragment DirectoryContents on Directory {
+        children {
+          __typename: id
+        }
+      }
+
+      fragment Node on Node {
+        __typename: id
+      }
+    `)
+    expect(errors).toEqual([])
+    expect(result.get(`mockFile`)).toMatchSnapshot()
+  })
+
   it(`adds id field if type has it`, () => {
     const [result, errors] = transformQuery(`
       query mockFileQuery {

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -500,7 +500,10 @@ const addExtraFields = (document, schema) => {
         // Entering a field of the current selection-set:
         //   mark which fields already exist in this selection set to avoid duplicates
         const context = contextStack[contextStack.length - 1]
-        if (node.name.value === `__typename`) {
+        if (
+          node.name.value === `__typename` ||
+          node?.alias?.value === `__typename`
+        ) {
           context.hasTypename = true
         }
         if (node.name.value === `id` || node?.alias?.value === `id`) {

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -503,7 +503,7 @@ const addExtraFields = (document, schema) => {
         if (node.name.value === `__typename`) {
           context.hasTypename = true
         }
-        if (node.name.value === `id`) {
+        if (node.name.value === `id` || node?.alias?.value === `id`) {
           context.hasId = true
         }
       },


### PR DESCRIPTION
## Description

A follow up for #20849 That PR doesn't take into account aliases. So when alias for `id` exists, we shouldn't auto-add `id` field to the query

## Related Issues

#20943 