### PR TITLE
chore(docs): Correctly identify node and nvm versions in tutorial

### DIFF
--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -57,11 +57,11 @@ xcode-select --install
 brew install node
 ```
 
-> 💡 If you don't want to install it through Homebrew, download the latest Node.js version from [the official Node.js website](https://nodejs.org/en/), double click on the downloaded file and go through the installation process.
+> 💡 If you don't want to install it through Homebrew, download your preferred version of Node.js version from [the official Node.js website](https://nodejs.org/en/), double click on the downloaded file and go through the installation process.
 
 ### Windows Instructions
 
-- Download and install the latest Node.js version from [the official Node.js website](https://nodejs.org/en/)
+- Download and install your preferred version of Node.js version from [the official Node.js website](https://nodejs.org/en/)
 
 ### Linux Instructions
 
@@ -92,7 +92,7 @@ sudo apt -y upgrade
 sudo apt-get install curl
 ```
 
-3. After it finishes installing, download the latest nvm version:
+3. After it finishes installing, download the your preferred nvm version:
 
 ```shell
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
@@ -152,7 +152,7 @@ nvm --version
 
 #### Set default Node.js version
 
-When nvm is installed, it does not default to a particular node version. You’ll need to install the version you want and give nvm instructions to use it. This example uses the latest release of version 10, but more recent version numbers can be used instead.
+When nvm is installed, it does not default to a particular node version. You’ll need to install the version you want and give nvm instructions to use it. This example uses the version 10 release, but more recent version numbers can be used instead.
 
 ```shell
 nvm install 10


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Correctly identify node and nvm versions in tutorial
As requested in PR #22291

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
The documentation in https://www.gatsbyjs.org/tutorial/part-zero/ does not use the latest version number of nvm and node, but it says that it is the latest version.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->


