### PR TITLE
[contributing] Defer Google Analytics to improve load performance

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -83,7 +83,7 @@ export const onRenderBody = (
   }) {
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    m=s.getElementsByTagName(o)[0];a.defer=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
   }
   if (typeof ga === "function") {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Deferring javascript means that we are literally lowering the priority for the browser to run our javascript.

This does not mean that it won't load, but the browser will prioritize running any other HTML and Javascript that is synchronous and asynchronous. Deferred javascript is the last set of components of your website that will be loaded.

So any javascript that your app needs to run, f.ex javascript that loads information from a user on a logged-in page, should be loaded either synchronously or asynchronously.

Telemetry and analytics software such as Google Tag Manager and Google Analytics, however, is not required for the page to run and can be given a lower priority.
