### PR TITLE
Adding plugin name line before configuration

### DIFF
--- a/docs/docs/adding-analytics.md
+++ b/docs/docs/adding-analytics.md
@@ -39,6 +39,7 @@ npm install --save gatsby-plugin-google-analytics
 ```js:title=gatsby-config.js
 module.exports = {
   plugins: [
+    `gatsby-plugin-google-analytics`,
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {


### PR DESCRIPTION
Adding the relevant name of the analytics plugin before the configuration for it in the example, re-opened this PR due to a prettier check that failed the first time

## Description

I am proposing adding a line with the name of the analytics plugin before its configuration in the documentation example

### Documentation

[www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/)

## Related Issues

I was having trouble getting the plugin to track on Google Analytics until I saw an example where the plugins had a line with their name before - this seemed to fix it before I had a chance to open an issue
