### PR TITLE
serve with --prefix-paths

### DIFF
--- a/docs/docs/path-prefix.md
+++ b/docs/docs/path-prefix.md
@@ -33,6 +33,16 @@ gatsby build --prefix-paths
 
 If this flag is not passed, Gatsby will ignore your `pathPrefix` and build the site as if hosted from the root domain.
 
+## Serve
+
+Serve your application with the `--prefix-paths` flag, like so:
+
+```shell
+gatsby serve --prefix-paths
+```
+
+If this flag is not passed, Gatsby will ignore your `pathPrefix`.
+
 ## In-app linking
 
 Gatsby provides APIs and libraries to make using this feature seamless. Specifically, the [`Link`](/docs/gatsby-link/) component has built-in functionality to handle path prefixing.


### PR DESCRIPTION
gatsby build --prefix-paths don't guarantee all the components will be serve using the prefix, only the links.
what about gh-pages?

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

There's no documentation telling about serve --prefix-paths (on prefix path documentation)

### Documentation



## Related Issues
https://github.com/gatsbyjs/gatsby/issues/14898
https://github.com/gatsbyjs/gatsby/issues/21313
