### PR TITLE
fix(gatsby-plugin-netlify-cms): Prevent injected CSS clashes in Preview Pane

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/cms-identity.js
+++ b/packages/gatsby-plugin-netlify-cms/src/cms-identity.js
@@ -18,4 +18,8 @@ netlifyIdentityWidget.on(`init`, user => {
   }
 })
 
-netlifyIdentityWidget.init()
+// Boot on next tick to prevent clashes with css injected into NetlifyCMS
+// preview pane.
+setImmediate(() => {
+  netlifyIdentityWidget.init()
+})


### PR DESCRIPTION
When initializing NetlifyCMS with the identity widget, CSS programmatically injected into the Preview Pane (via `styled-components`) does not appear. By deferring initialization to next tick via `setImmediate` it fixes the problem. 

See [here](https://github.com/damassi/toolshed-soundlab/blob/master/src/cms/injectStyles.jsx) for example how I'm injecting styles into the preview pane. Unfortunately, it is unclear why `enableIdentityWidget: true` creates this conflict.