### PR TITLE
chore(docs): fix url fragment of link in gatsby-plugin-catch-links README

### DIFF
--- a/packages/gatsby-plugin-catch-links/README.md
+++ b/packages/gatsby-plugin-catch-links/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-catch-links
 
-This plugin intercepts all local links that have not been created in React using [`gatsby-link`](https://gatsbyjs.org/docs/gatsby-link), and replaces their behavior with that of the `gatsby-link` [`navigate`](https://gatsbyjs.org/docs/gatsby-link/#programmatic-navigation). This avoids the browser having to refresh the whole page when navigating between local pages, preserving the Single Page Application (SPA) feel.
+This plugin intercepts all local links that have not been created in React using [`gatsby-link`](https://gatsbyjs.org/docs/gatsby-link), and replaces their behavior with that of the `gatsby-link` [`navigate`](https://gatsbyjs.org/docs/gatsby-link/#how-to-use-the-navigate-helper-function). This avoids the browser having to refresh the whole page when navigating between local pages, preserving the Single Page Application (SPA) feel.
 
 Example use cases:
 


### PR DESCRIPTION
## Description

It was corrected because it did not exist id.