### PR TITLE
refactor(www): remove unused fields from graphql queries

### DIFF
--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -55,11 +55,9 @@ exports.createPages = async ({ graphql, actions }) => {
             released
           }
           frontmatter {
-            title
             draft
             canonicalLink
             publishedAt
-            issue
             tags
             jsdoc
             apiCalls

--- a/www/src/utils/node/starters.js
+++ b/www/src/utils/node/starters.js
@@ -42,7 +42,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
           fields {
             starterShowcase {
               slug
-              stub
             }
             hasScreenshot
           }
@@ -75,7 +74,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       component: slash(starterTemplate),
       context: {
         slug: node.fields.starterShowcase.slug,
-        stub: node.fields.starterShowcase.stub,
       },
     })
   })


### PR DESCRIPTION
It looks like there're a couple of fields in graphql queries we don't use within gatsby-node or in the template component. Having these fields will probably not affect the performance significantly, but it would be good to get rid of them I guess.

Cc: @tesseralis @dvrylc 
 