### PR TITLE
chore(scripts): update the list of core pages for translation

### DIFF
--- a/scripts/i18n/pages.json
+++ b/scripts/i18n/pages.json
@@ -20,6 +20,41 @@
   },
   {
     "name": "docs",
-    "pages": ["index", "quick-start", "recipes", "glossary", "gatsby-cli"]
+    "pages": [
+      "index",
+      "quick-start",
+      "recipes",
+      "recipes/pages-layouts",
+      "recipes/styling-css",
+      "recipes/working-with-starters",
+      "recipes/working-with-themes",
+      "recipes/sourcing-data",
+      "recipes/querying-data",
+      "recipes/working-with-images",
+      "recipes/transforming-data",
+      "recipes/deploying-your-site",
+      "api-reference",
+      "theme-api",
+      "gatsby-link",
+      "gatsby-image",
+      "gatsby-config",
+      "browser-apis",
+      "ssr-apis",
+      "api-files",
+      "api-files-gatsby-config",
+      "api-files-gatsby-browser",
+      "api-files-gatsby-node",
+      "api-files-gatsby-ssr",
+      "actions",
+      "graphql-api",
+      "node-apis",
+      "node-api-helpers",
+      "node-model",
+      "node-interface",
+      "schema-customization",
+      "api-specification",
+      "glossary",
+      "gatsby-cli"
+    ]
   }
 ]


### PR DESCRIPTION
## Description

Update the list of core docs for translation.

* recipes has been split up into multiple files
* added API files, which are all now .md files and can be translated (though content in jsdoc still cannot be translated)

## Follow-up

* [x] go to all the translation repos and update their progress issue