### PR TITLE
fix(gatsby-source-drupal): Check if referenced nodes exist before map…

### DIFF
--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -146,9 +146,9 @@ const handleWebhookUpdate = async (
     nodesToUpdate.push(...addedReferencedNodes)
   } else {
     // if we are inserting new node, we need to update all referenced nodes
-    const newNodeReferencedNodes = referencedNodesLookup
-      .get(newNode)
-      .map(id => getNode(id))
+    const referencedNodes = referencedNodesLookup.get(newNode)
+    if (!referencedNodes) return
+    const newNodeReferencedNodes = referencedNodes.map(id => getNode(id))
     nodesToUpdate.push(...newNodeReferencedNodes)
   }
 


### PR DESCRIPTION
## Description

Check if referenced nodes exist before mapping over them.

Some users were seeing this error during Preview updates on Gatsby Cloud:

```
10:33:18 AM: Updated node: a9240467-a405-5020-9188-405cfcdb238c Updated node: a9240467-a405-5020-9188-405cfcdb238c Updated node: 12b8c91c-e6e5-55d8-bbaf-c635a719cca1 Updated node: 59eba7b4-4cf5-5ec8-9b93-86a3493a3ff5

10:33:18 AM: error UNHANDLED REJECTION Cannot read property 'map' of undefined

10:33:18 AM: TypeError: Cannot read property 'map' of undefined - utils.js:147 handleWebhookUpdate [www]/[gatsby-source-drupal]/utils.js:147:70 - gatsby-node.js:206 [www]/[gatsby-source-drupal]/gatsby-node.js:206:20 - layer.js:95 Layer.handle [as handle_request] [www]/[express]/lib/router/layer.js:95:5 - index.js:317 trim_prefix [www]/[express]/lib/router/index.js:317:13 - index.js:284 [www]/[express]/lib/router/index.js:284:7 - index.js:335 Function.process_params [www]/[express]/lib/router/index.js:335:12 - index.js:275 next [www]/[express]/lib/router/index.js:275:10 - read.js:130 [www]/[body-parser]/lib/read.js:130:5 - index.js:224 invokeCallback [www]/[raw-body]/index.js:224:16 - index.js:213 done [www]/[raw-body]/index.js:213:7 - index.js:273 IncomingMessage.onEnd [www]/[raw-body]/index.js:273:7 - task_queues.js:84 processTicksAndRejections internal/process/task_queues.js:84:21

10:33:19 AM: not finished rebuild schema - 4.704s
```

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
