### PR TITLE
Typo in the query

### DIFF
--- a/docs/docs/add-seo-component.md
+++ b/docs/docs/add-seo-component.md
@@ -77,7 +77,7 @@ const query = graphql`
         defaultDescription: description
         siteUrl: url
         defaultImage: image
-        twitterUsername
+        twitterUserName
       }
     }
   }

--- a/docs/docs/add-seo-component.md
+++ b/docs/docs/add-seo-component.md
@@ -20,6 +20,7 @@ module.exports = {
     url: "https://www.doe.com", // No trailing slash allowed!
     image: "/images/snape.jpg", // Path to your image you placed in the 'static' folder
     twitterUsername: "@occlumency",
+    // twitterUsername: "@occlumency",
   },
 }
 ```


### PR DESCRIPTION
You have a typo in the query.
const query = graphql`
  query SEO {
    site {
      siteMetadata {
        defaultTitle: title
        titleTemplate
        defaultDescription: description
        siteUrl: url
        defaultImage: image
        twitterUsername
      }
    }
  }
`
It should be 'twitterUserName' instead of 'twitterUsername'.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
