### PR TITLE
Update CircleCI benchmarks with new env variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,49 @@ commands:
             - slack/status:
               channel: eng-react-integration-status
 
+  run-benchmark:
+    parameters:
+      working_directory:
+        type: string
+      NUM_PAGES:
+        type: string
+      BENCHMARK_CONTENT_SOURCE:
+        type: string
+      BENCHMARK_REPO_NAME:
+        type: string
+        default: gatsbyjs/gatsby
+      BENCHMARK_SITE_TYPE:
+        type: string
+        default: BLOG
+    steps:
+      - checkout
+      - run:
+          command: npm install
+          working_directory: << parameters.working_directory >>
+      - run:
+          command: npm run build
+          working_directory: << parameters.working_directory >>
+          environment:
+            BENCHMARK_BUILD_TYPE: COLD_START
+            NUM_PAGES: << parameters.NUM_PAGES >>
+            BENCHMARK_CONTENT_SOURCE: << parameters.BENCHMARK_CONTENT_SOURCE >>
+            BENCHMARK_REPO_NAME: << parameters.BENCHMARK_REPO_NAME >>
+            BENCHMARK_SITE_TYPE: << parameters.BENCHMARK_SITE_TYPE >>
+            CI_NAME: circleci
+      - run:
+          command: npm install
+          working_directory: << parameters.working_directory >>
+      - run:
+          command: npm run build
+          working_directory: << parameters.working_directory >>
+          environment:
+            BENCHMARK_BUILD_TYPE: WARM_START
+            NUM_PAGES: << parameters.NUM_PAGES >>
+            BENCHMARK_CONTENT_SOURCE: << parameters.BENCHMARK_CONTENT_SOURCE >>
+            BENCHMARK_REPO_NAME: << parameters.BENCHMARK_REPO_NAME >>
+            BENCHMARK_SITE_TYPE: << parameters.BENCHMARK_SITE_TYPE >>
+            CI_NAME: circleci
+
   e2e-test:
     parameters:
       skip_file_change_test:
@@ -365,193 +408,145 @@ jobs:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "512"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_id
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_id
+          NUM_PAGES: "512"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_id_4096:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "4096"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_id
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_id
+          NUM_PAGES: "4096"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_id_8192:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "8192"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_id
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_id
+          NUM_PAGES: "8192"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_id_32768:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "32768"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_id
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_id
+          NUM_PAGES: "32768"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_slug_512:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "512"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_slug
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_slug
+          NUM_PAGES: "512"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_slug_4096:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "4096"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_slug
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_slug
+          NUM_PAGES: "4096"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_slug_8192:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "8192"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_slug
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_slug
+          NUM_PAGES: "8192"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_slug_32768:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "32768"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_slug
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_slug
+          NUM_PAGES: "32768"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_table_512:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "512"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_table
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_table
+          NUM_PAGES: "512"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_table_4096:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "4096"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_table
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_table
+          NUM_PAGES: "4096"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_table_8192:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "8192"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_table
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_table
+          NUM_PAGES: "8192"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_table_32768:
     docker:
       - image: "circleci/node:12"
     resource_class: xlarge
-    environment:
-      CI_NAME: circleci
-      NUM_PAGES: "32768"
     steps:
-      - checkout
-      - run:
-          command: npm install
+      - run-benchmark:
           working_directory: benchmarks/markdown_table
-      - run:
-          command: npm run build
-          working_directory: benchmarks/markdown_table
+          NUM_PAGES: "32768"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_SITE_TYPE: BLOG
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,7 @@ jobs:
           working_directory: benchmarks/markdown_table/benchmarks/markdown_table
           NUM_PAGES: "32768"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,7 +413,7 @@ jobs:
           working_directory: benchmarks/markdown_id
           NUM_PAGES: "512"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_id
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_id_4096:
@@ -425,7 +425,7 @@ jobs:
           working_directory: benchmarks/markdown_id
           NUM_PAGES: "4096"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_id
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_id_8192:
@@ -437,7 +437,7 @@ jobs:
           working_directory: benchmarks/markdown_id
           NUM_PAGES: "8192"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_id
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_id_32768:
@@ -449,7 +449,7 @@ jobs:
           working_directory: benchmarks/markdown_id
           NUM_PAGES: "32768"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_id
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_slug_512:
@@ -461,7 +461,7 @@ jobs:
           working_directory: benchmarks/markdown_slug
           NUM_PAGES: "512"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_slug
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_slug_4096:
@@ -473,7 +473,7 @@ jobs:
           working_directory: benchmarks/markdown_slug
           NUM_PAGES: "4096"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_slug
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_slug_8192:
@@ -485,7 +485,7 @@ jobs:
           working_directory: benchmarks/markdown_slug
           NUM_PAGES: "8192"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_slug
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_slug_32768:
@@ -497,7 +497,7 @@ jobs:
           working_directory: benchmarks/markdown_slug
           NUM_PAGES: "32768"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_slug
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_table_512:
@@ -509,7 +509,7 @@ jobs:
           working_directory: benchmarks/markdown_table
           NUM_PAGES: "512"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_table_4096:
@@ -521,7 +521,7 @@ jobs:
           working_directory: benchmarks/markdown_table
           NUM_PAGES: "4096"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_table_8192:
@@ -533,7 +533,7 @@ jobs:
           working_directory: benchmarks/markdown_table
           NUM_PAGES: "8192"
           BENCHMARK_CONTENT_SOURCE: MDX
-          BENCHMARK_REPO_NAME: gatsbyjs/gatsby
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 
   benchmark_markdown_table_32768:
@@ -542,7 +542,7 @@ jobs:
     resource_class: xlarge
     steps:
       - run-benchmark:
-          working_directory: benchmarks/markdown_table
+          working_directory: benchmarks/markdown_table/benchmarks/markdown_table
           NUM_PAGES: "32768"
           BENCHMARK_CONTENT_SOURCE: MDX
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

- Update the CircleCI benchmarks to use necessary environment variables for benchmark runs
  - `BENCHMARK_CONTENT_SOURCE`
  - `BENCHMARK_REPO_NAME`
  - `BENCHMARK_SITE_TYPE`
- Extract the benchmark run into a command
- Note a specific cold vs. warm environment variable in `BENCHMARK_BUILD_TYPE` for subsequent runs

I don't know how to test this. We wait and see if this works?

cc/ @nicholascapo 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
