### PR TITLE
chore(docs): fix typo in schema customization

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -174,7 +174,7 @@ provided, they will still be handled by Gatsby's type inference.
 > Actions to customize Gatsby's schema generation are made available in the
 > [`createSchemaCustomization`](/docs/node-apis/#createSchemaCustomization)
 > (available in Gatsby v2.12 and above),
-> and [`sourcesNodes`](/docs/node-apis/#sourceNodes) APIs.
+> and [`sourceNodes`](/docs/node-apis/#sourceNodes) APIs.
 
 #### Opting out of type inference
 


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Was looking into createSchemaCustomisation as was previously using `sourceNodes` API. Scrolled down and found this tiny typo.

Couldn't find this paragraph with ctrl-F.