### PR TITLE
fix(gatsby-graphiql-explorer): Allow graphiql to set initial query variables from query string

### DIFF
--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -90,6 +90,11 @@ const DEFAULT_QUERY =
   (window.localStorage && window.localStorage.getItem(`graphiql:query`)) ||
   null
 
+const DEFAULT_VARIABLES =
+  parameters.variables ||
+  (window.localStorage && window.localStorage.getItem(`graphiql:variables`)) ||
+  null
+
 const QUERY_EXAMPLE_SITEMETADATA_TITLE = `#     {
 #       site {
 #         siteMetadata {
@@ -159,6 +164,7 @@ class App extends React.Component {
   state = {
     schema: null,
     query: DEFAULT_QUERY,
+    variables: DEFAULT_VARIABLES,
     explorerIsOpen: storedExplorerPaneState,
     codeExporterIsOpen: storedCodeExporterPaneState,
   }
@@ -297,7 +303,7 @@ class App extends React.Component {
   }
 
   render() {
-    const { query, schema, codeExporterIsOpen } = this.state
+    const { query, variables, schema, codeExporterIsOpen } = this.state
     const codeExporter = codeExporterIsOpen ? (
       <CodeExporter
         hideCodeExporter={this._handleToggleExporter}
@@ -324,6 +330,7 @@ class App extends React.Component {
           fetcher={graphQLFetcher}
           schema={schema}
           query={query}
+          variables={variables}
           onEditQuery={this._handleEditQuery}
           onEditVariables={onEditVariables}
           onEditOperationName={onEditOperationName}


### PR DESCRIPTION
## Description
This PR allows graphiql to set initial query variables from the following, in order: 

- `variables` query parameter in the URL
- `graphiql:variables` from localstorage

If both are not found, the initial query variables is set to `null`. 

## Related Issues
Fixes #20192. 