### PR TITLE
fix(gatsby): Check for nullable locations in query-runner

### DIFF
--- a/packages/gatsby/src/query/query-runner.js
+++ b/packages/gatsby/src/query/query-runner.js
@@ -58,8 +58,8 @@ module.exports = async (graphqlRunner, queryJob: QueryJob) => {
           ...structuredError.context,
           codeFrame: getCodeFrame(
             queryJob.query,
-            e.locations[0].line,
-            e.locations[0].column
+            e.locations && e.locations[0].line,
+            e.locations && e.locations[0].column
           ),
           filePath: queryJob.componentPath,
           ...(urlPath && { urlPath }),


### PR DESCRIPTION
## Description

See context in #21838 

I tested this change locally by just updating Gatsby in node_modules. It worked!

--

Note: I tried using optional chaining but I had issues so I just went with good ol' `&&`

## Related Issues

#21838 