### PR TITLE
fix(www): Fixes broken UI on home page of gatsbyjs.org in landscape orientation

### DIFF
--- a/www/src/components/homepage/homepage-ecosystem.js
+++ b/www/src/components/homepage/homepage-ecosystem.js
@@ -36,6 +36,7 @@ const Section = styled(EcosystemSection)`
   ${mediaQueries.md} {
     margin: 0 ${p => p.theme.space[2]} 0;
     padding: ${p => p.theme.space[6]};
+    max-height: nonel
 
     :last-child {
       align-self: stretch;

--- a/www/src/components/homepage/homepage-ecosystem.js
+++ b/www/src/components/homepage/homepage-ecosystem.js
@@ -36,7 +36,7 @@ const Section = styled(EcosystemSection)`
   ${mediaQueries.md} {
     margin: 0 ${p => p.theme.space[2]} 0;
     padding: ${p => p.theme.space[6]};
-    max-height: nonel
+    max-height: none;
 
     :last-child {
       align-self: stretch;


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

In devices like iPhone X and Pixel 2 XL, the plugins and starter section in the home page of GatsbyJS is broken. This was because on these devices in landscape mode, styles are applied for breakpoint md. (See [ecomsystem-section.js](https://github.com/gatsbyjs/gatsby/blob/master/www/src/components/ecosystem/ecosystem-section.js#L15)) 
The max-height set to 60vh was causing the problem. So a change was made in [homepage-ecosystem.js](https://github.com/TheFirstMe/gatsby/blob/thefirstme/broken-ui-on-gatsbyjs-21446/www/src/components/homepage/homepage-ecosystem.js#L39) to set max-height to none. 

Before the fix: 

![before](https://user-images.githubusercontent.com/23120939/74612195-22592d00-5129-11ea-898b-64e1d7916ccf.png)

After the fix:

![after](https://user-images.githubusercontent.com/23120939/74612198-2be29500-5129-11ea-81c9-51d0ef1a4cb2.png)

## Related Issues
Fixes #21446 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
