### PR TITLE
fix(www): Remove crashing starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -34,18 +34,6 @@
     - MDX
     - MaterialUI Components
     - React Icons
-- url: https://authenticaysh.netlify.com/
-  repo: https://github.com/ben-siewert/gatsby-starter-auth-aws-amplify
-  description: Full-featured Auth with AWS Amplify & AWS Cognito
-  tags:
-    - AWS
-    - Authentication
-  features:
-    - Full-featured AWS Authentication with Cognito
-    - Error feedback in forms
-    - Password Reset
-    - Multi-Factor Authentication
-    - Styling with Bootstrap and Sass
 - url: https://gatsby-starter-blog-demo.netlify.com/
   repo: https://github.com/gatsbyjs/gatsby-starter-blog
   description: official blog


### PR DESCRIPTION
## Description

Fix builds crashing due to not finding a starter:

Error getting repo data for starter “gatsby-starter-auth-aws-amplify”: Could not resolve to a User with the username ‘ben-siewert’.: {“response”:{“data”:{“repository”:null},“errors”:[{“type”:“NOT_FOUND”,“path”:[“repository”],“locations”:[{“line”:3,“column”:15}],“message”:“Could not resolve to a User with the username ‘ben-siewert’.“}],“status”:200},“request”:{“query”:“\n query {\n repository(owner:\“ben-siewert\“, name:\“gatsby-starter-auth-aws-amplify\“) {\n name\n stargazers {\n totalCount\n }\n createdAt\n pushedAt\n owner {\n login\n }\n nameWithOwner\n }\n }\n “}}