### PR TITLE
fix(docs): Guide for syncing translation repos

### DIFF
--- a/docs/contributing/translation/sync-guide.md
+++ b/docs/contributing/translation/sync-guide.md
@@ -51,7 +51,7 @@ Fix all [merge conflicts](https://help.github.com/en/github/collaborating-with-i
 
 ### Frontmatter changes
 
-This type of conflict reflects a change to the [frontmatter]() of a document.
+This type of conflict reflects a change to the [frontmatter](/docs/adding-markdown-pages/#frontmatter-for-metadata-in-markdown-files) of a document.
 
 Removing a field:
 

--- a/docs/contributing/translation/ui-messages.md
+++ b/docs/contributing/translation/ui-messages.md
@@ -76,7 +76,7 @@ msgstr: ""
 
 These represent text in interpolated strings:
 
-```
+```javascript
 t`${item.title} collapse`
 ```
 

--- a/docs/contributing/translation/ui-messages.md
+++ b/docs/contributing/translation/ui-messages.md
@@ -76,7 +76,7 @@ msgstr: ""
 
 These represent text in interpolated strings:
 
-```javascript
+```
 t`${item.title} collapse`
 ```
 


### PR DESCRIPTION
## Description

changed
- fix missing link - i guessed a possible link to markdown frontmatter section

## Related Issues

- #21753 `feat(docs): Guide for syncing translation repos`  
- #19267 `Add link checker for Gatsby Docs`