### PR TITLE
fix(gatsby-dev-cli): Include theme src directories

### DIFF
--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -262,6 +262,9 @@ const monoRepoPackages = [
   `gatsby-source-shopify`,
   `gatsby-source-wikipedia`,
   `gatsby-source-wordpress`,
+  `gatsby-theme-blog`,
+  `gatsby-theme-blog-core`,
+  `gatsby-theme-notes`,
   `gatsby-telemetry`,
   `gatsby-transformer-asciidoc`,
   `gatsby-transformer-csv`,
@@ -312,7 +315,7 @@ jest.mock(`../utils/promisified-spawn`, () => {
   }
 })
 
-describe(`dependency changs`, () => {
+describe(`dependency changes`, () => {
   const { publishPackage } = require(`../local-npm-registry/publish-package`)
   const { installPackages } = require(`../local-npm-registry/install-packages`)
   const { checkDepsChanges } = require(`../utils/check-deps-changes`)

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -151,6 +151,10 @@ async function watch(
     return
   }
 
+  const allPackagesIgnoringThemesToWatch = allPackagesToWatch.filter(
+    pkgName => !pkgName.startsWith(`gatsby-theme`)
+  )
+
   const ignored = [
     /[/\\]node_modules[/\\]/i,
     /\.git/i,
@@ -159,7 +163,9 @@ async function watch(
     /[/\\]__mocks__[/\\]/i,
     /\.npmrc/i,
   ].concat(
-    allPackagesToWatch.map(p => new RegExp(`${p}[\\/\\\\]src[\\/\\\\]`, `i`))
+    allPackagesIgnoringThemesToWatch.map(
+      p => new RegExp(`${p}[\\/\\\\]src[\\/\\\\]`, `i`)
+    )
   )
   const watchers = _.uniq(
     allPackagesToWatch


### PR DESCRIPTION
Themes aren't built/compiled like most packages in the gatsby monorepo so we shouldn't ignore their src directories. This now ensures that `gatsby-dev --packages gatsby-theme-blog` behaves as we'd expect.

~~**Note**: Right now the test is failing because the `gatsby/src` test is failing, I'd imagine because we're calling the add event directly which happens _after_ the watchers. So, in all reality then, my tests aren't actually testing anything. Is there some way to test this functionality that I'm missing?~~

**Edit**: We opted to not test here because it would require digging deeply into the chokidar mocking.