### PR TITLE
fix(gatsby-plugin-offline): Run app-shell.js from user cache directory for pnp compatibility

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -1,23 +1,17 @@
 // use `let` to workaround https://github.com/jhnns/rewire/issues/144
 let fs = require(`fs`)
 let workboxBuild = require(`workbox-build`)
-const { promisify } = require(`util`)
 const path = require(`path`)
 const { slash } = require(`gatsby-core-utils`)
 const glob = require(`glob`)
 const _ = require(`lodash`)
 
-const readFile = promisify(fs.readFile)
-const writeFile = promisify(fs.writeFile)
 let getResourcesFromHTML = require(`./get-resources-from-html`)
 
-exports.onPreBootstrap = async ({ cache }) => {
-  const appShellDir = cache.directory
+exports.onPreBootstrap = ({ cache }) => {
   const appShellSourcePath = path.join(__dirname, `app-shell.js`)
-  const appShellTargetPath = path.join(appShellDir, `app-shell.js`)
-  const appShellSource = await readFile(appShellSourcePath)
-
-  await writeFile(appShellTargetPath, appShellSource)
+  const appShellTargetPath = path.join(cache.directory, `app-shell.js`)
+  fs.copyFileSync(appShellSourcePath, appShellTargetPath)
 }
 
 exports.createPages = ({ actions, cache }) => {


### PR DESCRIPTION
## Description

This makes `gatsby-plugin-offline` write `app-shell.js` to the user's cache directory before using `createPage()`.

The reason for this is because `true-case-path` doesn't work well with yarn 2's virtual dependency paths.  The paths normally read:
`/path/to/project/.yarn/$$virtual/package-name/<number>`

As soon as `true-case-path` reaches `$$virtual`, it only finds the contents of `/path/to/project/.yarn`.  Which means it won't ever find `$$virtual/package-name/<number>`.  It wouldn't even be able to pick up a valid path again until it reaches the number that follows the package name (which resolves to wherever the yarn cache is located).

This explains why `gatsby-plugin-offline` throws an exception when trying to call `createPage()` with `${__dirname}/app-shell.js` as the component.  By copying that file to the user's cache, `true-case-path` is able to process it correctly.

An alternative would be to define a base path for `true-case-path` that represents that virtual path, up to `<number>`.  I didn't think that would be entirely reasonable, since it would require extra runs through `true-case-path` to get the correct case up to `$$virtual`, and then again after.  That's not particularly stable, because it would be dependent on yarn2's current implementation of their virtual paths.

## Related Issues

Related to https://github.com/gatsbyjs/gatsby/issues/20949#issuecomment-583499834