### PR TITLE
perf(gatsby-cli): avoid unnecesary rerenders for static messages in CLI

### DIFF
--- a/packages/gatsby-cli/src/reporter/loggers/ink/cli.js
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/cli.js
@@ -17,7 +17,7 @@ class CLI extends React.Component {
     hasError: false,
   }
 
-  messages = []
+  memoizedReactElementsForMessages = []
 
   componentDidCatch(error, info) {
     trackBuildError(`INK`, {
@@ -60,10 +60,14 @@ class CLI extends React.Component {
       This will avoid calling React.createElement completely for every message
       that can't change.
     */
-    if (messages.length > this.messages.length) {
-      for (let index = this.messages.length; index < messages.length; index++) {
+    if (messages.length > this.memoizedReactElementsForMessages.length) {
+      for (
+        let index = this.memoizedReactElementsForMessages.length;
+        index < messages.length;
+        index++
+      ) {
         const msg = messages[index]
-        this.messages.push(
+        this.memoizedReactElementsForMessages.push(
           msg.level === `ERROR` ? (
             <Error details={msg} key={index} />
           ) : (
@@ -93,7 +97,7 @@ class CLI extends React.Component {
     return (
       <Box flexDirection="column">
         <Box flexDirection="column">
-          <Static>{this.messages}</Static>
+          <Static>{this.memoizedReactElementsForMessages}</Static>
 
           {spinners.map(activity => (
             <Spinner key={activity.id} {...activity} />

--- a/packages/gatsby-cli/src/reporter/loggers/ink/cli.js
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/cli.js
@@ -17,6 +17,8 @@ class CLI extends React.Component {
     hasError: false,
   }
 
+  messages = []
+
   componentDidCatch(error, info) {
     trackBuildError(`INK`, {
       error: {
@@ -51,6 +53,26 @@ class CLI extends React.Component {
       )
     }
 
+    /*
+      Only operation on messages array is to push new message into it. Once
+      message is there it can't change. Because of that we can do single
+      transform from message object to react element and store it.
+      This will avoid calling React.createElement completely for every message
+      that can't change.
+    */
+    if (messages.length > this.messages.length) {
+      for (let index = this.messages.length; index < messages.length; index++) {
+        const msg = messages[index]
+        this.messages.push(
+          msg.level === `ERROR` ? (
+            <Error details={msg} key={index} />
+          ) : (
+            <Message key={index} {...msg} />
+          )
+        )
+      }
+    }
+
     const spinners = []
     const progressBars = []
     if (showProgress) {
@@ -71,15 +93,7 @@ class CLI extends React.Component {
     return (
       <Box flexDirection="column">
         <Box flexDirection="column">
-          <Static>
-            {messages.map((msg, index) =>
-              msg.level === `ERROR` ? (
-                <Error details={msg} key={index} />
-              ) : (
-                <Message key={index} {...msg} />
-              )
-            )}
-          </Static>
+          <Static>{this.messages}</Static>
 
           {spinners.map(activity => (
             <Spinner key={activity.id} {...activity} />

--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/error.js
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/error.js
@@ -34,7 +34,7 @@ const DocsLink = ({ docsUrl }) => {
   )
 }
 
-const Error = ({ details }) => (
+const Error = React.memo(({ details }) => (
   // const stackLength = get(details, `stack.length`, 0
 
   <Box marginY={1} flexDirection="column">
@@ -75,6 +75,6 @@ const Error = ({ details }) => (
         </Box>
       )} */}
   </Box>
-)
+))
 
 export default Error

--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/messages.js
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/messages.js
@@ -32,7 +32,7 @@ const getLabel = level => {
   }
 }
 
-export const Message = ({ level, text, duration, statusText }) => {
+export const Message = React.memo(({ level, text, duration, statusText }) => {
   let message = text
   if (duration) {
     message += ` - ${duration.toFixed(3)}s`
@@ -53,4 +53,4 @@ export const Message = ({ level, text, duration, statusText }) => {
       {message}
     </Box>
   )
-}
+})


### PR DESCRIPTION
This was tested on https://github.com/pieh/ink-stress-test/blob/master/gatsby-node.js
and it dropped from ~5-6s to ~1s locally

There is more we can do for CLI perf - particularly we do use development react build, which has additional perf overhead. (tho with those changes impact is greatly minimilized - at least for my testing sample https://github.com/pieh/ink-stress-test)