### PR TITLE
refactor(www): Split docs and blog MDX queries

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -213,7 +213,7 @@ module.exports = {
           `gatsby-remark-copy-linked-files`,
           `gatsby-remark-smartypants`,
           // convert images using http to https in plugin library READMEs
-          `gatsby-remark-http-to-https`
+          `gatsby-remark-http-to-https`,
         ],
       },
     },
@@ -271,7 +271,10 @@ module.exports = {
                 allMdx(
                   sort: { order: DESC, fields: [frontmatter___date] }
                   limit: 10,
-                  filter: { fields: { section: { eq: "blog" }, draft: { ne: true } } }
+                  filter: {
+                    fields: { section: { eq: "blog" } }
+                    frontmatter: { draft: { ne: true } }
+                  }
                 ) {
                   edges {
                     node {

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -269,10 +269,7 @@ module.exports = {
                 allMdx(
                   sort: { order: DESC, fields: [frontmatter___date] }
                   limit: 10,
-                  filter: {
-                    frontmatter: { draft: { ne: true } }
-                    fileAbsolutePath: { regex: "/docs.blog/" }
-                  }
+                  filter: { fields: { section: { eq: "blog" }, draft: { ne: true } } }
                 ) {
                   edges {
                     node {

--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -14,7 +14,11 @@ import Container from "../../components/container"
 import SearchIcon from "../../components/search-icon"
 import { TAGS_AND_DOCS } from "../../data/tags-docs"
 import { themedInput } from "../../utils/styles"
-import { colors, space, mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
+import {
+  colors,
+  space,
+  mediaQueries,
+} from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
 const POPULAR_TAGS = [
   `themes`,
@@ -222,10 +226,7 @@ export const pageQuery = graphql`
   query {
     allMdx(
       limit: 2000
-      filter: {
-        fields: { released: { eq: true } }
-        fileAbsolutePath: { regex: "/docs.blog/" }
-      }
+      filter: { fields: { section: { eq: "blog" }, released: { eq: true } } }
     ) {
       group(field: frontmatter___tags) {
         fieldValue

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -165,8 +165,7 @@ export const pageQuery = graphql`
       limit: 4
       filter: {
         frontmatter: { draft: { ne: true } }
-        fileAbsolutePath: { regex: "/docs.blog/" }
-        fields: { released: { eq: true } }
+        fields: { section: { eq: "blog" }, released: { eq: true } }
       }
     ) {
       edges {

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -86,8 +86,7 @@ export const pageQuery = graphql`
       sort: { fields: [frontmatter___date, fields___slug], order: DESC }
       filter: {
         frontmatter: { tags: { in: $tags } }
-        fileAbsolutePath: { regex: "/docs.blog/" }
-        fields: { released: { eq: true } }
+        fields: { section: { eq: "blog" }, released: { eq: true } }
       }
     ) {
       totalCount

--- a/www/src/templates/template-blog-list.js
+++ b/www/src/templates/template-blog-list.js
@@ -105,8 +105,7 @@ export const pageQuery = graphql`
       sort: { order: DESC, fields: [frontmatter___date, fields___slug] }
       filter: {
         frontmatter: { draft: { ne: true } }
-        fileAbsolutePath: { regex: "/docs.blog/" }
-        fields: { released: { eq: true } }
+        fields: { section: { eq: "blog" }, released: { eq: true } }
       }
       limit: $limit
       skip: $skip

--- a/www/src/templates/template-contributor-page.js
+++ b/www/src/templates/template-contributor-page.js
@@ -114,8 +114,7 @@ export const pageQuery = graphql`
     allMdx(
       sort: { order: DESC, fields: [frontmatter___date, fields___slug] }
       filter: {
-        fields: { released: { eq: true } }
-        fileAbsolutePath: { regex: "/blog/" }
+        fields: { section: { eq: "blog" }, released: { eq: true } }
         frontmatter: { draft: { ne: true } }
       }
     ) {


### PR DESCRIPTION
## Description

Part 1 of 2

* Add a `section` field to MDX nodes labelling them as docs or blog or package readme
* Split up the `allMdx` queries in gatsby-node
* Change blog queries to use section instead of regexes

Next steps:

* Split up blog related functions to a new file
* maybe create a new node type?

## Related Issues

Addresses: #21323 