### PR TITLE
refactor(www): Reorganize plugin pages layout

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -382,7 +382,6 @@ exports.createPages = ({ graphql, actions, reporter }) => {
             context: {
               slug: edge.node.slug,
               id: edge.node.id,
-              layout: `plugins`,
             },
           })
         } else {
@@ -392,7 +391,6 @@ exports.createPages = ({ graphql, actions, reporter }) => {
             context: {
               slug: edge.node.slug,
               id: edge.node.id,
-              layout: `plugins`,
             },
           })
         }
@@ -656,17 +654,6 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
   }
   // end Creator pages
   return null
-}
-
-exports.onCreatePage = ({ page, actions }) => {
-  if (page.path === `/plugins/`) {
-    const { createPage, deletePage } = actions
-    const oldPage = Object.assign({}, page)
-
-    page.context.layout = `plugins`
-    deletePage(oldPage)
-    createPage(page)
-  }
 }
 
 exports.onPostBuild = () => {

--- a/www/src/components/page-with-plugin-searchbar.js
+++ b/www/src/components/page-with-plugin-searchbar.js
@@ -1,8 +1,10 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { Fragment } from "react"
-import PluginSearchBar from "./plugin-searchbar-body"
+import loadable from "@loadable/component"
 import { mediaQueries } from "../gatsby-plugin-theme-ui"
+
+const PluginSearchBar = loadable(() => import("./plugin-searchbar-body"))
 
 const PageWithPluginSearchBar = ({ isPluginsIndex, location, children }) => (
   <Fragment>

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -1,22 +1,3 @@
-import React, { useState } from "react"
-
-let PluginLibraryWrapper
-export default props => {
-  const [loaded, setLoaded] = useState(false)
-
-  const promise = import(`../components/layout/plugin-library-wrapper`)
-  if (props.pageContext.layout === `plugins` && !loaded) {
-    promise.then(pl => {
-      PluginLibraryWrapper = pl.default
-      setLoaded(true)
-    })
-    return null
-  } else if (props.pageContext.layout === `plugins` && loaded) {
-    return (
-      <PluginLibraryWrapper location={props.location}>
-        {props.children}
-      </PluginLibraryWrapper>
-    )
-  }
-  return <>{props.children}</>
+export default function Layout({ children }) {
+  return children
 }

--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -9,122 +9,126 @@ import { Link } from "gatsby"
 import logo from "../assets/monogram.svg"
 import { sizes } from "../gatsby-plugin-theme-ui"
 import FooterLinks from "../components/shared/footer-links"
+import Layout from "../components/layout"
+import PageWithPluginSearchBar from "../components/page-with-plugin-searchbar"
 
 class Plugins extends Component {
   render() {
     return (
-      <React.Fragment>
-        <Helmet>
-          <title>Plugins</title>
-          <meta
-            name="description"
-            content="The library for searching and exploring Gatsby's vast plugin ecosystem to implement Node.js packages using Gatsby APIs"
-          />
-        </Helmet>
-        <Container
-          overrideCSS={{
-            alignItems: `center`,
-            display: `flex`,
-            flexDirection: `column`,
-            minHeight: `calc(100vh - (${sizes.headerHeight} + ${sizes.bannerHeight}))`,
-          }}
-        >
-          <div
-            css={{
+      <Layout location={location}>
+        <PageWithPluginSearchBar location={location} isPluginsIndex={true}>
+          <Helmet>
+            <title>Plugins</title>
+            <meta
+              name="description"
+              content="The library for searching and exploring Gatsby's vast plugin ecosystem to implement Node.js packages using Gatsby APIs"
+            />
+          </Helmet>
+          <Container
+            overrideCSS={{
+              alignItems: `center`,
               display: `flex`,
               flexDirection: `column`,
+              minHeight: `calc(100vh - (${sizes.headerHeight} + ${sizes.bannerHeight}))`,
             }}
           >
-            <img
-              src={logo}
-              sx={{
-                display: `inline-block`,
-                height: t => t.space[12],
-                width: t => t.space[12],
-                mx: `auto`,
-              }}
-              alt=""
-            />
-            <h1
-              sx={{
-                fontSize: 6,
-                fontWeight: `heading`,
-                mx: 5,
-                mb: 0,
-                textAlign: `center`,
+            <div
+              css={{
+                display: `flex`,
+                flexDirection: `column`,
               }}
             >
-              Welcome to the Gatsby Plugin Library!
-            </h1>
-            <Rotator
-              items={[
-                {
-                  text: `SEO?`,
-                  pluginName: `gatsby-plugin-react-helmet`,
-                },
-                {
-                  text: `responsive images?`,
-                  pluginName: `gatsby-image`,
-                },
-                {
-                  text: `offline support?`,
-                  pluginName: `gatsby-plugin-offline`,
-                },
-                {
-                  text: `Sass support?`,
-                  pluginName: `gatsby-plugin-sass`,
-                },
-                {
-                  text: `a sitemap?`,
-                  pluginName: `gatsby-plugin-sitemap`,
-                },
-                {
-                  text: `an RSS feed?`,
-                  pluginName: `gatsby-plugin-feed`,
-                },
-                {
-                  text: `great typography?`,
-                  pluginName: `gatsby-plugin-typography`,
-                },
-                {
-                  text: `TypeScript?`,
-                  pluginName: `gatsby-plugin-typescript`,
-                },
-                {
-                  text: `Google Analytics?`,
-                  pluginName: `gatsby-plugin-google-analytics`,
-                },
-                {
-                  text: `WordPress integration?`,
-                  pluginName: `gatsby-source-wordpress`,
-                },
-                {
-                  text: `anything?`,
-                },
-              ]}
-              color="lilac"
-            />
+              <img
+                src={logo}
+                sx={{
+                  display: `inline-block`,
+                  height: t => t.space[12],
+                  width: t => t.space[12],
+                  mx: `auto`,
+                }}
+                alt=""
+              />
+              <h1
+                sx={{
+                  fontSize: 6,
+                  fontWeight: `heading`,
+                  mx: 5,
+                  mb: 0,
+                  textAlign: `center`,
+                }}
+              >
+                Welcome to the Gatsby Plugin Library!
+              </h1>
+              <Rotator
+                items={[
+                  {
+                    text: `SEO?`,
+                    pluginName: `gatsby-plugin-react-helmet`,
+                  },
+                  {
+                    text: `responsive images?`,
+                    pluginName: `gatsby-image`,
+                  },
+                  {
+                    text: `offline support?`,
+                    pluginName: `gatsby-plugin-offline`,
+                  },
+                  {
+                    text: `Sass support?`,
+                    pluginName: `gatsby-plugin-sass`,
+                  },
+                  {
+                    text: `a sitemap?`,
+                    pluginName: `gatsby-plugin-sitemap`,
+                  },
+                  {
+                    text: `an RSS feed?`,
+                    pluginName: `gatsby-plugin-feed`,
+                  },
+                  {
+                    text: `great typography?`,
+                    pluginName: `gatsby-plugin-typography`,
+                  },
+                  {
+                    text: `TypeScript?`,
+                    pluginName: `gatsby-plugin-typescript`,
+                  },
+                  {
+                    text: `Google Analytics?`,
+                    pluginName: `gatsby-plugin-google-analytics`,
+                  },
+                  {
+                    text: `WordPress integration?`,
+                    pluginName: `gatsby-source-wordpress`,
+                  },
+                  {
+                    text: `anything?`,
+                  },
+                ]}
+                color="lilac"
+              />
 
-            <p
-              sx={{
-                color: `textMuted`,
-                fontSize: 2,
-                textAlign: `center`,
-              }}
-            >
-              Please use the search bar to find plugins that will make your
-              blazing fast site even more awesome. If you
-              {`'`}d like to create your own plugin, see the
-              {` `}
-              <Link to="/docs/creating-plugins/">Plugin Authoring</Link> page in
-              the docs! To learn more about Gatsby plugins, visit the
-              {` `}
-              <Link to="/docs/plugins">plugins doc page</Link>.
-            </p>
-          </div>
-          <FooterLinks />
-        </Container>
-      </React.Fragment>
+              <p
+                sx={{
+                  color: `textMuted`,
+                  fontSize: 2,
+                  textAlign: `center`,
+                }}
+              >
+                Please use the search bar to find plugins that will make your
+                blazing fast site even more awesome. If you
+                {`'`}d like to create your own plugin, see the
+                {` `}
+                <Link to="/docs/creating-plugins/">Plugin Authoring</Link> page
+                in the docs! To learn more about Gatsby plugins, visit the
+                {` `}
+                <Link to="/docs/plugins">plugins doc page</Link>.
+              </p>
+            </div>
+            <FooterLinks />
+          </Container>
+        </PageWithPluginSearchBar>
+      </Layout>
     )
   }
 }

--- a/www/src/templates/template-docs-local-packages.js
+++ b/www/src/templates/template-docs-local-packages.js
@@ -2,6 +2,8 @@ import React from "react"
 import { graphql } from "gatsby"
 import { pick } from "lodash-es"
 
+import Layout from "../components/layout"
+import PageWithPluginSearchBar from "../components/page-with-plugin-searchbar"
 import PackageReadme from "../components/package-readme"
 
 class DocsLocalPackagesTemplate extends React.Component {
@@ -27,47 +29,49 @@ class DocsLocalPackagesTemplate extends React.Component {
     }
 
     return (
-      <>
-        <PackageReadme
-          page={markdownRemark ? pick(markdownRemark, `parent`) : false}
-          packageName={
-            markdownRemark
-              ? markdownRemark.fields.title
-              : markdownRemarkNotFound.fields.title
-          }
-          excerpt={
-            markdownRemark
-              ? markdownRemark.excerpt
-              : markdownRemarkNotFound.excerpt
-          }
-          html={
-            markdownRemark ? markdownRemark.html : markdownRemarkNotFound.html
-          }
-          githubUrl={`https://github.com/gatsbyjs/gatsby/tree/master/packages/${
-            markdownRemark
-              ? markdownRemark.fields.title
-              : markdownRemarkNotFound.fields.title
-          }`}
-          timeToRead={
-            markdownRemark
-              ? markdownRemark.timeToRead
-              : markdownRemarkNotFound.timeToRead
-          }
-          modified={
-            npmPackage && npmPackage.modified
-              ? npmPackage.modified
-              : npmPackageNotFound.modified
-          }
-          keywords={
-            npmPackage ? npmPackage.keywords : npmPackageNotFound.keywords
-          }
-          lastPublisher={
-            npmPackage
-              ? npmPackage.lastPublisher
-              : npmPackageNotFound.lastPublisher
-          }
-        />
-      </>
+      <Layout location={location}>
+        <PageWithPluginSearchBar location={location}>
+          <PackageReadme
+            page={markdownRemark ? pick(markdownRemark, `parent`) : false}
+            packageName={
+              markdownRemark
+                ? markdownRemark.fields.title
+                : markdownRemarkNotFound.fields.title
+            }
+            excerpt={
+              markdownRemark
+                ? markdownRemark.excerpt
+                : markdownRemarkNotFound.excerpt
+            }
+            html={
+              markdownRemark ? markdownRemark.html : markdownRemarkNotFound.html
+            }
+            githubUrl={`https://github.com/gatsbyjs/gatsby/tree/master/packages/${
+              markdownRemark
+                ? markdownRemark.fields.title
+                : markdownRemarkNotFound.fields.title
+            }`}
+            timeToRead={
+              markdownRemark
+                ? markdownRemark.timeToRead
+                : markdownRemarkNotFound.timeToRead
+            }
+            modified={
+              npmPackage && npmPackage.modified
+                ? npmPackage.modified
+                : npmPackageNotFound.modified
+            }
+            keywords={
+              npmPackage ? npmPackage.keywords : npmPackageNotFound.keywords
+            }
+            lastPublisher={
+              npmPackage
+                ? npmPackage.lastPublisher
+                : npmPackageNotFound.lastPublisher
+            }
+          />
+        </PageWithPluginSearchBar>
+      </Layout>
     )
   }
 }

--- a/www/src/templates/template-docs-remote-packages.js
+++ b/www/src/templates/template-docs-remote-packages.js
@@ -1,6 +1,8 @@
 import React from "react"
 import { graphql } from "gatsby"
 
+import Layout from "../components/layout"
+import PageWithPluginSearchBar from "../components/page-with-plugin-searchbar"
 import PackageReadme from "../components/package-readme"
 
 class DocsRemotePackagesTemplate extends React.Component {
@@ -9,23 +11,25 @@ class DocsRemotePackagesTemplate extends React.Component {
       data: { npmPackage, markdownRemark },
     } = this.props
     return (
-      <>
-        <PackageReadme
-          page={markdownRemark}
-          packageName={npmPackage.name}
-          excerpt={npmPackage.readme.childMarkdownRemark.excerpt}
-          html={npmPackage.readme.childMarkdownRemark.html}
-          githubUrl={
-            npmPackage.repository !== null
-              ? npmPackage.repository.url
-              : `https://github.com/search?q=${npmPackage.name}`
-          }
-          modified={npmPackage.modified}
-          timeToRead={npmPackage.readme.childMarkdownRemark.timeToRead}
-          keywords={npmPackage.keywords}
-          lastPublisher={npmPackage.lastPublisher}
-        />
-      </>
+      <Layout location={location}>
+        <PageWithPluginSearchBar location={location}>
+          <PackageReadme
+            page={markdownRemark}
+            packageName={npmPackage.name}
+            excerpt={npmPackage.readme.childMarkdownRemark.excerpt}
+            html={npmPackage.readme.childMarkdownRemark.html}
+            githubUrl={
+              npmPackage.repository !== null
+                ? npmPackage.repository.url
+                : `https://github.com/search?q=${npmPackage.name}`
+            }
+            modified={npmPackage.modified}
+            timeToRead={npmPackage.readme.childMarkdownRemark.timeToRead}
+            keywords={npmPackage.keywords}
+            lastPublisher={npmPackage.lastPublisher}
+          />
+        </PageWithPluginSearchBar>
+      </Layout>
     )
   }
 }


### PR DESCRIPTION
## Description

Reorganize the way the plugin pages/templates use layouts:

* Use `@loadable/component` instead of our custom thing
* Get rid of the custom logic in `gatsby-node` and `layouts/index.js`
* Import <Layout> and <PageWithPluginSearchbar> directly in the the plugin pages/templates