### PR TITLE
fix(www): Cannot read property 'resolve' of undefined

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -166,9 +166,9 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              offsetY: 104
+              offsetY: 104,
             },
-          },,
+          },
           `gatsby-remark-copy-linked-files`,
           `gatsby-remark-smartypants`,
         ],
@@ -197,7 +197,7 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              offsetY: 104
+              offsetY: 104,
             },
           },
           {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

fix the error `Cannot read property 'resolve' of undefined`

- the double comma result in an `undefied` plugin
- the comma after `104` value added by prettier

see #21021 


## Related Issues

fixes #21021 `chore(www): Cannot read property 'resolve' of undefined`
introduced in #20989 `Changed autolink headers offset`