### PR TITLE
feat(gatsby-design-tokens): Add "Inter" font stack

### DIFF
--- a/packages/gatsby-design-tokens/src/fonts.js
+++ b/packages/gatsby-design-tokens/src/fonts.js
@@ -2,7 +2,7 @@ import preval from "preval.macro"
 
 // TODO re:system-ui, keep an eye on https://github.com/primer/css/issues/838
 const f = preval`
-  const system = sans = body = [
+  const system = body = [
     "-apple-system",
     "BlinkMacSystemFont",
     "Segoe UI",
@@ -16,6 +16,8 @@ const f = preval`
     "Segoe UI Symbol",
     "Noto Color Emoji",
   ]
+
+  const sans = inter = ["Inter", ...system]
 
   const heading = brand = ["Futura PT", ...system]
 

--- a/packages/gatsby-design-tokens/src/fonts.js
+++ b/packages/gatsby-design-tokens/src/fonts.js
@@ -31,7 +31,7 @@ const f = preval`
 
   const serif = ["Georgia", "Times New Roman", "Times", "serif"]
 
-  const fonts = { body, system, heading, monospace, serif }
+  const fonts = { body, system, sans, heading, brand, monospace, serif }
 
   let fontsStrings = {}
   for (const fontFamily in fonts) {


### PR DESCRIPTION
Intermediate step needed to replace the system font stack with excellent [Inter](https://rsms.me/inter/) (for .com, the Gatsby Cloud dashboard). Why?

- consistency across/control of the experience across all platforms (not least, a consistent set of font weights)
- improve typography for users on Windows (and replace Segoe, which has problems) and Android (Roboto, also has problems)
- potentially benefit from specific typeface features that Inter provides (tabular numbers, case alternates, stylistic sets 1 (alternate digits) and 2 (disambiguation))
- great language support
- variable font available
- drop-in replacement for at least Apple's San Francisco
- open source

---

Along the way: Fix `fonts.sans` and `.brand` aliases.