### PR TITLE
[docs][guides] Running a Gatsby Preview Server

### DIFF
--- a/docs/docs/running-a-gatsby-preview-server.md
+++ b/docs/docs/running-a-gatsby-preview-server.md
@@ -1,0 +1,18 @@
+---
+title: Running a Gatsby Preview Server
+---
+
+When editing content in a CMS, it's great to see a preview of changes before they go live.
+
+This can be accomplished by setting up a preview server with Gatsby, which can be accomplished a couple of different ways:
+
+## Rolling your own Preview
+
+Roughly, you can follow these steps to enable your own preview server:
+
+- Run `gatsby develop` on a Node.js host like Heroku with the [ENABLE_GATSBY_REFRESH_ENDPOINT environment variable](/docs/environment-variables/#reserved-environment-variables) enabled, which will configure the develop server to re-source data when it receives a `POST` request to `/__refresh`.
+- Then setup your CMS to ping this URL on the preview server whenever content is changed.
+
+## Using Gatsby Cloud Preview
+
+For a managed Preview server, try out [Gatsby Cloud](https://www.gatsbyjs.com/cloud). It's free for personal projects and single-purpose sites, with paid packages for a range of project and company needs.

--- a/docs/docs/running-a-gatsby-preview-server.md
+++ b/docs/docs/running-a-gatsby-preview-server.md
@@ -4,7 +4,7 @@ title: Running a Gatsby Preview Server
 
 When editing content in a CMS, it's great to see a preview of changes before they go live.
 
-This can be accomplished by setting up a preview server with Gatsby, which can be accomplished a couple of different ways:
+This can be accomplished by setting up a preview server with Gatsby, for which there are two options:
 
 ## Rolling your own Preview
 
@@ -15,4 +15,4 @@ Roughly, you can follow these steps to enable your own preview server:
 
 ## Using Gatsby Cloud Preview
 
-For a managed Preview server, try out [Gatsby Cloud](https://www.gatsbyjs.com/cloud). It's free for personal projects and single-purpose sites, with paid packages for a range of project and company needs.
+For a managed Preview server without having to create infrastructure yourself, try out [Gatsby Cloud](https://www.gatsbyjs.com/cloud). It's free for personal projects and single-purpose sites, with paid packages for a range of project and company needs.

--- a/docs/docs/running-a-gatsby-preview-server.md
+++ b/docs/docs/running-a-gatsby-preview-server.md
@@ -10,7 +10,7 @@ This can be accomplished by setting up a preview server with Gatsby, for which t
 
 Roughly, you can follow these steps to enable your own preview server:
 
-- Run `gatsby develop` on a Node.js host like [Heroku](/docs/deploying-to-heroku/) with the [ENABLE_GATSBY_REFRESH_ENDPOINT environment variable](/docs/environment-variables/#reserved-environment-variables) enabled, which will configure the develop server to re-source data when it receives a `POST` request to `/__refresh`.
+- Run `gatsby develop` on a Node.js host like [Heroku](/docs/deploying-to-heroku/) with the [ENABLE_GATSBY_REFRESH_ENDPOINT environment variable](/docs/environment-variables/#reserved-environment-variables) enabled. This will configure the develop server to re-source data when it receives a `POST` request to `/__refresh`.
 - Then setup your CMS to ping this URL on the preview server whenever content is changed.
 
 ## Using Gatsby Cloud Preview

--- a/docs/docs/running-a-gatsby-preview-server.md
+++ b/docs/docs/running-a-gatsby-preview-server.md
@@ -10,7 +10,7 @@ This can be accomplished by setting up a preview server with Gatsby, for which t
 
 Roughly, you can follow these steps to enable your own preview server:
 
-- Run `gatsby develop` on a Node.js host like Heroku with the [ENABLE_GATSBY_REFRESH_ENDPOINT environment variable](/docs/environment-variables/#reserved-environment-variables) enabled, which will configure the develop server to re-source data when it receives a `POST` request to `/__refresh`.
+- Run `gatsby develop` on a Node.js host like [Heroku](/docs/deploying-to-heroku/) with the [ENABLE_GATSBY_REFRESH_ENDPOINT environment variable](/docs/environment-variables/#reserved-environment-variables) enabled, which will configure the develop server to re-source data when it receives a `POST` request to `/__refresh`.
 - Then setup your CMS to ping this URL on the preview server whenever content is changed.
 
 ## Using Gatsby Cloud Preview

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -121,6 +121,8 @@
             - title: Using Environment Variables
               link: /docs/environment-variables/
               breadcrumbTitle: Environment Variables
+            - title: Running a Gatsby Preview Server
+              link: /docs/running-a-gatsby-preview-server/
             - title: Using ESLint
               link: /docs/eslint/
               breadcrumbTitle: ESLint


### PR DESCRIPTION
## Description

Based on feedback from users, we need a docs page on Running a Gatsby Preview Server. It has been unclear for quite a while that there are multiple options–not totally limited to Gatsby Cloud–so this PR intends to put important details in a single place that users can find them.

cc @KyleAMathews 

### Documentation

N/A

## Related Issues

Related to https://github.com/gatsbyjs/gatsby/issues/10328