### PR TITLE
fix(gatsby): Pin reach since they do not pass in location.href anymore

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -19,7 +19,7 @@
     "@hapi/joi": "^15.1.1",
     "@mikaelkristiansson/domready": "^1.0.10",
     "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
-    "@reach/router": "^1.2.1",
+    "@reach/router": "1.2.1",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",
     "address": "1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,7 +3673,7 @@
     string-width "^2.0.0"
     strip-ansi "^3"
 
-"@reach/router@^1.2.1":
+"@reach/router@1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
   integrity sha512-kTaX08X4g27tzIFQGRukaHmNbtMYDS3LEWIS8+l6OayGIw6Oyo1HIF/JzeuR2FoF9z6oV+x/wJSVSq4v8tcUGQ==


### PR DESCRIPTION
https://github.com/reach/router/commit/0a8af930398570d07d380ef1b6f80833501c8a29 which was released 6 days ago as part of `@reach/router` 1.3.0 broke `gatsby` because we depend on `location.href` to fetch resources on url change in https://github.com/gatsbyjs/gatsby/blob/20df97b33e76c0d2b6cb763400b2d9571b148b7f/packages/gatsby/cache-dir/ensure-resources.js#L16

Fixes https://github.com/gatsbyjs/gatsby/issues/20918
Fixes https://github.com/gatsbyjs/gatsby/issues/21139