### PR TITLE
Offer a base Page props type which folks can extend

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -29,6 +29,78 @@ export const parsePath: (path: string) => WindowLocation
 
 export const prefetchPathname: (path: string) => void
 
+/** 
+ * A props object for adding type safety to your Gatsby pages, can be
+ * extended with both the query response shape, and the page context.
+ * 
+ * @example 
+ * // When typing a default page from the ./pages dir
+ * 
+ * import {PageProps} from "gatsby"
+ * export default (props: PageProps) => {
+ * 
+ * @example
+ * // When adding types for both pageContext and GraphQL query data
+ * 
+ * import {PageProps} from "gatsby"
+ * 
+ * type IndexQueryProps = { downloadCount: number }
+ * type LocaleLookUpInfo = { translationStrings: any } & { langKey: string, slug: string }
+ * type IndexPageProps = PageProps<IndexPageProps, LocaleLookUpInfo>
+ * 
+ * export default (props: IndexProps) => {
+ *   ..
+ */
+export type PageProps<DataType = object, PageContextType = { langKey: string, slug: string }> = {
+  /** The path for this current page */
+  path: string
+  /** The URI for the current page */
+  uri: string
+  /** An extended version of window.document which comes from @react/router */
+  location: WindowLocation  
+  /** A way to handle programmatically controlling navigation */
+  navigate:  NavigateFn
+  "*": string
+  children: undefined
+  /** @deprecated use pageContext instead */
+  pathContext: object
+  
+  pageResources: object
+  /** 
+   * Data passed into the page via an exported GraphQL query. To set up this type
+   * you need to use [generics](https://www.typescriptlang.org/play/#example/generic-functions), 
+   * see below for an example
+   * 
+   * @example
+   * 
+   * import {PageProps} from "gatsby"
+   * 
+   * type IndexQueryProps = { downloadCount: number }
+   * type IndexPageProps = PageProps<IndexPageProps>
+   * 
+   * export default (props: IndexProps) => {
+   *   ..
+   * 
+   */
+  data: DataType
+  /** 
+   * A context object which is passed in during the creation of the page. Can be extended if you are using
+   * `createPage` yourself using generics:
+   * 
+   * @example
+   * 
+   * import {PageProps} from "gatsby"
+   * 
+   * type IndexQueryProps = { downloadCount: number }
+   * type LocaleLookUpInfo = { translationStrings: any } & { langKey: string, slug: string }
+   * type IndexPageProps = PageProps<IndexPageProps, LocaleLookUpInfo>
+   * 
+   * export default (props: IndexProps) => {
+   *   ..
+   */
+  pageContext: PageContextType
+}
+
 export interface PageRendererProps {
   location: WindowLocation
 }
@@ -1206,18 +1278,7 @@ export interface RouteUpdateArgs extends BrowserPluginArgs {
 }
 
 export interface ReplaceComponentRendererArgs extends BrowserPluginArgs {
-  props: {
-    path: string
-    "*": string
-    uri: string
-    location: Location
-    navigate: NavigateFn
-    children: undefined
-    pageResources: object
-    data: object
-    pageContext: Record<string, unknown>
-    pathContext: Record<string, unknown>
-  }
+  props: PageProps
   loader: object
 }
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -51,7 +51,7 @@ export const prefetchPathname: (path: string) => void
  * export default (props: IndexProps) => {
  *   ..
  */
-export type PageProps<DataType = object, PageContextType = { langKey: string, slug: string }> = {
+export type PageProps<DataType = object, PageContextType = object> = {
   /** The path for this current page */
   path: string
   /** The URI for the current page */

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -29,25 +29,25 @@ export const parsePath: (path: string) => WindowLocation
 
 export const prefetchPathname: (path: string) => void
 
-/** 
+/**
  * A props object for adding type safety to your Gatsby pages, can be
  * extended with both the query response shape, and the page context.
- * 
- * @example 
+ *
+ * @example
  * // When typing a default page from the ./pages dir
- * 
+ *
  * import {PageProps} from "gatsby"
  * export default (props: PageProps) => {
- * 
+ *
  * @example
  * // When adding types for both pageContext and GraphQL query data
- * 
+ *
  * import {PageProps} from "gatsby"
- * 
+ *
  * type IndexQueryProps = { downloadCount: number }
  * type LocaleLookUpInfo = { translationStrings: any } & { langKey: string, slug: string }
  * type IndexPageProps = PageProps<IndexPageProps, LocaleLookUpInfo>
- * 
+ *
  * export default (props: IndexProps) => {
  *   ..
  */
@@ -57,44 +57,56 @@ export type PageProps<DataType = object, PageContextType = { langKey: string, sl
   /** The URI for the current page */
   uri: string
   /** An extended version of window.document which comes from @react/router */
-  location: WindowLocation  
+  location: WindowLocation
   /** A way to handle programmatically controlling navigation */
   navigate:  NavigateFn
-  "*": string
+  /** You can't get passed children as this is the root user-land component */
   children: undefined
   /** @deprecated use pageContext instead */
   pathContext: object
-  
-  pageResources: object
-  /** 
+  /** Holds information about the build process for this component */
+  pageResources: {
+    component: React.Component
+      json: {
+        data: DataType
+        pageContext: PageContextType
+      },
+      page: {
+        componentChunkName: string,
+        path: string,
+        webpackCompilationHash: string,
+        matchPath?: string,
+      },
+  }
+  /**
    * Data passed into the page via an exported GraphQL query. To set up this type
-   * you need to use [generics](https://www.typescriptlang.org/play/#example/generic-functions), 
+   * you need to use [generics](https://www.typescriptlang.org/play/#example/generic-functions),
    * see below for an example
-   * 
+   *
    * @example
-   * 
+   *
    * import {PageProps} from "gatsby"
-   * 
+   *
    * type IndexQueryProps = { downloadCount: number }
    * type IndexPageProps = PageProps<IndexPageProps>
-   * 
+   *
    * export default (props: IndexProps) => {
    *   ..
-   * 
+   *
    */
   data: DataType
-  /** 
+  /**
    * A context object which is passed in during the creation of the page. Can be extended if you are using
    * `createPage` yourself using generics:
-   * 
+   *
    * @example
-   * 
+   *
    * import {PageProps} from "gatsby"
-   * 
+   *
    * type IndexQueryProps = { downloadCount: number }
    * type LocaleLookUpInfo = { translationStrings: any } & { langKey: string, slug: string }
    * type IndexPageProps = PageProps<IndexPageProps, LocaleLookUpInfo>
-   * 
+   *
    * export default (props: IndexProps) => {
    *   ..
    */


### PR DESCRIPTION
## Description

Once I started using shared fragments, all the auto-generate types tooling broke, so I went manual. 

I started using this type in TypeScript v2 and figured it'd be better that I give it to Gatsby instead. Effectively gives people a base type to build on top of for describing the data in their 

This is how I define my types which have both a query and custom context from `createPage`.

<img width="962" alt="Screen Shot 2020-02-17 at 10 46 15 PM" src="https://user-images.githubusercontent.com/49038/74702612-766f1a80-51d8-11ea-85b1-955096c24885.png">

( and yah yah, `lang` vs `langKey` - I couldn't find docs on `langKey` so I just used my own everywhere) 

### Documentation

When there's official TS docs, this should go in as a way to describe your own props - I included a bunch of examples inline which you can copy & paste later

### Discussion

I do not know what these are/do:

- `"*"` could be on the props, but I included it because it was on the older one (it doesn't show up in any of my props at runtime)

- `pageResources` - I don't get what this does, and couldn't figure it out from some googling and reading docs -  so I didn't document it and left it ambiguous but there