### PR TITLE
Changed color on tutorial part-seven for better visibility

### DIFF
--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -382,7 +382,7 @@ export default ({ data }) => {
                 {node.frontmatter.title}{" "}
                 <span
                   css={css`
-                    color: #bbb;
+                    color: #555;
                   `}
                 >
                   — {node.frontmatter.date}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The color used previously (bbb) had a contrast ratio of 1.91:1 which fails WCAG AA as well as WCAG AAA tests on both normal & large text.

![Old Color (bbb)](https://user-images.githubusercontent.com/25903939/73398438-80090f00-430b-11ea-88cb-c098f2fc3fc4.png)

The new color I've implemented (555) has a contrast ratio of 7.15:1 which passes WCAG AA as well as WCAG AAA tests on both normal & large text. Also, the new color passes the UI Components WCAG AA test.

![New Color (555)](https://user-images.githubusercontent.com/25903939/73398437-80090f00-430b-11ea-8dec-5488207bbb28.png)

Passing WCAG Test is better as it allows better readability.

### Documentation
The page affected by this commit is https://www.gatsbyjs.org/tutorial/part-seven/
@gatsbyjs/learning

## Related Issues
Fixes #20694
