### PR TITLE
fix(docs): links are not selected in TOC

### DIFF
--- a/www/src/data/sidebars/contributing-links.yaml
+++ b/www/src/data/sidebars/contributing-links.yaml
@@ -27,7 +27,7 @@
     - title: Gatsby Style Guide
       link: /contributing/gatsby-style-guide/
     - title: Translating Gatsbyjs.org
-      link: /contributing/translation
+      link: /contributing/translation/
       items:
         - title: Starting a New Translation
           link: /contributing/translation/new-translations/


### PR DESCRIPTION
## Description

TOC is not selected with a link with a trailing slash `/`

## Related Issues

- fixes #21604 `docs: redirect not select TOC`
- #21254 `(docs) Split translation guide into multiple pages for clarity`
- #21413 `add redirect for translation guide refactor`

