### PR TITLE
(docs): Reference guide for using WooCommerce

### DIFF
--- a/docs/docs/sourcing-from-woocommerce.md
+++ b/docs/docs/sourcing-from-woocommerce.md
@@ -12,18 +12,18 @@ You’ll need a WordPress site with the [WooCommerce](https://woocommerce.com/) 
 
 ## Existing plugins
 
-This guide assumes the use of the [`gatsby-source-woocommerce` plugin](/packages/@pasdo501/gatsby-source-woocommerce/). It is a straightforward solution specific to WooCommerce. 
+This guide assumes the use of the [`gatsby-source-woocommerce` plugin](/packages/@pasdo501/gatsby-source-woocommerce/). It is a straightforward solution specific to WooCommerce.
 
 Install it:
 
 ```bash
 npm install --save @pasdo501/gatsby-source-woocommerce
-``` 
+```
 
 Configure its options:
 
 ```js:title=gatsby-config.js
-{       
+{
   resolve: "@pasdo501/gatsby-source-woocommerce",
   options: {
     // Base URL of Wordpress site
@@ -54,7 +54,7 @@ The WPGraphQL plugin is also undergoing significant changes. It has not yet hit 
 
 ## Adding products
 
-WooCommerce products are the core of your WooCommerce site, so you’ll want to add some to your store. When you’re first getting started, there’s no need to dump absolutely everything you want to sell into your store. Begin with a few products that you can use to verify that everything is hooked up correctly. You can also [import products from a CSV file](https://docs.woocommerce.com/document/product-csv-importer-exporter/). 
+WooCommerce products are the core of your WooCommerce site, so you’ll want to add some to your store. When you’re first getting started, there’s no need to dump absolutely everything you want to sell into your store. Begin with a few products that you can use to verify that everything is hooked up correctly. You can also [import products from a CSV file](https://docs.woocommerce.com/document/product-csv-importer-exporter/).
 
 You should see a prompt to create your first product after completing the WooCommerce setup wizard. Doing so at this time will trigger a guided tour of the new product form. Walk through this process for each product you'd like to add to your store.
 

--- a/docs/docs/sourcing-from-woocommerce.md
+++ b/docs/docs/sourcing-from-woocommerce.md
@@ -1,0 +1,78 @@
+---
+title: Sourcing from WooCommerce
+---
+
+WooCommerce is the e-commerce platform for WordPress. This guide will serve as a helpful reference whether you’re interested in getting started with e-commerce for your WordPress site or beginning to use Gatsby with your current WooCommerce setup.
+
+## Prerequisites
+
+This guide assumes some familiarity with WordPress. You may want to read about [Sourcing from WordPress](/docs/sourcing-from-wordpress/) or step through a [tutorial on how to build a blog with WordPress and Gatsby](/blog/2019-04-26-how-to-build-a-blog-with-wordpress-and-gatsby-part-1) before diving in.
+
+You’ll need a WordPress site with the [WooCommerce](https://woocommerce.com/) plugin installed and activated.
+
+## Existing plugins
+
+This guide assumes the use of the [`gatsby-source-woocommerce` plugin](/packages/@pasdo501/gatsby-source-woocommerce/). It is a stable, straightforward solution specific to WooCommerce. You can install it with `npm install --save @pasdo501/gatsby-source-woocommerce` and then configure its options:
+
+```js:title=gatsby-config.js
+{       
+  resolve: "@pasdo501/gatsby-source-woocommerce",
+  options: {
+    // Base URL of Wordpress site
+    api: 'wordpress.domain',
+    // true if using https. false if nah.
+    https: false,
+    api_keys: {
+      consumer_key: `your key`,
+      consumer_secret: `your secret`,
+    },
+    // Array of strings with fields you'd like to create nodes for...
+    fields: ['products', 'products/categories', 'products/attributes'],
+  }
+},
+```
+
+However, there are other options which may make more sense for your project. For example, you may want to source more general site data like posts and pages from WordPress as well.
+
+### Pending Changes
+
+Note that `gatsby-source-wordpress` is undergoing a major rewrite at the time of writing. This new major version of the official source plugin is likely to change the optimal solution for using WooCommerce with Gatsby. For now, new projects should start with [`gatsby-source-graphql`](/packages/gatsby-source-graphql/) rather than `gatsby-source-wordpress` to ease the transition. If you’re interested in the current progress of the plugin, you can [check out the working alpha version](https://github.com/gatsbyjs/gatsby/issues/19292#issuecomment-587946239). **Once this work is done, the [`wp-graphql-woocommerce` plugin](https://github.com/wp-graphql/wp-graphql-woocommerce) will be the recommended option.**
+
+If you decide to go with this more experimental route, you'll need to install and activate the [WPGraphQL](https://www.wpgraphql.com/) and [wp-graphql-woocommerce](https://github.com/wp-graphql/wp-graphql-woocommerce) plugins on your WordPress site as well.
+
+The WPGraphQL plugin is also undergoing significant changes. It has not yet hit v1 and may therefore introduce [breaking changes](https://docs.wpgraphql.com/getting-started/install-and-activate/#breaking-change-notice) as it continues to progress through development. It can be used in production but keep this in mind when using the plugin!
+
+## Adding products
+
+WooCommerce products are the core of your WooCommerce site, so you’ll want to add some to your store. When you’re first getting started, there’s no need to dump absolutely everything you want to sell into your store. Begin with a few products that you can use to verify that everything is hooked up correctly. You can also [import products from a CSV file](https://docs.woocommerce.com/document/product-csv-importer-exporter/). You should see as prompt to create your first product after completing the WooCommerce setup wizard. 
+
+Once this is done, you’ll be able to use GraphQL to query for your products:
+
+```graphql
+allWcProducts {
+  edges {
+    node {
+      name
+      price
+    }
+  }
+}
+```
+
+## Testing queries
+
+### Using GraphiQL
+
+You can explore the data available to your site [using GraphiQL](/docs/running-queries-with-graphiql/). This is dependent on the fields you have specified in `gatsby-config.js`. The plugin documentation has tons of [suggested GraphQL queries](/packages/@pasdo501/gatsby-source-woocommerce/#some-graphql-query-examples). If you don't see the options listed there, try adjusting the `fields` array and/or refreshing your GraphiQL tab.
+
+### Using WPGraphQL
+
+You can explore possible queries in the [WPGraphQL WooCommerce Playground](https://docs.wpgraphql.com/extensions/wpgraphql-woocommerce/#playground). Note that some queries are only available to shop managers as opposed to customers.
+
+## Other resources
+
+- [`gatsby-source-woocommerce`](/packages/@pasdo501/gatsby-source-woocommerce/)
+- [`gatsby-theme-woocommerce`](/packages/@ccerda0520/gatsby-theme-woocommerce/)
+- [`wp-graphql-woocommerce` plugin](https://github.com/wp-graphql/wp-graphql-woocommerce)
+- [experimental `gatsby-source-wordpress` starter](https://github.com/TylerBarnes/using-gatsby-source-wordpress-experimental)
+- [Sourcing from WordPress](/docs/sourcing-from-wordpress/)

--- a/docs/docs/sourcing-from-woocommerce.md
+++ b/docs/docs/sourcing-from-woocommerce.md
@@ -28,7 +28,7 @@ Configure its options:
   options: {
     // Base URL of Wordpress site
     api: 'wordpress.domain',
-    // true if using https. false if nah.
+    // true if using https. false otherwise.
     https: false,
     api_keys: {
       consumer_key: `your key`,
@@ -40,7 +40,7 @@ Configure its options:
 },
 ```
 
-The consumer key and secret come from WooCommerce. From your dashboard, go to WooCommerce > Settings > Advanced > REST API and then add a key. You can then copy and paste both the key and secret. Make sure to store any sensitive information in [environment variables](/docs/environment-variables/)!
+The `consumer_key` and `consumer_secret` come from WooCommerce. From your dashboard, go to WooCommerce > Settings > Advanced > REST API and then add a key. You can then copy and paste both the key and secret. Make sure to store any sensitive information in [environment variables](/docs/environment-variables/)!
 
 There are other options which may make more sense for your project. For example, you may want to source more general site data like posts and pages from WordPress as well.
 

--- a/docs/docs/sourcing-from-woocommerce.md
+++ b/docs/docs/sourcing-from-woocommerce.md
@@ -42,15 +42,7 @@ Configure its options:
 
 The `consumer_key` and `consumer_secret` come from WooCommerce. From your dashboard, go to WooCommerce > Settings > Advanced > REST API and then add a key. You can then copy and paste both the key and secret. Make sure to store any sensitive information in [environment variables](/docs/environment-variables/)!
 
-There are other options which may make more sense for your project. For example, you may want to source more general site data like posts and pages from WordPress as well.
-
-### Pending Changes
-
-Note that `gatsby-source-wordpress` is undergoing a major rewrite at the time of writing. This new major version of the official source plugin is likely to change the optimal solution for using WooCommerce with Gatsby. For now, new projects should start with [`gatsby-source-graphql`](/packages/gatsby-source-graphql/) rather than `gatsby-source-wordpress` to ease the transition. If you’re interested in the current progress of the plugin, you can [check out the working alpha version](https://github.com/gatsbyjs/gatsby/issues/19292#issuecomment-587946239). **Once this work is done, the [`wp-graphql-woocommerce` plugin](https://github.com/wp-graphql/wp-graphql-woocommerce) will be the recommended option.**
-
-If you decide to go with this more experimental route, you'll need to install and activate the [WPGraphQL](https://www.wpgraphql.com/) and [wp-graphql-woocommerce](https://github.com/wp-graphql/wp-graphql-woocommerce) plugins on your WordPress site as well.
-
-The WPGraphQL plugin is also undergoing significant changes. It has not yet hit v1 and may therefore introduce [breaking changes](https://docs.wpgraphql.com/getting-started/install-and-activate/#breaking-change-notice) as it continues to progress through development. It can be used in production but keep this in mind when using the plugin!
+It's worth noting that the offical WordPress source plugin is in active development. Knowing that this work is in-progress, if you're interested in working with a GraphQL endpoint directly in your WordPress installation, see the section below on [pending changes](#pending-changes) to get started with WPGraphQL and WooCommerce.
 
 ## Adding products
 
@@ -58,7 +50,7 @@ WooCommerce products are the core of your WooCommerce site, so you’ll want to 
 
 You should see a prompt to create your first product after completing the WooCommerce setup wizard. Doing so at this time will trigger a guided tour of the new product form. Walk through this process for each product you'd like to add to your store.
 
-Once this is done, you’ll be able to use GraphQL to query for your products:
+Once this is done, you’ll be able to use GraphQL to query for your products by adding this query to the appropriate component:
 
 ```graphql
 allWcProducts {
@@ -80,6 +72,14 @@ You can explore the data available to your site [using GraphiQL](/docs/running-q
 ### Using WPGraphQL
 
 You can explore possible queries in the [WPGraphQL WooCommerce Playground](https://docs.wpgraphql.com/extensions/wpgraphql-woocommerce/#playground). Note that some queries are only available to shop managers as opposed to customers.
+
+## Pending Changes
+
+Note that `gatsby-source-wordpress` is undergoing a major rewrite at the time of writing. This new major version of the official source plugin is likely to change the optimal solution for using WooCommerce with Gatsby. For now, new projects should start with [`gatsby-source-graphql`](/packages/gatsby-source-graphql/) rather than `gatsby-source-wordpress` to ease the transition. If you’re interested in the current progress of the plugin, you can [check out the working alpha version](https://github.com/gatsbyjs/gatsby/issues/19292#issuecomment-587946239). **Once this work is done, the [`wp-graphql-woocommerce` plugin](https://github.com/wp-graphql/wp-graphql-woocommerce) will be the recommended option.**
+
+If you decide to go with this more experimental route, you'll need to install and activate the [WPGraphQL](https://www.wpgraphql.com/) and [wp-graphql-woocommerce](https://github.com/wp-graphql/wp-graphql-woocommerce) plugins on your WordPress site as well.
+
+The WPGraphQL plugin is also undergoing significant changes. It has not yet hit v1 and may therefore introduce [breaking changes](https://docs.wpgraphql.com/getting-started/install-and-activate/#breaking-change-notice) as it continues to progress through development. It can be used in production but keep this in mind when using the plugin!
 
 ## Other resources
 

--- a/docs/docs/sourcing-from-woocommerce.md
+++ b/docs/docs/sourcing-from-woocommerce.md
@@ -12,7 +12,7 @@ You’ll need a WordPress site with the [WooCommerce](https://woocommerce.com/) 
 
 ## Existing plugins
 
-This guide assumes the use of the [`gatsby-source-woocommerce` plugin](/packages/@pasdo501/gatsby-source-woocommerce/). It is a straightforward solution specific to WooCommerce.
+This guide assumes the use of the [`gatsby-source-woocommerce` plugin](/packages/@pasdo501/gatsby-source-woocommerce/).
 
 Install it:
 

--- a/docs/docs/sourcing-from-woocommerce.md
+++ b/docs/docs/sourcing-from-woocommerce.md
@@ -12,7 +12,15 @@ You’ll need a WordPress site with the [WooCommerce](https://woocommerce.com/) 
 
 ## Existing plugins
 
-This guide assumes the use of the [`gatsby-source-woocommerce` plugin](/packages/@pasdo501/gatsby-source-woocommerce/). It is a stable, straightforward solution specific to WooCommerce. You can install it with `npm install --save @pasdo501/gatsby-source-woocommerce` and then configure its options:
+This guide assumes the use of the [`gatsby-source-woocommerce` plugin](/packages/@pasdo501/gatsby-source-woocommerce/). It is a straightforward solution specific to WooCommerce. 
+
+Install it:
+
+```bash
+npm install --save @pasdo501/gatsby-source-woocommerce
+``` 
+
+Configure its options:
 
 ```js:title=gatsby-config.js
 {       
@@ -32,7 +40,9 @@ This guide assumes the use of the [`gatsby-source-woocommerce` plugin](/packages
 },
 ```
 
-However, there are other options which may make more sense for your project. For example, you may want to source more general site data like posts and pages from WordPress as well.
+The consumer key and secret come from WooCommerce. From your dashboard, go to WooCommerce > Settings > Advanced > REST API and then add a key. You can then copy and paste both the key and secret. Make sure to store any sensitive information in [environment variables](/docs/environment-variables/)!
+
+There are other options which may make more sense for your project. For example, you may want to source more general site data like posts and pages from WordPress as well.
 
 ### Pending Changes
 
@@ -44,7 +54,9 @@ The WPGraphQL plugin is also undergoing significant changes. It has not yet hit 
 
 ## Adding products
 
-WooCommerce products are the core of your WooCommerce site, so you’ll want to add some to your store. When you’re first getting started, there’s no need to dump absolutely everything you want to sell into your store. Begin with a few products that you can use to verify that everything is hooked up correctly. You can also [import products from a CSV file](https://docs.woocommerce.com/document/product-csv-importer-exporter/). You should see as prompt to create your first product after completing the WooCommerce setup wizard. 
+WooCommerce products are the core of your WooCommerce site, so you’ll want to add some to your store. When you’re first getting started, there’s no need to dump absolutely everything you want to sell into your store. Begin with a few products that you can use to verify that everything is hooked up correctly. You can also [import products from a CSV file](https://docs.woocommerce.com/document/product-csv-importer-exporter/). 
+
+You should see a prompt to create your first product after completing the WooCommerce setup wizard. Doing so at this time will trigger a guided tour of the new product form. Walk through this process for each product you'd like to add to your store.
 
 Once this is done, you’ll be able to use GraphQL to query for your products:
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -469,6 +469,8 @@
                   link: /docs/processing-payments-with-stripe/
                 - title: Processing Payments with Square
                   link: /docs/processing-payments-with-square/
+                - title: Sourcing from WooCommerce
+                  link: /docs/sourcing-from-woocommerce
         - title: Improving Performance
           link: /docs/performance/
           items:


### PR DESCRIPTION
## Description

There's a lot of work being done on the WP source plugin but a lot of visitors to the site are requesting information on WooCommerce specifically. I'm proposing this as a sort of in-between to at least point people in the right direction while that work is being done. This guide presents some options for working with WordPress and WooCommerce.

I went back and forth about including some more Woo-specific instructions (things done in the dashboard). Thoughts on whether I should I add that back in?

## Related Issues

Addresses #20222
