### PR TITLE
Revert "feat(gatsby-plugin-typescript): Supports linting (#18721)"

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -77,9 +77,3 @@ Visual Studio Code is very good in this regard.
 
 In addition, you can see the instructions in [TypeScript-Babel-Starter](https://github.com/Microsoft/TypeScript-Babel-Starter)
 for setting up a `type-check` task.
-
-## ESLint
-
-This plugin supports linting TSX with [typescript-eslint](https://typescript-eslint.io) using [Gatsby's default ESLint config](https://www.gatsbyjs.org/docs/eslint/). To enable linting TSX, install `typescript`.
-
-`npm install typescript`

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -33,13 +33,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0",
-    "typescript": "^3.2.1"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
+    "gatsby": "^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -49,40 +49,13 @@ describe(`gatsby-plugin-typescript`, () => {
       const actions = { setWebpackConfig: jest.fn() }
       const jsLoader = {}
       const loaders = { js: jest.fn(() => jsLoader) }
-      const stage = `develop`
-      const eslintLoader = { loader: `eslint-loader` }
-      const webpackConfig = {
-        module: {
-          rules: [
-            {
-              enforce: `pre`,
-              test: /\.jsx?$/,
-              exclude: /(node_modules|bower_components)/,
-              use: [eslintLoader],
-            },
-          ],
-        },
-      }
-      const getConfig = jest.fn(() => webpackConfig)
-      onCreateWebpackConfig({ actions, getConfig, loaders, stage })
+      onCreateWebpackConfig({ actions, loaders })
       expect(actions.setWebpackConfig).toHaveBeenCalledWith({
         module: {
           rules: [
             {
               test: /\.tsx?$/,
               use: jsLoader,
-            },
-          ],
-        },
-      })
-      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
-        module: {
-          rules: [
-            {
-              enforce: `pre`,
-              test: /\.tsx?$/,
-              exclude: /(node_modules|bower_components)/,
-              use: [eslintLoader],
             },
           ],
         },
@@ -92,99 +65,8 @@ describe(`gatsby-plugin-typescript`, () => {
     it(`does not set the webpack config if there isn't a js loader`, () => {
       const actions = { setWebpackConfig: jest.fn() }
       const loaders = { js: jest.fn() }
-      const stage = `develop`
-      const getConfig = jest.fn()
-      onCreateWebpackConfig({ actions, getConfig, loaders, stage })
+      onCreateWebpackConfig({ actions, loaders })
       expect(actions.setWebpackConfig).not.toHaveBeenCalled()
-    })
-
-    it(`does not set the typescript-eslint webpack config if the built-in eslint-loader isn't set`, () => {
-      const actions = { setWebpackConfig: jest.fn() }
-      const jsLoader = {}
-      const loaders = {
-        js: jest.fn(() => jsLoader),
-      }
-      const stage = `develop`
-      const webpackConfig = {
-        module: {
-          rules: [
-            {
-              enforce: `pre`,
-              test: /\.jsx?$/,
-              exclude: /(node_modules|bower_components)/,
-              use: [],
-            },
-          ],
-        },
-      }
-      const getConfig = jest.fn(() => webpackConfig)
-      onCreateWebpackConfig({ actions, getConfig, loaders, stage })
-      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
-        module: {
-          rules: [
-            {
-              test: /\.tsx?$/,
-              use: jsLoader,
-            },
-          ],
-        },
-      })
-      expect(actions.setWebpackConfig).not.toHaveBeenCalledWith({
-        module: {
-          rules: [
-            {
-              enforce: `pre`,
-              test: /\.tsx?$/,
-              exclude: /(node_modules|bower_components)/,
-              use: [],
-            },
-          ],
-        },
-      })
-    })
-
-    it(`set the typescript-eslint webpack config only if in develop stage`, () => {
-      const actions = { setWebpackConfig: jest.fn() }
-      const jsLoader = {}
-      const loaders = { js: jest.fn(() => jsLoader) }
-      const stage = `build-html`
-      const eslintLoader = { loader: `eslint-loader` }
-      const webpackConfig = {
-        module: {
-          rules: [
-            {
-              enforce: `pre`,
-              test: /\.jsx?$/,
-              exclude: /(node_modules|bower_components)/,
-              use: [eslintLoader],
-            },
-          ],
-        },
-      }
-      const getConfig = jest.fn(() => webpackConfig)
-      onCreateWebpackConfig({ actions, getConfig, loaders, stage })
-      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
-        module: {
-          rules: [
-            {
-              test: /\.tsx?$/,
-              use: jsLoader,
-            },
-          ],
-        },
-      })
-      expect(actions.setWebpackConfig).not.toHaveBeenCalledWith({
-        module: {
-          rules: [
-            {
-              enforce: `pre`,
-              test: /\.tsx?$/,
-              exclude: /(node_modules|bower_components)/,
-              use: [eslintLoader],
-            },
-          ],
-        },
-      })
     })
   })
 })

--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -89,49 +89,6 @@ describe(`gatsby-plugin-typescript`, () => {
       })
     })
 
-    it(`sets the correct webpack config with rule.loader shortcut`, () => {
-      const actions = { setWebpackConfig: jest.fn() }
-      const jsLoader = {}
-      const loaders = { js: jest.fn(() => jsLoader) }
-      const stage = `develop`
-      const webpackConfig = {
-        module: {
-          rules: [
-            {
-              enforce: `pre`,
-              test: /\.jsx?$/,
-              exclude: /(node_modules|bower_components)/,
-              loader: `eslint-loader`,
-            },
-          ],
-        },
-      }
-      const getConfig = jest.fn(() => webpackConfig)
-      onCreateWebpackConfig({ actions, getConfig, loaders, stage })
-      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
-        module: {
-          rules: [
-            {
-              test: /\.tsx?$/,
-              use: jsLoader,
-            },
-          ],
-        },
-      })
-      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
-        module: {
-          rules: [
-            {
-              enforce: `pre`,
-              test: /\.tsx?$/,
-              exclude: /(node_modules|bower_components)/,
-              loader: `eslint-loader`,
-            },
-          ],
-        },
-      })
-    })
-
     it(`does not set the webpack config if there isn't a js loader`, () => {
       const actions = { setWebpackConfig: jest.fn() }
       const loaders = { js: jest.fn() }

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -16,13 +16,7 @@ function onCreateBabelConfig({ actions }, options) {
   })
 }
 
-function onCreateWebpackConfig({
-  actions,
-  getConfig,
-  loaders,
-  stage,
-  reporter,
-}) {
+function onCreateWebpackConfig({ actions, loaders }) {
   const jsLoader = loaders.js()
 
   if (!jsLoader) {
@@ -39,38 +33,6 @@ function onCreateWebpackConfig({
       ],
     },
   })
-
-  if (stage === `develop`) {
-    let isTypescriptDepAvailable
-    try {
-      isTypescriptDepAvailable = require.resolve(`typescript`)
-    } catch (e) {
-      reporter.warn(
-        `"typescript" is not installed. Builtin ESLint won't be working on typescript files.`
-      )
-    }
-
-    if (isTypescriptDepAvailable) {
-      const builtInEslintRule = getConfig().module.rules.find(rule => {
-        if (rule.enforce === `pre`) {
-          return rule.use.some(use => /eslint-loader/.test(use.loader))
-        }
-        return false
-      })
-
-      if (builtInEslintRule) {
-        const typescriptEslintRule = {
-          ...builtInEslintRule,
-          test: /\.tsx?$/,
-        }
-        actions.setWebpackConfig({
-          module: {
-            rules: [typescriptEslintRule],
-          },
-        })
-      }
-    }
-  }
 }
 
 exports.resolvableExtensions = resolvableExtensions

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -53,11 +53,7 @@ function onCreateWebpackConfig({
     if (isTypescriptDepAvailable) {
       const builtInEslintRule = getConfig().module.rules.find(rule => {
         if (rule.enforce === `pre`) {
-          if (rule.use) {
-            return rule.use.some(use => /eslint-loader/.test(use.loader))
-          } else {
-            return /eslint-loader/.test(rule.loader)
-          }
+          return rule.use.some(use => /eslint-loader/.test(use.loader))
         }
         return false
       })


### PR DESCRIPTION
## Description
Seems like we broke our typescript plugin for many users so reverting

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/21913