### PR TITLE
fix(www): inherit from layout in ecosystem page and fix weird styling

### DIFF
--- a/www/src/components/layout/layout-with-heading.js
+++ b/www/src/components/layout/layout-with-heading.js
@@ -1,49 +1,22 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import PropTypes from "prop-types"
-import { Helmet } from "react-helmet"
 
-import Banner from "../banner"
 import PageHeading from "./page-heading"
-import Navigation from "../navigation"
-import MobileNavigation from "../navigation-mobile"
+import BaseLayout from "../layout"
 import { mediaQueries } from "../../gatsby-plugin-theme-ui"
-import SkipNavLink from "../skip-nav-link"
-
-// Import Futura PT typeface
-import "../../assets/fonts/futura"
 
 const LayoutWithHeading = props => {
-  const {
-    children,
-    location: { pathname },
-    pageTitle = ``,
-    pageIcon,
-  } = props
-
-  const isHomepage = pathname === `/`
+  const { children, location, pageTitle = ``, pageIcon } = props
 
   return (
-    <div className={` ${isHomepage ? `isHomepage` : ``}`}>
-      <Helmet>
-        <title>{pageTitle ? `${pageTitle} | GatsbyJS` : `GatsbyJS`}</title>
-        <meta name="twitter:site" content="@gatsbyjs" />
-        <meta name="og:type" content="website" />
-        <meta name="og:site_name" content="GatsbyJS" />
-        <link rel="canonical" href={`https://gatsbyjs.org${pathname}`} />
-        <html lang="en" />
-      </Helmet>
-      <SkipNavLink />
-      <Banner />
-      <Navigation pathname={props.location.pathname} />
+    <BaseLayout location={location}>
       <div
         sx={{
-          pt: t => t.sizes.bannerHeight,
           pb: t => t.fontSizes[10],
 
           [mediaQueries.md]: {
             ml: t => t.sizes.pageHeadingDesktopWidth,
-            pt: t => `calc(${t.sizes.bannerHeight} + ${t.sizes.headerHeight})`,
             pb: 0,
           },
         }}
@@ -51,8 +24,7 @@ const LayoutWithHeading = props => {
         {pageTitle && <PageHeading title={pageTitle} icon={pageIcon} />}
         {children}
       </div>
-      <MobileNavigation />
-    </div>
+    </BaseLayout>
   )
 }
 

--- a/www/src/components/layout/page-heading.js
+++ b/www/src/components/layout/page-heading.js
@@ -19,6 +19,7 @@ const PageHeadingContainer = styled(`header`)`
 
 const H1 = styled(`h1`)`
   align-items: center;
+  font-weight: bold;
   color: ${p => p.theme.colors.heading};
   display: flex;
   font-size: ${p => p.theme.fontSizes[4]};

--- a/www/src/pages/ecosystem.js
+++ b/www/src/pages/ecosystem.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import { graphql } from "gatsby"
+import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout/layout-with-heading"
 import EcosystemBoard from "../components/ecosystem/ecosystem-board"
@@ -52,6 +53,9 @@ class EcosystemPage extends Component {
         pageTitle={pageTitle}
         pageIcon={EcosystemIcon}
       >
+        <Helmet>
+          <title>Ecosystem</title>
+        </Helmet>
         <EcosystemBoard
           icons={boardIcons}
           starters={starters}


### PR DESCRIPTION
## Description

Fix weird styling in gatsbyjs.org/ecosystem by inheriting from the same Layout used everywhere else.

The current /ecosystem page has some issues:

<img width="1280" alt="Screen Shot 2020-02-10 at 7 44 38 PM" src="https://user-images.githubusercontent.com/1278991/74209772-068feb80-4c3e-11ea-9c75-ef620904e0ac.png">

* The link to "Gatsby Cloud" in the banner is double-underlined
* All text is slightly more bold than in all other pages of the site

By pulling in the normal `<Layout>` component and making some adjustments, we resolve these issues:

<img width="1280" alt="Screen Shot 2020-02-10 at 7 44 46 PM" src="https://user-images.githubusercontent.com/1278991/74209839-4e167780-4c3e-11ea-9a5a-d5b6e0392fdd.png">

