### PR TITLE
fix(gatsby-source-lever): Removed inference opt out dontInfer

### DIFF
--- a/packages/gatsby-source-lever/src/gatsby-node.js
+++ b/packages/gatsby-source-lever/src/gatsby-node.js
@@ -5,7 +5,7 @@ const typePrefix = `lever__`
 
 exports.createSchemaCustomization = async ({ actions }) => {
   const typeDefs = `
-    type lever implements Node @dontInfer {
+    type lever implements Node {
       additional: String
       additionalPlain: String
       applyUrl: String


### PR DESCRIPTION
## Description
Removed inference opt out `dontInfer` in order to allow developers to add custom fields with `createNodeField`.

### Documentation
https://www.gatsbyjs.org/docs/schema-customization/#opting-out-of-type-inference

## Related Issues
Fixes https://github.com/gatsbyjs/gatsby/issues/21009