### PR TITLE
Add link to the Firebase Hosting docs

### DIFF
--- a/docs/docs/preparing-for-deployment.md
+++ b/docs/docs/preparing-for-deployment.md
@@ -53,6 +53,7 @@ If you have a server from one of the following providers, you should read the in
 - [Surge](/docs/deploying-to-surge)
 - [GitHub Pages](/docs/how-gatsby-works-with-github-pages)
 - [Microsoft Internet Information Server (IIS)](/docs/deploying-to-iis)
+- [Firebase Hosting](/docs/deploying-to-firebase)
 - [KintoHub](/docs/deploying-to-kintohub)
 
 If you don't see the hosting you are interested, it's possible to add other hosting providers through [contributions to the docs](/contributing/docs-contributions).


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The missing link to the ["Deploying to Firebase Hosting"](https://www.gatsbyjs.org/docs/deploying-to-firebase/) page has been added to the ["Preparing a Site for Deployment"](https://www.gatsbyjs.org/docs/preparing-for-deployment/) page.

<!--
### Documentation


  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

<!-- ## Related Issues -->

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
