### PR TITLE
Ensure markdown (remark) image urls include pathPrefix

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -197,7 +197,7 @@ module.exports = (
 
       if (basePath) {
         // Ensure relative links include `pathPrefix`
-        visit(markdownAST, [`link`, `definition`], node => {
+        visit(markdownAST, [`link`, `definition`, `image`], node => {
           if (
             node.url &&
             node.url.startsWith(`/`) &&


### PR DESCRIPTION
## Description

We have a website built with Gatsby that can be hosted in a number of sub-directories. We found that using `pathPrefix` works for every link but was not prefixing image URLs written in markdown (resulting in 404 errors because the images exist in the sub-directory, not the root).

It looks like the `gatsby-transformer-remark` plugin was not including images in the logic that ensures a `pathPrefix`. Adding the image to that check fixes the problem for us.

`gatsby@2.19.7`
`gatsby-transformer-remark@2.6.51`

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

Fixes #8479
Fixes #14067
