### PR TITLE
chore(docs): 🧹 remove trailing whitespace from Markdown.

### DIFF
--- a/docs/docs/glossary/markdown.md
+++ b/docs/docs/glossary/markdown.md
@@ -26,7 +26,7 @@ You can use Markdown to create documents for [Gatsby](https://www.gatsbyjs.org/)
 <figure class="chart">
   <object data="chart.svg" type="image/svg+xml"></object>
   <figcaption>
-    Developers who love using Gatsby versus those who haven't tried it yet.  
+    Developers who love using Gatsby versus those who haven't tried it yet.
   </figcaption>
 </figure>
 ```

--- a/packages/gatsby-design-tokens/CHANGELOG.md
+++ b/packages/gatsby-design-tokens/CHANGELOG.md
@@ -34,7 +34,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 #### Tokens
 
-This update moves the rudimentary tokens even closer to our current sole target, CSS. This e.g. means that instead of exporting an array of integers for `fontSizes` or `space`, we now provide `rem` values instead (while still making the v1 variants available — but we do have "soft" preferences regarding default units for CSS, which are emphasized by these breaking changes).  
+This update moves the rudimentary tokens even closer to our current sole target, CSS. This e.g. means that instead of exporting an array of integers for `fontSizes` or `space`, we now provide `rem` values instead (while still making the v1 variants available — but we do have "soft" preferences regarding default units for CSS, which are emphasized by these breaking changes).
 We currently only consume these tokens in the context of CSS, so let's make things a bit easier there:
 
 - `fontsSizes` exports `rem` values now; old values available at `fontSizesRaw`

--- a/packages/gatsby-design-tokens/CHANGELOG.md
+++ b/packages/gatsby-design-tokens/CHANGELOG.md
@@ -35,6 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 #### Tokens
 
 This update moves the rudimentary tokens even closer to our current sole target, CSS. This e.g. means that instead of exporting an array of integers for `fontSizes` or `space`, we now provide `rem` values instead (while still making the v1 variants available — but we do have "soft" preferences regarding default units for CSS, which are emphasized by these breaking changes).
+
 We currently only consume these tokens in the context of CSS, so let's make things a bit easier there:
 
 - `fontsSizes` exports `rem` values now; old values available at `fontSizesRaw`


### PR DESCRIPTION
Found 2 Markdown files with trailing whitespace.
