### PR TITLE
feat(gatsby-plugin-benchmark-reporting): allow passing a secret to benchmark reporting endpoint

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -254,12 +254,12 @@ class BenchMeta {
       body: json,
     }).then(res => {
       lastStatus = res.status
-      if (lastStatus === 500) {
-        reportInfo(`Got 500 response, waiting for text`)
+      if ([401, 500].includes(lastStatus)) {
+        reportInfo(`Got ${lastStatus} response, waiting for text`)
         res.text().then(content => {
           reportError(
             `Response error`,
-            new Error(`Server responded with a 500 error: ${content}`)
+            new Error(`Server responded with a ${lastStatus} error: ${content}`)
           )
           process.exit(1)
         })

--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -249,7 +249,7 @@ class BenchMeta {
       method: `POST`,
       headers: {
         "content-type": `application/json`,
-        // "user-agent": this.getUserAgent(),
+        "x-benchmark-secret": process.env.BENCHMARK_REPORTING_SECRET,
       },
       body: json,
     }).then(res => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->