### PR TITLE
fix(gatsby-plugin-netlify): add page-data & app-data to preload list

### DIFF
--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -20,8 +20,6 @@ X-Frame-Options
   Cache-Control: public, max-age=31536000, immutable
 /component---src-pages-index-js-0bdd01c77ee09ef0224c.js
   Cache-Control: public, max-age=31536000, immutable
-/pages-manifest-ab11f09e0ca7ecd3b43e.js
-  Cache-Control: public, max-age=31536000, immutable
 /webpack-runtime-acaa8994f1f704475e21.js
   Cache-Control: public, max-age=31536000, immutable
 /styles.1025963f4f2ec7abbad4.css
@@ -110,8 +108,6 @@ exports[`build-headers-program with caching headers 1`] = `
   Cache-Control: public, max-age=31536000, immutable
 /component---src-pages-index-js-0bdd01c77ee09ef0224c.js
   Cache-Control: public, max-age=31536000, immutable
-/pages-manifest-ab11f09e0ca7ecd3b43e.js
-  Cache-Control: public, max-age=31536000, immutable
 /webpack-runtime-acaa8994f1f704475e21.js
   Cache-Control: public, max-age=31536000, immutable
 /styles.1025963f4f2ec7abbad4.css
@@ -182,6 +178,89 @@ exports[`build-headers-program with caching headers 1`] = `
 "
 `;
 
+exports[`build-headers-program with manifest['pages-manifest'] 1`] = `
+"## Created with gatsby-plugin-netlify
+
+/*
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: same-origin
+/component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js
+  Cache-Control: public, max-age=31536000, immutable
+/0-0180cd94ef2497ac7db8.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-templates-blog-post-js-517987eae96e75cddbe7.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-pages-404-js-53e6c51a5a7e73090f50.js
+  Cache-Control: public, max-age=31536000, immutable
+/component---src-pages-index-js-0bdd01c77ee09ef0224c.js
+  Cache-Control: public, max-age=31536000, immutable
+/pages-manifest-ab11f09e0ca7ecd3b43e.js
+  Cache-Control: public, max-age=31536000, immutable
+/webpack-runtime-acaa8994f1f704475e21.js
+  Cache-Control: public, max-age=31536000, immutable
+/styles.1025963f4f2ec7abbad4.css
+  Cache-Control: public, max-age=31536000, immutable
+/styles-565f081c8374bbda155f.js
+  Cache-Control: public, max-age=31536000, immutable
+/app-f33c13590352da20930f.js
+  Cache-Control: public, max-age=31536000, immutable
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+/sw.js
+  Cache-Control: no-cache
+/offline-plugin-app-shell-fallback/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+/hi-folks/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+/my-second-post/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+/hello-world/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+/404/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+/
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+/404.html
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+"
+`;
+
 exports[`build-headers-program with security headers 1`] = `
 "## Created with gatsby-plugin-netlify
 
@@ -202,8 +281,6 @@ exports[`build-headers-program with security headers 1`] = `
 /component---src-pages-404-js-53e6c51a5a7e73090f50.js
   Cache-Control: public, max-age=31536000, immutable
 /component---src-pages-index-js-0bdd01c77ee09ef0224c.js
-  Cache-Control: public, max-age=31536000, immutable
-/pages-manifest-ab11f09e0ca7ecd3b43e.js
   Cache-Control: public, max-age=31536000, immutable
 /webpack-runtime-acaa8994f1f704475e21.js
   Cache-Control: public, max-age=31536000, immutable
@@ -283,94 +360,6 @@ exports[`build-headers-program without caching headers 1`] = `
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
   Referrer-Policy: same-origin
-/offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
-/hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
-/my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
-/hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
-/404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
-/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
-/404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
-"
-`;
-
-exports[`build-headers-program without manifest['pages-manifest'] 1`] = `
-"## Created with gatsby-plugin-netlify
-
-/*
-  X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
-  X-Content-Type-Options: nosniff
-  Referrer-Policy: same-origin
-/component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js
-  Cache-Control: public, max-age=31536000, immutable
-/0-0180cd94ef2497ac7db8.js
-  Cache-Control: public, max-age=31536000, immutable
-/component---src-templates-blog-post-js-517987eae96e75cddbe7.js
-  Cache-Control: public, max-age=31536000, immutable
-/component---src-pages-404-js-53e6c51a5a7e73090f50.js
-  Cache-Control: public, max-age=31536000, immutable
-/component---src-pages-index-js-0bdd01c77ee09ef0224c.js
-  Cache-Control: public, max-age=31536000, immutable
-/webpack-runtime-acaa8994f1f704475e21.js
-  Cache-Control: public, max-age=31536000, immutable
-/styles.1025963f4f2ec7abbad4.css
-  Cache-Control: public, max-age=31536000, immutable
-/styles-565f081c8374bbda155f.js
-  Cache-Control: public, max-age=31536000, immutable
-/app-f33c13590352da20930f.js
-  Cache-Control: public, max-age=31536000, immutable
-/static/*
-  Cache-Control: public, max-age=31536000, immutable
-/sw.js
-  Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
   Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush

--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -35,46 +35,60 @@ X-Frame-Options
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 "
 `;
 
@@ -111,46 +125,60 @@ exports[`build-headers-program with caching headers 1`] = `
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 "
 `;
 
@@ -190,46 +218,60 @@ exports[`build-headers-program with security headers 1`] = `
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 "
 `;
 
@@ -242,46 +284,60 @@ exports[`build-headers-program without caching headers 1`] = `
   X-Content-Type-Options: nosniff
   Referrer-Policy: same-origin
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 "
 `;
 
@@ -316,45 +372,59 @@ exports[`build-headers-program without manifest['pages-manifest'] 1`] = `
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
 "
 `;

--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -215,49 +215,42 @@ exports[`build-headers-program with manifest['pages-manifest'] 1`] = `
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
   Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
   Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /hi-folks/
   Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
   Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
   Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
   Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /my-second-post/
   Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
   Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
   Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
   Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /hello-world/
   Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
   Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
   Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
   Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /404/
   Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
   Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
   Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
   Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /
   Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
   Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
   Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
   Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /404.html
   Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
   Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
   Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
   Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
   Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 "
 `;
 

--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -33,60 +33,60 @@ X-Frame-Options
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin
 "
 `;
 
@@ -121,60 +121,60 @@ exports[`build-headers-program with caching headers 1`] = `
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin
 "
 `;
 
@@ -211,53 +211,53 @@ exports[`build-headers-program with manifest['pages-manifest'] 1`] = `
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
 "
 `;
 
@@ -295,60 +295,60 @@ exports[`build-headers-program with security headers 1`] = `
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin
 "
 `;
 
@@ -361,59 +361,59 @@ exports[`build-headers-program without caching headers 1`] = `
   X-Content-Type-Options: nosniff
   Referrer-Policy: same-origin
 /offline-plugin-app-shell-fallback/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </component---node-modules-gatsby-plugin-offline-app-shell-js-78f9e4dea04737fa062d.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/offline-plugin-app-shell-fallback/page-data.json>; rel=preload; as=fetch; crossorigin
 /hi-folks/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/hi-folks/page-data.json>; rel=preload; as=fetch; crossorigin
 /my-second-post/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/my-second-post/page-data.json>; rel=preload; as=fetch; crossorigin
 /hello-world/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-templates-blog-post-js-517987eae96e75cddbe7.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/hello-world/page-data.json>; rel=preload; as=fetch; crossorigin
 /404/
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/404/page-data.json>; rel=preload; as=fetch; crossorigin
 /
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-index-js-0bdd01c77ee09ef0224c.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/index/page-data.json>; rel=preload; as=fetch; crossorigin
 /404.html
-  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script; nopush
-  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script; nopush
-  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script; nopush
-  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script; nopush
-  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script; nopush
-  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin; nopush
-  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin; nopush
+  Link: </webpack-runtime-acaa8994f1f704475e21.js>; rel=preload; as=script
+  Link: </styles-565f081c8374bbda155f.js>; rel=preload; as=script
+  Link: </app-f33c13590352da20930f.js>; rel=preload; as=script
+  Link: </0-0180cd94ef2497ac7db8.js>; rel=preload; as=script
+  Link: </component---src-pages-404-js-53e6c51a5a7e73090f50.js>; rel=preload; as=script
+  Link: </page-data/app-data.json>; rel=preload; as=fetch; crossorigin
+  Link: </page-data/404.html/page-data.json>; rel=preload; as=fetch; crossorigin
 "
 `;

--- a/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
@@ -1,8 +1,15 @@
 import buildHeadersProgram from "../build-headers-program"
-import path from "path"
-import os from "os"
-import fs from "fs-extra"
+import * as path from "path"
+import * as os from "os"
+import * as fs from "fs-extra"
 import { DEFAULT_OPTIONS } from "../constants"
+
+jest.mock(`fs-extra`, () => {
+  return {
+    ...jest.requireActual(`fs-extra`),
+    existsSync: jest.fn(),
+  }
+})
 
 describe(`build-headers-program`, () => {
   let reporter
@@ -11,6 +18,8 @@ describe(`build-headers-program`, () => {
     reporter = {
       warn: jest.fn(),
     }
+    fs.existsSync.mockClear()
+    fs.existsSync.mockReturnValue(true)
   })
 
   const createPluginData = async () => {
@@ -150,10 +159,9 @@ describe(`build-headers-program`, () => {
           `0-0180cd94ef2497ac7db8.js`,
           `component---src-pages-index-js-0bdd01c77ee09ef0224c.js`,
         ],
-        "pages-manifest": [`pages-manifest-ab11f09e0ca7ecd3b43e.js`],
       },
       pathPrefix: ``,
-      publicFolder: fileName => path.join(tmpDir, fileName),
+      publicFolder: (...files) => path.join(tmpDir, ...files),
     }
   }
 
@@ -168,16 +176,32 @@ describe(`build-headers-program`, () => {
     await buildHeadersProgram(pluginData, pluginOptions, reporter)
 
     expect(reporter.warn).not.toHaveBeenCalled()
-    expect(
-      await fs.readFile(pluginData.publicFolder(`_headers`), `utf8`)
-    ).toMatchSnapshot()
+    const output = await fs.readFile(
+      pluginData.publicFolder(`_headers`),
+      `utf8`
+    )
+    expect(output).toMatchSnapshot()
+    expect(output).toMatch(/app-data\.json/)
+    expect(output).toMatch(/page-data\.json/)
+    // we should only check page-data & app-data once which leads to 2 times
+    expect(fs.existsSync).toBeCalledTimes(2)
   })
 
-  it(`without manifest['pages-manifest']`, async () => {
+  it(`with manifest['pages-manifest']`, async () => {
     const pluginData = await createPluginData()
 
-    // gatsby 2.9+ no longer has a pages-manifest key
-    delete pluginData.manifest[`pages-manifest`]
+    fs.existsSync.mockImplementation(path => {
+      if (path.includes(`page-data.json`)) {
+        return false
+      }
+
+      return true
+    })
+
+    // gatsby < 2.9 uses page-manifest
+    pluginData.manifest[`pages-manifest`] = [
+      `pages-manifest-ab11f09e0ca7ecd3b43e.js`,
+    ]
 
     const pluginOptions = {
       ...DEFAULT_OPTIONS,
@@ -192,6 +216,37 @@ describe(`build-headers-program`, () => {
       `utf8`
     )
     expect(output).toMatchSnapshot()
+    expect(output).toMatch(/\/pages-manifest-ab11f09e0ca7ecd3b43e\.js/g)
+    expect(output).not.toMatch(/\/page-data\.json/g)
+    expect(output).not.toMatch(/\/undefined/g)
+  })
+
+  it(`without app-data file`, async () => {
+    const pluginData = await createPluginData()
+
+    // gatsby 2.17.0+ adds an app-data file
+    delete pluginData.manifest[`pages-manifest`]
+
+    const pluginOptions = {
+      ...DEFAULT_OPTIONS,
+      mergeCachingHeaders: true,
+    }
+    fs.existsSync.mockImplementation(path => {
+      if (path.includes(`app-data.json`)) {
+        return false
+      }
+
+      return true
+    })
+
+    await buildHeadersProgram(pluginData, pluginOptions, reporter)
+
+    expect(reporter.warn).not.toHaveBeenCalled()
+    const output = await fs.readFile(
+      pluginData.publicFolder(`_headers`),
+      `utf8`
+    )
+    expect(output).not.toMatch(/app-data\.json/g)
     expect(output).not.toMatch(/\/undefined/g)
   })
 

--- a/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/build-headers-program.js
@@ -191,7 +191,7 @@ describe(`build-headers-program`, () => {
     const pluginData = await createPluginData()
 
     fs.existsSync.mockImplementation(path => {
-      if (path.includes(`page-data.json`)) {
+      if (path.includes(`page-data.json`) || path.includes(`app-data.json`)) {
         return false
       }
 
@@ -217,6 +217,7 @@ describe(`build-headers-program`, () => {
     )
     expect(output).toMatchSnapshot()
     expect(output).toMatch(/\/pages-manifest-ab11f09e0ca7ecd3b43e\.js/g)
+    expect(output).not.toMatch(/\/app-data\.json/g)
     expect(output).not.toMatch(/\/page-data\.json/g)
     expect(output).not.toMatch(/\/undefined/g)
   })

--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -47,7 +47,7 @@ function validHeaders(headers, reporter) {
 function linkTemplate(assetPath, type = `script`) {
   return `Link: <${assetPath}>; rel=preload; as=${type}${
     type === `fetch` ? `; crossorigin` : ``
-  }; nopush`
+  }`
 }
 
 function pathChunkName(path) {

--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -38,3 +38,5 @@ export const ROOT_WILDCARD = `/*`
 export const COMMON_BUNDLES = [`commons`, `app`]
 
 export const HEADER_COMMENT = `## Created with gatsby-plugin-netlify`
+
+export const PAGE_DATA_DIR = `page-data/`


### PR DESCRIPTION
## Description
Improve netlify headers by adding page-data & app-data to HTTP preload, this will let the browser start the download sooner.

It works :) You can see the difference in these snapshots, the important part is when our images start to load. As these are our indicators when our js is being executed.

**Mobile 4G**:
https://webpagetest.org/video/compare.php?tests=200224_T2_3323f0e578a9efc861f44ddcd2bd4250%2C200224_F2_68e33c289ced2e9c826d9617f4e8f18a&thumbSize=200&ival=100&end=full

**Desktop 4G**:
https://webpagetest.org/video/compare.php?tests=200224_DW_f3516a43d45095def0edab713dd22f73%2C200224_8C_75beb58838faed97672a522b7b21458b&thumbSize=200&ival=100&end=full

**Desktop fast internet**:
https://webpagetest.org/video/compare.php?tests=200224_MV_a147387f2c846b1685f05bc407ef5ac7%2C200224_MT_d1b109458f8135fde63248ed82b20f1a&thumbSize=200&ival=100&end=full
