### PR TITLE
docs(gatsbt-theme-blog): add instructions on avatar image

### DIFF
--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -50,7 +50,11 @@ module.exports = {
 
    > Note that if you've changed the default `contentPath` in the configuration, you'll want to add your markdown files in the directory specified by that path.
 
-4. Run your site using `gatsby develop` and navigate to your blog posts. If you used the above configuration, your URL will be `http://localhost:8000/blog`
+4. Add image named avatar inside /assets to include a small image next to the post footer of every post page.
+
+> Note that if you've changed the default `assetPath` in the configuration, you'll want to add your asset files in the directory specified by that path.
+
+5. Run your site using `gatsby develop` and navigate to your blog posts. If you used the above configuration, your URL will be `http://localhost:8000/blog`
 
 ## Usage
 

--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -50,7 +50,7 @@ module.exports = {
 
    > Note that if you've changed the default `contentPath` in the configuration, you'll want to add your markdown files in the directory specified by that path.
 
-4. Add image named avatar inside /assets to include a small image next to the post footer of every post page.
+4. Add an image with the file name `avatar` (can be jpg or png) inside the `/assets` directory to include a small image next to the footer on every post page.
 
 > Note that if you've changed the default `assetPath` in the configuration, you'll want to add your asset files in the directory specified by that path.
 


### PR DESCRIPTION

## Description

Adds more installation instructions for the existing site section regarding the usage of the avatar image located in the defined assets directory that then renders in every post's post footer.

## Related Issues

Fixes #21985 