### PR TITLE
chore(doc):Add babel preset css prop to jest-preprocess.js

### DIFF
--- a/docs/docs/testing-css-in-js.md
+++ b/docs/docs/testing-css-in-js.md
@@ -22,7 +22,7 @@ If you followed along with the [Unit testing guide](/docs/unit-testing) you'll h
 
 ```diff:title=jest-preprocess.js
 const babelOptions = {
-  presets: ["babel-preset-gatsby"],
+~  presets: ["babel-preset-gatsby", "@emotion/babel-preset-css-prop"],
 +  plugins: [
 +    "emotion",
 +  ],


### PR DESCRIPTION
## Description

Add `@emotion/babel-preset-css-prop` to the `jest-preprocess.js` file. This allows for the stringificaiton of CSS properties in snapshot testing. Currently, with Emotion 10, if the babel option is not set, you will not have readable css properties. @emotion/babel-preset-css-prop is shipped by default with Emotion 10 and does not need to be installed seperately by npm.

### Documentation

[https://github.com/emotion-js/emotion/tree/master/packages/babel-preset-css-prop](https://github.com/emotion-js/emotion/tree/master/packages/babel-preset-css-prop)
