### PR TITLE
fix(gatsby): Resolve linked interfaces consistently with object and union types

### DIFF
--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -1,13 +1,7 @@
 const systemPath = require(`path`)
 const normalize = require(`normalize-path`)
 const _ = require(`lodash`)
-const {
-  GraphQLList,
-  getNullableType,
-  getNamedType,
-  Kind,
-  GraphQLInterfaceType,
-} = require(`graphql`)
+const { GraphQLList, getNullableType, getNamedType, Kind } = require(`graphql`)
 const { getValueAt } = require(`../utils/get-value-at`)
 
 const findMany = typeName => (source, args, context, info) =>

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -137,7 +137,7 @@ const link = (options = {}, fieldConfig) => async (
   const returnType = getNullableType(options.type || info.returnType)
   const type = getNamedType(returnType)
 
-  if (options.by === `id` && !(type instanceof GraphQLInterfaceType)) {
+  if (options.by === `id`) {
     if (Array.isArray(fieldValue)) {
       return context.nodeModel.getNodesByIds(
         { ids: fieldValue, type: type },


### PR DESCRIPTION
## Description

This PR fixes a performance issue with resolving of linked interface fields. We've discovered that 

```graphql
type Foo {
   bar: [InterfaceType] @link(by: "id", from: "bar___NODE")
}
```

Is much slower than 

```graphql
type Foo {
   bar: [ObjectType] @link(by: "id", from: "bar___NODE")
}
```

We had a special path for interfaces which was introduced in #17942

But this doesn't seem necessary anymore. Tests are passing without it. Tried this PR on a local project with schema customization. It gave a 10x speed increase for this kind of query.

### Documentation
N/A - this is a performance fix
