### PR TITLE
fix(readme): Update Readme gatsby-source-contentful missing code languages

### DIFF
--- a/docs/contributing/translation/ui-messages.md
+++ b/docs/contributing/translation/ui-messages.md
@@ -76,7 +76,7 @@ msgstr: ""
 
 These represent text in interpolated strings:
 
-```
+```javascript
 t`${item.title} collapse`
 ```
 

--- a/docs/contributing/translation/ui-messages.md
+++ b/docs/contributing/translation/ui-messages.md
@@ -76,7 +76,7 @@ msgstr: ""
 
 These represent text in interpolated strings:
 
-```javascript
+```
 t`${item.title} collapse`
 ```
 

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -9,7 +9,9 @@ https://using-contentful.gatsbyjs.org/
 
 ## Install
 
-`npm install --save gatsby-source-contentful`
+```shell
+npm install --save gatsby-source-contentful
+```
 
 ## How to use
 
@@ -396,7 +398,7 @@ Check out the examples at [@contentful/rich-text-react-renderer](https://github.
 
 To source from multiple Contentful environments/spaces, add another configuration for `gatsby-source-contentful` in `gatsby-config.js`:
 
-```
+```javascript
 // In your gatsby-config.js
 module.exports = {
   plugins: [
@@ -413,7 +415,7 @@ module.exports = {
         spaceId: `your_second_space_id`,
         accessToken: process.env.SECONDARY_CONTENTFUL_ACCESS_TOKEN,
       },
-    }
+    },
   ],
 }
 ```


### PR DESCRIPTION
## Description

changes:

- add missing code block languages

## Related Issues

- #21740 `Update Readme with information for multiple spaces`