### PR TITLE
fix(docs): 404 on static site generator

### DIFF
--- a/docs/docs/glossary/static-site-generator.md
+++ b/docs/docs/glossary/static-site-generator.md
@@ -13,9 +13,9 @@ Static site generators are an alternative to database-driven content management 
 
 Static site generators, on the other hand, generate HTML pages during a [build](/docs/glossary/#build) process. Gatsby, for example, loads JSON from [GraphQL](/docs/glossary/graphql), and merges that data with components to create HTML pages. These generated pages are then deployed to a web server. When the server receives a request, it responds with rendered HTML. Static pages eliminate the latency that databases introduce.
 
-> Note: It's also possible to use Gatsby [without GraphQL](/using-gatsby-without-graphql/), using the `createPages` API.
+> Note: It's also possible to use Gatsby [without GraphQL](/docs/using-gatsby-without-graphql/), using the `createPages` API.
 
-You can also use static site generators to create [JAMStack](/docs/glossary/jamstack.md) sites. JAMStack is a modern web site architecture that uses JavaScript, content APIs, and markup. Gatsby, for example, can use the [WordPress REST API](/sourcing-from-wordpress/) as a data source.
+You can also use static site generators to create [JAMStack](/docs/glossary/#jamstack) sites. JAMStack is a modern web site architecture that uses JavaScript, content APIs, and markup. Gatsby, for example, can use the [WordPress REST API](/docs/sourcing-from-wordpress/) as a data source.
 
 ### Advantages of static site generators
 
@@ -26,10 +26,10 @@ Static site generators **reduce site complexity**. That, in turn, improves speed
 - You can use version control software to manage and track changes to your content.
 - Because your site is static, you can even forgo web servers and load balancers altogether. Instead, you can host your site with a content delivery network that scales with your site's traffic.
 
-There are dozens of static site generators available, created with a range of programming languages. Gatsby is [JavaScript](/glossary#javascript) at its core, and is built with [React](/glossary/react), GraphQL, and [Node.js](/glossary/node/). See how Gatsby [compares to WordPress and Drupal](/features/cms/gatsby-vs-wordpress-vs-drupal) or to popular [static site generators](/features/jamstack/).
+There are dozens of static site generators available, created with a range of programming languages. Gatsby is [JavaScript](/docs/glossary/#javascript) at its core, and is built with [React](/docs/glossary/#react), GraphQL, and [Node.js](/docs/glossary/#nodejs). See how Gatsby [compares to WordPress and Drupal](/features/cms/gatsby-vs-wordpress-vs-drupal) or to popular [static site generators](/features/jamstack/).
 
 ### Learn more
 
-- [JAMStack](/docs/glossary/jamstack.md) architecture from the Gatsby docs
-- [Sourcing Content and Data](/content-and-data/) for Gatsby
+- [JAMStack](/docs/glossary/#jamstack) architecture from the Gatsby docs
+- [Sourcing Content and Data](/docs/content-and-data/) for Gatsby
 - [Adding Markdown Pages](/docs/adding-markdown-pages/) from the Gatsby docs


### PR DESCRIPTION
## Description

- fix 404
- fix broken links and changed links to main glossary


## Related Issues

- #20824 `Add glossary/static-site-generator entry.`
- #19267 `Add link checker for Gatsby Docs`