### PR TITLE
fix(www): import design tokens from gatsby-design-tokens in modal.js

### DIFF
--- a/www/src/components/modal.js
+++ b/www/src/components/modal.js
@@ -11,7 +11,7 @@ import {
   space,
   zIndices,
   mediaQueries,
-} from "../gatsby-plugin-theme-ui"
+} from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 import "../assets/fonts/futura"
 import LazyModal from "./lazy-modal"
 import { globalStyles } from "../utils/styles/global"


### PR DESCRIPTION
Seems like this was missing in https://github.com/gatsbyjs/gatsby/pull/21276