### PR TITLE
feat(gatsby-source-drupal): Add Drupal JSON:API Includes support

### DIFF
--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -182,6 +182,12 @@ module.exports = {
 }
 ```
 
+_NOTES_:
+
+When using [includes](https://www.drupal.org/docs/8/modules/jsonapi/includes) in your JSON:API calls the included data will be automatically become available to query, even if the link types are skipped using `disallowedLinkTypes`.
+
+This enables you to only fetch the data you need at build time, instead of all data of a certain entity type or bundle.
+
 ## Gatsby Preview (experimental)
 
 You will need to have the Drupal module installed, more information on that here: https://www.drupal.org/project/gatsby

--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -184,9 +184,9 @@ module.exports = {
 
 _NOTES_:
 
-When using [includes](https://www.drupal.org/docs/8/modules/jsonapi/includes) in your JSON:API calls the included data will be automatically become available to query, even if the link types are skipped using `disallowedLinkTypes`.
+When using [includes](https://www.drupal.org/docs/8/modules/jsonapi/includes) in your JSON:API calls the included data will automatically become available to query, even if the link types are skipped using `disallowedLinkTypes`.
 
-This enables you to only fetch the data you need at build time, instead of all data of a certain entity type or bundle.
+This enables you to fetch only the data you need at build time, instead of all data of a certain entity type or bundle.
 
 ## Gatsby Preview (experimental)
 

--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -214,7 +214,7 @@ module.exports = {
 }
 ```
 
-## Gatsby Preview
+## Gatsby Preview (experimental)
 
 You will need to have the Drupal module installed, more information on that here: https://www.drupal.org/project/gatsby
 

--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -188,7 +188,33 @@ When using [includes](https://www.drupal.org/docs/8/modules/jsonapi/includes) in
 
 This enables you to fetch only the data you need at build time, instead of all data of a certain entity type or bundle.
 
-## Gatsby Preview (experimental)
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-drupal`,
+      options: {
+        baseUrl: `https://live-contentacms.pantheonsite.io/`,
+        // Skip the node--page resource type and paragraph components.
+        disallowedLinkTypes: [
+          `self`,
+          `describedby`,
+          `node--page`,
+          `paragraph--text`,
+          `paragraph--image`,
+        ],
+        filters: {
+          // Use includes so only the news content paragraph components are fetched.
+          "node--news": "include=field_content",
+        },
+      },
+    },
+  ],
+}
+```
+
+## Gatsby Preview
 
 You will need to have the Drupal module installed, more information on that here: https://www.drupal.org/project/gatsby
 

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/article-includes.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/article-includes.json
@@ -1,0 +1,52 @@
+{
+  "data": [
+    {
+      "type": "node--article",
+      "id": "article-5",
+      "attributes": {
+        "id": 24,
+        "uuid": "article-5",
+        "title": "Article #5",
+        "body": "Aliquam non varius libero, sit amet consequat ex. Aenean porta turpis quis vulputate blandit. Suspendisse in porta erat. Sed sit amet scelerisque turpis, at rutrum mauris. Sed tempor eleifend lobortis. Proin maximus, massa sed dignissim sollicitudin, quam risus mattis justo, sit amet aliquam odio ligula quis urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut mollis leo nisi, at interdum urna fermentum ut. Fusce id suscipit neque, eu fermentum lacus. Donec egestas laoreet felis ac luctus. Vestibulum molestie mattis ante, a vulputate nunc ullamcorper at. Ut hendrerit ipsum eget gravida ultricies."
+      },
+      "relationships": {
+        "field_main_image": {
+          "data": {
+            "type": "file--file",
+            "id": "file-1"
+          }
+        },
+        "field_tags": {
+          "data": [
+            {
+              "type": "taxonomy_term--tags",
+              "id": "tag-3"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "taxonomy_term--tags",
+      "id": "tag-3",
+      "attributes": {
+        "id": 12,
+        "uuid": "tag-3",
+        "langcode": "en",
+        "name": "Tag #3",
+        "description": null,
+        "weight": 0,
+        "changed": 1523031646,
+        "default_langcode": true,
+        "path": {
+          "alias": null,
+          "pid": null,
+          "langcode": "en"
+        }
+      }
+    }
+  ],
+  "links": {}
+}

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi-includes.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi-includes.json
@@ -1,0 +1,14 @@
+{
+  "data": [],
+  "links": {
+    "self": "http://fixture/jsonapi",
+    "file--file": "http://fixture/jsonapi/file/file",
+    "node--article": "http://fixture/jsonapi/node/article-includes",
+    "taxonomy_term--tags": {
+      "href": "http://fixture/jsonapi/taxonomy_term/tags"
+    },
+    "describedby": {
+      "href": "http://fixture/jsonapi/schema"
+    }
+  }
+}

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -264,4 +264,20 @@ describe(`gatsby-source-drupal`, () => {
     expect(nodes[createNodeId(`article-2`)]).toBeDefined()
     expect(nodes[createNodeId(`article-3`)]).toBeDefined()
   })
+
+  it(`Verify JSON:API includes relationships`, async () => {
+    // Reset nodes and test includes relationships.
+    Object.keys(nodes).forEach(key => delete nodes[key])
+    const disallowedLinkTypes = [`self`, `describedby`, `taxonomy_term--tags`]
+    const filters = {
+      "node--article": `include=field_tags`,
+    }
+    const apiBase = `jsonapi-includes`
+    await sourceNodes(args, { baseUrl, apiBase, disallowedLinkTypes, filters })
+    expect(Object.keys(nodes).length).not.toEqual(0)
+    expect(nodes[createNodeId(`tag-1`)]).toBeUndefined()
+    expect(nodes[createNodeId(`tag-2`)]).toBeUndefined()
+    expect(nodes[createNodeId(`tag-3`)]).toBeDefined()
+    expect(nodes[createNodeId(`article-5`)]).toBeDefined()
+  })
 })

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -102,7 +102,7 @@ exports.sourceNodes = async (
         // in the JSON API response.
         // See https://www.drupal.org/docs/8/modules/jsonapi/includes
         if (d.data.included) {
-          data = data.concat(d.data.included);
+          data = data.concat(d.data.included)
         }
         if (d.data.links && d.data.links.next) {
           data = await getNext(d.data.links.next, data)

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -97,6 +97,12 @@ exports.sourceNodes = async (
           }
         }
         data = data.concat(d.data.data)
+        // Add support for includes. Includes allow entity data to be expanded
+        // based on relationships.
+        // See https://www.drupal.org/docs/8/modules/jsonapi/includes
+        if (d.data.included) {
+          data = data.concat(d.data.included);
+        }
         if (d.data.links && d.data.links.next) {
           data = await getNext(d.data.links.next, data)
         }

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -98,7 +98,8 @@ exports.sourceNodes = async (
         }
         data = data.concat(d.data.data)
         // Add support for includes. Includes allow entity data to be expanded
-        // based on relationships.
+        // based on relationships. The expanded data is exposed as `included`
+        // in the JSON API response.
         // See https://www.drupal.org/docs/8/modules/jsonapi/includes
         if (d.data.included) {
           data = data.concat(d.data.included);


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Drupal's JSON:API module supports [includes](https://www.drupal.org/docs/8/modules/jsonapi/includes), a method for including relationships data. 

This PR adds very simple and basic support for creating Gatsby data out of the data in the `included` property of the JSON:API result. This way only data that is used is included in Gatsby, without having to fetch all data for a certain resource type.

See #21379 for the full motivation.

### Documentation

Updated documentation in the README.md of the `gatsby-source-drupal` plugin.

## Related Issues

Addresses #21379

