### PR TITLE
chore(showcase): Add Roboto Studio site  to showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -9611,3 +9611,17 @@
   built_by: Chris Otto
   built_by_url: https://github.com/chrisotto6
   featured: false
+- title: Roboto Studio
+  url: https://roboto.studio
+  main_url: https://roboto.studio
+  description: >
+    Faster than a speeding bullet Website Development based in sunny old Nottingham
+  categories:
+    - Agency
+    - Blog
+    - Business
+    - Design
+    - Featured
+    - Freelance
+    - Web Development
+  featured: true


### PR DESCRIPTION
Hi we're a Nottingham based dev studio, and we'd absolutely love it if you'd be able to showcase our site on the official Gatsby website. We're huge believers in Gatsby, to the degree that we have pivoted our entire dev process to focus on producing ultra-fast, SEO rich website using Gatsby.js and we're proactive in a lot of Headless CMS/JAMstack projects out there.

If there's any changes you'd love to see, drop a message across, we're always looking to improve the site.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
