### PR TITLE
Fix typo in blog post

### DIFF
--- a/docs/blog/2019-04-06-security-for-modern-web-frameworks/index.md
+++ b/docs/blog/2019-04-06-security-for-modern-web-frameworks/index.md
@@ -100,7 +100,7 @@ Medium's "clap" feature, up-voting on Hacker News or Reddit, liking something on
 
 Why address this scenario? Two reasons:
 
-- **Simplicity** - Consider a small blog or non-profit site where authentication is not already needed. To develop it would require a lot of time and long term investment. Users authenticating to a small blog just to hit "like" is a poor user experience and probably a hurtle they will not bother jumping.
+- **Simplicity** - Consider a small blog or non-profit site where authentication is not already needed. To develop it would require a lot of time and long term investment. Users authenticating to a small blog just to hit "like" is a poor user experience and probably a hurdle they will not bother jumping.
 
 - **Privacy** - No matter the size of your platform, requiring users to authenticate means having to secure private data: this requires time and money. Alternatively, as a platform, you may decide your users' privacy is more important then better security controls.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This fixes a simple typo for `hurtle` -> `hurdle`. Low impact, but excited to contribute! 😄 

### Documentation

n/a

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

No issue was created or exists since this is just a typo correction. 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
