### PR TITLE
chore(gatsby-plugin-benchmark-reporter): Read versions from node_modules

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -80,6 +80,7 @@ class BenchMeta {
     const nodejsVersion = process.version
 
     // This assumes the benchmark is started explicitly from `node_modules/.bin/gatsby`, and not a global install
+    // (This is what `gatsby --version` does too, ultimately)
     const gatsbyCliVersion = require(`gatsby-cli/package.json`).version
 
     const gatsbyVersion = require(`gatsby/package.json`).version
@@ -88,7 +89,7 @@ class BenchMeta {
       ? require(`sharp/package.json`).version
       : `none`
 
-    const webpackVersion = require(`webpack`).version
+    const webpackVersion = require(`webpack/package.json`).version
 
     const publicJsSize = glob(`public/*.js`).reduce(
       (t, file) => t + fs.statSync(file).size,

--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -79,7 +79,8 @@ class BenchMeta {
 
     const nodejsVersion = process.version
 
-    const gatsbyCliVersion = execToStr(`gatsby --version`)
+    // This assumes the benchmark is started explicitly from `node_modules/.bin/gatsby`, and not a global install
+    const gatsbyCliVersion = require(`gatsby-cli/package.json`).version
 
     const gatsbyVersion = require(`gatsby/package.json`).version
 
@@ -87,7 +88,7 @@ class BenchMeta {
       ? require(`sharp/package.json`).version
       : `none`
 
-    const webpackVersion = execToStr(`node_modules/.bin/webpack --version`)
+    const webpackVersion = require(`webpack`).version
 
     const publicJsSize = glob(`public/*.js`).reduce(
       (t, file) => t + fs.statSync(file).size,


### PR DESCRIPTION
This fixes the benchmarks which currently assume `gatsby` is available in `$PATH` which is not always the case. So instead the benchmarks are now assumed to run from `node_modules/.bin/gatsby`, which should be true for our own benchmarks (which is what this plugin is targeting in the first place).

It also fixes the unnecessary cli output problem which was triggered by calling `webpack --version` without a global webpack installation. Reading from `node_modules` should be fine.