### PR TITLE
chore(starter): Add a WordPress GraphQL Gatsby Starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5199,3 +5199,14 @@
     - Disqus
     - Resume
     - Place plan on the top
+- url: https://wp-graphql-gatsby-starter.netlify.com/
+  repo: https://github.com/n8finch/wp-graphql-gatsby-starter
+  description: A super simple, bare-bone starter that uses the WP GraphQL plugin to pull posts, pages, categories, tags, and a menu from your WordPress site.
+  tags:
+    - Blog
+    - CMS:WordPress
+  features:
+    - WP GraphQL plugin integration
+    - Light/Dark Mode
+    - React Helmet for SEO
+    - Integrated navigation

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5212,5 +5212,5 @@
     - Light/Dark Mode
     - React Helmet for SEO
     - Integrated navigation
-    - Verbose (i.e., not D.R.Y.) GraphQL queries to get data from 
+    - Verbose (i.e., not D.R.Y.) GraphQL queries to get data from
     - Includes plugins for offline support out of the box

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5201,12 +5201,16 @@
     - Place plan on the top
 - url: https://wp-graphql-gatsby-starter.netlify.com/
   repo: https://github.com/n8finch/wp-graphql-gatsby-starter
-  description: A super simple, bare-bone starter that uses the WP GraphQL plugin to pull posts, pages, categories, tags, and a menu from your WordPress site.
+  description: A super simple, bare-bone starter based on the Gatsby Starter for the front end and the WP GraphQL plugin on your WordPress install. This is a basic "headless CMS" setup. This starter will pull posts, pages, categories, tags, and a menu from your WordPress site. You should use either the TwentyNineteen or TwentyTwenty WordPress themes on your WordPress install. See the starter repo for more detailed instructions on getting set up. The example here uses the WordPress Theme Unit Test Data for post and page dummy content. Find something wrong? Issues are welcome on the starter reository.
   tags:
     - Blog
+    - CMS:Headless
     - CMS:WordPress
+    - Netlify
   features:
     - WP GraphQL plugin integration
     - Light/Dark Mode
     - React Helmet for SEO
     - Integrated navigation
+    - Verbose (i.e., not D.R.Y.) GraphQL queries to get data from 
+    - Includes plugins for offline support out of the box


### PR DESCRIPTION
## Description

This PR adds a WP GraphQL starter to the Starters area.

The idea behind the starter is to have "A super simple, bare-bone starter based on the Gatsby Starter for the front end and the WP GraphQL plugin on your WordPress install."

This is a basic "headless CMS" setup. This starter will pull posts, pages, categories, tags, and a menu from your WordPress site. You should use either the TwentyNineteen or TwentyTwenty WordPress themes on your WordPress install.

The example here uses the WordPress Theme Unit Test Data for post and page dummy content.

This Stater should get you started at 100 across the board in Chrome Lighthouse test.

Here's the [DEMO](https://wp-graphql-gatsby-starter.netlify.com/).

See the repo for more instructions on how to get set up [here](https://wp-graphql-gatsby-starter.netlify.com/).
