### PR TITLE
feat(gatsby-cli): Add version output and print summary on build/develop

### DIFF
--- a/packages/gatsby-cli/src/util/version.js
+++ b/packages/gatsby-cli/src/util/version.js
@@ -1,8 +1,12 @@
 const { setDefaultTags } = require(`gatsby-telemetry`)
 const path = require(`path`)
 
+let localGatsbyVersionCache
 exports.getLocalGatsbyVersion = () => {
-  let version
+  if (localGatsbyVersionCache) {
+    return localGatsbyVersionCache
+  }
+
   try {
     const packageInfo = require(path.join(
       process.cwd(),
@@ -10,10 +14,10 @@ exports.getLocalGatsbyVersion = () => {
       `gatsby`,
       `package.json`
     ))
-    version = packageInfo.version
+    localGatsbyVersionCache = packageInfo.version
 
     try {
-      setDefaultTags({ installedGatsbyVersion: version })
+      setDefaultTags({ installedGatsbyVersion: localGatsbyVersionCache })
     } catch (e) {
       // ignore
     }
@@ -21,5 +25,18 @@ exports.getLocalGatsbyVersion = () => {
     /* ignore */
   }
 
-  return version
+  return localGatsbyVersionCache
 }
+
+let currentGatsbyCliVersionCache
+exports.getCurrentCliVersion = () => {
+  if (currentGatsbyCliVersionCache) {
+    return currentGatsbyCliVersionCache
+  }
+
+  const { version } = require(`../../package.json`)
+  currentGatsbyCliVersionCache = version
+  return currentGatsbyCliVersionCache
+}
+
+exports.getCurrentNodeVersion = () => process.version


### PR DESCRIPTION
This updates the `gatsby --version` output to also show the current (executing) nodejs version and the installed sharp version, if any:

```
$ gatsby --version
Current call:
  Gatsby CLI version: 2.8.29
  NodeJS version: v10.18.1
For the site at: ~/gatsby/sites/ifsc-150k
  Gatsby version: 2.19.16-dev-1581506531816
  Sharp version: not installed
```

It also `reporter.info()` a oneliner summary with this information at the start of a `gatsby build` or `gatsby develop`

```
info Using: gatsby-cli@2.8.29, gatsby@2.19.16-dev-1581506531816, sharp@none, nodejs@v10.18.1
```
