### PR TITLE
feat(gatsby-remark-copy-linked-files): Add support for poster attribute in video elements

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -210,6 +210,24 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).toHaveBeenCalled()
   })
 
+  it(`can copy HTML images from video elements with the poster attribute `, async () => {
+    const videoPath = `videos/sample-video.mp4`
+    const posterPath = `images/sample-image.jpg`
+
+    const markdownAST = remark.parse(
+      `<video controls="controls" autoplay="true" src="${videoPath}" poster="${posterPath}">\n<p>Your browser does not support the video element.</p>\n</video>`
+    )
+
+    await plugin({
+      files: [...getFiles(videoPath), ...getFiles(posterPath)],
+      markdownAST,
+      markdownNode,
+      getNode,
+    })
+
+    expect(fsExtra.copy).toHaveBeenCalledTimes(2)
+  })
+
   it(`can copy flash from object elements with the value attribute`, async () => {
     const path = `myMovie.swf`
 

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -223,10 +223,10 @@ module.exports = (
   visit(markdownAST, [`html`, `jsx`], node => {
     const $ = cheerio.load(node.value)
 
-    function processUrl({ url }) {
+    function processUrl({ url, isRequired }) {
       try {
         const ext = url.split(`.`).pop()
-        if (!options.ignoreFileExtensions.includes(ext)) {
+        if (!options.ignoreFileExtensions.includes(ext) || isRequired) {
           // The link object will be modified to the new location so we'll
           // use that data to update our ref
           const link = { url }
@@ -277,6 +277,14 @@ module.exports = (
       $(`video source[src], video[src]`),
       `src`
     ).forEach(processUrl)
+
+    // Handle video poster.
+    extractUrlAttributeAndElement(
+      $(`video[poster]`),
+      `poster`
+    ).forEach(extractedUrlAttributeAndElement =>
+      processUrl({ ...extractedUrlAttributeAndElement, isRequired: true })
+    )
 
     // Handle audio tags.
     extractUrlAttributeAndElement(


### PR DESCRIPTION
Currently `gatsby-remark-copy-linked-files` doesn't support copy of video posters. This PR add support by parsing "poster" attribute in video tags. Results in copy of poster image when "poster" attribute is specified in video element.

Also I've added `isRequired` field in argument object of `processUrl` function. It's necessary because this plugin ussually ignores image extensions (which video paster has) and allow `gatsby-remark-images` plugin to handle them. But `gatsby-remark-images` plugin shouldn't handle video posters.  