### PR TITLE
fix(gatsby-source-graphql): support yarn 2

### DIFF
--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -10,6 +10,7 @@
     "@babel/runtime": "^7.7.6",
     "apollo-link": "1.2.13",
     "apollo-link-http": "^1.5.16",
+    "graphql": "^14.5.8",
     "graphql-tools-fork": "^8.0.1",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

In order to support yarn 2 (berry, PnP). We have to list `graphql` as dependency in `gatsby-source-graphql`. The approach I take here is to simply list it as dependency rather than using `createRequire` as seen in #20638 due to the suggestions https://github.com/gatsbyjs/gatsby/pull/20638#pullrequestreview-350114991 and https://github.com/yarnpkg/berry/issues/689#issuecomment-575036872. It should also be compatible to npm or yarn 1. I've tested it with the [reproduction repo](https://github.com/esphen/gatsby-peer-dep-repro) created by @esphen.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Addresses https://github.com/gatsbyjs/gatsby/issues/20949#issuecomment-579912953