### PR TITLE
fix(www): fallback to github renamed owner (starters)

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -34,6 +34,18 @@
     - MDX
     - MaterialUI Components
     - React Icons
+- url: https://authenticaysh.netlify.com/
+  repo: https://github.com/ben-siewert/gatsby-starter-auth-aws-amplify
+  description: Full-featured Auth with AWS Amplify & AWS Cognito
+  tags:
+    - AWS
+    - Authentication
+  features:
+    - Full-featured AWS Authentication with Cognito
+    - Error feedback in forms
+    - Password Reset
+    - Multi-Factor Authentication
+    - Styling with Bootstrap and Sass
 - url: https://gatsby-starter-blog-demo.netlify.com/
   repo: https://github.com/gatsbyjs/gatsby-starter-blog
   description: official blog


### PR DESCRIPTION
## Description
Should fix failing starters when a GitHub rename has happened.

![image](https://user-images.githubusercontent.com/1120926/75606589-88ad5a80-5aee-11ea-95e6-5e9373e47d57.png)

Some extra context, the GitHub API doesn't follow GitHub username renames, it will throw a NOT FOUND error. When this happens we try to follow the redirect by doing a head request and retry our query. When only try this once per repo, if we fail the second time, we fail hard but that should only happen because of GitHub.

We should occasionally check our build pipeline to rename starters.

## Related Issues
Fixes https://github.com/gatsbyjs/gatsby/issues/21813
