### PR TITLE
chore(gatsby-design-tokens): Manually fix CHANGELOG

### DIFF
--- a/packages/gatsby-design-tokens/CHANGELOG.md
+++ b/packages/gatsby-design-tokens/CHANGELOG.md
@@ -7,11 +7,126 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package gatsby-design-tokens
 
+### Bug Fixes
+
+- fix(gatsby-design-tokens): Fix `files` field in `package.json`: `dist` now includes `index.esm.js` and the two `dist/theme`s; before it only offered the main CommonJS module ([8c0d55c](https://github.com/gatsbyjs/gatsby/commit/8c0d55c))
+
 # [2.0.0](https://github.com/gatsbyjs/gatsby/compare/gatsby-design-tokens@1.0.10...gatsby-design-tokens@2.0.0) (2020-02-10)
 
 ### Features
 
 - **gatsby-design-tokens:** v2 ([#21240](https://github.com/gatsbyjs/gatsby/issues/21240)) ([f754fc2](https://github.com/gatsbyjs/gatsby/commit/f754fc2))
+
+#### Tokens
+
+This update moves the rudimentary tokens even closer to our current sole target, CSS. This e.g. means that instead of exporting an array of integers for `fontSizes` or `space`, we now provide `rem` values instead (while still making the v1 variants available — but we do have "soft" preferences irt default units for CSS, which are emphasized by these breaking changes).  
+We currently only consume these tokens in the context of CSS, so let's make things a bit easier there:
+
+- `fontsSizes` exports `rem` values now; old values available at `fontSizesRaw`
+- `space` exports `rem` values now, too; old stuff available at `spaceRaw`
+- `fonts` exports a string now, ready to be used with the `font-family` CSS prop; old array of font family names available as `fontsLists`
+- `radii` now contains the `px` unit
+
+The update also embraces `theme-ui` a bit more directly by partially adopting and/or inheriting its naming conventions for a bunch of tokens, making "theme composition using token groups" even easier than before.
+
+Regarding the discussion in https://github.com/gatsby-inc/gatsby-interface/issues/181, everything but the `space` scale has been adjusted to hopefully "just work", or work easier than before. The update to v2 of `gatsby-design-tokens` should require almost no refactoring of values in `gatsby-interface` —
+
+- the `transition` properties partially follow a different naming convention
+- `fonts.header` changed to `fonts.headling`
+- `radii` values now come with the `px` unit, so the latter is not needed anymore in template literals
+
+— and apart from that should be solved by removing the transformation of `fontSizes` and `spaces` `to`rem`, and the`join`of`fonts` stacks. (cc @amberleyromo @greglobinski @Elanhant — please also see the "Infamous last words" section at the end).
+
+Here's all changes listed by "token group":
+
+##### `breakpoints`
+
+- BREAKING CHANGE: Remove `breakpoints.xxs`
+  - All tokens started as only being consumed via `styled-system`. In its context, and using an object to define breakpoints, `breakpoints.xxs` made sense/was required. Since we switched to `theme-ui`, it doesn't anymore. `gatsby-interface` defines its own set of `breakpoints`; the `www` source already adjusted this when composing its `theme-ui`theme, so this shouldn't hurt at all.
+- feat: add export `breakpointsArray`, ready for `theme-ui`'s [responsive styles](https://theme-ui.com/getting-started/#responsive-styles) feature
+
+##### `colors`
+
+- feat: add missing steps in `colors.blackFade` and `colors.whiteFade`:
+  - add `colors.blackFade[90]`
+  - add `colors.blackFade[40]`
+  - add `colors.blackFade[20]`
+  - add `colors.blackFade[5]`
+  - add `colors.whiteFade[90]`
+  - add `colors.whiteFade[40]`
+  - add `colors.whiteFade[20]`
+  - add `colors.whiteFade[5]`
+- BREAKING CHANGE: fix `colors.blackFade[80]`, `colors.whiteFade[80]`
+  - both were set to an opacity of `.85`, adjusted to `.8`
+  - TODO: Adjust a couple of values for gatsbyjs.org; no clue about where we currently might use this in `gatsby-interface` and related (.com/Cloud dashboard).
+- feat: port `colors.code` from the gatsbyjs.org `theme-ui` theme to the `colors` tokens
+  - 💚 This improves compliance with WCAG 2.0 AA color contrasts.
+- feat: add `colors.code.copyButton`
+- feat: add `colors.code.lineHighlightBackground`
+- feat: add `colors.code.scrollbarTrack`
+
+##### `fonts`
+
+- feat: Add aliases `body` and `sans` for `fonts.system`
+- BREAKING CHANGE: rename `fonts.header` to `fonts.heading`
+  - Comply with `theme-ui` requirements: https://theme-ui.com/theme-spec#typography.
+- feat: Add alias `brand` for `fonts.heading`
+- BREAKING CHANGE: `fonts` exports a string now, ready to be used with the `font-family` CSS prop; the array of font family names is still available as `fontsLists`
+
+##### `fontSizes`
+
+- BREAKING CHANGE: `fontSizes` does now contain `rem` values; old scale (integers) still available as `fontSizesRaw`
+- feat: add export `fontSizesPx`
+
+##### `fontWeights`
+
+- BREAKING CHANGE: Name `fontWeights` — switch from array to object
+  - Include the required theme-ui defaults `body`, `heading`, and `bold` (https://theme-ui.com/theme-spec#typography).
+  - `body: 400`
+  - `semiBold: 600`
+  - `bold: 700`
+  - `heading: 700`
+  - `extraBold: 800`
+
+##### `lineHeights`
+
+- feat: Add line heights `heading` (equivalent to the existing `dense`) and `body` (equivalent to the existing `default`) to satisfy `theme-ui`'s ["Typography" theme requirements](https://theme-ui.com/theme-spec/#typography)
+
+##### `radii`
+
+- BREAKING CHANGE: Add `px` unit to radii scale values.
+
+##### `sizes`
+
+- BREAKING CHANGE: removed
+  - As discussed in https://github.com/gatsby-inc/gatsby-interface/issues/181, this moves the current gatsbyjs.org-centric `sizes` tokens to `theme-gatsbyjs-org` for clarity, until a clear pattern emerges.
+
+##### `space`
+
+- BREAKING CHANGE: `space` does now contain `rem` values; old scale (integers) still available as `spaceRaw`
+- feat: add export `spacePx`
+
+##### `transition`
+
+- feat: Add `transition.default` shortcut
+- feat: Add `transition.curve.fastOutLinearIn` from `gatsby-interface`
+- feat: Add `transition.speed.faster` (`50ms`), matching `gatsby-interface`'s `blink`
+- feat: Add `transition.speed.slower` (`1000ms`), matching `gatsby-interface`'s `snail`
+- BREAKING CHANGE: change `transition.speed.slow` from `350ms` to `500ms`, now matching `gatsby-interface`
+
+##### `zIndices`
+
+- BREAKING CHANGE: removed
+  - As discussed in https://github.com/gatsby-inc/gatsby-interface/issues/181, this moves the current gatsbyjs.org-centric `zIndices` tokens to `theme-gatsbyjs-org`for clarity, until a clear pattern emerges.
+
+#### Themes
+
+- feat: add base `theme-ui` Gatsby theme, gatsbyjs.org `theme-ui` theme
+  - Both themes don't tree-shake yet, so no `agadoo` yet in the corresponding `gatsby-design-tokens/package.json` scripts.
+  - Both export the `theme-ui` theme as `theme` and also provide individual token group exports (because we require them in `www` for usage outside of the `theme-ui` context).
+  - Example usage:
+    - `export { theme as default } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"` in `www/src/gatsby-plugin-theme-ui/index`
+    - Directly import individual token groups with `import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"`.
 
 ## [1.0.10](https://github.com/gatsbyjs/gatsby/compare/gatsby-design-tokens@1.0.9...gatsby-design-tokens@1.0.10) (2019-10-14)
 

--- a/packages/gatsby-design-tokens/CHANGELOG.md
+++ b/packages/gatsby-design-tokens/CHANGELOG.md
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 #### Tokens
 
-This update moves the rudimentary tokens even closer to our current sole target, CSS. This e.g. means that instead of exporting an array of integers for `fontSizes` or `space`, we now provide `rem` values instead (while still making the v1 variants available — but we do have "soft" preferences irt default units for CSS, which are emphasized by these breaking changes).  
+This update moves the rudimentary tokens even closer to our current sole target, CSS. This e.g. means that instead of exporting an array of integers for `fontSizes` or `space`, we now provide `rem` values instead (while still making the v1 variants available — but we do have "soft" preferences regarding default units for CSS, which are emphasized by these breaking changes).  
 We currently only consume these tokens in the context of CSS, so let's make things a bit easier there:
 
 - `fontsSizes` exports `rem` values now; old values available at `fontSizesRaw`
@@ -32,10 +32,10 @@ The update also embraces `theme-ui` a bit more directly by partially adopting an
 Regarding the discussion in https://github.com/gatsby-inc/gatsby-interface/issues/181, everything but the `space` scale has been adjusted to hopefully "just work", or work easier than before. The update to v2 of `gatsby-design-tokens` should require almost no refactoring of values in `gatsby-interface` —
 
 - the `transition` properties partially follow a different naming convention
-- `fonts.header` changed to `fonts.headling`
+- `fonts.header` changed to `fonts.heading`
 - `radii` values now come with the `px` unit, so the latter is not needed anymore in template literals
 
-— and apart from that should be solved by removing the transformation of `fontSizes` and `spaces` `to`rem`, and the`join`of`fonts` stacks. (cc @amberleyromo @greglobinski @Elanhant — please also see the "Infamous last words" section at the end).
+— and apart from that should be solved by removing the transformation of `fontSizes` and `spaces` `to`rem`, and the`join`of`fonts` stacks.
 
 Here's all changes listed by "token group":
 


### PR DESCRIPTION
Manually fix the `gatsby-design-tokens` 2.0.0 changelog, and add a description for the 2.0.1 bugfix release.

@sidharthachatterjee 