### PR TITLE
fix(gatsby-source-contentful): fix missing data with rich text fields - Improvements to WIP on #15084

### DIFF
--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -75,7 +75,7 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`)
 
   let currentSyncData
   try {
-    let query = syncToken ? { nextSyncToken: syncToken } : { initial: true }
+    let query = syncToken ? { nextSyncToken: syncToken } : { initial: true, resolveLinks: false }
     currentSyncData = await client.sync(query)
   } catch (e) {
     reporter.panic(`Fetching contentful data failed`, e)


### PR DESCRIPTION
## Description

This PR includes and improves WIP from #15084 , and in addition to changes from there:

- Fetch full (initial) data from contentful only once, if there isn't a cached sync_token. Otherwise only delta updates are fetched and merged with the existing config
- Fetched data doesn't have link resolved. This makes the fetched entries cacheable. In fact if link are resolved and content has circular references the fetched data won't be cacheable, due the fetched data not stringify-able.

This PR also branches from gatsby-source-contentful:2.1.72 because I couldn't get this working on 2.1.73, I believe not due the changes in here but for something in 2.1.73.

### Documentation

For any documentation refer to #15084 .

## Related Issues

For any related issue refer to #15084
