### PR TITLE
fix(www): Fix Gatsby Showcase Details View

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -97,7 +97,6 @@ function usePrevAndNextSite(item) {
     query {
       allSitesYaml(
         filter: {
-          featured: { eq: true }
           main_url: { ne: null }
           fields: { hasScreenshot: { eq: true } }
         }


### PR DESCRIPTION
When you go to [Gatsby Showcase](https://www.gatsbyjs.org/showcase/) and click on a site that is not a featured one (e.g. https://www.gatsbyjs.org/showcase/www.ventura-digital.de), the page is broken -- it doesn't show anything. Turns out we're querying data only for featured sites and it's breaking the details view for other sites. This PR removes the filter to get only featured sites from the query and everything looks to be working fine.

**Before:**

![gatsby-showcase-before](https://user-images.githubusercontent.com/450559/74521982-545b6b00-4f40-11ea-9828-a4209c8eaeea.gif)


**After:**

![gatsby-showcase-after](https://user-images.githubusercontent.com/450559/74521440-6b4d8d80-4f3f-11ea-8f73-41189f43561c.gif)


