### PR TITLE
fix(www): Netlify redirect rules require force

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -18,7 +18,7 @@ exports.createPages = async helpers => {
   const { createRedirect } = actions
 
   redirects.forEach(redirect => {
-    createRedirect({ isPermanent: true, ...redirect })
+    createRedirect({ isPermanent: true, ...redirect, force: true })
   })
 
   Object.entries(startersRedirects).forEach(([fromSlug, toSlug]) => {
@@ -26,6 +26,7 @@ exports.createPages = async helpers => {
       fromPath: `/starters${fromSlug}`,
       toPath: `/starters${toSlug}`,
       isPermanent: true,
+      force: true,
     })
   })
 


### PR DESCRIPTION
Based on [Netlify's breaking change](https://community.netlify.com/t/changed-behavior-in-redirects/10084) we need existing redirects for .org to use the force flag. Behind the scenes in the netlify plugin this will set `!` on the redirect. Netlify previously treated redirects as forced by default and no longer will, resulting in this change being necessary.