### PR TITLE
fix(gatsby): Improve warning for built-in GraphQL type overrides

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -379,6 +379,7 @@ const mergeTypes = ({
         `\`${typeComposer.getTypeName()}\`, which has already been defined ` +
         `by the plugin \`${typeOwner}\`.`
     )
+    return false
   } else {
     report.warn(
       `Plugin \`${plugin.name}\` tried to define built-in Gatsby GraphQL type ` +

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -373,11 +373,16 @@ const mergeTypes = ({
     addExtensions({ schemaComposer, typeComposer, plugin, createdFrom })
 
     return true
-  } else {
+  } else if (typeOwner) {
     report.warn(
       `Plugin \`${plugin.name}\` tried to define the GraphQL type ` +
         `\`${typeComposer.getTypeName()}\`, which has already been defined ` +
         `by the plugin \`${typeOwner}\`.`
+    )
+  } else {
+    report.warn(
+      `Plugin \`${plugin.name}\` tried to define built-in Gatsby GraphQL type ` +
+        `\`${typeComposer.getTypeName()}\``
     )
     return false
   }


### PR DESCRIPTION
## Description

This PR improves a warning message that is shown when some plugin is trying to override/extend built-in GraphQL types using schema customization APIs.

Before this PR the warning looks like this:

```
Plugin `bad-plugin` tried to define the GraphQL type `File`, which has already been defined by the plugin `null`
```

After this PR it looks like this:
```
Plugin `bad-plugin` tried to define built-in Gatsby GraphQL type `File`
```

## Related Issues

We introduced built-in GraphQL types here: #19951

#21673
#21636
