### PR TITLE
Add link to gatsby-plugin-meta-redirect

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1345,7 +1345,9 @@ const maybeAddPathPrefix = (path, pathPrefix) => {
  * of the box. You must have a plugin setup to integrate the redirect data with
  * your hosting technology e.g. the [Netlify
  * plugin](/packages/gatsby-plugin-netlify/), or the [Amazon S3
- * plugin](/packages/gatsby-plugin-s3/).
+ * plugin](/packages/gatsby-plugin-s3/). Alternatively, you can use
+ * [this plugin](/packages/gatsby-plugin-meta-redirect/) to generate meta redirect
+ * html files for redirecting on any static file host.
  *
  * @param {Object} redirect Redirect data
  * @param {string} redirect.fromPath Any valid URL. Must start with a forward slash


### PR DESCRIPTION
## Description

Simply adds a link to [gatsby-plugin-meta-redirect](https://www.gatsbyjs.org/packages/gatsby-plugin-meta-redirect/) which is quite helpful for redirects independent of your hosting solution.