### PR TITLE
Keep frontmatter declaration in content

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -124,7 +124,7 @@ module.exports = async function(content) {
       id: `fakeNodeIdMDXFileABugIfYouSeeThis`,
       node: fileNode,
       content,
-      options
+      options,
     })
   } catch (e) {
     return callback(e)
@@ -144,7 +144,7 @@ module.exports = async function(content) {
   if (!hasDefaultExport(content, DEFAULT_OPTIONS) && !!defaultLayout) {
     debug(`inserting default layout`, defaultLayout)
     const { content: contentWithoutFrontmatter, data } = grayMatter(content)
-    const matter = grayMatter.stringify('', data )
+    const matter = grayMatter.stringify(``, data )
 
     code = `${matter ? matter : ``}
 

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -124,6 +124,7 @@ module.exports = async function(content) {
       id: `fakeNodeIdMDXFileABugIfYouSeeThis`,
       node: fileNode,
       content,
+      options
     })
   } catch (e) {
     return callback(e)
@@ -142,7 +143,8 @@ module.exports = async function(content) {
   // check needs to happen first.
   if (!hasDefaultExport(content, DEFAULT_OPTIONS) && !!defaultLayout) {
     debug(`inserting default layout`, defaultLayout)
-    const { content: contentWithoutFrontmatter, matter } = grayMatter(content)
+    const { content: contentWithoutFrontmatter, data } = grayMatter(content)
+    const matter = grayMatter.stringify('', data )
 
     code = `${matter ? matter : ``}
 

--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -86,8 +86,8 @@ module.exports = async function genMDX(
 
   // pull classic style frontmatter off the raw MDX body
   debug(`processing classic frontmatter`)
-  const { data, content: frontMatterCodeResult } = grayMatter(node.rawBody)
-  const content = `${frontMatterCodeResult}
+  const { data } = grayMatter(node.rawBody)
+  const content = `${node.rawBody}
 
 export const _frontmatter = ${JSON.stringify(data)}`
 

--- a/packages/gatsby-plugin-mdx/utils/mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/mdx.js
@@ -11,7 +11,7 @@ const grayMatter = require(`gray-matter`)
 module.exports = async function mdxToJsx(source, options) {
   const { data, content } = grayMatter(source)
 
-  let code = await mdx(content, options || {})
+  let code = await mdx(source, options || {})
 
   return `${code}
 

--- a/packages/gatsby-plugin-mdx/utils/mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/mdx.js
@@ -9,7 +9,7 @@ const grayMatter = require(`gray-matter`)
  * @return {String}         JSX source
  */
 module.exports = async function mdxToJsx(source, options) {
-  const { data, content } = grayMatter(source)
+  const { data } = grayMatter(source)
 
   let code = await mdx(source, options || {})
 


### PR DESCRIPTION
... so other remark plugins can parse and process them. 
It make the behaviour of gatsby-plugin-mdx more coherent with direct mdx call when you configure 'remarkplugins' that works on frontmatter elements.
With this PR Frontmatters informations can be processed by remarkplugins.


## Description

With this PR the frontmatter related informations are not removed from the content, and thus available to other remarkplugins configured.

### Documentation

Documentation states that remarkplugins attribute works like mdx's one, but the frontmatter informations are removed, so it create question like : "why this not works on Gatsby, whereas it's okay on mdx(content, option) processor configuration ?"

## Related Issues

It"s a little bit Related to #16865.

## Side note : 

A mdx() processing is called during `gatsby-plugin-mdx/gatsby/preprocess-source.js` step, but this is a different code from "genMDX" that seems used everywhere else.
This may cause miss-understandings between results from Gatsby with no cache and Gatsby with caches. no ? 
This PR update both.
