### PR TITLE
fix(gatsby): Fix invalid algorithm of fragment cycles detection

### DIFF
--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -431,7 +431,7 @@ const determineUsedFragmentsForDefinition = (
   definition,
   definitionsByName,
   fragmentsUsedByFragment,
-  visitedFragments = new Set()
+  traversalPath = []
 ) => {
   const { def, name, isFragment, filePath } = definition
   const cachedUsedFragments = fragmentsUsedByFragment.get(name)
@@ -445,10 +445,12 @@ const determineUsedFragmentsForDefinition = (
         const name = node.name.value
         const fragmentDefinition = definitionsByName.get(name)
         if (fragmentDefinition) {
-          if (visitedFragments.has(name)) {
+          if (traversalPath.includes(name)) {
+            // Already visited this fragment during current traversal.
+            //   Visiting it again will cause a stack overflow
             return
           }
-          visitedFragments.add(name)
+          traversalPath.push(name)
           usedFragments.add(name)
           const {
             usedFragments: usedFragmentsForFragment,
@@ -457,8 +459,9 @@ const determineUsedFragmentsForDefinition = (
             fragmentDefinition,
             definitionsByName,
             fragmentsUsedByFragment,
-            visitedFragments
+            traversalPath
           )
+          traversalPath.pop()
           usedFragmentsForFragment.forEach(fragmentName =>
             usedFragments.add(fragmentName)
           )


### PR DESCRIPTION
## Description

This PR fixes a bug in fragment cycle detection, which was causing an "Unknown fragment" error in several edge cases (when the same fragment was referenced twice in one query in specific positions and then was referenced in the other query).

It contains a fix and a test that fails without the fix.

## Related Issues

Fixes #20984
