### PR TITLE
Add page limit to gatsby-source-contentful

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -168,6 +168,10 @@ Using the ID is a much more stable property to work with as it will change less 
 
 If you are confident your Content Types will have natural-language IDs (e.g. `blogPost`), then you should set this option to `false`. If you are unable to ensure this, then you should leave this option set to `true` (the default).
 
+**`pageLimit`** [number][optional] [default: `1000`]
+
+Number of entries to retrieve from Contentful at a time. This can be adjusted to fix issues related to "Response size too big" error.
+
 ## Notes on Contentful Content Models
 
 There are currently some things to keep in mind when building your content models at Contentful.

--- a/packages/gatsby-source-contentful/src/__tests__/fetch.js
+++ b/packages/gatsby-source-contentful/src/__tests__/fetch.js
@@ -121,6 +121,7 @@ it(`calls contentful.createClient with expected params and default fallbacks`, a
     }),
     reporter,
   })
+
   expect(reporter.panic).not.toBeCalled()
   expect(contentful.createClient).toBeCalledWith(
     expect.objectContaining({
@@ -130,6 +131,41 @@ it(`calls contentful.createClient with expected params and default fallbacks`, a
       space: `rocybtov1ozk`,
     })
   )
+})
+
+it(`calls contentful.getContentTypes with default page limit`, async () => {
+  await fetchData({
+    pluginConfig: createPluginConfig({
+      accessToken: `6f35edf0db39085e9b9c19bd92943e4519c77e72c852d961968665f1324bfc94`,
+      spaceId: `rocybtov1ozk`,
+    }),
+    reporter,
+  })
+
+  expect(reporter.panic).not.toBeCalled()
+  expect(mockClient.getContentTypes).toHaveBeenCalledWith({
+    limit: 1000,
+    order: `sys.createdAt`,
+    skip: 0,
+  })
+})
+
+it(`calls contentful.getContentTypes with custom plugin option page limit`, async () => {
+  await fetchData({
+    pluginConfig: createPluginConfig({
+      accessToken: `6f35edf0db39085e9b9c19bd92943e4519c77e72c852d961968665f1324bfc94`,
+      spaceId: `rocybtov1ozk`,
+      pageLimit: 50,
+    }),
+    reporter,
+  })
+
+  expect(reporter.panic).not.toBeCalled()
+  expect(mockClient.getContentTypes).toHaveBeenCalledWith({
+    limit: 50,
+    order: `sys.createdAt`,
+    skip: 0,
+  })
 })
 
 describe(`Displays troubleshooting tips and detailed plugin options on contentful client error`, () => {

--- a/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
@@ -170,6 +170,7 @@ describe(`Options validation`, () => {
         localeFilter: `yup`,
         downloadLocal: 5,
         useNameForId: 5,
+        pageLimit: `fifty`,
       }
     )
 
@@ -198,6 +199,9 @@ describe(`Options validation`, () => {
     )
     expect(reporter.panic).toBeCalledWith(
       expect.stringContaining(`"useNameForId" must be a boolean`)
+    )
+    expect(reporter.panic).toBeCalledWith(
+      expect.stringContaining(`"pageLimit" must be a number`)
     )
   })
 

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -85,7 +85,9 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`)
   // doesn't support this.
   let contentTypes
   try {
-    contentTypes = await pagedGet(client, `getContentTypes`)
+    const pageLimit = pluginConfig.get(`pageLimit`)
+
+    contentTypes = await pagedGet(client, `getContentTypes`, pageLimit)
   } catch (e) {
     console.log(`error fetching content types`, e)
   }
@@ -119,9 +121,9 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`)
 function pagedGet(
   client,
   method,
+  pageLimit,
   query = {},
   skip = 0,
-  pageLimit = 1000,
   aggregatedResponse = null
 ) {
   return client[method]({
@@ -139,9 +141,9 @@ function pagedGet(
       return pagedGet(
         client,
         method,
+        pageLimit,
         query,
         skip + pageLimit,
-        pageLimit,
         aggregatedResponse
       )
     }

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -3,12 +3,15 @@ const chalk = require(`chalk`)
 
 const _ = require(`lodash`)
 
+const DEFAULT_PAGE_LIMIT = 1000
+
 const defaultOptions = {
   host: `cdn.contentful.com`,
   environment: `master`,
   downloadLocal: false,
   localeFilter: () => true,
   forceFullSync: false,
+  pageLimit: DEFAULT_PAGE_LIMIT,
   useNameForId: true,
 }
 
@@ -33,6 +36,7 @@ const optionsSchema = Joi.object().keys({
   downloadLocal: Joi.boolean(),
   localeFilter: Joi.func(),
   forceFullSync: Joi.boolean(),
+  pageLimit: Joi.number().integer(),
   proxy: Joi.object().keys({
     host: Joi.string().required(),
     port: Joi.number().required(),


### PR DESCRIPTION
## Description

_This is my first PR in gatsby. Please let me know of any adjustments or improvements I could make._

It is possible with Contentful that you have too much Content to receive
in the default 1000 page size, so you may need to add a custom page
limit to not get rate limited.

`Common error message: "400 Response size too big. Maximum allowed response size: 7340032b"`

I've added a new `pageLimit` plugin option to the `gatsby-source-contentful` plugin that allows the user to select the page size to use when downloading content from Contentful.

### Documentation

I added basic documentation to the `README.md` file in the `gatsby-source-contentful` package. Should I add any additional documentation for this?

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes #21026 
