### PR TITLE
fix doc: delete import { Link } from "gatsby"

### DIFF
--- a/docs/tutorial/ecommerce-tutorial/index.md
+++ b/docs/tutorial/ecommerce-tutorial/index.md
@@ -363,7 +363,6 @@ Once you're happy with your query, create a new page where you can import the ne
 
 ```jsx:title=src/pages/advanced.js
 import React from "react"
-import { Link } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"


### PR DESCRIPTION
## Description

delete following line because, it is never used in `jsx:title=src/pages/advanced.js`
```
import { Link } from "gatsby"
```
### Documentation

https://www.gatsbyjs.org/tutorial/ecommerce-tutorial/

## Related Issues
Fixes: #21090