### PR TITLE
fix(docs): update readme typo and hyperlink

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # Read docs at https://www.gatsbyjs.org/docs
 
-We intend the docs to be read on gatsbyjs.org — You can read them here of course
-:-) Just be warned that links won't often work and other things will be missing
+We intend the docs to be read on [gatsbyjs.org](https://gatsby.org) — You can read them here of course
+:-)  
+Just be warned that links won't often work and other things will be missing
 or less than optimal.
 
 Go forth and build cool stuff.


### PR DESCRIPTION
### Description

A simple update adding a hyperlink to `gatsby.org` text and enter a new line after `:-)`.