### PR TITLE
chore(gatsby): Convert is-32-bit-integer to TypeScript

### DIFF
--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -7,7 +7,7 @@ const report = require(`gatsby-cli/lib/reporter`)
 const { isFile } = require(`./is-file`)
 const { isDate } = require(`../types/date`)
 const { addDerivedType } = require(`../types/derived-types`)
-import { is32BitInteger } from "./is-32-bit-integer"
+import { is32BitInteger } from "../../utils/is-32-bit-integer"
 
 const addInferredFields = ({
   schemaComposer,

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -7,7 +7,7 @@ const report = require(`gatsby-cli/lib/reporter`)
 const { isFile } = require(`./is-file`)
 const { isDate } = require(`../types/date`)
 const { addDerivedType } = require(`../types/derived-types`)
-const is32BitInteger = require(`./is-32-bit-integer`)
+import { is32BitInteger } from "./is-32-bit-integer"
 
 const addInferredFields = ({
   schemaComposer,

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -122,7 +122,7 @@ type TypeInfoRelatedNode = TypeInfo & {
 */
 
 const { isEqual } = require(`lodash`)
-const is32BitInteger = require(`./is-32-bit-integer`)
+import { is32BitInteger } from "./is-32-bit-integer"
 const { looksLikeADate } = require(`../types/date`)
 
 const getType = (value, key) => {

--- a/packages/gatsby/src/schema/infer/inference-metadata.js
+++ b/packages/gatsby/src/schema/infer/inference-metadata.js
@@ -122,7 +122,7 @@ type TypeInfoRelatedNode = TypeInfo & {
 */
 
 const { isEqual } = require(`lodash`)
-import { is32BitInteger } from "./is-32-bit-integer"
+import { is32BitInteger } from "../../utils/is-32-bit-integer"
 const { looksLikeADate } = require(`../types/date`)
 
 const getType = (value, key) => {

--- a/packages/gatsby/src/schema/infer/is-32-bit-integer.js
+++ b/packages/gatsby/src/schema/infer/is-32-bit-integer.js
@@ -1,3 +1,0 @@
-const is32BitInteger = num => (num | 0) === num
-
-module.exports = is32BitInteger

--- a/packages/gatsby/src/schema/infer/is-32-bit-integer.ts
+++ b/packages/gatsby/src/schema/infer/is-32-bit-integer.ts
@@ -1,0 +1,3 @@
+export function is32BitInteger(x: unknown): boolean {
+  return typeof x === `number` && (x | 0) === x
+}

--- a/packages/gatsby/src/schema/infer/is-32-bit-integer.ts
+++ b/packages/gatsby/src/schema/infer/is-32-bit-integer.ts
@@ -1,3 +1,0 @@
-export function is32BitInteger(x: unknown): boolean {
-  return typeof x === `number` && (x | 0) === x
-}

--- a/packages/gatsby/src/utils/__tests__/is-32-bit-integer.ts
+++ b/packages/gatsby/src/utils/__tests__/is-32-bit-integer.ts
@@ -1,4 +1,4 @@
-const is32BitInteger = require(`../is-32-bit-integer.js`)
+import { is32BitInteger } from "../is-32-bit-integer"
 
 const MAX_INT = 2147483647
 const MIN_INT = -2147483648

--- a/packages/gatsby/src/utils/is-32-bit-integer.js
+++ b/packages/gatsby/src/utils/is-32-bit-integer.js
@@ -1,3 +1,0 @@
-module.exports = function(x) {
-  return (x | 0) === x
-}

--- a/packages/gatsby/src/utils/is-32-bit-integer.ts
+++ b/packages/gatsby/src/utils/is-32-bit-integer.ts
@@ -1,0 +1,3 @@
+export function is32BitInteger(x: unknown): boolean {
+  return typeof x === `number` && (x | 0) === x
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I converted two `is-32-bit-integer` to TypeScript.

- `utils/is-32-bit-integer`
- `schema/infer/is-32-bit-integer`

## Related Issues

Related to #21995
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
