### PR TITLE
Add docs/glossary/build article

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -34,7 +34,7 @@ A tool that lets you write the most modern [JavaScript](#javascript), and on [bu
 
 The behind the scenes that the [public](#public) does not see. This often refers to the control panel of your [CMS](#cms). These are often powered by server-side programming languages such as Node.js, PHP, Go, ASP.net, Ruby, or Java.
 
-### Build
+### [Build](/docs/glossary/build/)
 
 In Gatsby, this is the process of taking your code and content and packaging it into a website that can be hosted and accessed. Commonly referred to as _build time_. See also: [backend](#backend) and [server-side](#server-side).
 

--- a/docs/docs/glossary/build.md
+++ b/docs/docs/glossary/build.md
@@ -30,4 +30,4 @@ When you're ready to publish your project, run the `gatsby build` command to cre
 ### Learn more about builds
 
 - [Deploying and Hosting](/docs/deploying-and-hosting/) from the Gatsby docs
-- How to enabled super fast [Distributed Builds](/docs/distributed-builds/) for Gatsby Cloud
+- How to enable super fast [Distributed Builds](https://www.gatsbyjs.com/docs/distributed-builds/) for Gatsby Cloud

--- a/docs/docs/glossary/build.md
+++ b/docs/docs/glossary/build.md
@@ -5,7 +5,7 @@ disableTableOfContents: true
 
 Learn what _build_ means and how to set up a build process for your Gatsby project.
 
-## What is build?
+## What is a build?
 
 _Build_ refers to the process of compiling your site. During a build, or at _build time_, your project gets transformed from component files to optimized HTML, CSS, and JavaScript files that you can [deploy](/docs/glossary#deploy) to your hosting provider.
 

--- a/docs/docs/glossary/build.md
+++ b/docs/docs/glossary/build.md
@@ -9,11 +9,11 @@ Learn what _build_ means and how to set up a build process for your Gatsby proje
 
 _Build_ refers to the process of compiling your site. During a build, or at _build time_, your project gets transformed from component files to optimized HTML, CSS, and JavaScript files that you can [deploy](/docs/glossary#deploy) to your hosting provider.
 
-There are a few ways to create a build. You can build your site locally on your computer using the [Gatsby CLI](https://www.gatsbyjs.org/docs/gatsby-cli/#build), and then deploy changes to your [host](/docs/glossary#hosting). If you use [Gatsby Cloud](https://www.gatsbyjs.com/), you can take advantage of [Gatsby Builds](/blog/2020-01-27-announcing-gatsby-builds-and-reports/), a feature available with every Gatsby Cloud account. You can also use a [continuous deployment](/docs/glossary/continuous-deployment/) service such as [AWS Amplify](/docs/deploying-to-aws-amplify/) or [Netlify](/docs/deploying-to-netlify/).
+There are a few ways to create a build. You can build your site locally on your computer using the [Gatsby CLI](/docs/gatsby-cli/#build), and then deploy changes to your [host](/docs/glossary#hosting). If you use [Gatsby Cloud](https://www.gatsbyjs.com/), you can take advantage of [Gatsby Builds](/blog/2020-01-27-announcing-gatsby-builds-and-reports/), a feature available with every Gatsby Cloud account. You can also use a [continuous deployment](/docs/glossary/continuous-deployment/) service such as [AWS Amplify](/docs/deploying-to-aws-amplify/) or [Netlify](/docs/deploying-to-netlify/).
 
-For larger teams or larger projects, you may want to use a continuous deployment approach to creating your build. Each CD/CI service works slightly differently. Almost all of them, however, use the contents of a Git repository to build your site. Gatsby Cloud, for example, integrates with [GitHub](https://github.com/), and a number of hosted [content management systems](/docs/glossary#cms). It creates a new build after every commit, although you can also trigger a build manually.
+For larger teams or larger projects, you may want to use a continuous deployment approach to create builds. Each CD/CI service works slightly differently. Almost all of them, however, use the contents of a Git repository to build your site.
 
-With a continuous deployment workflow, each commit to your version control repository triggers a new build and a round of automated testing. If your change passes the tests, it will be deployed to your hosting environment.
+Gatsby Cloud, for example, integrates with [GitHub](https://github.com/), and a number of hosted [content management systems](/docs/glossary#cms). Gatsby Cloud creates a new build after every commit, although you can also trigger a build manually.
 
 ### Using Gatsby <abbr>CLI</abbr>
 
@@ -29,5 +29,5 @@ When you're ready to publish your project, run the `gatsby build` command to cre
 
 ### Learn more about builds
 
-- [Deploying and Hosting](https://www.gatsbyjs.org/docs/deploying-and-hosting/) from the Gatsby docs
-- How to enabled super fast [Distributed Builds](https://www.gatsbyjs.com/docs/distributed-builds/) for Gatsby Cloud
+- [Deploying and Hosting](/docs/deploying-and-hosting/) from the Gatsby docs
+- How to enabled super fast [Distributed Builds](/docs/distributed-builds/) for Gatsby Cloud

--- a/docs/docs/glossary/build.md
+++ b/docs/docs/glossary/build.md
@@ -13,7 +13,7 @@ There are a few ways to create a build. You can build your site locally on your 
 
 For larger teams or larger projects, you may want to use a continuous deployment approach to create builds. Each CD/CI service works slightly differently. Almost all of them, however, use the contents of a Git repository to build your site.
 
-Gatsby Cloud, for example, integrates with [GitHub](https://github.com/), and a number of hosted [content management systems](/docs/glossary#cms). Gatsby Cloud creates a new build after every commit, although you can also trigger a build manually.
+Gatsby Cloud, for example, integrates with [GitHub](https://github.com/), and a number of hosted [content management systems](/docs/glossary#cms). Gatsby Cloud creates a new build after every commit or content change, although you can also trigger a build manually.
 
 ### Using Gatsby <abbr>CLI</abbr>
 

--- a/docs/docs/glossary/build.md
+++ b/docs/docs/glossary/build.md
@@ -1,0 +1,33 @@
+---
+title: Build
+disableTableOfContents: true
+---
+
+Learn what _build_ means and how to set up a build process for your Gatsby project.
+
+## What is build?
+
+_Build_ refers to the process of compiling your site. During a build, or at _build time_, your project gets transformed from component files to optimized HTML, CSS, and JavaScript files that you can [deploy](/docs/glossary#deploy) to your hosting provider.
+
+There are a few ways to create a build. You can build your site locally on your computer using the [Gatsby CLI](https://www.gatsbyjs.org/docs/gatsby-cli/#build), and then deploy changes to your [host](/docs/glossary#hosting). If you use [Gatsby Cloud](https://www.gatsbyjs.com/), you can take advantage of [Gatsby Builds](/blog/2020-01-27-announcing-gatsby-builds-and-reports/), a feature available with every Gatsby Cloud account. You can also use a [continuous deployment](/docs/glossary/continuous-deployment/) service such as [AWS Amplify](/docs/deploying-to-aws-amplify/) or [Netlify](/docs/deploying-to-netlify/).
+
+For larger teams or larger projects, you may want to use a continuous deployment approach to creating your build. Each CD/CI service works slightly differently. Almost all of them, however, use the contents of a Git repository to build your site. Gatsby Cloud, for example, integrates with [GitHub](https://github.com/), and a number of hosted [content management systems](/docs/glossary#cms). It creates a new build after every commit, although you can also trigger a build manually.
+
+With a continuous deployment workflow, each commit to your version control repository triggers a new build and a round of automated testing. If your change passes the tests, it will be deployed to your hosting environment.
+
+### Using Gatsby <abbr>CLI</abbr>
+
+For smaller teams and projects, use `gatsby build`. The `gatsby build` command is part of the Gatsby command line interface (or CLI). You'll need to install the CLI interface to create a site with Gatsby. Install it globally using [npm](/docs/glossary/#npm).
+
+```shell
+npm install -g gatsby-cli
+```
+
+Installing `gatsby-cli` globally makes Gatsby commands available system-wide. You'll use `gatsby new` to [create a new site](/tutorial/part-zero/#create-a-gatsby-site), and `gatsby develop` to start a development server on your local machine.
+
+When you're ready to publish your project, run the `gatsby build` command to create a production-ready version of your site. Once built, you can use an SFTP client, the [rsync](https://en.wikipedia.org/wiki/Rsync) utility, or similar tool to transfer these files to your host.
+
+### Learn more about builds
+
+- [Deploying and Hosting](https://www.gatsbyjs.org/docs/deploying-and-hosting/) from the Gatsby docs
+- How to enabled super fast [Distributed Builds](https://www.gatsbyjs.com/docs/distributed-builds/) for Gatsby Cloud

--- a/docs/docs/glossary/continuous-deployment.md
+++ b/docs/docs/glossary/continuous-deployment.md
@@ -5,7 +5,7 @@ disableTableOfContents: true
 
 ## What is continuous deployment?
 
-Continuous deployment (CD) is the automation of code deployments. In a continuous deployment system, you don't push a <q>Deploy</q> button or run a `deploy` command. Instead, you build a _pipeline_ &mdash; a process that builds and releases code automatically, without human intervention.
+Continuous deployment (CD) is the automation of code deployments. In a continuous deployment system, you don't push a <q>Deploy</q> button or run a `deploy` command. Instead, you build a _pipeline_ &mdash; a process that [builds](/docs/glossary/build/) and releases code automatically, without human intervention.
 
 You'll most likely use a service to create your continuous deployment pipeline. Services such as [Netlify](http://netlify.com/), [AWS Amplify](https://aws.amazon.com/amplify/), [Azure](https://azure.microsoft.com/en-us/), and [Zeit](https://zeit.co/) are popular with Gatsby users. Or you can use [Gatsby Builds](/blog/2020-01-27-announcing-gatsby-builds-and-reports/), a feature of the [Gatsby Cloud](https://www.gatsbyjs.com/) service.
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -745,6 +745,8 @@
     - title: Glossary
       link: /docs/glossary/
       items:
+        - title: Build
+          link: /docs/glossary/build/
         - title: Continuous Deployment
           link: /docs/glossary/continuous-deployment/
         - title: Decoupled Drupal


### PR DESCRIPTION
Update doc-links and glossary.md. Added a link to Build article from the Continuous Deployment entry.