### PR TITLE
Add policy for gatsby cloud references in OSS

### DIFF
--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -404,6 +404,17 @@ wording.
 
 ## Best practices
 
+### Referencing Gatsby Cloud
+
+While Gatsby Cloud is hosted on a separate site [gatsbyjs.com](https://www.gatsbyjs.com/), it is part of the Gatsby [founding organization](/blog/2018-05-24-launching-new-gatsby-company/) and focused specifically on Gatsby sites. There are various parts of the OSS documentation that may benefit from pointing to Gatsby Cloud as a potential platform to explore.
+
+The guidelines for doing so are as follows:
+
+- If possible, Gatsby Cloud should be accompanied by other relevant technologies
+- If Gatsby Cloud does something by default, the docs should still include instructions for accessing that functionality manually
+
+The spirit of these guidelines is to ensure that users are aware of multiple options for running their Gatsby site. However, the open source documentation should preclude assumptions about technology choices other than gatsby-cli.
+
 ### Support software versions
 
 When Gatsby commits to support a specific version of software (e.g. Node 8 and up), this is reflected in documentation. Gatsby documentation should be usable by all people on supported software, which means we don't introduce any commands or practices that can't be used by people on versions we've committed to support. In rare circumstances, we'll consider mentioning a newly introduced command or practice as side notes.

--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -413,7 +413,7 @@ The guidelines for doing so are as follows:
 - If possible, Gatsby Cloud should be accompanied by other relevant technologies
 - If Gatsby Cloud does something by default, the docs should still include instructions for accessing that functionality manually
 
-The spirit of these guidelines is to ensure that users are aware of multiple options for running their Gatsby site. With the exception of gatsby-cli, the open source documentation should generally preclude assumptions about technology choices.
+The spirit of these guidelines is to ensure that users are aware of multiple options for running their Gatsby site. With the exception of `gatsby-cli`, the open-source documentation should generally preclude assumptions about technology choices.
 
 ### Support software versions
 

--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -413,7 +413,7 @@ The guidelines for doing so are as follows:
 - If possible, Gatsby Cloud should be accompanied by other relevant technologies
 - If Gatsby Cloud does something by default, the docs should still include instructions for accessing that functionality manually
 
-The spirit of these guidelines is to ensure that users are aware of multiple options for running their Gatsby site. With the exception of `gatsby-cli`, the open-source documentation should generally preclude assumptions about technology choices.
+The spirit of these guidelines is to ensure that users are aware of multiple options for running their Gatsby site. With the exception of `gatsby-cli`, the open source documentation should generally preclude assumptions about technology choices.
 
 ### Support software versions
 

--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -410,8 +410,8 @@ While Gatsby Cloud is hosted on a separate site, [gatsbyjs.com](https://www.gats
 
 The guidelines for doing so are as follows:
 
-- If possible, Gatsby Cloud should be accompanied by other relevant technologies
-- If Gatsby Cloud does something by default, the docs should still include instructions for accessing that functionality manually
+- If possible, Gatsby Cloud should be accompanied by other relevant technologies.
+- If Gatsby Cloud does something by default, the docs should still include instructions for accessing that functionality manually.
 
 The spirit of these guidelines is to ensure that users are aware of multiple options for running their Gatsby site. With the exception of `gatsby-cli`, the open source documentation should generally preclude assumptions about technology choices.
 

--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -413,7 +413,7 @@ The guidelines for doing so are as follows:
 - If possible, Gatsby Cloud should be accompanied by other relevant technologies
 - If Gatsby Cloud does something by default, the docs should still include instructions for accessing that functionality manually
 
-The spirit of these guidelines is to ensure that users are aware of multiple options for running their Gatsby site. However, the open source documentation should preclude assumptions about technology choices other than gatsby-cli.
+The spirit of these guidelines is to ensure that users are aware of multiple options for running their Gatsby site. With the exception of gatsby-cli, the open source documentation should generally preclude assumptions about technology choices.
 
 ### Support software versions
 

--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -406,7 +406,7 @@ wording.
 
 ### Referencing Gatsby Cloud
 
-While Gatsby Cloud is hosted on a separate site [gatsbyjs.com](https://www.gatsbyjs.com/), it is part of the Gatsby [founding organization](/blog/2018-05-24-launching-new-gatsby-company/) and focused specifically on Gatsby sites. There are various parts of the OSS documentation that may benefit from pointing to Gatsby Cloud as a potential platform to explore.
+While Gatsby Cloud is hosted on a separate site, [gatsbyjs.com](https://www.gatsbyjs.com/), it is part of the Gatsby [founding organization](/blog/2018-05-24-launching-new-gatsby-company/) and focused specifically on Gatsby sites. There are various parts of the OSS documentation that may benefit from pointing to Gatsby Cloud as a potential platform to explore.
 
 The guidelines for doing so are as follows:
 


### PR DESCRIPTION
This PR introduces a policy in the contributing docs of .org for referencing and pointing to Gatsby Cloud uses.

With this set we can begin to add Gatsby Cloud as a technology solution in the OSS docs.