### PR TITLE
fix: Allow include in asciidoc

### DIFF
--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -35,6 +35,7 @@ async function onCreateNode(
 
   // changes the incoming imagesdir option to take the
   const asciidocOptions = processPluginOptions(pluginOptions, pathPrefix)
+  asciidocOptions.base_dir = node.dir
 
   const { createNode, createParentChildLink } = actions
   // Load Asciidoc contents


### PR DESCRIPTION
## Description

Added `base_dir` convert [option](https://asciidoctor-docs.netlify.com/asciidoctor.js/processor/convert-options/) for [asciidoc.js](https://asciidoctor-docs.netlify.com/asciidoctor.js/).

This enables the use of asciidoc includes `include::folder/_doc-to-include.adoc[]`when used in combination with unsafe.

```
{
  resolve: 'gatsby-transformer-asciidoc',
  options: {
    safe: 'unsafe'
  }
},
```

The resulting document will have the included document's content embedded instead of a link.

