### PR TITLE
chore(gatsby): Fix minor bug with ts check output for Windows

### DIFF
--- a/scripts/check-ts.js
+++ b/scripts/check-ts.js
@@ -52,7 +52,7 @@ if (filterPackage) {
 
 packagesWithTs.forEach(project => {
   console.log(
-    `TS Check: Checking ./packages/${project.split(/.*packages\//)[1]}`
+    `TS Check: Checking ./packages/${project.split(/.*packages[\/\\]/)[1]}`
   )
 
   const args = [

--- a/scripts/check-ts.js
+++ b/scripts/check-ts.js
@@ -52,7 +52,7 @@ if (filterPackage) {
 
 packagesWithTs.forEach(project => {
   console.log(
-    `TS Check: Checking ./packages/${project.split(/.*packages[\/\\]/)[1]}`
+    `TS Check: Checking ./packages/${project.split(/.*packages[/\\]/)[1]}`
   )
 
   const args = [


### PR DESCRIPTION
## Description

Before this PR TypeScript check output on windows was:

```
$ node ./scripts/check-ts
TS Check: Running...
TS Check: Checking ./packages/undefined
TS Check: Checking ./packages/undefined
TS Check: Success
```

Note the `undefined`. After this PR:

```
$ node ./scripts/check-ts
TS Check: Running...
TS Check: Checking ./packages/gatsby
TS Check: Checking ./packages/gatsby-cli
TS Check: Success
```