### PR TITLE
fix(gatsby-source-contentful): Don’t crash when GATSBY_CONTENTFUL_OFFLINE and downloadLocal are used

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -49,9 +49,18 @@ exports.sourceNodes = async (
     process.env.GATSBY_CONTENTFUL_OFFLINE === `true` &&
     process.env.NODE_ENV !== `production`
   ) {
-    getNodes()
-      .filter(n => n.internal.owner === `gatsby-source-contentful`)
-      .forEach(n => touchNode({ nodeId: n.id }))
+    let contentfulNodes = getNodes().filter(
+      n => n.internal.owner === `gatsby-source-contentful`
+    )
+    contentfulNodes.forEach(n =>
+      touchNode({
+        nodeId: n.id,
+      })
+    )
+    contentfulNodes
+      .map(n => n.localFile___NODE)
+      .filter(id => id)
+      .forEach(id => touchNode({ nodeId: id }))
 
     console.log(`Using Contentful Offline cache ⚠️`)
     console.log(

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -49,18 +49,16 @@ exports.sourceNodes = async (
     process.env.GATSBY_CONTENTFUL_OFFLINE === `true` &&
     process.env.NODE_ENV !== `production`
   ) {
-    let contentfulNodes = getNodes().filter(
-      n => n.internal.owner === `gatsby-source-contentful`
-    )
-    contentfulNodes.forEach(n =>
-      touchNode({
-        nodeId: n.id,
-      })
-    )
-    contentfulNodes
-      .map(n => n.localFile___NODE)
-      .filter(id => id)
-      .forEach(id => touchNode({ nodeId: id }))
+    getNodes().forEach(node => {
+      if (node.internal.owner !== `gatsby-source-contentful`) {
+        return
+      }
+      touchNode({ nodeId: node.id })
+      if (node.localFile___NODE) {
+        // Prevent GraphQL type inference from crashing on this property
+        touchNode({ nodeId: node.localFile___NODE })
+      }
+    })
 
     console.log(`Using Contentful Offline cache ⚠️`)
     console.log(


### PR DESCRIPTION
## Description

This touches the `gatsby-source-contentful` nodes indicated by the `localFile___NODE` identifier, so that in `GATSBY_CONTENTFUL_OFFLINE` mode, startup does not crash on attempting to infer GraphQL types for these files (see #21463).

### Tests?

I haven't yet added any tests - partly because I haven't found any for the rest of this file, and partly because I just wanted to validate this fix. Open to suggestions here on how other parts of the codebase are testing this *kind* of change.

### Further explanation, continued from the linked issue

In debugging, I found that in `gatsby-source-contentful/src/gatsby-node.js`, the `getNodes()` collection (called [here](https://github.com/gatsbyjs/gatsby/blob/f8b02b859fcc33d223f258349a2c42697773e939/packages/gatsby-source-contentful/src/gatsby-node.js#L52)) included the relevant nodes that went missing by the time the startup crash happened due to `gatsby/src/schema/infer/add-inferred-fields.js` looking for them (like [this](https://github.com/gatsbyjs/gatsby/blob/f8b02b859fcc33d223f258349a2c42697773e939/packages/gatsby/src/schema/infer/add-inferred-fields.js#L264)).

In looking closer at the code paths, I noticed [this `touchNode` stuff](https://github.com/gatsbyjs/gatsby/blob/f8b02b859fcc33d223f258349a2c42697773e939/packages/gatsby-source-contentful/src/gatsby-node.js#L52-L54), `gatsby-source-contentful/src/gatsby-node.js`, that seemed relevant.

And sure enough, what seems to be working locally for me is to apply something like this, to *also* `touchNode` on the nodes referenced by these `localFile___NODE` bits that got set by `packages/gatsby-source-contentful/src/download-contentful-assets.js`.

### Documentation

N/A, not a new feature, this is a bug fix.

## Related Issues

#21463
