### PR TITLE
www: Persist filters on Site Showcase in opened modals

### DIFF
--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -101,19 +101,17 @@ function usePrevAndNextSite(item, filters = []) {
           fields: { hasScreenshot: { eq: true } }
         }
       ) {
-        edges {
-          node {
-            title
-            categories
-            fields {
-              slug
-            }
-            childScreenshot {
-              screenshotFile {
-                childImageSharp {
-                  resize(width: 200, height: 200) {
-                    src
-                  }
+        nodes {
+          title
+          categories
+          fields {
+            slug
+          }
+          childScreenshot {
+            screenshotFile {
+              childImageSharp {
+                resize(width: 200, height: 200) {
+                  src
                 }
               }
             }
@@ -123,11 +121,11 @@ function usePrevAndNextSite(item, filters = []) {
     }
   `)
 
-  const sites = filterByCategories(allSitesYaml.edges, filters)
-  const currentIndex = sites.findIndex(edge => edge.node.fields.slug === item)
-  const nextSite = sites[(currentIndex + 1) % sites.length].node
+  const sites = filterByCategories(allSitesYaml.nodes, filters)
+  const currentIndex = sites.findIndex(node => node.fields.slug === item)
+  const nextSite = sites[(currentIndex + 1) % sites.length]
   const previousSite =
-    sites[currentIndex === 0 ? sites.length - 1 : currentIndex - 1].node
+    sites[currentIndex === 0 ? sites.length - 1 : currentIndex - 1]
   return { nextSite, previousSite }
 }
 

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -92,7 +92,7 @@ const SourceLink = ({ ...props }) => (
   </a>
 )
 
-function usePrevAndNextSite(item, filters) {
+function usePrevAndNextSite(item, filters = []) {
   const { allSitesYaml } = useStaticQuery(graphql`
     query {
       allSitesYaml(

--- a/www/src/components/showcase-details.js
+++ b/www/src/components/showcase-details.js
@@ -143,7 +143,6 @@ function getExitLocation(filters = {}) {
 
 function ShowcaseModal({ children, location, isModal }) {
   if (!isModal) return children
-  const { previousSite, nextSite } = usePrevAndNextSite(location.pathname)
   const { filters } = location.state || {}
   const { previousSite, nextSite } = usePrevAndNextSite(
     location.pathname,

--- a/www/src/views/showcase/filtered-showcase.js
+++ b/www/src/views/showcase/filtered-showcase.js
@@ -19,7 +19,7 @@ import { themedInput } from "../../utils/styles"
 
 const OPEN_SOURCE_CATEGORY = `Open Source`
 
-const filterByCategories = (list, categories) => {
+export const filterByCategories = (list, categories) => {
   const items = list.reduce((aggregated, node) => {
     if (node.categories) {
       const filteredCategories = node.categories.filter(c =>


### PR DESCRIPTION
This PR makes the showcase modal work in consistent with selected filters in the showcase list. Closes #21467 

Before:
![showcase-modal-BEFORE2](https://user-images.githubusercontent.com/450559/75029878-f216e300-54c8-11ea-9939-67bfe28201f9.gif)

After:

![showcase-modal-AFTER1](https://user-images.githubusercontent.com/450559/75030096-6a7da400-54c9-11ea-9e61-ee036b1da754.gif)


Couple of questions:

1. I've directly exported the `filterByCategories` function from `filtered-showcase.js` -- should it be moved to some util and be used in both these components?
2. I've changed the query in `showcase-details.js` to include `edges` (instead of directly querying `nodes`) to make it work with `filterByCategroies` function. We could also modify the query for the showcase list to just get `nodes` instead of `edges` and refactor `filterByCategories`, but it'll make this PR slightly bigger. If that's preferred, can it be done in a follow-up PR?

