### PR TITLE
feat: add an option to resolve locales in entries referenced by rich text

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -172,6 +172,10 @@ If you are confident your Content Types will have natural-language IDs (e.g. `bl
 
 Number of entries to retrieve from Contentful at a time. This can be adjusted to fix issues related to "Response size too big" error.
 
+**`richText.resolveFieldLocales`** [boolean][optional] [default: `false`]
+
+If you want to resolve the locales in fields of assets and entries that are referenced by rich text (e.g., via embedded entries or entry hyperlinks), set this to `true`. Otherwise, fields of referenced assets or entries will be objects keyed by locale.
+
 ## Notes on Contentful Content Models
 
 There are currently some things to keep in mind when building your content models at Contentful.

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.6",
+    "@contentful/rich-text-types": "^13.1.0",
     "@hapi/joi": "^15.1.1",
     "axios": "^0.19.0",
     "base64-img": "^1.0.4",

--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -60,7 +60,7 @@ describe(`Process contentful data (by name)`, () => {
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
     contentTypeItems.forEach((contentTypeItem, i) => {
       entryList[i].forEach(normalize.fixIds)
-      normalize.createContentTypeNodes({
+      normalize.createNodesForContentType({
         contentTypeItem,
         restrictedNodeFields,
         conflictFieldPrefix,
@@ -139,7 +139,7 @@ describe(`Process contentful data (by id)`, () => {
     createNodeId.mockReturnValue(`uuid-from-gatsby`)
     contentTypeItems.forEach((contentTypeItem, i) => {
       entryList[i].forEach(normalize.fixIds)
-      normalize.createContentTypeNodes({
+      normalize.createNodesForContentType({
         contentTypeItem,
         restrictedNodeFields,
         conflictFieldPrefix,

--- a/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/__tests__/plugin-options.js
@@ -171,6 +171,7 @@ describe(`Options validation`, () => {
         downloadLocal: 5,
         useNameForId: 5,
         pageLimit: `fifty`,
+        richText: true,
       }
     )
 
@@ -202,6 +203,9 @@ describe(`Options validation`, () => {
     )
     expect(reporter.panic).toBeCalledWith(
       expect.stringContaining(`"pageLimit" must be a number`)
+    )
+    expect(reporter.panic).toBeCalledWith(
+      expect.stringContaining(`"richText" must be an object`)
     )
   })
 

--- a/packages/gatsby-source-contentful/src/__tests__/rich-text.js
+++ b/packages/gatsby-source-contentful/src/__tests__/rich-text.js
@@ -46,15 +46,14 @@ describe(`getNormalizedRichTextField()`, () => {
   let getField
 
   beforeEach(() => {
-    contentTypesById = {
-      article: {
-        sys: { id: `article` },
-        fields: [
-          { id: `title`, localized: true },
-          { id: `relatedArticle`, localized: false },
-        ],
-      },
-    }
+    contentTypesById = new Map()
+    contentTypesById.set(`article`, {
+      sys: { id: `article` },
+      fields: [
+        { id: `title`, localized: true },
+        { id: `relatedArticle`, localized: false },
+      ],
+    })
     currentLocale = `en`
     defaultLocale = `en`
     getField = field => field[currentLocale]
@@ -203,7 +202,7 @@ describe(`getNormalizedRichTextField()`, () => {
   describe(`when a referenced entry contains an asset field`, () => {
     describe(`when the current locale is \`en\``, () => {
       beforeEach(() => {
-        contentTypesById.article.fields.push({
+        contentTypesById.get(`article`).fields.push({
           id: `assetReference`,
           localized: true,
         })
@@ -241,11 +240,11 @@ describe(`getNormalizedRichTextField()`, () => {
 
   describe(`when an entry/asset reference field is an array`, () => {
     beforeEach(() => {
-      contentTypesById.article.fields.push({
+      contentTypesById.get(`article`).fields.push({
         id: `relatedArticles`,
         localized: false,
       })
-      contentTypesById.article.fields.push({
+      contentTypesById.get(`article`).fields.push({
         id: `relatedAssets`,
         localized: false,
       })

--- a/packages/gatsby-source-contentful/src/__tests__/rich-text.js
+++ b/packages/gatsby-source-contentful/src/__tests__/rich-text.js
@@ -1,0 +1,355 @@
+const { getNormalizedRichTextField } = require(`../rich-text`)
+
+const entryFactory = () => {
+  return {
+    sys: {
+      contentType: { sys: { id: `article` } },
+      type: `Entry`,
+    },
+    fields: {
+      title: { en: `Title`, de: `Titel` },
+      relatedArticle: {
+        en: {
+          sys: {
+            contentType: { sys: { id: `article` } },
+            type: `Entry`,
+          },
+          fields: {
+            title: { en: `Title two`, de: `Titel zwei` },
+          },
+        },
+      },
+    },
+  }
+}
+
+const assetFactory = () => {
+  return {
+    sys: {
+      type: `Asset`,
+    },
+    fields: {
+      file: {
+        en: {
+          url: `//images.ctfassets.net/asset.jpg`,
+        },
+      },
+    },
+  }
+}
+
+describe(`getNormalizedRichTextField()`, () => {
+  let contentTypes
+  let currentLocale
+  let defaultLocale
+  let getField
+
+  beforeEach(() => {
+    contentTypes = [
+      {
+        sys: { id: `article` },
+        fields: [
+          { id: `title`, localized: true },
+          { id: `relatedArticle`, localized: false },
+        ],
+      },
+    ]
+    currentLocale = `en`
+    defaultLocale = `en`
+    getField = field => field[currentLocale]
+  })
+
+  describe(`when the rich-text object has no entry references`, () => {
+    it(`returns the object as-is`, () => {
+      const field = {
+        nodeType: `document`,
+        data: {},
+        content: [
+          {
+            nodeType: `text`,
+            data: {},
+            content: `This is a test`,
+          },
+        ],
+      }
+      expect(
+        getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        })
+      ).toEqual(field)
+    })
+  })
+
+  describe(`when a rich-text node contains an entry reference`, () => {
+    describe(`a localized field`, () => {
+      describe(`when the current locale is \`en\``, () => {
+        beforeEach(() => (currentLocale = `en`))
+
+        it(`resolves the locale for the field`, () => {
+          const field = {
+            nodeType: `document`,
+            data: {},
+            content: [
+              {
+                nodeType: `embedded-entry-inline`,
+                data: { target: entryFactory() },
+              },
+            ],
+          }
+
+          const expectedTitle = `Title`
+          const actualTitle = getNormalizedRichTextField({
+            field,
+            contentTypes,
+            getField,
+            defaultLocale,
+          }).content[0].data.target.fields.title
+
+          expect(actualTitle).toBe(expectedTitle)
+        })
+      })
+
+      describe(`when the current locale is \`de\``, () => {
+        beforeEach(() => (currentLocale = `de`))
+
+        it(`resolves the locale for the field`, () => {
+          const field = {
+            nodeType: `document`,
+            data: {},
+            content: [
+              {
+                nodeType: `embedded-entry-inline`,
+                data: { target: entryFactory() },
+              },
+            ],
+          }
+
+          const expectedTitle = `Titel`
+          const actualTitle = getNormalizedRichTextField({
+            field,
+            contentTypes,
+            getField,
+            defaultLocale,
+          }).content[0].data.target.fields.title
+
+          expect(actualTitle).toBe(expectedTitle)
+        })
+      })
+    })
+
+    describe(`a nested localized field`, () => {
+      beforeEach(() => {
+        currentLocale = `de`
+      })
+
+      it(`resolves the locale for the nested field`, () => {
+        const field = {
+          nodeType: `document`,
+          data: {},
+          content: [
+            {
+              nodeType: `embedded-entry-inline`,
+              data: { target: entryFactory() },
+            },
+          ],
+        }
+
+        const expectedTitle = `Titel zwei`
+        const actualTitle = getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        }).content[0].data.target.fields.relatedArticle.fields.title
+
+        expect(actualTitle).toBe(expectedTitle)
+      })
+    })
+  })
+
+  describe(`when a rich-text node contains an asset reference`, () => {
+    describe(`when the current locale is \`en\``, () => {
+      beforeEach(() => (currentLocale = `en`))
+
+      it(`resolves the locale for the field`, () => {
+        const field = {
+          nodeType: `document`,
+          data: {},
+          content: [
+            {
+              nodeType: `embedded-asset-block`,
+              data: { target: assetFactory() },
+            },
+          ],
+        }
+
+        const expectedURL = `//images.ctfassets.net/asset.jpg`
+        const actualURL = getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        }).content[0].data.target.fields.file.url
+
+        expect(actualURL).toBe(expectedURL)
+      })
+    })
+  })
+
+  describe(`when a referenced entry contains an asset field`, () => {
+    describe(`when the current locale is \`en\``, () => {
+      beforeEach(() => {
+        contentTypes[0].fields.push({
+          id: `assetReference`,
+          localized: true,
+        })
+        currentLocale = `en`
+      })
+
+      it(`resolves the locale for the asset's own fields`, () => {
+        const field = {
+          nodeType: `document`,
+          data: {},
+          content: [
+            {
+              nodeType: `embedded-entry-block`,
+              data: { target: entryFactory() },
+            },
+          ],
+        }
+
+        field.content[0].data.target.fields.assetReference = {
+          en: assetFactory(),
+        }
+
+        const expectedURL = `//images.ctfassets.net/asset.jpg`
+        const actualURL = getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        }).content[0].data.target.fields.assetReference.fields.file.url
+
+        expect(actualURL).toBe(expectedURL)
+      })
+    })
+  })
+
+  describe(`when an entry/asset reference field is an array`, () => {
+    beforeEach(() => {
+      contentTypes[0].fields.push({
+        id: `relatedArticles`,
+        localized: false,
+      })
+      contentTypes[0].fields.push({
+        id: `relatedAssets`,
+        localized: false,
+      })
+    })
+
+    it(`resolves the locales of each entry in the array`, () => {
+      const field = {
+        nodeType: `document`,
+        data: {},
+        content: [
+          {
+            nodeType: `embedded-entry-block`,
+            data: { target: entryFactory() },
+          },
+        ],
+      }
+
+      const relatedArticle = entryFactory()
+      relatedArticle.fields.title = { en: `Related article #1` }
+
+      field.content[0].data.target.fields.relatedArticles = {
+        en: [relatedArticle],
+      }
+
+      const expectedTitle = `Related article #1`
+      const actualTitle = getNormalizedRichTextField({
+        field,
+        contentTypes,
+        getField,
+        defaultLocale,
+      }).content[0].data.target.fields.relatedArticles[0].fields.title
+
+      expect(actualTitle).toBe(expectedTitle)
+    })
+
+    it(`resolves the locales of each asset in the array`, () => {
+      const field = {
+        nodeType: `document`,
+        data: {},
+        content: [
+          {
+            nodeType: `embedded-entry-block`,
+            data: { target: entryFactory() },
+          },
+        ],
+      }
+
+      const relatedAsset = assetFactory()
+      relatedAsset.fields.file = {
+        en: {
+          url: `//images.ctfassets.net/related-asset.jpg`,
+        },
+      }
+
+      field.content[0].data.target.fields.relatedAssets = {
+        en: [relatedAsset],
+      }
+
+      const expectedURL = `//images.ctfassets.net/related-asset.jpg`
+      const actualURL = getNormalizedRichTextField({
+        field,
+        contentTypes,
+        getField,
+        defaultLocale,
+      }).content[0].data.target.fields.relatedAssets[0].fields.file.url
+
+      expect(actualURL).toBe(expectedURL)
+    })
+  })
+
+  describe(`circular references`, () => {
+    it(`prevents infinite loops when two entries reference each other`, () => {
+      const entry1 = entryFactory()
+      entry1.sys.id = `entry1-id`
+      const entry2 = entryFactory()
+      entry2.sys.id = `entry2-id`
+
+      entry2.fields.title = {
+        en: `Related article`,
+        de: `German for "related article" ;)`,
+      }
+
+      // Link the two to each other
+      entry1.fields.relatedArticle.en = entry2
+      entry2.fields.relatedArticle.en = entry1
+
+      const field = {
+        nodeType: `document`,
+        data: {},
+        content: [
+          {
+            nodeType: `embedded-entry-inline`,
+            data: { target: entry1 },
+          },
+        ],
+      }
+
+      expect(() => {
+        getNormalizedRichTextField({
+          field,
+          contentTypes,
+          getField,
+          defaultLocale,
+        })
+      }).not.toThrowError()
+    })
+  })
+})

--- a/packages/gatsby-source-contentful/src/__tests__/rich-text.js
+++ b/packages/gatsby-source-contentful/src/__tests__/rich-text.js
@@ -39,21 +39,21 @@ const assetFactory = () => {
 }
 
 describe(`getNormalizedRichTextField()`, () => {
-  let contentTypes
+  let contentTypesById
   let currentLocale
   let defaultLocale
   let getField
 
   beforeEach(() => {
-    contentTypes = [
-      {
+    contentTypesById = {
+      article: {
         sys: { id: `article` },
         fields: [
           { id: `title`, localized: true },
           { id: `relatedArticle`, localized: false },
         ],
       },
-    ]
+    }
     currentLocale = `en`
     defaultLocale = `en`
     getField = field => field[currentLocale]
@@ -75,7 +75,7 @@ describe(`getNormalizedRichTextField()`, () => {
       expect(
         getNormalizedRichTextField({
           field,
-          contentTypes,
+          contentTypesById,
           getField,
           defaultLocale,
         })
@@ -103,7 +103,7 @@ describe(`getNormalizedRichTextField()`, () => {
           const expectedTitle = `Title`
           const actualTitle = getNormalizedRichTextField({
             field,
-            contentTypes,
+            contentTypesById,
             getField,
             defaultLocale,
           }).content[0].data.target.fields.title
@@ -130,7 +130,7 @@ describe(`getNormalizedRichTextField()`, () => {
           const expectedTitle = `Titel`
           const actualTitle = getNormalizedRichTextField({
             field,
-            contentTypes,
+            contentTypesById,
             getField,
             defaultLocale,
           }).content[0].data.target.fields.title
@@ -160,7 +160,7 @@ describe(`getNormalizedRichTextField()`, () => {
         const expectedTitle = `Titel zwei`
         const actualTitle = getNormalizedRichTextField({
           field,
-          contentTypes,
+          contentTypesById,
           getField,
           defaultLocale,
         }).content[0].data.target.fields.relatedArticle.fields.title
@@ -189,7 +189,7 @@ describe(`getNormalizedRichTextField()`, () => {
         const expectedURL = `//images.ctfassets.net/asset.jpg`
         const actualURL = getNormalizedRichTextField({
           field,
-          contentTypes,
+          contentTypesById,
           getField,
           defaultLocale,
         }).content[0].data.target.fields.file.url
@@ -202,7 +202,7 @@ describe(`getNormalizedRichTextField()`, () => {
   describe(`when a referenced entry contains an asset field`, () => {
     describe(`when the current locale is \`en\``, () => {
       beforeEach(() => {
-        contentTypes[0].fields.push({
+        contentTypesById.article.fields.push({
           id: `assetReference`,
           localized: true,
         })
@@ -228,7 +228,7 @@ describe(`getNormalizedRichTextField()`, () => {
         const expectedURL = `//images.ctfassets.net/asset.jpg`
         const actualURL = getNormalizedRichTextField({
           field,
-          contentTypes,
+          contentTypesById,
           getField,
           defaultLocale,
         }).content[0].data.target.fields.assetReference.fields.file.url
@@ -240,11 +240,11 @@ describe(`getNormalizedRichTextField()`, () => {
 
   describe(`when an entry/asset reference field is an array`, () => {
     beforeEach(() => {
-      contentTypes[0].fields.push({
+      contentTypesById.article.fields.push({
         id: `relatedArticles`,
         localized: false,
       })
-      contentTypes[0].fields.push({
+      contentTypesById.article.fields.push({
         id: `relatedAssets`,
         localized: false,
       })
@@ -272,7 +272,7 @@ describe(`getNormalizedRichTextField()`, () => {
       const expectedTitle = `Related article #1`
       const actualTitle = getNormalizedRichTextField({
         field,
-        contentTypes,
+        contentTypesById,
         getField,
         defaultLocale,
       }).content[0].data.target.fields.relatedArticles[0].fields.title
@@ -306,7 +306,7 @@ describe(`getNormalizedRichTextField()`, () => {
       const expectedURL = `//images.ctfassets.net/related-asset.jpg`
       const actualURL = getNormalizedRichTextField({
         field,
-        contentTypes,
+        contentTypesById,
         getField,
         defaultLocale,
       }).content[0].data.target.fields.relatedAssets[0].fields.file.url
@@ -345,7 +345,7 @@ describe(`getNormalizedRichTextField()`, () => {
       expect(() => {
         getNormalizedRichTextField({
           field,
-          contentTypes,
+          contentTypesById,
           getField,
           defaultLocale,
         })

--- a/packages/gatsby-source-contentful/src/__tests__/rich-text.js
+++ b/packages/gatsby-source-contentful/src/__tests__/rich-text.js
@@ -3,6 +3,7 @@ const { getNormalizedRichTextField } = require(`../rich-text`)
 const entryFactory = () => {
   return {
     sys: {
+      id: `abc123`,
       contentType: { sys: { id: `article` } },
       type: `Entry`,
     },

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -211,6 +211,7 @@ exports.sourceNodes = async (
       locales,
       space,
       useNameForId: pluginConfig.get(`useNameForId`),
+      richTextOptions: pluginConfig.get(`richText`),
     })
   })
 

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -197,8 +197,9 @@ exports.sourceNodes = async (
     })
 
   contentTypeItems.forEach((contentTypeItem, i) => {
-    normalize.createContentTypeNodes({
+    normalize.createNodesForContentType({
       contentTypeItem,
+      contentTypeItems,
       restrictedNodeFields,
       conflictFieldPrefix,
       entries: entryList[i],

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -347,10 +347,19 @@ exports.createNodesForContentType = ({
           fieldProps.type === `RichText` &&
           richTextOptions.resolveFieldLocales
         ) {
+          const contentTypesById = contentTypeItems.reduce(
+            (acc, contentTypeItem) => {
+              return {
+                ...acc,
+                [contentTypeItem.sys.id]: contentTypeItem,
+              }
+            },
+            {}
+          )
           return getNormalizedRichTextField({
             field: localizedField,
             fieldProps,
-            contentTypes: contentTypeItems,
+            contentTypesById,
             getField,
             defaultLocale,
           })

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -347,15 +347,11 @@ exports.createNodesForContentType = ({
           fieldProps.type === `RichText` &&
           richTextOptions.resolveFieldLocales
         ) {
-          const contentTypesById = contentTypeItems.reduce(
-            (acc, contentTypeItem) => {
-              return {
-                ...acc,
-                [contentTypeItem.sys.id]: contentTypeItem,
-              }
-            },
-            {}
+          const contentTypesById = new Map()
+          contentTypeItems.forEach(contentTypeItem =>
+            contentTypesById.set(contentTypeItem.sys.id, contentTypeItem)
           )
+
           return getNormalizedRichTextField({
             field: localizedField,
             fieldProps,

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -295,6 +295,7 @@ exports.createNodesForContentType = ({
   locales,
   space,
   useNameForId,
+  richTextOptions,
 }) => {
   // Establish identifier for content type
   //  Use `name` if specified, otherwise, use internal id (usually a natural-language constant,
@@ -342,7 +343,10 @@ exports.createNodesForContentType = ({
           ? getField(v)
           : v[defaultLocale]
 
-        if (fieldProps.type === `RichText`) {
+        if (
+          fieldProps.type === `RichText` &&
+          richTextOptions.resolveFieldLocales
+        ) {
           return getNormalizedRichTextField({
             field: localizedField,
             fieldProps,

--- a/packages/gatsby-source-contentful/src/plugin-options.js
+++ b/packages/gatsby-source-contentful/src/plugin-options.js
@@ -48,6 +48,11 @@ const optionsSchema = Joi.object().keys({
   useNameForId: Joi.boolean(),
   // default plugins passed by gatsby
   plugins: Joi.array(),
+  richText: Joi.object()
+    .keys({
+      resolveFieldLocales: Joi.boolean(),
+    })
+    .default({}),
 })
 
 const maskedFields = [`accessToken`, `spaceId`]

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -34,7 +34,7 @@ const getFieldWithLocaleResolved = ({
   // If the field is itself a reference to another entry, recursively resolve
   // that entry's field locales too.
   if (isEntryReferenceField(field)) {
-    if (resolvedEntryIDs.indexOf(field.sys.id) >= 0) {
+    if (resolvedEntryIDs.has(field.sys.id)) {
       return field
     }
 
@@ -43,7 +43,7 @@ const getFieldWithLocaleResolved = ({
       contentTypesById,
       getField,
       defaultLocale,
-      resolvedEntryIDs: [...resolvedEntryIDs, field.sys.id],
+      resolvedEntryIDs: resolvedEntryIDs.add(field.sys.id),
     })
   }
 
@@ -79,7 +79,7 @@ const getEntryWithFieldLocalesResolved = ({
    * Keep track of entries we've already resolved, in case two or more entries
    * have circular references (so as to prevent an infinite loop).
    */
-  resolvedEntryIDs = [],
+  resolvedEntryIDs = new Set(),
 }) => {
   const contentType = contentTypesById[entry.sys.contentType.sys.id]
 

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -36,7 +36,7 @@ const getFieldWithLocaleResolved = ({
   contentTypes,
   getField,
   defaultLocale,
-  resolvedEntryIDs = [],
+  resolvedEntryIDs,
 }) => {
   // If the field is itself a reference to another entry, recursively resolve
   // that entry's field locales too.

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -14,13 +14,6 @@ const isAssetReferenceNode = node =>
 const isEntryReferenceField = field => _.get(field, `sys.type`) === `Entry`
 const isAssetReferenceField = field => _.get(field, `sys.type`) === `Asset`
 
-const getEntryContentType = (entry, contentTypes) =>
-  contentTypes.find(
-    contentType =>
-      entry.sys.contentType &&
-      contentType.sys.id === entry.sys.contentType.sys.id
-  )
-
 const getFieldProps = (contentType, fieldName) =>
   contentType.fields.find(({ id }) => id === fieldName)
 
@@ -33,7 +26,7 @@ const getAssetWithFieldLocalesResolved = ({ asset, getField }) => {
 
 const getFieldWithLocaleResolved = ({
   field,
-  contentTypes,
+  contentTypesById,
   getField,
   defaultLocale,
   resolvedEntryIDs,
@@ -47,7 +40,7 @@ const getFieldWithLocaleResolved = ({
 
     return getEntryWithFieldLocalesResolved({
       entry: field,
-      contentTypes,
+      contentTypesById,
       getField,
       defaultLocale,
       resolvedEntryIDs: [...resolvedEntryIDs, field.sys.id],
@@ -65,7 +58,7 @@ const getFieldWithLocaleResolved = ({
     return field.map(fieldItem =>
       getFieldWithLocaleResolved({
         field: fieldItem,
-        contentTypes,
+        contentTypesById,
         getField,
         defaultLocale,
         resolvedEntryIDs,
@@ -78,7 +71,7 @@ const getFieldWithLocaleResolved = ({
 
 const getEntryWithFieldLocalesResolved = ({
   entry,
-  contentTypes,
+  contentTypesById,
   getField,
   defaultLocale,
 
@@ -88,7 +81,7 @@ const getEntryWithFieldLocalesResolved = ({
    */
   resolvedEntryIDs = [],
 }) => {
-  const contentType = getEntryContentType(entry, contentTypes)
+  const contentType = contentTypesById[entry.sys.contentType.sys.id]
 
   return {
     ...entry,
@@ -101,7 +94,7 @@ const getEntryWithFieldLocalesResolved = ({
 
       return getFieldWithLocaleResolved({
         field: fieldValue,
-        contentTypes,
+        contentTypesById,
         getField,
         defaultLocale,
         resolvedEntryIDs,
@@ -112,7 +105,7 @@ const getEntryWithFieldLocalesResolved = ({
 
 const getNormalizedRichTextNode = ({
   node,
-  contentTypes,
+  contentTypesById,
   getField,
   defaultLocale,
 }) => {
@@ -123,7 +116,7 @@ const getNormalizedRichTextNode = ({
         ...node.data,
         target: getEntryWithFieldLocalesResolved({
           entry: node.data.target,
-          contentTypes,
+          contentTypesById,
           getField,
           defaultLocale,
         }),
@@ -150,7 +143,7 @@ const getNormalizedRichTextNode = ({
       content: node.content.map(childNode =>
         getNormalizedRichTextNode({
           node: childNode,
-          contentTypes,
+          contentTypesById,
           getField,
           defaultLocale,
         })
@@ -167,7 +160,7 @@ const getNormalizedRichTextNode = ({
  */
 const getNormalizedRichTextField = ({
   field,
-  contentTypes,
+  contentTypesById,
   getField,
   defaultLocale,
 }) => {
@@ -177,7 +170,7 @@ const getNormalizedRichTextField = ({
       content: field.content.map(node =>
         getNormalizedRichTextNode({
           node,
-          contentTypes,
+          contentTypesById,
           getField,
           defaultLocale,
         })

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -81,7 +81,7 @@ const getEntryWithFieldLocalesResolved = ({
    */
   resolvedEntryIDs = new Set(),
 }) => {
-  const contentType = contentTypesById[entry.sys.contentType.sys.id]
+  const contentType = contentTypesById.get(entry.sys.contentType.sys.id)
 
   return {
     ...entry,

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -1,0 +1,191 @@
+const _ = require(`lodash`)
+const { BLOCKS, INLINES } = require(`@contentful/rich-text-types`)
+
+const isEntryReferenceNode = node =>
+  [
+    BLOCKS.EMBEDDED_ENTRY,
+    INLINES.ENTRY_HYPERLINK,
+    INLINES.EMBEDDED_ENTRY,
+  ].indexOf(node.nodeType) >= 0
+
+const isAssetReferenceNode = node =>
+  [BLOCKS.EMBEDDED_ASSET, INLINES.ASSET_HYPERLINK].indexOf(node.nodeType) >= 0
+
+const isEntryReferenceField = field => _.get(field, `sys.type`) === `Entry`
+const isAssetReferenceField = field => _.get(field, `sys.type`) === `Asset`
+
+const getEntryContentType = (entry, contentTypes) =>
+  contentTypes.find(
+    contentType =>
+      entry.sys.contentType &&
+      contentType.sys.id === entry.sys.contentType.sys.id
+  )
+
+const getFieldProps = (contentType, fieldName) =>
+  contentType.fields.find(({ id }) => id === fieldName)
+
+const getAssetWithFieldLocalesResolved = ({ asset, getField }) => {
+  return {
+    ...asset,
+    fields: _.mapValues(asset.fields, getField),
+  }
+}
+
+const getFieldWithLocaleResolved = ({
+  field,
+  contentTypes,
+  getField,
+  defaultLocale,
+  resolvedEntryIDs = [],
+}) => {
+  // If the field is itself a reference to another entry, recursively resolve
+  // that entry's field locales too.
+  if (isEntryReferenceField(field)) {
+    if (resolvedEntryIDs.indexOf(field.sys.id) >= 0) {
+      return field
+    }
+
+    return getEntryWithFieldLocalesResolved({
+      entry: field,
+      contentTypes,
+      getField,
+      defaultLocale,
+      resolvedEntryIDs: [...resolvedEntryIDs, field.sys.id],
+    })
+  }
+
+  if (isAssetReferenceField(field)) {
+    return getAssetWithFieldLocalesResolved({
+      asset: field,
+      getField,
+    })
+  }
+
+  if (Array.isArray(field)) {
+    return field.map(fieldItem =>
+      getFieldWithLocaleResolved({
+        field: fieldItem,
+        contentTypes,
+        getField,
+        defaultLocale,
+        resolvedEntryIDs,
+      })
+    )
+  }
+
+  return field
+}
+
+const getEntryWithFieldLocalesResolved = ({
+  entry,
+  contentTypes,
+  getField,
+  defaultLocale,
+
+  /**
+   * Keep track of entries we've already resolved, in case two or more entries
+   * have circular references (so as to prevent an infinite loop).
+   */
+  resolvedEntryIDs = [],
+}) => {
+  const contentType = getEntryContentType(entry, contentTypes)
+
+  return {
+    ...entry,
+    fields: _.mapValues(entry.fields, (field, fieldName) => {
+      const fieldProps = getFieldProps(contentType, fieldName)
+
+      const fieldValue = fieldProps.localized
+        ? getField(field)
+        : field[defaultLocale]
+
+      return getFieldWithLocaleResolved({
+        field: fieldValue,
+        contentTypes,
+        getField,
+        defaultLocale,
+        resolvedEntryIDs,
+      })
+    }),
+  }
+}
+
+const getNormalizedRichTextNode = ({
+  node,
+  contentTypes,
+  getField,
+  defaultLocale,
+}) => {
+  if (isEntryReferenceNode(node)) {
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        target: getEntryWithFieldLocalesResolved({
+          entry: node.data.target,
+          contentTypes,
+          getField,
+          defaultLocale,
+        }),
+      },
+    }
+  }
+
+  if (isAssetReferenceNode(node)) {
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        target: getAssetWithFieldLocalesResolved({
+          asset: node.data.target,
+          getField,
+        }),
+      },
+    }
+  }
+
+  if (Array.isArray(node.content)) {
+    return {
+      ...node,
+      content: node.content.map(childNode =>
+        getNormalizedRichTextNode({
+          node: childNode,
+          contentTypes,
+          getField,
+          defaultLocale,
+        })
+      ),
+    }
+  }
+
+  return node
+}
+
+/**
+ * Walk through the rich-text object, resolving locales on referenced entries
+ * (and on entries they've referenced, etc.).
+ */
+const getNormalizedRichTextField = ({
+  field,
+  contentTypes,
+  getField,
+  defaultLocale,
+}) => {
+  if (field && field.content) {
+    return {
+      ...field,
+      content: field.content.map(node =>
+        getNormalizedRichTextNode({
+          node,
+          contentTypes,
+          getField,
+          defaultLocale,
+        })
+      ),
+    }
+  }
+
+  return field
+}
+
+exports.getNormalizedRichTextField = getNormalizedRichTextField

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,6 +1973,11 @@
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
+"@contentful/rich-text-types@^13.1.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-13.4.0.tgz#a59c311ebd1b801ee00edbc08663c8d78da26171"
+  integrity sha512-YPdYqGmWiGAood7ri2BUXfPQKNthkQYV1rmQdaq4UAxWK5NLB5NXckaUYLbohqhHKtrq4tnfzVn+ePWID7Dzbg==
+
 "@emotion/babel-plugin-jsx-pragmatic@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.4.tgz#12fd120ecb202c6110dc98d3edabddafda1515f1"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When rich-text fields reference an entry or asset, the fields of the entry or asset don't have their locales resolved like the rest of the GraphQL response.

For example, consider the following GraphQL query:

```graphql
{
  contentfulArticle(slug: { eq: "my-article" }, node_locale: { eq: "en-US" }) {
    title
    bodyRichText {
      json
    }
  }
}
```

The response will look like this: 
```javascript
{
  contentfulArticle: {
    title: 'My article',
    bodyRichText: {
      json: {
        content: [
          {
            nodeType: 'embedded-entry-block',
            data: {
              target: {
                fields: {
                  title: {
                    'en-US': 'My other article',
                    'de-DE': 'Meine andere Artikel'
                  }
                }
              }
            }
          }
        ]
      } 
    }
  }
}
```

Note that, while the title of the outer article has a resolved locale — that is, the `title` property is simply the title string in the requested locale — the title of the inner article does _not_ have a resolved locale. Instead, the `title` property is an object containing `en-US` and `de-DE` properties. This makes for an inconsistent experience when working with the GraphQL response.

This PR provides a config setting, `richText.resolveFieldLocales`. When set to `true`, it fixes this issue by walking through the rich-text JSON tree and resolving locales of referenced entries. It also works recursively: if a referenced entry has its own reference to a third entry, it resolves the locales for the third (and fourth, and...) entry as well.  It does the same for assets (although not recursively, since assets don't have reference fields).

cc @Khaledgarbaya @pvdz

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
