### PR TITLE
chore(starters): add gatsby-starter-builton

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -4,6 +4,7 @@ starter:
   - Authentication
   - AWS
   - Blog
+  - BuiltOn
   - Client-side App
   - CMS:Agility CMS
   - CMS:Cosmic JS

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5532,3 +5532,18 @@
     - Robots.txt
     - Sitemap
     - PWA
+- url: https://builtondev.github.io/gatsby-starter-builton
+  repo: https://github.com/BuiltonDev/gatsby-starter-builton
+  description: A simple starter to get up and developing quickly with Gatsby and BuiltOn.
+  tags:
+    - BuiltOn
+    - eCommerce
+    - Pagination
+  features:
+    - Lightweight
+    - Linting
+    - Imports BuiltOn products and images
+    - Images lazy loading
+    - Products list paginated
+    - Product page
+    - Subproduct listing


### PR DESCRIPTION
## Description
Adding a new gatsby starter. It's very simple and lightweight. It fetches products and images from a https://builton.dev project and displays them.

Demo: https://builtondev.github.io/gatsby-starter-builton/
Repository: https://github.com/BuiltonDev/gatsby-starter-builton