### PR TITLE
docs: fixed closing bracket synthax error in breadcrumbs array

### DIFF
--- a/docs/docs/porting-an-html-site-to-gatsby.md
+++ b/docs/docs/porting-an-html-site-to-gatsby.md
@@ -400,7 +400,7 @@ import { Link } from "gatsby"
 
 export default () => (
   {/* highlight-start */}
-  <Layout breadcrumbs={["Who We Are", "Ella"}}>
+  <Layout breadcrumbs={["Who We Are", "Ella"]}>
   {/* highlight-end */}
     <h1>Ella - Arborist</h1>
     <h2>Ella is an excellent Arborist. We guarantee it.</h2>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fixed closing bracket synthax error in breadcrumbs array.

Issue is located in this code snippet:
https://www.gatsbyjs.org/docs/porting-an-html-site-to-gatsby/#porting-other-pages

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
