### PR TITLE
Community Event Support on hold

### DIFF
--- a/docs/contributing/organize-a-gatsby-event.md
+++ b/docs/contributing/organize-a-gatsby-event.md
@@ -2,44 +2,12 @@
 title: Organize a Gatsby Event
 ---
 
-Interested in organizing a Gatsby event? We want to help build the Gatsby community in your area. If your event meets a few basic requirements listed below, you’ll be eligible to receive support from Gatsby such as Gatsby stickers, learning resources, up to \$300 for event costs, and more. Get started by requesting event support below.
-
-[Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)
+Our communiy event support offerings and process are undergoing some changes. Check back soon to see our updated community event support opportunities!
 
 ## What constitutes a Gatsby event?
 
 A community-organized Gatsby event can be a local meetup, a small conference, a “lunch and learn” with coworkers, or a larger event - as long as **it includes at least one Gatsby-focused presentation or discussion**. It’s up to you how many people you want to invite and how casual the environment. You can organize an event at your workplace or for the local community.
 
-## What support does Gatsby provide?
-
-There are several ways Gatsby can support your event:
-
-- Promote event on the [Gatsbyjs.org Events Page](/contributing/events/)
-- Promote event via [Gatsby’s Twitter account](https://twitter.com/gatsbyjs)
-- \$300 off event expenses (food, supplies, space rental, etc.)
-- Free Gatsby stickers from the [Gatsby Swag Store](https://store.gatsbyjs.org/)
-- 20% off swag in the [Gatsby Swag Store](https://store.gatsbyjs.org/) for your attendees
-
-### A note on shipping
-
-We support US and international Gatsby events, but it’s not uncommon to run into issues with international shipping that can delay orders for weeks. Shipments to non-western countries in particular can often take well over a month to arrive. We’re working on finding international shipping partners, but until that’s sorted out, **if you need stickers shipped internationally, please make sure you’re submitting your event at least 6 weeks in advance**.
-
-## Requirements
-
-- Requests should be made at least 1 month in advance of your event date. (If your event is outside the US and you plan to request stickers, we strongly recommend making your request at least 6 weeks in advance.)
-- The event must have at least one Gatsby-focused presentation or discussion.
-- Please announce Gatsby as a sponsor for the event and/or list us on the event as a sponsor.
-- If you’re requesting the \$300 reimbursement, then you must submit a receipt or receipts for event-related expenses.
-- The event must be in harmony with the [Gatsby Code of Conduct](/contributing/code-of-conduct/) and follow the [Gatsby brand guidelines](/guidelines/logo/)
-
-## How do you qualify for Gatsby support?
-
-To request support and submit your event to the Gatsby events page, apply at the link below.
-
-[Request Event Support](https://airtable.com/shrpwc99yogJm9sfI)
-
-Events are evaluated on a weekly basis. If your submission is approved, you will receive an email with instructions for receiving event support and other guidance.
-If you have any questions, please send them to events@gatsbyjs.com.
 
 ## Related Links
 

--- a/docs/contributing/organize-a-gatsby-event.md
+++ b/docs/contributing/organize-a-gatsby-event.md
@@ -8,7 +8,6 @@ Our communiy event support offerings and process are undergoing some changes. Ch
 
 A community-organized Gatsby event can be a local meetup, a small conference, a “lunch and learn” with coworkers, or a larger event - as long as **it includes at least one Gatsby-focused presentation or discussion**. It’s up to you how many people you want to invite and how casual the environment. You can organize an event at your workplace or for the local community.
 
-
 ## Related Links
 
 - [Gatsby's Community Events](/contributing/events/)


### PR DESCRIPTION
We're going to be updating our community event support process, policy, and offerings in the next few weeks. In the short term, this page needs to be updated to reflect that community event support is currently on hold.

