### PR TITLE
Add an example with Workbox CLI

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -118,7 +118,7 @@ plugins: [
 
 In version 3, Workbox is also upgraded to version 4 so you may need to update your `workboxConfig` if any of those changes apply to you. Please see the [docs on Google Developers](https://developers.google.com/web/tools/workbox/guides/migrations/migrate-from-v3) for more information.
 
-## Overriding Workbox configuration
+## Overriding Workbox (v4.3.1) configuration
 
 When adding this plugin to your `gatsby-config.js`, you can use the option `workboxConfig` to override the default Workbox config. To see the full list of options, see [this article on Google Developers](https://developers.google.com/web/tools/workbox/modules/workbox-build#full_generatesw_config).
 
@@ -164,6 +164,28 @@ const options = {
   skipWaiting: true,
   clientsClaim: true,
 }
+```
+
+You can also use [Workbox CLI](https://developers.google.com/web/tools/workbox/modules/workbox-cli) to generate this file automatically. 
+
+```
+workbox wizard
+? What is the root of your web app (i.e. which directory do you deploy)? public/
+? Which file types would you like to precache?
+? Where would you like your service worker file to be saved? public/sw.js
+? Where would you like to save these configuration options? workbox-config.js
+```
+
+Copy the content from `workbox-config.js` into your `gatsby-plugin-offline` options.
+
+For instance, the following configuration does the trick for a full offline website
+
+```
+  "globDirectory": "public/",
+  "globPatterns": [
+    "**/*.{html,js,json,png,jpg,webmanifest,woff,woff2,ttf,eot,css,mjs}"
+  ],
+  "swDest": "public/sw.js"
 ```
 
 ## Remove


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I spent lot of time trying to configure gatsby-plugin-offline to get a full offline website experience. This add a working example with Workbox CLI to get a quickly working configuration.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
