### PR TITLE
Replace siteMetadata 'subtitle' with 'description'

### DIFF
--- a/examples/using-wordpress/src/templates/page.js
+++ b/examples/using-wordpress/src/templates/page.js
@@ -26,7 +26,7 @@ export const pageQuery = graphql`
       id
       siteMetadata {
         title
-        subtitle
+        description
       }
     }
   }

--- a/examples/using-wordpress/src/templates/post.js
+++ b/examples/using-wordpress/src/templates/post.js
@@ -31,7 +31,7 @@ export const postQuery = graphql`
     site {
       siteMetadata {
         title
-        subtitle
+        description
       }
     }
   }


### PR DESCRIPTION
## Description

Replace non-existing siteMetadata.subtitle with siteMetadata.description in the 'using-wordpress' example. This resolves the otherwise failing example.

### Documentation

Not applicable

## Related Issues

None to my knowledge
