### PR TITLE
fix(docs): Set table of contents depth for recipes

### DIFF
--- a/docs/docs/recipes/deploying-your-site.md
+++ b/docs/docs/recipes/deploying-your-site.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Deploying Your Site"
+tableOfContentsDepth: 1
 ---
 
 Showtime. Once you are happy with your site, you are ready to go live with it!

--- a/docs/docs/recipes/pages-layouts.md
+++ b/docs/docs/recipes/pages-layouts.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Pages and Layouts"
+tableOfContentsDepth: 1
 ---
 
 Add pages to your Gatsby site, and use layouts to manage common page elements.

--- a/docs/docs/recipes/querying-data.md
+++ b/docs/docs/recipes/querying-data.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Querying Data"
+tableOfContentsDepth: 1
 ---
 
 Gatsby lets you access your data across all sources using a single GraphQL interface.

--- a/docs/docs/recipes/sourcing-data.md
+++ b/docs/docs/recipes/sourcing-data.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Sourcing Data"
+tableOfContentsDepth: 1
 ---
 
 Data sourcing in Gatsby is plugin-driven; Source plugins fetch data from their source (e.g. the `gatsby-source-filesystem` plugin fetches data from the file system, the `gatsby-source-wordpress` plugin fetches data from the WordPress API, etc). You can also source the data yourself.

--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Styling with CSS"
+tableOfContentsDepth: 1
 ---
 
 There are so many ways to add styles to your website; Gatsby supports almost every possible option, through official and community plugins.

--- a/docs/docs/recipes/transforming-data.md
+++ b/docs/docs/recipes/transforming-data.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Transforming Data"
+tableOfContentsDepth: 1
 ---
 
 Transforming data in Gatsby is plugin-driven. Transformer plugins take data fetched using source plugins, and process it into something more usable (e.g. JSON into JavaScript objects, and more).

--- a/docs/docs/recipes/working-with-images.md
+++ b/docs/docs/recipes/working-with-images.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Working with Images"
+tableOfContentsDepth: 1
 ---
 
 Access images as static resources, or automate the process of optimizing them through powerful plugins.

--- a/docs/docs/recipes/working-with-starters.md
+++ b/docs/docs/recipes/working-with-starters.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Working with Starters"
+tableOfContentsDepth: 1
 ---
 
 [Starters](/docs/starters/) are boilerplate Gatsby sites maintained officially, or by the community.

--- a/docs/docs/recipes/working-with-themes.md
+++ b/docs/docs/recipes/working-with-themes.md
@@ -1,5 +1,6 @@
 ---
 title: "Recipes: Working with Themes"
+tableOfContentsDepth: 1
 ---
 
 A [Gatsby theme](/docs/themes/what-are-gatsby-themes) abstracts Gatsby configuration (shared functionality, data sourcing, design) into an installable package. This means that the configuration and functionality isn’t directly written into your project, but rather versioned, centrally managed, and installed as a dependency. You can seamlessly update a theme, compose themes together, and even swap out one compatible theme for another.


### PR DESCRIPTION
## Description

Set the table of contents depth for the recipes pages so that only the names of the recipes are listed. The subheadings take a lot of space in the TOC and are the same for each one ("Prerequisites", "Directions", "Additional Resources").

Before, the names of most recipes are under the fold:

<img width="1280" alt="Screenshot of Recipe page showing table of contents with subheadings" src="https://user-images.githubusercontent.com/1278991/74113047-7fb41380-4b56-11ea-94d3-d27fe4ff44b3.png">


Removing these subheadings puts all the recipes above the fold and makes it easier to find things:

// TODO result screenshot
<img width="1280" alt="Screen Shot 2020-02-09 at 4 10 33 PM" src="https://user-images.githubusercontent.com/1278991/74113078-bbe77400-4b56-11ea-9556-8a79d710dfac.png">
