### PR TITLE
feat(gatsby-plugin-subfont): Make async, add configurable option

### DIFF
--- a/packages/gatsby-plugin-subfont/README.md
+++ b/packages/gatsby-plugin-subfont/README.md
@@ -17,6 +17,15 @@ If you want the ability to run font subsetting locally you'l need Python and ins
 ```javascript
 // In your gatsby-config.js
 module.exports = {
-  plugins: [`gatsby-plugin-subfont`],
+  plugins: [{
+    resolve: `gatsby-plugin-subfont`,
+    options: {
+      silent: true,
+      fallback: false,
+      inlineFonts: true,
+    }
+  }],
 }
 ```
+
+You can use any option of [https://github.com/Munter/subfont/blob/4b5a59afd17008ca35b6c32b52e3e922159e22fc/lib/subfont.js#L10](subfont)

--- a/packages/gatsby-plugin-subfont/README.md
+++ b/packages/gatsby-plugin-subfont/README.md
@@ -17,15 +17,38 @@ If you want the ability to run font subsetting locally you'l need Python and ins
 ```javascript
 // In your gatsby-config.js
 module.exports = {
-  plugins: [{
-    resolve: `gatsby-plugin-subfont`,
-    options: {
-      silent: true,
-      fallback: false,
-      inlineFonts: true,
-    }
-  }],
+  plugins: [
+    {
+      resolve: `gatsby-plugin-subfont`,
+      options: {
+        silent: true,
+        fallback: false,
+        inlineFonts: true,
+      },
+    },
+  ],
 }
 ```
 
-You can use any option of [https://github.com/Munter/subfont/blob/4b5a59afd17008ca35b6c32b52e3e922159e22fc/lib/subfont.js#L10](subfont)
+## Options
+
+See [subfont](https://github.com/Munter/subfont/blob/4b5a59afd17008ca35b6c32b52e3e922159e22fc/lib/subfont.js#L10) for a full list of options.
+
+| Name            | Default                 | Description                                                                                                       |
+| --------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `root`          | `public`                | Path to your web root                                                                                             |
+| `canonicalRoot` |                         | URI root where the site will be deployed. Must be either an absolute, a protocol-relative, or a root-relative url |
+| `output`        |                         | Directory where results should be written to                                                                      |  |  |
+| `fallbacks`     | `true`                  | Include fallbacks so the original font will be loaded when dynamic content gets injected at runtime.              |
+| `dynamic`       | `false`                 | Also trace the usage of fonts in a headless browser with JavaScript enabled                                       |
+| `inPlace`       | `true`                  | Modify HTML-files in-place. Only use on build artifacts                                                           |
+| `inlineFonts`   | `false`                 | Inline fonts as data-URIs inside the @font-face declaration                                                       |
+| `inlineCss`     | `true`                  | Inline CSS that declares the @font-face for the subset fonts                                                      |
+| `fontDisplay`   | `swap`                  | Injects a font-display value into the @font-face CSS. Valid values: auto, block, swap, fallback, optional         |
+| `formats`       | `['woff2', 'woff']`     | Font formats to use when subsetting. [choices: "woff2", "woff", "truetype"]                                       |
+| `subsetPerPage` | `false`                 | Create a unique subset for each page.                                                                             |
+| `recursive`     | `false`                 | Crawl all HTML-pages linked with relative and root relative links. This stays inside your domain                  |
+| `silent`        | `true`                  | Do not write anything to stdout                                                                                   |
+| `debug`         | `false`                 | Verbose insights into font glyph detection                                                                        |
+| `dryRun`        | `false`                 | Don't write anything to disk                                                                                      |
+| `inputFiles`    | `['public/index.html']` | htmlFile(s) or url(s)                                                                                             |

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-subfont",
-  "version": "2.0.0",
+  "version": "1.1.21",
   "description": "Runs the font delivery optimizing CLI tool subfont on the homepage of your site during the Gatsby build",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.7.6",
     "subfont": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -25,8 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
-    "shell-escape": "^0.2.0",
-    "subfont": "^3.7.1"
+    "subfont": "^4.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-subfont",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Runs the font delivery optimizing CLI tool subfont on the homepage of your site during the Gatsby build",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-subfont",
-  "version": "1.1.21",
+  "version": "1.2.0",
   "description": "Runs the font delivery optimizing CLI tool subfont on the homepage of your site during the Gatsby build",
   "main": "index.js",
   "scripts": {

--- a/packages/gatsby-plugin-subfont/src/gatsby-node.js
+++ b/packages/gatsby-plugin-subfont/src/gatsby-node.js
@@ -4,17 +4,13 @@ const subfont = require(`subfont`)
 exports.onPostBuild = async ({ store }, options) => {
   const root = path.join(store.getState().program.directory, `public`)
 
-  const urlPaths = [`/`]
-
   await subfont(
     {
-      root: `file://${root}`,
+      root,
       inPlace: true,
       inlineCss: true,
       silent: true,
-      inputFiles: urlPaths.map(currentPath =>
-        path.join(root, currentPath, `index.html`)
-      ),
+      inputFiles: [path.join(root, `index.html`)],
       ...options,
     },
     console

--- a/packages/gatsby-plugin-subfont/src/gatsby-node.js
+++ b/packages/gatsby-plugin-subfont/src/gatsby-node.js
@@ -20,5 +20,4 @@ exports.onPostBuild = async ({ store, reporter }, options) => {
     },
     subfontConsole
   )
-  return
 }

--- a/packages/gatsby-plugin-subfont/src/gatsby-node.js
+++ b/packages/gatsby-plugin-subfont/src/gatsby-node.js
@@ -1,22 +1,23 @@
 const path = require(`path`)
-const { execSync } = require(`child_process`)
-const shellescape = require(`shell-escape`)
+const subfont = require(`subfont`)
 
-exports.onPostBuild = ({ store }) => {
+exports.onPostBuild = async ({ store }) => {
   const root = path.join(store.getState().program.directory, `public`)
   // TODO make this configurable
+
   const urlPaths = [`/`]
-  const baseArgs = [
-    `node_modules/.bin/subfont`,
-    `-i`,
-    `--no-recursive`,
-    `--inline-css`,
-    `--root`,
-    `file://${root}`,
-  ]
-  const args = baseArgs.concat(
-    urlPaths.map(currentPath => path.join(root, currentPath, `index.html`))
+
+  await subfont(
+    {
+      root: `file://${root}`,
+      inPlace: true,
+      inlineCss: true,
+      silent: true,
+      inputFiles: urlPaths.map(currentPath =>
+        path.join(root, currentPath, `index.html`)
+      ),
+    },
+    console
   )
-  const command = shellescape(args)
-  execSync(command)
+  return
 }

--- a/packages/gatsby-plugin-subfont/src/gatsby-node.js
+++ b/packages/gatsby-plugin-subfont/src/gatsby-node.js
@@ -1,8 +1,13 @@
 const path = require(`path`)
 const subfont = require(`subfont`)
 
-exports.onPostBuild = async ({ store }, options) => {
+exports.onPostBuild = async ({ store, reporter }, options) => {
   const root = path.join(store.getState().program.directory, `public`)
+  const subfontConsole = {
+    log: reporter.info,
+    warn: reporter.warn,
+    error: reporter.error,
+  }
 
   await subfont(
     {
@@ -13,7 +18,7 @@ exports.onPostBuild = async ({ store }, options) => {
       inputFiles: [path.join(root, `index.html`)],
       ...options,
     },
-    console
+    subfontConsole
   )
   return
 }

--- a/packages/gatsby-plugin-subfont/src/gatsby-node.js
+++ b/packages/gatsby-plugin-subfont/src/gatsby-node.js
@@ -1,9 +1,8 @@
 const path = require(`path`)
 const subfont = require(`subfont`)
 
-exports.onPostBuild = async ({ store }) => {
+exports.onPostBuild = async ({ store }, options) => {
   const root = path.join(store.getState().program.directory, `public`)
-  // TODO make this configurable
 
   const urlPaths = [`/`]
 
@@ -16,6 +15,7 @@ exports.onPostBuild = async ({ store }) => {
       inputFiles: urlPaths.map(currentPath =>
         path.join(root, currentPath, `index.html`)
       ),
+      ...options,
     },
     console
   )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add gatsby-plugin-subfont configurable option feature
Update subfont version (Maybe issue #16840?)

### Documentation

see: packages/gatsby-plugin-subfont/README.md
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Related to #16840
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
