### PR TITLE
fix(gatsby): revert auto-adding id field to queries

### DIFF
--- a/packages/gatsby/src/query/__tests__/__snapshots__/query-compiler.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/query-compiler.js.snap
@@ -26,7 +26,6 @@ Object {
   "text": "query mockFileQuery {
   allDirectory {
     nodes {
-      id
       contents {
         __typename
         ... on File {
@@ -92,15 +91,12 @@ Object {
   "text": "query mockFileQuery {
   allDirectory {
     nodes {
-      id
       contents {
         __typename
         ... on Directory {
-          id
           contents {
             __typename
             ... on Directory {
-              id
               contents {
                 __typename
                 ... on Directory {
@@ -117,16 +113,13 @@ Object {
       }
       children {
         __typename
-        id
         children {
           __typename
-          id
           children {
             __typename
             id
           }
           ... on Directory {
-            id
             contents {
               __typename
               ... on File {
@@ -170,7 +163,6 @@ Object {
     ",
   "path": "mockFile",
   "text": "fragment DirectoryContents on Directory {
-  id
   contents {
     __typename
     ... on File {
@@ -186,7 +178,6 @@ Object {
 query mockFileQuery {
   allDirectory {
     nodes {
-      id
       ...DirectoryContents
     }
   }
@@ -223,9 +214,7 @@ Object {
   "text": "query mockFileQuery {
   allDirectory {
     nodes {
-      id
       ... on Directory {
-        id
         contents {
           __typename
           ... on File {
@@ -263,7 +252,6 @@ Object {
   "text": "query mockFileQuery {
   allDirectory {
     nodes {
-      id
       __typename
     }
   }
@@ -320,23 +308,18 @@ Object {
   "text": "query mockFileQuery {
   allDirectory {
     nodes {
-      id
       contents {
         __typename
         ... on Directory {
-          id
           contents {
             __typename
             ... on Directory {
-              id
               contents {
                 __typename
                 ... on File {
-                  id
                   __typename
                 }
                 ... on Directory {
-                  id
                   __typename
                 }
               }
@@ -346,20 +329,15 @@ Object {
       }
       children {
         __typename
-        id
         children {
           __typename
-          id
           children {
-            id
             __typename
           }
           ... on Directory {
-            id
             contents {
               __typename
               ... on File {
-                id
                 __typename
               }
             }
@@ -394,14 +372,12 @@ Object {
     ",
   "path": "mockFile",
   "text": "fragment Directory on Directory {
-  id
   __typename
 }
 
 query mockFileQuery {
   allDirectory {
     nodes {
-      id
       ...Directory
     }
   }
@@ -431,9 +407,7 @@ Object {
   "text": "query mockFileQuery {
   allDirectory {
     nodes {
-      id
       ... on Directory {
-        id
         __typename
       }
     }
@@ -500,17 +474,14 @@ Object {
 }
 
 fragment Node on Node {
-  id
   __typename
 }
 
 fragment DirectoryContents on Directory {
-  id
   contents {
     __typename
   }
   children {
-    id
     __typename
   }
 }
@@ -518,7 +489,6 @@ fragment DirectoryContents on Directory {
 query mockFileQuery {
   allDirectory {
     nodes {
-      id
       contents {
         __typename
         ... on File {
@@ -527,17 +497,14 @@ query mockFileQuery {
         ...FileOrDirectory
       }
       children {
-        id
         __typename
         ...Node
       }
       ... on Directory {
-        id
         contents {
           __typename
         }
         children {
-          id
           __typename
         }
       }
@@ -595,7 +562,6 @@ Object {
 }
 
 fragment DirectoryContents on Directory {
-  id
   children {
     __typename: id
   }
@@ -616,7 +582,6 @@ query mockFileQuery {
         ...Node
       }
       ... on Directory {
-        id
         children {
           __typename: id
         }
@@ -688,7 +653,6 @@ Object {
 }
 
 fragment DirectoryContents on Directory {
-  id
   contents {
     __typename
     ... on File {
@@ -776,7 +740,6 @@ Object {
     ",
   "path": "mockFile",
   "text": "fragment DirectoryContents on Directory {
-  id
   contents {
     __typename
     ... on File {
@@ -791,7 +754,6 @@ Object {
 query mockFileQuery {
   allDirectory {
     nodes {
-      id
       contents {
         __typename
         ... on File {
@@ -838,7 +800,6 @@ Map {
 query mockFileQuery {
   allPostsJson {
     nodes {
-      id
       ...PostsJsonFragment
     }
   }
@@ -869,7 +830,6 @@ Object {
 query mockFileQuery {
   allPostsJson {
     nodes {
-      id
       ...PostsJsonFragment
     }
   }
@@ -903,7 +863,6 @@ Object {
 query mockFileQuery {
   allPostsJson {
     nodes {
-      id
       ...PostsJsonFragment
     }
   }
@@ -1050,14 +1009,12 @@ Object {
 }
 
 fragment AnotherPostsJsonFragment on PostsJson {
-  id
   text
 }
 
 query mockFileQuery {
   allPostsJson {
     nodes {
-      id
       ...PostsJsonFragment
     }
   }
@@ -1095,7 +1052,6 @@ Object {
 query mockFileQuery {
   allPostsJson {
     nodes {
-      id
       ...PostsJsonFragment
     }
   }

--- a/packages/gatsby/src/query/__tests__/query-compiler.js
+++ b/packages/gatsby/src/query/__tests__/query-compiler.js
@@ -342,10 +342,8 @@ describe(`actual compiling`, () => {
       }
 
       fragment Bar on Directory {
-        id
         parent {
           __typename
-          id
           ...Foo
         }
       }
@@ -353,7 +351,6 @@ describe(`actual compiling`, () => {
       query mockFileQuery1 {
         allDirectory {
           nodes {
-            id
             ...Foo
             ...Bar
           }
@@ -377,10 +374,8 @@ describe(`actual compiling`, () => {
               }",
         "path": "mockFile2",
         "text": "fragment Bar on Directory {
-        id
         parent {
           __typename
-          id
           ...Foo
         }
       }
@@ -392,7 +387,6 @@ describe(`actual compiling`, () => {
       query mockFileQuery2 {
         allDirectory {
           nodes {
-            id
             ...Bar
           }
         }

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -18,8 +18,6 @@ const {
   visitWithTypeInfo,
   TypeInfo,
   isAbstractType,
-  isObjectType,
-  isInterfaceType,
   Kind,
   FragmentsOnCompositeTypesRule,
   KnownTypeNamesRule,
@@ -497,7 +495,7 @@ const addExtraFields = (document, schema) => {
       [Kind.SELECTION_SET]: node => {
         // Entering selection set:
         //   selection sets can be nested, so keeping their metadata stacked
-        contextStack.push({ hasTypename: false, hasId: false })
+        contextStack.push({ hasTypename: false })
       },
       [Kind.FIELD]: node => {
         // Entering a field of the current selection-set:
@@ -508,9 +506,6 @@ const addExtraFields = (document, schema) => {
           node?.alias?.value === `__typename`
         ) {
           context.hasTypename = true
-        }
-        if (node.name.value === `id` || node?.alias?.value === `id`) {
-          context.hasId = true
         }
       },
     },
@@ -528,16 +523,6 @@ const addExtraFields = (document, schema) => {
             name: { kind: Kind.NAME, value: `__typename` },
           })
         }
-        if (
-          !context.hasId &&
-          (isObjectType(parentType) || isInterfaceType(parentType)) &&
-          hasIdField(parentType)
-        ) {
-          extraFields.push({
-            kind: Kind.FIELD,
-            name: { kind: Kind.NAME, value: `id` },
-          })
-        }
         return extraFields.length > 0
           ? { ...node, selections: [...extraFields, ...node.selections] }
           : undefined
@@ -546,10 +531,4 @@ const addExtraFields = (document, schema) => {
   })
 
   return visit(document, transformer)
-}
-
-const hasIdField = type => {
-  const idField = type.getFields()[`id`]
-  const fieldType = idField ? String(idField.type) : ``
-  return fieldType === `ID` || fieldType === `ID!`
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Don't audo add `id` field at all.

Reproduce steps: https://github.com/gatsbyjs/gatsby/issues/20943#issuecomment-581733538

https://github.com/antvis/gatsby-theme-antv/pull/105/checks?check_run_id=424609520#step:4:166

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes  #20943

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
