### PR TITLE
fix(gatsby): invalidate cache when switching GATSBY_DB_NODES

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -83,6 +83,11 @@ module.exports = async (args: BootstrapArgs) => {
     payload: program,
   })
 
+  store.dispatch({
+    type: `SET_DB_TYPE`,
+    payload: process.env.GATSBY_DB_NODES ?? `redux`,
+  })
+
   let activityForJobs
 
   emitter.on(`CREATE_JOB`, () => {

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -16,6 +16,7 @@ Object {
       "query": "",
     },
   },
+  "dbType": "loki",
   "jobsV2": Object {
     "complete": Map {},
     "incomplete": Map {},
@@ -46,6 +47,7 @@ Object {
       "query": "",
     },
   },
+  "dbType": "redux",
   "jobsV2": Object {
     "complete": Map {},
     "incomplete": Map {},

--- a/packages/gatsby/src/redux/actions/internal.ts
+++ b/packages/gatsby/src/redux/actions/internal.ts
@@ -11,6 +11,7 @@ import {
   ISetProgramStatusAction,
   IPageQueryRunAction,
   IRemoveStaleJobAction,
+  ISetDbTypeAction,
 } from "../types"
 
 // import type { Plugin } from "./types"
@@ -246,5 +247,16 @@ export const removeStaleJob = (
     payload: {
       contentDigest,
     },
+  }
+}
+
+/**
+ * Set the db type to the current state of redux or loki (or <future expansion>)
+ * In essence this should reflect process.env.GATSBY_DB_NODES, defaults to redux
+ */
+export const setDbType = (dbState: "redux" | "loki"): ISetDbTypeAction => {
+  return {
+    type: `SET_DB_TYPE`,
+    payload: dbState,
   }
 }

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -55,18 +55,18 @@ export function readFromCache(): ICachedReduxState {
   ).map(file => v8.deserialize(readFileSync(file)))
 
   const nodes: [string, IReduxNode][] = [].concat(...chunks)
-
-  // If `obj.dbType` is not set then assume redux
-  if ((obj.dbType === 'loki') !== (process.env.GATSBY_DB_NODES === 'loki')) {
-    // This cache was stored while the (experimental) GATSBY_DB_NODES flag was
-    // set to a different value. Since these databases are incompatible, we now
-    // have to reset it.
-    report.info(
-      `Cache exists but was stored with a different GATSBY_DB_NODES value. Disregarding the cache and proceeding as if there was none to prevent compatibility issues.`
-    )
-    // TODO: this is a DeepPartial<ICachedReduxState> but requires a big change
-    return {} as ICachedReduxState
-  }
+console.log(obj)
+  // // If `obj.dbType` is not set then assume redux
+  // if ((obj.dbType === 'loki') !== (process.env.GATSBY_DB_NODES === 'loki')) {
+  //   // This cache was stored while the (experimental) GATSBY_DB_NODES flag was
+  //   // set to a different value. Since these databases are incompatible, we now
+  //   // have to reset it.
+  //   report.info(
+  //     `Cache exists but was stored with a different GATSBY_DB_NODES value. Disregarding the cache and proceeding as if there was none to prevent compatibility issues.`
+  //   )
+  //   // TODO: this is a DeepPartial<ICachedReduxState> but requires a big change
+  //   return {} as ICachedReduxState
+  // }
   if (!chunks.length && process.env.GATSBY_DB_NODES !== `loki`) {
     report.info(
       `Cache exists but contains no nodes. There should be at least some nodes available so it seems the cache was corrupted. Disregarding the cache and proceeding as if there was none.`
@@ -147,11 +147,6 @@ function safelyRenameToBak(reduxCacheFolder: string): string {
 }
 
 export function writeToCache(contents: ICachedReduxState): void {
-  // Force-set the dbType to the current config (do it here because we want
-  // to make sure the stored value is correctly representing the state under
-  // which it was generated)
-  contents.dbType = process.env.GATSBY_DB_NODES === 'loki' ? 'loki' : 'redux'
-
   // Note: this should be a transactional operation. So work in a tmp dir and
   // make sure the cache cannot be left in a corruptable state due to errors.
 

--- a/packages/gatsby/src/redux/reducers/program.js
+++ b/packages/gatsby/src/redux/reducers/program.js
@@ -1,5 +1,5 @@
 module.exports = (
-  state = { directory: `/`, state: `BOOTSTRAPPING` },
+  state = { directory: `/`, state: `BOOTSTRAPPING`, dbType: `` },
   action
 ) => {
   switch (action.type) {
@@ -18,6 +18,12 @@ module.exports = (
       return {
         ...state,
         status: `BOOTSTRAP_FINISHED`,
+      }
+
+    case `SET_DB_TYPE`:
+      return {
+        ...state,
+        dbType: action.payload,
       }
 
     default:

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -33,6 +33,7 @@ export interface IReduxState {
     proxy: any
   }
   pageData: any
+  dbType?: 'redux' | 'loki'
 }
 
 export interface ICachedReduxState {
@@ -45,6 +46,7 @@ export interface ICachedReduxState {
   webpackCompilationHash: IReduxState["webpackCompilationHash"]
   pageDataStats: IReduxState["pageDataStats"]
   pageData: IReduxState["pageData"]
+  dbType?: 'redux' | 'loki'
 }
 
 export type ActionsUnion =

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -33,7 +33,6 @@ export interface IReduxState {
     proxy: any
   }
   pageData: any
-  dbType?: 'redux' | 'loki'
 }
 
 export interface ICachedReduxState {
@@ -46,7 +45,6 @@ export interface ICachedReduxState {
   webpackCompilationHash: IReduxState["webpackCompilationHash"]
   pageDataStats: IReduxState["pageDataStats"]
   pageData: IReduxState["pageData"]
-  dbType?: 'redux' | 'loki'
 }
 
 export type ActionsUnion =
@@ -148,4 +146,9 @@ export interface IRemoveStaleJobAction {
   plugin: Plugin
   traceId?: string
   payload: { contentDigest: string }
+}
+
+export interface ISetDbTypeAction {
+  type: `SET_DB_TYPE`
+  payload: "redux" | "loki"
 }


### PR DESCRIPTION
This will store the state of the experimental env flag `GATSBY_DB_NODES` into the cache and check it when reading the cache. If there is a mismatch then we invalidate the cache.

Doing this at the cache storing layer because, right now, that's where it matters most.