### PR TITLE
feat(gatsby-plugin-benchmark-reporting): Use the telemetry session id

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -51,7 +51,7 @@ class BenchMeta {
 
     return {
       time: this.localTime,
-      sessionId: process.gatsbyTelemetrySessionId,
+      sessionId: process.gatsbyTelemetrySessionId || uuidv4(),
       pageCount,
       timestamps: this.timestamps,
     }

--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -51,7 +51,7 @@ class BenchMeta {
 
     return {
       time: this.localTime,
-      sessionId: uuidv4(),
+      sessionId: process.gatsbyTelemetrySessionId,
       pageCount,
       timestamps: this.timestamps,
     }


### PR DESCRIPTION
Use the telemetry session id so that we can correlate the data