### PR TITLE
perf(gatsby): more efficient parent-child check through arrays

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1034,9 +1034,9 @@ actions.createParentChildLink = (
   { parent, child }: { parent: any, child: any },
   plugin?: Plugin
 ) => {
-  // Update parent
-  parent.children.push(child.id)
-  parent.children = _.uniq(parent.children)
+  if (!parent.children.includes(child.id)) {
+    parent.children.push(child.id)
+  }
 
   return {
     type: `ADD_CHILD_NODE_TO_PARENT_NODE`,


### PR DESCRIPTION
This replaces a `_.uniq` with a `.includes` which is called `N` times, once for each node, while the array of nodes is building up (or on the full set even?). The only reason, I think, is to make sure the newly inserted child does not already exist in the array of children. The `includes` simply does a subset of things `uniq` does.

Another change is that a new array is no longer created; `parent.children` remains the same array reference after this step now.

Addresses a problem surfaced by @tsriram in #21447

Drops the `source and transform` step by about 33% at scale. This step in a benchmark of 100k pages drops from 30s to 20s, a 150k pages bench drops from 45s to 30s.

This is the long hanging fruit. There's still a lot of room for improvement.