### PR TITLE
chore(gatsby-source-filesystem): fix jdoc

### DIFF
--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -74,7 +74,7 @@ export function createProgress(message, reporter) {
  *
  * @param  {String} directory
  * @param  {String} filename
- * @param  {String} url
+ * @param  {String} ext
  * @return {String}
  */
 export function createFilePath(directory, filename, ext) {


### PR DESCRIPTION
## Description

changed:
- fix doc parameter name

