### PR TITLE
chore(gatsby): Convert utils/path to typescript

### DIFF
--- a/packages/gatsby/src/internal-plugins/load-babel-config/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/load-babel-config/gatsby-node.js
@@ -3,7 +3,7 @@
 const fs = require(`fs-extra`)
 
 const apiRunnerNode = require(`../../utils/api-runner-node`)
-const { withBasePath } = require(`../../utils/path`)
+import { withBasePath } from "../../utils/path"
 
 exports.onPreBootstrap = async ({ store, parentSpan }) => {
   const { directory, browserslist } = store.getState().program

--- a/packages/gatsby/src/utils/__tests__/path.ts
+++ b/packages/gatsby/src/utils/__tests__/path.ts
@@ -1,6 +1,6 @@
-const { joinPath } = require(`gatsby-core-utils`)
-const { withBasePath, getCommonDir } = require(`../path`)
-const os = require(`os`)
+import { joinPath } from "gatsby-core-utils"
+import { withBasePath, getCommonDir } from "../path"
+import os from "os"
 
 describe(`paths`, () => {
   describe(`joinPath`, () => {
@@ -55,7 +55,7 @@ describe(`paths`, () => {
   })
 
   describe(`getCommonDir`, () => {
-    it.each([
+    it.each<[string, { path1: string; path2: string; expected: string }]>([
       [
         `posix: path2 is sub-path of path1`,
         {

--- a/packages/gatsby/src/utils/path.ts
+++ b/packages/gatsby/src/utils/path.ts
@@ -1,22 +1,20 @@
-const path = require(`path`)
-const { joinPath } = require(`gatsby-core-utils`)
+import path from "path"
+import { joinPath } from "gatsby-core-utils"
 
-export function withBasePath(basePath) {
-  return (...paths) => joinPath(basePath, ...paths)
-}
+export const withBasePath = (basePath: string) => (
+  ...paths: string[]
+): string => joinPath(basePath, ...paths)
 
-export function withTrailingSlash(basePath) {
-  return `${basePath}/`
-}
+export const withTrailingSlash = (basePath: string): string => `${basePath}/`
 
-const posixJoinWithLeadingSlash = paths =>
+const posixJoinWithLeadingSlash = (paths: string[]): string =>
   path.posix.join(
     ...paths.map((segment, index) =>
       segment === `` && index === 0 ? `/` : segment
     )
   )
 
-export function getCommonDir(path1, path2) {
+export const getCommonDir = (path1: string, path2: string): string => {
   const path1Segments = path1.split(/[/\\]/)
   const path2Segments = path2.split(/[/\\]/)
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -9,7 +9,7 @@ const { actions } = require(`../redux/actions`)
 const { getPublicPath } = require(`./get-public-path`)
 const debug = require(`debug`)(`gatsby:webpack-config`)
 const report = require(`gatsby-cli/lib/reporter`)
-const { withBasePath, withTrailingSlash } = require(`./path`)
+import { withBasePath, withTrailingSlash } from "./path"
 const getGatsbyDependents = require(`./gatsby-dependents`)
 
 const apiRunnerNode = require(`./api-runner-node`)


### PR DESCRIPTION
## Description
Convert `utils/path` and test to typescript

## Related Issues

Related to #21995

