### PR TITLE
chore(gatsby): Convert local-eslint-config-finder to typescript

### DIFF
--- a/packages/gatsby/src/utils/gatsby-webpack-eslint-graphql-schema-reload-plugin.js
+++ b/packages/gatsby/src/utils/gatsby-webpack-eslint-graphql-schema-reload-plugin.js
@@ -6,7 +6,7 @@
  */
 const { store } = require(`../redux`)
 const eslintConfig = require(`./eslint-config`)
-const hasLocalEslint = require(`./local-eslint-config-finder`)
+const { hasLocalEslint } = require(`./local-eslint-config-finder`)
 
 const isEslintRule = rule => {
   const options = rule && rule.use && rule.use[0] && rule.use[0].options

--- a/packages/gatsby/src/utils/local-eslint-config-finder.ts
+++ b/packages/gatsby/src/utils/local-eslint-config-finder.ts
@@ -1,11 +1,13 @@
-const path = require(`path`)
-const glob = require(`glob`)
-const debug = require(`debug`)(`gatsby:webpack-eslint-config`)
-const report = require(`gatsby-cli/lib/reporter`)
+import path from "path"
+import glob from "glob"
+import debug from "debug"
+import report from "gatsby-cli/lib/reporter"
 
-module.exports = directory => {
+const log = debug(`gatsby:webpack-eslint-config`)
+
+export const hasLocalEslint = (directory: string): boolean => {
   try {
-    debug(`Attempting to load package.json for eslint config check`)
+    log(`Attempting to load package.json for eslint config check`)
 
     const pkg = require(path.resolve(directory, `package.json`))
     if (pkg.eslintConfig) {
@@ -15,7 +17,7 @@ module.exports = directory => {
     report.error(`There was a problem processing the package.json file`, err)
   }
 
-  debug(`Checking for eslint config file`)
+  log(`Checking for eslint config file`)
   const eslintFiles = glob.sync(`.eslintrc?(.js|.json|.yaml|.yml)`, {
     cwd: directory,
   })

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -14,7 +14,7 @@ const getGatsbyDependents = require(`./gatsby-dependents`)
 
 const apiRunnerNode = require(`./api-runner-node`)
 const createUtils = require(`./webpack-utils`)
-const hasLocalEslint = require(`./local-eslint-config-finder`)
+import { hasLocalEslint } from "./local-eslint-config-finder"
 
 // Four stages or modes:
 //   1) develop: for `gatsby develop` command, hot reload and CSS injection into page


### PR DESCRIPTION
## Description

Convert local-eslint-config-finder to typescript

## Related Issues

Related to #21995