### PR TITLE
fix(benchmark/readme): adjust images count

### DIFF
--- a/benchmarks/image-processing/README.md
+++ b/benchmarks/image-processing/README.md
@@ -5,7 +5,7 @@ by downloading and processing images.
 
 Defaults to building a site with 100 image pages. Set the `NUM_IMAGES` environment variable to change that e.g. `NUM_IMAGES=1000 gatsby build`
 
-The max number of images you can process is 1300.
+The max number of images you can process is 65535.
 
 # Running the benchmark
 


### PR DESCRIPTION
## Description

images added in: 
- #21283 `Add more images to benchmark from Open Images Dataset`

## Related Issues

- #21283 `Add more images to benchmark from Open Images Dataset`