### PR TITLE
chore(gatsby): migrate webpack-plugins to TypeScript

### DIFF
--- a/packages/gatsby/src/utils/webpack-plugins.ts
+++ b/packages/gatsby/src/utils/webpack-plugins.ts
@@ -1,13 +1,11 @@
-// @flow
+import webpack, { Plugin } from "webpack"
 
-const webpack = require(`webpack`)
-
-const plugin = (name, optimize) => {
-  const Plugin = (optimize ? webpack.optimize : webpack)[name]
-  return (...args: any) => new Plugin(...args)
+const plugin = (name: string, optimize?: boolean): Plugin => {
+  const WebpackPlugin = (optimize ? webpack.optimize : webpack)[name]
+  return (...args: any): Plugin => new WebpackPlugin(...args)
 }
 
-const plugins = {
+export const builtinPlugins = {
   normalModuleReplacement: plugin(`NormalModuleReplacementPlugin`),
   contextReplacement: plugin(`ContextReplacementPlugin`),
   ignore: plugin(`IgnorePlugin`),
@@ -53,5 +51,3 @@ const plugins = {
   occurrenceOrder: plugin(`OccurrenceOrderPlugin`, true),
   moduleConcatenation: plugin(`ModuleConcatenationPlugin`, true),
 }
-
-module.exports = plugins

--- a/packages/gatsby/src/utils/webpack-utils.js
+++ b/packages/gatsby/src/utils/webpack-utils.js
@@ -11,7 +11,7 @@ const isWsl = require(`is-wsl`)
 const GatsbyWebpackStatsExtractor = require(`./gatsby-webpack-stats-extractor`)
 const GatsbyWebpackEslintGraphqlSchemaReload = require(`./gatsby-webpack-eslint-graphql-schema-reload-plugin`)
 
-const builtinPlugins = require(`./webpack-plugins`)
+import { builtinPlugins } from "./webpack-plugins"
 const eslintConfig = require(`./eslint-config`)
 
 type LoaderSpec = string | { loader: string, options?: Object }
@@ -132,7 +132,7 @@ module.exports = async ({
   const makeExternalOnly = (original: RuleFactory<*>) => (
     options = {}
   ): Rule => {
-    let rule = original(options)
+    const rule = original(options)
     rule.include = vendorRegex
     return rule
   }
@@ -140,7 +140,7 @@ module.exports = async ({
   const makeInternalOnly = (original: RuleFactory<*>) => (
     options = {}
   ): Rule => {
-    let rule = original(options)
+    const rule = original(options)
     rule.exclude = vendorRegex
     return rule
   }
@@ -307,7 +307,7 @@ module.exports = async ({
    * and packages that depend on `gatsby`
    */
   {
-    let js = ({ modulesThatUseGatsby = [], ...options } = {}) => {
+    const js = ({ modulesThatUseGatsby = [], ...options } = {}) => {
       return {
         test: /\.(js|mjs|jsx)$/,
         include: modulePath => {
@@ -342,7 +342,7 @@ module.exports = async ({
    * Excludes modules that use Gatsby since the `rules.js` already transpiles those
    */
   {
-    let dependencies = ({ modulesThatUseGatsby = [] } = {}) => {
+    const dependencies = ({ modulesThatUseGatsby = [] } = {}) => {
       const jsOptions = {
         babelrc: false,
         configFile: false,
@@ -391,7 +391,7 @@ module.exports = async ({
   }
 
   {
-    let eslint = schema => {
+    const eslint = schema => {
       return {
         enforce: `pre`,
         test: /\.jsx?$/,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Part of #21995 

I migrated `webpack-plugins.js` to TypeScript

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

#21995 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
