### PR TITLE
chore(gatsby-react-router-scroll): convert to TS

### DIFF
--- a/packages/gatsby-react-router-scroll/.babelrc
+++ b/packages/gatsby-react-router-scroll/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package", { "browser": true }]],
+  "overrides": [
+    {
+      "test": "**/*.ts",
+      "plugins": [["@babel/plugin-transform-typescript", { "isTSX": true }]]
+    }
+  ]
 }

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -8,12 +8,15 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.6",
-    "scroll-behavior": "^0.9.10",
+    "scroll-behavior": "^0.10.0",
     "warning": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",
     "@babel/core": "^7.7.5",
+    "@babel/plugin-transform-typescript": "^7.7.4",
+    "@types/reach__router": "^1.3.0",
+    "@types/warning": "^3.0.0",
     "babel-plugin-dev-expression": "^0.2.2",
     "babel-preset-gatsby-package": "^0.2.17",
     "cross-env": "^5.2.1"
@@ -36,9 +39,9 @@
     "directory": "packages/gatsby-react-router-scroll"
   },
   "scripts": {
-    "build": "babel src --out-dir . --ignore **/__tests__",
+    "build": "babel src --out-dir . --ignore **/__tests__ --ignore **/__mocks__ --extensions \".ts\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore **/__tests__"
+    "watch": "babel -w src --out-dir . --ignore **/__tests__ --extensions \".ts\""
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/gatsby-react-router-scroll/src/ScrollContainer.ts
+++ b/packages/gatsby-react-router-scroll/src/ScrollContainer.ts
@@ -2,6 +2,9 @@ import React from "react"
 import ReactDOM from "react-dom"
 import warning from "warning"
 import PropTypes from "prop-types"
+import { ShouldUpdateScroll, LocationBase } from "scroll-behavior"
+import { History } from "@reach/router"
+import ScrollContext from "./ScrollBehaviorContext"
 
 const propTypes = {
   scrollKey: PropTypes.string.isRequired,
@@ -16,8 +19,30 @@ const contextTypes = {
   scrollBehavior: PropTypes.object,
 }
 
-class ScrollContainer extends React.Component {
-  constructor(props, context) {
+interface IProps {
+  scrollKey: string
+  shouldUpdateScroll: ShouldUpdateScroll<ILocation>
+  children: React.ReactNode
+}
+
+interface IContext {
+  scrollBehavior: ScrollContext
+}
+
+interface ILocation {
+  location?: LocationBase
+  history?: History
+}
+
+class ScrollContainer extends React.Component<IProps> {
+  static propTypes: typeof propTypes
+  static contextTypes: typeof contextTypes
+
+  context!: React.ContextType<React.Context<IContext>>
+  domNode: Element | Text | null = null
+  scrollKey: string
+
+  constructor(props: IProps, context: IContext) {
     super(props, context)
 
     // We don't re-register if the scroll key changes, so make sure we
@@ -25,10 +50,10 @@ class ScrollContainer extends React.Component {
     this.scrollKey = props.scrollKey
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.context.scrollBehavior.registerElement(
       this.props.scrollKey,
-      ReactDOM.findDOMNode(this), // eslint-disable-line react/no-find-dom-node
+      ReactDOM.findDOMNode(this) as HTMLElement, // eslint-disable-line react/no-find-dom-node
       this.shouldUpdateScroll
     )
 
@@ -39,7 +64,7 @@ class ScrollContainer extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: IProps): void {
     warning(
       prevProps.scrollKey === this.props.scrollKey,
       `<ScrollContainer> does not support changing scrollKey.`
@@ -55,11 +80,14 @@ class ScrollContainer extends React.Component {
     }
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     this.context.scrollBehavior.unregisterElement(this.scrollKey)
   }
 
-  shouldUpdateScroll = (prevRouterProps, routerProps) => {
+  shouldUpdateScroll: ShouldUpdateScroll<ILocation> = (
+    prevRouterProps,
+    routerProps
+  ) => {
     const { shouldUpdateScroll } = this.props
     if (!shouldUpdateScroll) {
       return true
@@ -73,7 +101,7 @@ class ScrollContainer extends React.Component {
     )
   }
 
-  render() {
+  render(): React.ReactNode {
     return this.props.children
   }
 }

--- a/packages/gatsby-react-router-scroll/src/StateStorage.ts
+++ b/packages/gatsby-react-router-scroll/src/StateStorage.ts
@@ -1,13 +1,23 @@
+import { LocationBase, ScrollPosition } from "scroll-behavior"
+
 const STATE_KEY_PREFIX = `@@scroll|`
 const GATSBY_ROUTER_SCROLL_STATE = `___GATSBY_REACT_ROUTER_SCROLL`
 
+interface ILocation extends LocationBase {
+  key?: string
+  pathname?: string
+}
+
 export default class SessionStorage {
-  read(location, key) {
+  read(
+    location: LocationBase,
+    key: string | null
+  ): ScrollPosition | null | undefined {
     const stateKey = this.getStateKey(location, key)
 
     try {
       const value = window.sessionStorage.getItem(stateKey)
-      return JSON.parse(value)
+      return JSON.parse(value || `{}`)
     } catch (e) {
       if (process.env.NODE_ENV !== `production`) {
         console.warn(
@@ -23,11 +33,11 @@ export default class SessionStorage {
         return window[GATSBY_ROUTER_SCROLL_STATE][stateKey]
       }
 
-      return {}
+      return ({} as unknown) as undefined
     }
   }
 
-  save(location, key, value) {
+  save(location: LocationBase, key: string | null, value: unknown): void {
     const stateKey = this.getStateKey(location, key)
     const storedValue = JSON.stringify(value)
 
@@ -49,7 +59,7 @@ export default class SessionStorage {
     }
   }
 
-  getStateKey(location, key) {
+  getStateKey(location: ILocation, key?: string | null): string {
     const locationKey = location.key || location.pathname
     const stateKeyBase = `${STATE_KEY_PREFIX}${locationKey}`
     return key === null || typeof key === `undefined`

--- a/packages/gatsby-react-router-scroll/src/index.ts
+++ b/packages/gatsby-react-router-scroll/src/index.ts
@@ -1,4 +1,4 @@
 import ScrollBehaviorContext from "./ScrollBehaviorContext"
 import ScrollContainer from "./ScrollContainer"
-exports.ScrollContainer = ScrollContainer
-exports.ScrollContext = ScrollBehaviorContext
+
+export { ScrollContainer, ScrollBehaviorContext as ScrollContext }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1842,6 +1842,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.1.2":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
+  integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.6.0":
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
@@ -4048,6 +4055,14 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/reach__router@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.0.tgz#4c05a947ccecca05c72bb335a0f7bb43fec12446"
+  integrity sha512-0aL79bFPJzJOJOOMZm2301ErQVaveBdpW88uuavXymUlcYIAOCmI1ujJ2XLH6Mzn76O94eQCHIl1FDzNNKJCYA==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+
 "@types/react-dom@*":
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.0.tgz#ba6ddb00bf5de700b0eb91daa452081ffccbfdea"
@@ -4149,6 +4164,11 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
 "@types/webpack-sources@*":
   version "0.1.5"
@@ -8759,9 +8779,12 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
+dom-helpers@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-serializer@0, dom-serializer@~0.1.0, dom-serializer@~0.1.1:
   version "0.1.1"
@@ -17232,6 +17255,11 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
+page-lifecycle@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/page-lifecycle/-/page-lifecycle-0.1.2.tgz#f17a083c082bd5ababddd77f1025a4b1c8808012"
+  integrity sha512-+3uccYgL0CXG0KSXRxZi4uc2E6mqFWV5HqiJJgcnaJCiS0LqiuJ4vB420N21NFuLvuvLB4Jr5drgQ2NXAXF9Iw==
+
 pako@^0.2.5:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -19179,6 +19207,11 @@ regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
+regenerator-runtime@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz#e96bf612a3362d12bb69f7e8f74ffeab25c7ac91"
+  integrity sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==
+
 regenerator-transform@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.0.tgz#2ca9aaf7a2c239dd32e4761218425b8c7a86ecaf"
@@ -20250,13 +20283,14 @@ schemes@^1.0.1:
   dependencies:
     extend "^3.0.0"
 
-scroll-behavior@^0.9.10:
-  version "0.9.10"
-  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.10.tgz#c8953adeeb3586060b903328d860aa8346d62861"
-  integrity sha512-JVJQkBkqMLEM4ATtbHTKare97zhz/qlla9mNttFYY/bcpyOb4BuBGEQ/N9AQWXvshzf6zo9jP60TlphnJ4YPoQ==
+scroll-behavior@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.10.0.tgz#046b3a074ed9de4dd491128aaea4d23b6364f9ad"
+  integrity sha512-ayL5Hb+klX8+17uQB4y+DheT9h/1a8oRcs84XFvnKBkxR9f4PeMvtiOELTs39ISnbx+fdSxOjlwyMaIWVf/x9A==
   dependencies:
-    dom-helpers "^3.2.1"
-    invariant "^2.2.2"
+    dom-helpers "^3.4.0"
+    invariant "^2.2.4"
+    page-lifecycle "^0.1.2"
 
 section-matter@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR will convert `gatsby-react-router-scroll` to TypeScript.
It is not perfect and is open for discussions.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to #21995