### PR TITLE
chore(gatsby-core-utils): add typescript as dev dependency

### DIFF
--- a/packages/gatsby-core-utils/package.json
+++ b/packages/gatsby-core-utils/package.json
@@ -38,6 +38,7 @@
     "@babel/core": "^7.7.5",
     "@types/ci-info": "2.0.0",
     "babel-preset-gatsby-package": "^0.2.17",
-    "cross-env": "^5.2.1"
+    "cross-env": "^5.2.1",
+    "typescript": "^3.7.3"
   }
 }


### PR DESCRIPTION
## Description

This is follow up to https://github.com/gatsbyjs/gatsby/pull/22143.

With `typegen` now being part of build, we do need `typescript` to get `tsc` in `node_modules/.bin`. Otherwise if system doesn't have global typescript installed it will fail to build the package - as example https://circleci.com/gh/gatsbyjs/gatsby/351790?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

```shell
> gatsby-core-utils@1.0.33-dev-1584140132901 prepare .
> cross-env NODE_ENV=production npm run build && npm run typegen


> gatsby-core-utils@1.0.33-dev-1584140132901 build /home/circleci/project/packages/gatsby-core-utils
> babel src --out-dir dist/ --ignore **/__tests__ --ignore **/__mocks__ --extensions ".ts"

Successfully compiled 10 files with Babel.

> gatsby-core-utils@1.0.33-dev-1584140132901 typegen /home/circleci/project/packages/gatsby-core-utils
> tsc --emitDeclarationOnly --declaration --declarationDir dist/

sh: 1: tsc: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! gatsby-core-utils@1.0.33-dev-1584140132901 typegen: `tsc --emitDeclarationOnly --declaration --declarationDir dist/`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the gatsby-core-utils@1.0.33-dev-1584140132901 typegen script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

No `yarn.lock` changes needed - same `typescript` version as in monorepo package.jsopn

## Related Issues

Related to #22143 
