### PR TITLE
fix(gatsby-remark-autolink-headers): remove hardcoded "let" keyword

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -48,6 +48,11 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     }
   `
 
+  // This script used to have `let scrollTop` and `let clientTop` instead of
+  // current ones which are `var`. It is changed due to incompatibility with
+  // older browsers (that do not implement `let`). See:
+  //  - https://github.com/gatsbyjs/gatsby/issues/21058
+  //  - https://github.com/gatsbyjs/gatsby/pull/21083
   const script = `
     document.addEventListener("DOMContentLoaded", function(event) {
       var hash = window.decodeURI(location.hash.replace('#', ''))

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js
@@ -54,8 +54,8 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
       if (hash !== '') {
         var element = document.getElementById(hash)
         if (element) {
-          let scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop
-          let clientTop = document.documentElement.clientTop || document.body.clientTop || 0
+          var scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop
+          var clientTop = document.documentElement.clientTop || document.body.clientTop || 0
           var offset = element.getBoundingClientRect().top + scrollTop - clientTop
           // Wait for the browser to finish rendering before scrolling.
           setTimeout((function() {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In `gatsby-remark-autolink-headers`, this code snippet https://github.com/gatsbyjs/gatsby/blob/5e7ccd13f79e54036869a72e423bf7cf4ab486af/packages/gatsby-remark-autolink-headers/src/gatsby-ssr.js#L51-L67
contains 2 instances of hardcoded "let" keyword, which  is being rendered into the HTML without transpilation. This makes the script crash in old browsers, such as IE (all versions).

This commit replaces "let" to "var". Care should be taken because this is an unsafe transformation, due to var scope hoisting. My initial tests show that everything is good.

I initially encountered this error while porting https://nextstrain.org to IE: https://github.com/nextstrain/nextstrain.org/issues/113

This fix should help scientists researching 2019-nCoV outbreak (some of them still use Internet Explorer)

### Documentation

N/A
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #21058 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
