### PR TITLE
docs(gatsby-plugin-preload-fonts): add external chrome env var

### DIFF
--- a/packages/gatsby-plugin-preload-fonts/README.md
+++ b/packages/gatsby-plugin-preload-fonts/README.md
@@ -139,4 +139,4 @@ This comes with [inherent security risks](https://chromium.googlesource.com/chro
 but you should be alright since you're only running it locally.
 
 #### Environment Variables
-In some cases you might have to point Puppeteer to an external installation of Chromium (e.g. on Alpine Linux, the build-in version of Chromium does not work). To do that, you can set the `PUPPETEER_EXECUTABLE_PATH` environment variable. A list with all enviroment variables to configure Puppeteer can be found [here](https://pptr.dev/#?product=Puppeteer&version=v1.20.0&show=api-environment-variables).
+In some cases you might have to point Puppeteer to an external installation of Chromium (e.g. on Alpine Linux, the build-in version of Chromium does not work). To do that, you can set the `PUPPETEER_EXECUTABLE_PATH` environment variable. A list with all environment variables to configure Puppeteer can be found [here](https://pptr.dev/#?product=Puppeteer&version=v1.20.0&show=api-environment-variables).

--- a/packages/gatsby-plugin-preload-fonts/README.md
+++ b/packages/gatsby-plugin-preload-fonts/README.md
@@ -137,3 +137,6 @@ npm run preload-fonts -- --no-sandbox
 
 This comes with [inherent security risks](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md),
 but you should be alright since you're only running it locally.
+
+#### Environment Variables
+In some cases you might have to point Puppeteer to an external installation of Chromium (e.g. on Alpine Linux, the build-in version of Chromium does not work). To do that, you can set the `PUPPETEER_EXECUTABLE_PATH` environment variable. A list with all enviroment variables to configure Puppeteer can be found [here](https://pptr.dev/#?product=Puppeteer&version=v1.20.0&show=api-environment-variables).

--- a/packages/gatsby-plugin-preload-fonts/README.md
+++ b/packages/gatsby-plugin-preload-fonts/README.md
@@ -138,5 +138,5 @@ npm run preload-fonts -- --no-sandbox
 This comes with [inherent security risks](https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md),
 but you should be alright since you're only running it locally.
 
-#### Environment Variables
-In some cases you might have to point Puppeteer to an external installation of Chromium (e.g. on Alpine Linux, the build-in version of Chromium does not work). To do that, you can set the `PUPPETEER_EXECUTABLE_PATH` environment variable. A list with all environment variables to configure Puppeteer can be found [here](https://pptr.dev/#?product=Puppeteer&version=v1.20.0&show=api-environment-variables).
+### Use different Chrome/Chromium executable
+In some cases, you might have to point Puppeteer to an external installation of Chrome/Chromium (e.g., on Alpine Linux, the build-in version of Chromium does not work). You can set the `PUPPETEER_EXECUTABLE_PATH` environment variable to the path of your custom chromium installation. A list with all environment variables to configure Puppeteer can be found [at the official docs](https://pptr.dev/#?product=Puppeteer&version=v1.20.0&show=api-environment-variables).


### PR DESCRIPTION
## Description
A hint, that Puppeteer can be configured with environment variables, which is required in some configurations (e.g. Alpine Linux)

## Related Issues
fixes #21778 
