### PR TITLE
chore(doc):add or fix syntax highlight language

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -6,7 +6,7 @@ Example sites for benchmarking `gatsby`.
 
 The standard interface for running a benchmark is:
 
-```
+```shell
 cd {benchmark directory}
 export NUM_PAGES={n}
 npm install
@@ -19,6 +19,6 @@ Any `postinstall` script must ensure that previous benchmark runs do not interfe
 
 For example:
 
-```
+```text
 "postinstall": "del-cli ./generated && gatsby clean && npm run generate"
 ```

--- a/benchmarks/create-pages/README.md
+++ b/benchmarks/create-pages/README.md
@@ -8,13 +8,13 @@ Defaults to building a site with 5k pages. Set the `NUM_PAGES` environment varia
 
 First, install node modules required by package.json. This is needed only one time. Then run the build
 
-```bash
+```shell
 npm install
 npm run build
 ```
 
 Alternatively;
 
-```sh
+```shell
 NUM_PAGES=2000 yarn bench
 ```

--- a/benchmarks/image-processing/README.md
+++ b/benchmarks/image-processing/README.md
@@ -11,13 +11,13 @@ The max number of images you can process is 1300.
 
 First, install node modules required by package.json. This is needed only one time. Then run the build
 
-```bash
+```shell
 npm install
 npm run build
 ```
 
 Alternatively;
 
-```sh
+```shell
 NUM_PAGES=2000 yarn bench
 ```

--- a/benchmarks/markdown_id/README.md
+++ b/benchmarks/markdown_id/README.md
@@ -10,7 +10,7 @@ The pre-generate script stores pages in root/markdown-pages.
 
 ## Usage
 
-```
+```shell
 yarn
 yarn bench
 ```
@@ -21,7 +21,7 @@ If you want to run the same pages without regenerating them you can use `yarn be
 
 Use `yarn` to install if you want to use `gatsby-dev`. Otherwise I don't think it matters between `yarn` or `npm install`.
 
-```sh
+```shell
 # Requires node 8+
 # nvm use 8
 yarn

--- a/benchmarks/markdown_slug/README.md
+++ b/benchmarks/markdown_slug/README.md
@@ -10,7 +10,7 @@ The pre-generate script stores pages in root/markdown-pages.
 
 ## Usage
 
-```
+```shell
 yarn
 yarn bench
 ```
@@ -21,7 +21,7 @@ If you want to run the same pages without regenerating them you can use `yarn be
 
 Use `yarn` to install if you want to use `gatsby-dev`. Otherwise I don't think it matters between `yarn` or `npm install`.
 
-```sh
+```shell
 # Requires node 8+
 # nvm use 8
 yarn

--- a/benchmarks/markdown_table/README.md
+++ b/benchmarks/markdown_table/README.md
@@ -18,13 +18,13 @@ Defaults to building a site with 5k markdown pages and 25 maximum rows per age. 
 
 First, install node modules required by package.json. This is needed only one time. Then run the build
 
-```bash
+```shell
 yarn
 yarn build
 ```
 
 Alternatively
 
-```sh
+```shell
 yarn bench
 ```

--- a/benchmarks/query/README.md
+++ b/benchmarks/query/README.md
@@ -4,7 +4,7 @@ Stress tests creating lots of queries.
 
 # Usage
 
-```sh
+```shell
 NUM_TYPES=5 NUM_PAGES=1000 yarn bench
 ```
 

--- a/benchmarks/query/recording.md
+++ b/benchmarks/query/recording.md
@@ -15,22 +15,22 @@ Performed on 2018 13" MBP. 4-core 2.7 GHz Intel Core i7. 16 GB 2133 MHz LPDDR3
 
 - Gatsby: master
 
-```
+```shell
 query $ NUM_TYPES=1 NUM_PAGES=10000 bin/runQueryTiming.sh
 21.135
 ```
 
-```
+```shell
 query $ NUM_TYPES=100 NUM_PAGES=10000 bin/runQueryTiming.sh
 13.112
 ```
 
-```
+```shell
 query $ NUM_TYPES=1 NUM_PAGES=20000 bin/runQueryTiming.sh
 67.812
 ```
 
-```
+```shell
 query $ NUM_TYPES=100 NUM_PAGES=20000 bin/runQueryTiming.sh
 24.656
 ```
@@ -41,22 +41,22 @@ query $ NUM_TYPES=100 NUM_PAGES=20000 bin/runQueryTiming.sh
 - Index = false
 - loki nested index patch
 
-```
+```shell
 query $ NUM_TYPES=1 NUM_PAGES=10000 bin/runQueryTiming.sh
 14.834
 ```
 
-```
+```shell
 query $ NUM_TYPES=100 NUM_PAGES=10000 bin/runQueryTiming.sh
 14.676
 ```
 
-```
+```shell
 query $ NUM_TYPES=1 NUM_PAGES=20000 bin/runQueryTiming.sh
 58.377
 ```
 
-```
+```shell
 query $ NUM_TYPES=100 NUM_PAGES=20000 bin/runQueryTiming.sh
 27.486
 ```
@@ -67,22 +67,22 @@ query $ NUM_TYPES=100 NUM_PAGES=20000 bin/runQueryTiming.sh
 - Index = true
 - loki nested index patch
 
-```
+```shell
 query $ NUM_TYPES=1 NUM_PAGES=10000 bin/runQueryTiming.sh
 8.126
 ```
 
-```
+```shell
 query $ NUM_TYPES=100 NUM_PAGES=10000 bin/runQueryTiming.sh
 15.050
 ```
 
-```
+```shell
 query $ NUM_TYPES=1 NUM_PAGES=20000 bin/runQueryTiming.sh
 12.797
 ```
 
-```
+```shell
 query $ NUM_TYPES=100 NUM_PAGES=20000 bin/runQueryTiming.sh
 27.020
 ```

--- a/docs/blog/2019-12-20-integrate-tinacms-with-your-gatsby-website/index.md
+++ b/docs/blog/2019-12-20-integrate-tinacms-with-your-gatsby-website/index.md
@@ -258,7 +258,7 @@ When it's time to allow your editors to edit a site with Tina on a hosted server
 
 To get Tina working in Gatsby Cloud, you'll need to configure the following environment variables in your `Site Settings`:
 
-```
+```text
 GIT_AUTHOR_EMAIL
 GIT_AUTHOR_NAME
 SSH_KEY

--- a/docs/docs/creating-a-local-plugin.md
+++ b/docs/docs/creating-a-local-plugin.md
@@ -8,7 +8,7 @@ If a plugin is only relevant to your specific use-case, or if you’re developin
 
 Place the code in the `plugins` folder in the root of your project like this:
 
-```
+```text
 /my-gatsby-site
 └── gatsby-config.js
 └── /src

--- a/docs/docs/gatsby-project-structure.md
+++ b/docs/docs/gatsby-project-structure.md
@@ -4,7 +4,7 @@ title: Gatsby Project Structure
 
 Inside a Gatsby project, you may see some or all of the following folders and files:
 
-```
+```text
 /
 |-- /.cache
 |-- /plugins

--- a/docs/docs/graphql-concepts.md
+++ b/docs/docs/graphql-concepts.md
@@ -152,7 +152,7 @@ If you give Gatsby data that looks like this:
 
 Gatsby will create a schema that looks something like this:
 
-```
+```text
 title: String
 ```
 

--- a/docs/docs/loading-plugins-from-your-local-plugins-folder.md
+++ b/docs/docs/loading-plugins-from-your-local-plugins-folder.md
@@ -6,7 +6,7 @@ Gatsby can load plugins from your website's local plugins folder, which is a fol
 
 Consider this example project structure which includes a local plugin called `gatsby-local-plugin`:
 
-```
+```text
 /my-gatsby-site
 └── /src
     └── /pages

--- a/docs/docs/recipes/pages-layouts.md
+++ b/docs/docs/recipes/pages-layouts.md
@@ -9,7 +9,7 @@ Add pages to your Gatsby site, and use layouts to manage common page elements.
 
 Inside a Gatsby project, you may see some or all of the following folders and files:
 
-```
+```text
 |-- /.cache
 |-- /plugins
 |-- /public

--- a/examples/styleguide/src/components/Button/README.md
+++ b/examples/styleguide/src/components/Button/README.md
@@ -1,25 +1,37 @@
 The basic button.
 
-```
+```jsx
 <Button>Get Started</Button>
 ```
 
 Colors are configurable.
 
-```
+```jsx
 <div>
-  <div><Button backgroundColor="blue">Get Started</Button></div>
-  <div><Button backgroundColor="green">Get Started</Button></div>
-  <div><Button backgroundColor="orange">Get Started</Button></div>
+  <div>
+    <Button backgroundColor="blue">Get Started</Button>
+  </div>
+  <div>
+    <Button backgroundColor="green">Get Started</Button>
+  </div>
+  <div>
+    <Button backgroundColor="orange">Get Started</Button>
+  </div>
 </div>
 ```
 
 Sizes are also configurable.
 
-```
+```jsx
 <div>
-  <div><Button size="sm">Get Started</Button></div>
-  <div><Button size="md">Get Started</Button></div>
-  <div><Button size="lg">Get Started</Button></div>
+  <div>
+    <Button size="sm">Get Started</Button>
+  </div>
+  <div>
+    <Button size="md">Get Started</Button>
+  </div>
+  <div>
+    <Button size="lg">Get Started</Button>
+  </div>
 </div>
 ```

--- a/examples/using-MDX/README.md
+++ b/examples/using-MDX/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 <h1 align="center">
-  Using MDX Example 
+  Using MDX Example
 </h1>
 
 This repository demonstrates how to add MDX pages to a new Gatsby site.
@@ -17,7 +17,7 @@ In this section you will see two examples of using MDX, one of which is from a 3
 
 In the pages directory of this example you will find the `chart-info.mdx` file which uses some components to display this array of information in multiple graphs.
 
-```
+```javascript
 export const data = [
   {
     label: "In App Purchase Income",
@@ -34,7 +34,7 @@ export const data = [
   {
     label: "Advertising Income",
     datums: [
-      { x: "2020", y: 4},
+      { x: "2020", y: 4 },
       { x: "2019", y: 3 },
       { x: "2018", y: 12 },
       { x: "2017", y: 14 },

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -281,13 +281,13 @@ Unless the text is Markdown-free, you cannot use the returned value directly. In
 
 You can then insert the returned HTML inline in your JSX:
 
-```
-  <div
+```jsx
+<div
   className="body"
   dangerouslySetInnerHTML={{
-       __html: data.contentfulCaseStudy.body.childMarkdownRemark.html,
-     }}
-   />
+    __html: data.contentfulCaseStudy.body.childMarkdownRemark.html,
+  }}
+/>
 ```
 
 #### Duplicated entries


### PR DESCRIPTION
## Description

fixed in code blocks:
- add missing language marker
- changed some language marker `sh` and `bash` to `shell` -> to unify it in one readme 
- add missing language marker `text` to directory trees 
- prettier tool done some automatic reformatting while syntax change