### PR TITLE
fix(gatsby-cli): lower required react version

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -37,7 +37,7 @@
     "pretty-error": "^2.1.1",
     "progress": "^2.0.3",
     "prompts": "^2.3.0",
-    "react": "^16.12.0",
+    "react": "^16.8.0",
     "redux": "^4.0.4",
     "resolve-cwd": "^2.0.0",
     "semver": "^6.3.0",

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   },
   "masterIssue": true,
   "rebaseStalePrs": false,
+  "excludePackageNames": ["react", "react-dom"],
   "rangeStrategy": "bump",
   "bumpVersion": null,
   "semanticCommitScope": null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18611,7 +18611,7 @@ react-typography@^0.16.19:
   resolved "https://registry.yarnpkg.com/react-typography/-/react-typography-0.16.19.tgz#5736b47961dcf6b9605b6fa38d41980db2588e28"
   integrity sha512-kV2qLEsdm0x9P4YXQEDVc88tDb4Vg0h/vdVZGgbqaRn8ERvNzV76JHUeOby3vvcUYU5MPd5Kz5DPH9Bhp4I/iw==
 
-react@^16.12.0:
+react@^16.12.0, react@^16.8.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==


### PR DESCRIPTION
Requiring latest `react` version in `gatsby-cli` (for `ink`) causes trouble with npm installs - if user specified `react` version doesn't satisfy `>= 16.8` constraint then it seems like `npm` can't properly resolve `node_modules` hierarchy

This does not take care of https://github.com/gatsbyjs/gatsby/issues/19827 completely, but it limits scenario when this error will happen (with this change it should only happen when user specified version of react is in range `>= 16.3 && < 16.8` (instead of `>= 16.3 && 16.12`):

```
npm WARN ink@2.7.1 requires a peer of react@>=16.8.0 but none is installed. You must install peer dependencies yourself.
```

```
gatsby-shopify-starter@0.1.0 /Users/misiek/test/marcuswelds-gatsby-test
├─┬ UNMET PEER DEPENDENCY gatsby@2.19.18-cli-react-from-ink.35
│ └─┬ gatsby-cli@2.8.30-cli-react-from-ink.162
│   └── UNMET PEER DEPENDENCY react@16.12.0 
└── react@16.7.0 
```

`16.8.0` version is needed by ink and our ink logger (we use hooks), so can't go lower in this PR

Commits where cherry-picked from scratched attempt at fixing it completely ( https://github.com/gatsbyjs/gatsby/pull/21508 )