### PR TITLE
chore(gatsby): Convert utils/browserslist to typescript

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -11,7 +11,7 @@ const Promise = require(`bluebird`)
 const telemetry = require(`gatsby-telemetry`)
 
 const apiRunnerNode = require(`../utils/api-runner-node`)
-const getBrowserslist = require(`../utils/browserslist`)
+import { getBrowsersList } from "../utils/browserslist"
 const { store, emitter } = require(`../redux`)
 const loadPlugins = require(`./load-plugins`)
 const loadThemes = require(`./load-themes`)
@@ -73,7 +73,7 @@ module.exports = async (args: BootstrapArgs) => {
 
   const program = {
     ...args,
-    browserslist: getBrowserslist(directory),
+    browserslist: getBrowsersList(directory),
     // Fix program directory path for windows env.
     directory,
   }

--- a/packages/gatsby/src/utils/__tests__/browserslist.js
+++ b/packages/gatsby/src/utils/__tests__/browserslist.js
@@ -4,7 +4,7 @@ jest.mock(`browserslist/node`, () => {
   }
 })
 const path = require(`path`)
-const getBrowsersList = require(`../browserslist`)
+import { getBrowsersList } from "../browserslist"
 const { findConfig: mockedFindConfig } = require(`browserslist/node`)
 
 const BASE = path.resolve(`.`)

--- a/packages/gatsby/src/utils/browserslist.ts
+++ b/packages/gatsby/src/utils/browserslist.ts
@@ -1,8 +1,9 @@
-const path = require(`path`)
-const browserslist = require(`browserslist/node`)
+import path from "path"
+import browserslist from "browserslist/node"
 
-function installedGatsbyVersion(directory) {
+const installedGatsbyVersion = (directory: string): number | undefined => {
   try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { version } = require(path.join(
       directory,
       `node_modules`,
@@ -15,7 +16,7 @@ function installedGatsbyVersion(directory) {
   }
 }
 
-module.exports = function getBrowsersList(directory) {
+export const getBrowsersList = (directory: string): string[] => {
   const fallback =
     installedGatsbyVersion(directory) === 1
       ? [`>1%`, `last 2 versions`, `IE >= 9`]


### PR DESCRIPTION
## Description
Convert `utils/browserslist` to typescript

## Related Issues

Related to #21995

