### PR TITLE
fix(gatsby-cli): Fix an import change that broke `gatsby new`

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -379,7 +379,7 @@ module.exports = argv => {
       command: `new [rootPath] [starter]`,
       desc: `Create new Gatsby project.`,
       handler: handlerP(({ rootPath, starter }) => {
-        const initStarter = require(`./init-starter`)
+        const { initStarter } = require(`./init-starter`)
         return initStarter(starter, { rootPath })
       }),
     })

--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -268,10 +268,10 @@ Your new Gatsby site has been successfully bootstrapped. Start developing it by 
 /**
  * Main function that clones or copies the starter.
  */
-export default async (
+export async function initStarter(
   starter: string,
   options: IInitOptions
-): Promise<void> => {
+): Promise<void> {
   const { starterPath, rootPath, selectedOtherStarter } = await getPaths(
     starter,
     options.rootPath


### PR DESCRIPTION
## Description

In our recent TypeScript changes, we've been switching from `module.exports` to ES6 module syntax. The interop between those modules and commonjs `require` results in a different API (e.g., `require('foo').default`). 

In the future we will be more mindful of all importing modules when making these changes to avoid this.

## Related Issues

Fixes #22157 
