### PR TITLE
fix(gatsby-cli): Update build script to properly handle .tsx files

### DIFF
--- a/packages/gatsby-cli/.babelrc
+++ b/packages/gatsby-cli/.babelrc
@@ -9,7 +9,7 @@
   ],
   "overrides": [
     {
-      "test": "**/*.ts",
+      "test": ["**/*.ts", "**/*.tsx"],
       "plugins": [["@babel/plugin-transform-typescript", { "isTSX": true }]]
     }
   ]

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -76,9 +76,9 @@
     "directory": "packages/gatsby-cli"
   },
   "scripts": {
-    "build": "babel src --out-dir lib --ignore \"**/__tests__\" --extensions \".ts,.js\"",
+    "build": "babel src --out-dir lib --ignore \"**/__tests__\" --extensions \".ts,.js,.tsx\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\"  --extensions \".ts,.js\"",
+    "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\"  --extensions \".ts,.js,.tsx\"",
     "postinstall": "node scripts/postinstall.js"
   },
   "yargs": {


### PR DESCRIPTION
## Description

hotfix for `progress-bar` not being in the built output. The infrastructure was set up for `.ts` files, but not for `.tsx` files. Thus they were not being built and currently `gatsby-cli@2.10.3` does not work.

## Related Issues

Related #22109