### PR TITLE
chore(gatsby-cli): Convert util/version to typescript

### DIFF
--- a/packages/gatsby-cli/src/util/version.ts
+++ b/packages/gatsby-cli/src/util/version.ts
@@ -1,24 +1,13 @@
 import { setDefaultTags } from "gatsby-telemetry"
-import path from "path"
+import { getGatsbyVersion } from "gatsby-core-utils"
 
 export const getLocalGatsbyVersion = (): string => {
-  let version = ``
-  try {
-    const packageInfo = require(path.join(
-      process.cwd(),
-      `node_modules`,
-      `gatsby`,
-      `package.json`
-    ))
-    version = packageInfo.version
+  const version = getGatsbyVersion()
 
-    try {
-      setDefaultTags({ installedGatsbyVersion: version })
-    } catch (e) {
-      // ignore
-    }
-  } catch (err) {
-    /* ignore */
+  try {
+    setDefaultTags({ installedGatsbyVersion: version })
+  } catch (e) {
+    // ignore
   }
 
   return version

--- a/packages/gatsby-cli/src/util/version.ts
+++ b/packages/gatsby-cli/src/util/version.ts
@@ -1,8 +1,8 @@
-const { setDefaultTags } = require(`gatsby-telemetry`)
-const path = require(`path`)
+import { setDefaultTags } from "gatsby-telemetry"
+import path from "path"
 
-exports.getLocalGatsbyVersion = () => {
-  let version
+export const getLocalGatsbyVersion = (): string => {
+  let version = ``
   try {
     const packageInfo = require(path.join(
       process.cwd(),


### PR DESCRIPTION
## Description

chore(gatsby-cli): Convert util/version to typescript

## Related Issues

Related to #21995