### PR TITLE
chore(showcase):Add Marathon Oil to the Site Showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -9928,3 +9928,12 @@
     - Agency
     - Consulting
   featured: false
+- title: Marathon Oil
+  main_url: "https://www.marathonoil.com/"
+  url: "https://www.marathonoil.com/"
+  featured: false
+  categories:
+    - Business
+    - Marketing
+  built_by: Corey Ward
+  built_by_url: "http://www.coreyward.me/"


### PR DESCRIPTION
This adds the recently relaunched [Marathon Oil](https://www.marathonoil.com) website to the site showcase. 