### PR TITLE
Added previous location check

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -1,7 +1,8 @@
-exports.onRouteUpdate = (_, pluginOptions) => {
+exports.onRouteUpdate = ({ location, prevLocation }, pluginOptions) => {
   if (
     process.env.NODE_ENV === `production` ||
-    pluginOptions.includeInDevelopment
+    pluginOptions.includeInDevelopment &&
+    (prevLocation && prevLocation.pathname !== location.pathname)
   ) {
     // wrap inside a timeout to ensure the title has properly been changed
     setTimeout(() => {


### PR DESCRIPTION
Not sure why but on page load gtm tagged with ga detects double page view firing on page load, one from Page View and other by gatsby route-change event. adding this check prevents the latter on page load

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
My fix check compares with the previous location and if it exists & is different, only then the `gatsby-route-change` event gets fired
