### PR TITLE
fix(www): Add slashes to links in features overview

### DIFF
--- a/www/src/pages/features.js
+++ b/www/src/pages/features.js
@@ -48,7 +48,7 @@ const FeaturesHeader = () => (
         you’ve added. These files can be cached and served from a CDN.
         <br />
         <p sx={{ mt: 2 }}>Coming from the JAMstack world?</p>
-        <Button to="/features/jamstack" secondary>
+        <Button to="/features/jamstack/" secondary>
           Compare Gatsby vs JAMstack
         </Button>
       </li>
@@ -77,7 +77,7 @@ const FeaturesHeader = () => (
         provider.
         <br />
         <p sx={{ mt: 2 }}>Coming from the CMS world?</p>
-        <Button to="/features/cms" secondary>
+        <Button to="/features/cms/" secondary>
           Compare Gatsby vs CMS
         </Button>
       </li>


### PR DESCRIPTION
## Description

Add slashes to the links in the features overview so that the pages are marked as 'active' in the sidebar.

Not having the slashes means the page doesn't show as "active" in the sidebar:

https://www.gatsbyjs.org/features/jamstack

But adding the slashes fixes it:

https://www.gatsbyjs.org/features/jamstack/