### PR TITLE
fix(gatsby-plugin-mdx): add context dependency to mdx-scopes loader

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-scopes.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-scopes.js
@@ -8,6 +8,8 @@ module.exports = function() {
   const { cache } = loaderUtils.getOptions(this)
   const abs = path.join(cache.directory, MDX_SCOPES_LOCATION)
   const files = fs.readdirSync(abs)
+  // make webpack rebuild when new scopes are created
+  this.addContextDependency(abs)
   return (
     files
       .map(


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Otherwise webpack will not rebuild when new scpoes is writed into cache. This can happen if you change mdx file when `gatsby develop`.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
