### PR TITLE
fix(gatsby): Fix missing fragment definition

### DIFF
--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -435,7 +435,9 @@ const determineUsedFragmentsForDefinition = (
 ) => {
   const { def, name, isFragment, filePath } = definition
   const cachedUsedFragments = fragmentsUsedByFragment.get(name)
-  if (cachedUsedFragments) {
+
+  // `cachedUsedFragments` could be a Set with size 0 which happens to be truthy
+  if (cachedUsedFragments?.size) {
     return { usedFragments: cachedUsedFragments, missingFragments: [] }
   } else {
     const usedFragments = new Set()


### PR DESCRIPTION
It looks like some Fragment definitions were missing due to the code path in https://github.com/gatsbyjs/gatsby/blob/91994197a2f95eb07680e4d6c2699cf78bae95c7/packages/gatsby/src/query/query-compiler.js#L438

This is a hot fix which adds a check for the size of the Set

Fixes https://github.com/gatsbyjs/gatsby/issues/20984