### PR TITLE
fix(gatsby-starter-blog): Move hardcoded author summary to site metadata (#21747)

### DIFF
--- a/starters/blog/gatsby-config.js
+++ b/starters/blog/gatsby-config.js
@@ -1,7 +1,10 @@
 module.exports = {
   siteMetadata: {
     title: `Gatsby Starter Blog`,
-    author: `Kyle Mathews`,
+    author: {
+      name: `Kyle Mathews`,
+      summary: `who lives and works in San Francisco building useful things.`,
+    },
     description: `A starter blog demonstrating what Gatsby can do.`,
     siteUrl: `https://gatsby-starter-blog-demo.netlify.com/`,
     social: {

--- a/starters/blog/src/components/bio.js
+++ b/starters/blog/src/components/bio.js
@@ -23,7 +23,10 @@ const Bio = () => {
       }
       site {
         siteMetadata {
-          author
+          author {
+            name
+            summary
+          }
           social {
             twitter
           }
@@ -54,8 +57,7 @@ const Bio = () => {
         }}
       />
       <p>
-        Written by <strong>{author}</strong> who lives and works in San
-        Francisco building useful things.
+        Written by <strong>{author.name}</strong> {author.summary}
         {` `}
         <a href={`https://twitter.com/${social.twitter}`}>
           You should follow him on Twitter

--- a/starters/blog/src/components/bio.js
+++ b/starters/blog/src/components/bio.js
@@ -45,7 +45,7 @@ const Bio = () => {
     >
       <Image
         fixed={data.avatar.childImageSharp.fixed}
-        alt={author}
+        alt={author.name}
         style={{
           marginRight: rhythm(1 / 2),
           marginBottom: 0,

--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -18,7 +18,6 @@ const SEO = ({ description, lang, meta, title }) => {
           siteMetadata {
             title
             description
-            author
           }
         }
       }

--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -18,7 +18,7 @@ const SEO = ({ description, lang, meta, title }) => {
           siteMetadata {
             title
             description
-            author { name }
+            social { twitter }
           }
         }
       }
@@ -57,7 +57,7 @@ const SEO = ({ description, lang, meta, title }) => {
         },
         {
           name: `twitter:creator`,
-          content: site.siteMetadata.author.name,
+          content: site.siteMetadata.social.twitter,
         },
         {
           name: `twitter:title`,

--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -18,6 +18,7 @@ const SEO = ({ description, lang, meta, title }) => {
           siteMetadata {
             title
             description
+            author { name }
           }
         }
       }
@@ -56,7 +57,7 @@ const SEO = ({ description, lang, meta, title }) => {
         },
         {
           name: `twitter:creator`,
-          content: site.siteMetadata.author,
+          content: site.siteMetadata.author.name,
         },
         {
           name: `twitter:title`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The blog starter template is a great way to have a blog site up and running, but while most of the stuff can be configured from the `gatsby-config.js` file, the author summary is missing and is hardcoded in `src/components/bio.js`.

## Related Issues
Fixes  #21747
