### PR TITLE
chore(gatsby): Convert util/worker/render-html to typescript

### DIFF
--- a/packages/gatsby/src/utils/worker/child.js
+++ b/packages/gatsby/src/utils/worker/child.js
@@ -1,7 +1,8 @@
 // Note: this doesn't check for conflicts between module exports
 import { getFilePath } from "./page-data"
+import { renderHTML } from "./render-html"
 
 module.exports = {
   getFilePath,
-  ...require(`./render-html`),
+  renderHTML,
 }

--- a/packages/gatsby/src/utils/worker/render-html.ts
+++ b/packages/gatsby/src/utils/worker/render-html.ts
@@ -1,9 +1,17 @@
-const fs = require(`fs-extra`)
-const Promise = require(`bluebird`)
-const { join } = require(`path`)
+import fs from "fs-extra"
+import Promise from "bluebird"
+import { join } from "path"
 import { getPageHtmlFilePath } from "../../utils/page-html"
 
-export function renderHTML({ htmlComponentRendererPath, paths, envVars }) {
+export const renderHTML = ({
+  htmlComponentRendererPath,
+  paths,
+  envVars,
+}: {
+  htmlComponentRendererPath: string
+  paths: string
+  envVars: [string, string][]
+}): Promise<unknown[]> => {
   // This is being executed in child process, so we need to set some vars
   // for modules that aren't bundled by webpack.
   envVars.forEach(([key, value]) => (process.env[key] = value))
@@ -14,7 +22,7 @@ export function renderHTML({ htmlComponentRendererPath, paths, envVars }) {
       new Promise((resolve, reject) => {
         const htmlComponentRenderer = require(htmlComponentRendererPath)
         try {
-          htmlComponentRenderer.default(path, (throwAway, htmlString) => {
+          htmlComponentRenderer.default(path, (_throwAway, htmlString) => {
             resolve(
               fs.outputFile(
                 getPageHtmlFilePath(join(process.cwd(), `public`), path),


### PR DESCRIPTION
## Description

Convert `util/worker/render-html ` to typescript.

## Related Issues

Related to #21995