### PR TITLE
fix(blog): fix link to relative link to image

### DIFF
--- a/docs/blog/100days/index.md
+++ b/docs/blog/100days/index.md
@@ -9,7 +9,7 @@ import EmailCaptureForm100Days from "../../../www/src/components/email-capture-f
 
 ### If you're looking for a fun way to explore how to build blazing fast websites with Gatsby, our #100DaysOfGatsby challenge is for you!
 
-![alt text](/100daysofgatsby.png "100 Days of Gatsby")
+![alt text](./100daysofgatsby.png "100 Days of Gatsby")
 
 We’re kicking off this “100 Days” challenge on January 1st, so why not start the year with a Gatsby project?
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

changes:
- fix link to relative link to image

Notes:
- surprising it not show an error on blog page - but other image links in md* are relative with a dot 
- -> or asked the reverse way: why i there no "image not found" with this wrong absolute path? 
( i created #21174 `absolute image path not throw an error`)

## Related Issues

#20228 `[blog] add 100 days of Gatsby and new email capture form`