### PR TITLE
chore(gatsby): Clean up file name and dir for wait-until-jobs-complete

### DIFF
--- a/packages/gatsby/src/commands/build.js
+++ b/packages/gatsby/src/commands/build.js
@@ -23,7 +23,7 @@ import {
 } from "../utils/feedback"
 const buildUtils = require(`../commands/build-utils`)
 const { boundActionCreators } = require(`../redux/actions`)
-import { waitUntilAllJobsComplete } from "../utils/commands/jobs-manager"
+import { waitUntilAllJobsComplete } from "../utils/wait-until-jobs-complete"
 
 let cachedPageData
 let cachedWebpackCompilationHash

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -52,7 +52,7 @@ import {
   reportWebpackWarnings,
   structureWebpackErrors,
 } from "../utils/webpack-error-utils"
-import { waitUntilAllJobsComplete } from "../utils/commands/jobs-manager"
+import { waitUntilAllJobsComplete } from "../utils/wait-until-jobs-complete"
 import {
   userPassesFeedbackRequestHeuristic,
   showFeedbackRequest,

--- a/packages/gatsby/src/utils/wait-until-jobs-complete.ts
+++ b/packages/gatsby/src/utils/wait-until-jobs-complete.ts
@@ -1,6 +1,6 @@
-import { emitter, store } from "../../redux"
+import { emitter, store } from "../redux"
 
-import { waitUntilAllJobsComplete as waitUntilAllJobsV2Complete } from "../jobs-manager"
+import { waitUntilAllJobsComplete as waitUntilAllJobsV2Complete } from "./jobs-manager"
 
 export const waitUntilAllJobsComplete = (): Promise<void> => {
   const jobsV1Promise = new Promise(resolve => {


### PR DESCRIPTION
Based on feedback from @wardpeet in https://github.com/gatsbyjs/gatsby/pull/22059/files