### PR TITLE
fix(gatsby-source-drupal): Add safety check for existence of datum.

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -131,6 +131,7 @@ exports.sourceNodes = async (
   _.each(allData, contentType => {
     if (!contentType) return
     _.each(contentType.data, datum => {
+      if (!datum) return
       const node = nodeFromData(datum, createNodeId)
       nodes.set(node.id, node)
     })


### PR DESCRIPTION
## Description

Adds a safety check for datum while creating nodes.

### Documentation

## Related Issues

Fixes #22212
Fixes: https://www.drupal.org/project/gatsby/issues/3118764
