### PR TITLE
Fix missing <FooterLinks> from gatsby.org pages

### DIFF
--- a/www/src/pages/blog/tags.js
+++ b/www/src/pages/blog/tags.js
@@ -12,6 +12,7 @@ import Button from "../../components/button"
 import Layout from "../../components/layout"
 import Container from "../../components/container"
 import SearchIcon from "../../components/search-icon"
+import FooterLinks from "../../components/shared/footer-links"
 import { TAGS_AND_DOCS } from "../../data/tags-docs"
 import { themedInput } from "../../utils/styles"
 import { colors, space, mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
@@ -211,6 +212,7 @@ class TagsPage extends React.Component {
             </ul>
           </div>
         </Container>
+        <FooterLinks />
       </Layout>
     )
   }

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -10,6 +10,7 @@ import BlogPostPreviewItem from "../components/blog-post-preview-item"
 import Button from "../components/button"
 import Container from "../components/container"
 import Layout from "../components/layout"
+import FooterLinks from "../components/shared/footer-links"
 import { TAGS_AND_DOCS } from "../data/tags-docs"
 
 // Select first tag with whitespace instead of hyphens for
@@ -73,6 +74,7 @@ const Tags = ({ pageContext, data, location }) => {
           />
         ))}
       </Container>
+      <FooterLinks />
     </Layout>
   )
 }

--- a/www/src/views/creators/index.js
+++ b/www/src/views/creators/index.js
@@ -3,6 +3,7 @@ import { jsx } from "theme-ui"
 import { Component } from "react"
 import { Helmet } from "react-helmet"
 import Layout from "../../components/layout"
+import FooterLinks from "../../components/shared/footer-links"
 import CreatorsHeader from "./creators-header"
 import Badge from "./badge"
 import GithubIcon from "react-icons/lib/go/mark-github"
@@ -182,6 +183,7 @@ class CreatorsView extends Component {
             {creators.length && <EmptyGridItems styles={styles.creatorCard} />}
           </div>
         </main>
+        <FooterLinks />
       </Layout>
     )
   }


### PR DESCRIPTION
## Description

Add missing footer links to the following pages/templates

- https://gatsbyjs.org/blog/tags
- https://www.gatsbyjs.org/blog/tags/themes (and other tag pages)
- https://www.gatsbyjs.org/creators/


## Related Issues
https://github.com/gatsbyjs/gatsby/issues/21482
