### PR TITLE
fix(gatsby-source-contentful): prevent unpublished Contentful entries from breaking content sync

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -119,7 +119,11 @@ exports.sourceNodes = async (
       })
       .filter(node => node)
 
-    localizedNodes.forEach(node => deleteNode({ node }))
+    localizedNodes.forEach(node => {
+      // touchNode first, to populate typeOwners & avoid erroring
+      touchNode({ nodeId: node.id })
+      deleteNode({ node })
+    })
   }
 
   currentSyncData.deletedEntries.forEach(deleteContentfulNode)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This prevents an issues during the `sourceNodes` lifecycle when an entry has been unpublished. Specifically, without `touchNode`, the `typeOwners` entry for these nodes can be `undefined`, which can prevent all Contentful graphql queries from working.

The initial symptom is:
```
"gatsby-source-contentful" threw an error while running the sourceNodes lifecycle:

The plugin "gatsby-source-contentful" deleted a node of a type owned by another plugin.

          The node type "ContentfulBlogPost" is owned by "undefined".
```

But also, before this change, all the GraphQL queries related to Contentful go missing in the unpublished-entry scenario. This has even more negative implications in the case of TypeScript, when the available queries are used to generate types, such that even non-Contentful components break due to compiler errors.

```
There was an error in your GraphQL query:

Unknown type "ContentfulFixed".
```
...etc.




### Documentation

- No docs, this is a bug fix.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

- Fixes the bug described in #16189
- More context on this property of `touchNode` (ensuring `typeOwners` is populated) is in #15919

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
