### PR TITLE
chore(categories): add Milligram 

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -59,6 +59,7 @@ starter:
   - Styling:PostCSS
   - Styling:SCSS
   - Styling:Tailwind
+  - Styling:Milligram
   - Styling:Other
   - Styling:None
   - Testing


### PR DESCRIPTION
## Description

Added the [Milligram](https://github.com/milligram/milligram) CSS framework to the `categories.yml`.

I used this framework for my gatsby [starter](https://github.com/masoudkarimif/gatsby-starter-clean-resume).