### PR TITLE
perf(www): get rid of unnecessary items in query

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -187,13 +187,6 @@ exports.createPages = ({ graphql, actions, reporter }) => {
               id
               title
               slug
-              readme {
-                id
-                childMarkdownRemark {
-                  id
-                  html
-                }
-              }
             }
           }
         }


### PR DESCRIPTION
## Description

Get rid of unneeded properties on the graphql query in www/gatsby-node.js. This saves around ~10s running locally. (The queries still like... 14 minutes, but it's better than nothing 🤷‍♀️)