### PR TITLE
www(fix): update line height for newlines in code blocks

### DIFF
--- a/www/src/utils/styles/global.js
+++ b/www/src/utils/styles/global.js
@@ -47,6 +47,11 @@ const prismToken = t => {
     ".token.entity": {
       cursor: `help`,
     },
+    ".token-line > span.token:empty::after": {
+      minHeight: `1em`,
+      display: `inline-block`,
+      content: `""`,
+    },
     ".namespace": {
       opacity: 0.7,
     },


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR adds some styles to how Prism renders empty lines so that our code blocks are more readable.

Here's how it looks on the left, compared to what .org shows on the right:

<img width="996" alt="Screen Shot 2020-02-24 at 5 08 52 PM" src="https://user-images.githubusercontent.com/21114044/75202491-a793a180-5728-11ea-8279-725b27001984.png">

The code blocks in the docs have newlines so clicking the copy button accurately copies the code with line breaks preserved, but when rendered there is an element created by Prism with no content inside. By giving it a minimum height and updating it's display property it pushes the content below it down to display like the code is represented in reality.

## Related Issues

None (that I know of), noticed this problem a while ago