### PR TITLE
refactor(www): Convert email-capture-form to a function component

### DIFF
--- a/www/src/components/email-capture-form.js
+++ b/www/src/components/email-capture-form.js
@@ -80,238 +80,201 @@ const SuccessMessage = styled(`div`)`
   font-family: ${p => p.theme.fonts.system};
 `
 
-class Form extends React.Component {
-  constructor(props) {
-    super(props)
+function Form({ isHomepage, portalId, formId, sfdcCampaignId, onSuccess }) {
+  const emailRef = React.useRef(null)
+  const [errorMessage, setErrorMessage] = React.useState("")
+  const [fieldErrors, setFieldErrors] = React.useState({})
 
-    this.onSubmit = this.onSubmit.bind(this)
+  const onSubmit = React.useCallback(
+    e => {
+      e.preventDefault()
 
-    // let's use uncontrolled components https://reactjs.org/docs/uncontrolled-components.html
-    this.email = null
-  }
+      // validation here or use Formik or something like that
+      // we can also rely on server side validation like I do right now
 
-  state = {
-    errorMessage: ``,
-    fieldErrors: {},
-  }
-
-  onSubmit(e) {
-    e.preventDefault()
-
-    // validation here or use Formik or something like that
-    // we can also rely on server side validation like I do right now
-
-    const { portalId, formId, sfdcCampaignId } = this.props
-    const url = `https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`
-    const data = {
-      fields: [
-        {
-          name: `email`,
-          value: this.email.value,
+      const url = `https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`
+      const data = {
+        fields: [
+          {
+            name: `email`,
+            value: emailRef.current.value,
+          },
+        ],
+        context: {
+          pageUri: window.location.href,
+          pageName: document.title,
         },
-      ],
-      context: {
-        pageUri: window.location.href,
-        pageName: document.title,
-      },
-    }
+      }
 
-    if (sfdcCampaignId) {
-      data.context.sfdcCampaignId = sfdcCampaignId
-    }
+      if (sfdcCampaignId) {
+        data.context.sfdcCampaignId = sfdcCampaignId
+      }
 
-    const xhr = new XMLHttpRequest()
-    xhr.open(`POST`, url, false)
-    xhr.setRequestHeader(`Content-Type`, `application/json`)
+      const xhr = new XMLHttpRequest()
+      xhr.open(`POST`, url, false)
+      xhr.setRequestHeader(`Content-Type`, `application/json`)
 
-    xhr.onreadystatechange = () => {
-      if (xhr.readyState == 4) {
-        const response = JSON.parse(xhr.responseText)
-        if (xhr.status == 200) {
-          // https://developers.hubspot.com/docs/methods/forms/submit_form_ajax
-          // docs mention response should "thankYouMessage" field,
-          // but I get inlineMessage in my testing
-          this.props.onSuccess(
-            response.thankYouMessage || response.inlineMessage
-          )
-        } else {
-          let errorMessage,
-            fieldErrors = {}
-          if (response.errors) {
-            // {"message":"Error in 'fields.email'. Invalid email address","errorType":"INVALID_EMAIL"}
-            // {"message":"Error in 'fields.email'. Required field 'email' is missing","errorType":"REQUIRED_FIELD"}
-
-            const errorRe = /^Error in 'fields.([^']+)'. (.+)$/
-            response.errors.map(error => {
-              const [, fieldName, message] = errorRe.exec(error.message)
-              fieldErrors[fieldName] = message
-            })
-
-            // hubspot use "The request is not valid" message, so probably better use custom one
-            errorMessage = `Errors in the form`
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState == 4) {
+          const response = JSON.parse(xhr.responseText)
+          if (xhr.status == 200) {
+            // https://developers.hubspot.com/docs/methods/forms/submit_form_ajax
+            // docs mention response should "thankYouMessage" field,
+            // but I get inlineMessage in my testing
+            onSuccess(response.thankYouMessage || response.inlineMessage)
           } else {
-            errorMessage = response.message
-          }
+            let errorMessage,
+              fieldErrors = {}
+            if (response.errors) {
+              // {"message":"Error in 'fields.email'. Invalid email address","errorType":"INVALID_EMAIL"}
+              // {"message":"Error in 'fields.email'. Required field 'email' is missing","errorType":"REQUIRED_FIELD"}
 
-          this.setState({ fieldErrors, errorMessage })
+              const errorRe = /^Error in 'fields.([^']+)'. (.+)$/
+              response.errors.map(error => {
+                const [, fieldName, message] = errorRe.exec(error.message)
+                fieldErrors[fieldName] = message
+              })
+
+              // hubspot use "The request is not valid" message, so probably better use custom one
+              errorMessage = `Errors in the form`
+            } else {
+              errorMessage = response.message
+            }
+
+            setFieldErrors(fieldErrors)
+            setErrorMessage(errorMessage)
+          }
         }
       }
-    }
 
-    xhr.send(JSON.stringify(data))
-  }
+      xhr.send(JSON.stringify(data))
+    },
+    [portalId, formId, sfdcCampaignId]
+  )
 
-  render() {
-    const { isHomepage } = this.props
+  return (
+    <StyledForm onSubmit={onSubmit} isHomepage={isHomepage}>
+      {!isHomepage && (
+        <Label isRequired htmlFor="email">
+          Email
+        </Label>
+      )}
+      <input
+        id="email"
+        name="email"
+        type="email"
+        required
+        autoComplete="email"
+        ref={emailRef}
+        aria-label={isHomepage ? `Email` : ``}
+        placeholder={`your.email@example.com`}
+        sx={{
+          ...themedInput,
+          width: `100%`,
+          "&:focus": {
+            ...formInputFocus,
+          },
+        }}
+      />
+      {fieldErrors.email && <ErrorMessage>{fieldErrors.email}</ErrorMessage>}
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
 
-    return (
-      <StyledForm onSubmit={this.onSubmit} isHomepage={isHomepage}>
-        {!isHomepage && (
-          <Label isRequired htmlFor="email">
-            Email
-          </Label>
-        )}
-        <input
-          id="email"
-          name="email"
-          type="email"
-          required
-          autoComplete="email"
-          ref={input => {
-            this.email = input
-          }}
-          aria-label={isHomepage ? `Email` : ``}
-          placeholder={`your.email@example.com`}
+      {isHomepage ? (
+        <button
+          type="submit"
           sx={{
-            ...themedInput,
+            ...buttonStyles().default,
+            fontSize: 3,
+            mt: 3,
             width: `100%`,
-            "&:focus": {
-              ...formInputFocus,
+            span: {
+              alignItems: `center`,
+              display: `flex`,
+              justifyContent: `space-between`,
+              width: `100%`,
+            },
+            [mediaQueries.lg]: {
+              ml: 2,
+              mt: 0,
+              width: `auto`,
             },
           }}
+        >
+          <span>
+            Subscribe
+            <SendIcon />
+          </span>
+        </button>
+      ) : (
+        <input
+          type="submit"
+          value="Subscribe"
+          sx={{
+            ...buttonStyles().default,
+            mt: 3,
+          }}
         />
-        {this.state.fieldErrors.email && (
-          <ErrorMessage>{this.state.fieldErrors.email}</ErrorMessage>
-        )}
-        {this.state.errorMessage && (
-          <ErrorMessage>{this.state.errorMessage}</ErrorMessage>
-        )}
+      )}
+    </StyledForm>
+  )
+}
 
-        {isHomepage ? (
-          <button
-            type="submit"
+function EmailCaptureForm({
+  formId = "089352d8-a617-4cba-ba46-6e52de5b6a1d",
+  signupMessage = `Enjoyed this post? Receive the next one in your inbox!`,
+  isHomepage = false,
+  className = ``,
+}) {
+  const [successMessage, setSuccessMessage] = React.useState("")
+
+  const FormComponent = props => (
+    <Form
+      onSuccess={setSuccessMessage}
+      portalId="4731712"
+      formId={formId}
+      sfdcCampaignId="701f4000000Us7pAAC"
+      {...props}
+    />
+  )
+
+  return (
+    <React.Fragment>
+      {isHomepage ? (
+        <div className={className}>
+          {successMessage ? (
+            <SuccessMessage
+              dangerouslySetInnerHTML={{ __html: successMessage }}
+            />
+          ) : (
+            <FormComponent isHomepage={true} />
+          )}
+        </div>
+      ) : (
+        <Container>
+          <p
             sx={{
-              ...buttonStyles().default,
+              color: `newsletter.heading`,
+              fontWeight: `bold`,
               fontSize: 3,
-              mt: 3,
-              width: `100%`,
-              span: {
-                alignItems: `center`,
-                display: `flex`,
-                justifyContent: `space-between`,
-                width: `100%`,
-              },
-              [mediaQueries.lg]: {
-                ml: 2,
-                mt: 0,
-                width: `auto`,
-              },
+              fontFamily: `header`,
+              lineHeight: `dense`,
             }}
           >
-            <span>
-              Subscribe
-              <SendIcon />
-            </span>
-          </button>
-        ) : (
-          <input
-            type="submit"
-            value="Subscribe"
-            sx={{
-              ...buttonStyles().default,
-              mt: 3,
-            }}
-          />
-        )}
-      </StyledForm>
-    )
-  }
-}
-
-class EmailCaptureForm extends React.Component {
-  constructor(props) {
-    super(props)
-    this.onSuccess = this.onSuccess.bind(this)
-  }
-
-  state = {
-    successMessage: ``,
-  }
-
-  onSuccess(successMessage) {
-    this.setState({ successMessage })
-  }
-
-  render() {
-    const { formId, signupMessage, isHomepage, className } = this.props
-
-    const FormComponent = props => (
-      <Form
-        onSuccess={this.onSuccess}
-        portalId="4731712"
-        formId={formId}
-        sfdcCampaignId="701f4000000Us7pAAC"
-        {...props}
-      />
-    )
-
-    return (
-      <React.Fragment>
-        {isHomepage ? (
-          <div className={className}>
-            {this.state.successMessage ? (
-              <SuccessMessage
-                dangerouslySetInnerHTML={{ __html: this.state.successMessage }}
-              />
-            ) : (
-              <FormComponent isHomepage={true} />
-            )}
-          </div>
-        ) : (
-          <Container>
-            <p
-              sx={{
-                color: `newsletter.heading`,
-                fontWeight: `bold`,
-                fontSize: 3,
-                fontFamily: `header`,
-                lineHeight: `dense`,
+            {signupMessage}
+          </p>
+          {successMessage ? (
+            <div
+              dangerouslySetInnerHTML={{
+                __html: successMessage,
               }}
-            >
-              {signupMessage}
-            </p>
-            {this.state.successMessage ? (
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: this.state.successMessage,
-                }}
-              />
-            ) : (
-              <FormComponent />
-            )}
-          </Container>
-        )}
-      </React.Fragment>
-    )
-  }
-}
-
-EmailCaptureForm.defaultProps = {
-  formId: "089352d8-a617-4cba-ba46-6e52de5b6a1d",
-  signupMessage: `Enjoyed this post? Receive the next one in your inbox!`,
-  confirmMessage: `Thank you! Youʼll receive your first email shortly.`,
-  isHomepage: false,
-  className: ``,
+            />
+          ) : (
+            <FormComponent />
+          )}
+        </Container>
+      )}
+    </React.Fragment>
+  )
 }
 
 export default EmailCaptureForm


### PR DESCRIPTION
## Description

Convert `<EmailCaptureForm>` to a function component.

## Motivation

It's a component with UI text that should be localized, and I want don't want to use [HOC injection](https://github.com/gatsbyjs/gatsby/pull/21024/files#diff-f772c656e3adc950a1dfc1c014c753e1R445) to do it.