### PR TITLE
chore: Ts/setup typescript for all

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/tsconfig.json
+++ b/packages/babel-plugin-remove-graphql-queries/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/babel-preset-gatsby-package/tsconfig.json
+++ b/packages/babel-preset-gatsby-package/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/babel-preset-gatsby/tsconfig.json
+++ b/packages/babel-preset-gatsby/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/gatsby-core-utils/tsconfig.json
+++ b/packages/gatsby-core-utils/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/gatsby-image/tsconfig.json
+++ b/packages/gatsby-image/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/gatsby-link/tsconfig.json
+++ b/packages/gatsby-link/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/gatsby-page-utils/tsconfig.json
+++ b/packages/gatsby-page-utils/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/gatsby-react-router-scroll/tsconfig.json
+++ b/packages/gatsby-react-router-scroll/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/gatsby-telemetry/tsconfig.json
+++ b/packages/gatsby-telemetry/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/scripts/check-ts.js
+++ b/scripts/check-ts.js
@@ -7,6 +7,7 @@
 "use strict"
 
 const fs = require(`fs`)
+const glob = require(`glob`)
 const path = require(`path`)
 const chalk = require(`chalk`)
 const yargs = require(`yargs`)
@@ -23,9 +24,17 @@ const packages = fs
   .map(file => path.resolve(PACKAGES_DIR, file))
   .filter(f => fs.lstatSync(path.resolve(f)).isDirectory())
 
-let packagesWithTs = packages.filter(p =>
-  fs.existsSync(path.resolve(p, `tsconfig.json`))
-)
+// We only want to typecheck against packages that have a tsconfig.json
+// AND have some ts files in it's source code.
+let packagesWithTs = packages
+  .filter(p => fs.existsSync(path.resolve(p, `tsconfig.json`)))
+  .filter(
+    project =>
+      glob.sync(`/**/*.ts`, {
+        root: project,
+        ignore: `**/node_modules/**`,
+      }).length
+  )
 
 if (filterPackage) {
   packagesWithTs = packagesWithTs.filter(project =>


### PR DESCRIPTION
From the recent RFC #21798 that was merged, we have defined the core packages that we are interested in converting to TypeScript. 

This PR just sets up the infrastructure for each of those packages so as we start getting community contributions they do not have to fight with tooling.

The change to the script is to make sure we don't invoke `tsc` if a package doesn't have `.ts` files. Which is the case for many packages after this PR. So this is a safe-guard to let us set up the tsconfig.json without crashing `yarn typecheck`