### PR TITLE
remove console log from gatsby-plugin-sharp

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -304,14 +304,6 @@ async function generateBase64({ file, args = {}, reporter }) {
     args.toFormat = forceBase64Format
   }
 
-  console.log({
-    src: file.absolutePath,
-    width: options.width,
-    height: options.height,
-    position: options.cropFocus,
-    fit: options.fit,
-    background: options.background,
-  })
   pipeline
     .resize({
       width: options.width,


### PR DESCRIPTION
Looks like the latest release had a console.log left in it!