### PR TITLE
chore(gatsby-plugin-emotion): add @babel/core as peer dependency for pnp

### DIFF
--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -27,7 +27,8 @@
   "main": "index.js",
   "peerDependencies": {
     "@emotion/core": "^10.0.5",
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0",
+    "@babel/core": "^7.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This is for yarn-pnp compatibility.  Without `@babel/core` listed as a peer dependency, yarn will be unable to build.

## Related Issues

No related issues, as of right now.