### PR TITLE
fix(plugin-netlify-cms): use 'netlify-identity.js' instead of 'netlify-identity-widget.js'

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -175,8 +175,8 @@ exports.onCreateWebpackConfig = (
       name: `netlify-identity-widget`,
       global: `netlifyIdentity`,
       assetDir: `build`,
-      assetName: `netlify-identity-widget.js`,
-      sourceMap: `netlify-identity-widget.js.map`,
+      assetName: `netlify-identity.js`,
+      sourceMap: `netlify-identity.js.map`,
     })
   }
 


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/22386

Netlify Identity Widget provides two build outputs:
1. [`netlify-identity-widget.js`](https://github.com/netlify/netlify-identity-widget/blob/05152b12587e5093940c004f647d59799daaa21f/webpack.config.babel.js#L14) which initializes the widget on [DOMContentLoaded](https://github.com/netlify/netlify-identity-widget/blob/05152b12587e5093940c004f647d59799daaa21f/src/index.js#L11).
2. [`netlify-identity.js`](https://github.com/netlify/netlify-identity-widget/blob/05152b12587e5093940c004f647d59799daaa21f/webpack.umd.config.babel.js#L6) which doesn't initialize the widget.

This PR switches from number 1 to number 2 to avoid duplicate initialization as the widget is already initialized here https://github.com/gatsbyjs/gatsby/blob/9e291e916058e6100bf7f8be59d119f3a44c1639/packages/gatsby-plugin-netlify-cms/src/cms-identity.js#L24
