### PR TITLE
Adjust Windows-specific notice about 0.0.0.0:8000

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -103,7 +103,7 @@ You can now view gatsbyjs.org in the browser.
   On Your Network:  http://192.168.0.212:8000/ // highlight-line
 ```
 
-**Note**: you can't visit 0.0.0.0:8000 on Windows (but things will work using either localhost:8000 or the "On Your Network" URL on Windows)
+**Note**: To access Gatsby on your local machine, use either localhost:8000 or the "On Your Network" URL.
 
 ### `build`
 


### PR DESCRIPTION
Technically, `0.0.0.0` is a non-routable IP, so it's not even supposed to work. The fact that hitting `http://0.0.0.0:8000/` works on some OSes is an oddity with the networking stack. Always using either `localhost` or the network IP is the best thing to do on every OS, not just on Windows.