### PR TITLE
fix(gatsby-plugin-benchmark-reporting): Read gatsby-cli version from n_m

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -81,7 +81,7 @@ class BenchMeta {
 
     // This assumes the benchmark is started explicitly from `node_modules/.bin/gatsby`, and not a global install
     // (This is what `gatsby --version` does too, ultimately)
-    const gatsbyCliVersion = require(`gatsby-cli/package.json`).version
+    const gatsbyCliVersion = execToInt(`node_modules/.bin/gatsby --version`)
 
     const gatsbyVersion = require(`gatsby/package.json`).version
 

--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -81,7 +81,7 @@ class BenchMeta {
 
     // This assumes the benchmark is started explicitly from `node_modules/.bin/gatsby`, and not a global install
     // (This is what `gatsby --version` does too, ultimately)
-    const gatsbyCliVersion = execToInt(`node_modules/.bin/gatsby --version`)
+    const gatsbyCliVersion = execToStr(`node_modules/.bin/gatsby --version`)
 
     const gatsbyVersion = require(`gatsby/package.json`).version
 


### PR DESCRIPTION
It seems `gatsby-cli` isn't installed in all repo's explicitly so the change to use `require('gatsby-cli/package.json').version` fails in some cases. So instead let's use `node_modules/.bin/gatsby --version`.