### PR TITLE
fix(gatsby): fix codepaths that result in js errors

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -353,7 +353,9 @@ const createComponentUrls = componentChunkName =>
 export class ProdLoader extends BaseLoader {
   constructor(asyncRequires, matchPaths) {
     const loadComponent = chunkName =>
-      asyncRequires.components[chunkName]().then(preferDefault)
+      asyncRequires.components[chunkName]
+        ? asyncRequires.components[chunkName]().then(preferDefault)
+        : Promise.resolve()
 
     super(loadComponent, matchPaths)
   }

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -84,7 +84,10 @@ const navigate = (to, options = {}) => {
     if (!pageResources || pageResources.status === `error`) {
       window.history.replaceState({}, ``, location.href)
       window.location = pathname
+      clearTimeout(timeoutId)
+      return
     }
+
     // If the loaded page has a different compilation hash to the
     // window, then a rebuild has occurred on the server. Reload.
     if (process.env.NODE_ENV === `production` && pageResources) {


### PR DESCRIPTION
## Description
When page-data.json results in a 500 or when we can't fetch a component we've hit some js errors instead of our own. So now we are actually throwing gatsby errors and error trackers make more sense.

**Before:**
- When component can't be loaded we had: `TypeError: e.components[t] is not a function` and loaded the 404 page.
- when page-data results in 500 we had: `TypeError: Cannot read property 'webpackCompilationHash' of undefined` and refresh the page.

**After:**
- When component can't be loaded we have: `Error: page resources for /stale/ not found. Not rendering React` and loaded the 404 page.
- when page-data results in 500 we have: `Error: page resources for /new-beginnings/ not found. Not rendering React' of undefined` and refresh the page.

## Related Issues
https://github.com/gatsbyjs/gatsby/pull/21429
