### PR TITLE
tailwind.macro has depreciated

### DIFF
--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -75,19 +75,22 @@ These steps assume you have a CSS-in-JS library already installed, and the examp
 **Option 1**: Install `twin.macro` and use Tailwind 1.2.0+
 
 1. Install Twin and Emotion
+
 ```shell
 npm install -D twin.macro @emotion/core @emotion/styled gatsby-plugin-emotion
 ```
 
 2. Import the Tailwind base styles
+
 ```javascript:title=gatsby-browser.js
-import 'tailwindcss/dist/base.css'
+import "tailwindcss/dist/base.css"
 ```
 
 3. Enable the Gatsby emotion plugin
+
 ```javascript:title=gatsby-config.js
 module.exports = {
-  plugins: [`gatsby-plugin-emotion`]
+  plugins: [`gatsby-plugin-emotion`],
 }
 ```
 

--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -85,7 +85,7 @@ import 'tailwindcss/dist/base.css'
 ```
 
 3. Enable the Gatsby emotion plugin
-```javascript
+```javascript:title=gatsby-config.js
 // gatsby-config.js
 module.exports = {
   plugins: [`gatsby-plugin-emotion`]

--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -70,12 +70,27 @@ These steps assume you have a CSS-in-JS library already installed, and the examp
 
 1. Install Tailwind Babel Macro
 
-**Note**: `tailwind.macro` isn't currently compatible with Tailwind 1.0.0+. However, a compatible beta is available at `tailwind.macro@next`. Feel free to either use the beta or revert to Tailwind 0.7.4.
+**Note**: `tailwind.macro` isn't currently compatible with Tailwind 1.0.0+. However, a new forked project can be found at `twin.macro` that supports Tailwindcss v1.2 classes. It's currently in pre-release so all plugins arn't supported at the time of writting. Feel free to either use `twin.macro` or revert to Tailwind 0.7.4.
 
-**Option 1**: Install `tailwind.macro@next` and use Tailwind 1.0.0+
+**Option 1**: Install `twin.macro` and use Tailwind 1.2.0+
 
+1. Install Twin and Emotion
 ```shell
-npm install --save tailwind.macro@next
+npm install -D twin.macro @emotion/core @emotion/styled gatsby-plugin-emotion
+```
+
+2. Import the Tailwind base styles
+```javascript
+// gatsby-browser.js
+import 'tailwindcss/dist/base.css'
+```
+
+3. Enable the Gatsby emotion plugin
+```javascript
+// gatsby-config.js
+module.exports = {
+  plugins: [`gatsby-plugin-emotion`]
+}
 ```
 
 **Option 2**: Install stable `tailwind.macro` and use Tailwind 0.7.4

--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -86,7 +86,6 @@ import 'tailwindcss/dist/base.css'
 
 3. Enable the Gatsby emotion plugin
 ```javascript:title=gatsby-config.js
-// gatsby-config.js
 module.exports = {
   plugins: [`gatsby-plugin-emotion`]
 }

--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -80,7 +80,7 @@ npm install -D twin.macro @emotion/core @emotion/styled gatsby-plugin-emotion
 ```
 
 2. Import the Tailwind base styles
-```javascript
+```javascript:title=gatsby-browser.js
 // gatsby-browser.js
 import 'tailwindcss/dist/base.css'
 ```

--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -81,7 +81,6 @@ npm install -D twin.macro @emotion/core @emotion/styled gatsby-plugin-emotion
 
 2. Import the Tailwind base styles
 ```javascript:title=gatsby-browser.js
-// gatsby-browser.js
 import 'tailwindcss/dist/base.css'
 ```
 

--- a/docs/docs/tailwind-css.md
+++ b/docs/docs/tailwind-css.md
@@ -70,7 +70,7 @@ These steps assume you have a CSS-in-JS library already installed, and the examp
 
 1. Install Tailwind Babel Macro
 
-**Note**: `tailwind.macro` isn't currently compatible with Tailwind 1.0.0+. However, a new forked project can be found at `twin.macro` that supports Tailwindcss v1.2 classes. It's currently in pre-release so all plugins arn't supported at the time of writting. Feel free to either use `twin.macro` or revert to Tailwind 0.7.4.
+**Note**: `tailwind.macro` isn't currently compatible with Tailwind 1.0.0+. However, a new forked project can be found at `twin.macro` that supports Tailwindcss v1.2 classes. It's currently in pre-release so not all plugins are supported at the time of writing. Alternatively, you can revert to Tailwind 0.7.4.
 
 **Option 1**: Install `twin.macro` and use Tailwind 1.2.0+
 


### PR DESCRIPTION
added Twin docs for versions 1.0.0+ of Tailwind

## Description

Tailwindcss support for the CSS-in-JS macro `tailwind.macro` has depreciated, users of v1.0.0+ should use forked project Twin `twin.macro`

### Documentation

API is identical with some new features, future support for classes and soon to be released plugin support [Twin](https://github.com/ben-rogerson/twin.macro)
