### PR TITLE
chores(docs): typo in schema customization

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -461,7 +461,7 @@ out-of-the-box extension, so resolving a field to a default value (instead of
 tag to every blog post:
 
 ```js:title=gatsby-node.js
-exports.createSchemaCustomization = ({ action, schema }) => {
+exports.createSchemaCustomization = ({ actions, schema }) => {
   const { createTypes } = actions
   const typeDefs = [
     "type MarkdownRemark implements Node { frontmatter: Frontmatter }",


### PR DESCRIPTION
## Description

Just a quick fix, ran into this when I was playing around with schema customization and ran the code example.  The example had 'action' but should be 'actions'.