### PR TITLE
feat(gatsby): Tweak eslint not to emit no-use-before-define on funcs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,7 +119,10 @@ module.exports = {
           "error",
           "interface",
         ],
-
+        "@typescript-eslint/no-use-before-define": [
+          "error",
+          { functions: false },
+        ],
         // Allows us to write unions like `type Foo = "baz" | "bar"`
         // otherwise eslint will want to switch the strings to backticks,
         // which then crashes the ts compiler


### PR DESCRIPTION
Before eslint would complain about calling a function from another function if the called function appeared later in the file:
```
function f() { g() }
function g() {}
```
Requiring that the order is reversed. However, in JS that doesn't really matter and should be fine to do. In TS that doesn't seem to be different so it's fine to relax the rule to ignore functions. (Note that this rule is entirely disabled for JS files)