### PR TITLE
fix(gatsby): Update types for WrapPageElement*Args

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -891,7 +891,7 @@ export interface ReplaceRendererArgs extends NodePluginArgs {
 
 export interface WrapPageElementNodeArgs extends NodePluginArgs {
   element: object
-  props: object
+  props: PageProps
   pathname: string
 }
 
@@ -1307,7 +1307,7 @@ export interface ShouldUpdateScrollArgs extends BrowserPluginArgs {
 
 export interface WrapPageElementBrowserArgs extends BrowserPluginArgs {
   element: object
-  props: object
+  props: PageProps
 }
 
 export interface WrapRootElementBrowserArgs extends BrowserPluginArgs {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -889,9 +889,9 @@ export interface ReplaceRendererArgs extends NodePluginArgs {
   setBodyProps: Function
 }
 
-export interface WrapPageElementNodeArgs extends NodePluginArgs {
+export interface WrapPageElementNodeArgs<DataType = object, PageContextType = object> extends NodePluginArgs {
   element: object
-  props: PageProps
+  props: PageProps<DataType, PageContextType>
   pathname: string
 }
 
@@ -1305,9 +1305,9 @@ export interface ShouldUpdateScrollArgs extends BrowserPluginArgs {
   getSavedScrollPosition: Function
 }
 
-export interface WrapPageElementBrowserArgs extends BrowserPluginArgs {
+export interface WrapPageElementBrowserArgs<DataType = object, PageContextType = object> extends BrowserPluginArgs {
   element: object
-  props: PageProps
+  props: PageProps<DataType, PageContextType>
 }
 
 export interface WrapRootElementBrowserArgs extends BrowserPluginArgs {


### PR DESCRIPTION
## Description

Hi, and thanks for a great project! This (my first) PR is just a small thing proposing an update to the typescript types. It should possibly be opened as an issue first, but since the changes are so small I thought it would be easiest to make it a PR directly – a PR which of course can be closed if I've misunderstood anything.

I propose updated types for the interfaces `WrapPageElementBrowserArgs` and `WrapPageElementNodeArgs` with a more detailed `props` definition. PR #21542 introduced a new detailed interface for page props and I figured this interface can also be used for the types for `wrapPageElement`.

I could of course be wrong ([the docs](https://www.gatsbyjs.org/docs/browser-apis/#wrapPageElement) and [the current interface](https://github.com/gatsbyjs/gatsby/blob/509339f2aeecc261c0c7e1193d873a6d4b183a35/packages/gatsby/index.d.ts#L1310) only specify `props` as a vague `object`) but my guess is that `props` in `wrapPageElement` is the same props passed to pages. Please correct me if I'm wrong.

### Documentation

The arguments passed to `wrapPageElement` are documented in two places – [browser](https://www.gatsbyjs.org/docs/browser-apis/#wrapPageElement) and [ssr](https://www.gatsbyjs.org/docs/ssr-apis/#wrapPageElement). Would you like me to touch on these as well?

## Related Issues

No related issues found.
