### PR TITLE
doc: fix netlify command option

### DIFF
--- a/docs/docs/recipes/deploying-your-site.md
+++ b/docs/docs/recipes/deploying-your-site.md
@@ -74,7 +74,7 @@ Use [`netlify-cli`](https://www.netlify.com/docs/cli/) to deploy your Gatsby app
 
 6. Change the deploy path to `public/`
 
-7. Make sure that everything looks fine before deploying to production using `netlify deploy --prod`
+7. Make sure that everything looks fine before deploying to production using `netlify deploy -d . --prod`
 
 ### Additional resources
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
<!-- Write a brief description of the changes introduced by this PR -->

When I try to deploy to netlify following [directions in documentation](https://www.gatsbyjs.org/docs/recipes/deploying-your-site#directions-1), I encountered timeout error.

```
Deploying to live site URL...
✔ Finished hashing 0 files
🕛✔ CDN requesting 0 files
✔ Finished uploading 0 assets
dp Waiting for deploy to go live... ›   Warning: 
 ›   {
 ›      "name": "TimeoutError"
 ›   }
 ›
 b Waiting for deploy to go live...TimeoutError: Promise timed out after 1200000 milliseconds
    at Timeout._onTimeout (~/.nodenv/versions/12.14.1/lib/node_modules/netlify-cli/node_modules/p-timeout/index.js:27:54)
```

I could solve this problem by adding `-d .` option to the command.
Reference: https://community.netlify.com/t/deploy-with-gatsby-is-hanging/6775

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

- https://www.gatsbyjs.org/docs/recipes/deploying-your-site#directions-1