### PR TITLE
feat(gatsby-plugin-benchmark-reporting): Add more fields to the report

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -302,7 +302,7 @@ async function onPreBuild(api) {
 async function onPostBuild(api, pluginOptions) {
   lastApi = api
 
-  benchmark.setPluginOptions(pluginOptions)
+  benchMeta.setPluginOptions(pluginOptions)
 
   benchMeta.markDataPoint(`postBuild`)
   return benchMeta.markEnd()


### PR DESCRIPTION
## Description
Add some data sent to the reporting url via pluginOptions / env

### Documentation
These values are used internally so I didnt add them to the docs
