### PR TITLE
fix: check that richTextOptions exists before using it

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -345,6 +345,7 @@ exports.createNodesForContentType = ({
 
         if (
           fieldProps.type === `RichText` &&
+          richTextOptions &&
           richTextOptions.resolveFieldLocales
         ) {
           const contentTypesById = new Map()


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
If someone doesn't have a `richText` setting in their `gatsby-config`, this extension breaks, complaining that it can't access `resolveFieldLocales` on `undefined`.

It looks like the `default` Joi option used in `plugin-options` isn't working. I've created this hotfix to get around that issue.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->
`packages/gatsby-source-contentful/README.md`

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
