### PR TITLE
WIP: fix(gatsby-source-contentful) No Contentful assets causes build failures

### DIFF
--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -20,7 +20,6 @@ const {
   isAbstractType,
   Kind,
   FragmentsOnCompositeTypesRule,
-  KnownTypeNamesRule,
   LoneAnonymousOperationRule,
   PossibleFragmentSpreadsRule,
   ScalarLeafsRule,
@@ -185,7 +184,6 @@ export const processQueries = ({
 
 const preValidationRules = [
   LoneAnonymousOperationRule,
-  KnownTypeNamesRule,
   FragmentsOnCompositeTypesRule,
   VariablesAreInputTypesRule,
   ScalarLeafsRule,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Inlines an image to guarantee build has an image to infer the model around.  

Not the biggest fan of this solution.  

Also tried to get a schema typed before hand to guarantee the schema types existed, but that runs into problems where multiple schema types of the same name exist. 

This does not actually make the fragments pass when executed on inside a query, as this mock item doesn't actually exist in Contentful the resolved urls are not accurate.  I toyed with the idea of actually having a local gatsby image file to reference if no assets are found. 

## Related Issues

Fixes #16455 
Fixes #15397 
