### PR TITLE
fix(gatsby-source-contentful): Add panic messaging to builds with no locales

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/fetch.js
+++ b/packages/gatsby-source-contentful/src/__tests__/fetch.js
@@ -168,6 +168,24 @@ it(`calls contentful.getContentTypes with custom plugin option page limit`, asyn
   })
 })
 
+it(`panics when localeFilter reduces locale list to 0`, async () => {
+  await fetchData({
+    pluginConfig: createPluginConfig({
+      accessToken: `6f35edf0db39085e9b9c19bd92943e4519c77e72c852d961968665f1324bfc94`,
+      spaceId: `rocybtov1ozk`,
+      pageLimit: 50,
+      localeFilter: () => false,
+    }),
+    reporter,
+  })
+
+  expect(reporter.panic).toBeCalledWith(
+    expect.stringContaining(
+      `No locales found to build data model. Plase check if your localeFilter configuration is configured properly.`
+    )
+  )
+})
+
 describe(`Displays troubleshooting tips and detailed plugin options on contentful client error`, () => {
   it(`Generic fallback error`, async () => {
     mockClient.getLocales.mockImplementation(() => {

--- a/packages/gatsby-source-contentful/src/__tests__/fetch.js
+++ b/packages/gatsby-source-contentful/src/__tests__/fetch.js
@@ -181,7 +181,7 @@ it(`panics when localeFilter reduces locale list to 0`, async () => {
 
   expect(reporter.panic).toBeCalledWith(
     expect.stringContaining(
-      `No locales found to build data model. Plase check if your localeFilter configuration is configured properly.`
+      `Please check if your localeFilter is configured properly. Locales 'en-us' were found but were filtered down to none.`
     )
   )
 })

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -31,12 +31,17 @@ module.exports = async ({ syncToken, reporter, pluginConfig }) => {
   try {
     console.log(`Fetching default locale`)
     space = await client.getSpace()
-    locales = await client.getLocales().then(response => response.items)
-    defaultLocale = _.find(locales, { default: true }).code
-    locales = locales.filter(pluginConfig.get(`localeFilter`))
+    let contentfulLocales = await client
+      .getLocales()
+      .then(response => response.items)
+    defaultLocale = _.find(contentfulLocales, { default: true }).code
+    locales = contentfulLocales.filter(pluginConfig.get(`localeFilter`))
     if (locales.length === 0) {
       reporter.panic(
-        `No locales found to build data model. Plase check if your localeFilter configuration is configured properly.`
+        `Please check if your localeFilter is configured properly. Locales '${_.join(
+          contentfulLocales.map(item => item.code),
+          `,`
+        )}' were found but were filtered down to none.`
       )
     }
     console.log(`default locale is : ${defaultLocale}`)

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -34,6 +34,11 @@ module.exports = async ({ syncToken, reporter, pluginConfig }) => {
     locales = await client.getLocales().then(response => response.items)
     defaultLocale = _.find(locales, { default: true }).code
     locales = locales.filter(pluginConfig.get(`localeFilter`))
+    if (locales.length === 0) {
+      reporter.panic(
+        `No locales found to build data model. Plase check if your localeFilter configuration is configured properly.`
+      )
+    }
     console.log(`default locale is : ${defaultLocale}`)
   } catch (e) {
     let details


### PR DESCRIPTION
## Description

Panics when a user defined configuration causes no locales to be found from Contentful.  When no locales are found the gatsby-source-contentful plugin is unable to build any default content model fragments and causes GraphQL errors to be thrown. 

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/21651
