### PR TITLE
chore(staters): Add gatsby-starter-netlify-lambda

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5311,3 +5311,10 @@
     - Serverless
     - Gatsby
     - Square payments
+- url: https://gatsby-starter-netlify-function.netlify.com/
+  repo: https://github.com/nickmcmillan/gatsby-starter-netlify-lambda
+  description: A simple Netlify serverless lambda function starter
+  tags:
+    - Netlify
+  features:
+    - Barebones example of POSTing to a Netlify function and receiving a response from it.


### PR DESCRIPTION
## Description

A barebones starter project showing how to integrate with Netlify functions.

### Documentation

I wrote an accompanying article; https://medium.com/@nick.a.mcmillan/a-guide-to-adding-a-netlify-serverless-function-to-your-gatsby-site-34a85f4a5d2b

## Related Issues

N/A