### PR TITLE
fix(gatsby-source-contentful): Remove whitespace from default long text value

### DIFF
--- a/docs/contributing/how-to-file-an-issue.md
+++ b/docs/contributing/how-to-file-an-issue.md
@@ -18,7 +18,7 @@ Please do not use the issue tracker for personal support requests. [Stack Overfl
 If an issue is affecting you, start at the top of this list and complete as many tasks on the list as you can:
 
 1.  If there is an issue, add a reaction or more details to the issue to indicate that it's affecting you
-2.  If there is an issue and you can add more detail, write a comment describing how the bug is affecting OR if you can, write up a work-around for the bug
-3.  If there _is not_ an issue, write the most complete description of what's happening, preferably with link to a Gatsby site that reproduces the problem or [create a reproducible test case](/contributing/how-to-make-a-reproducible-test-case/)
+2.  If there is an issue and you can add more detail, write a comment describing how the bug is affecting you, OR if you can, write up a work-around for the bug
+3.  If there _is not_ an issue, write the most complete description of what's happening, preferably with a link to a Gatsby site that reproduces the problem or [create a reproducible test case](/contributing/how-to-make-a-reproducible-test-case/)
 4.  Offer to help fix the bug (and it is totally expected that you ask for help; open-source maintainers want to help contributors)
 5.  [Deliver a well-crafted, tested PR](/contributing/how-to-open-a-pull-request/)

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -221,7 +221,7 @@ exports.buildForeignReferenceMap = ({
 }
 
 function prepareTextNode(node, key, text, createNodeId) {
-  const str = _.isString(text) ? text : ` `
+  const str = _.isString(text) ? text : ``
   const textNode = {
     id: createNodeId(`${node.id}${key}TextNode`),
     parent: node.id,


### PR DESCRIPTION
## Description

As described in the linked issue, currently when querying an empty "long text" field with the `gatsby-source-contentful` package, a string with a single whitespace character is returned. It seems this whitespace serves no purpose and makes falsy checks unintuitive and overcomplicated. This PR simply removes the unnecessary whitespace.

## Related Issues

Fixes #20579