### PR TITLE
fix(gatsby-transformer-sharp) remove default export

### DIFF
--- a/packages/gatsby-transformer-sharp/src/create-resolvers.js
+++ b/packages/gatsby-transformer-sharp/src/create-resolvers.js
@@ -1,4 +1,4 @@
-const supportedExtensions = require(`./supported-extensions`)
+const { supportedExtensions } = require(`./supported-extensions`)
 
 module.exports = ({ createResolvers, reporter }) => {
   const resolvers = {

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,4 +1,4 @@
-import supportedExtensions from "./supported-extensions"
+const { supportedExtensions } = require(`./supported-extensions`)
 
 module.exports = async function onCreateNode({ node, actions, createNodeId }) {
   const { createNode, createParentChildLink } = actions

--- a/packages/gatsby-transformer-sharp/src/supported-extensions.js
+++ b/packages/gatsby-transformer-sharp/src/supported-extensions.js
@@ -7,4 +7,6 @@ const supportedExtensions = {
   tiff: true,
 }
 
-export default supportedExtensions
+module.exports = {
+  supportedExtensions,
+}


### PR DESCRIPTION
## Description

This PR fixes a recent regression introduced in https://github.com/gatsbyjs/gatsby/pull/20782, where a mix of `import` and `require` caused file extension warnings (e.g. `You can't use childImageSharp together with x.png — use publicURL instead. The childImageSharp portion of the query in this file`).

## Related Issues

Fixed https://github.com/gatsbyjs/gatsby/issues/21776

## Next steps
I would love to introduce more safety nets in the code to avoid this problem in the future. Any plans to embrace TypeScript? Or limit the mix of `import`, `default export`, `export`, `module.exports` and `require` (this could be done using eslint)?
