### PR TITLE
chore(www): add tabindex attr to Img components in home-logo-banner file

### DIFF
--- a/www/src/components/homepage/homepage-logo-banner.js
+++ b/www/src/components/homepage/homepage-logo-banner.js
@@ -92,11 +92,12 @@ const HomepageLogoBanner = () => {
       </Title>
       <LogoGroup>
         {data.allFile.nodes.map(image => (
-          <Img
-            alt={`${image.base.split(`.`)[0]}`}
-            fixed={image.childImageSharp.fixed}
-            key={image.base}
-          />
+          <div key={image.base} tabIndex="0">
+            <Img
+              alt={`${image.base.split(`.`)[0]}`}
+              fixed={image.childImageSharp.fixed}
+            />
+          </div>
         ))}
       </LogoGroup>
     </Section>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

To make it easier to browse "Trusted by" widget on the [GatsbyJS homepage](https://www.gatsbyjs.org/) using a keyboard, I added the `tabindex` attribute to the `Img` components in the `homepage-logo-banner` file

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #22214

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
