### PR TITLE
fix(www): replace image url using http:// with https://

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -212,6 +212,8 @@ module.exports = {
           },
           `gatsby-remark-copy-linked-files`,
           `gatsby-remark-smartypants`,
+          // convert images using http to https in plugin library READMEs
+          `gatsby-remark-http-to-https`
         ],
       },
     },

--- a/www/package.json
+++ b/www/package.json
@@ -49,7 +49,7 @@
     "gatsby-remark-copy-linked-files": "^2.1.31",
     "gatsby-remark-embedder": "^1.11.0",
     "gatsby-remark-graphviz": "^1.1.18",
-    "gatsby-remark-http-to-https": "^1.0.1",
+    "gatsby-remark-http-to-https": "^1.0.2",
     "gatsby-remark-images": "^3.1.35",
     "gatsby-remark-normalize-paths": "^1.0.0",
     "gatsby-remark-prismjs": "^3.3.25",

--- a/www/package.json
+++ b/www/package.json
@@ -49,6 +49,7 @@
     "gatsby-remark-copy-linked-files": "^2.1.31",
     "gatsby-remark-embedder": "^1.11.0",
     "gatsby-remark-graphviz": "^1.1.18",
+    "gatsby-remark-http-to-https": "^1.0.0",
     "gatsby-remark-images": "^3.1.35",
     "gatsby-remark-normalize-paths": "^1.0.0",
     "gatsby-remark-prismjs": "^3.3.25",

--- a/www/package.json
+++ b/www/package.json
@@ -49,7 +49,7 @@
     "gatsby-remark-copy-linked-files": "^2.1.31",
     "gatsby-remark-embedder": "^1.11.0",
     "gatsby-remark-graphviz": "^1.1.18",
-    "gatsby-remark-http-to-https": "^1.0.0",
+    "gatsby-remark-http-to-https": "^1.0.1",
     "gatsby-remark-images": "^3.1.35",
     "gatsby-remark-normalize-paths": "^1.0.0",
     "gatsby-remark-prismjs": "^3.3.25",


### PR DESCRIPTION
In plugin library we render content that we don't own and sometimes it will have images using `http://` which cause "mixed content" issues. This enforces usage of `https://` - it might break some images, but they are already broken:

![Screenshot 2020-02-12 at 15 20 35](https://user-images.githubusercontent.com/419821/74343365-3c061780-4dab-11ea-935a-9f32bfeda85c.png)

It's using plugin I authored outside of this repo - https://github.com/pieh/gatsby-remark-http-to-https

What the plugin does - it will change absolute image urls if they contain `http://` to `https://`