### PR TITLE
fixes typo on the page "prefer-webp"

### DIFF
--- a/examples/using-gatsby-image/src/pages/prefer-webp.js
+++ b/examples/using-gatsby-image/src/pages/prefer-webp.js
@@ -29,8 +29,7 @@ const PreferWebp = ({ data, location }) => (
       The <strong>WebP</strong> technique is similar to other gatsby-image
       techniques in that it can be applied in image queries with GraphQL. To
       specify that an image should be loaded in the WebP format in supporting
-      browsers, use a fragment with
-      <code>withWebp</code> at the end.
+      browsers, use a fragment with <code>withWebp</code> at the end.
     </p>
     <Img
       fluid={data.fullWidthImage.localFile.childImageSharp.fluid}


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

fixes a missing space between the words "with" and "withWebp" on the page https://using-gatsby-image.gatsbyjs.org/prefer-webp/

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
