### PR TITLE
chore(gatsby): Convert normalize-page-path to typescript

### DIFF
--- a/packages/gatsby/cache-dir/find-path.js
+++ b/packages/gatsby/cache-dir/find-path.js
@@ -1,6 +1,6 @@
 import { match } from "@reach/router/lib/utils"
 import stripPrefix from "./strip-prefix"
-import normalizePagePath from "./normalize-page-path"
+import { normalizePagePath } from "./normalize-page-path"
 
 const pathCache = new Map()
 let matchPaths = []

--- a/packages/gatsby/cache-dir/normalize-page-path.ts
+++ b/packages/gatsby/cache-dir/normalize-page-path.ts
@@ -10,16 +10,3 @@ export function normalizePagePath(path: string): string {
   }
   return path
 }
-
-export function denormalizePagePath(path: string): string {
-  if (path === undefined) {
-    return path
-  }
-  if (path === `/`) {
-    return `/`
-  }
-  if (path.charAt(path.length - 1) !== `/`) {
-    return path + `/`
-  }
-  return path
-}

--- a/packages/gatsby/cache-dir/normalize-page-path.ts
+++ b/packages/gatsby/cache-dir/normalize-page-path.ts
@@ -10,3 +10,16 @@ export function normalizePagePath(path: string): string {
   }
   return path
 }
+
+export function denormalizePagePath(path: string): string {
+  if (path === undefined) {
+    return path
+  }
+  if (path === `/`) {
+    return `/`
+  }
+  if (path.charAt(path.length - 1) !== `/`) {
+    return path + `/`
+  }
+  return path
+}

--- a/packages/gatsby/cache-dir/normalize-page-path.ts
+++ b/packages/gatsby/cache-dir/normalize-page-path.ts
@@ -1,4 +1,4 @@
-export default path => {
+export default (path: string): string => {
   if (path === undefined) {
     return path
   }

--- a/packages/gatsby/cache-dir/normalize-page-path.ts
+++ b/packages/gatsby/cache-dir/normalize-page-path.ts
@@ -1,4 +1,4 @@
-export default (path: string): string => {
+export function normalizePagePath(path: string): string {
   if (path === undefined) {
     return path
   }

--- a/packages/gatsby/cache-dir/query-result-store.js
+++ b/packages/gatsby/cache-dir/query-result-store.js
@@ -7,7 +7,7 @@ import {
   getStaticQueryData,
 } from "./socketIo"
 import PageRenderer from "./page-renderer"
-import normalizePagePath from "./normalize-page-path"
+import { normalizePagePath } from "./normalize-page-path"
 
 if (process.env.NODE_ENV === `production`) {
   throw new Error(

--- a/packages/gatsby/cache-dir/socketIo.js
+++ b/packages/gatsby/cache-dir/socketIo.js
@@ -1,5 +1,5 @@
 import { reportError, clearError } from "./error-overlay-handler"
-import normalizePagePath from "./normalize-page-path"
+import { normalizePagePath } from "./normalize-page-path"
 
 let socket = null
 

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -199,7 +199,7 @@
     "postbuild": "node scripts/output-api-file.js",
     "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
     "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
-    "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs --ignore **/__tests__",
+    "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs --ignore **/__tests__ --extensions \".ts,.js\"",
     "build:src": "babel src --out-dir dist --source-maps --verbose --ignore **/gatsby-cli.js,src/internal-plugins/dev-404-page/raw_dev-404-page.js,**/__tests__ --extensions \".ts,.js\"",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "prebuild": "rimraf dist && rimraf cache-dir/commonjs",

--- a/packages/gatsby/src/utils/normalize-page-path.ts
+++ b/packages/gatsby/src/utils/normalize-page-path.ts
@@ -1,6 +1,6 @@
 // This is a duplicate of the runtime util
 // file cache-dir/normalize-page-path.js
-module.exports = path => {
+export default (path: string): string => {
   if (path === undefined) {
     return path
   }

--- a/packages/gatsby/src/utils/normalize-page-path.ts
+++ b/packages/gatsby/src/utils/normalize-page-path.ts
@@ -12,3 +12,16 @@ export function normalizePagePath(path: string): string {
   }
   return path
 }
+
+export function denormalizePagePath(path: string): string {
+  if (path === undefined) {
+    return path
+  }
+  if (path === `/`) {
+    return `/`
+  }
+  if (path.charAt(path.length - 1) !== `/`) {
+    return path + `/`
+  }
+  return path
+}

--- a/packages/gatsby/src/utils/normalize-page-path.ts
+++ b/packages/gatsby/src/utils/normalize-page-path.ts
@@ -1,6 +1,6 @@
 // This is a duplicate of the runtime util
 // file cache-dir/normalize-page-path.js
-export default (path: string): string => {
+export function normalizePagePath(path: string): string {
   if (path === undefined) {
     return path
   }

--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -4,7 +4,7 @@ const path = require(`path`)
 const { store } = require(`../redux`)
 const fs = require(`fs`)
 const pageDataUtil = require(`../utils/page-data`)
-import { normalizePagePath } from "./normalize-page-path"
+import { normalizePagePath, denormalizePagePath } from "./normalize-page-path"
 const telemetry = require(`gatsby-telemetry`)
 const url = require(`url`)
 const { createHash } = require(`crypto`)
@@ -27,7 +27,7 @@ const getCachedPageData = async (
 ): QueryResult => {
   const { program, pages } = store.getState()
   const publicDir = path.join(program.directory, `public`)
-  if (pages.has(denormalize(pagePath)) || pages.has(pagePath)) {
+  if (pages.has(denormalizePagePath(pagePath)) || pages.has(pagePath)) {
     try {
       const pageData = await pageDataUtil.read({ publicDir }, pagePath)
 

--- a/packages/gatsby/src/utils/websocket-manager.js
+++ b/packages/gatsby/src/utils/websocket-manager.js
@@ -4,7 +4,7 @@ const path = require(`path`)
 const { store } = require(`../redux`)
 const fs = require(`fs`)
 const pageDataUtil = require(`../utils/page-data`)
-const normalizePagePath = require(`../utils/normalize-page-path`)
+import { normalizePagePath } from "./normalize-page-path"
 const telemetry = require(`gatsby-telemetry`)
 const url = require(`url`)
 const { createHash } = require(`crypto`)
@@ -15,19 +15,6 @@ type QueryResult = {
 }
 
 type QueryResultsMap = Map<string, QueryResult>
-
-const denormalize = path => {
-  if (path === undefined) {
-    return path
-  }
-  if (path === `/`) {
-    return `/`
-  }
-  if (path.charAt(path.length - 1) !== `/`) {
-    return path + `/`
-  }
-  return path
-}
 
 /**
  * Get cached page query result for given page path.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Convert `utils/normalize-page-path` and `cache-dir/normalize-page-path` to Typescript

<!-- ### Documentation -->

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to #21995 
