### PR TITLE
fix:(gatsby-plugin-mdx) Require a default export when needed

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -14,7 +14,7 @@ const getTableOfContents = require(`../utils/get-table-of-content`)
 const defaultOptions = require(`../utils/default-options`)
 const genMDX = require(`../utils/gen-mdx`)
 const { mdxHTMLLoader: loader } = require(`../utils/render-html`)
-const { interopDefault } = require(`../utils/interop-defaul`)
+const { interopDefault } = require(`../utils/interop-default`)
 
 async function getCounts({ mdast }) {
   let counts = {}

--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -14,6 +14,7 @@ const getTableOfContents = require(`../utils/get-table-of-content`)
 const defaultOptions = require(`../utils/default-options`)
 const genMDX = require(`../utils/gen-mdx`)
 const { mdxHTMLLoader: loader } = require(`../utils/render-html`)
+const { interopDefault } = require(`../utils/interop-defaul`)
 
 async function getCounts({ mdast }) {
   let counts = {}
@@ -96,7 +97,7 @@ module.exports = (
    */
   for (let plugin of options.gatsbyRemarkPlugins) {
     debug(`requiring`, plugin.resolve)
-    const requiredPlugin = require(plugin.resolve)
+    const requiredPlugin = interopDefault(require(plugin.resolve))
     debug(`required`, plugin)
     if (_.isFunction(requiredPlugin.setParserPlugins)) {
       for (let parserPlugin of requiredPlugin.setParserPlugins(

--- a/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -1,6 +1,7 @@
 const visit = require(`unist-util-visit`)
 const _ = require(`lodash`)
 const debug = require(`debug`)(`get-source-plugins-as-remark-plugins`)
+const { interopDefault } = require(`./interop-default`)
 
 let fileNodes
 
@@ -43,7 +44,7 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
   // return list of remarkPlugins
   const userPlugins = gatsbyRemarkPlugins
     .filter(plugin => {
-      if (_.isFunction(require(plugin.resolve))) {
+      if (_.isFunction(interopDefault(require(plugin.resolve)))) {
         return true
       } else {
         debug(`userPlugins: filtering out`, plugin)
@@ -52,7 +53,7 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
     })
     .map(plugin => {
       debug(`userPlugins: constructing remark plugin for `, plugin)
-      const requiredPlugin = require(plugin.resolve)
+      const requiredPlugin = interopDefault(require(plugin.resolve))
       const wrappedPlugin = () =>
         async function transformer(markdownAST) {
           await requiredPlugin(

--- a/packages/gatsby-plugin-mdx/utils/interop-default.js
+++ b/packages/gatsby-plugin-mdx/utils/interop-default.js
@@ -1,0 +1,4 @@
+const interopDefault = exp =>
+  exp && typeof exp === `object` && `default` in exp ? exp[`default`] : exp
+
+exports.interopDefault = interopDefault


### PR DESCRIPTION
## Description

This PR fixes an issue where plugins that have `default` exports are not required properly by `gatsby-plugin-mdx`.  I had this problem with my own plugin which is written in ES6 - and Babel transpiles it to have `exports.default`.

To check :

1. Clone an mdx starter

```gatsby new my-mdx-starter https://github.com/ChristopherBiscardi/gatsby-starter-mdx-basic```

2. Install `gatsby-remark-shiki` (my plugin with default exports) and add `gatsby-remark-shiki` to `gatsbyRemarkPlugins` of `gatsby-plugin-mdx` config in `gatsby-config.js`:

```
{
      resolve: `gatsby-plugin-mdx`,
      options: {
        gatsbyRemarkPlugins: ["gatsby-remark-shiki"],
        defaultLayouts: { default: path.resolve("./src/components/layout.js") }
      }
},
```

3. Run `gatsby-dev --packages gatsby-plugin-mdx` in gatsby repo with this branch checked out.

4. Add some Javascript code to mdx files  in mdx repo, run `gatsby develop` and make sure that the code is highlighted.

### Documentation

https://www.gatsbyjs.org/docs/remark-plugin-tutorial/

## Related Issues

Fixes #21821
