### PR TITLE
chore(gatsby): Convert js-chunk-names to typescript

### DIFF
--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -1,4 +1,5 @@
 import { GraphQLSchema } from "graphql"
+import { IProgram } from "../commands/types"
 
 export enum ProgramStatus {
   BOOTSTRAP_FINISHED = `BOOTSTRAP_FINISHED`,
@@ -40,6 +41,7 @@ export interface IReduxState {
   babelrc: any
   themes: any
   flattenedPlugins: any
+  program: IProgram
 }
 
 export interface ICachedReduxState {

--- a/packages/gatsby/src/utils/js-chunk-names.ts
+++ b/packages/gatsby/src/utils/js-chunk-names.ts
@@ -1,8 +1,8 @@
-const { kebabCase } = require(`lodash`)
-const path = require(`path`)
-const { store } = require(`../redux`)
+import { kebabCase } from "lodash"
+import path from "path"
+import { store } from "../redux"
 
-const generateComponentChunkName = componentPath => {
+export const generateComponentChunkName = (componentPath: string): string => {
   const program = store.getState().program
   let directory = `/`
   if (program && program.directory) {
@@ -11,5 +11,3 @@ const generateComponentChunkName = componentPath => {
   const name = path.relative(directory, componentPath)
   return `component---${kebabCase(name)}`
 }
-
-exports.generateComponentChunkName = generateComponentChunkName


### PR DESCRIPTION
## Description

I converted js-chunk-names to typescript

## Related Issues

Related to #21995

