### PR TITLE
fix(gatsby-remark-images): Figcaption not aligned vertically with image

### DIFF
--- a/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
@@ -359,7 +359,7 @@ exports[`it uses tracedSVG placeholder when enabled 1`] = `
 `;
 
 exports[`markdownCaptions display title in markdown as caption when showCaptions === true && markdownCaptions === true 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -392,7 +392,7 @@ exports[`markdownCaptions display title in markdown as caption when showCaptions
 `;
 
 exports[`markdownCaptions display title in text as caption when showCaptions === true && markdownCaptions === false 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -425,7 +425,7 @@ exports[`markdownCaptions display title in text as caption when showCaptions ===
 `;
 
 exports[`showCaptions display alt as caption if specified first in showCaptions array 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -458,7 +458,7 @@ exports[`showCaptions display alt as caption if specified first in showCaptions 
 `;
 
 exports[`showCaptions display alt as caption if specified in showCaptions array 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -491,7 +491,7 @@ exports[`showCaptions display alt as caption if specified in showCaptions array 
 `;
 
 exports[`showCaptions display alt as caption if specified in showCaptions array, even if it matches filename 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -524,7 +524,7 @@ exports[`showCaptions display alt as caption if specified in showCaptions array,
 `;
 
 exports[`showCaptions display alt as caption if title was not found and showCaptions === true 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -557,7 +557,7 @@ exports[`showCaptions display alt as caption if title was not found and showCapt
 `;
 
 exports[`showCaptions display title as caption if specified first in showCaptions array 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -590,7 +590,7 @@ exports[`showCaptions display title as caption if specified first in showCaption
 `;
 
 exports[`showCaptions display title as caption if specified in showCaptions array 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -623,7 +623,7 @@ exports[`showCaptions display title as caption if specified in showCaptions arra
 `;
 
 exports[`showCaptions display title as caption when showCaptions === true 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -656,7 +656,7 @@ exports[`showCaptions display title as caption when showCaptions === true 1`] = 
 `;
 
 exports[`showCaptions fallback to alt as caption if specified second in showCaptions array 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
@@ -689,7 +689,7 @@ exports[`showCaptions fallback to alt as caption if specified second in showCapt
 `;
 
 exports[`showCaptions fallback to title as caption if specified second in showCaptions array 1`] = `
-"<figure class=\\"gatsby-resp-image-figure\\" style=\\"\\">
+"<figure class=\\"gatsby-resp-image-figure\\" style=\\" max-width: 300px;\\">
     <span
       class=\\"gatsby-resp-image-wrapper\\"
       style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -343,7 +343,7 @@ module.exports = (
     // Wrap in figure and use title as caption
     if (imageCaption) {
       rawHTML = `
-  <figure class="gatsby-resp-image-figure" style="${wrapperStyle}">
+  <figure class="gatsby-resp-image-figure" style="${wrapperStyle} max-width: ${presentationWidth}px;">
     ${rawHTML}
     <figcaption class="gatsby-resp-image-figcaption">${imageCaption}</figcaption>
   </figure>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add the `max-width` property to the `<figure>` element when `showCaptions` is set to true.
With setting like this
![Screenshot from 2020-02-10 11-59-41](https://user-images.githubusercontent.com/48516031/74120037-e8ee6200-4bfc-11ea-8a7d-88776193dfdb.png)

will display
![Screenshot from 2020-02-10 11-59-55](https://user-images.githubusercontent.com/48516031/74120045-ee4bac80-4bfc-11ea-8900-0ff6ee098b1f.png)
seems more intuitive.
### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

#21326
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
