### PR TITLE
fix(doc): redirects

### DIFF
--- a/www/redirects.yaml
+++ b/www/redirects.yaml
@@ -76,9 +76,9 @@
   toPath: /docs/creating-a-transformer-plugin/
 - fromPath: /docs/plugin-authoring/
   toPath: /docs/how-plugins-work/
-- fromPath: /tutorial/theme-tutorials
-  toPath: /tutorial/plugin-and-theme-tutorials
-- fromPath: docs/remark-plugin-tutorial.md
+- fromPath: /tutorial/theme-tutorials/
+  toPath: /tutorial/plugin-and-theme-tutorials/
+- fromPath: /docs/remark-plugin-tutorial/
   toPath: /tutorial/remark-plugin-tutorial/
 - fromPath: /docs/source-plugin-tutorial/
   toPath: /tutorial/pixabay-source-plugin-tutorial/


### PR DESCRIPTION
## Description

changes:

- add trainling slashes
- point path without `.md`
- add missing beginning slash

## Related Issues

-  #21908 `Rename Theme tutorials to Plugin and Theme Tutorials and update redir…`
- #19267 `Add link checker for Gatsby Docs`