### PR TITLE
Removed deprecated fluidImages and fixedImages props from docs

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -430,8 +430,6 @@ While you could achieve a similar effect with plain CSS media queries, `gatsby-i
 | `objectPosition`       | `string`            | Passed to the `object-fit-images` polyfill when importing from `gatsby-image/withIEPolyfill`. Defaults to `50% 50%`.                          |
 | `loading`              | `string`            | Set the browser's native lazy loading attribute. One of `lazy`, `eager` or `auto`. Defaults to `lazy`.                                        |
 | `critical`             | `bool`              | Opt-out of lazy-loading behavior. Defaults to `false`. Deprecated, use `loading` instead.                                                     |
-| `fixedImages`          | `array`             | An array of objects returned from `fixed` queries. When combined with `media` keys, allows for art directing `fixed` images.                  |
-| `fluidImages`          | `array`             | An array of objects returned from `fluid` queries. When combined with `media` keys, allows for art directing `fluid` images.                  |
 | `draggable`            | `bool`              | Set the img tag draggable to either `false`, `true`                                                                                           |
 | `itemProp`             | `string`            | Add an [`itemprop` schema.org structured data attribute](https://schema.org/docs/gs.html#microdata_itemprop) on the image.                    |
 


### PR DESCRIPTION
## Description
Removed `fluidImages` and `fixedImages` from [gatsby image docs](https://www.gatsbyjs.org/packages/gatsby-image/#art-directing-multiple-images)
These props are no longer used as the functionality for art directing images is handled by passing arrays to `fluid` or `fixed` props

### Documentation

[gatsby image docs](https://www.gatsbyjs.org/packages/gatsby-image/#art-directing-multiple-images)
