### PR TITLE
fix: hot fix for `gatsby develop` when HOME is not set

### DIFF
--- a/packages/gatsby/src/utils/get-ssl-cert.js
+++ b/packages/gatsby/src/utils/get-ssl-cert.js
@@ -1,7 +1,7 @@
-const certificateFor = require(`devcert`).certificateFor
 const report = require(`gatsby-cli/lib/reporter`)
 const fs = require(`fs`)
 const path = require(`path`)
+const os = require(`os`)
 
 const absoluteOrDirectory = (directory, filePath) => {
   // Support absolute paths
@@ -35,6 +35,17 @@ module.exports = async ({ name, certFile, keyFile, directory }) => {
 
   report.info(`setting up automatic SSL certificate (may require sudo)\n`)
   try {
+    if ([`linux`, `darwin`].includes(os.platform()) && !process.env.HOME) {
+      // this is a total hack to ensure process.env.HOME is set on linux and mac
+      // devcert creates config path at import time (hence we import devcert after setting dummy value):
+      // - https://github.com/davewasmer/devcert/blob/2b1b8d40eda251616bf74fd69f00ae8222ca1171/src/constants.ts#L15
+      // - https://github.com/LinusU/node-application-config-path/blob/ae49ff6748b68b29ec76c00ce4a28ba8e9161d9b/index.js#L13
+      // if HOME is not set, we will get:
+      // "The "path" argument must be of type s tring. Received type undefined"
+      // fatal error. This still likely will result in fatal error, but at least it's not on import time
+      process.env.HOME = `dummy`
+    }
+    const certificateFor = require(`devcert`).certificateFor
     return await certificateFor(name, {
       installCertutil: true,
     })

--- a/packages/gatsby/src/utils/get-ssl-cert.js
+++ b/packages/gatsby/src/utils/get-ssl-cert.js
@@ -43,7 +43,8 @@ module.exports = async ({ name, certFile, keyFile, directory }) => {
       // if HOME is not set, we will get:
       // "The "path" argument must be of type s tring. Received type undefined"
       // fatal error. This still likely will result in fatal error, but at least it's not on import time
-      process.env.HOME = `dummy`
+      const mkdtemp = fs.mkdtempSync(path.join(os.tmpdir(), `home-`))
+      process.env.HOME = mkdtemp
     }
     const certificateFor = require(`devcert`).certificateFor
     return await certificateFor(name, {


### PR DESCRIPTION
This is super hacky hot fix for `gatsby develop` in environments that don't have `process.env.HOME` set, as `devcert` relies on those right now to be set (otherwise just importing `devcert` cause fatal error)

/cc @benrobertsonio 