### PR TITLE
Adds a missing dependency on `configstore`

### DIFF
--- a/packages/gatsby-core-utils/package.json
+++ b/packages/gatsby-core-utils/package.json
@@ -30,6 +30,7 @@
   "types": "index.d.ts",
   "dependencies": {
     "ci-info": "2.0.0",
+    "configstore": "^5.0.0",
     "node-object-hash": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This file now depends on `configstore`, so the dependency needs to be defined:
https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-core-utils/src/get-config-store.js

Cf a failing test here:
https://github.com/yarnpkg/berry/runs/490908199
