### PR TITLE
Fix variable names

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -76,11 +76,11 @@ class BenchMeta {
      */
 
     let buildType = process.env.BENCHMARK_BUILD_TYPE
-    const incomingHookBody = process.env.INCOMING_HOOK_BODY
+    const incomingHookBodyEnv = process.env.INCOMING_HOOK_BODY
 
-    if (CI_NAME === `netlify` && incomingHookBody) {
+    if (CI_NAME === `netlify` && incomingHookBodyEnv) {
       try {
-        const incomingHookBody = JSON.parse(incomingHookBody)
+        const incomingHookBody = JSON.parse(incomingHookBodyEnv)
         buildType = incomingHookBody && incomingHookBody.buildType
       } catch (e) {
         reportInfo(


### PR DESCRIPTION
There was a clash with the variable name `incomingHookBody` that made the JSON.parse fail.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->