### PR TITLE
Moving Documentation Order To Match File Structure

### DIFF
--- a/docs/docs/gatsby-project-structure.md
+++ b/docs/docs/gatsby-project-structure.md
@@ -24,9 +24,9 @@ Inside a Gatsby project, you may see some or all of the following folders and fi
 
 - **`/.cache`** _Automatically generated._ This folder is an internal cache created automatically by Gatsby. The files inside this folder are not meant for modification. Should be added to the `.gitignore` file if not added already.
 
-- **`/public`** _Automatically generated._ The output of the build process will be exposed inside this folder. Should be added to the `.gitignore` file if not added already.
-
 - **`/plugins`** This folder hosts any project-specific ("local") plugins that aren't published as an `npm` package. Check out the [plugin docs](/docs/plugins/) for more detail.
+
+- **`/public`** _Automatically generated._ The output of the build process will be exposed inside this folder. Should be added to the `.gitignore` file if not added already.
 
 - **`/src`** This directory will contain all of the code related to what you will see on the frontend of your site (what you see in the browser), like your site header, or a page template. “Src” is a convention for “source code”.
 


### PR DESCRIPTION
### Description

Fixes documentation order to match the file structure talked about in the doc

### Documentation

This is a documentation PR already

## Related Issues

N/A
