### PR TITLE
fix(gatsby-plugin-offline): overwrite workboxConfig.runtimeCaching with user's option

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -150,15 +150,20 @@ exports.onPostBuild = (
     skipWaiting: true,
     clientsClaim: true,
   }
-  
+
   const customMergeFunction = (objValue, srcValue) => {
-    if (_.isArray(objValue))
+    if (_.isArray(objValue)) {
       return srcValue
-    else
+    } else {
       return _.mergeWith(objValue, srcValue, customMergeFunction)
+    }
   }
 
-  const combinedOptions = _.mergeWith(options, workboxConfig, customMergeFunction);
+  const combinedOptions = _.mergeWith(
+    options,
+    workboxConfig,
+    customMergeFunction
+  )
 
   const idbKeyvalFile = `idb-keyval-iife.min.js`
   const idbKeyvalSource = require.resolve(`idb-keyval/dist/${idbKeyvalFile}`)

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -154,6 +154,8 @@ exports.onPostBuild = (
   const customMergeFunction = (objValue, srcValue) => {
     if (_.isArray(objValue))
       return srcValue
+    else
+      return _.mergeWith(objValue, srcValue, customMergeFunction)
   }
 
   const combinedOptions = _.mergeWith(options, workboxConfig, customMergeFunction);

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -150,8 +150,13 @@ exports.onPostBuild = (
     skipWaiting: true,
     clientsClaim: true,
   }
+  
+  const customMergeFunction = (objValue, srcValue) => {
+    if (_.isArray(objValue))
+      return srcValue
+  }
 
-  const combinedOptions = _.merge(options, workboxConfig)
+  const combinedOptions = _.mergeWith(options, workboxConfig, customMergeFunction);
 
   const idbKeyvalFile = `idb-keyval-iife.min.js`
   const idbKeyvalSource = require.resolve(`idb-keyval/dist/${idbKeyvalFile}`)


### PR DESCRIPTION
Overwrite default option with user's options.

I'm not sure whether it is a bug or a feature.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

See #22264.

### Documentation

This pr is a bug fix.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

fix #22264

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
