### PR TITLE
chore(gatsby): Migrate utils/get-cache.js to ts

### DIFF
--- a/packages/gatsby/src/utils/__tests__/get-cache.ts
+++ b/packages/gatsby/src/utils/__tests__/get-cache.ts
@@ -1,4 +1,4 @@
-const getCache = require(`../get-cache`)
+import { getCache } from "../get-cache"
 
 const CACHE_KEY = `__test__`
 

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -8,7 +8,7 @@ const reporter = require(`gatsby-cli/lib/reporter`)
 const stackTrace = require(`stack-trace`)
 const { codeFrameColumns } = require(`@babel/code-frame`)
 const fs = require(`fs-extra`)
-const getCache = require(`./get-cache`)
+const { getCache } = require(`./get-cache`)
 const createNodeId = require(`./create-node-id`)
 const { createContentDigest } = require(`gatsby-core-utils`)
 const {
@@ -170,7 +170,7 @@ const runAPI = (plugin, api, args, activity) => {
         },
       }
     }
-    let localReporter = getLocalReporter(activity, reporter)
+    const localReporter = getLocalReporter(activity, reporter)
 
     const apiCallArgs = [
       {
@@ -238,8 +238,8 @@ const runAPI = (plugin, api, args, activity) => {
   return null
 }
 
-let apisRunningById = new Map()
-let apisRunningByTraceId = new Map()
+const apisRunningById = new Map()
+const apisRunningByTraceId = new Map()
 let waitingForCasacadeToFinish = []
 
 module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
@@ -332,7 +332,7 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
         return null
       }
 
-      let pluginName =
+      const pluginName =
         plugin.name === `default-site-plugin` ? `gatsby-node.js` : plugin.name
 
       return new Promise(resolve => {
@@ -342,7 +342,7 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
           pluginName: `${plugin.name}@${plugin.version}`,
         })
 
-        let localReporter = getLocalReporter(activity, reporter)
+        const localReporter = getLocalReporter(activity, reporter)
 
         const file = stackTrace
           .parse(err)

--- a/packages/gatsby/src/utils/get-cache.ts
+++ b/packages/gatsby/src/utils/get-cache.ts
@@ -1,8 +1,8 @@
-const Cache = require(`./cache`).default
+import Cache from "./cache"
 
-const caches = new Map()
+const caches = new Map<string, Cache>()
 
-module.exports = function getCache(name) {
+export const getCache = (name: string): Cache => {
   let cache = caches.get(name)
   if (!cache) {
     cache = new Cache({ name }).init()


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Convert `utils/get-cache` to typescript
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
Related to #21995
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
