### PR TITLE
fix(www): change outline color of the buttons in the docs to match the theme

### DIFF
--- a/www/src/components/dark-mode-toggle.js
+++ b/www/src/components/dark-mode-toggle.js
@@ -51,6 +51,10 @@ const IconWrapper = styled.button`
   transition: opacity 0.3s ease;
   vertical-align: middle;
   width: 40px;
+  outline: none;
+  &:focus {
+    box-shadow: 0 0 0 3px ${p => p.theme.colors.input.focusBoxShadow};
+  }
 
   &:hover {
     opacity: 1;

--- a/www/src/components/guidelines/color/swatch.js
+++ b/www/src/components/guidelines/color/swatch.js
@@ -73,6 +73,7 @@ export default class Swatch extends React.Component {
               right: 0,
               top: 0,
               width: `100%`,
+              outlineColor: `input.focusBoxShadow`,
               zIndex: 1,
               ":focus .tooltip, :hover .tooltip": {
                 display: `block`,

--- a/www/src/components/sidebar/button-expand-all.js
+++ b/www/src/components/sidebar/button-expand-all.js
@@ -25,6 +25,7 @@ const ExpandAllButton = ({ onClick, expandAll }) => (
       lineHeight: `solid`,
       py: 2,
       textAlign: `left`,
+      outlineColor: `input.focusBoxShadow`,
       transition: t => `all ${t.transition.speed.fast}`,
       "&:hover": {
         bg: `sidebar.itemHoverBackground`,

--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -209,6 +209,7 @@ const styles = {
     border: 0,
     cursor: `pointer`,
     padding: 0,
+    outlineColor: `input.focusBoxShadow`,
   },
   button: {
     position: `relative`,


### PR DESCRIPTION
## Description
change the outline colour of the buttons in the docs to match the theme colors. 
## Related Issues
Fixes issues: [#20884](https://github.com/gatsbyjs/gatsby/issues/20884)
