### PR TITLE
update an example of configuration in README file

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -34,16 +34,18 @@ module.exports = {
     {
       resolve: `gatsby-plugin-typescript`,
       options: {
-        isTSX: true, // defaults to false
-        jsxPragma: `jsx`, // defaults to "React"
-        allExtensions: true, // defaults to false
+        // default values
+        isTSX: false,
+        jsxPragma: `React`,
+        allExtensions: false,
+        allowNamespaces: false,
       },
     },
   ],
 }
 ```
 
-For more detailed documentation on the available options, visit https://babeljs.io/docs/en/babel-preset-typescript#options.
+Check the documentation for details about options, visit https://babeljs.io/docs/en/babel-preset-typescript#options.
 
 ## Caveats
 


### PR DESCRIPTION
The list of options was incomplete and set with the values different from the defaults without explanation of reasons of why the modifica>

Those modified values easily could cause to a pretty cryptic exception that users will see within the browser

```
ReferenceError: React is not defined

...path/.cache/app.js:67

  64 | const preferDefault = m => (m && m.default) || m
  65 | let Root = preferDefault(require(`./root`))
  66 | domReady(() => {
> 67 |   renderer(<Root />, rootElement, () => {
  68 |     apiRunner(`onInitialClientRender`)
  69 |   })
  70 | })
```
The default values has no such problem.

closes #21135 