### PR TITLE
chore(gatsby-cli): Convert src/util/version to typescript

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -4,7 +4,7 @@ const yargs = require(`yargs`)
 const report = require(`./reporter`)
 const { setStore } = require(`./reporter/redux`)
 const { didYouMean } = require(`./did-you-mean`)
-const { getLocalGatsbyVersion } = require(`./util/version`)
+import { getLocalGatsbyVersion } from "./util/version"
 const envinfo = require(`envinfo`)
 const existsSync = require(`fs-exists-cached`).sync
 const clipboardy = require(`clipboardy`)

--- a/packages/gatsby-cli/src/util/version.ts
+++ b/packages/gatsby-cli/src/util/version.ts
@@ -1,8 +1,8 @@
 const { setDefaultTags } = require(`gatsby-telemetry`)
 const path = require(`path`)
 
-exports.getLocalGatsbyVersion = () => {
-  let version
+export const getLocalGatsbyVersion = (): string | undefined => {
+  let version: string | undefined
   try {
     const packageInfo = require(path.join(
       process.cwd(),


### PR DESCRIPTION
## Description

Convert `src/utils/version` to typescript.

## Related Issues

Related to #21995