### PR TITLE
gatsby-theme-blog-core(fix): Define schema for social object in siteMetadata

### DIFF
--- a/packages/gatsby-theme-blog-core/gatsby-node.js
+++ b/packages/gatsby-theme-blog-core/gatsby-node.js
@@ -44,13 +44,26 @@ const mdxResolverPassthrough = fieldName => async (
 }
 
 exports.createSchemaCustomization = ({ actions, schema }) => {
-  const { createTypes } = actions
+  const { createFieldExtension, createTypes } = actions
+  createFieldExtension({
+    name: `defaultArray`,
+    extend() {
+      return {
+        resolve(source, args, context, info) {
+          if (source[info.fieldName] == null) {
+            return []
+          }
+          return source[info.fieldName]
+        },
+      }
+    },
+  })
   createTypes(`
     type Site implements Node {
       siteMetadata: SiteMetadata
     }
     type SiteMetadata {
-      social: Social
+      social: [Social] @defaultArray
     }
     type Social {
       name: String

--- a/packages/gatsby-theme-blog-core/gatsby-node.js
+++ b/packages/gatsby-theme-blog-core/gatsby-node.js
@@ -45,6 +45,18 @@ const mdxResolverPassthrough = fieldName => async (
 
 exports.createSchemaCustomization = ({ actions, schema }) => {
   const { createTypes } = actions
+  createTypes(`
+    type Site implements Node {
+      siteMetadata: SiteMetadata
+    }
+    type SiteMetadata {
+      social: Social
+    }
+    type Social {
+      name: String
+      url: String
+    }
+  `)
   createTypes(`interface BlogPost @nodeInterface {
       id: ID!
       title: String!


### PR DESCRIPTION
## Description

**Do Not Merge**

I am working on some docs related to composing multiple themes.  This exposed some weaknesses in the GraphQL queries for gatsby-theme-blog-core.  Specifically the `social` object on siteMetadata which is not a guarantee like some `title` or `description`.  This PR adds in some schema definition for this type.

I did some more testing and digging. Composing themes can get tricky without a preset starter with the correctly seeded gatsby-config.js.

Ideally it would be good if gatsby-theme-blog and gatsby-theme-notes defined their siteMetadata schema in `gatsby-node.js` in a way that allowed them to be added as a plugin and 'just work'.  Right now if you add them as a plugin to a `gatsby-config.js` without the correct fields you start getting a bunch of errors.

### Documentation

Not necessary in my view.

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/21714