### PR TITLE
chore(gatsby): Migrate utils/tracer/zipkin-local to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,5 +131,8 @@
   ],
   "resolutions": {
     "write-file-atomic": "2.4.3"
+  },
+  "dependencies": {
+    "@types/node-fetch": "^2.5.5"
   }
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -145,7 +145,10 @@
     "webpack-merge": "^4.2.2",
     "webpack-stats-plugin": "^0.3.1",
     "xstate": "^4.8.0",
-    "yaml-loader": "^0.5.0"
+    "yaml-loader": "^0.5.0",
+    "zipkin": "^0.19.2",
+    "zipkin-transport-http": "^0.19.2",
+    "zipkin-javascript-opentracing": "^2.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -145,10 +145,7 @@
     "webpack-merge": "^4.2.2",
     "webpack-stats-plugin": "^0.3.1",
     "xstate": "^4.8.0",
-    "yaml-loader": "^0.5.0",
-    "zipkin": "^0.19.2",
-    "zipkin-transport-http": "^0.19.2",
-    "zipkin-javascript-opentracing": "^2.1.0"
+    "yaml-loader": "^0.5.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -161,7 +158,10 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "rimraf": "^3.0.2",
-    "xhr-mock": "^2.5.1"
+    "xhr-mock": "^2.5.1",
+    "zipkin": "^0.19.2",
+    "zipkin-transport-http": "^0.19.2",
+    "zipkin-javascript-opentracing": "^2.1.0"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/gatsby/src/utils/tracer/index.ts
+++ b/packages/gatsby/src/utils/tracer/index.ts
@@ -2,7 +2,12 @@ import { slash } from "gatsby-core-utils"
 import path from "path"
 import { Tracer, initGlobalTracer } from "opentracing"
 
-let tracerProvider
+interface ITracerProvider {
+  create(): Tracer
+  stop(): Promise<void>
+}
+
+let tracerProvider: ITracerProvider | undefined
 
 /**
  * tracerFile should be a js file that exports two functions.
@@ -18,7 +23,7 @@ export const initTracer = (tracerFile: string): Tracer => {
   if (tracerFile) {
     const resolvedPath = slash(path.resolve(tracerFile))
     tracerProvider = require(resolvedPath)
-    tracer = tracerProvider.create()
+    tracer = tracerProvider!.create()
   } else {
     tracer = new Tracer() // Noop
   }
@@ -29,7 +34,7 @@ export const initTracer = (tracerFile: string): Tracer => {
 }
 
 export const stopTracer = async (): Promise<void> => {
-  if (tracerProvider && tracerProvider.stop) {
+  if (tracerProvider?.stop) {
     await tracerProvider.stop()
   }
 }

--- a/packages/gatsby/src/utils/tracer/zipkin-types.d.ts
+++ b/packages/gatsby/src/utils/tracer/zipkin-types.d.ts
@@ -1,0 +1,27 @@
+import zipkin from "zipkin"
+import logger from "zipkin-transport-http"
+import { Span } from "opentracing"
+import { HeadersInit } from "node-fetch"
+
+export class ZipkinPartialSpan {
+  traceId: string
+  timeoutTimestamp: number
+  delegate: Span
+  localEndpoint: unknown
+  shouldFlush: boolean
+}
+
+export class ZipkinBatchRecorder extends zipkin.BatchRecorder {
+  partialSpans: Map<string, ZipkinPartialSpan>
+  _timedOut(span: ZipkinPartialSpan): boolean
+  _writeSpan(id: string): void
+}
+
+export class ZipkinHttpLogger extends logger.HttpLogger {
+  queue: string[]
+  endpoint: string
+  headers: HeadersInit
+  timeout: number
+  errorListenerSet: boolean
+  emit(event: string | symbol, ...args: any[]): boolean
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -24775,6 +24775,26 @@ zen-observable@^0.8.0:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.9.tgz#0475c760ff0eda046bbdfa4dc3f95d392807ac53"
 
+zipkin-javascript-opentracing@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/zipkin-javascript-opentracing/-/zipkin-javascript-opentracing-2.1.0.tgz#05aed5ff7b609f60ca54020de7f3b0b6c0b0a973"
+  integrity sha512-Rzvy7kas6RXNDH0qjh2QcCv76nPIO2yjg17OzmqccNEmvePFEqFYpiwfLQ2ClBlYwj7p4PsquY2OxtA825k3nw==
+
+zipkin-transport-http@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/zipkin-transport-http/-/zipkin-transport-http-0.19.2.tgz#11ccd3c8e322ebe2e16074e4c2ffb87925c20807"
+  integrity sha512-44ySrHXAr42fTYJmHYkSD3Wy246l6C0Lyw6y9MGHRKw74ZEPFE4R7FmpyR4YHzLuRJP0BF4YoaFGjh0x/2B1yw==
+  dependencies:
+    zipkin "^0.19.2"
+
+zipkin@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/zipkin/-/zipkin-0.19.2.tgz#bfc4d9a3dc175751434327c686d86530faa6ad8f"
+  integrity sha512-nUgb+FGuchirCsUK7IL/pQKwo1QVm7lSnDvjlql7jO1zSPodDqHhCnEs4gy+AXbotPy0niDmjcl/dhIzpFR3+Q==
+  dependencies:
+    base64-js "^1.1.2"
+    is-promise "^2.1.0"
+
 zwitch@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.3.tgz#159fae4b3f737db1e42bf321d3423e4c96688a18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3993,6 +3993,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@^2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.5.tgz#cd264e20a81f4600a6c52864d38e7fef72485e92"
+  integrity sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"


### PR DESCRIPTION
## Description

Convert `utils/tracer/zipkin-local` to typescript.

## Related Issues

Related to #21995