### PR TITLE
feat(gatsby-theme-blog): Refactor some larger components to be smaller

### DIFF
--- a/packages/gatsby-theme-blog/src/components/post-date.js
+++ b/packages/gatsby-theme-blog/src/components/post-date.js
@@ -1,0 +1,15 @@
+/** @jsx jsx */
+import { Styled, jsx } from "theme-ui"
+
+const PostDate = props => (
+  <Styled.p
+    sx={{
+      fontSize: 1,
+      mt: -3,
+      mb: 3,
+    }}
+    {...props}
+  />
+)
+
+export default PostDate

--- a/packages/gatsby-theme-blog/src/components/post-link.js
+++ b/packages/gatsby-theme-blog/src/components/post-link.js
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { Styled, jsx } from "theme-ui"
+import { Link } from "gatsby"
+
+const PostLink = ({ title, slug, date, excerpt }) => (
+  <div>
+    <Styled.h2
+      sx={{
+        mb: 1,
+      }}
+    >
+      <Styled.a
+        as={Link}
+        sx={{
+          textDecoration: `none`,
+        }}
+        to={slug}
+      >
+        {title || slug}
+      </Styled.a>
+    </Styled.h2>
+    <small>{date}</small>
+    <Styled.p>{excerpt}</Styled.p>
+  </div>
+)
+
+export default PostLink

--- a/packages/gatsby-theme-blog/src/components/post-list.js
+++ b/packages/gatsby-theme-blog/src/components/post-list.js
@@ -1,0 +1,13 @@
+import React from "react"
+
+import PostLink from "./post-link"
+
+const PostList = ({ posts }) => (
+  <>
+    {posts.map(({ node }) => (
+      <PostLink key={node.slug} {...node} />
+    ))}
+  </>
+)
+
+export default PostList

--- a/packages/gatsby-theme-blog/src/components/post-title.js
+++ b/packages/gatsby-theme-blog/src/components/post-title.js
@@ -1,0 +1,6 @@
+import React from "react"
+import { Styled } from "theme-ui"
+
+const PostTitle = props => <Styled.h1 {...props} />
+
+export default PostTitle

--- a/packages/gatsby-theme-blog/src/components/post.js
+++ b/packages/gatsby-theme-blog/src/components/post.js
@@ -1,10 +1,12 @@
 import React from "react"
-import { Styled, css } from "theme-ui"
 
-import PostFooter from "../components/post-footer"
-import Layout from "../components/layout"
-import SEO from "../components/seo"
 import { MDXRenderer } from "gatsby-plugin-mdx"
+
+import Layout from "./layout"
+import SEO from "./seo"
+import PostTitle from "./post-title"
+import PostDate from "./post-date"
+import PostFooter from "./post-footer"
 
 const Post = ({
   data: {
@@ -18,18 +20,14 @@ const Post = ({
   next,
 }) => (
   <Layout location={location} title={title}>
-    <SEO title={post.title} description={post.excerpt} />
+    <SEO
+      title={post.title}
+      description={post.excerpt}
+      keywords={post.keywords}
+    />
     <main>
-      <Styled.h1>{post.title}</Styled.h1>
-      <Styled.p
-        css={css({
-          fontSize: 1,
-          mt: -3,
-          mb: 3,
-        })}
-      >
-        {post.date}
-      </Styled.p>
+      <PostTitle>{post.title}</PostTitle>
+      <PostDate>{post.date}</PostDate>
       <MDXRenderer>{post.body}</MDXRenderer>
     </main>
     <PostFooter {...{ previous, next }} />

--- a/packages/gatsby-theme-blog/src/components/posts.js
+++ b/packages/gatsby-theme-blog/src/components/posts.js
@@ -1,42 +1,15 @@
-import React, { Fragment } from "react"
-import { Link } from "gatsby"
-import { Styled, css } from "theme-ui"
+import React from "react"
 
-import Layout from "../components/layout"
-import SEO from "../components/seo"
-import Footer from "../components/home-footer"
+import Layout from "./layout"
+import SEO from "./seo"
+import Footer from "./home-footer"
+import PostList from "./post-list"
 
 const Posts = ({ location, posts, siteTitle, socialLinks }) => (
   <Layout location={location} title={siteTitle}>
+    <SEO title="Home" />
     <main>
-      {posts.map(({ node }) => {
-        const title = node.title || node.slug
-        const keywords = node.keywords || []
-        return (
-          <Fragment key={node.slug}>
-            <SEO title="Home" keywords={keywords} />
-            <div>
-              <Styled.h2
-                css={css({
-                  mb: 1,
-                })}
-              >
-                <Styled.a
-                  as={Link}
-                  css={css({
-                    textDecoration: `none`,
-                  })}
-                  to={node.slug}
-                >
-                  {title}
-                </Styled.a>
-              </Styled.h2>
-              <small>{node.date}</small>
-              <Styled.p>{node.excerpt}</Styled.p>
-            </div>
-          </Fragment>
-        )
-      })}
+      <PostList posts={posts} />
     </main>
     <Footer socialLinks={socialLinks} />
   </Layout>

--- a/packages/gatsby-theme-blog/src/components/seo.js
+++ b/packages/gatsby-theme-blog/src/components/seo.js
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-function SEO({ description, lang, meta, keywords, title }) {
+function SEO({ description, lang, meta, keywords = [], title }) {
   const { site } = useStaticQuery(
     graphql`
       query {


### PR DESCRIPTION
This will improve the extensibility for users that want to use component shadowing because they can extend/customize components at a [more granular level](https://johno.com/component-organization-with-gatsby-themes/).

Since this PR is only splitting up components it _shouldn't_ be a breaking change because any existing usages of shadowing by end users would be shadowing further up the component tree already.