### PR TITLE
chore(gatsby-cli): Convert ensure-windows-drive-letter-is-uppercase to typescript

### DIFF
--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -8,7 +8,7 @@ import createCli from "./create-cli"
 import report from "./reporter"
 import pkg from "../package.json"
 import updateNotifier from "update-notifier"
-import ensureWindowsDriveLetterIsUppercase from "./util/ensure-windows-drive-letter-is-uppercase"
+import { ensureWindowsDriveLetterIsUppercase } from "./util/ensure-windows-drive-letter-is-uppercase"
 
 const useJsonLogger = process.argv.slice(2).some(arg => arg.includes(`json`))
 
@@ -39,7 +39,7 @@ if (!semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`)) {
 if (!semver.satisfies(process.version, `>=${NEXT_MIN_NODE_VERSION}`)) {
   report.warn(
     report.stripIndent(`
-      Node.js ${process.version} has reached End of Life status on 31 December, 2019. 
+      Node.js ${process.version} has reached End of Life status on 31 December, 2019.
       Gatsby will only actively support ${NEXT_MIN_NODE_VERSION} or higher and drop support for Node 8 soon.
       Please upgrade Node.js to a currently active LTS release: https://gatsby.dev/upgrading-node-js
     `)

--- a/packages/gatsby-cli/src/util/ensure-windows-drive-letter-is-uppercase.ts
+++ b/packages/gatsby-cli/src/util/ensure-windows-drive-letter-is-uppercase.ts
@@ -1,5 +1,5 @@
-const { tmpdir } = require(`os`)
-const report = require(`../reporter`)
+import { tmpdir } from "os"
+import report from "../reporter"
 
 /**
  * This function ensures that the current working directory on Windows
@@ -20,7 +20,7 @@ const report = require(`../reporter`)
  * and then the next one from "C:" shell, you may get a bunch of webpack warnings
  * because it expects module paths to be case-sensitive.
  */
-module.exports = function ensureWindowsDriveLetterIsUppercase() {
+export function ensureWindowsDriveLetterIsUppercase(): void {
   const cwd = process.cwd()
   const normalizedCwd = driveLetterToUpperCase(cwd)
 
@@ -51,9 +51,9 @@ module.exports = function ensureWindowsDriveLetterIsUppercase() {
   }
 }
 
-function driveLetterToUpperCase(path) {
+function driveLetterToUpperCase(path: string): string {
   const segments = path.split(`:\\`)
   return segments.length > 1
-    ? segments.shift().toUpperCase() + `:\\` + segments.join(`:\\`)
+    ? segments.shift()!.toUpperCase() + `:\\` + segments.join(`:\\`)
     : path
 }


### PR DESCRIPTION
## Description

Convert `ensure-windows-drive-letter-is-uppercase` to typescript

## Related Issues

Related to #21995
