### PR TITLE
fix(gatsby): Use argument for updating cache

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -85,7 +85,7 @@ class LocalNodeModel {
    *   cached instead of a Set of Nodes.
    */
   replaceTypeKeyValueCache(map = new Map()) {
-    this._typedKeyValueIndexes = new Map() // See redux/nodes.js for usage
+    this._typedKeyValueIndexes = map // See redux/nodes.js for usage
   }
 
   withContext(context) {


### PR DESCRIPTION
Use the argument to update the cache.

As suggested by @blainekasten in https://github.com/gatsbyjs/gatsby/pull/20729#pullrequestreview-350948674