### PR TITLE
fix(www): starter is already a node

### DIFF
--- a/www/src/views/starter-library/filtered-starters.js
+++ b/www/src/views/starter-library/filtered-starters.js
@@ -82,8 +82,8 @@ export default class FilteredStarterLibrary extends Component {
     )
 
     if (urlState.s.length > 0) {
-      starterNodes = starterNodes.filter(starter =>
-        JSON.stringify(starter.node)
+      starterNodes = starterNodes.filter(node =>
+        JSON.stringify(node)
           .toLowerCase()
           .includes(urlState.s.toLowerCase())
       )


### PR DESCRIPTION
The `starters` array used to be an array of edges and is "now" an array of nodes so accessing `.node` is no longer necessary. So dropping the access should make it work again.

Fixes #21942

Bug was introduced by #21792
