### PR TITLE
perf(www): Add additional filter when searching sites in creator-details template

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -148,6 +148,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
         allCreatorsYaml {
           edges {
             node {
+              name
               fields {
                 slug
               }
@@ -331,6 +332,7 @@ exports.createPages = ({ graphql, actions, reporter }) => {
           component: slash(creatorPageTemplate),
           context: {
             slug: edge.node.fields.slug,
+            name: edge.node.name,
           },
         })
       })

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -65,12 +65,7 @@ class CreatorTemplate extends Component {
     const isAgencyOrCompany =
       creator.type === `agency` || creator.type === `company`
 
-    let sites = []
-    data.allSitesYaml.edges.map(site => {
-      if (site.node.built_by === creator.name) {
-        sites.push(site)
-      }
-    })
+    const sites = data.allSitesYaml.edges
 
     return (
       <Layout location={location}>
@@ -246,7 +241,7 @@ class CreatorTemplate extends Component {
 export default CreatorTemplate
 
 export const pageQuery = graphql`
-  query($slug: String!) {
+  query($slug: String!, $name: String!) {
     creatorsYaml(fields: { slug: { eq: $slug } }) {
       name
       description
@@ -268,10 +263,14 @@ export const pageQuery = graphql`
         slug
       }
     }
-    allSitesYaml(filter: { fields: { hasScreenshot: { eq: true } } }) {
+    allSitesYaml(
+      filter: {
+        built_by: { eq: $name }
+        fields: { hasScreenshot: { eq: true } }
+      }
+    ) {
       edges {
         node {
-          built_by
           url
           title
           childScreenshot {


### PR DESCRIPTION
## Description

Add an additional filter in the search query for sites. Before, we were querying the entire set of site screenshots each time, which gets expensive. This saves ~1s per creator page (playing around with the graphql editor, at least) for a total save of ~45s. 