### PR TITLE
fix: make 11321 and 11330 error formatters backward compatible

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -312,7 +312,8 @@ const errors = {
     text: (context): string =>
       `"${context.pluginName}" threw an error while running the ${
         context.api
-      } lifecycle:\n\n${context.sourceMessage}${optionalGraphQLInfo(context)}`,
+      } lifecycle:\n\n${context.sourceMessage ??
+        context.message}${optionalGraphQLInfo(context)}`,
     type: Type.PLUGIN,
     level: Level.ERROR,
   },
@@ -408,7 +409,15 @@ const errors = {
   // "X" is not defined in Gatsby's node APIs
   "11330": {
     text: (context): string =>
-      `"${context.pluginName}" threw an error while running the ${context.api} lifecycle:\n\n${context.sourceMessage}\n\n${context.codeFrame}\n\nMake sure that you don't have a typo somewhere and use valid arguments in ${context.api} lifecycle.\nLearn more about ${context.api} here: https://www.gatsbyjs.org/docs/node-apis/#${context.api}`,
+      `"${context.pluginName}" threw an error while running the ${
+        context.api
+      } lifecycle:\n\n${context.sourceMessage ?? context.message}\n\n${
+        context.codeFrame
+      }\n\nMake sure that you don't have a typo somewhere and use valid arguments in ${
+        context.api
+      } lifecycle.\nLearn more about ${
+        context.api
+      } here: https://www.gatsbyjs.org/docs/node-apis/#${context.api}`,
     type: Type.PLUGIN,
     level: Level.ERROR,
   },


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/20597 renamed some field names for consistency with other errors, but this is dangerous because errorMap and error showing are in different packages which versions might drift, so we do need to add a bit of compat code (to fallback to previous fieldname if new one is undefined)