### PR TITLE
feat: add an option to resolve locales in entries referenced by rich text

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.6",
+    "@contentful/rich-text-types": "^13.1.0",
     "@hapi/joi": "^15.1.1",
     "axios": "^0.19.0",
     "base64-img": "^1.0.4",

--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -60,7 +60,7 @@ describe(`Process contentful data (by name)`, () => {
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
     contentTypeItems.forEach((contentTypeItem, i) => {
       entryList[i].forEach(normalize.fixIds)
-      normalize.createContentTypeNodes({
+      normalize.createNodesForContentType({
         contentTypeItem,
         restrictedNodeFields,
         conflictFieldPrefix,
@@ -139,7 +139,7 @@ describe(`Process contentful data (by id)`, () => {
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
     contentTypeItems.forEach((contentTypeItem, i) => {
       entryList[i].forEach(normalize.fixIds)
-      normalize.createContentTypeNodes({
+      normalize.createNodesForContentType({
         contentTypeItem,
         restrictedNodeFields,
         conflictFieldPrefix,

--- a/packages/gatsby-source-contentful/src/__tests__/rich-text.js
+++ b/packages/gatsby-source-contentful/src/__tests__/rich-text.js
@@ -1,0 +1,355 @@
+const { getNormalizedRichTextField } = require(`../rich-text`)
+
+const entryFactory = () => {
+  return {
+    sys: {
+      contentType: { sys: { id: `article` } },
+      type: `Entry`,
+    },
+    fields: {
+      title: { en: `Title`, de: `Titel` },
+      relatedArticle: {
+        en: {
+          sys: {
+            contentType: { sys: { id: `article` } },
+            type: `Entry`,
+          },
+          fields: {
+            title: { en: `Title two`, de: `Titel zwei` },
+          },
+        },
+      },
+    },
+  }
+}
+
+const assetFactory = () => {
+  return {
+    sys: {
+      type: `Asset`,
+    },
+    fields: {
+      file: {
+        en: {
+          url: `//images.ctfassets.net/asset.jpg`,
+        },
+      },
+    },
+  }
+}
+
+describe(`getNormalizedRichTextField()`, () => {
+  let contentTypes
+  let currentLocale
+  let defaultLocale
+  let getField
+
+  beforeEach(() => {
+    contentTypes = [
+      {
+        sys: { id: `article` },
+        fields: [
+          { id: `title`, localized: true },
+          { id: `relatedArticle`, localized: false },
+        ],
+      },
+    ]
+    currentLocale = `en`
+    defaultLocale = `en`
+    getField = field => field[currentLocale]
+  })
+
+  describe(`when the rich-text object has no entry references`, () => {
+    it(`returns the object as-is`, () => {
+      const field = {
+        nodeType: `document`,
+        data: {},
+        content: [
+          {
+            nodeType: `text`,
+            data: {},
+            content: `This is a test`,
+          },
+        ],
+      }
+      expect(
+        getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        })
+      ).toEqual(field)
+    })
+  })
+
+  describe(`when a rich-text node contains an entry reference`, () => {
+    describe(`a localized field`, () => {
+      describe(`when the current locale is \`en\``, () => {
+        beforeEach(() => (currentLocale = `en`))
+
+        it(`resolves the locale for the field`, () => {
+          const field = {
+            nodeType: `document`,
+            data: {},
+            content: [
+              {
+                nodeType: `embedded-entry-inline`,
+                data: { target: entryFactory() },
+              },
+            ],
+          }
+
+          const expectedTitle = `Title`
+          const actualTitle = getNormalizedRichTextField({
+            field,
+            contentTypes,
+            getField,
+            defaultLocale,
+          }).content[0].data.target.fields.title
+
+          expect(actualTitle).toBe(expectedTitle)
+        })
+      })
+
+      describe(`when the current locale is \`de\``, () => {
+        beforeEach(() => (currentLocale = `de`))
+
+        it(`resolves the locale for the field`, () => {
+          const field = {
+            nodeType: `document`,
+            data: {},
+            content: [
+              {
+                nodeType: `embedded-entry-inline`,
+                data: { target: entryFactory() },
+              },
+            ],
+          }
+
+          const expectedTitle = `Titel`
+          const actualTitle = getNormalizedRichTextField({
+            field,
+            contentTypes,
+            getField,
+            defaultLocale,
+          }).content[0].data.target.fields.title
+
+          expect(actualTitle).toBe(expectedTitle)
+        })
+      })
+    })
+
+    describe(`a nested localized field`, () => {
+      beforeEach(() => {
+        currentLocale = `de`
+      })
+
+      it(`resolves the locale for the nested field`, () => {
+        const field = {
+          nodeType: `document`,
+          data: {},
+          content: [
+            {
+              nodeType: `embedded-entry-inline`,
+              data: { target: entryFactory() },
+            },
+          ],
+        }
+
+        const expectedTitle = `Titel zwei`
+        const actualTitle = getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        }).content[0].data.target.fields.relatedArticle.fields.title
+
+        expect(actualTitle).toBe(expectedTitle)
+      })
+    })
+  })
+
+  describe(`when a rich-text node contains an asset reference`, () => {
+    describe(`when the current locale is \`en\``, () => {
+      beforeEach(() => (currentLocale = `en`))
+
+      it(`resolves the locale for the field`, () => {
+        const field = {
+          nodeType: `document`,
+          data: {},
+          content: [
+            {
+              nodeType: `embedded-asset-block`,
+              data: { target: assetFactory() },
+            },
+          ],
+        }
+
+        const expectedURL = `//images.ctfassets.net/asset.jpg`
+        const actualURL = getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        }).content[0].data.target.fields.file.url
+
+        expect(actualURL).toBe(expectedURL)
+      })
+    })
+  })
+
+  describe(`when a referenced entry contains an asset field`, () => {
+    describe(`when the current locale is \`en\``, () => {
+      beforeEach(() => {
+        contentTypes[0].fields.push({
+          id: `assetReference`,
+          localized: true,
+        })
+        currentLocale = `en`
+      })
+
+      it(`resolves the locale for the asset's own fields`, () => {
+        const field = {
+          nodeType: `document`,
+          data: {},
+          content: [
+            {
+              nodeType: `embedded-entry-block`,
+              data: { target: entryFactory() },
+            },
+          ],
+        }
+
+        field.content[0].data.target.fields.assetReference = {
+          en: assetFactory(),
+        }
+
+        const expectedURL = `//images.ctfassets.net/asset.jpg`
+        const actualURL = getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        }).content[0].data.target.fields.assetReference.fields.file.url
+
+        expect(actualURL).toBe(expectedURL)
+      })
+    })
+  })
+
+  describe(`when an entry/asset reference field is an array`, () => {
+    beforeEach(() => {
+      contentTypes[0].fields.push({
+        id: `relatedArticles`,
+        localized: false,
+      })
+      contentTypes[0].fields.push({
+        id: `relatedAssets`,
+        localized: false,
+      })
+    })
+
+    it(`resolves the locales of each entry in the array`, () => {
+      const field = {
+        nodeType: `document`,
+        data: {},
+        content: [
+          {
+            nodeType: `embedded-entry-block`,
+            data: { target: entryFactory() },
+          },
+        ],
+      }
+
+      const relatedArticle = entryFactory()
+      relatedArticle.fields.title = { en: `Related article #1` }
+
+      field.content[0].data.target.fields.relatedArticles = {
+        en: [relatedArticle],
+      }
+
+      const expectedTitle = `Related article #1`
+      const actualTitle = getNormalizedRichTextField({
+        field,
+        contentTypes,
+        getField,
+        defaultLocale,
+      }).content[0].data.target.fields.relatedArticles[0].fields.title
+
+      expect(actualTitle).toBe(expectedTitle)
+    })
+
+    it(`resolves the locales of each asset in the array`, () => {
+      const field = {
+        nodeType: `document`,
+        data: {},
+        content: [
+          {
+            nodeType: `embedded-entry-block`,
+            data: { target: entryFactory() },
+          },
+        ],
+      }
+
+      const relatedAsset = assetFactory()
+      relatedAsset.fields.file = {
+        en: {
+          url: `//images.ctfassets.net/related-asset.jpg`,
+        },
+      }
+
+      field.content[0].data.target.fields.relatedAssets = {
+        en: [relatedAsset],
+      }
+
+      const expectedURL = `//images.ctfassets.net/related-asset.jpg`
+      const actualURL = getNormalizedRichTextField({
+        field,
+        contentTypes,
+        getField,
+        defaultLocale,
+      }).content[0].data.target.fields.relatedAssets[0].fields.file.url
+
+      expect(actualURL).toBe(expectedURL)
+    })
+  })
+
+  describe(`circular references`, () => {
+    it(`prevents infinite loops when two entries reference each other`, () => {
+      const entry1 = entryFactory()
+      entry1.sys.id = `entry1-id`
+      const entry2 = entryFactory()
+      entry2.sys.id = `entry2-id`
+
+      entry2.fields.title = {
+        en: `Related article`,
+        de: `German for "related article" ;)`,
+      }
+
+      // Link the two to each other
+      entry1.fields.relatedArticle.en = entry2
+      entry2.fields.relatedArticle.en = entry1
+
+      const field = {
+        nodeType: `document`,
+        data: {},
+        content: [
+          {
+            nodeType: `embedded-entry-inline`,
+            data: { target: entry1 },
+          },
+        ],
+      }
+
+      expect(() => {
+        getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        })
+      }).not.toThrowError()
+    })
+  })
+})

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -197,8 +197,9 @@ exports.sourceNodes = async (
     })
 
   contentTypeItems.forEach((contentTypeItem, i) => {
-    normalize.createContentTypeNodes({
+    normalize.createNodesForContentType({
       contentTypeItem,
+      contentTypeItems,
       restrictedNodeFields,
       conflictFieldPrefix,
       entries: entryList[i],

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -14,12 +14,26 @@ const isAssetReferenceNode = node =>
 const isEntryReferenceField = field => _.get(field, `sys.type`) === `Entry`
 const isAssetReferenceField = field => _.get(field, `sys.type`) === `Asset`
 
-const getEntryContentType = (entry, contentTypes) =>
-  contentTypes.find(
-    contentType =>
-      entry.sys.contentType &&
-      contentType.sys.id === entry.sys.contentType.sys.id
-  )
+const getEntryContentType = (() => {
+  const contentTypesCachedById = {}
+
+  return (entry, contentTypes) => {
+    const entryContentTypeId = entry.sys.contentType.sys.id
+    if (contentTypesCachedById[entryContentTypeId]) {
+      return contentTypesCachedById[entryContentTypeId]
+    }
+
+    const entryContentType = contentTypes.find(
+      contentType =>
+        entry.sys.contentType &&
+        contentType.sys.id === entry.sys.contentType.sys.id
+    )
+
+    contentTypesCachedById[entryContentTypeId] = entryContentType
+
+    return entryContentType
+  }
+})()
 
 const getFieldProps = (contentType, fieldName) =>
   contentType.fields.find(({ id }) => id === fieldName)

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -36,7 +36,7 @@ const getFieldWithLocaleResolved = ({
   contentTypes,
   getField,
   defaultLocale,
-  resolvedEntryIDs = [],
+  resolvedEntryIDs,
 }) => {
   // If the field is itself a reference to another entry, recursively resolve
   // that entry's field locales too.

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -1,0 +1,191 @@
+const _ = require(`lodash`)
+const { BLOCKS, INLINES } = require(`@contentful/rich-text-types`)
+
+const isEntryReferenceNode = node =>
+  [
+    BLOCKS.EMBEDDED_ENTRY,
+    INLINES.ENTRY_HYPERLINK,
+    INLINES.EMBEDDED_ENTRY,
+  ].indexOf(node.nodeType) >= 0
+
+const isAssetReferenceNode = node =>
+  [BLOCKS.EMBEDDED_ASSET, INLINES.ASSET_HYPERLINK].indexOf(node.nodeType) >= 0
+
+const isEntryReferenceField = field => _.get(field, `sys.type`) === `Entry`
+const isAssetReferenceField = field => _.get(field, `sys.type`) === `Asset`
+
+const getEntryContentType = (entry, contentTypes) =>
+  contentTypes.find(
+    contentType =>
+      entry.sys.contentType &&
+      contentType.sys.id === entry.sys.contentType.sys.id
+  )
+
+const getFieldProps = (contentType, fieldName) =>
+  contentType.fields.find(({ id }) => id === fieldName)
+
+const getAssetWithFieldLocalesResolved = ({ asset, getField }) => {
+  return {
+    ...asset,
+    fields: _.mapValues(asset.fields, getField),
+  }
+}
+
+const getFieldWithLocaleResolved = ({
+  field,
+  contentTypes,
+  getField,
+  defaultLocale,
+  resolvedEntryIDs = [],
+}) => {
+  // If the field is itself a reference to another entry, recursively resolve
+  // that entry's field locales too.
+  if (isEntryReferenceField(field)) {
+    if (resolvedEntryIDs.indexOf(field.sys.id) >= 0) {
+      return field
+    }
+
+    return getEntryWithFieldLocalesResolved({
+      entry: field,
+      contentTypes,
+      getField,
+      defaultLocale,
+      resolvedEntryIDs: [...resolvedEntryIDs, field.sys.id],
+    })
+  }
+
+  if (isAssetReferenceField(field)) {
+    return getAssetWithFieldLocalesResolved({
+      asset: field,
+      getField,
+    })
+  }
+
+  if (Array.isArray(field)) {
+    return field.map(fieldItem =>
+      getFieldWithLocaleResolved({
+        field: fieldItem,
+        contentTypes,
+        getField,
+        defaultLocale,
+        resolvedEntryIDs,
+      })
+    )
+  }
+
+  return field
+}
+
+const getEntryWithFieldLocalesResolved = ({
+  entry,
+  contentTypes,
+  getField,
+  defaultLocale,
+
+  /**
+   * Keep track of entries we've already resolved, in case two or more entries
+   * have circular references (so as to prevent an infinite loop).
+   */
+  resolvedEntryIDs = [],
+}) => {
+  const contentType = getEntryContentType(entry, contentTypes)
+
+  return {
+    ...entry,
+    fields: _.mapValues(entry.fields, (field, fieldName) => {
+      const fieldProps = getFieldProps(contentType, fieldName)
+
+      const fieldValue = fieldProps.localized
+        ? getField(field)
+        : field[defaultLocale]
+
+      return getFieldWithLocaleResolved({
+        field: fieldValue,
+        contentTypes,
+        getField,
+        defaultLocale,
+        resolvedEntryIDs,
+      })
+    }),
+  }
+}
+
+const getNormalizedRichTextNode = ({
+  node,
+  contentTypes,
+  getField,
+  defaultLocale,
+}) => {
+  if (isEntryReferenceNode(node)) {
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        target: getEntryWithFieldLocalesResolved({
+          entry: node.data.target,
+          contentTypes,
+          getField,
+          defaultLocale,
+        }),
+      },
+    }
+  }
+
+  if (isAssetReferenceNode(node)) {
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        target: getAssetWithFieldLocalesResolved({
+          asset: node.data.target,
+          getField,
+        }),
+      },
+    }
+  }
+
+  if (Array.isArray(node.content)) {
+    return {
+      ...node,
+      content: node.content.map(childNode =>
+        getNormalizedRichTextNode({
+          node: childNode,
+          contentTypes,
+          getField,
+          defaultLocale,
+        })
+      ),
+    }
+  }
+
+  return node
+}
+
+/**
+ * Walk through the rich-text object, resolving locales on referenced entries
+ * (and on entries they've referenced, etc.).
+ */
+const getNormalizedRichTextField = ({
+  field,
+  contentTypes,
+  getField,
+  defaultLocale,
+}) => {
+  if (field && field.content) {
+    return {
+      ...field,
+      content: field.content.map(node =>
+        getNormalizedRichTextNode({
+          node,
+          contentTypes,
+          getField,
+          defaultLocale,
+        })
+      ),
+    }
+  }
+
+  return field
+}
+
+exports.getNormalizedRichTextField = getNormalizedRichTextField

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,6 +1973,11 @@
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
+"@contentful/rich-text-types@^13.1.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-13.4.0.tgz#a59c311ebd1b801ee00edbc08663c8d78da26171"
+  integrity sha512-YPdYqGmWiGAood7ri2BUXfPQKNthkQYV1rmQdaq4UAxWK5NLB5NXckaUYLbohqhHKtrq4tnfzVn+ePWID7Dzbg==
+
 "@emotion/babel-plugin-jsx-pragmatic@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.4.tgz#12fd120ecb202c6110dc98d3edabddafda1515f1"


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
