### PR TITLE
feat(gatsby-source-filesystem): Unify publicURL

### DIFF
--- a/packages/gatsby-source-filesystem/src/extend-file-node.js
+++ b/packages/gatsby-source-filesystem/src/extend-file-node.js
@@ -14,7 +14,7 @@ module.exports = ({ type, getNodeAndSavePathDependency, pathPrefix = `` }) => {
       description: `Copy file to static directory and return public url to it`,
       resolve: (file, fieldArgs, context) => {
         const details = getNodeAndSavePathDependency(file.id, context.path)
-        const fileName = `${file.name}-${file.internal.contentDigest}${details.ext}`
+        const fileName = `${file.internal.contentDigest}/${details.base}`
 
         const publicPath = path.join(
           process.cwd(),


### PR DESCRIPTION
## Description

As discussed in #22244, this patch lets `gatsby-source-filesystem` use the same generated URL as `gatsby-remark-copy-linked-files`, i.e. the content digest as a parent directory so that the filename does not change.

### Documentation

Should it? However it makes sense to notify users that their URLs will probably change.

## Related Issues

Fixes #22244 which addressed #9777.