### PR TITLE
fix(www): Fix dot-org build by removing missing starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -4028,20 +4028,6 @@
     - Uses SCSS for styling
     - Font Awesome Support
     - Progressive Web App
-- url: https://gatsby-starter-monolith.netlify.com
-  repo: https://github.com/danspratling/gatsby-starter-monolith
-  description: A Gatsby Starter designed to work with monolith. Monolith is a workspace starter which provides a good base to begin a medium-large (multisite) project
-  tags:
-    - Language:TypeScript
-    - Storybook
-    - Styling:CSS-in-JS
-  features:
-    - A minimal site with the option to add loads of functionality
-    - Based on the Monolith repo to provide an easy starting point for large projects https://github.com/danspratling/monolith
-    - Uses Theme-UI to handle theming and styling
-    - Uses TypeScript to encourage good coding
-    - Uses Storybook to encourage visual testing
-    - This site is set up with all 3 of the above working together. This makes it really easy to jump in and start a project while still having very few restrictions
 - url: https://gatsby-starter-ts-pwa.netlify.com/
   repo: https://github.com/markselby9/gatsby-starter-typescript-pwa
   description: The default Gatsby starter fork with TypeScript and PWA support added


### PR DESCRIPTION
## Description

`gatsby-starter-monolith` can't be found any more:

https://github.com/danspratling/gatsby-starter-monolith

Remove it so that it doesn't break the build of gatsbyjs.org

@danspratling, if this is a mistake, please let us know.