### PR TITLE
refractor(www): Use `nodes` in gatsbyjs.org code instead of `edges.node`

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -287,20 +287,18 @@ module.exports = {
                     fileAbsolutePath: { regex: "/docs.blog/" }
                   }
                 ) {
-                  edges {
-                    node {
-                      html
-                      frontmatter {
-                        title
-                        date
-                        author {
-                          id
-                        }
+                  nodes {
+                    html
+                    frontmatter {
+                      title
+                      date
+                      author {
+                        id
                       }
-                      fields {
-                        excerpt
-                        slug
-                      }
+                    }
+                    fields {
+                      excerpt
+                      slug
                     }
                   }
                 }
@@ -321,7 +319,7 @@ module.exports = {
               }
             },
             serialize: ({ query: { site, allMdx } }) =>
-              allMdx.edges.map(({ node }) => {
+              allMdx.nodes.map(node => {
                 return {
                   title: node.frontmatter.title,
                   description: node.fields.excerpt,

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -204,16 +204,14 @@ const Diagram = () => (
     query={graphql`
       query StaticHostsQuery {
         allStaticHostsYaml {
-          edges {
-            node {
-              title
-              url
-            }
+          nodes {
+            title
+            url
           }
         }
       }
     `}
-    render={({ allStaticHostsYaml: { edges: staticHosts } }) => (
+    render={({ allStaticHostsYaml: { nodes: staticHosts } }) => (
       <section
         className="Diagram"
         sx={{
@@ -308,7 +306,7 @@ const Diagram = () => (
           >
             <ItemTitle>Web Hosting</ItemTitle>
             <ItemDescription>
-              {staticHosts.map(({ node: staticHost }, index) => (
+              {staticHosts.map((staticHost, index) => (
                 <Fragment key={staticHost.url}>
                   {index > 0 && `, `}
                   <ItemDescriptionLink to={staticHost.url}>

--- a/www/src/components/features/evaluation-table.js
+++ b/www/src/components/features/evaluation-table.js
@@ -53,8 +53,8 @@ class EvaluationTable extends Component {
                     [].concat([
                       <SectionHeaderBottom
                         options={options}
-                        display={row.node.Subcategory}
-                        category={row.node.Subcategory}
+                        display={row.Subcategory}
+                        category={row.Subcategory}
                         key={`section-header-${s}-bottom-${i}`}
                       />,
                       // table row with the name of the feature and corresponding scores
@@ -81,7 +81,7 @@ class EvaluationTable extends Component {
                             }}
                             id={
                               j === 0
-                                ? row.node.Feature.toLowerCase()
+                                ? row.Feature.toLowerCase()
                                     .split(` `)
                                     .join(`-`)
                                 : undefined
@@ -92,7 +92,7 @@ class EvaluationTable extends Component {
                               })
                             }}
                           >
-                            {renderCell(row.node[nodeProperty], j)}
+                            {renderCell(row[nodeProperty], j)}
                           </td>
                         ))}
                       </tr>,
@@ -117,7 +117,7 @@ class EvaluationTable extends Component {
                           {
                             <span
                               dangerouslySetInnerHTML={{
-                                __html: row.node.Description,
+                                __html: row.Description,
                               }}
                             />
                           }

--- a/www/src/components/features/simple-evaluation-table.js
+++ b/www/src/components/features/simple-evaluation-table.js
@@ -12,7 +12,7 @@ const SimpleEvaluationTable = ({ title, headers, data }) => (
     <table>
       <tbody>
         <SectionHeaderTop columnHeaders={headers.map(h => h.display)} />
-        {data.map(({ node }, idx) => (
+        {data.map((node, idx) => (
           <tr key={`feature-row-${idx}`}>
             {headers.map((header, i) => (
               <td

--- a/www/src/components/homepage/homepage-logo-banner.js
+++ b/www/src/components/homepage/homepage-logo-banner.js
@@ -73,13 +73,11 @@ const HomepageLogoBanner = () => {
         }
         sort: { fields: publicURL }
       ) {
-        edges {
-          node {
-            base
-            childImageSharp {
-              fixed(quality: 75, height: 24) {
-                ...GatsbyImageSharpFixed_tracedSVG
-              }
+        nodes {
+          base
+          childImageSharp {
+            fixed(quality: 75, height: 24) {
+              ...GatsbyImageSharpFixed_tracedSVG
             }
           }
         }
@@ -93,7 +91,7 @@ const HomepageLogoBanner = () => {
         <Name>Trusted by</Name>
       </Title>
       <LogoGroup>
-        {data.allFile.edges.map(({ node: image }) => (
+        {data.allFile.nodes.map(image => (
           <Img
             alt={`${image.base.split(`.`)[0]}`}
             fixed={image.childImageSharp.fixed}

--- a/www/src/pages/creators/agencies.js
+++ b/www/src/pages/creators/agencies.js
@@ -14,10 +14,8 @@ export default AgenciesPage
 export const pageQuery = graphql`
   query {
     allCreatorsYaml(filter: { type: { eq: "agency" } }) {
-      edges {
-        node {
-          ...CreatorData
-        }
+      nodes {
+        ...CreatorData
       }
     }
   }

--- a/www/src/pages/creators/companies.js
+++ b/www/src/pages/creators/companies.js
@@ -14,10 +14,8 @@ export default CompaniesPage
 export const pageQuery = graphql`
   query {
     allCreatorsYaml(filter: { type: { eq: "company" } }) {
-      edges {
-        node {
-          ...CreatorData
-        }
+      nodes {
+        ...CreatorData
       }
     }
   }

--- a/www/src/pages/creators/index.js
+++ b/www/src/pages/creators/index.js
@@ -14,10 +14,8 @@ export default CreatorsPage
 export const pageQuery = graphql`
   query {
     allCreatorsYaml {
-      edges {
-        node {
-          ...CreatorData
-        }
+      nodes {
+        ...CreatorData
       }
     }
   }

--- a/www/src/pages/creators/people.js
+++ b/www/src/pages/creators/people.js
@@ -14,10 +14,8 @@ export default PeoplePage
 export const pageQuery = graphql`
   query {
     allCreatorsYaml(filter: { type: { eq: "individual" } }) {
-      edges {
-        node {
-          ...CreatorData
-        }
+      nodes {
+        ...CreatorData
       }
     }
   }

--- a/www/src/pages/ecosystem.js
+++ b/www/src/pages/ecosystem.js
@@ -14,21 +14,19 @@ class EcosystemPage extends Component {
     const {
       location,
       data: {
-        allStartersYaml: { edges: startersData },
-        allNpmPackage: { edges: pluginsData },
+        allStartersYaml: { nodes: startersData },
+        allNpmPackage: { nodes: pluginsData },
       },
     } = this.props
 
     const starters = startersData.map(item => {
       const {
-        node: {
-          fields: {
-            starterShowcase: { slug, name, description, stars },
-          },
-          childScreenshot: {
-            screenshotFile: {
-              childImageSharp: { fixed: thumbnail },
-            },
+        fields: {
+          starterShowcase: { slug, name, description, stars },
+        },
+        childScreenshot: {
+          screenshotFile: {
+            childImageSharp: { fixed: thumbnail },
           },
         },
       } = item
@@ -42,7 +40,7 @@ class EcosystemPage extends Component {
       }
     })
 
-    const plugins = pluginsData.map(item => item.node)
+    const plugins = pluginsData
 
     const pageTitle = `Ecosystem`
     const boardIcons = { plugins: PluginsIcon, starters: StartersIcon }
@@ -76,22 +74,20 @@ export const ecosystemQuery = graphql`
         fields: { featured: { eq: true }, hasScreenshot: { eq: true } }
       }
     ) {
-      edges {
-        node {
-          fields {
-            starterShowcase {
-              slug
-              description
-              stars
-              name
-            }
+      nodes {
+        fields {
+          starterShowcase {
+            slug
+            description
+            stars
+            name
           }
-          childScreenshot {
-            screenshotFile {
-              childImageSharp {
-                fixed(width: 64, height: 64) {
-                  ...GatsbyImageSharpFixed_noBase64
-                }
+        }
+        childScreenshot {
+          screenshotFile {
+            childImageSharp {
+              fixed(width: 64, height: 64) {
+                ...GatsbyImageSharpFixed_noBase64
               }
             }
           }
@@ -99,13 +95,11 @@ export const ecosystemQuery = graphql`
       }
     }
     allNpmPackage(filter: { fields: { featured: { eq: true } } }) {
-      edges {
-        node {
-          slug
-          name
-          description
-          humanDownloadsLast30Days
-        }
+      nodes {
+        slug
+        name
+        description
+        humanDownloadsLast30Days
       }
     }
   }

--- a/www/src/pages/features.js
+++ b/www/src/pages/features.js
@@ -126,7 +126,7 @@ class FeaturesPage extends Component {
                 },
                 { display: `Traditional CMS`, nodeFieldProperty: `Cms` },
               ]}
-              data={this.props.data.allGatsbyFeaturesSpecsCsv.edges}
+              data={this.props.data.allGatsbyFeaturesSpecsCsv.nodes}
             />
             <FeaturesFooter />
           </main>
@@ -142,14 +142,12 @@ export default FeaturesPage
 export const pageQuery = graphql`
   query {
     allGatsbyFeaturesSpecsCsv {
-      edges {
-        node {
-          Category
-          Gatsby
-          Jamstack
-          Cms
-          Description
-        }
+      nodes {
+        Category
+        Gatsby
+        Jamstack
+        Cms
+        Description
       }
     }
   }

--- a/www/src/pages/features/cms.js
+++ b/www/src/pages/features/cms.js
@@ -31,7 +31,7 @@ const CmsFeaturesPage = ({ data, location }) => {
   })
 
   const { sections, sectionHeaders } = getFeaturesData(
-    data.allGatsbyCmsSpecsCsv.edges
+    data.allGatsbyCmsSpecsCsv.nodes
   )
 
   return (
@@ -98,16 +98,14 @@ export default CmsFeaturesPage
 export const pageQuery = graphql`
   query {
     allGatsbyCmsSpecsCsv {
-      edges {
-        node {
-          Category
-          Subcategory
-          Feature
-          Gatsby
-          WordPress
-          Drupal
-          Description
-        }
+      nodes {
+        Category
+        Subcategory
+        Feature
+        Gatsby
+        WordPress
+        Drupal
+        Description
       }
     }
   }

--- a/www/src/pages/features/jamstack.js
+++ b/www/src/pages/features/jamstack.js
@@ -34,7 +34,7 @@ const JamstackFeaturesPage = ({ data, location }) => {
   })
 
   const { sections, sectionHeaders } = getFeaturesData(
-    data.allGatsbyJamstackSpecsCsv.edges
+    data.allGatsbyJamstackSpecsCsv.nodes
   )
 
   return (
@@ -99,18 +99,16 @@ export default JamstackFeaturesPage
 export const pageQuery = graphql`
   query {
     allGatsbyJamstackSpecsCsv {
-      edges {
-        node {
-          Category
-          Subcategory
-          Feature
-          Gatsby
-          Nextjs
-          Jekyll
-          Hugo
-          Nuxtjs
-          Description
-        }
+      nodes {
+        Category
+        Subcategory
+        Feature
+        Gatsby
+        Nextjs
+        Jekyll
+        Hugo
+        Nuxtjs
+        Description
       }
     }
   }

--- a/www/src/pages/guidelines/logo.js
+++ b/www/src/pages/guidelines/logo.js
@@ -608,7 +608,7 @@ const Logo = ({ data, location }) => {
           </CopyColumn>
           <ContentColumn>
             <Flex flexWrap="wrap">
-              {data.allGuidanceYaml.edges.map(({ node }, index) => (
+              {data.allGuidanceYaml.nodes.map((node, index) => (
                 <Guidance
                   image={node.image && node.image}
                   key={`logo-guidance-${index}`}
@@ -633,7 +633,7 @@ const Logo = ({ data, location }) => {
           </CopyColumn>
           <ContentColumn>
             <ul>
-              {data.allFootnotesYaml.edges.map(({ node }, index) => (
+              {data.allFootnotesYaml.nodes.map((node, index) => (
                 <Text as="li" key={`logo-footnotes-${index}`} mb={3}>
                   {node.description}:<br />
                   <a
@@ -661,22 +661,18 @@ export default Logo
 export const pageQuery = graphql`
   query logoGuideQuery {
     allFootnotesYaml {
-      edges {
-        node {
-          description
-          href
-        }
+      nodes {
+        description
+        href
       }
     }
     allGuidanceYaml {
-      edges {
-        node {
-          description
-          image {
-            childImageSharp {
-              fluid(maxWidth: 380, quality: 80) {
-                ...GatsbyImageSharpFluid_noBase64
-              }
+      nodes {
+        description
+        image {
+          childImageSharp {
+            fluid(maxWidth: 380, quality: 80) {
+              ...GatsbyImageSharpFluid_noBase64
             }
           }
         }

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -41,22 +41,20 @@ class IndexRoute extends React.Component {
   render() {
     const {
       data: {
-        allMdx: { edges: postsData },
-        allStartersYaml: { edges: startersData },
-        allNpmPackage: { edges: pluginsData },
+        allMdx: { nodes: postsData },
+        allStartersYaml: { nodes: startersData },
+        allNpmPackage: { nodes: pluginsData },
       },
     } = this.props
 
     const starters = startersData.map(item => {
       const {
-        node: {
-          fields: {
-            starterShowcase: { slug, name, description, stars },
-          },
-          childScreenshot: {
-            screenshotFile: {
-              childImageSharp: { fixed: thumbnail },
-            },
+        fields: {
+          starterShowcase: { slug, name, description, stars },
+        },
+        childScreenshot: {
+          screenshotFile: {
+            childImageSharp: { fixed: thumbnail },
           },
         },
       } = item
@@ -72,17 +70,15 @@ class IndexRoute extends React.Component {
     })
 
     const plugins = pluginsData.map(item => {
-      item.node.type = `Plugin`
+      item.type = `Plugin`
 
-      return item.node
+      return item
     })
 
     const ecosystemFeaturedItems = this.combineEcosystemFeaturedItems({
       plugins,
       starters,
     })
-
-    const posts = postsData.map(item => item.node)
 
     return (
       <>
@@ -136,7 +132,7 @@ class IndexRoute extends React.Component {
 
           <HomepageEcosystem featuredItems={ecosystemFeaturedItems} />
 
-          <HomepageBlog posts={posts} />
+          <HomepageBlog posts={postsData} />
 
           <HomepageNewsletter />
         </main>
@@ -168,10 +164,8 @@ export const pageQuery = graphql`
         fields: { released: { eq: true } }
       }
     ) {
-      edges {
-        node {
-          ...HomepageBlogPostData
-        }
+      nodes {
+        ...HomepageBlogPostData
       }
     }
     allStartersYaml(
@@ -180,22 +174,20 @@ export const pageQuery = graphql`
       }
       sort: { order: DESC, fields: [fields___starterShowcase___stars] }
     ) {
-      edges {
-        node {
-          fields {
-            starterShowcase {
-              slug
-              description
-              stars
-              name
-            }
+      nodes {
+        fields {
+          starterShowcase {
+            slug
+            description
+            stars
+            name
           }
-          childScreenshot {
-            screenshotFile {
-              childImageSharp {
-                fixed(width: 64, height: 64) {
-                  ...GatsbyImageSharpFixed_noBase64
-                }
+        }
+        childScreenshot {
+          screenshotFile {
+            childImageSharp {
+              fixed(width: 64, height: 64) {
+                ...GatsbyImageSharpFixed_noBase64
               }
             }
           }
@@ -203,13 +195,11 @@ export const pageQuery = graphql`
       }
     }
     allNpmPackage(filter: { fields: { featured: { eq: true } } }) {
-      edges {
-        node {
-          slug
-          name
-          description
-          humanDownloadsLast30Days
-        }
+      nodes {
+        slug
+        name
+        description
+        humanDownloadsLast30Days
       }
     }
   }

--- a/www/src/pages/showcase.js
+++ b/www/src/pages/showcase.js
@@ -22,21 +22,19 @@ export const showcaseQuery = graphql`
         fields: { hasScreenshot: { eq: true } }
       }
     ) {
-      edges {
-        node {
-          id
-          title
-          categories
-          built_by
-          fields {
-            slug
-          }
-          childScreenshot {
-            screenshotFile {
-              childImageSharp {
-                fluid(maxWidth: 512) {
-                  ...GatsbyImageSharpFluid_noBase64
-                }
+      nodes {
+        id
+        title
+        categories
+        built_by
+        fields {
+          slug
+        }
+        childScreenshot {
+          screenshotFile {
+            childImageSharp {
+              fluid(maxWidth: 512) {
+                ...GatsbyImageSharpFluid_noBase64
               }
             }
           }
@@ -49,27 +47,25 @@ export const showcaseQuery = graphql`
         fields: { hasScreenshot: { eq: true } }
       }
     ) {
-      edges {
-        node {
-          id
-          featured
-          title
-          categories
-          built_by
-          description
-          main_url
-          built_by_url
-          source_url
-          childScreenshot {
-            screenshotFile {
-              childImageSharp {
-                ...ShowcaseThumbnailFragment_item
-              }
+      nodes {
+        id
+        featured
+        title
+        categories
+        built_by
+        description
+        main_url
+        built_by_url
+        source_url
+        childScreenshot {
+          screenshotFile {
+            childImageSharp {
+              ...ShowcaseThumbnailFragment_item
             }
           }
-          fields {
-            slug
-          }
+        }
+        fields {
+          slug
         }
       }
     }

--- a/www/src/pages/starters.js
+++ b/www/src/pages/starters.js
@@ -17,39 +17,37 @@ export default StarterLibraryWrapper
 export const showcaseQuery = graphql`
   query SiteShowcaseQuery {
     allStartersYaml(filter: { fields: { hasScreenshot: { eq: true } } }) {
-      edges {
-        node {
-          id
-          fields {
-            starterShowcase {
-              slug
-              stub
-              description
-              stars
-              lastUpdated
-              owner
-              name
-              githubFullName
-              gatsbyMajorVersion
-              allDependencies
-              gatsbyDependencies
-              miscDependencies
-            }
+      nodes {
+        id
+        fields {
+          starterShowcase {
+            slug
+            stub
+            description
+            stars
+            lastUpdated
+            owner
+            name
+            githubFullName
+            gatsbyMajorVersion
+            allDependencies
+            gatsbyDependencies
+            miscDependencies
           }
-          url
-          repo
-          description
-          tags
-          features
-          internal {
-            type
-          }
-          childScreenshot {
-            screenshotFile {
-              childImageSharp {
-                fluid(maxWidth: 512) {
-                  ...GatsbyImageSharpFluid_noBase64
-                }
+        }
+        url
+        repo
+        description
+        tags
+        features
+        internal {
+          type
+        }
+        childScreenshot {
+          screenshotFile {
+            childImageSharp {
+              fluid(maxWidth: 512) {
+                ...GatsbyImageSharpFluid_noBase64
               }
             }
           }

--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -26,7 +26,7 @@ const preferSpacedTag = tags => {
 
 const Tags = ({ pageContext, data }) => {
   const { tags } = pageContext
-  const { edges, totalCount } = data.allMdx
+  const { nodes, totalCount } = data.allMdx
   const tagHeader = `${totalCount} post${
     totalCount === 1 ? `` : `s`
   } tagged with "${preferSpacedTag(tags)}"`
@@ -64,7 +64,7 @@ const Tags = ({ pageContext, data }) => {
           </Button>
         </React.Fragment>
       ) : null}
-      {edges.map(({ node }) => (
+      {nodes.map(node => (
         <BlogPostPreviewItem
           post={node}
           key={node.fields.slug}
@@ -90,10 +90,8 @@ export const pageQuery = graphql`
       }
     ) {
       totalCount
-      edges {
-        node {
-          ...BlogPostPreview_item
-        }
+      nodes {
+        ...BlogPostPreview_item
       }
     }
   }

--- a/www/src/templates/template-blog-list.js
+++ b/www/src/templates/template-blog-list.js
@@ -48,7 +48,7 @@ class BlogPostsIndex extends React.Component {
               View all Tags <TagsIcon />
             </Button>
           </div>
-          {allMdx.edges.map(({ node }, index) => (
+          {allMdx.nodes.map((node, index) => (
             <BlogPostPreviewItem
               post={node}
               key={node.fields.slug}
@@ -57,7 +57,7 @@ class BlogPostsIndex extends React.Component {
                 borderBottomStyle: `solid`,
                 borderColor: `ui.border`,
                 pb: 8,
-                mb: index === allMdx.edges.length - 1 ? 0 : 8,
+                mb: index === allMdx.nodes.length - 1 ? 0 : 8,
                 ...pullIntoGutter,
                 [breakpointGutter]: {
                   p: 9,
@@ -108,10 +108,8 @@ export const pageQuery = graphql`
       limit: $limit
       skip: $skip
     ) {
-      edges {
-        node {
-          ...BlogPostPreview_item
-        }
+      nodes {
+        ...BlogPostPreview_item
       }
     }
   }

--- a/www/src/templates/template-creator-details.js
+++ b/www/src/templates/template-creator-details.js
@@ -64,7 +64,7 @@ class CreatorTemplate extends Component {
     const isAgencyOrCompany =
       creator.type === `agency` || creator.type === `company`
 
-    const sites = data.allSitesYaml.edges
+    const sites = data.allSitesYaml.nodes
 
     return (
       <React.Fragment>
@@ -204,7 +204,7 @@ class CreatorTemplate extends Component {
                 >
                   {sites.map(site => (
                     <Link
-                      key={site.node.title}
+                      key={site.title}
                       sx={{
                         "&&": {
                           mr: 6,
@@ -214,12 +214,12 @@ class CreatorTemplate extends Component {
                           transition: `default`,
                         },
                       }}
-                      to={site.node.fields.slug}
+                      to={site.fields.slug}
                     >
                       <Img
-                        alt={`${site.node.title}`}
+                        alt={`${site.title}`}
                         fixed={
-                          site.node.childScreenshot.screenshotFile
+                          site.childScreenshot.screenshotFile
                             .childImageSharp.fixed
                         }
                       />
@@ -267,22 +267,20 @@ export const pageQuery = graphql`
         fields: { hasScreenshot: { eq: true } }
       }
     ) {
-      edges {
-        node {
-          url
-          title
-          childScreenshot {
-            screenshotFile {
-              childImageSharp {
-                fixed(width: 100, height: 100) {
-                  ...GatsbyImageSharpFixed
-                }
+      nodes {
+        url
+        title
+        childScreenshot {
+          screenshotFile {
+            childImageSharp {
+              fixed(width: 100, height: 100) {
+                ...GatsbyImageSharpFixed
               }
             }
           }
-          fields {
-            slug
-          }
+        }
+        fields {
+          slug
         }
       }
     }

--- a/www/src/templates/template-feature-comparison.js
+++ b/www/src/templates/template-feature-comparison.js
@@ -28,8 +28,8 @@ class FeatureComparison extends Component {
 
     const { sections, sectionHeaders } =
       featureType === `cms`
-        ? getFeaturesData(data.allGatsbyCmsSpecsCsv.edges)
-        : getFeaturesData(data.allGatsbyJamstackSpecsCsv.edges)
+        ? getFeaturesData(data.allGatsbyCmsSpecsCsv.nodes)
+        : getFeaturesData(data.allGatsbyJamstackSpecsCsv.nodes)
 
     return (
       <PageWithSidebar location={location}>
@@ -81,31 +81,27 @@ export default FeatureComparison
 export const pageQuery = graphql`
   query {
     allGatsbyCmsSpecsCsv {
-      edges {
-        node {
-          Category
-          Subcategory
-          Feature
-          Gatsby
-          WordPress
-          Drupal
-          Description
-        }
+      nodes {
+        Category
+        Subcategory
+        Feature
+        Gatsby
+        WordPress
+        Drupal
+        Description
       }
     }
     allGatsbyJamstackSpecsCsv {
-      edges {
-        node {
-          Category
-          Subcategory
-          Feature
-          Gatsby
-          Nextjs
-          Jekyll
-          Hugo
-          Nuxtjs
-          Description
-        }
+      nodes {
+        Category
+        Subcategory
+        Feature
+        Gatsby
+        Nextjs
+        Jekyll
+        Hugo
+        Nuxtjs
+        Description
       }
     }
   }

--- a/www/src/utils/__tests__/get-csv-features-data.js
+++ b/www/src/utils/__tests__/get-csv-features-data.js
@@ -1,67 +1,55 @@
 import { getFeaturesData } from "../get-csv-features-data"
 
-const mockEdges = [
+const mockNodes = [
   {
-    node: {
-      Category: `Performance`,
-      Gatsby: `3`,
-      Jamstack: `3`,
-      Cms: `2`,
-      Description: ``,
-    },
+    Category: `Performance`,
+    Gatsby: `3`,
+    Jamstack: `3`,
+    Cms: `2`,
+    Description: ``,
   },
   {
-    node: {
-      Category: `Developer Experience`,
-      Gatsby: `3`,
-      Jamstack: `3`,
-      Cms: `2`,
-      Description: ``,
-    },
+    Category: `Developer Experience`,
+    Gatsby: `3`,
+    Jamstack: `3`,
+    Cms: `2`,
+    Description: ``,
   },
   {
-    node: {
-      Category: `Governance`,
-      Gatsby: `3`,
-      Jamstack: `2`,
-      Cms: `3`,
-      Description: ``,
-    },
+    Category: `Governance`,
+    Gatsby: `3`,
+    Jamstack: `2`,
+    Cms: `3`,
+    Description: ``,
   },
   {
-    node: {
-      Category: `Accessibility`,
-      Gatsby: `2`,
-      Jamstack: `2`,
-      Cms: `3`,
-      Description: ``,
-    },
+    Category: `Accessibility`,
+    Gatsby: `2`,
+    Jamstack: `2`,
+    Cms: `3`,
+    Description: ``,
   },
   {
-    node: {
-      Category: `Documentation`,
-      Gatsby: `3`,
-      Jamstack: `3`,
-      Cms: `3`,
-      Description: ``,
-    },
+    Category: `Documentation`,
+    Gatsby: `3`,
+    Jamstack: `3`,
+    Cms: `3`,
+    Description: ``,
   },
   {
-    node: {
-      Category: `Ecosystem`,
-      Gatsby: `3`,
-      Jamstack: `2`,
-      Cms: `2`,
-      Description: ``,
-    },
+    Category: `Ecosystem`,
+    Gatsby: `3`,
+    Jamstack: `2`,
+    Cms: `2`,
+    Description: ``,
   },
 ]
 
 test(`it gets the correct number of sections and headers`, () => {
-  const { sections, sectionHeaders } = getFeaturesData(mockEdges)
+  const { sections, sectionHeaders } = getFeaturesData(mockNodes)
 
   expect(sections).toBeDefined()
-  expect(sections).toHaveLength(mockEdges.length)
+  expect(sections).toHaveLength(mockNodes.length)
   expect(sectionHeaders).toBeDefined()
-  expect(sectionHeaders).toHaveLength(mockEdges.length)
+  expect(sectionHeaders).toHaveLength(mockNodes.length)
 })

--- a/www/src/utils/get-csv-features-data.js
+++ b/www/src/utils/get-csv-features-data.js
@@ -1,12 +1,12 @@
 /**
  * Splits data from the Features query into more manageable data structures"
- * @param {Array} data Edges in response from GraphQL
+ * @param {Array} data Nodes in response from GraphQL
  * @returns {Object} headers and sections for features tables
  */
 
 export const getFeaturesData = function(data) {
   const sections = (data || [])
-    .map((row, i) => (row.node.Category ? i : -1))
+    .map((row, i) => (row.Category ? i : -1))
     .filter(rowNum => rowNum !== -1)
     .map((rowNum, i, arr) => {
       if (i < arr.length - 1) {
@@ -18,8 +18,8 @@ export const getFeaturesData = function(data) {
     .map(bounds => data.slice(bounds[0], bounds[1]))
 
   const sectionHeaders = (data || [])
-    .filter(row => row.node.Category)
-    .map(row => row.node.Category)
+    .filter(row => row.Category)
+    .map(row => row.Category)
 
   return {
     sectionHeaders,

--- a/www/src/views/creators/index.js
+++ b/www/src/views/creators/index.js
@@ -15,7 +15,7 @@ import { meta, shortcutIcon } from "../shared/styles"
 
 class CreatorsView extends Component {
   state = {
-    creators: this.props.data.allCreatorsYaml.edges,
+    creators: this.props.data.allCreatorsYaml.nodes,
     for_hire: false,
     hiring: false,
   }
@@ -28,13 +28,13 @@ class CreatorsView extends Component {
       const isFiltered = this.props.location.state.filter !== ``
       if (filterStateChanged && isNotFiltered) {
         this.setState({
-          creators: this.props.data.allCreatorsYaml.edges,
+          creators: this.props.data.allCreatorsYaml.nodes,
           [prevProps.location.state.filter]: false,
         })
       }
       if (filterStateChanged && isFiltered) {
         let items = this.state.creators.filter(
-          item => item.node[this.props.location.state.filter] === true
+          item => item[this.props.location.state.filter] === true
         )
         this.setState({
           creators: items,
@@ -49,7 +49,7 @@ class CreatorsView extends Component {
     const query = qs.parse(this.props.location.search.slice(1))
     if (query.filter) {
       let items = this.state.creators.filter(
-        item => item.node[query.filter] === true
+        item => item[query.filter] === true
       )
       this.setState({
         creators: items,
@@ -80,12 +80,12 @@ class CreatorsView extends Component {
     const applyFilter = filter => {
       if (this.state[filter] === true) {
         this.setState({
-          creators: data.allCreatorsYaml.edges,
+          creators: data.allCreatorsYaml.nodes,
           [filter]: false,
         })
         navigate(`${location.pathname}`, { state: { filter: `` } })
       } else {
-        let items = creators.filter(item => item.node[filter] === true)
+        let items = creators.filter(item => item[filter] === true)
         this.setState({
           creators: items,
           [filter]: true,
@@ -134,14 +134,14 @@ class CreatorsView extends Component {
             {creators.length < 1 ? (
               <p sx={{ color: `gatsby` }}>No results</p>
             ) : (
-              creators.map(item => (
-                <div key={item.node.name} sx={styles.creatorCard}>
+              creators.map(node => (
+                <div key={node.name} sx={styles.creatorCard}>
                   <ThumbnailLink
-                    slug={item.node.fields.slug}
-                    image={item.node.image}
-                    title={item.node.name}
+                    slug={node.fields.slug}
+                    image={node.image}
+                    title={node.name}
                   >
-                    <strong className="title">{item.node.name}</strong>
+                    <strong className="title">{node.name}</strong>
                   </ThumbnailLink>
                   <div sx={{ display: `flex`, ...meta }}>
                     <div
@@ -150,29 +150,29 @@ class CreatorsView extends Component {
                         color: `textMuted`,
                       }}
                     >
-                      {item.node.location}
+                      {node.location}
                     </div>
-                    {item.node.github && (
+                    {node.github && (
                       <a
                         sx={{
                           ...shortcutIcon,
                           ml: `auto`,
                         }}
-                        href={item.node.github}
+                        href={node.github}
                       >
                         <GithubIcon style={{ verticalAlign: `text-top` }} />
                       </a>
                     )}
                   </div>
-                  {item.node.for_hire || item.node.hiring ? (
+                  {node.for_hire || node.hiring ? (
                     <div
                       sx={{
                         alignSelf: `flex-start`,
                         fontSize: 0,
                       }}
                     >
-                      <Badge forHire={item.node.for_hire}>
-                        {item.node.for_hire ? `For Hire` : `Hiring`}
+                      <Badge forHire={node.for_hire}>
+                        {node.for_hire ? `For Hire` : `Hiring`}
                       </Badge>
                     </div>
                   ) : null}

--- a/www/src/views/shared/sidebar.js
+++ b/www/src/views/shared/sidebar.js
@@ -125,7 +125,7 @@ export const ContentTitle = ({
   search,
   items,
   filters,
-  edges,
+  nodes,
   label,
   // TODO smooth that out ("Starters" uses "size")
   what = `length`,
@@ -142,7 +142,7 @@ export const ContentTitle = ({
       filters[what] === 0 ? (
         // no search or filters
         <span>
-          {label}s <ResultCount>({edges.length})</ResultCount>
+          {label}s <ResultCount>({nodes.length})</ResultCount>
         </span>
       ) : (
         <span>

--- a/www/src/views/showcase/featured-sites.js
+++ b/www/src/views/showcase/featured-sites.js
@@ -10,7 +10,10 @@ import { screenshot, screenshotHover, withTitleHover } from "../shared/styles"
 import MdArrowForward from "react-icons/lib/md/arrow-forward"
 import ShowcaseItemCategories from "./showcase-item-categories"
 import { ShowcaseIcon } from "../../assets/icons"
-import { mediaQueries, colors } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
+import {
+  mediaQueries,
+  colors,
+} from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 import { svgStyles } from "../../utils/styles"
 import Button from "../../components/button"
 import ArrowForwardIcon from "react-icons/lib/md/arrow-forward"
@@ -164,7 +167,7 @@ class FeaturedSites extends Component {
               padding: t => `${t.space[6]} ${t.space[6]} 0`,
             }}
           >
-            {featured.slice(0, 9).map(({ node }) => (
+            {featured.slice(0, 9).map(node => (
               <div
                 key={node.id}
                 sx={{

--- a/www/src/views/showcase/filtered-showcase.js
+++ b/www/src/views/showcase/filtered-showcase.js
@@ -20,9 +20,9 @@ import { themedInput } from "../../utils/styles"
 const OPEN_SOURCE_CATEGORY = `Open Source`
 
 const filterByCategories = (list, categories) => {
-  const items = list.reduce((aggregated, edge) => {
-    if (edge.node.categories) {
-      const filteredCategories = edge.node.categories.filter(c =>
+  const items = list.reduce((aggregated, node) => {
+    if (node.categories) {
+      const filteredCategories = node.categories.filter(c =>
         categories.includes(c)
       )
       if (
@@ -58,20 +58,20 @@ class FilteredShowcase extends Component {
       maxPatternLength: 32,
       minMatchCharLength: 1,
       keys: [
-        `node.title`,
-        `node.categories`,
-        `node.built_by`,
-        `node.description`,
+        `title`,
+        `categories`,
+        `built_by`,
+        `description`,
       ],
     }
 
-    this.fuse = new Fuse(props.data.allSitesYaml.edges, options)
+    this.fuse = new Fuse(props.data.allSitesYaml.nodes, options)
   }
 
   render() {
     const { data, filters, setFilters } = this.props
 
-    let items = data.allSitesYaml.edges
+    let items = data.allSitesYaml.nodes
 
     if (this.state.search.length > 0) {
       items = this.fuse.search(this.state.search)
@@ -82,18 +82,18 @@ class FilteredShowcase extends Component {
     }
 
     // create map of categories with totals
-    const aggregatedCategories = items.reduce((categories, edge) => {
-      if (!edge.node.categories) {
-        edge.node.categories = []
+    const aggregatedCategories = items.reduce((categories, node) => {
+      if (!node.categories) {
+        node.categories = []
       }
-      const idx = edge.node.categories.indexOf(OPEN_SOURCE_CATEGORY)
+      const idx = node.categories.indexOf(OPEN_SOURCE_CATEGORY)
       if (idx !== -1) {
-        edge.node.categories.splice(idx, 1)
+        node.categories.splice(idx, 1)
       }
-      if (edge.node.source_url) {
-        edge.node.categories.push(OPEN_SOURCE_CATEGORY)
+      if (node.source_url) {
+        node.categories.push(OPEN_SOURCE_CATEGORY)
       }
-      edge.node.categories.forEach(category => {
+      node.categories.forEach(category => {
         // if we already have the category recorded, increase count
         if (categories[category]) {
           categories[category] = categories[category] + 1
@@ -102,7 +102,7 @@ class FilteredShowcase extends Component {
           categories[category] = 1
         }
       })
-      edge.node.categories.sort((str1, str2) =>
+      node.categories.sort((str1, str2) =>
         str1.toLowerCase().localeCompare(str2.toLowerCase())
       )
 
@@ -129,7 +129,7 @@ class FilteredShowcase extends Component {
               filters={filters}
               label="Site"
               items={items}
-              edges={data.allSitesYaml.edges}
+              nodes={data.allSitesYaml.nodes}
             />
             <div sx={{ ml: `auto` }}>
               <label css={{ display: `block`, position: `relative` }}>

--- a/www/src/views/showcase/index.js
+++ b/www/src/views/showcase/index.js
@@ -58,7 +58,7 @@ class ShowcaseView extends Component {
         </Helmet>
         <FeaturedSites
           setFilters={this.setFilters}
-          featured={data.featured.edges}
+          featured={data.featured.nodes}
         />
         <div id="showcase" css={{ height: 0 }} ref={this.showcase} />
         <FilteredShowcase

--- a/www/src/views/showcase/showcase-list.js
+++ b/www/src/views/showcase/showcase-list.js
@@ -26,7 +26,7 @@ const ShowcaseList = ({ items, count, filters, onCategoryClick }) => {
   return (
     <main id={`reach-skip-nav`} sx={showcaseList}>
       {items.map(
-        ({ node }) =>
+        node =>
           node.fields &&
           node.fields.slug && ( // have to filter out null fields from bad data
             <div key={node.id} sx={showcaseItem}>

--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -41,7 +41,7 @@ export default class FilteredStarterLibrary extends Component {
     })
   resetFilters = () => this.props.setURLState({ c: [], d: [], v: [], s: `` })
   showMoreSites = starters => {
-    let showAll =
+    const showAll =
       this.state.sitesToShow + 15 > starters.length ? starters.length : false
     this.setState({
       sitesToShow: showAll ? showAll : this.state.sitesToShow + 15,
@@ -77,8 +77,8 @@ export default class FilteredStarterLibrary extends Component {
     )
 
     // stopgap for missing gh data (#8763)
-    let starters = data.allStartersYaml.edges.filter(
-      ({ node: starter }) => starter.fields && starter.fields.starterShowcase
+    let starters = data.allStartersYaml.nodes.filter(
+      starter => starter.fields && starter.fields.starterShowcase
     )
 
     if (urlState.s.length > 0) {
@@ -116,7 +116,7 @@ export default class FilteredStarterLibrary extends Component {
               data={Array.from(
                 count(
                   starters.map(
-                    ({ node }) =>
+                    node =>
                       node.fields &&
                       node.fields.starterShowcase.gatsbyMajorVersion.map(
                         str => str[1]
@@ -129,9 +129,7 @@ export default class FilteredStarterLibrary extends Component {
             />
             <LHSFilter
               heading="Categories"
-              data={Array.from(
-                count(starters.map(({ node: starter }) => starter.tags))
-              )}
+              data={Array.from(count(starters.map(starter => starter.tags)))}
               filters={filtersCategory}
               setFilters={setFiltersCategory}
               sortRecent={urlState.sort === `recent`}
@@ -141,7 +139,7 @@ export default class FilteredStarterLibrary extends Component {
               data={Array.from(
                 count(
                   starters.map(
-                    ({ node: starter }) =>
+                    starter =>
                       starter.fields &&
                       starter.fields.starterShowcase.gatsbyDependencies.map(
                         str => str[0]
@@ -171,7 +169,7 @@ export default class FilteredStarterLibrary extends Component {
               filters={filters}
               label="Gatsby Starter"
               items={starters}
-              edges={starters}
+              nodes={starters}
               what="size"
             />
             <div
@@ -259,12 +257,12 @@ export default class FilteredStarterLibrary extends Component {
 // utility functions
 
 function count(arrays) {
-  let counts = new Map()
+  const counts = new Map()
 
-  for (let categories of arrays) {
+  for (const categories of arrays) {
     if (!categories) continue
 
-    for (let category of categories) {
+    for (const category of categories) {
       if (!counts.has(category)) {
         counts.set(category, 0)
       }
@@ -300,11 +298,12 @@ function filterByDependencies(list, categories) {
 
 function filterByVersions(list, versions) {
   let starters = list
+
   starters = starters.filter(
-    ({ node }) =>
-      node.fields &&
+    ({ fields }) =>
+      fields &&
       isSuperset(
-        node.fields.starterShowcase.gatsbyMajorVersion.map(c => c[1]),
+        fields.starterShowcase.gatsbyMajorVersion.map(c => c[1]),
         versions
       )
   )
@@ -312,7 +311,7 @@ function filterByVersions(list, versions) {
 }
 
 function isSuperset(set, subset) {
-  for (var elem of subset) {
+  for (const elem of subset) {
     if (!set.includes(elem)) {
       return false
     }

--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -60,7 +60,7 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
     starters = starters.sort(sortingFunction()).slice(0, count)
     return (
       <div sx={showcaseList}>
-        {starters.map(({ node: starter }) => {
+        {starters.map(starter => {
           const {
             description,
             gatsbyMajorVersion,
@@ -89,7 +89,11 @@ const StartersList = ({ urlState, starters, count, sortRecent }) => {
                 />
                 <div sx={meta}>
                   <div
-                    css={{ display: `flex`, justifyContent: `space-between`, alignItems: `start` }}
+                    css={{
+                      display: `flex`,
+                      justifyContent: `space-between`,
+                      alignItems: `start`,
+                    }}
                   >
                     <span
                       sx={{


### PR DESCRIPTION
## Description

Replacing where there are `edges.node` on the docs codes to `nodes` to maintain Code cleanliness of the gatsby website.

## Related Issues

Fixes issue [#21255](https://github.com/gatsbyjs/gatsby/issues/21255)
