### PR TITLE
fix: Allow include in asciidoc

### DIFF
--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -42,7 +42,10 @@ async function onCreateNode(
   // Load Asciidoc file for extracting
   // https://asciidoctor-docs.netlify.com/asciidoctor.js/processor/extract-api/
   // We use a `let` here as a warning: some operations, like .convert() mutate the document
-  let doc = await asciidoc.load(content, asciidocOptions)
+  let doc = await asciidoc.load(content, {
+    base_dir: node.dir,
+    ...asciidocOptions,
+  })
 
   try {
     const html = doc.convert()


### PR DESCRIPTION
## Description

Added `base_dir` convert [option](https://asciidoctor-docs.netlify.com/asciidoctor.js/processor/convert-options/) for [asciidoc.js](https://asciidoctor-docs.netlify.com/asciidoctor.js/).

This enables the use of asciidoc includes `include::folder/_doc-to-include.adoc[]`when used in combination with unsafe.

```
{
  resolve: 'gatsby-transformer-asciidoc',
  options: {
    safe: 'unsafe'
  }
},
```

The resulting document will have the included document's content embedded instead of a link.

