### PR TITLE
feat(manifest): add locale metadata when available

### DIFF
--- a/packages/gatsby-plugin-manifest/src/get-manifest-pathname.js
+++ b/packages/gatsby-plugin-manifest/src/get-manifest-pathname.js
@@ -1,3 +1,5 @@
+import getPageLocalization from "./get-page-localization"
+
 /**
  * Get a manifest filename depending on localized pathname
  *
@@ -6,18 +8,6 @@
  * @return string
  */
 export default (pathname, localizedManifests) => {
-  const defaultFilename = `manifest.webmanifest`
-  if (!Array.isArray(localizedManifests)) {
-    return defaultFilename
-  }
-
-  const localizedManifest = localizedManifests.find(app =>
-    pathname.startsWith(app.start_url)
-  )
-
-  if (!localizedManifest) {
-    return defaultFilename
-  }
-
-  return `manifest_${localizedManifest.lang}.webmanifest`
+  const { lang } = getPageLocalization(pathname, localizedManifests)
+  return lang ? `manifest_${lang}.webmanifest` : `manifest.webmanifest`
 }

--- a/packages/gatsby-plugin-manifest/src/get-page-localization.js
+++ b/packages/gatsby-plugin-manifest/src/get-page-localization.js
@@ -1,0 +1,18 @@
+/**
+ * Get page `lang` and `start_url` depending on localized pathname
+ *
+ * @param {string} pathname
+ * @param {Array<{start_url: string, lang: string}>} localizedManifests
+ * @param {{start_url: string, lang: string}} defaultLocalization
+ * @return {{start_url?: string, lang?: string}}
+ */
+export default (pathname, localizedManifests, defaultLocalization = {}) => {
+  if (!Array.isArray(localizedManifests)) {
+    return defaultLocalization
+  }
+
+  const localizedManifest = localizedManifests.find(app =>
+    pathname.startsWith(app.start_url)
+  )
+  return localizedManifest || defaultLocalization
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Language metadata is crucial for search engine optimization. This PR sets the `<html lang>` attribute based on the localized `pathname` of each page. Also, it generates [tags for alternative versions](https://html.spec.whatwg.org/multipage/links.html#rel-alternate) of a page available in different languages, e.g.:

```jsx
<link
  rel="alternate"
  hrefLang={localizedManifest.lang}
  href={pathname.replace(start_url, localizedManifest.start_url)}
/>
```
