### PR TITLE
fix(gatsby-transformer-sqip): properly check for correct input file type

### DIFF
--- a/packages/gatsby-transformer-sqip/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sqip/src/extend-node-type.js
@@ -195,7 +195,7 @@ async function sqipContentful({ type, cache, store }) {
           file: { contentType },
         } = asset
 
-        if (contentType.includes(`image/`)) {
+        if (!contentType.includes(`image/`)) {
           return null
         }
 


### PR DESCRIPTION
I wondered why my projects stopped to output the SQIP generated previews.

This one line change fixes it, as the plugin was just checking the file type in the wrong way.