### PR TITLE
chore(showcase): Remove Gratsy

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -6729,18 +6729,6 @@
     - Nonprofit
   built_by: Jacob Herper
   built_by_url: https://herper.io
-- title: Gratsy
-  url: https://gratsy.com/
-  main_url: https://gratsy.com/
-  description: >
-    Gratsy: Feedback To Give Back
-  categories:
-    - Agency
-    - Marketing
-    - Landing Page
-  built_by: Whalar
-  built_by_url: https://whalar.com/
-  featured: false
 - title: deepThreads
   main_url: https://deepthreads.com
   url: https://deepthreads.com/


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Removing Gratsy from showcases since it was moved to somewhere else (not because Gatsby JS, we love it, but because other business reasons).


## Related Issues
Related to #16558 
