### PR TITLE
fix: Routing docs - location data code example typo

### DIFF
--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -41,7 +41,7 @@ Through client-side routing in Gatsby you can provide a location object instead 
 <Link
   to={'/somepagecomponent'}
   state={{modal: true}}
-}}>
+/>
 ```
 
 Then from the receiving component you can conditionally render markup based on the `location` state.


### PR DESCRIPTION
### Description

Under '[Example of providing state to a link component](https://www.gatsbyjs.org/docs/location-data-from-props/#example-of-providing-state-to-a-link-component)', closing link bracket showed <Link ... }}> instead of <Link ... />.

### Documentation

Can be found in "Routing" section in docs under "[Location Data from Props](https://www.gatsbyjs.org/docs/location-data-from-props/)". 