### PR TITLE
feat: Change mdx flag into mdxOtherwise to prevent confusion

### DIFF
--- a/packages/gatsby-theme-blog-core/README.md
+++ b/packages/gatsby-theme-blog-core/README.md
@@ -54,12 +54,12 @@ module.exports = {
 
 ### Theme options
 
-| Key           | Default value    | Description                                                                                                                                                                    |
-| ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `basePath`    | `/`              | Root url for all blog posts                                                                                                                                                    |
-| `contentPath` | `content/posts`  | Location of blog posts                                                                                                                                                         |
-| `assetPath`   | `content/assets` | Location of assets                                                                                                                                                             |
-| `mdx`         | `true`           | Configure `gatsby-plugin-mdx`. Note that most sites will not need to use this flag. If your site has already configured `gatsby-plugin-mdx` separately, set this flag `false`. |
+| Key                      | Default value    | Description                                                                      |
+| ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
+| `basePath`               | `/`              | Root url for all blog posts                                                      |
+| `contentPath`            | `content/posts`  | Location of blog posts                                                           |
+| `assetPath`              | `content/assets` | Location of assets                                                               |
+| `mdxOtherwiseConfigured` | `false`          | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site. |
 
 #### Example usage
 

--- a/packages/gatsby-theme-blog-core/gatsby-config.js
+++ b/packages/gatsby-theme-blog-core/gatsby-config.js
@@ -2,7 +2,8 @@ const withDefaults = require(`./utils/default-options`)
 
 module.exports = themeOptions => {
   const options = withDefaults(themeOptions)
-  const { mdxOtherwiseConfigured = false } = themeOptions
+  let { mdxOtherwiseConfigured = false, mdx: legacyConfigureMdxFlag = true } = themeOptions // keep mdx flag so we don't introduce a breaking change
+  
   return {
     siteMetadata: {
       title: `Blog Title Placeholder`,
@@ -20,7 +21,7 @@ module.exports = themeOptions => {
       ],
     },
     plugins: [
-      !mdxOtherwiseConfigured && {
+      (!mdxOtherwiseConfigured && legacyConfigureMdxFlag) && {
         resolve: `gatsby-plugin-mdx`,
         options: {
           extensions: [`.mdx`, `.md`],

--- a/packages/gatsby-theme-blog-core/gatsby-config.js
+++ b/packages/gatsby-theme-blog-core/gatsby-config.js
@@ -2,7 +2,7 @@ const withDefaults = require(`./utils/default-options`)
 
 module.exports = themeOptions => {
   const options = withDefaults(themeOptions)
-  const { mdx = true } = themeOptions
+  const { mdxOtherwiseConfigured = false } = themeOptions
   return {
     siteMetadata: {
       title: `Blog Title Placeholder`,
@@ -20,7 +20,7 @@ module.exports = themeOptions => {
       ],
     },
     plugins: [
-      mdx && {
+      !mdxOtherwiseConfigured && {
         resolve: `gatsby-plugin-mdx`,
         options: {
           extensions: [`.mdx`, `.md`],

--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -56,12 +56,12 @@ module.exports = {
 
 ### Theme options
 
-| Key           | Default value    | Description                                                                                                                                                                    |
-| ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `basePath`    | `/`              | Root url for all blog posts                                                                                                                                                    |
-| `contentPath` | `content/posts`  | Location of blog posts                                                                                                                                                         |
-| `assetPath`   | `content/assets` | Location of assets                                                                                                                                                             |
-| `mdx`         | `true`           | Configure `gatsby-plugin-mdx`. Note that most sites will not need to use this flag. If your site has already configured `gatsby-plugin-mdx` separately, set this flag `false`. |
+| Key                      | Default value    | Description                                                                      |
+| ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
+| `basePath`               | `/`              | Root url for all blog posts                                                      |
+| `contentPath`            | `content/posts`  | Location of blog posts                                                           |
+| `assetPath`              | `content/assets` | Location of assets                                                               |
+| `mdxOtherwiseConfigured` | `false`          | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site. |
 
 #### Example configuration
 

--- a/packages/gatsby-theme-notes/README.md
+++ b/packages/gatsby-theme-notes/README.md
@@ -45,14 +45,17 @@ module.exports = {
 ```
 
 3. Add notes to your site by creating `md` or `mdx` files inside `/content/notes`.
+
    > Note that if you've changed the default `contentPath` in the configuration, you'll want to add your markdown files in the directory specified by that path.
+
+4. Run your site using `gatsby develop` and navigate to your notes. If you used the above configuration, your URL will be `http://localhost:8000/notes`
 
 ### Options
 
-| Key                   | Default value    | Description                                                                                                                                                                    |
-| --------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `basePath`            | `/`              | Root url for all notes pages                                                                                                                                                   |
-| `contentPath`         | `/content/notes` | Location of notes content                                                                                                                                                      |
-| `mdx`                 | `true`           | Configure `gatsby-plugin-mdx`. Note that most sites will not need to use this flag. If your site has already configured `gatsby-plugin-mdx` separately, set this flag `false`. |
-| `homeText`            | `~`              | Root text for notes breadcrumb trail                                                                                                                                           |
-| `breadcrumbSeparator` | `/`              | Separator for the breadcrumb trail                                                                                                                                             |
+| Key                      | Default value    | Description                                                                      |
+| ------------------------ | ---------------- | -------------------------------------------------------------------------------- |
+| `basePath`               | `/`              | Root url for all notes pages                                                     |
+| `contentPath`            | `/content/notes` | Location of notes content                                                        |
+| `mdxOtherwiseConfigured` | `false`          | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site. |
+| `homeText`               | `~`              | Root text for notes breadcrumb trail                                             |
+| `breadcrumbSeparator`    | `/`              | Separator for the breadcrumb trail                                               |

--- a/packages/gatsby-theme-notes/gatsby-config.js
+++ b/packages/gatsby-theme-notes/gatsby-config.js
@@ -1,5 +1,5 @@
 module.exports = options => {
-  const { mdxOtherwiseConfigured = false, mdxLayouts = {} } = options
+  const { mdxOtherwiseConfigured = false, mdx: legacyConfigureMdxFlag = true, mdxLayouts = {} } = options
 
   return {
     siteMetadata: {
@@ -8,7 +8,7 @@ module.exports = options => {
       siteUrl: `http://example.com/`,
     },
     plugins: [
-      !mdxOtherwiseConfigured && {
+      (!mdxOtherwiseConfigured && legacyConfigureMdxFlag) && {
         resolve: `gatsby-plugin-mdx`,
         options: {
           extensions: [`.md`, `.mdx`],

--- a/packages/gatsby-theme-notes/gatsby-config.js
+++ b/packages/gatsby-theme-notes/gatsby-config.js
@@ -1,5 +1,5 @@
 module.exports = options => {
-  const { mdx = true, mdxLayouts = {} } = options
+  const { mdxOtherwiseConfigured = false, mdxLayouts = {} } = options
 
   return {
     siteMetadata: {
@@ -8,7 +8,7 @@ module.exports = options => {
       siteUrl: `http://example.com/`,
     },
     plugins: [
-      mdx && {
+      !mdxOtherwiseConfigured && {
         resolve: `gatsby-plugin-mdx`,
         options: {
           extensions: [`.md`, `.mdx`],


### PR DESCRIPTION
Currently, the `mdx` flag is confusing as a configuration setting. It's meant to prevent multiple plugins from attempting to configure MDX on the same site.

My proposal is to change the key name to `mdxOtherwiseConfigured` and set it to `false` by default. Users can explicitly set it to `true` if they need to and the READMEs reflect that.

The reason I opted for this instead of `configureMdx` with a default to `true` is that users who anticipate only using `.md` files may misunderstand the flag. This implementation should prevent that confusion.