### PR TITLE
chore(gatsby): remove yarn.lock from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ node_modules/
 
 # lock files
 yarn.lock
+package-lock.json
 # ignore any lock file other than main lock file
 !/yarn.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,17 +51,9 @@ node_modules/
 .eslintcache
 
 # lock files
-benchmarks/*/yarn.lock
-e2e-tests/*/yarn.lock
-examples/*/yarn.lock
-integration-tests/*/yarn.lock
-peril/*/yarn.lock
-rcfs/*/yarn.lock
-scripts/*/yarn.lock
-starters/*/yarn.lock
-www/*/yarn.lock
-packages/*/yarn.lock
-package-lock.json
+yarn.lock
+# ignore any lock file other than main lock file
+!/yarn.lock
 
 # starters are special; we want to persist the lock files
 !starters/*/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-
-packages/*/yarn.lock
-packages/*/package-lock.json
-
 # Logs
 logs
 *.log
@@ -55,7 +51,16 @@ node_modules/
 .eslintcache
 
 # lock files
-yarn.lock
+benchmarks/*/yarn.lock
+e2e-tests/*/yarn.lock
+examples/*/yarn.lock
+integration-tests/*/yarn.lock
+peril/*/yarn.lock
+rcfs/*/yarn.lock
+scripts/*/yarn.lock
+starters/*/yarn.lock
+www/*/yarn.lock
+packages/*/yarn.lock
 package-lock.json
 
 # starters are special; we want to persist the lock files


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Removed `yarn.lock` from `.gitignore`
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #22072 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
