### PR TITLE
Move buildTime into new node type

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.js.snap
@@ -36,6 +36,8 @@ Array [
     "name": "internal-data-bridge",
     "nodeAPIs": Array [
       "sourceNodes",
+      "createSchemaCustomization",
+      "createResolvers",
       "onCreatePage",
     ],
     "pluginOptions": Object {
@@ -220,6 +222,8 @@ Array [
     "name": "internal-data-bridge",
     "nodeAPIs": Array [
       "sourceNodes",
+      "createSchemaCustomization",
+      "createResolvers",
       "onCreatePage",
     ],
     "pluginOptions": Object {
@@ -432,6 +436,8 @@ Array [
     "name": "internal-data-bridge",
     "nodeAPIs": Array [
       "sourceNodes",
+      "createSchemaCustomization",
+      "createResolvers",
       "onCreatePage",
     ],
     "pluginOptions": Object {

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -110,14 +110,16 @@ exports.sourceNodes = ({ createContentDigest, actions, store }) => {
     .startOf(`second`)
     .toJSON()
 
+  const metadataNode = { buildTime }
+
   createNode({
-    id: `SiteBuildTime`,
+    ...metadataNode,
+    id: `SiteBuildMetadata`,
     parent: null,
     children: [],
-    buildTime,
     internal: {
-      contentDigest: createContentDigest(buildTime),
-      type: `SiteBuildTime`,
+      contentDigest: createContentDigest(metadataNode),
+      type: `SiteBuildMetadata`,
     },
   })
 
@@ -158,8 +160,8 @@ exports.createResolvers = ({ createResolvers }) => {
         type: `Date`,
         resolve(source, args, context, info) {
           const { buildTime } = context.nodeModel.getNodeById({
-            id: `SiteBuildTime`,
-            type: `SiteBuildTime`,
+            id: `SiteBuildMetadata`,
+            type: `SiteBuildMetadata`,
           })
           return info.originalResolver(
             {

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -141,17 +141,35 @@ exports.sourceNodes = ({ createContentDigest, actions, store }) => {
   })
 }
 
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+    type Site implements Node {
+      buildTime: Date @dateformat
+    }
+  `
+  createTypes(typeDefs)
+}
+
 exports.createResolvers = ({ createResolvers }) => {
   const resolvers = {
     Site: {
       buildTime: {
         type: `Date`,
         resolve(source, args, context, info) {
-          const buildNode = context.nodeModel.getNodeById({
+          const { buildTime } = context.nodeModel.getNodeById({
             id: `SiteBuildTime`,
             type: `SiteBuildTime`,
           })
-          return buildNode.buildTime
+          return info.originalResolver(
+            {
+              ...source,
+              buildTime,
+            },
+            args,
+            context,
+            info
+          )
         },
       },
     },


### PR DESCRIPTION
## Description

This creates a new node type `SiteBuildTime`, with one node that includes a `buildTime` field. It then replaces the buildTime field on `Site` with a resolver that returns the value from the `SiteBuildTime` node. This prevents changes to buildTime affecting the Site node contentDigest, which would mark any page that uses siteMetadata as dirty.

Based on discussion https://github.com/gatsbyjs/gatsby/pull/21795#issuecomment-591979862

## Related Issue

Replaces #21795 