### PR TITLE
Add branch name env var for benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,9 @@ commands:
       BENCHMARK_SITE_TYPE:
         type: string
         default: BLOG
+      BENCHMARK_BRANCH:
+        type: string
+        default: master
     steps:
       - checkout
       - run:
@@ -158,6 +161,7 @@ commands:
             BENCHMARK_CONTENT_SOURCE: << parameters.BENCHMARK_CONTENT_SOURCE >>
             BENCHMARK_REPO_NAME: << parameters.BENCHMARK_REPO_NAME >>
             BENCHMARK_SITE_TYPE: << parameters.BENCHMARK_SITE_TYPE >>
+            BENCHMARK_BRANCH: << parameters.BENCHMARK_BRANCH >>
             CI_NAME: circleci
       - run:
           command: npm install
@@ -171,6 +175,7 @@ commands:
             BENCHMARK_CONTENT_SOURCE: << parameters.BENCHMARK_CONTENT_SOURCE >>
             BENCHMARK_REPO_NAME: << parameters.BENCHMARK_REPO_NAME >>
             BENCHMARK_SITE_TYPE: << parameters.BENCHMARK_SITE_TYPE >>
+            BENCHMARK_BRANCH: << parameters.BENCHMARK_BRANCH >>
             CI_NAME: circleci
 
   e2e-test:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This adds the `BENCHMARK_BRANCH` environment variable to benchmarks. It is only `master` in this particular instance, but it is a variable that we want to capture in case we run benchmarks on different branches in the future.

This is already captured in the benchmark plugin, so this is only to add the variable to the benchmark runs in the CircleCI config.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

None.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

None.
