### PR TITLE
Update doc, missing line in example code

### DIFF
--- a/docs/docs/testing-components-with-graphql.md
+++ b/docs/docs/testing-components-with-graphql.md
@@ -141,6 +141,7 @@ you will be defining it directly inside your test file:
 ```js:title=src/pages/__tests__/index.js
 import React from "react"
 import renderer from "react-test-renderer"
+import { StaticQuery } from "gatsby"
 import Index from "../index"
 
 beforeEach(() => {


### PR DESCRIPTION
Missing line in example code: import { StaticQuery } from "gatsby"

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I added a missing line to the example code.
```import { StaticQuery } from "gatsby"```

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
