### PR TITLE
chore(starters): Add ZEIT Now Deployment badge

### DIFF
--- a/starters/README-template.md
+++ b/starters/README-template.md
@@ -92,3 +92,5 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 ## 💫 Deploy
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-<%= name %>)
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/import/project?template=https://github.com/gatsbyjs/gatsby-starter-<%= name %>)


### PR DESCRIPTION
## Description

This PR adds ZEIT Now to the template README, allowing a deployment button to be generated for Gatsby starters.