### PR TITLE
chore(gatsby) Convert get-value-at to typescript

### DIFF
--- a/packages/gatsby/src/db/loki/nodes-query.js
+++ b/packages/gatsby/src/db/loki/nodes-query.js
@@ -17,7 +17,7 @@ const {
   objectToDottedField,
   liftResolvedFields,
 } = require(`../common/query`)
-const { getValueAt } = require(`../../utils/get-value-at`)
+import { getValueAt } from "../../utils/get-value-at"
 const { runSiftOnNodes } = require(`../../redux/run-sift`)
 
 // Takes a raw graphql filter and converts it into a mongo-like args

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -3,7 +3,7 @@ const { default: sift } = require(`sift`)
 const _ = require(`lodash`)
 const { prepareRegex } = require(`../utils/prepare-regex`)
 const { makeRe } = require(`micromatch`)
-const { getValueAt } = require(`../utils/get-value-at`)
+import { getValueAt } from "../utils/get-value-at"
 const {
   toDottedFields,
   objectToDottedField,

--- a/packages/gatsby/src/schema/infer/is-file.js
+++ b/packages/gatsby/src/schema/infer/is-file.js
@@ -3,7 +3,7 @@ const { slash } = require(`gatsby-core-utils`)
 const mime = require(`mime`)
 const isRelative = require(`is-relative`)
 const isRelativeUrl = require(`is-relative-url`)
-const { getValueAt } = require(`../../utils/get-value-at`)
+import { getValueAt } from "../../utils/get-value-at"
 
 const isFile = (nodeStore, fieldPath, relativePath) => {
   const filePath = getFilePath(nodeStore, fieldPath, relativePath)

--- a/packages/gatsby/src/schema/resolvers.js
+++ b/packages/gatsby/src/schema/resolvers.js
@@ -2,7 +2,7 @@ const systemPath = require(`path`)
 const normalize = require(`normalize-path`)
 const _ = require(`lodash`)
 const { GraphQLList, getNullableType, getNamedType, Kind } = require(`graphql`)
-const { getValueAt } = require(`../utils/get-value-at`)
+import { getValueAt } from "../utils/get-value-at"
 
 const findMany = typeName => (source, args, context, info) =>
   context.nodeModel.runQuery(

--- a/packages/gatsby/src/utils/__tests__/get-value-at.ts
+++ b/packages/gatsby/src/utils/__tests__/get-value-at.ts
@@ -1,4 +1,4 @@
-const { getValueAt } = require(`../get-value-at`)
+import { getValueAt } from "../get-value-at"
 
 describe(`getValueAt util`, () => {
   it(`handles object properties`, () => {

--- a/packages/gatsby/src/utils/get-value-at.ts
+++ b/packages/gatsby/src/utils/get-value-at.ts
@@ -1,10 +1,10 @@
-export function getValueAt(obj: object, selector: string | string[]): Any {
+export function getValueAt(obj: object, selector: string | string[]): any {
   const selectors =
     typeof selector === `string` ? selector.split(`.`) : selector
   return get(obj, selectors)
 }
 
-function get(obj: object, selectors: string[]): Any {
+function get(obj: object, selectors: string[]): any {
   if (Array.isArray(obj)) return getArray(obj, selectors)
   const [key, ...rest] = selectors
   const value = obj[key]
@@ -14,7 +14,7 @@ function get(obj: object, selectors: string[]): Any {
   return undefined
 }
 
-function getArray(arr: object, selectors: string[]): Any[] {
+function getArray(arr: object[], selectors: string[]): any[] {
   return arr
     .map(value =>
       Array.isArray(value) ? getArray(value, selectors) : get(value, selectors)

--- a/packages/gatsby/src/utils/get-value-at.ts
+++ b/packages/gatsby/src/utils/get-value-at.ts
@@ -1,10 +1,10 @@
-const getValueAt = (obj, selector) => {
+export function getValueAt(obj: object, selector: string | string[]): Any {
   const selectors =
     typeof selector === `string` ? selector.split(`.`) : selector
   return get(obj, selectors)
 }
 
-const get = (obj, selectors) => {
+function get(obj: object, selectors: string[]): Any {
   if (Array.isArray(obj)) return getArray(obj, selectors)
   const [key, ...rest] = selectors
   const value = obj[key]
@@ -14,11 +14,10 @@ const get = (obj, selectors) => {
   return undefined
 }
 
-const getArray = (arr, selectors) =>
-  arr
+function getArray(arr: object, selectors: string[]): Any[] {
+  return arr
     .map(value =>
       Array.isArray(value) ? getArray(value, selectors) : get(value, selectors)
     )
     .filter(v => v !== undefined)
-
-module.exports = { getValueAt }
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Convert `utils/get-value-at` and `__tests__/get-value-at` to Typescript

<!-- ### Documentation -->

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to #21995 
