### PR TITLE
[gatsby-plugin-mdx] Add support for file argument in remark plugins

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-page.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-page.js
@@ -14,7 +14,10 @@ module.exports = async ({ page, actions }, pluginOptions) => {
   // we're trying to insert and if we don't check we can end up in infinite loops
   if (extensions.includes(ext) && !page.context.frontmatter) {
     const content = await fs.readFile(page.component, `utf8`)
-    const code = await mdx(content, options)
+    const code = await mdx(content, {
+      filepath: page.component,
+      ...options,
+    })
 
     // grab the exported frontmatter
     const { frontmatter } = extractExports(code)

--- a/packages/gatsby-plugin-mdx/gatsby/preprocess-source.js
+++ b/packages/gatsby-plugin-mdx/gatsby/preprocess-source.js
@@ -10,7 +10,10 @@ module.exports = async function preprocessSource(
   const ext = path.extname(filename)
 
   if (extensions.includes(ext)) {
-    const code = await mdx(contents, options)
+    const code = await mdx(contents, {
+      filepath: filename,
+      ...options,
+    })
     return code
   }
   return null

--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -122,6 +122,7 @@ export const _frontmatter = ${JSON.stringify(data)}`
 
   debug(`running mdx`)
   let code = await mdx(content, {
+    filepath: node.fileAbsolutePath,
     ...options,
     remarkPlugins: options.remarkPlugins.concat(
       gatsbyRemarkPluginsAsremarkPlugins


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Currently the `remarkPlugins` field in `gatsby-plugin-mdx` doesn't support using plugins with the second argument `file`. This PR add support by passing [`filepath`](https://github.com/mdx-js/mdx/blob/790d8e3fa86221482f42419eb8458ebc8747f966/packages/mdx/index.js#L106-L108) in mdx. Results in creating a `vfile` instance when applying mdx.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

N/A

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

N/A