### PR TITLE
chore(starter): Add ecommerce-blog-contentful-starter to starters

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5695,3 +5695,18 @@
     - SEO optimized
     - Robots.txt
     - OpenGraph structured data
+- url: https://ecommerce-blog.netlify.com/
+  repo: https://github.com/billp72/ecommerce-blog-contentful-starter
+  description: A Gatsby Starter built with Contenful CMS to launch your dream store and blog with a click.
+  tags:
+    - Blog
+    - SEO
+    - eCommerce
+    - CMS:Headless
+    - CMS:Contentful
+    - Styling:PostCSS
+  features:
+    - Advanced ecommerce and blog created for designer and developers
+    - Manage Ecommerce with Contenful CMS
+    - Option to add featured image and meta description while adding products
+    - create blog posts easily using static markdown pages


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
eCommerce plus Blog
* contentful 
* snipcart
* stripe
* algolia search
* blogging
* e-commerce
* PWA
* BundleAnalyzerPlugin 
* modal (displays for first-time visitors using cookies)

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
