### PR TITLE
Updating README.md - importing index.scss

### DIFF
--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -26,7 +26,7 @@ html {
 ```
 
 ```javascript:title=gatsby-browser.js
-import("./src/index.scss")
+import "./src/index.scss"
 ```
 
 ## Other options


### PR DESCRIPTION
#21062  Description

Removing brackets in documentation surrounded import statement

`import("./src/index.scss")` to `import "./src/index.scss".`

Fixes webpack build error. 

![Screenshot 2020-02-19 at 14 58 32](https://user-images.githubusercontent.com/739061/74846455-5babbb80-5328-11ea-9e70-8a94fdef188b.png)
