### PR TITLE
feat(www): Add the ability to add custom descriptions to docs

### DIFF
--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -103,6 +103,25 @@ It can be necessary to change a heading within the docs. It's important to note 
 - Determine the URL you're looking for. `Changing headers` is linked with a URL ending in `changing-headers`, `Docs renaming instructions` becomes `docs-renaming-instructions`, etc.
 - Update all instances of the old URL to your new one. [Find and replace](https://code.visualstudio.com/docs/editor/codebasics#_search-across-files) in VS Code can help. Check that the context of the original link reference still makes sense with the new one.
 
+## Adding a description
+
+The site automatically creates description tags in order to boost SEO:
+
+```html
+<meta name="description" content="Documentation of Gatsby" />
+<meta property="og:description" content="Documentation of Gatsby" />
+<meta name="twitter:description" content="Documentation of Gatsby" />
+```
+
+By default, this description is generated from the `page.excerpt`. If you would like to add a custom description, you can use the `description` frontmatter tag:
+
+```markdown
+---
+title: Gatsby Community Events
+description: Learn about other events happening around the globe to connect with other members of the Gatsby community
+---
+```
+
 ## Configuring site navigation
 
 The docs include custom built components to aid with navigation. In order to customize the navigation experience, these components allow some configurations without changing any of the React code.

--- a/docs/contributing/events.md
+++ b/docs/contributing/events.md
@@ -1,5 +1,6 @@
 ---
 title: Gatsby Community Events
+description: Learn about other events happening around the globe to connect with other members of the Gatsby community
 ---
 
 Interested in connecting with the Gatsby community in person? Take a look at the list below to see community-organized Gatsby events.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,5 +1,6 @@
 ---
 title: Contributing to Gatsby.js
+description: Learn about contributing to one of the most welcoming communities helping develop the future of the web
 disableTableOfContents: true
 ---
 

--- a/docs/contributing/stub-list.md
+++ b/docs/contributing/stub-list.md
@@ -1,5 +1,6 @@
 ---
 title: Stub List
+description: Find places in the documentation that are still a work in progress, in need of community help
 ---
 
 There are a variety of pages that are currently stubbed out but do not contain any content yet. If you are interested in helping write any of these pages, head to any of them or head over to [How to Write a Stub](/contributing/how-to-write-a-stub/) to learn more.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Gatsby.js Documentation
+description: The one stop location for tutorials, guides, and information about building with Gatsby
 disableTableOfContents: true
 ---
 

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -32,15 +32,17 @@ function DocsTemplate({ data, location, pageContext: { next, prev } }) {
   const toc =
     !page.frontmatter.disableTableOfContents && page.tableOfContents.items
 
+  const description = page.frontmatter.description || page.excerpt
+
   return (
     <React.Fragment>
       <Helmet>
         <title>{page.frontmatter.title}</title>
-        <meta name="description" content={page.excerpt} />
-        <meta property="og:description" content={page.excerpt} />
+        <meta name="description" content={description} />
+        <meta property="og:description" content={description} />
         <meta property="og:title" content={page.frontmatter.title} />
         <meta property="og:type" content="article" />
-        <meta name="twitter:description" content={page.excerpt} />
+        <meta name="twitter:description" content={description} />
         <meta name="twitter.label1" content="Reading time" />
         <meta name="twitter:data1" content={`${page.timeToRead} min read`} />
       </Helmet>
@@ -146,6 +148,7 @@ export const pageQuery = graphql`
       }
       frontmatter {
         title
+        description
         overview
         issue
         disableTableOfContents


### PR DESCRIPTION
## Description

Add a new `description` frontmatter tag to enable custom SEO descriptions and add documentation for it.

Add descriptions back to the following pages that were converted to MDX recently:

* docs/index.md (#18014)
* contributing/index.md (#19057)
* contributing/events.md (#21227)
* contributing/stub-list.md (#21287)