### PR TITLE
feat(gatsby): Allow silencing the warning for adding resolvers for missing types

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -746,7 +746,10 @@ const processThirdPartyTypeFields = ({ typeComposer, schemaQueryType }) => {
 
 const addCustomResolveFunctions = async ({ schemaComposer, parentSpan }) => {
   const intermediateSchema = schemaComposer.buildSchema()
-  const createResolvers = resolvers => {
+  const createResolvers = (
+    resolvers,
+    { ignoreNonexistentTypes = false } = {}
+  ) => {
     Object.keys(resolvers).forEach(typeName => {
       const fields = resolvers[typeName]
       if (schemaComposer.has(typeName)) {
@@ -814,7 +817,7 @@ const addCustomResolveFunctions = async ({ schemaComposer, parentSpan }) => {
             tc.setFieldExtension(fieldName, `createdFrom`, `createResolvers`)
           }
         })
-      } else {
+      } else if (!ignoreNonexistentTypes) {
         report.warn(
           `\`createResolvers\` passed resolvers for type \`${typeName}\` that ` +
             `doesn't exist in the schema. Use \`createTypes\` to add the type ` +

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -287,7 +287,9 @@ exports.createSchemaCustomization = true
  * @param {GraphQLSchema} $0.intermediateSchema Current GraphQL schema
  * @param {function} $0.createResolvers Add custom resolvers to GraphQL field configs
  * @param {object} $1
- * @param {object} $1.resolvers Resolvers from plugin options in `gatsby-config.js`.
+ * @param {object} $1.resolvers An object map of GraphQL type names to custom resolver functions.
+ * @param {object} $1.options Optional createResolvers options.
+ * @param {object} $1.options.ignoreNonexistentTypes Silences the warning when trying to add resolvers for types that don't exist. Useful for optional extensions
  * @example
  * exports.createResolvers = ({ createResolvers }) => {
  *   const resolvers = {

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -289,7 +289,7 @@ exports.createSchemaCustomization = true
  * @param {object} $1
  * @param {object} $1.resolvers An object map of GraphQL type names to custom resolver functions.
  * @param {object} $1.options Optional createResolvers options.
- * @param {object} $1.options.ignoreNonexistentTypes Silences the warning when trying to add resolvers for types that don't exist. Useful for optional extensions
+ * @param {object} $1.options.ignoreNonexistentTypes Silences the warning when trying to add resolvers for types that don't exist. Useful for optional extensions.
  * @example
  * exports.createResolvers = ({ createResolvers }) => {
  *   const resolvers = {


### PR DESCRIPTION
## Description

Useful for theme authors who want to extend plugin types if they exist.

### Documentation

I updated the jsdoc comments

I also did not see any tests for createResolvers otherwise I would have written one
