### PR TITLE
chore: add labels to github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,8 @@
 ---
 name: Bug Report 🐞
 about: Something isn't working as expected? Here is the right place to report.
+labels:
+  - "type: bug"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,6 +1,8 @@
 ---
 name: Documentation 📝
 about: Suggest better docs coverage for a particular tool or process.
+labels:
+  - "type: documentation"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,8 @@
 ---
 name: Feature Request 💡
 about: Suggest a new idea for the project.
+labels:
+  - "type: feature or enhancement"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/new_translation.md
+++ b/.github/ISSUE_TEMPLATE/new_translation.md
@@ -1,6 +1,10 @@
 ---
 name: New Translation Request 🌐
 about: Suggest a new language translation of the repo.
+labels:
+  - "type: translation request"
+  - "topic: i18n"
+  - "not stale" # translation requests should be left open for more maintainers
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,8 @@
 ---
 name: Question 🤔
 about: Usage question or discussion about Gatsby.
+labels:
+  - "type: question or discussion"
 ---
 
 <!--


### PR DESCRIPTION
## Description

Add labels to github issue templates. Cause what's the point of templates if you don't label 'em?

Github docs: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser