### PR TITLE
chore(gatsby): Migrate gatsby-dependents to TypeScript

### DIFF
--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -29,7 +29,7 @@ const {
   VariablesInAllowedPositionRule,
 } = require(`graphql`)
 
-const getGatsbyDependents = require(`../utils/gatsby-dependents`)
+import { getGatsbyDependents } from "../utils/gatsby-dependents"
 const { store } = require(`../redux`)
 import * as actions from "../redux/actions/internal"
 const { default: FileParser } = require(`./file-parser`)

--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -20,7 +20,7 @@ const queryCompiler = require(`./query-compiler`).default
 const report = require(`gatsby-cli/lib/reporter`)
 const queryUtil = require(`./index`)
 const debug = require(`debug`)(`gatsby:query-watcher`)
-const getGatsbyDependents = require(`../utils/gatsby-dependents`)
+import { getGatsbyDependents } from "../utils/gatsby-dependents"
 
 const getQueriesSnapshot = () => {
   const state = store.getState()

--- a/packages/gatsby/src/utils/gatsby-dependents.ts
+++ b/packages/gatsby/src/utils/gatsby-dependents.ts
@@ -1,7 +1,7 @@
 import { store } from "../redux"
 import { memoize, MemoizedFunction } from "lodash"
 
-import { createRequireFromPath } from "gatsby-core-utils/src"
+import { createRequireFromPath } from "gatsby-core-utils"
 import { join, dirname } from "path"
 import { PackageJson } from "../.."
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -10,7 +10,7 @@ const { getPublicPath } = require(`./get-public-path`)
 const debug = require(`debug`)(`gatsby:webpack-config`)
 const report = require(`gatsby-cli/lib/reporter`)
 import { withBasePath, withTrailingSlash } from "./path"
-const getGatsbyDependents = require(`./gatsby-dependents`)
+import { getGatsbyDependents } from "./gatsby-dependents"
 
 const apiRunnerNode = require(`./api-runner-node`)
 const createUtils = require(`./webpack-utils`)


### PR DESCRIPTION
## Description

This PR migrates `packages/gatsby/src/utils/gatsby-dependents` to TypeScript.

## Related Issues

Part of #21995. 