### PR TITLE
fix(gatsby-plugin-manifest): Only reassign start_url if it already exists

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -226,7 +226,10 @@ const makeManifest = async ({
       src: slash(path.join(basePath, icon.src)),
     }
   })
-  manifest.start_url = path.posix.join(basePath, manifest.start_url)
+  
+  if (manifest.start_url) {
+    manifest.start_url = path.posix.join(basePath, manifest.start_url)
+  }
 
   //Write manifest
   fs.writeFileSync(

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -226,7 +226,7 @@ const makeManifest = async ({
       src: slash(path.join(basePath, icon.src)),
     }
   })
-  
+
   if (manifest.start_url) {
     manifest.start_url = path.posix.join(basePath, manifest.start_url)
   }


### PR DESCRIPTION
Currently, I'm seeing the following error coming from `gatsby-plugin-manifest` when I'm using only the `icon` option:

```
The "path" argument must be of type string. Received type undefined
```

This happens because the `start_url` option is undefined unless set by the user, yet we're passing it as an argument to `path.posix.join`, which expects each argument to be a string. This change adds a condition around the line reassigning `manifest.start_url` to make sure it exists first.