### PR TITLE
fix(docs): fix 404 and apply redirects

### DIFF
--- a/docs/contributing/translation/maintainers.md
+++ b/docs/contributing/translation/maintainers.md
@@ -14,7 +14,7 @@ As repo maintainers and members of the Gatsby community, your responsibilities a
 - Act as point of contact for your language and answer questions from both contributors to your language and the core Gatsby team.
 - Set up a process in order to get your translation published. (details to come)
 
-As a maintainer, you are welcome to add a contributing doc written in your language to assist with the process. You can find an example in the [gatsby-es repo](https://github.com/gatsbyjs/gatsby-es/blob/master/CONTRIBUTING.MD). Translating [this page](https://github.com/gatsbyjs/gatsby/blob/master/docs/contributing/gatsby-docs-translation-guide.md) and copying it into a `contributing.md` file would be an option as well.
+As a maintainer, you are welcome to add a contributing doc written in your language to assist with the process. You can find an example in the [gatsby-es repo](https://github.com/gatsbyjs/gatsby-es/blob/master/CONTRIBUTING.MD). Translating files from the folder [`docs/contributing/translation`](https://github.com/gatsbyjs/gatsby/tree/master/docs/contributing/translation) and copying it into a `contributing.md` file would be an option as well.
 
 ## Tips
 

--- a/docs/contributing/translation/new-translations.md
+++ b/docs/contributing/translation/new-translations.md
@@ -20,7 +20,7 @@ If you don't see the language among the issues listed, feel free to create a new
 
 ### Finding codeowners
 
-For a new translation, open an issue with information about your intended language. If you already have co-contributors to act as fellow [code owners](https://help.github.com/en/articles/about-code-owners) and provide checks and balances for PR reviews and quality assurance, that would be very helpful! Otherwise, you can check out other [translation request issues](https://github.com/gatsbyjs/gatsby/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+%22New+Translation+Request%22) people have made and offer to join, or [get in touch with us](/contributing/how-to-contribute/#not-sure-how-to-start-contributing) at Gatsby for help in building your translation team.
+For a new translation, open an issue with information about your intended language. If you already have co-contributors to act as fellow [code owners](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) and provide checks and balances for PR reviews and quality assurance, that would be very helpful! Otherwise, you can check out other [translation request issues](https://github.com/gatsbyjs/gatsby/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+%22New+Translation+Request%22) people have made and offer to join, or [get in touch with us](/contributing/how-to-contribute/#not-sure-how-to-start-contributing) at Gatsby for help in building your translation team.
 
 ## Criteria for translation approval
 

--- a/docs/contributing/translation/translators.md
+++ b/docs/contributing/translation/translators.md
@@ -39,4 +39,4 @@ If you would like to be a maintainer of an existing translation repo, submit a P
 
 ## When a contributor will be removed
 
-Consistent with the [Code of Conduct](/docs/code-of-conduct/) the Gatsby team reserves the right to remove a contributor (including translation maintainers) from the Gatsby organization if necessary. Some reasons for being removed include spammy comments, closing PRs or issues without action or productive dialogue, or generally harmful or abusive behavior inconsistent with Gatsby's policies.
+Consistent with the [Code of Conduct](/contributing/code-of-conduct/) the Gatsby team reserves the right to remove a contributor (including translation maintainers) from the Gatsby organization if necessary. Some reasons for being removed include spammy comments, closing PRs or issues without action or productive dialogue, or generally harmful or abusive behavior inconsistent with Gatsby's policies.


### PR DESCRIPTION
## Description

- apply redirects
- fix 404

## Related Issues

- #21254 `(docs) Split translation guide into multiple pages for clarity`
- #19267 `Add link checker for Gatsby Docs`