### PR TITLE
fix(.github): try to fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,7 @@
 ---
 name: Bug Report 🐞
 about: Something isn't working as expected? Here is the right place to report.
-labels:
-  - "type: bug"
+labels: "type: bug"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,8 +1,7 @@
 ---
 name: Documentation 📝
 about: Suggest better docs coverage for a particular tool or process.
-labels:
-  - "type: documentation"
+labels: "type: documentation"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,7 @@
 ---
 name: Feature Request 💡
 about: Suggest a new idea for the project.
-labels:
-  - "type: feature or enhancement"
+labels: "type: feature or enhancement"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/new_translation.md
+++ b/.github/ISSUE_TEMPLATE/new_translation.md
@@ -1,10 +1,8 @@
 ---
 name: New Translation Request 🌐
 about: Suggest a new language translation of the repo.
-labels:
-  - "type: translation request"
-  - "topic: i18n"
-  - "not stale" # translation requests should be left open for more maintainers
+# "not stale" b/c translation requests should be left open for more maintainers
+labels: "type: translation request, topic: i18n, not stale"
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,7 @@
 ---
 name: Question 🤔
 about: Usage question or discussion about Gatsby.
-labels:
-  - "type: question or discussion"
+labels: "type: question or discussion"
 ---
 
 <!--


### PR DESCRIPTION
## Description

Well, apparently GitHub thought that yaml lists are too cool for them and decided labels should be a comma separated list.