### PR TITLE
fix(gatsby-plugin-benchmark-reporter): Do not rely on env for js size

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -85,8 +85,9 @@ class BenchMeta {
 
     const webpackVersion = execToStr(`node_modules/.bin/webpack --version`)
 
-    const publicJsSize = execToInt(
-      `echo "0 $(find public -maxdepth 1 -iname "*.js" -printf " + %s")" | bc`
+    const publicJsSize = glob(`public/*.js`).reduce(
+      (t, file) => t + fs.statSync(file).size,
+      0
     )
 
     const jpgCount = execToInt(


### PR DESCRIPTION
This fixes an error in the container environment where this is intended to run, which does not have `bc`.