### PR TITLE
fix(gatsby-plugin-typescript): Broader webpack support

### DIFF
--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -89,6 +89,49 @@ describe(`gatsby-plugin-typescript`, () => {
       })
     })
 
+    it(`sets the correct webpack config with rule.loader shortcut`, () => {
+      const actions = { setWebpackConfig: jest.fn() }
+      const jsLoader = {}
+      const loaders = { js: jest.fn(() => jsLoader) }
+      const stage = `develop`
+      const webpackConfig = {
+        module: {
+          rules: [
+            {
+              enforce: `pre`,
+              test: /\.jsx?$/,
+              exclude: /(node_modules|bower_components)/,
+              loader: `eslint-loader`,
+            },
+          ],
+        },
+      }
+      const getConfig = jest.fn(() => webpackConfig)
+      onCreateWebpackConfig({ actions, getConfig, loaders, stage })
+      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
+        module: {
+          rules: [
+            {
+              test: /\.tsx?$/,
+              use: jsLoader,
+            },
+          ],
+        },
+      })
+      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
+        module: {
+          rules: [
+            {
+              enforce: `pre`,
+              test: /\.tsx?$/,
+              exclude: /(node_modules|bower_components)/,
+              loader: `eslint-loader`,
+            },
+          ],
+        },
+      })
+    })
+
     it(`does not set the webpack config if there isn't a js loader`, () => {
       const actions = { setWebpackConfig: jest.fn() }
       const loaders = { js: jest.fn() }

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -53,7 +53,11 @@ function onCreateWebpackConfig({
     if (isTypescriptDepAvailable) {
       const builtInEslintRule = getConfig().module.rules.find(rule => {
         if (rule.enforce === `pre`) {
-          return rule.use.some(use => /eslint-loader/.test(use.loader))
+          if (rule.use) {
+            return rule.use.some(use => /eslint-loader/.test(use.loader))
+          } else {
+            return /eslint-loader/.test(rule.loader)
+          }
         }
         return false
       })


### PR DESCRIPTION
## Description

Support Webpacks's rule.loader shortcut syntax in typescript plugin

### Documentation

[Module | webpack](https://webpack.js.org/configuration/module/#ruleloader)

## Related Issues

Fixes #22002 
