### PR TITLE
add missing issues on gatsby stubs

### DIFF
--- a/docs/docs/adding-search-with-elasticlunr.md
+++ b/docs/docs/adding-search-with-elasticlunr.md
@@ -1,5 +1,6 @@
 ---
 title: Adding Search with Elasticlunr
+issue: https://github.com/gatsbyjs/gatsby/issues/21066
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/data-storage-redux.md
+++ b/docs/docs/data-storage-redux.md
@@ -1,5 +1,6 @@
 ---
 title: Data Storage (Redux)
+issue: https://github.com/gatsbyjs/gatsby/issues/21068
 ---
 
 This is a stub. Help our community expand it.

--- a/docs/docs/gatsby-for-freelancers.md
+++ b/docs/docs/gatsby-for-freelancers.md
@@ -1,5 +1,6 @@
 ---
 title: Gatsby for Freelancers
+issue: https://github.com/gatsbyjs/gatsby/issues/21069
 ---
 
 As a freelancer, the most important thing is [helping clients understand](/docs/winning-over-clients) the benefits of Gatsby.

--- a/docs/docs/maintaining-a-plugin.md
+++ b/docs/docs/maintaining-a-plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Maintaining a Plugin
+issue: https://github.com/gatsbyjs/gatsby/issues/21067
 ---
 
 This is a stub article meant to be filled with tips on how to maintain a Gatsby plugin once you've published it as an npm package.


### PR DESCRIPTION
Add missing `issue:` in frontmatter of stub pages.

## Related Issues

Issues created: #21066 #21067 #21068 #21069

Part of: https://github.com/gatsbyjs/gatsby/pull/21064