### PR TITLE
fix(gatsby-theme-blog): fix functions that are interpolated in css

### DIFF
--- a/packages/gatsby-theme-blog/src/components/header.js
+++ b/packages/gatsby-theme-blog/src/components/header.js
@@ -55,9 +55,9 @@ const Title = ({ children, location }) => {
 }
 
 const iconCss = [
-  css({
+  {
     pointerEvents: `none`,
-  }),
+  },
   { margin: 4 }, // Explicitly leave margin out of theme-ui, this positioning should not change based on theme
 ]
 

--- a/packages/gatsby-theme-blog/src/components/header.js
+++ b/packages/gatsby-theme-blog/src/components/header.js
@@ -54,12 +54,7 @@ const Title = ({ children, location }) => {
   }
 }
 
-const iconCss = [
-  {
-    pointerEvents: `none`,
-  },
-  { margin: 4 }, // Explicitly leave margin out of theme-ui, this positioning should not change based on theme
-]
+const iconCss = [{ pointerEvents: `none`, margin: 4 }]
 
 const checkedIcon = (
   <img


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Remove call to css call from theme-ui for iconCss in header file of gatsby-theme-blog

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->
No updates required

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #20326 