### PR TITLE
feat(www): update pairing session

### DIFF
--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -30,8 +30,8 @@ We also expect the following from pair programming participants:
 
 ## How to sign up
 
-We allow booking up to 30 days in advance, and spots tend to fill up fast. If we’re all booked up today, check back tomorrow for the next batch of spots. The core team is spread across North America, India, and Europe, so most time zones will have availability during working hours.
+Fill in the [request a pairing session form][cal] to reserve your spot. The Gatsby team will be notified. You should get an email shortly with a calendar link where you can choose a spot that fits you and the organizer. The core team is spread across North America, India, and Europe, so most time zones will have availability during working hours.
 
 [Reserve your spot today][cal] and let’s build something amazing together!
 
-[cal]: https://calendly.com/gatsbyjs/pair-programming
+[cal]: https://gatsby.dev/register-pair-programming

--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -30,7 +30,10 @@ We also expect the following from pair programming participants:
 
 ## How to sign up
 
-Fill in the [request a pairing session form][cal] to reserve your spot. The Gatsby team will be notified. You should get an email shortly with a calendar link where you can choose a spot that fits you and the organizer. The core team is spread across North America, India, and Europe, so most time zones will have availability during working hours.
+Fill in the [request a pairing session form][cal] to reserve your spot. The Gatsby team will be notified. You should get an email shortly with next steps.
+
+**Note:** Pairing sessions are currently paused as we establish a new process that will include recording so we can create lasting resources for the community from these sessions. We'll reach out to set up a time that works for you once we have the details ironed out. The core team is spread across North America, India, and Europe, so most time zones will have availability during working hours.
+
 
 [Reserve your spot today][cal] and let’s build something amazing together!
 

--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -34,7 +34,6 @@ Fill in the [request a pairing session form][cal] to reserve your spot. The Gats
 
 **Note:** Pairing sessions are currently paused as we establish a new process that will include recording so we can create lasting resources for the community from these sessions. We'll reach out to set up a time that works for you once we have the details ironed out. The core team is spread across North America, India, and Europe, so most time zones will have availability during working hours.
 
-
 [Reserve your spot today][cal] and let’s build something amazing together!
 
 [cal]: https://gatsby.dev/register-pair-programming


### PR DESCRIPTION
## Description
Created a google form for registering pairing sessions instead of a calendly link. I've created a gatsby-dev alias in case we want to change our workflow. `https://gatsby.dev/pair-programming` was taken so I'm using `https://gatsby.dev/register-pair-programming`. Happy to change it to something else.

Gatsby members will see a notification in slack
![image](https://user-images.githubusercontent.com/1120926/74911850-cf4bd800-53bd-11ea-808c-1295322cab0d.png)

**I'm marking as draft to get some feedback first.**