### PR TITLE
fix(www): remove prettier ignore comment causing MDX parsing error

### DIFF
--- a/docs/docs/caching.md
+++ b/docs/docs/caching.md
@@ -51,9 +51,12 @@ When deploying with Now, follow the instructions in the [Now documentation](http
 
 ---
 
- <!-- prettier-ignore-start -->
-<sup>1</sup> You can use 'no-cache' instead of 'max-age=0, must-revalidate'. Despite what the name might imply, 'no-cache' permits a cache to serve cached content as long as it validates the cache freshness first. <sup>[2][3] </sup> In either case, clients have to make a round trip to the origin server on each request. However, if you are correctly utilizing ETags or Last-Modified validation you will avoid downloading assets when the cached copy is still valid (e.g. the file hasn't changed on the origin server since it was cached).
-<!-- prettier-ignore-end -->
+<sup>
+  1
+</sup> You can use 'no-cache' instead of 'max-age=0, must-revalidate'. Despite what the name might imply, 'no-cache' permits a cache to serve cached content as long as it validates the cache freshness first.
+<sup>
+  [2][3]{" "}
+</sup> In either case, clients have to make a round trip to the origin server on each request. However, if you are correctly utilizing ETags or Last-Modified validation you will avoid downloading assets when the cached copy is still valid (e.g. the file hasn't changed on the origin server since it was cached).
 
 [2]: https://tools.ietf.org/html/rfc7234#section-5.2.2.1
 [3]: https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#no-cache_and_no-store


### PR DESCRIPTION
Remove a prettier-ignore comment that was somehow interpreted wrong by our mdx parser. The content was originally ignored because it was ugly when formatted, but we're trying to restructure the content anyways so it shouldn't matter that much.