### PR TITLE
fix(www): add declaration to field in for/in loop

### DIFF
--- a/www/plugins/gatsby-plugin-i18n/gatsby-node.js
+++ b/www/plugins/gatsby-plugin-i18n/gatsby-node.js
@@ -4,7 +4,7 @@ exports.onCreatePage = ({ page, actions }, pluginOptions) => {
 
   // NOTE: Right now, the default language (English) isn't counted among the list of languages.
   // If we were to add it, we'd need to run `deletePage` on the original page and create a new one.
-  for (lang of languages) {
+  for (const lang of languages) {
     createPage({
       ...page,
       path: `/${lang}${page.path}`,


### PR DESCRIPTION
## Description

- add declaration to field in for/in loop

## Discussion

- i did see approximately the same amount of `let` vs `const` in code base, but since the value is not changed i decided for `const`

## Related Issues

- #21632 `feature(www): Create localized versions of all pages`