### PR TITLE
Muescha/fix/clourflare 404

### DIFF
--- a/docs/docs/deploying-to-cloudflare-workers.md
+++ b/docs/docs/deploying-to-cloudflare-workers.md
@@ -20,7 +20,7 @@ npm i -g @cloudflare/wrangler
 
 To create the Worker code that will serve your Gatsby files, from the root of your Gatsby project run:
 
-```
+```shell
 wrangler init --site
 ```
 
@@ -44,7 +44,7 @@ You'll notice your project structure should now look something like:
 
 To authenticate into your Cloudflare account run:
 
-```
+```shell
 wrangler config
 ```
 
@@ -52,13 +52,13 @@ Follow the [Quick Start](https://developers.cloudflare.com/workers/quickstart/#c
 
 If you don't already have a workers.dev domain run:
 
-```
+```shell
 wrangler subdomain
 ```
 
 Then, add your account ID to the `wrangler.toml` file, and set `bucket` to `"./public"`, which is where Gatsby's built files are output by default:
 
-```
+```toml
 name = "gatsby-project"
 type = "webpack"
 account_id = "abcd..."
@@ -87,7 +87,7 @@ Use wrangler's GitHub action [plugin](https://github.com/cloudflare/wrangler-act
 
 Once GitHub Actions is enabled on your repo, add a file to your project's root called `.github/workflows/main.yml` with the contents:
 
-```
+```yaml
 name: Deploy production site
 
 on:
@@ -99,21 +99,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Navigate to repo
-      run: cd $GITHUB_WORKSPACE
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '10.x'
-    - name: Install deps
-      run: npm install
-    - name: Build docs
-      run: npm run build
-    - name: Publish
-      uses: cloudflare/wrangler-action@1.1.0
-      with:
-        apiToken: ${{ secrets.CF_API_TOKEN }}
-        environment: "production"
+      - uses: actions/checkout@v1
+      - name: Navigate to repo
+        run: cd $GITHUB_WORKSPACE
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+      - name: Install deps
+        run: npm install
+      - name: Build docs
+        run: npm run build
+      - name: Publish
+        uses: cloudflare/wrangler-action@1.1.0
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          environment: "production"
 ```
 
 Set up `CF_API_TOKEN` in GitHub secrets with appropriate values from [Quick Start](https://developers.cloudflare.com/workers/quickstart/#configure).

--- a/docs/docs/deploying-to-cloudflare-workers.md
+++ b/docs/docs/deploying-to-cloudflare-workers.md
@@ -2,7 +2,7 @@
 title: Deploying to Cloudflare Workers
 ---
 
-[Cloudflare Workers](https://workers.cloudflare.com/) is a serverless platform for creating entirely new applications or augmenting existing ones without configuring or maintaining infrastructure. With [Workers Sites](https://developers.cloudflare.com/workers/sites/start-from-existing/) you can deploy any static site including your Gatsby projects to a domain on Cloudflare or for free with on your [workers.dev](workers.dev) subdomain.
+[Cloudflare Workers](https://workers.cloudflare.com/) is a serverless platform for creating entirely new applications or augmenting existing ones without configuring or maintaining infrastructure. With [Workers Sites](https://developers.cloudflare.com/workers/sites/start-from-existing/) you can deploy any static site including your Gatsby projects to a domain on Cloudflare or for free with on your [workers.dev](https://workers.dev) subdomain.
 
 To enable the KV store required to serve the Gatsby files, you'll need the [Workers Unlimited plan](https://developers.cloudflare.com/workers/about/pricing/) for \$5/month.
 

--- a/docs/docs/deploying-to-cloudflare-workers.md
+++ b/docs/docs/deploying-to-cloudflare-workers.md
@@ -20,7 +20,7 @@ npm i -g @cloudflare/wrangler
 
 To create the Worker code that will serve your Gatsby files, from the root of your Gatsby project run:
 
-```shell
+```
 wrangler init --site
 ```
 
@@ -44,7 +44,7 @@ You'll notice your project structure should now look something like:
 
 To authenticate into your Cloudflare account run:
 
-```shell
+```
 wrangler config
 ```
 
@@ -52,13 +52,13 @@ Follow the [Quick Start](https://developers.cloudflare.com/workers/quickstart/#c
 
 If you don't already have a workers.dev domain run:
 
-```shell
+```
 wrangler subdomain
 ```
 
 Then, add your account ID to the `wrangler.toml` file, and set `bucket` to `"./public"`, which is where Gatsby's built files are output by default:
 
-```toml
+```
 name = "gatsby-project"
 type = "webpack"
 account_id = "abcd..."
@@ -87,7 +87,7 @@ Use wrangler's GitHub action [plugin](https://github.com/cloudflare/wrangler-act
 
 Once GitHub Actions is enabled on your repo, add a file to your project's root called `.github/workflows/main.yml` with the contents:
 
-```yaml
+```
 name: Deploy production site
 
 on:
@@ -99,21 +99,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Navigate to repo
-        run: cd $GITHUB_WORKSPACE
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "10.x"
-      - name: Install deps
-        run: npm install
-      - name: Build docs
-        run: npm run build
-      - name: Publish
-        uses: cloudflare/wrangler-action@1.1.0
-        with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
-          environment: "production"
+    - uses: actions/checkout@v1
+    - name: Navigate to repo
+      run: cd $GITHUB_WORKSPACE
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: Install deps
+      run: npm install
+    - name: Build docs
+      run: npm run build
+    - name: Publish
+      uses: cloudflare/wrangler-action@1.1.0
+      with:
+        apiToken: ${{ secrets.CF_API_TOKEN }}
+        environment: "production"
 ```
 
 Set up `CF_API_TOKEN` in GitHub secrets with appropriate values from [Quick Start](https://developers.cloudflare.com/workers/quickstart/#configure).


### PR DESCRIPTION
## Description

changes:

- fix 404 link to `workers.dev`

other option would be to make a code block:

```markdown
`workers.dev`
```

## Related Issues

- #21658 `docs: add Cloudflare Workers documentation`
- #19267 `Add link checker for Gatsby Docs`