### PR TITLE
Update Theme READMEs with more explicit instructions

### DIFF
--- a/packages/gatsby-theme-blog-core/README.md
+++ b/packages/gatsby-theme-blog-core/README.md
@@ -11,30 +11,55 @@ A Gatsby theme for creating a blog child theme. It includes all of the data stru
 
 ## Installation
 
-### Use the blog core theme starter
+### For a new site
 
-This will generate a new site that pre-configures use of the blog core theme.
+If you're creating a new site and want to use the blog theme, you can use the blog theme starter. This will generate a new site that pre-configures use of the blog theme.
 
 ```shell
 gatsby new my-themed-blog https://github.com/gatsbyjs/gatsby-starter-blog-theme-core
 ```
 
-### Manually add to your site
+### For an existing site
+
+1. Install the theme
 
 ```shell
-npm install --save gatsby-theme-blog-core
+npm install gatsby-theme-blog-core
 ```
+
+2. Add the configuration to your `gatsby-config.js` file
+
+```js
+// gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-theme-blog-core`,
+      options: {
+        // basePath defaults to `/`
+        basePath: `/blog`,
+      },
+    },
+  ],
+}
+```
+
+3. Add blog posts to your site by creating `md` or `mdx` files inside `/content/posts`.
+
+   > Note that if you've changed the default `contentPath` in the configuration, you'll want to add your markdown files in the directory specified by that path.
+
+4. Run your site using `gatsby develop` and navigate to your notes. If you used the above configuration, your URL will be `http://localhost:8000/blog`
 
 ## Usage
 
 ### Theme options
 
-| Key           | Default value    | Description                                                                                               |
-| ------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
-| `basePath`    | `/`              | Root url for all blog posts                                                                               |
-| `contentPath` | `content/posts`  | Location of blog posts                                                                                    |
-| `assetPath`   | `content/assets` | Location of assets                                                                                        |
-| `mdx`         | `true`           | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| Key           | Default value    | Description                                                                                                                                                                    |
+| ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `basePath`    | `/`              | Root url for all blog posts                                                                                                                                                    |
+| `contentPath` | `content/posts`  | Location of blog posts                                                                                                                                                         |
+| `assetPath`   | `content/assets` | Location of assets                                                                                                                                                             |
+| `mdx`         | `true`           | Configure `gatsby-plugin-mdx`. Note that most sites will not need to use this flag. If your site has already configured `gatsby-plugin-mdx` separately, set this flag `false`. |
 
 #### Example usage
 

--- a/packages/gatsby-theme-blog-core/README.md
+++ b/packages/gatsby-theme-blog-core/README.md
@@ -48,7 +48,7 @@ module.exports = {
 
    > Note that if you've changed the default `contentPath` in the configuration, you'll want to add your markdown files in the directory specified by that path.
 
-4. Run your site using `gatsby develop` and navigate to your notes. If you used the above configuration, your URL will be `http://localhost:8000/blog`
+4. Run your site using `gatsby develop` and navigate to your blog posts. If you used the above configuration, your URL will be `http://localhost:8000/blog`
 
 ## Usage
 

--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -11,32 +11,59 @@ A Gatsby theme for creating a blog.
 
 ## Installation
 
-### Use the blog theme starter
+### For a new site
 
-This will generate a new site that pre-configures use of the blog theme.
+If you're creating a new site and want to use the blog theme, you can use the blog theme starter. This will generate a new site that pre-configures use of the blog theme.
 
 ```shell
 gatsby new my-themed-blog https://github.com/gatsbyjs/gatsby-starter-blog-theme
 ```
 
-### Manually add to your site
+### For an existing site
+
+If you already have a site you'd like to add the blog theme to, you can manually configure it.
+
+1. Install the blog theme
 
 ```shell
-npm install --save gatsby-theme-blog
+npm install gatsby-theme-blog
 ```
+
+2. Add the configuration to your `gatsby-config.js` file
+
+```js
+// gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-theme-blog`,
+      options: {
+        // basePath defaults to `/`
+        basePath: `/blog`,
+      },
+    },
+  ],
+}
+```
+
+3. Add blog posts to your site by creating `md` or `mdx` files inside `/content/posts`.
+
+   > Note that if you've changed the default `contentPath` in the configuration, you'll want to add your markdown files in the directory specified by that path.
+
+4. Run your site using `gatsby develop` and navigate to your notes. If you used the above configuration, your URL will be `http://localhost:8000/blog`
 
 ## Usage
 
 ### Theme options
 
-| Key           | Default value    | Description                                                                                               |
-| ------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
-| `basePath`    | `/`              | Root url for all blog posts                                                                               |
-| `contentPath` | `content/posts`  | Location of blog posts                                                                                    |
-| `assetPath`   | `content/assets` | Location of assets                                                                                        |
-| `mdx`         | `true`           | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
+| Key           | Default value    | Description                                                                                                                                                                    |
+| ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `basePath`    | `/`              | Root url for all blog posts                                                                                                                                                    |
+| `contentPath` | `content/posts`  | Location of blog posts                                                                                                                                                         |
+| `assetPath`   | `content/assets` | Location of assets                                                                                                                                                             |
+| `mdx`         | `true`           | Configure `gatsby-plugin-mdx`. Note that most sites will not need to use this flag. If your site has already configured `gatsby-plugin-mdx` separately, set this flag `false`. |
 
-#### Example usage
+#### Example configuration
 
 ```js
 // gatsby-config.js

--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -50,7 +50,7 @@ module.exports = {
 
    > Note that if you've changed the default `contentPath` in the configuration, you'll want to add your markdown files in the directory specified by that path.
 
-4. Run your site using `gatsby develop` and navigate to your notes. If you used the above configuration, your URL will be `http://localhost:8000/blog`
+4. Run your site using `gatsby develop` and navigate to your blog posts. If you used the above configuration, your URL will be `http://localhost:8000/blog`
 
 ## Usage
 

--- a/packages/gatsby-theme-notes/README.md
+++ b/packages/gatsby-theme-notes/README.md
@@ -11,9 +11,9 @@ A Gatsby theme for publishing notes to your website.
 
 ## Installation
 
-### Use the notes theme starter
+### For a new site
 
-This will generate a new site that pre-configures use of the notes theme.
+If you're creating a new site and want to use the notes theme, you can use the notes theme starter. This will generate a new site that pre-configures use of the notes theme.
 
 ```shell
 gatsby new my-themed-notes https://github.com/gatsbyjs/gatsby-starter-notes-theme
@@ -21,11 +21,13 @@ gatsby new my-themed-notes https://github.com/gatsbyjs/gatsby-starter-notes-them
 
 ### Manually add to your site
 
+1. Install the theme
+
 ```shell
-npm install --save gatsby-theme-notes
+npm install gatsby-theme-notes
 ```
 
-## Usage
+2. Add the configuration to your `gatsby-config.js` file
 
 ```js
 // gatsby-config.js
@@ -42,12 +44,15 @@ module.exports = {
 }
 ```
 
+3. Add notes to your site by creating `md` or `mdx` files inside `/content/notes`.
+   > Note that if you've changed the default `contentPath` in the configuration, you'll want to add your markdown files in the directory specified by that path.
+
 ### Options
 
-| Key                   | Default value    | Description                                                                                               |
-| --------------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
-| `basePath`            | `/`              | Root url for all notes pages                                                                              |
-| `contentPath`         | `/content/notes` | Location of notes content                                                                                 |
-| `mdx`                 | `true`           | Configure `gatsby-plugin-mdx` (if your website already is using the plugin pass `false` to turn this off) |
-| `homeText`            | `~`              | Root text for notes breadcrumb trail                                                                      |
-| `breadcrumbSeparator` | `/`              | Separator for the breadcrumb trail                                                                        |
+| Key                   | Default value    | Description                                                                                                                                                                    |
+| --------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `basePath`            | `/`              | Root url for all notes pages                                                                                                                                                   |
+| `contentPath`         | `/content/notes` | Location of notes content                                                                                                                                                      |
+| `mdx`                 | `true`           | Configure `gatsby-plugin-mdx`. Note that most sites will not need to use this flag. If your site has already configured `gatsby-plugin-mdx` separately, set this flag `false`. |
+| `homeText`            | `~`              | Root text for notes breadcrumb trail                                                                                                                                           |
+| `breadcrumbSeparator` | `/`              | Separator for the breadcrumb trail                                                                                                                                             |


### PR DESCRIPTION
When walking through theme setup I noticed that the READMEs would benefit from additional instructions for those not using a starter. This PR addresses the READMEs for the blog, blog core, and notes theme.
