### PR TITLE
fix(gatsby-plugin-preload-fonts): lookup routes with and without trailing slash

### DIFF
--- a/packages/gatsby-plugin-preload-fonts/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-preload-fonts/src/gatsby-ssr.js
@@ -20,7 +20,7 @@ exports.onRenderBody = (
 ) => {
   const cache = loadCache()
   // try to load assets from cache. Consider route with and without trailing slash as lookup key
-  const cacheEntry = cache.assets[pathname] || cache.assets[pathname + "/"]
+  const cacheEntry = cache.assets[pathname] || cache.assets[pathname + `/`]
   if (!cacheEntry) return
 
   const props = getLinkProps({ crossOrigin, pathname })

--- a/packages/gatsby-plugin-preload-fonts/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-preload-fonts/src/gatsby-ssr.js
@@ -19,11 +19,13 @@ exports.onRenderBody = (
   { crossOrigin = `anonymous` } = {}
 ) => {
   const cache = loadCache()
-  if (!cache.assets[pathname]) return
+  // try to load assets from cache. Consider route with and without trailing slash as lookup key
+  const cacheEntry = cache.assets[pathname] || cache.assets[pathname + "/"]
+  if (!cacheEntry) return
 
   const props = getLinkProps({ crossOrigin, pathname })
 
-  const assets = Object.keys(cache.assets[pathname])
+  const assets = Object.keys(cacheEntry)
 
   setHeadComponents(
     assets.map(href => {


### PR DESCRIPTION
## Description
Fixes #21814. A detailed description of the problem can be found in the issue.
