### PR TITLE
chore(docs): Adds Dgraph's GraphQL API example link

### DIFF
--- a/docs/docs/third-party-graphql.md
+++ b/docs/docs/third-party-graphql.md
@@ -100,3 +100,4 @@ exports.createPages = async ({ actions, graphql }) => {
 - [Example with GraphCMS](https://github.com/freiksenet/gatsby-graphcms)
 - [Example with Hasura](https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/gatsby-postgres-graphql)
 - [Example with AWS AppSync](https://github.com/aws-samples/aws-appsync-gatsby-sample)
+- [Example with Dgraph](https://github.com/vardhanapoorv/gatsby-dgraph-graphql)


### PR DESCRIPTION
Simple blog app with Gatsby and Dgraph. Adds the example to "Further reading" section.