### PR TITLE
test: use property matcher to not rely on relative location of loader package

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.js.snap
@@ -7,7 +7,7 @@ Object {
   "type": "javascript/auto",
   "use": Array [
     Object {
-      "loader": "<PROJECT_ROOT>/packages/gatsby/node_modules/babel-loader/lib/index.js",
+      "loader": StringContaining "babel-loader",
       "options": Object {
         "babelrc": false,
         "cacheIdentifier": "develop---gatsby-dependencies@1.0.0",
@@ -30,7 +30,7 @@ Object {
   "type": "javascript/auto",
   "use": Array [
     Object {
-      "loader": "<PROJECT_ROOT>/packages/gatsby/src/utils/babel-loader.js",
+      "loader": StringContaining "babel-loader",
       "options": Object {
         "compact": false,
         "configFile": true,

--- a/packages/gatsby/src/utils/__tests__/webpack-utils.js
+++ b/packages/gatsby/src/utils/__tests__/webpack-utils.js
@@ -25,7 +25,13 @@ describe(`webpack utils`, () => {
     it(`returns default values without any options`, () => {
       const rule = config.rules.js()
 
-      expect(rule).toMatchSnapshot()
+      expect(rule).toMatchSnapshot({
+        use: [
+          {
+            loader: expect.stringContaining(`babel-loader`),
+          },
+        ],
+      })
     })
     describe(`include function`, () => {
       let js
@@ -84,7 +90,13 @@ describe(`webpack utils`, () => {
     it(`returns default values without any options`, () => {
       const rule = config.rules.dependencies()
 
-      expect(rule).toMatchSnapshot()
+      expect(rule).toMatchSnapshot({
+        use: [
+          {
+            loader: expect.stringContaining(`babel-loader`),
+          },
+        ],
+      })
     })
     describe(`exclude function`, () => {
       let dependencies


### PR DESCRIPTION
This is meant to have snapshot assertion be more resilient to to node_modules hierarchy.

For example in https://github.com/gatsbyjs/gatsby/pull/20727 this test breaks because `babel-loader` lands in different spot. This will keep spirit of the test, just making sure that loader is a string containing `babel-loader`.