### PR TITLE
feat(gatsby-plugin-sitemap): handle different query structures and allow custom siteUrl resolution

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -27,11 +27,12 @@ The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packa
 
 The options are as follows:
 
-- `query` (GraphQL Query) The query for the data you need to generate the sitemap. It's required to get the `site.siteMetadata.siteUrl`. If you override the query, you probably will need to set a `serializer` to return the correct data for the sitemap.
+- `query` (GraphQL Query) The query for the data you need to generate the sitemap. It's required to get the site's URL, if you are not fetching it from `site.siteMetadata.siteUrl`, you will need to set a cusome `resolveSiteUrl` function. If you override the query, you probably will also need to set a `serializer` to return the correct data for the sitemap. Due to how this plugin was built it is currently expected/required to fetch the page paths from `allSitePage`, but you may use the `allSitePage.edges.node` or `allSitePage.nodes` query structure.
 - `output` (string) The filepath and name. Defaults to `/sitemap.xml`.
 - `exclude` (array of strings) An array of paths to exclude from the sitemap.
 - `createLinkInHead` (boolean) Whether to populate the `<head>` of your site with a link to the sitemap.
 - `serialize` (function) Takes the output of the data query and lets you return an array of sitemap entries.
+- `resolveSiteUrl` (function) Takes the output of the data query and lets you return the site URL.
 
 We _ALWAYS_ exclude the following pages: `/dev-404-page`,`/404` &`/offline-plugin-app-shell-fallback`, this cannot be changed.
 
@@ -53,24 +54,26 @@ plugins: [
       exclude: [`/category/*`, `/path/to/page`],
       query: `
         {
-          site {
-            siteMetadata {
+          wp {
+            generalSettings {
               siteUrl
             }
           }
 
           allSitePage {
-            edges {
-              node {
-                path
-              }
+            node {
+              path
             }
           }
       }`,
+      resolveSiteUrl: ({site, allSitePage}) => {
+        //Alternativly, you may also pass in an environment variable (or any location) at the beginning of your `gatsby-config.js`.
+        return site.wp.generalSettings.siteUrl
+      },
       serialize: ({ site, allSitePage }) =>
-        allSitePage.edges.map(edge => {
+        allSitePage.nodes.map(node => {
           return {
-            url: site.siteMetadata.siteUrl + edge.node.path,
+            url: `${site.wp.generalSettings.siteUrl}${node.path}`,
             changefreq: `daily`,
             priority: 0.7,
           }

--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -27,7 +27,7 @@ The `defaultOptions` [here](https://github.com/gatsbyjs/gatsby/blob/master/packa
 
 The options are as follows:
 
-- `query` (GraphQL Query) The query for the data you need to generate the sitemap. It's required to get the site's URL, if you are not fetching it from `site.siteMetadata.siteUrl`, you will need to set a cusome `resolveSiteUrl` function. If you override the query, you probably will also need to set a `serializer` to return the correct data for the sitemap. Due to how this plugin was built it is currently expected/required to fetch the page paths from `allSitePage`, but you may use the `allSitePage.edges.node` or `allSitePage.nodes` query structure.
+- `query` (GraphQL Query) The query for the data you need to generate the sitemap. It's required to get the site's URL, if you are not fetching it from `site.siteMetadata.siteUrl`, you will need to set a custom `resolveSiteUrl` function. If you override the query, you probably will also need to set a `serializer` to return the correct data for the sitemap. Due to how this plugin was built it is currently expected/required to fetch the page paths from `allSitePage`, but you may use the `allSitePage.edges.node` or `allSitePage.nodes` query structure.
 - `output` (string) The filepath and name. Defaults to `/sitemap.xml`.
 - `exclude` (array of strings) An array of paths to exclude from the sitemap.
 - `createLinkInHead` (boolean) Whether to populate the `<head>` of your site with a link to the sitemap.

--- a/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
@@ -1,11 +1,15 @@
 const {
-  runQuery,
+  filterQuery,
   defaultOptions: { serialize },
 } = require(`../internals`)
 
 beforeEach(() => {
   global.__PATH_PREFIX__ = ``
 })
+
+const verifyUrlsExistInResults = (results, urls) => {
+  expect(results.map(result => result.url)).toEqual(urls)
+}
 
 describe(`results using default settings`, () => {
   const generateQueryResultsMock = (
@@ -36,10 +40,6 @@ describe(`results using default settings`, () => {
     }
   }
 
-  const verifyUrlsExistInResults = (results, urls) => {
-    expect(results.map(result => result.url)).toEqual(urls)
-  }
-
   const runTests = (pathPrefix = ``) => {
     beforeEach(() => {
       global.__PATH_PREFIX__ = pathPrefix
@@ -47,7 +47,8 @@ describe(`results using default settings`, () => {
 
     it(`prepares all urls correctly`, async () => {
       const graphql = () => Promise.resolve(generateQueryResultsMock())
-      const queryRecords = await runQuery(graphql, ``, [], pathPrefix)
+      const results = await graphql(``)
+      const queryRecords = filterQuery(results, [], pathPrefix)
       const urls = serialize(queryRecords)
 
       verifyUrlsExistInResults(urls, [
@@ -61,7 +62,9 @@ describe(`results using default settings`, () => {
         Promise.resolve(
           generateQueryResultsMock({ siteUrl: `http://dummy.url/` })
         )
-      const queryRecords = await runQuery(graphql, ``, [], pathPrefix)
+
+      const data = await graphql(``)
+      const queryRecords = filterQuery(data, [], pathPrefix)
       const urls = serialize(queryRecords)
 
       verifyUrlsExistInResults(urls, [
@@ -72,7 +75,8 @@ describe(`results using default settings`, () => {
 
     it(`excludes pages without trailing slash`, async () => {
       const graphql = () => Promise.resolve(generateQueryResultsMock())
-      const queryRecords = await runQuery(graphql, ``, [`/page-2`], pathPrefix)
+      const data = await graphql(``)
+      const queryRecords = filterQuery(data, [`/page-2`], pathPrefix)
       const urls = serialize(queryRecords)
 
       verifyUrlsExistInResults(urls, [`http://dummy.url${pathPrefix}/page-1`])
@@ -80,7 +84,8 @@ describe(`results using default settings`, () => {
 
     it(`excludes pages with trailing slash`, async () => {
       const graphql = () => Promise.resolve(generateQueryResultsMock())
-      const queryRecords = await runQuery(graphql, ``, [`/page-2/`], pathPrefix)
+      const data = await graphql(``)
+      const queryRecords = filterQuery(data, [`/page-2/`], pathPrefix)
       const urls = serialize(queryRecords)
 
       verifyUrlsExistInResults(urls, [`http://dummy.url${pathPrefix}/page-1`])
@@ -92,7 +97,8 @@ describe(`results using default settings`, () => {
       expect.assertions(1)
 
       try {
-        await runQuery(graphql, ``, [], pathPrefix)
+        const data = await graphql(``)
+        filterQuery(data, [], pathPrefix)
       } catch (err) {
         expect(err.message).toEqual(
           expect.stringContaining(`SiteMetaData 'siteUrl' property is required`)
@@ -107,5 +113,53 @@ describe(`results using default settings`, () => {
 
   describe(`with path-prefix`, () => {
     runTests(`/path-prefix`)
+  })
+})
+
+describe(`results using non default alternatives`, () => {
+  const generateQueryResultsMockNodes = (
+    { siteUrl } = { siteUrl: `http://dummy.url` }
+  ) => {
+    return {
+      data: {
+        site: {
+          siteMetadata: {
+            siteUrl: siteUrl,
+          },
+        },
+        allSitePage: {
+          nodes: [
+            {
+              path: `/page-1`,
+            },
+            {
+              path: `/page-2`,
+            },
+          ],
+        },
+      },
+    }
+  }
+
+  it(`handles allSitePage.nodes type query properly`, async () => {
+    const graphql = () => Promise.resolve(generateQueryResultsMockNodes())
+    const results = await graphql(``)
+    const queryRecords = filterQuery(results, [], ``)
+    const urls = serialize(queryRecords)
+
+    verifyUrlsExistInResults(urls, [
+      `http://dummy.url/page-1`,
+      `http://dummy.url/page-2`,
+    ])
+  })
+
+  it(`handles custom siteUrl Resolver Properly type query properly`, async () => {
+    const customUrl = `https://another.dummy.url`
+    const customSiteResolver = () => customUrl
+    const graphql = () => Promise.resolve(generateQueryResultsMockNodes())
+    const results = await graphql(``)
+    const queryRecords = filterQuery(results, [], ``, customSiteResolver)
+
+    expect(queryRecords.site.siteMetadata.siteUrl).toEqual(customUrl)
   })
 })

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -8,46 +8,62 @@ export const withoutTrailingSlash = path =>
 export const writeFile = pify(fs.writeFile)
 export const renameFile = pify(fs.rename)
 
-export const runQuery = (handler, query, excludes, pathPrefix) =>
-  handler(query).then(r => {
-    if (r.errors) {
-      throw new Error(r.errors.join(`, `))
-    }
+export function filterQuery(
+  results,
+  excludes,
+  pathPrefix,
+  resolveSiteUrl = defaultOptions.resolveSiteUrl
+) {
+  const { errors, data } = results
 
-    // Removing excluded paths
-    r.data.allSitePage.edges = r.data.allSitePage.edges.filter(
-      page =>
-        !excludes.some(excludedRoute =>
-          minimatch(
-            withoutTrailingSlash(page.node.path),
-            withoutTrailingSlash(excludedRoute)
-          )
+  if (errors) {
+    throw new Error(errors.join(`, `))
+  }
+
+  let { allPages, originalType } = getNodes(data.allSitePage)
+
+  // Removing excluded paths
+  allPages = allPages.filter(
+    page =>
+      !excludes.some(excludedRoute =>
+        minimatch(
+          withoutTrailingSlash(page.path),
+          withoutTrailingSlash(excludedRoute)
         )
-    )
-
-    // Add path prefix
-    r.data.allSitePage.edges = r.data.allSitePage.edges.map(page => {
-      page.node.path = (pathPrefix + page.node.path).replace(/^\/\//g, `/`)
-      return page
-    })
-
-    // siteUrl Validation
-    if (
-      !r.data.site.siteMetadata.siteUrl ||
-      r.data.site.siteMetadata.siteUrl.trim().length == 0
-    ) {
-      throw new Error(
-        `SiteMetaData 'siteUrl' property is required and cannot be left empty. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
       )
-    }
+  )
 
-    // remove trailing slash of siteUrl
-    r.data.site.siteMetadata.siteUrl = withoutTrailingSlash(
-      r.data.site.siteMetadata.siteUrl
-    )
-
-    return r.data
+  // Add path prefix
+  allPages = allPages.map(page => {
+    page.path = (pathPrefix + page.path).replace(/^\/\//g, `/`)
+    return page
   })
+
+  // siteUrl Validation
+
+  let siteUrl = resolveSiteUrl(data)
+
+  if (!siteUrl || siteUrl.trim().length == 0) {
+    throw new Error(
+      `SiteMetaData 'siteUrl' property is required and cannot be left empty. Check out the documentation to see a working example: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/#how-to-use`
+    )
+  }
+
+  // remove trailing slash of siteUrl
+  siteUrl = withoutTrailingSlash(siteUrl)
+
+  return {
+    allSitePage: {
+      [originalType]:
+        originalType === `nodes`
+          ? allPages
+          : allPages.map(page => {
+              return { node: page }
+            }),
+    },
+    site: { siteMetadata: { siteUrl } },
+  }
+}
 
 export const defaultOptions = {
   query: `
@@ -74,12 +90,31 @@ export const defaultOptions = {
     `/offline-plugin-app-shell-fallback`,
   ],
   createLinkInHead: true,
-  serialize: ({ site, allSitePage }) =>
-    allSitePage.edges.map(edge => {
+  serialize: ({ site, allSitePage }) => {
+    const { allPages } = getNodes(allSitePage)
+    return allPages?.map(page => {
       return {
-        url: site.siteMetadata.siteUrl + edge.node.path,
+        url: `${site.siteMetadata?.siteUrl ?? ``}${page.path}`,
         changefreq: `daily`,
         priority: 0.7,
       }
-    }),
+    })
+  },
+  resolveSiteUrl: data => data.site.siteMetadata.siteUrl,
+}
+
+function getNodes(results) {
+  if (`nodes` in results) {
+    return { allPages: results.nodes, originalType: `nodes` }
+  }
+
+  if (`edges` in results) {
+    return {
+      allPages: results?.edges?.map(edge => edge.node),
+      originalType: `edges`,
+    }
+  }
+  throw new Error(
+    `[gatsby-plugin-sitemap]: Plugin is unsure how to handle the results of your query, you'll need to write custom page filter and serilizer in your gatsby conig`
+  )
 }


### PR DESCRIPTION
## Description

Resolves some of the issues discussed in #20692.

- Previously when querying pages using `allSitePage.nodes` instead of `allSitePage.edges` was impossible because the serializer and internal page filter expected the edges object structure. 

- Previously you had to set your siteUrl at `site.siteMetaData.siteUrl` or the default resolver would fail. This seemed pointless when using other methods to resolve siteUrl. You can now define a function that receives the query result as "data", and you can return a string that will be used for siteUrl.

## TBD

While this solution works there is a lot of "odd" things i had to do to make it backwards compatible. Specifically when filtering pages I convert the the data structure to an array of pages from either the `edges` or `nodes` structure. But it also still assumes use of `allSitePage` which kinda defeats the point of being able to write a custom query.

Logic has been added to handle both data structures. The absurd part is I have to return that data structure back to its original state to maintain backwards compatibility when handing the data back to the serializer. This applies to siteUrl resolution as well. Even if you write a custom resolver, accessing in in the serializer is still done at `site.siteMetaData.siteUrl`.

All this could be eliminated and the general api made more flexible and probably simpler, if we are okay with doing a major version bump.

## Documentation
//TODO 

## Related Issues

closes #20692 
