### PR TITLE
fix(gatsby-plugin-mdx): Pass node API helpers through mdx-loader to remark plugins

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/create-webpack-config.js
+++ b/packages/gatsby-plugin-mdx/gatsby/create-webpack-config.js
@@ -75,6 +75,7 @@ module.exports = (
               loader: path.join(`gatsby-plugin-mdx`, `loaders`, `mdx-loader`),
               options: {
                 cache: cache,
+                actions: actions,
                 ...other,
                 pluginOptions: options,
               },

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -97,6 +97,7 @@ module.exports = async function(content) {
     cache,
     pathPrefix,
     pluginOptions,
+    ...helpers,
   } = getOptions(this)
 
   const options = withDefaultOptions(pluginOptions)
@@ -161,6 +162,7 @@ ${contentWithoutFrontmatter}`
   }
 
   const { rawMDXOutput } = await genMdx({
+    ...helpers,
     isLoader: true,
     options,
     node: { ...mdxNode, rawBody: code },

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -97,7 +97,7 @@ module.exports = async function(content) {
     cache,
     pathPrefix,
     pluginOptions,
-    ...helpers,
+    ...helpers
   } = getOptions(this)
 
   const options = withDefaultOptions(pluginOptions)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This is a follow-up to #20879, doing exactly the same thing, but from the loader entrypoint rather than the sourceNodes and onCreateNode entrypoints.
