### PR TITLE
fix(gatsby-starter-blog): use twitter user metadata for twitter card tag

### DIFF
--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -18,7 +18,7 @@ const SEO = ({ description, lang, meta, title }) => {
           siteMetadata {
             title
             description
-            author
+            social { twitter }
           }
         }
       }
@@ -57,7 +57,7 @@ const SEO = ({ description, lang, meta, title }) => {
         },
         {
           name: `twitter:creator`,
-          content: site.siteMetadata.author,
+          content: site.siteMetadata.social.twitter,
         },
         {
           name: `twitter:title`,


### PR DESCRIPTION
## Description

According to [developer.twitter.com](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started#card-and-content-attribution) `twitter:creator` is used as attribution of the content to the Twitter `@username`, while in seo.js it has the content of the site **author name**. 

## Related Issues

Fixes #21773 