### PR TITLE
fix(gatsby-source-contentful): Remove whitespace from default long text value

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -221,7 +221,7 @@ exports.buildForeignReferenceMap = ({
 }
 
 function prepareTextNode(node, key, text, createNodeId) {
-  const str = _.isString(text) ? text : ` `
+  const str = _.isString(text) ? text : ``
   const textNode = {
     id: createNodeId(`${node.id}${key}TextNode`),
     parent: node.id,


### PR DESCRIPTION
## Description

As described in the linked issue, currently when querying an empty "long text" field with the `gatsby-source-contentful` package, a string with a single whitespace character is returned. It seems this whitespace serves no purpose and makes falsy checks unintuitive and overcomplicated. This PR simply removes the unnecessary whitespace.

## Related Issues

Fixes #20579