### PR TITLE
docs(gatsby-source-wordpress): Add wp-rest-polylang-pro plugin to readme

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -204,6 +204,9 @@ plugins.
 - [x] [wp-rest-polylang](https://github.com/maru3l/wp-rest-polylang) which adds
       the current locale and available translations to all post types translated with Polylang.
 
+- [x] [wp-rest-polylang-pro](https://github.com/dannyvaughton/wp-rest-polylang-pro) which adds
+      the current locale and available translations to all post types & taxonomies translated with Polylang Pro.
+
 - [x] [Yoast](https://yoast.com/wordpress/plugins/seo/)
   - You must have the plugin [wp-api-yoast-meta](https://github.com/maru3l/wp-api-yoast-meta) installed in WordPress.
   - Will pull the `yoast_meta: { ... }` field's contents in entity.


### PR DESCRIPTION
Adding Polylang Pro to the WordPress Plugin list in gatsby-source-wordpress README.md: https://github.com/dannyvaughton/wp-rest-polylang-pro

This plugin adds translation support for posts & taxonomies for Polylang Pro users (unlike the existing wp-rest-polylang plugin).