### PR TITLE
docs(plugin-netlify-cms): update support link to slack

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/README.md
+++ b/packages/gatsby-plugin-netlify-cms/README.md
@@ -256,7 +256,7 @@ exports.onCreateWebpackConfig = ({ actions }) => {
 ## Support
 
 For help with integrating Netlify CMS with Gatsby, check out the community
-[Gitter](https://gitter.im/netlify/netlifycms).
+[Slack](https://join.slack.com/t/netlifycms/shared_invite/enQtODE1NTcxODA5Mjg1LTRjYWExM2MyZDJmODA3YmVkMjI2YmQwZDg2ZDUyYTMyM2Y3Zjc1ZTJhNDBkYmMwNjA2ZTkwODY4YjZjNGNlNTE).
 
 [1]: https://github.com/gatsbyjs/gatsby/blob/gatsby-plugin-netlify-cms@2.0.1/packages/gatsby-plugin-netlify-cms/README.md
 [2]: https://github.com/gatsbyjs/gatsby/blob/gatsby-plugin-netlify-cms@3.0.18/packages/gatsby-plugin-netlify-cms/README.md


### PR DESCRIPTION
We recently moved from Gitter to Slack.