### PR TITLE
fix(docs): 🧹 Fix case of GitHub

### DIFF
--- a/docs/docs/deploying-to-cloudflare-workers.md
+++ b/docs/docs/deploying-to-cloudflare-workers.md
@@ -121,4 +121,4 @@ Set up `CF_API_TOKEN` in GitHub secrets with appropriate values from [Quick Star
 ## Additional resources
 
 - [Quickstart for Workers Sites](https://developers.cloudflare.com/workers/sites/start-from-existing/)
-- [Github Action wrangler plugin](https://github.com/cloudflare/wrangler-action)
+- [GitHub Action wrangler plugin](https://github.com/cloudflare/wrangler-action)


### PR DESCRIPTION
## Description

changes:

- 🧹 Fix case of GitHub

