### PR TITLE
fix(www): get location prop for remote and local package templates

### DIFF
--- a/www/src/pages/plugins.js
+++ b/www/src/pages/plugins.js
@@ -14,6 +14,7 @@ import PageWithPluginSearchBar from "../components/page-with-plugin-searchbar"
 
 class Plugins extends Component {
   render() {
+    const { location } = this.props
     return (
       <Layout location={location}>
         <PageWithPluginSearchBar location={location} isPluginsIndex={true}>

--- a/www/src/templates/template-docs-local-packages.js
+++ b/www/src/templates/template-docs-local-packages.js
@@ -9,6 +9,7 @@ import PackageReadme from "../components/package-readme"
 class DocsLocalPackagesTemplate extends React.Component {
   render() {
     const {
+      location,
       data: { npmPackage, markdownRemark },
     } = this.props
     const npmPackageNotFound = {

--- a/www/src/templates/template-docs-remote-packages.js
+++ b/www/src/templates/template-docs-remote-packages.js
@@ -8,6 +8,7 @@ import PackageReadme from "../components/package-readme"
 class DocsRemotePackagesTemplate extends React.Component {
   render() {
     const {
+      location,
       data: { npmPackage, markdownRemark },
     } = this.props
     return (


### PR DESCRIPTION
## Description

Fix failing dot-org build by getting the location prop for remote and local package templates.