### PR TITLE
fix(www): Remove GraphQL playground

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -113,7 +113,7 @@
   "scripts": {
     "build": "gatsby build",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
-    "develop": "cross-env GATSBY_GRAPHQL_IDE=playground gatsby develop",
+    "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",


### PR DESCRIPTION
## Description

The already included GraphiQL is superior to GraphQL playground, so there's no reason to use that.
