### PR TITLE
[gatsby-plugin-mdx] Add mdxAST to nodes

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
@@ -52,11 +52,7 @@ module.exports = async (
     content,
   })
 
-  createNode(mdxNode)
-  createParentChildLink({ parent: node, child: mdxNode })
-
-  // write scope files into .cache for later consumption
-  const { scopeImports, scopeIdentifiers } = await genMDX(
+  const { scopeImports, scopeIdentifiers, mdast } = await genMDX(
     {
       node: mdxNode,
       getNode,
@@ -72,6 +68,13 @@ module.exports = async (
     },
     { forceDisableCache: true }
   )
+
+  mdxNode.mdxAST = mdast
+
+  createNode(mdxNode)
+  createParentChildLink({ parent: node, child: mdxNode })
+
+  // write scope files into .cache for later consumption
   await cacheScope({
     cache,
     scopeIdentifiers,


### PR DESCRIPTION
## Description

This PR will add the `mdxAST` generated in the `gatsby-plugin-mdx` to the nodes created by the plugin. Like that other plugins (e.g. transformer plugins) can use the `mdxAST` inside their `onCreateNode` hook and search it for certain components etc.

A real life use case would be in my new [gatsby-mdx-tts](https://github.com/flogy/gatsby-mdx-tts) plugin that enables text-to-speech output for all MDX content enclosed by the custom `<SpeechOutput>` react component. So the plugin should look up those components, extract the enclosed MDX and generate the TTS mp3 files out of it. 

### Documentation

Currently, the properties of the mdx nodes are not documented. I am not sure if it makes sense to add documentation just because of that one more property?

## Related Issues

I have opened an issue in my plugin repository about my insecurity if creating a sub-plugin for `gatsby-plugin-mdx` is the optimal approach on getting and transforming the MDXAST or if it would be better to go for the approach where I create a transformer plugin that gets the MDXAST from mdx-nodes, which will be allowed by accepting this PR: https://github.com/flogy/gatsby-mdx-tts/issues/3