### PR TITLE
chore(www): Remove extraneous stuff from doc-links

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -6,10 +6,6 @@
       link: /docs/
     - title: Quick Start
       link: /docs/quick-start/
-    - title: Plugin Library
-      link: /plugins/
-    - title: Starter Library
-      link: /starters/
     - title: Awesome Gatsby Resources
       link: /docs/awesome-gatsby-resources/
     - title: Recipes
@@ -713,13 +709,6 @@
                   link: /docs/making-components-discoverable/
         - title: How Gatsby Boosts Your Career
           link: /docs/how-gatsby-boosts-career/
-    - title: Contributing
-      link: /contributing/
-      items:
-        - title: Community
-          link: /contributing/community/
-        - title: How to Contribute
-          link: /contributing/how-to-contribute/
     - title: Partnering With Gatsby
       link: /docs/partnering-with-gatsby/
       items:


### PR DESCRIPTION
## Description

Remove "Plugin Library", "Starter Library", and "Community" sections from the doc links.

## Motivation

"Plugins" and "Contributing" are already top-level links in the nav bar, so it seems extraneous to include them in a nav link as well. These items take up space in the sidebar and push down other important content, such as Recipes and API.

## Related Issues

Addresses: #21324
