### PR TITLE
Ignore JS files with typo bot

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -25,6 +25,8 @@ excluded_files:
   - ".typo-ci.yml"
   - ".npmignore"
   - "packages/**/.npmignore"
+  - "**/*.js"
+  - "**/*.ts"
 
 # Any typos we should ignore?
 excluded_words:

--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -27,7 +27,8 @@ excluded_files:
   - "packages/**/.npmignore"
   - "**/*.js"
   - "**/*.ts"
-
+  - "**/*.jsx"
+  - "**/*.tsx"
 # Any typos we should ignore?
 excluded_words:
   - typoci


### PR DESCRIPTION
The typo bot is currently far too noisy. Going to try and ignore js/ts files in the hope it can quiet down.
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
