### PR TITLE
fix(docs): Move "Setting Up Your Local Dev Environment" under "Code Contributions"

### DIFF
--- a/www/src/data/sidebars/contributing-links.yaml
+++ b/www/src/data/sidebars/contributing-links.yaml
@@ -56,8 +56,9 @@
           link: /contributing/blog-and-website-contributions/
         - title: Code Contributions
           link: /contributing/code-contributions/
-        - title: Setting Up Your Local Dev Environment
-          link: /contributing/setting-up-your-local-dev-environment/
+          items:
+            - title: Setting Up Your Local Dev Environment
+              link: /contributing/setting-up-your-local-dev-environment/
         - title: Docs and Website Components
           link: /contributing/docs-and-website-components/
         - title: Community Contributions


### PR DESCRIPTION
## Description

Move the page ["Setting Up Your Local Dev Environment](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/)", which deals specifically with setting up the local dev environment for code contributions, under the ["Code Contributions"](https://www.gatsbyjs.org/contributing/code-contributions/) page. "Docs Contributions" and "Community Contributions" already have subpages, so it's not adding a new level of hierarchy that doesn't exist yet.