### PR TITLE
feat(gatsby-source-graphql): Query batching

### DIFF
--- a/packages/gatsby-source-graphql/.gitignore
+++ b/packages/gatsby-source-graphql/.gitignore
@@ -1,2 +1,3 @@
 /*.js
+/batching/*.js
 yarn.lock

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -176,5 +176,162 @@ module.exports = {
 }
 ```
 
+# Performance tuning
+
+By default, `gatsby-source-graphql` executes each query in a separate network request.
+But the plugin also supports query batching to improve query running performance
+
+**Caveat**: Batching is only possible for queries starting approximately at the same time. In other words
+it is bounded by the number of parallel GraphQL queries executed by Gatsby (by default it is **4**).
+
+Fortunately we can increase the number of queries executed in parallel by setting [environment variable](https://gatsby.dev/env-vars)
+`GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY` to a higher value and setting `batch` option of the plugin
+to `true`.
+
+Example:
+
+```
+cross-env GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY=20 gatsby develop
+```
+
+With plugin config:
+
+```js
+const fs = require("fs")
+const { buildSchema, buildClientSchema } = require("graphql")
+
+module.exports = {
+  plugins: [
+    {
+      resolve: "gatsby-source-graphql",
+      options: {
+        typeName: "SWAPI",
+        fieldName: "swapi",
+        url: "https://api.graphcms.com/simple/v1/swapi",
+        batch: true,
+      },
+    },
+  ],
+}
+```
+
+By default, the plugin batches up to 5 queries. You can override this by passing
+`dataLoaderOptions`:
+
+```js
+const fs = require("fs")
+const { buildSchema, buildClientSchema } = require("graphql")
+
+module.exports = {
+  plugins: [
+    {
+      resolve: "gatsby-source-graphql",
+      options: {
+        typeName: "SWAPI",
+        fieldName: "swapi",
+        url: "https://api.graphcms.com/simple/v1/swapi",
+        batch: true,
+        // See https://github.com/graphql/dataloader#new-dataloaderbatchloadfn--options
+        // for a full list of DataLoader options
+        dataLoaderOptions: {
+          maxBatchSize: 10,
+        },
+      },
+    },
+  ],
+}
+```
+
+Having 20 parallel queries with 5 queries per batch means we are still running 4 batches
+in parallel.
+
+Each project is unique so try tuning those two variables and see what works best for you.
+We've seen up to 5-10x speed-up for some setups.
+
+### How batching works
+
+Under the hood `gatsby-source-graphql` uses [DataLoader](https://github.com/graphql/dataloader)
+for query batching. It merges all queries from a batch to a single query that gets sent to the
+server in a single network request.
+
+Consider following example:
+
+```js
+{
+  query: `query(id: Int!) {
+    node(id: $id) {
+      foo
+    }
+  }`,
+  variables: { id: 1 },
+}
+```
+
+```js
+{
+  query: `query(id: Int!) {
+    node(id: $id) {
+      bar
+    }
+  }`,
+  variables: { id: 2 },
+}
+```
+
+They will be merged to a single query:
+
+```js
+{
+  query: `
+    query(
+      $gatsby0_id: Int!
+      $gatsby1_id: Int!
+    ) {
+      gatsby0_node: node(id: $gatsby0_id) {
+        foo
+      }
+      gatsby1_node: node(id: $gatsby1_id) {
+        bar
+      }
+    }
+  `,
+  variables: {
+    gatsby0_id: 1,
+    gatsby1_id: 2,
+  }
+}
+```
+
+Then `gatsby-source-graphql` splits the result of this single query to multiple results
+and delivers it back to Gatsby as if it executed multiple queries:
+
+```js
+{
+  data: {
+    gatsby0_node: { foo: `foo` },
+    gatsby1_node: { bar: `bar` },
+  },
+}
+```
+
+is transformed back to:
+
+```js
+[
+  { data { node: { foo: `foo` } } },
+  { data { node: { bar: `bar` } } },
+]
+```
+
+Note that if any query result contains errors the whole batch will fail.
+
+### Apollo-style batching
+
+If your server supports apollo-style query batching you can also try
+[HttpLinkDataLoader](https://github.com/prisma-labs/http-link-dataloader).
+Just pass it to the `gatsby-source-graphql` plugin via `createLink` option.
+
+This strategy is usually slower than query merging but provides better error reporting.
+
 [dotenv]: https://github.com/motdotla/dotenv
 [envvars]: https://gatsby.dev/env-vars

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -216,7 +216,7 @@ module.exports = {
 ```
 
 By default, the plugin batches up to 5 queries. You can override this by passing
-`dataLoaderOptions`:
+`dataLoaderOptions` and set a `maxBatchSize`:
 
 ```js
 const fs = require("fs")

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -181,7 +181,7 @@ module.exports = {
 By default, `gatsby-source-graphql` executes each query in a separate network request.
 But the plugin also supports query batching to improve query performance.
 
-**Caveat**: Batching is only possible for queries starting approximately at the same time. In other words
+**Caveat**: Batching is only possible for queries starting at approximately the same time. In other words
 it is bounded by the number of parallel GraphQL queries executed by Gatsby (by default it is **4**).
 
 Fortunately we can increase the number of queries executed in parallel by setting [environment variable](https://gatsby.dev/env-vars)

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -185,7 +185,7 @@ But the plugin also supports query batching to improve query performance.
 it is bounded by the number of parallel GraphQL queries executed by Gatsby (by default it is **4**).
 
 Fortunately, we can increase the number of queries executed in parallel by setting the [environment variable](https://gatsby.dev/env-vars)
-`GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY` to a higher value and setting `batch` option of the plugin
+`GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY` to a higher value and setting the `batch` option of the plugin
 to `true`.
 
 Example:

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -329,7 +329,7 @@ Note that if any query result contains errors the whole batch will fail.
 
 If your server supports apollo-style query batching you can also try
 [HttpLinkDataLoader](https://github.com/prisma-labs/http-link-dataloader).
-Just pass it to the `gatsby-source-graphql` plugin via `createLink` option.
+Pass it to the `gatsby-source-graphql` plugin via the `createLink` option.
 
 This strategy is usually slower than query merging but provides better error reporting.
 

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -278,7 +278,7 @@ Consider following example:
 }
 ```
 
-They will be merged to a single query:
+They will be merged into a single query:
 
 ```js
 {

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -302,7 +302,7 @@ They will be merged into a single query:
 }
 ```
 
-Then `gatsby-source-graphql` splits the result of this single query to multiple results
+Then `gatsby-source-graphql` splits the result of this single query into multiple results
 and delivers it back to Gatsby as if it executed multiple queries:
 
 ```js

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -179,7 +179,7 @@ module.exports = {
 # Performance tuning
 
 By default, `gatsby-source-graphql` executes each query in a separate network request.
-But the plugin also supports query batching to improve query running performance
+But the plugin also supports query batching to improve query performance.
 
 **Caveat**: Batching is only possible for queries starting approximately at the same time. In other words
 it is bounded by the number of parallel GraphQL queries executed by Gatsby (by default it is **4**).

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -190,7 +190,7 @@ to `true`.
 
 Example:
 
-```
+```shell
 cross-env GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY=20 gatsby develop
 ```
 

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -254,7 +254,7 @@ Under the hood `gatsby-source-graphql` uses [DataLoader](https://github.com/grap
 for query batching. It merges all queries from a batch to a single query that gets sent to the
 server in a single network request.
 
-Consider following example:
+Consider the following example where both of these queries are run:
 
 ```js
 {

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -184,7 +184,7 @@ But the plugin also supports query batching to improve query performance.
 **Caveat**: Batching is only possible for queries starting at approximately the same time. In other words
 it is bounded by the number of parallel GraphQL queries executed by Gatsby (by default it is **4**).
 
-Fortunately we can increase the number of queries executed in parallel by setting [environment variable](https://gatsby.dev/env-vars)
+Fortunately, we can increase the number of queries executed in parallel by setting the [environment variable](https://gatsby.dev/env-vars)
 `GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY` to a higher value and setting `batch` option of the plugin
 to `true`.
 

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -11,7 +11,7 @@
     "apollo-link": "1.2.13",
     "apollo-link-http": "^1.5.16",
     "dataloader": "^2.0.0",
-    "graphql": "^14.5.8",
+    "graphql": "^14.6.0",
     "graphql-tools-fork": "^8.9.6",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -10,6 +10,8 @@
     "@babel/runtime": "^7.8.7",
     "apollo-link": "1.2.13",
     "apollo-link-http": "^1.5.16",
+    "dataloader": "^2.0.0",
+    "graphql": "^14.5.8",
     "graphql-tools-fork": "^8.9.6",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",

--- a/packages/gatsby-source-graphql/src/batching/__tests__/dataloader-link.ts
+++ b/packages/gatsby-source-graphql/src/batching/__tests__/dataloader-link.ts
@@ -1,0 +1,102 @@
+import { parse } from "graphql"
+import { execute } from "apollo-link"
+import { createDataloaderLink } from "../dataloader-link"
+
+const sampleQuery = parse(`{ foo }`)
+const expectedSampleQueryResult = { data: { foo: `bar` } }
+
+// eslint-disable-next-line @typescript-eslint/camelcase
+const fetchResult = { data: { gatsby0_foo: `bar` } }
+
+const makeFetch = (expectedResult: any = fetchResult): jest.Mock<any> =>
+  jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve(expectedResult),
+    })
+  )
+
+describe(`createDataloaderLink`, () => {
+  it(`works with minimal set of options`, done => {
+    const link = createDataloaderLink({
+      uri: `some-endpoint`,
+      fetch: makeFetch(),
+    })
+    const observable = execute(link, { query: sampleQuery })
+    observable.subscribe({
+      next: (result: any) => {
+        expect(result).toEqual(expectedSampleQueryResult)
+        done()
+      },
+      error: done,
+    })
+  })
+
+  it(`reports fetch errors`, done => {
+    const link = createDataloaderLink({
+      uri: `some-endpoint`,
+      fetch: jest.fn(() => Promise.reject(`FetchError`)),
+    })
+    const observable = execute(link, { query: sampleQuery })
+    observable.subscribe({
+      error: error => {
+        expect(error).toEqual(`FetchError`)
+        done()
+      },
+      complete: () => {
+        done.fail(`Expected error not thrown`)
+      },
+    })
+  })
+
+  it(`reports graphql errors`, done => {
+    const result = {
+      errors: [{ message: `Error1` }, { message: `Error2`, path: [`foo`] }],
+    }
+    const link = createDataloaderLink({
+      uri: `some-endpoint`,
+      fetch: makeFetch(result),
+    })
+    const observable = execute(link, { query: sampleQuery })
+    observable.subscribe({
+      error: error => {
+        expect(error.name).toEqual(`GraphQLError`)
+        expect(error.message).toEqual(
+          `Failed to load query batch:\nError1\nError2 (path: ["foo"])`
+        )
+        expect(error.originalResult).toEqual(result)
+        done()
+      },
+      complete: () => {
+        done.fail(`Expected error not thrown`)
+      },
+    })
+  })
+
+  it(`supports custom fetch options`, done => {
+    const fetch = makeFetch()
+    const fetchOptions = {
+      credentials: `include`,
+      mode: `cors`,
+    }
+    const link = createDataloaderLink({
+      uri: `some-endpoint`,
+      fetch,
+      fetchOptions,
+    })
+
+    const observable = execute(link, { query: sampleQuery })
+    const next = jest.fn()
+
+    observable.subscribe({
+      next,
+      error: done,
+      complete: () => {
+        expect(fetch.mock.calls.length).toEqual(1)
+        const [uri, options] = fetch.mock.calls[0]
+        expect(uri).toEqual(`some-endpoint`)
+        expect(options).toEqual(expect.objectContaining(fetchOptions))
+        done()
+      },
+    })
+  })
+})

--- a/packages/gatsby-source-graphql/src/batching/__tests__/merge-queries.ts
+++ b/packages/gatsby-source-graphql/src/batching/__tests__/merge-queries.ts
@@ -1,0 +1,237 @@
+import { print, parse } from "graphql"
+import { IQuery, merge, resolveResult } from "../merge-queries"
+
+describe(`Query merging`, () => {
+  it(`merges simple queries`, () => {
+    const queries = fromFixtures([
+      [`{ foo }`, {}],
+      [`{ bar }`, {}],
+      [`{ baz }`, {}],
+      [`{ foo, bar, baz }`, {}],
+    ])
+    const { query, variables } = merge(queries)
+    const expected = parse(`{
+      gatsby0_foo: foo
+      gatsby1_bar: bar
+      gatsby2_baz: baz
+      gatsby3_foo: foo
+      gatsby3_bar: bar
+      gatsby3_baz: baz
+    }`)
+    expect(print(query)).toEqual(print(expected))
+    expect(variables).toEqual({})
+  })
+
+  it(`merges aliased queries`, () => {
+    const queries = fromFixtures([
+      [`{ foo, bar }`, {}],
+      [`{ foo, bar: foo }`, {}],
+      [`{ foo, bar: foo(id: 2) }`, {}],
+      [`{ foo: bar }`, {}],
+    ])
+    const { query, variables } = merge(queries)
+    const expected = parse(`{
+      gatsby0_foo: foo
+      gatsby0_bar: bar
+      gatsby1_foo: foo
+      gatsby1_bar: foo
+      gatsby2_foo: foo
+      gatsby2_bar: foo(id: 2)
+      gatsby3_foo: bar
+    }`)
+    expect(print(query)).toEqual(print(expected))
+    expect(variables).toEqual({})
+  })
+
+  it(`merges template queries`, () => {
+    const templateQuery = `
+    query Foo($id: ID!) { node(id: $id) { title } }
+  `
+    const queries = fromFixtures([
+      [templateQuery, { id: `1` }],
+      [templateQuery, { id: `2` }],
+      [templateQuery, { id: `3` }],
+    ])
+    const { query, variables } = merge(queries)
+
+    const expectedQuery = parse(`
+      query ($gatsby0_id: ID!, $gatsby1_id: ID!, $gatsby2_id: ID!) {
+        gatsby0_node: node(id: $gatsby0_id) { title }
+        gatsby1_node: node(id: $gatsby1_id) { title }
+        gatsby2_node: node(id: $gatsby2_id) { title }
+      }
+    `)
+    expect(print(query)).toEqual(print(expectedQuery))
+
+    expect(variables).toEqual({
+      /* eslint-disable @typescript-eslint/camelcase */
+      gatsby0_id: `1`,
+      gatsby1_id: `2`,
+      gatsby2_id: `3`,
+    })
+  })
+
+  it(`merges template queries with fragments`, () => {
+    const templateQueryWithFragment = `
+      query Foo($id: ID!, $withBody: Boolean!) { node(id: $id) { ...PostTitle ...PostBody } }
+      fragment PostTitle on Post { title }
+      fragment PostBody on Post { body @include(if: $withBody) }
+    `
+    const queries = fromFixtures([
+      [templateQueryWithFragment, { id: `1` }],
+      [templateQueryWithFragment, { id: `2` }],
+      [templateQueryWithFragment, { id: `3` }],
+    ])
+    const { query, variables } = merge(queries)
+    const expected = parse(`
+      query (
+        $gatsby0_id: ID!
+        $gatsby0_withBody: Boolean!
+        $gatsby1_id: ID!
+        $gatsby1_withBody: Boolean!
+        $gatsby2_id: ID!
+        $gatsby2_withBody: Boolean!
+      ) {
+        gatsby0_node: node(id: $gatsby0_id) { ...PostTitle ...gatsby0_PostBody }
+        gatsby1_node: node(id: $gatsby1_id) { ...PostTitle ...gatsby1_PostBody }
+        gatsby2_node: node(id: $gatsby2_id) { ...PostTitle ...gatsby2_PostBody }
+      }
+      fragment PostTitle on Post { title }
+      fragment gatsby0_PostBody on Post { body @include(if: $gatsby0_withBody) }
+      fragment gatsby1_PostBody on Post { body @include(if: $gatsby1_withBody) }
+      fragment gatsby2_PostBody on Post { body @include(if: $gatsby2_withBody) }
+    `)
+    expect(print(query)).toEqual(print(expected))
+    expect(variables).toEqual({
+      /* eslint-disable @typescript-eslint/camelcase */
+      gatsby0_id: `1`,
+      gatsby1_id: `2`,
+      gatsby2_id: `3`,
+    })
+  })
+
+  it(`handles fragments on Query type properly`, () => {
+    const templateQueriesWithQueryFragment = `
+      query Foo($id: ID!) {
+        node(id: $id)
+        foo
+        ...QueryFragment
+        ... on Query { foo, inlineFragmentField }
+      }
+      fragment QueryFragment on Query { foo, queryFragmentField }
+    `
+    const queries = fromFixtures([
+      [templateQueriesWithQueryFragment, { id: `1` }],
+      [templateQueriesWithQueryFragment, { id: `2` }],
+    ])
+    const { query, variables } = merge(queries)
+    const expected = parse(`
+      query ($gatsby0_id: ID!, $gatsby1_id: ID!) {
+        gatsby0_node: node(id: $gatsby0_id)
+        gatsby0_foo: foo
+        ...QueryFragment @skip(if: true)
+        ... on Query {
+          gatsby0_foo: foo
+          gatsby0_queryFragmentField: queryFragmentField
+        }
+        ... on Query {
+          gatsby0_foo: foo
+          gatsby0_inlineFragmentField: inlineFragmentField
+        }
+        gatsby1_node: node(id: $gatsby1_id)
+        gatsby1_foo: foo
+        ...QueryFragment @skip(if: true)
+        ... on Query {
+          gatsby1_foo: foo
+          gatsby1_queryFragmentField: queryFragmentField
+        }
+        ... on Query {
+          gatsby1_foo: foo
+          gatsby1_inlineFragmentField: inlineFragmentField
+        }
+      }
+
+      fragment QueryFragment on Query {
+        foo
+        queryFragmentField
+      }
+    `)
+    expect(print(query)).toEqual(print(expected))
+    expect(variables).toEqual({
+      /* eslint-disable @typescript-eslint/camelcase */
+      gatsby0_id: `1`,
+      gatsby1_id: `2`,
+    })
+  })
+})
+
+describe(`Resolving merged query results`, () => {
+  it(`resolves single result`, () => {
+    const result = {
+      data: {
+        gatsby0_foo: { foo: `foo` },
+      },
+    }
+    const resolved = resolveResult(result)
+    expect(resolved).toEqual([
+      {
+        data: {
+          foo: { foo: `foo` },
+        },
+      },
+    ])
+  })
+
+  it(`resolves query results`, () => {
+    const result = {
+      data: {
+        gatsby0_foo: { foo: `foo` },
+        gatsby0_bar: { bar: `bar` },
+        gatsby1_bar: { bar: `bar` },
+      },
+    }
+
+    const resolved = resolveResult(result)
+    expect(resolved).toEqual([
+      {
+        data: {
+          foo: { foo: `foo` },
+          bar: { bar: `bar` },
+        },
+      },
+      {
+        data: {
+          bar: { bar: `bar` },
+        },
+      },
+    ])
+  })
+
+  it(`correctly handles empty results`, () => {
+    const resolved = resolveResult({ data: {} })
+    expect(resolved).toEqual([])
+  })
+
+  it(`throws on unexpected results`, () => {
+    const shouldThrow = (): void => {
+      resolveResult({
+        data: {
+          gatsby0_foo: `foo`,
+          bar: `bar`,
+        },
+      })
+    }
+    expect(shouldThrow).toThrow(`Unexpected data key: bar`)
+  })
+})
+
+type QueryFixture = [string, object]
+
+function fromFixtures(fixtures: QueryFixture[]): IQuery[] {
+  return fixtures.map(([query, variables]: QueryFixture) => {
+    return {
+      query: parse(query),
+      variables,
+    }
+  })
+}

--- a/packages/gatsby-source-graphql/src/batching/dataloader-link.ts
+++ b/packages/gatsby-source-graphql/src/batching/dataloader-link.ts
@@ -1,0 +1,81 @@
+import DataLoader from "dataloader"
+import { ApolloLink, Observable, Operation, FetchResult } from "apollo-link"
+import { print } from "graphql"
+import { IQuery, IQueryResult, merge, resolveResult } from "./merge-queries"
+
+interface IOptions {
+  uri: string
+  fetch: Function
+  fetchOptions?: object
+  dataLoaderOptions?: object
+  headers?: object
+}
+
+export function createDataloaderLink(options: IOptions): ApolloLink {
+  const load = async (keys: ReadonlyArray<IQuery>): Promise<IQueryResult[]> => {
+    const query = merge(keys)
+    const result: object = await request(query, options)
+    if (!isValidGraphQLResult(result)) {
+      const error = extractFirstError(result)
+      throw new Error(`Failed to load query batch: ${error}`)
+    }
+    return resolveResult(result)
+  }
+
+  const dataloader = new DataLoader(load, {
+    cache: false,
+    maxBatchSize: 5,
+    batchScheduleFn: (callback): any => setTimeout(callback, 50),
+    ...options.dataLoaderOptions,
+  })
+
+  return new ApolloLink(
+    (operation: Operation): Observable<FetchResult> =>
+      new Observable(observer => {
+        const { query, variables } = operation
+
+        dataloader
+          .load({ query, variables })
+          .then(response => {
+            operation.setContext({ response })
+            observer.next(response)
+            observer.complete()
+            return response
+          })
+          .catch(err => {
+            if (err.name === `AbortError`) {
+              return
+            }
+            observer.error(err)
+          })
+      })
+  )
+}
+
+function extractFirstError(result: any): string {
+  if (result?.errors?.length > 0) {
+    const { message, path = [] } = result.errors[0]
+    return `${message} (path: ${JSON.stringify(path)}`
+  }
+  return `Unknown error`
+}
+
+function isValidGraphQLResult(response): response is IQueryResult {
+  return response?.data && (!response.errors || response.errors.length < 0)
+}
+
+async function request(query: IQuery, options: IOptions): Promise<object> {
+  const { uri, headers = {}, fetch, fetchOptions } = options
+
+  const body = JSON.stringify({
+    query: print(query.query),
+    variables: query.variables,
+  })
+  const response = await fetch(uri, {
+    method: `POST`,
+    ...fetchOptions,
+    headers: Object.assign({ "Content-Type": `application/json` }, headers),
+    body,
+  })
+  return response.json()
+}

--- a/packages/gatsby-source-graphql/src/batching/dataloader-link.ts
+++ b/packages/gatsby-source-graphql/src/batching/dataloader-link.ts
@@ -26,9 +26,14 @@ export function createDataloaderLink(options: IOptions): ApolloLink {
     return resolveResult(result)
   }
 
+  const concurrency =
+    Number(process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) || 4
+
+  const maxBatchSize = Math.min(4, Math.round(concurrency / 5))
+
   const dataloader = new DataLoader(load, {
     cache: false,
-    maxBatchSize: 5,
+    maxBatchSize,
     batchScheduleFn: (callback): any => setTimeout(callback, 50),
     ...options.dataLoaderOptions,
   })

--- a/packages/gatsby-source-graphql/src/batching/merge-queries.ts
+++ b/packages/gatsby-source-graphql/src/batching/merge-queries.ts
@@ -1,0 +1,410 @@
+import {
+  visit,
+  visitInParallel,
+  Kind,
+  DocumentNode,
+  VariableNode,
+  SelectionNode,
+  FragmentSpreadNode,
+  FragmentDefinitionNode,
+  InlineFragmentNode,
+  FieldNode,
+  NameNode,
+  OperationDefinitionNode,
+  Visitor,
+  ASTKindToNode,
+  VariableDefinitionNode,
+  DirectiveNode,
+} from "graphql"
+import _ from "lodash"
+
+export interface IQuery {
+  query: DocumentNode
+  variables: object
+}
+
+export interface IQueryResult {
+  data: object
+}
+
+const Prefix = {
+  create: (index: number): string => `gatsby${index}_`,
+  parseKey: (prefixedKey: string): { index: number; originalKey: string } => {
+    const match = /^gatsby([\d]+)_(.*)$/.exec(prefixedKey)
+    if (!match || match.length !== 3 || isNaN(Number(match[1])) || !match[2]) {
+      throw new Error(`Unexpected data key: ${prefixedKey}`)
+    }
+    return { index: Number(match[1]), originalKey: match[2] }
+  },
+}
+
+/**
+ * Merge multiple queries into a single query in such a way that query results
+ * can be split and transformed as if they were obtained by running original queries.
+ *
+ * Merging algorithm involves several transformations:
+ *  1. Replace top-level fragment spreads with inline fragments (... on Query {})
+ *  2. Add unique aliases to all top-level query fields (including those on inline fragments)
+ *  3. Prefix all variable definitions and variable usages
+ *  4. Prefix names (and spreads) of fragments with variables
+ *  5. Dedupe repeating fragments
+ *
+ * i.e transform:
+ *   [
+ *     `query Foo($id: ID!) { foo, bar(id: $id), ...FooQuery }
+ *     fragment FooQuery on Query { baz }`,
+ *
+ *    `query Bar($id: ID!) { foo: baz, bar(id: $id), ... on Query { baz } }`
+ *   ]
+ * to:
+ *   query (
+ *     $gatsby1_id: ID!
+ *     $gatsby2_id: ID!
+ *   ) {
+ *     gatsby1_foo: foo,
+ *     gatsby1_bar: bar(id: $gatsby1_id)
+ *     ... on Query @originalFragment(name: "FooQuery") {
+ *       gatsby1_baz: baz
+ *     }
+ *     gatsby2_foo: baz
+ *     gatsby2_bar: bar(id: $gatsby2_id)
+ *     ... on Query {
+ *       gatsby2_baz: baz
+ *     }
+ *   }
+ *   fragment FooQuery on Query { baz }
+ */
+export function merge(queries: ReadonlyArray<IQuery>): IQuery {
+  const mergedVariables: object = {}
+  const mergedVariableDefinitions: VariableDefinitionNode[] = []
+  const mergedSelections: SelectionNode[] = []
+  const mergedFragmentMap: Map<string, FragmentDefinitionNode> = new Map()
+
+  queries.forEach((query: IQuery, index: number) => {
+    const prefixedQuery = prefixQueryParts(Prefix.create(index), query)
+
+    prefixedQuery.query.definitions.forEach(def => {
+      if (isQueryDefinition(def)) {
+        mergedSelections.push(...def.selectionSet.selections)
+        mergedVariableDefinitions.push(...(def.variableDefinitions ?? []))
+      }
+      if (isFragmentDefinition(def)) {
+        // Theoretically it is possible to have fragments with the same name but different content
+        // in different queries. But Gatsby validation doesn't allow this and we rely on this here
+        mergedFragmentMap.set(def.name.value, def)
+      }
+    })
+    Object.assign(mergedVariables, prefixedQuery.variables)
+  })
+
+  const mergedQueryDefinition: OperationDefinitionNode = {
+    kind: Kind.OPERATION_DEFINITION,
+    operation: `query`,
+    variableDefinitions: mergedVariableDefinitions,
+    selectionSet: {
+      kind: Kind.SELECTION_SET,
+      selections: mergedSelections,
+    },
+  }
+
+  return {
+    query: {
+      kind: Kind.DOCUMENT,
+      definitions: [mergedQueryDefinition, ...mergedFragmentMap.values()],
+    },
+    variables: mergedVariables,
+  }
+}
+
+/**
+ * Split and transform result of the query produced by the `merge` function
+ */
+export function resolveResult(mergedQueryResult: IQueryResult): IQueryResult[] {
+  const data = mergedQueryResult.data
+
+  return Object.keys(data).reduce(
+    (acc: IQueryResult[], prefixedKey: string): IQueryResult[] => {
+      const { index, originalKey } = Prefix.parseKey(prefixedKey)
+      if (!acc[index]) acc[index] = { data: {} }
+      acc[index].data[originalKey] = data[prefixedKey]
+      return acc
+    },
+    []
+  )
+}
+
+const Visitors = {
+  detectFragmentsWithVariables: (
+    fragmentsWithVariables: Set<string>
+  ): Visitor<ASTKindToNode> => {
+    let currentFragmentName
+    return {
+      [Kind.FRAGMENT_DEFINITION]: {
+        enter: (def: FragmentDefinitionNode): void => {
+          currentFragmentName = def.name.value
+        },
+        leave: (): void => {
+          currentFragmentName = null
+        },
+      },
+      [Kind.VARIABLE]: (): void => {
+        if (currentFragmentName) {
+          fragmentsWithVariables.add(currentFragmentName)
+        }
+      },
+    }
+  },
+  prefixVariables: (prefix: string): Visitor<ASTKindToNode> => {
+    return {
+      [Kind.VARIABLE]: (variable: VariableNode): VariableNode =>
+        prefixNodeName(variable, prefix),
+    }
+  },
+  prefixFragmentNames: (
+    prefix: string,
+    fragmentNames: Set<string>
+  ): Visitor<ASTKindToNode> => {
+    return {
+      [Kind.FRAGMENT_DEFINITION]: (
+        def: FragmentDefinitionNode
+      ): FragmentDefinitionNode | void =>
+        fragmentNames.has(def.name.value) ? prefixNodeName(def, prefix) : def,
+
+      [Kind.FRAGMENT_SPREAD]: (def: FragmentSpreadNode): FragmentSpreadNode =>
+        fragmentNames.has(def.name.value) ? prefixNodeName(def, prefix) : def,
+    }
+  },
+}
+
+function prefixQueryParts(prefix: string, query: IQuery): IQuery {
+  let document: DocumentNode = aliasTopLevelFields(prefix, query.query)
+  const variableNames = Object.keys(query.variables)
+
+  if (variableNames.length === 0) {
+    return { ...query, query: document }
+  }
+
+  const fragmentsWithVariables: Set<string> = new Set()
+
+  document = visit(
+    document,
+    visitInParallel([
+      // Note: the sequence is important due to how visitInParallel deals with node edits
+      Visitors.detectFragmentsWithVariables(fragmentsWithVariables),
+      Visitors.prefixVariables(prefix),
+    ])
+  )
+
+  if (fragmentsWithVariables.size > 0) {
+    // Prefix all fragments and spreads having variables
+    // Sadly, have to do another pass as fragment spreads may occur at any level
+    // (fragments with variables are relatively rare though)
+    document = visit(
+      document,
+      Visitors.prefixFragmentNames(prefix, fragmentsWithVariables),
+      {
+        [Kind.DOCUMENT]: [`definitions`],
+        [Kind.OPERATION_DEFINITION]: [`selectionSet`],
+        [Kind.FRAGMENT_DEFINITION]: [`selectionSet`],
+        [Kind.INLINE_FRAGMENT]: [`selectionSet`],
+        [Kind.FIELD]: [`selectionSet`],
+        [Kind.SELECTION_SET]: [`selections`],
+      } as any
+    )
+  }
+
+  const prefixedVariables = variableNames.reduce((acc, name) => {
+    acc[prefix + name] = query.variables[name]
+    return acc
+  }, {})
+
+  return {
+    query: document,
+    variables: prefixedVariables,
+  }
+}
+
+/**
+ * Adds prefixed aliases to top-level fields of the query.
+ *
+ * @see aliasFieldsInSelection for implementation details
+ */
+function aliasTopLevelFields(prefix: string, doc: DocumentNode): DocumentNode {
+  const transformer = {
+    [Kind.OPERATION_DEFINITION]: (def): OperationDefinitionNode => {
+      const { selections } = def.selectionSet
+      return {
+        ...def,
+        selectionSet: {
+          ...def.selectionSet,
+          selections: aliasFieldsInSelection(prefix, selections, doc),
+        },
+      }
+    },
+  }
+  return visit(doc, transformer, { [Kind.DOCUMENT]: [`definitions`] } as any)
+}
+
+/**
+ * Add aliases to fields of the selection, including top-level fields of inline fragments.
+ * Fragment spreads are converted to inline fragments and their top-level fields are also aliased.
+ *
+ * Note that this method is shallow. It adds aliases only to the top-level fields and doesn't
+ * descend to field sub-selections.
+ *
+ * For example, transforms:
+ *   {
+ *     foo
+ *     ... on Query { foo }
+ *     ...FragmentWithBarField
+ *   }
+ * To:
+ *   {
+ *     gatsby1_foo: foo
+ *     ... on Query { gatsby1_foo: foo }
+ *     ... on Query { gatsby1_bar: bar }
+ *   }
+ */
+function aliasFieldsInSelection(
+  prefix: string,
+  selections: ReadonlyArray<SelectionNode>,
+  document: DocumentNode
+): SelectionNode[] {
+  return _.flatMap(selections, (selection: SelectionNode): SelectionNode[] => {
+    switch (selection.kind) {
+      case Kind.INLINE_FRAGMENT:
+        return [aliasFieldsInInlineFragment(prefix, selection, document)]
+
+      case Kind.FRAGMENT_SPREAD: {
+        const inlineFragment = inlineFragmentSpread(selection, document)
+        return [
+          addSkipDirective(selection),
+          aliasFieldsInInlineFragment(prefix, inlineFragment, document),
+          // Keep original spread in selection with @skip(if: true)
+          // otherwise if this was a single fragment usage the query will fail validation
+        ]
+      }
+
+      case Kind.FIELD:
+      default:
+        return [aliasField(selection, prefix)]
+    }
+  })
+}
+
+interface INodeWithDirectives {
+  readonly directives?: ReadonlyArray<DirectiveNode>
+}
+
+function addSkipDirective<T extends INodeWithDirectives>(node: T): T {
+  const skipDirective: DirectiveNode = {
+    kind: Kind.DIRECTIVE,
+    name: { kind: Kind.NAME, value: `skip` },
+    arguments: [
+      {
+        kind: Kind.ARGUMENT,
+        name: { kind: Kind.NAME, value: `if` },
+        value: { kind: Kind.BOOLEAN, value: true },
+      },
+    ],
+  }
+  return {
+    ...node,
+    directives: [skipDirective],
+  }
+}
+
+/**
+ * Add aliases to top-level fields of the inline fragment.
+ * Returns new inline fragment node.
+ *
+ * For Example, transforms:
+ *   ... on Query { foo, ... on Query { bar: foo } }
+ * To
+ *   ... on Query { gatsby1_foo: foo, ... on Query { gatsby1_bar: foo } }
+ */
+function aliasFieldsInInlineFragment(
+  prefix: string,
+  fragment: InlineFragmentNode,
+  document: DocumentNode
+): InlineFragmentNode {
+  const { selections } = fragment.selectionSet
+  return {
+    ...fragment,
+    selectionSet: {
+      ...fragment.selectionSet,
+      selections: aliasFieldsInSelection(prefix, selections, document),
+    },
+  }
+}
+
+/**
+ * Replaces fragment spread with inline fragment
+ *
+ * Example:
+ *   query { ...Spread }
+ *   fragment Spread on Query { bar }
+ *
+ * Transforms to:
+ *   query { ... on Query { bar } }
+ */
+function inlineFragmentSpread(
+  spread: FragmentSpreadNode,
+  document: DocumentNode
+): InlineFragmentNode {
+  const fragment = document.definitions.find(
+    def =>
+      def.kind === Kind.FRAGMENT_DEFINITION &&
+      def.name.value === spread.name.value
+  )
+  if (!fragment) {
+    throw new Error(`Fragment ${spread.name.value} does not exist`)
+  }
+  const { typeCondition, selectionSet } = fragment as FragmentDefinitionNode
+
+  return {
+    kind: Kind.INLINE_FRAGMENT,
+    typeCondition,
+    selectionSet,
+    directives: spread.directives,
+  }
+}
+
+function prefixNodeName<T extends { name: NameNode }>(
+  namedNode: T,
+  prefix: string
+): T {
+  return {
+    ...namedNode,
+    name: {
+      ...namedNode.name,
+      value: prefix + namedNode.name.value,
+    },
+  }
+}
+
+/**
+ * Returns a new FieldNode with prefixed alias
+ *
+ * Example. Given prefix === "gatsby1_" transforms:
+ *   { foo } -> { gatsby1_foo: foo }
+ *   { foo: bar } -> { gatsby1_foo: bar }
+ */
+function aliasField(field: FieldNode, aliasPrefix: string): FieldNode {
+  const aliasNode = field.alias ? field.alias : field.name
+  return {
+    ...field,
+    alias: {
+      ...aliasNode,
+      value: aliasPrefix + aliasNode.value,
+    },
+  }
+}
+
+function isQueryDefinition(def): def is OperationDefinitionNode {
+  return def.kind === Kind.OPERATION_DEFINITION && def.operation === `query`
+}
+
+function isFragmentDefinition(def): def is FragmentDefinitionNode {
+  return def.kind === Kind.FRAGMENT_DEFINITION
+}

--- a/packages/gatsby-source-graphql/src/batching/merge-queries.ts
+++ b/packages/gatsby-source-graphql/src/batching/merge-queries.ts
@@ -91,6 +91,8 @@ export function merge(queries: ReadonlyArray<IQuery>): IQuery {
       if (isFragmentDefinition(def)) {
         // Theoretically it is possible to have fragments with the same name but different content
         // in different queries. But Gatsby validation doesn't allow this and we rely on this here
+        // One example where this can occur is in gatsby-node or GraphiQL queries
+        // (but those are usually not batched)
         mergedFragmentMap.set(def.name.value, def)
       }
     })

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -8,6 +8,7 @@ const {
 const { createHttpLink } = require(`apollo-link-http`)
 const nodeFetch = require(`node-fetch`)
 const invariant = require(`invariant`)
+const { createDataloaderLink } = require(`./batching/dataloader-link`)
 
 const {
   NamespaceUnderFieldTransform,
@@ -29,6 +30,7 @@ exports.sourceNodes = async (
     createLink,
     createSchema,
     refetchInterval,
+    batch = false,
   } = options
 
   invariant(
@@ -48,12 +50,13 @@ exports.sourceNodes = async (
   if (createLink) {
     link = await createLink(options)
   } else {
-    link = createHttpLink({
+    const options = {
       uri: url,
       fetch,
       fetchOptions,
       headers: typeof headers === `function` ? await headers() : headers,
-    })
+    }
+    link = batch ? createDataloaderLink(options) : createHttpLink(options)
   }
 
   let introspectionSchema

--- a/packages/gatsby/src/query/queue.js
+++ b/packages/gatsby/src/query/queue.js
@@ -7,7 +7,8 @@ const GraphQLRunner = require(`./graphql-runner`)
 
 const createBaseOptions = () => {
   return {
-    concurrent: 4,
+    concurrent: Number(process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) || 4,
+    // eslint-disable-next-line new-cap
     store: FastMemoryStore(),
   }
 }
@@ -67,8 +68,7 @@ const createDevelopQueue = getRunner => {
  * Note: queue is reused in develop so make sure to thoroughly cleanup hooks
  */
 const processBatch = async (queue, jobs, activity) => {
-  let numJobs = jobs.length
-  if (numJobs === 0) {
+  if (jobs.length === 0) {
     return Promise.resolve()
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8150,6 +8150,11 @@ dataloader@^1.4.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
+dataloader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
+  integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
+
 date-fns@^1.27.2, date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"


### PR DESCRIPTION
## Description

This PR allows `gatsby-source-graphql` users to improve performance 2-10 times by introducing query batching strategy along with a new environment variable for controlling query concurrency.

By default, `gatsby-source-graphql` executes each query in a separate network request. Query batching strategy implemented in this PR merges several queries into a single query and sends it to the server.

Consider the following queries:

```js
{
  query: `query(id: Int!) {
    node(id: $id) {
      foo
    }
  }`,
  variables: { id: 1 },
}
```

```js
{
  query: `query(id: Int!) {
    node(id: $id) {
      bar
    }
  }`,
  variables: { id: 2 },
}
```

They will be merged into a single query:

```js
{
  query: `
    query(
      $gatsby0_id: Int!
      $gatsby1_id: Int!
    ) {
      gatsby0_node: node(id: $gatsby0_id) {
        foo
      }
      gatsby1_node: node(id: $gatsby1_id) {
        bar
      }
    }
  `,
  variables: {
    gatsby0_id: 1,
    gatsby1_id: 2,
  }
}
```

Then the response will be transformed back to the shape expected for original queries.

**Caveat**: Batching is only possible for queries starting approximately at the same time. In other words, it is bounded by the number of parallel GraphQL queries executed by Gatsby (by default it is **4**).

To work around this limitation this PR also introduces a new environment variable `GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY`.

By tweaking this concurrency level and number of queries in batch it possible to significantly improve the performance in some cases.

Bench on [my test site](https://github.com/vladar/source-graphql-bench) (queries per second, bigger is better):

|                              |    no batching    | 5 queries per batch| 10 queries per batch |
|------------------------------|-------------------|--------------------|--------------------|
| Concurrency: 4 (baseline)    |      5 q/s        |    4.8 q/s         |       4.8 q/s      |
| Concurrency: 20              |      18.95 q/s    |    19.07 q/s       |       22.73 q/s    |
| Concurrency: 50              |      15 q/s       |    40.3 q/s        |       45 q/s       |
| Concurrency: 100             |  server died :)   |    44.3 q/s        |       48 q/s       |


### Documentation

The documentation is outlined in the README.md (happy for any advice)


## Related Issues
Fixes #13425
