### PR TITLE
test: fix snapshot after merging #21523

### DIFF
--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -82,6 +82,7 @@ Object {
       },
     },
   },
+  "pageData": Map {},
   "pageDataStats": Map {},
   "staticQueryComponents": Map {},
   "status": Object {


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/21523 wasn't synced with master in quite some time and didn't have some changes to tests done in meantime, so it broke some snapshot assertions.

This syncs snapshot.