### PR TITLE
fix(gatsby): Fix static query parsing for for a special case

### DIFF
--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -1538,6 +1538,79 @@ query {
         "start": 0,
       },
     },
+    "filePath": "static-query-hooks-with-other-export.js",
+    "hash": 407706182,
+    "isHook": true,
+    "isStaticQuery": true,
+    "templateLoc": SourceLocation {
+      "end": Position {
+        "column": 67,
+        "line": 4,
+      },
+      "filename": true,
+      "start": Position {
+        "column": 38,
+        "line": 4,
+      },
+    },
+    "text": "query StaticQueryName { foo }",
+  },
+  Object {
+    "doc": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "loc": Object {
+            "end": 29,
+            "start": 0,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 21,
+              "start": 6,
+            },
+            "value": "StaticQueryName",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 29,
+              "start": 22,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 27,
+                  "start": 24,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 27,
+                    "start": 24,
+                  },
+                  "value": "foo",
+                },
+                "selectionSet": undefined,
+              },
+            ],
+          },
+          "variableDefinitions": Array [],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 29,
+        "start": 0,
+      },
+    },
     "filePath": "static-query-hooks-alternative-import.js",
     "hash": 407706182,
     "isHook": true,

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -167,6 +167,13 @@ export default () => {
   const data = useStaticQuery(graphql\`query StaticQueryName { foo }\`);
   return <div>{data.doo}</div>;
 }`,
+    "static-query-hooks-with-other-export.js": `import { graphql, useStaticQuery } from 'gatsby'
+export { Bar } from 'bar'
+export default () => {
+  const data = useStaticQuery(graphql\`query StaticQueryName { foo }\`);
+  return <div>{data.doo}</div>;
+}
+`,
     "static-query-hooks-alternative-import.js": `import * as Gatsby from 'gatsby'
 export default () => {
   const data = Gatsby.useStaticQuery(Gatsby.graphql\`query StaticQueryName { foo }\`);
@@ -229,12 +236,15 @@ export default () => {
   })
 
   it(`extracts query AST correctly from files`, async () => {
+    const errors = []
+    const addError = errors.push.bind(errors)
     const results = await parser.parseFiles(
       Object.keys(MOCK_FILE_INFO),
-      jest.fn()
+      addError
     )
     expect(results).toMatchSnapshot()
     expect(reporter.warn).toMatchSnapshot()
+    expect(errors.length).toEqual(1)
   })
 
   it(`generates spec-compliant query names out of path`, async () => {

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -366,6 +366,9 @@ async function findGraphQLTags(
         // Look for exported page queries
         traverse(ast, {
           ExportNamedDeclaration(path, state) {
+            if (path.node.source) {
+              return
+            }
             path.traverse({
               TaggedTemplateExpression,
               ExportSpecifier(path) {

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -363,9 +363,12 @@ async function findGraphQLTags(
           return binding
         }
 
-        // Look for exported page queries
+        // When a component has a StaticQuery we scan all of its exports and follow those exported variables
+        // to determine if they lead to this static query (via tagged template literal)
         traverse(ast, {
           ExportNamedDeclaration(path, state) {
+            // Skipping the edge case of re-exporting (i.e. "export { bar } from 'Bar'")
+            // (it is handled elsewhere for queries, see usages of warnForUnknownQueryVariable)
             if (path.node.source) {
               return
             }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Before this PR following component would have caused an error during static query parsing:

```js
import { graphql, useStaticQuery } from 'gatsby'

export { Bar } from 'bar'

export default () => {
  const data = useStaticQuery(graphql`query StaticQueryName { foo }`);
  return <div>{data.doo}</div>;
}
```

This was happening because of the presence of `export { Bar } from 'bar'` which was treated incorrectly while trying to follow static query variable chain

This issue was introduced in #20330

## Related Issues

Fixes #21212