### PR TITLE
chore(www): use canonical in og-url when available

### DIFF
--- a/www/src/components/site-metadata.js
+++ b/www/src/components/site-metadata.js
@@ -31,7 +31,7 @@ const SiteMetadata = ({ pathname, locale }) => {
         content="width=device-width,initial-scale=1,shrink-to-fit=no,viewport-fit=cover"
       />
 
-      <meta property="og:url" content={siteUrl} />
+      <meta property="og:url" content={`${siteUrl}${pathname}`} />
       <meta property="og:type" content="website" />
       <meta property="og:locale" content={locale} />
       <meta property="og:site_name" content={title} />

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -41,6 +41,7 @@ class BlogPostTemplate extends React.Component {
         <link rel="canonical" href={post.frontmatter.canonicalLink} />
       )
     }
+    console.log("location", href)
     return (
       <Layout location={this.props.location}>
         <Container>

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -35,13 +35,19 @@ class BlogPostTemplate extends React.Component {
       </p>
     )
     let canonicalLink
+    let ogUrl
 
     if (post.frontmatter.canonicalLink) {
       canonicalLink = (
         <link rel="canonical" href={post.frontmatter.canonicalLink} />
       )
+      ogUrl = (
+        <meta property="og:url" content={post.frontmatter.canonicalLink} />
+      )
+    } else {
+      ogUrl = <meta property="og:url" content={href} />
     }
-    console.log("location", href)
+
     return (
       <Layout location={this.props.location}>
         <Container>
@@ -75,7 +81,7 @@ class BlogPostTemplate extends React.Component {
               <meta property="og:description" content={post.excerpt} />
               <meta name="twitter:description" content={post.excerpt} />
               <meta property="og:title" content={post.frontmatter.title} />
-              <meta property="og:url" content={href} />
+              {ogUrl}
               {post.frontmatter.image && (
                 <meta
                   property="og:image"


### PR DESCRIPTION
## Description

Updated /www/src/components/site-metadata.js og:url to include ${pathName} in the og:url content

Updated /www/src/templates/template-blog-post.js to include a conditional to add either frontmatter.canonicalLink OR href to og:url content.


## Linked Issue
https://github.com/gatsbyjs/gatsby/issues/21563