### PR TITLE
fix(docs): fix obsolete redirects of themes/getting-started

### DIFF
--- a/www/redirects.yaml
+++ b/www/redirects.yaml
@@ -102,8 +102,6 @@
   toPath: /docs/gatsby-internals/
 - fromPath: /docs/behind-the-scenes-terminology/
   toPath: /docs/gatsby-internals-terminology/
-- fromPath: /docs/themes/getting-started
-  toPath: /docs/themes/using-a-gatsby-theme
 - fromPath: /docs/themes/introduction
   toPath: /docs/themes/what-are-gatsby-themes
 - fromPath: /docs/hosting-on-netlify/


### PR DESCRIPTION

## Description

different pages are shown with and without trailing slashes

- no redirect:
`https://www.gatsbyjs.org/docs/themes/getting-started/` ([link](https://www.gatsbyjs.org/docs/themes/getting-started/))
it is a valid page

- redirect:
from: `https://www.gatsbyjs.org/docs/themes/getting-started` ([link](https://www.gatsbyjs.org/docs/themes/getting-started))
to: `https://www.gatsbyjs.org/docs/themes/using-a-gatsby-theme/`


## Related Issues

- fixes #21480 `chore(docs): obsolete redirects of themes/getting-started`