### PR TITLE
chore(gatsby): Skip linting in the windows ci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
           key: yarn-packages-v2-{{ checksum "yarn.lock" }}
       - run:
           name: "Run Tests"
-          command: yarn test
+          command: yarn jest -w 1 --ci
 
   bootstrap-with-experimental-react:
     executor: node
@@ -627,14 +627,19 @@ workflows:
 
   build-test:
     jobs:
-      - windows_unit_tests
       - bootstrap
       - lint:
           requires:
             - bootstrap
+      - windows_unit_tests:
+          <<: *ignore_docs
+          requires:
+            - lint
+            - bootstrap
       - unit_tests_node8:
           <<: *ignore_docs
           requires:
+            - lint
             - bootstrap
       - unit_tests_node10:
           <<: *ignore_docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,8 +630,6 @@ workflows:
       - bootstrap
       - windows_unit_tests:
           <<: *ignore_docs
-          requires:
-            - bootstrap
       - lint:
           requires:
             - bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,11 +632,11 @@ workflows:
           <<: *ignore_docs
           requires:
             - bootstrap
-      - unit_tests_node8:
-          <<: *ignore_docs
+      - lint:
           requires:
             - bootstrap
-      - lint:
+      - unit_tests_node8:
+          <<: *ignore_docs
           requires:
             - bootstrap
       - unit_tests_node10:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,18 +628,16 @@ workflows:
   build-test:
     jobs:
       - bootstrap
-      - lint:
-          requires:
-            - bootstrap
       - windows_unit_tests:
           <<: *ignore_docs
           requires:
-            - lint
             - bootstrap
       - unit_tests_node8:
           <<: *ignore_docs
           requires:
-            - lint
+            - bootstrap
+      - lint:
+          requires:
             - bootstrap
       - unit_tests_node10:
           <<: *ignore_docs


### PR DESCRIPTION
- Make windows unit tests run the same command as the node8 unit tests
  - This means the windows tests no longer runs the linting etc
