### PR TITLE
fix(gatsby-plugin-sharp): throw error when not added to gatsby-config

### DIFF
--- a/examples/using-gatsby-image/gatsby-config.js
+++ b/examples/using-gatsby-image/gatsby-config.js
@@ -2,6 +2,7 @@ module.exports = {
   plugins: [
     `gatsby-plugin-emotion`,
     `gatsby-plugin-netlify`,
+    `gatsby-plugin-sharp`,
     `gatsby-transformer-sharp`,
     {
       resolve: `gatsby-source-filesystem`,

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -109,7 +109,7 @@ function prepareQueue({ file, args }) {
 function createJob(job, { reporter }) {
   if (!boundActionCreators) {
     reporter.panic(
-      `Gatsby-plugin-sharp wasn't setup correclty in gatsby-config.js. Make sure you add it to the plugins array.`
+      `Gatsby-plugin-sharp wasn't setup correctly in gatsby-config.js. Make sure you add it to the plugins array.`
     )
   }
 

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -40,7 +40,7 @@ const getImageSize = file => {
 // There is no guarantee that the module resolved is the module executing!
 // This can occur in mono repos depending on how dependencies have been hoisted.
 // The direct require has been left only to avoid breaking changes.
-let { boundActionCreators } = require(`gatsby/dist/redux/actions`)
+let boundActionCreators
 exports.setBoundActionCreators = actions => {
   boundActionCreators = actions
 }
@@ -107,6 +107,12 @@ function prepareQueue({ file, args }) {
 }
 
 function createJob(job, { reporter }) {
+  if (!boundActionCreators) {
+    reporter.panic(
+      `Gatsby-plugin-sharp wasn't setup correclty in gatsby-config.js. Make sure you add it to the plugins array.`
+    )
+  }
+
   // Jobs can be duplicates and usually are long running tasks.
   // Because of that we shouldn't use async/await and instead opt to use
   // .then() /.catch() handlers, because this allows V8 to release


### PR DESCRIPTION
## Description
With jobs-api we need to make sure that gatsby-plugin-sharp is set inside the gatsby-config array. It should always have been this case, this shows a valid error when it happens.
