### PR TITLE
Fix gatsby-remark-images inside gatsby-plugin-mdx

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -417,7 +417,9 @@ module.exports = (
               return resolve()
             }
 
-            const $ = cheerio.load(node.value)
+            const $ = cheerio.load(node.value, {
+              xmlMode: true,
+            })
             if ($(`img`).length === 0) {
               // No img tags
               return resolve()
@@ -464,8 +466,10 @@ module.exports = (
             }
 
             // Replace the image node with an inline HTML node.
-            node.type = `html`
-            node.value = $(`body`).html() // fix for cheerio v1
+            if (node.type !== `jsx`) {
+              node.type = `html`
+            }
+            node.value = $.html()
 
             return resolve(node)
           })


### PR DESCRIPTION
## Description

Allows gatsby-remark-images to work in a MDX file, by not renaming the elements to lower case.

Unlike @arshad's patch, I preferred using `xmlMode: true` since the doc states

> For feeds and other XML content (documents that don't consist of HTML), set this to true.
> (https://github.com/fb55/htmlparser2/wiki/Parser-options#option-xmlmode)

and I believe JSX does not consist of HTML. Besides, setting `lowerCaseTags: false` doesn't do anything.

For the record, **this is not perfect though.** Cheerio renders attributes as strings, e.g. `<CustomComponent foo={bar} ...` is transformed to `<CustomComponent foo="{bar}" ...`. Maybe someday cheerio will parse JSX, in the meantime avoid rendering images and complex component bindings in the same block.

I removed `// fix for cheerio v1` because I haven't found any such fix. Like @arshad I'm using the recommended way to render, which works.

### Documentation

NA

## Related Issues

Fixes #19785 