### PR TITLE
fix(gatsby): Incorrect PackageJson type

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1197,7 +1197,7 @@ export interface PackageJson {
   devDependencies?: Record<string, string>
   peerDependencies?: Record<string, string>
   optionalDependencies?: Record<string, string>
-  bundledDependecies?: Array<string>
+  bundledDependencies?: Array<string>
   keywords?: string[]
 }
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1193,11 +1193,11 @@ export interface PackageJson {
         email: string
       }
   license?: string
-  dependencies?: Array<Record<string, string>>
-  devDependencies?: Array<Record<string, string>>
-  peerDependencies?: Array<Record<string, string>>
-  optionalDependencies?: Array<Record<string, string>>
-  bundledDependecies?: Array<Record<string, string>>
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  bundledDependecies?: Array<string>
   keywords?: string[]
 }
 


### PR DESCRIPTION
## Description

This PR fixes the incorrect type for `PackageJson`. 

## Related Issues

Fixes #22394. 