### PR TITLE
docs(gatsby-plugin-catch-links): uses correct exclude pattern key

### DIFF
--- a/packages/gatsby-plugin-catch-links/README.md
+++ b/packages/gatsby-plugin-catch-links/README.md
@@ -32,7 +32,7 @@ Regular expression for paths to be excluded from being handled by this plugin.
 {
   resolve: `gatsby-plugin-catch-links`,
   options: {
-    excludePattern: /(excluded-link|external)/,
+    excludeRegex: /(excluded-link|external)/,
   },
 },
 ```


### PR DESCRIPTION
## Description

per this [commit](https://github.com/gatsbyjs/gatsby/commit/46f514cf0c9b8cebb2b59816f51377fa7ed27dbf), the actual key for excluding links is `excludeRegex`. I was able to verify this locally as well