### PR TITLE
Fix URL for gatsby-starter-tailwind

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -817,7 +817,7 @@
   features:
     - Based on gatsby-starter-default
     - Using Tachyons for CSS.
-- url: https://quizzical-mcclintock-0226ac.netlify.com/
+- url: https://gatsby-starter-tailwind.oddstronaut.com/
   repo: https://github.com/taylorbryant/gatsby-starter-tailwind
   description: A Gatsby v2 starter styled using Tailwind, a utility-first CSS framework. Uses Purgecss to remove unused CSS.
   tags:


### PR DESCRIPTION
## Description

This PR updates the URL listed for `gatsby-starter-tailwind` to the current one.
