### PR TITLE
fix:(gatsby-transformer-remark) Add utils to .gitignore

### DIFF
--- a/packages/gatsby-transformer-remark/.gitignore
+++ b/packages/gatsby-transformer-remark/.gitignore
@@ -1,2 +1,3 @@
 /*.js
 !index.js
+utils


### PR DESCRIPTION
## Description

A very minor change to `.gitignore`. Added `utils` folder (it is built now after #21312)

### Documentation

## Related Issues
