### PR TITLE
chore: bump redux

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -38,7 +38,7 @@
     "progress": "^2.0.3",
     "prompts": "^2.3.0",
     "react": "^16.8.0",
-    "redux": "^4.0.4",
+    "redux": "^4.0.5",
     "resolve-cwd": "^2.0.0",
     "semver": "^6.3.0",
     "signal-exit": "^3.0.2",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -120,7 +120,7 @@
     "react-error-overlay": "^3.0.0",
     "react-hot-loader": "^4.12.18",
     "react-refresh": "^0.7.0",
-    "redux": "^4.0.4",
+    "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "semver": "^5.7.1",
     "shallow-compare": "^1.2.2",

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -55,7 +55,7 @@ const multi: Middleware = ({ dispatch }) => next => (
 
 export const configureStore = (initialState: IReduxState): Store<IReduxState> =>
   createStore(
-    combineReducers({ ...reducers }),
+    combineReducers<IReduxState>({ ...reducers }),
     initialState,
     applyMiddleware(thunk, multi)
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -19145,10 +19145,10 @@ redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
 
-redux@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
-  integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
+redux@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"


### PR DESCRIPTION
This is split from https://github.com/gatsbyjs/gatsby/pull/20727. That PR is blocked on other things (which https://github.com/gatsbyjs/gatsby/pull/22224 tries to solve).

This PR is mostly to make sure fixed renovate PR will not need any additional code changes 