### PR TITLE
fix(docs): Guide for translating UI - 404

### DIFF
--- a/docs/contributing/translation/ui-messages.md
+++ b/docs/contributing/translation/ui-messages.md
@@ -8,7 +8,7 @@ Most content that needs to be translated is in Markdown files in translation rep
 
 Unlike Markdown documents, UI messages are kept in the same monorepo as the gatsby source.
 
-1. Follow the instructions for [running the Gatsby website](/contributing/blog-and-website-contributions/#making-changes-to-the-website).
+1. Follow the instructions for [running the Gatsby website](/contributing/website-contributions/).
 2. Go to `www/` and run `yarn lingui:add-locale [lang code]` to generate a file for your language at `src/data/locales/[lang-code]/messages.po`.
 3. Translate all the strings in `[lang code]/messages.po` by editing the `msgstr` field of each message.
 


### PR DESCRIPTION
## Description

changed
- fix redirect to right section (section moved in #21806)

## Related Issues

- #21805 `(docs) Guide for translating UI text with Lingui`
- #21806 `chore(www) reorganize contributing section`
- #19267 `Add link checker for Gatsby Docs`