### PR TITLE
chore(gatsby): migrate date to TypeScript

### DIFF
--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -6,7 +6,7 @@ const {
 } = require(`graphql`)
 
 const { link, fileByPath } = require(`../resolvers`)
-const { getDateResolver } = require(`../types/date`)
+import { getDateResolver } from "../types/date"
 
 import type { GraphQLFieldConfigArgumentMap, GraphQLFieldConfig } from "graphql"
 import type { ComposeFieldConfig, ComposeOutputType } from "graphql-compose"

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -15,7 +15,7 @@ const addInferredFields = ({
   typeComposer,
   exampleValue,
   typeMapping,
-  parentSpan
+  parentSpan,
 }) => {
   const config = getInferenceConfig({
     typeComposer,
@@ -23,8 +23,8 @@ const addInferredFields = ({
       shouldAddFields: true,
       shouldAddDefaultResolvers: typeComposer.hasExtension(`infer`)
         ? false
-        : true
-    }
+        : true,
+    },
   })
   addInferredFieldsImpl({
     schemaComposer,
@@ -33,12 +33,12 @@ const addInferredFields = ({
     prefix: typeComposer.getTypeName(),
     unsanitizedFieldPath: [typeComposer.getTypeName()],
     typeMapping,
-    config
+    config,
   })
 }
 
 module.exports = {
-  addInferredFields
+  addInferredFields,
 }
 
 const addInferredFieldsImpl = ({
@@ -48,7 +48,7 @@ const addInferredFieldsImpl = ({
   typeMapping,
   prefix,
   unsanitizedFieldPath,
-  config
+  config,
 }) => {
   const fields = []
   Object.keys(exampleObject).forEach(unsanitizedKey => {
@@ -56,7 +56,7 @@ const addInferredFieldsImpl = ({
     fields.push({
       key,
       unsanitizedKey,
-      exampleValue: exampleObject[unsanitizedKey]
+      exampleValue: exampleObject[unsanitizedKey],
     })
   })
 
@@ -85,7 +85,7 @@ const addInferredFieldsImpl = ({
       prefix,
       unsanitizedFieldPath,
       typeMapping,
-      config
+      config,
     })
 
     if (!fieldConfig) return
@@ -146,7 +146,7 @@ const getFieldConfig = ({
   unsanitizedKey,
   unsanitizedFieldPath,
   typeMapping,
-  config
+  config,
 }) => {
   const selector = `${prefix}.${key}`
   unsanitizedFieldPath.push(unsanitizedKey)
@@ -167,7 +167,7 @@ const getFieldConfig = ({
     fieldConfig = getFieldConfigFromFieldNameConvention({
       schemaComposer,
       value: exampleValue,
-      key: unsanitizedKey
+      key: unsanitizedKey,
     })
     arrays = arrays + (value.multiple ? 1 : 0)
   } else {
@@ -180,7 +180,7 @@ const getFieldConfig = ({
       unsanitizedFieldPath,
       typeMapping,
       config,
-      arrays
+      arrays,
     })
   }
 
@@ -193,8 +193,8 @@ const getFieldConfig = ({
       ...fieldConfig,
       extensions: {
         ...(fieldConfig.extensions || {}),
-        proxy: { from: unsanitizedKey }
-      }
+        proxy: { from: unsanitizedKey },
+      },
     }
   }
 
@@ -236,8 +236,8 @@ const getFieldConfigFromMapping = ({ typeMapping, selector }) => {
   return {
     type,
     extensions: {
-      link: { by: path.join(`.`) || `id` }
-    }
+      link: { by: path.join(`.`) || `id` },
+    },
   }
 }
 
@@ -245,7 +245,7 @@ const getFieldConfigFromMapping = ({ typeMapping, selector }) => {
 const getFieldConfigFromFieldNameConvention = ({
   schemaComposer,
   value,
-  key
+  key,
 }) => {
   const path = key.split(`___NODE___`)[1]
   // Allow linking by nested fields, e.g. `author___NODE___contact___email`
@@ -287,8 +287,8 @@ const getFieldConfigFromFieldNameConvention = ({
   return {
     type,
     extensions: {
-      link: { by: foreignKey || `id`, from: key }
-    }
+      link: { by: foreignKey || `id`, from: key },
+    },
   }
 }
 
@@ -301,7 +301,7 @@ const getSimpleFieldConfig = ({
   unsanitizedFieldPath,
   typeMapping,
   config,
-  arrays
+  arrays,
 }) => {
   switch (typeof value) {
     case `boolean`:
@@ -367,7 +367,7 @@ const getSimpleFieldConfig = ({
             )
             addDerivedType({
               typeComposer,
-              derivedTypeName: fieldTypeComposer.getTypeName()
+              derivedTypeName: fieldTypeComposer.getTypeName(),
             })
           }
         }
@@ -376,7 +376,7 @@ const getSimpleFieldConfig = ({
         // with directive/extension, or inherited from the parent type.
         const inferenceConfig = getInferenceConfig({
           typeComposer: fieldTypeComposer,
-          defaults: config
+          defaults: config,
         })
 
         return {
@@ -387,8 +387,8 @@ const getSimpleFieldConfig = ({
             typeMapping,
             prefix: selector,
             unsanitizedFieldPath,
-            config: inferenceConfig
-          })
+            config: inferenceConfig,
+          }),
         }
       }
   }
@@ -397,10 +397,7 @@ const getSimpleFieldConfig = ({
 
 const createTypeName = selector => {
   const keys = selector.split(`.`)
-  const suffix = keys
-    .slice(1)
-    .map(_.upperFirst)
-    .join(``)
+  const suffix = keys.slice(1).map(_.upperFirst).join(``)
   return `${keys[0]}${suffix}`
 }
 
@@ -441,6 +438,6 @@ const getInferenceConfig = ({ typeComposer, defaults }) => {
       : defaults.shouldAddFields,
     shouldAddDefaultResolvers: typeComposer.hasExtension(`addDefaultResolvers`)
       ? typeComposer.getExtension(`addDefaultResolvers`)
-      : defaults.shouldAddDefaultResolvers
+      : defaults.shouldAddDefaultResolvers,
   }
 }

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -5,7 +5,7 @@ const invariant = require(`invariant`)
 const report = require(`gatsby-cli/lib/reporter`)
 
 import { isFile } from "./is-file"
-const { isDate } = require(`../types/date`)
+import { isDate } from "../types/date"
 const { addDerivedType } = require(`../types/derived-types`)
 import { is32BitInteger } from "../../utils/is-32-bit-integer"
 const { getNode, getNodes } = require(`../../redux/nodes`)
@@ -15,7 +15,7 @@ const addInferredFields = ({
   typeComposer,
   exampleValue,
   typeMapping,
-  parentSpan,
+  parentSpan
 }) => {
   const config = getInferenceConfig({
     typeComposer,
@@ -23,8 +23,8 @@ const addInferredFields = ({
       shouldAddFields: true,
       shouldAddDefaultResolvers: typeComposer.hasExtension(`infer`)
         ? false
-        : true,
-    },
+        : true
+    }
   })
   addInferredFieldsImpl({
     schemaComposer,
@@ -33,12 +33,12 @@ const addInferredFields = ({
     prefix: typeComposer.getTypeName(),
     unsanitizedFieldPath: [typeComposer.getTypeName()],
     typeMapping,
-    config,
+    config
   })
 }
 
 module.exports = {
-  addInferredFields,
+  addInferredFields
 }
 
 const addInferredFieldsImpl = ({
@@ -48,7 +48,7 @@ const addInferredFieldsImpl = ({
   typeMapping,
   prefix,
   unsanitizedFieldPath,
-  config,
+  config
 }) => {
   const fields = []
   Object.keys(exampleObject).forEach(unsanitizedKey => {
@@ -56,7 +56,7 @@ const addInferredFieldsImpl = ({
     fields.push({
       key,
       unsanitizedKey,
-      exampleValue: exampleObject[unsanitizedKey],
+      exampleValue: exampleObject[unsanitizedKey]
     })
   })
 
@@ -85,7 +85,7 @@ const addInferredFieldsImpl = ({
       prefix,
       unsanitizedFieldPath,
       typeMapping,
-      config,
+      config
     })
 
     if (!fieldConfig) return
@@ -146,7 +146,7 @@ const getFieldConfig = ({
   unsanitizedKey,
   unsanitizedFieldPath,
   typeMapping,
-  config,
+  config
 }) => {
   const selector = `${prefix}.${key}`
   unsanitizedFieldPath.push(unsanitizedKey)
@@ -167,7 +167,7 @@ const getFieldConfig = ({
     fieldConfig = getFieldConfigFromFieldNameConvention({
       schemaComposer,
       value: exampleValue,
-      key: unsanitizedKey,
+      key: unsanitizedKey
     })
     arrays = arrays + (value.multiple ? 1 : 0)
   } else {
@@ -180,7 +180,7 @@ const getFieldConfig = ({
       unsanitizedFieldPath,
       typeMapping,
       config,
-      arrays,
+      arrays
     })
   }
 
@@ -193,8 +193,8 @@ const getFieldConfig = ({
       ...fieldConfig,
       extensions: {
         ...(fieldConfig.extensions || {}),
-        proxy: { from: unsanitizedKey },
-      },
+        proxy: { from: unsanitizedKey }
+      }
     }
   }
 
@@ -236,8 +236,8 @@ const getFieldConfigFromMapping = ({ typeMapping, selector }) => {
   return {
     type,
     extensions: {
-      link: { by: path.join(`.`) || `id` },
-    },
+      link: { by: path.join(`.`) || `id` }
+    }
   }
 }
 
@@ -245,7 +245,7 @@ const getFieldConfigFromMapping = ({ typeMapping, selector }) => {
 const getFieldConfigFromFieldNameConvention = ({
   schemaComposer,
   value,
-  key,
+  key
 }) => {
   const path = key.split(`___NODE___`)[1]
   // Allow linking by nested fields, e.g. `author___NODE___contact___email`
@@ -287,8 +287,8 @@ const getFieldConfigFromFieldNameConvention = ({
   return {
     type,
     extensions: {
-      link: { by: foreignKey || `id`, from: key },
-    },
+      link: { by: foreignKey || `id`, from: key }
+    }
   }
 }
 
@@ -301,7 +301,7 @@ const getSimpleFieldConfig = ({
   unsanitizedFieldPath,
   typeMapping,
   config,
-  arrays,
+  arrays
 }) => {
   switch (typeof value) {
     case `boolean`:
@@ -367,7 +367,7 @@ const getSimpleFieldConfig = ({
             )
             addDerivedType({
               typeComposer,
-              derivedTypeName: fieldTypeComposer.getTypeName(),
+              derivedTypeName: fieldTypeComposer.getTypeName()
             })
           }
         }
@@ -376,7 +376,7 @@ const getSimpleFieldConfig = ({
         // with directive/extension, or inherited from the parent type.
         const inferenceConfig = getInferenceConfig({
           typeComposer: fieldTypeComposer,
-          defaults: config,
+          defaults: config
         })
 
         return {
@@ -387,8 +387,8 @@ const getSimpleFieldConfig = ({
             typeMapping,
             prefix: selector,
             unsanitizedFieldPath,
-            config: inferenceConfig,
-          }),
+            config: inferenceConfig
+          })
         }
       }
   }
@@ -397,7 +397,10 @@ const getSimpleFieldConfig = ({
 
 const createTypeName = selector => {
   const keys = selector.split(`.`)
-  const suffix = keys.slice(1).map(_.upperFirst).join(``)
+  const suffix = keys
+    .slice(1)
+    .map(_.upperFirst)
+    .join(``)
   return `${keys[0]}${suffix}`
 }
 
@@ -438,6 +441,6 @@ const getInferenceConfig = ({ typeComposer, defaults }) => {
       : defaults.shouldAddFields,
     shouldAddDefaultResolvers: typeComposer.hasExtension(`addDefaultResolvers`)
       ? typeComposer.getExtension(`addDefaultResolvers`)
-      : defaults.shouldAddDefaultResolvers,
+      : defaults.shouldAddDefaultResolvers
   }
 }

--- a/packages/gatsby/src/schema/infer/inference-metadata.ts
+++ b/packages/gatsby/src/schema/infer/inference-metadata.ts
@@ -509,7 +509,7 @@ const initialMetadata = (state?: object): ITypeMetadata => {
     total: 0,
     ignoredFields: undefined,
     fieldMap: {},
-    ...state
+    ...state,
   }
 }
 
@@ -522,5 +522,5 @@ export {
   isEmpty,
   hasNodes,
   haveEqualFields,
-  initialMetadata
+  initialMetadata,
 }

--- a/packages/gatsby/src/schema/infer/inference-metadata.ts
+++ b/packages/gatsby/src/schema/infer/inference-metadata.ts
@@ -509,7 +509,7 @@ const initialMetadata = (state?: object): ITypeMetadata => {
     total: 0,
     ignoredFields: undefined,
     fieldMap: {},
-    ...state,
+    ...state
   }
 }
 
@@ -522,5 +522,5 @@ export {
   isEmpty,
   hasNodes,
   haveEqualFields,
-  initialMetadata,
+  initialMetadata
 }

--- a/packages/gatsby/src/schema/schema-composer.js
+++ b/packages/gatsby/src/schema/schema-composer.js
@@ -1,6 +1,6 @@
 const { SchemaComposer, GraphQLJSON } = require(`graphql-compose`)
 const { getNodeInterface } = require(`./types/node-interface`)
-const { GraphQLDate } = require(`./types/date`)
+import { GraphQLDate } from "./types/date"
 const { addDirectives } = require(`./extensions`)
 
 const createSchemaComposer = ({ fieldExtensions } = {}) => {

--- a/packages/gatsby/src/schema/types/__tests__/date.js
+++ b/packages/gatsby/src/schema/types/__tests__/date.js
@@ -4,7 +4,6 @@ const { build } = require(`../..`)
 const withResolverContext = require(`../../context`)
 const { defaultResolver } = require(`../../resolvers`)
 import { isDate, looksLikeADate } from "../date"
-require(`../../../db/__tests__/fixtures/ensure-loki`)()
 
 jest.mock(`gatsby-cli/lib/reporter`, () => {
   return {
@@ -16,15 +15,15 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
       return {
         start: jest.fn(),
         setStatus: jest.fn(),
-        end: jest.fn(),
+        end: jest.fn()
       }
     },
     phantomActivity: () => {
       return {
         start: jest.fn(),
-        end: jest.fn(),
+        end: jest.fn()
       }
-    },
+    }
   }
 })
 
@@ -57,7 +56,7 @@ describe(`isDate`, () => {
     `2010-01-30T00:00:00.000Z`,
     `1970-01-01T00:00:00.000001Z`,
     `2012-04-01T00:00:00-05:00`,
-    `2012-11-12T00:00:00+01:00`,
+    `2012-11-12T00:00:00+01:00`
   ])(`should return true for valid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeTruthy()
   })
@@ -79,7 +78,7 @@ describe(`isDate`, () => {
     `1970-01-01 00:00:00 Z`,
     `1970-01-01 000000 Z`,
     `1970-01-01 00:00 Z`,
-    `1970-01-01 00 Z`,
+    `1970-01-01 00 Z`
   ])(`should return true for ISO 8601 (no T, extra space): %s`, dateString => {
     expect(isDate(dateString)).toBeTruthy()
   })
@@ -131,7 +130,7 @@ describe(`isDate`, () => {
     {},
     ``,
     ` `,
-    `2012-04-01T00:basketball`,
+    `2012-04-01T00:basketball`
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeFalsy()
   })
@@ -164,7 +163,7 @@ describe(`looksLikeADate`, () => {
     `2010-01-30T00:00:00.000Z`,
     `1970-01-01T00:00:00.000001Z`,
     `2012-04-01T00:00:00-05:00`,
-    `2012-11-12T00:00:00+01:00`,
+    `2012-11-12T00:00:00+01:00`
   ])(`should return true for valid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -186,7 +185,7 @@ describe(`looksLikeADate`, () => {
     `1970-01-01 00:00:00 Z`,
     `1970-01-01 000000 Z`,
     `1970-01-01 00:00 Z`,
-    `1970-01-01 00 Z`,
+    `1970-01-01 00 Z`
   ])(`should return true for ISO 8601 (no T, extra space): %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -214,7 +213,7 @@ describe(`looksLikeADate`, () => {
     `2010-01-01T23:60`,
     `2010-01-01T23:59:60`,
     `2010-01-40T23:60+00:00`,
-    `2010-01-40T23:59:60+00:00`,
+    `2010-01-40T23:59:60+00:00`
   ])(`should return true for some valid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -236,7 +235,7 @@ describe(`looksLikeADate`, () => {
     {},
     ``,
     ` `,
-    `2012-04-01T00:basketball`,
+    `2012-04-01T00:basketball`
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeFalsy()
   })
@@ -302,8 +301,8 @@ describe(`dateResolver`, () => {
         invalidDate14: ``,
         invalidDate15: ` `,
         invalidDate16: `2012-04-01T00:basketball`,
-        defaultFormatDate: `2010-01-30T23:59:59.999-07:00`,
-      },
+        defaultFormatDate: `2010-01-30T23:59:59.999-07:00`
+      }
     ]
     nodes.forEach(node =>
       actions.createNode(node, { name: `test` })(store.dispatch)
@@ -404,7 +403,7 @@ describe(`dateResolver`, () => {
     `2018-01-29T23:25:16.019345Z`,
     // Seems to not require nanosecond definition to not fail
     `2018-01-29T23:25:16.019345123+02:00`,
-    `2018-01-29T23:25:16.019345123Z`,
+    `2018-01-29T23:25:16.019345123Z`
   ])(`should return "Jan 29, 2018": %s`, async dateString => {
     const schema = await buildTestSchema()
     const fields = schema.getType(`Test`).getFields()
@@ -414,7 +413,7 @@ describe(`dateResolver`, () => {
         { formatString: `MMM DD, YYYY` },
         withResolverContext({}, schema),
         {
-          fieldName: `date`,
+          fieldName: `date`
         }
       )
     ).toEqual(`Jan 29, 2018`)
@@ -427,7 +426,7 @@ describe(`dateResolver`, () => {
     `2010-01-01T24:01`,
     `2010-01-01T23:60`,
     `2010-01-01T23:59:60`,
-    `2010-01-40T23:59:59.9999`,
+    `2010-01-40T23:59:59.9999`
     // Combine with above statement once we figure out why it passes
     // `2018-08-31T23:25:16.01234567899993+02:00`,
   ])(`should return "Invalid Date": %s`, async dateString => {
@@ -439,7 +438,7 @@ describe(`dateResolver`, () => {
         { formatString: `MMM DD, YYYY` },
         withResolverContext({}, schema),
         {
-          fieldName: `date`,
+          fieldName: `date`
         }
       )
     ).toEqual(`Invalid date`)

--- a/packages/gatsby/src/schema/types/__tests__/date.js
+++ b/packages/gatsby/src/schema/types/__tests__/date.js
@@ -16,15 +16,15 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
       return {
         start: jest.fn(),
         setStatus: jest.fn(),
-        end: jest.fn()
+        end: jest.fn(),
       }
     },
     phantomActivity: () => {
       return {
         start: jest.fn(),
-        end: jest.fn()
+        end: jest.fn(),
       }
-    }
+    },
   }
 })
 
@@ -57,7 +57,7 @@ describe(`isDate`, () => {
     `2010-01-30T00:00:00.000Z`,
     `1970-01-01T00:00:00.000001Z`,
     `2012-04-01T00:00:00-05:00`,
-    `2012-11-12T00:00:00+01:00`
+    `2012-11-12T00:00:00+01:00`,
   ])(`should return true for valid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeTruthy()
   })
@@ -79,7 +79,7 @@ describe(`isDate`, () => {
     `1970-01-01 00:00:00 Z`,
     `1970-01-01 000000 Z`,
     `1970-01-01 00:00 Z`,
-    `1970-01-01 00 Z`
+    `1970-01-01 00 Z`,
   ])(`should return true for ISO 8601 (no T, extra space): %s`, dateString => {
     expect(isDate(dateString)).toBeTruthy()
   })
@@ -131,7 +131,7 @@ describe(`isDate`, () => {
     {},
     ``,
     ` `,
-    `2012-04-01T00:basketball`
+    `2012-04-01T00:basketball`,
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeFalsy()
   })
@@ -164,7 +164,7 @@ describe(`looksLikeADate`, () => {
     `2010-01-30T00:00:00.000Z`,
     `1970-01-01T00:00:00.000001Z`,
     `2012-04-01T00:00:00-05:00`,
-    `2012-11-12T00:00:00+01:00`
+    `2012-11-12T00:00:00+01:00`,
   ])(`should return true for valid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -186,7 +186,7 @@ describe(`looksLikeADate`, () => {
     `1970-01-01 00:00:00 Z`,
     `1970-01-01 000000 Z`,
     `1970-01-01 00:00 Z`,
-    `1970-01-01 00 Z`
+    `1970-01-01 00 Z`,
   ])(`should return true for ISO 8601 (no T, extra space): %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -214,7 +214,7 @@ describe(`looksLikeADate`, () => {
     `2010-01-01T23:60`,
     `2010-01-01T23:59:60`,
     `2010-01-40T23:60+00:00`,
-    `2010-01-40T23:59:60+00:00`
+    `2010-01-40T23:59:60+00:00`,
   ])(`should return true for some valid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -236,7 +236,7 @@ describe(`looksLikeADate`, () => {
     {},
     ``,
     ` `,
-    `2012-04-01T00:basketball`
+    `2012-04-01T00:basketball`,
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeFalsy()
   })
@@ -302,8 +302,8 @@ describe(`dateResolver`, () => {
         invalidDate14: ``,
         invalidDate15: ` `,
         invalidDate16: `2012-04-01T00:basketball`,
-        defaultFormatDate: `2010-01-30T23:59:59.999-07:00`
-      }
+        defaultFormatDate: `2010-01-30T23:59:59.999-07:00`,
+      },
     ]
     nodes.forEach(node =>
       actions.createNode(node, { name: `test` })(store.dispatch)
@@ -404,7 +404,7 @@ describe(`dateResolver`, () => {
     `2018-01-29T23:25:16.019345Z`,
     // Seems to not require nanosecond definition to not fail
     `2018-01-29T23:25:16.019345123+02:00`,
-    `2018-01-29T23:25:16.019345123Z`
+    `2018-01-29T23:25:16.019345123Z`,
   ])(`should return "Jan 29, 2018": %s`, async dateString => {
     const schema = await buildTestSchema()
     const fields = schema.getType(`Test`).getFields()
@@ -414,7 +414,7 @@ describe(`dateResolver`, () => {
         { formatString: `MMM DD, YYYY` },
         withResolverContext({}, schema),
         {
-          fieldName: `date`
+          fieldName: `date`,
         }
       )
     ).toEqual(`Jan 29, 2018`)
@@ -427,7 +427,7 @@ describe(`dateResolver`, () => {
     `2010-01-01T24:01`,
     `2010-01-01T23:60`,
     `2010-01-01T23:59:60`,
-    `2010-01-40T23:59:59.9999`
+    `2010-01-40T23:59:59.9999`,
     // Combine with above statement once we figure out why it passes
     // `2018-08-31T23:25:16.01234567899993+02:00`,
   ])(`should return "Invalid Date": %s`, async dateString => {
@@ -439,7 +439,7 @@ describe(`dateResolver`, () => {
         { formatString: `MMM DD, YYYY` },
         withResolverContext({}, schema),
         {
-          fieldName: `date`
+          fieldName: `date`,
         }
       )
     ).toEqual(`Invalid date`)

--- a/packages/gatsby/src/schema/types/__tests__/date.js
+++ b/packages/gatsby/src/schema/types/__tests__/date.js
@@ -3,7 +3,8 @@ const { actions } = require(`../../../redux/actions`)
 const { build } = require(`../..`)
 const withResolverContext = require(`../../context`)
 const { defaultResolver } = require(`../../resolvers`)
-const { isDate, looksLikeADate } = require(`../date`)
+import { isDate, looksLikeADate } from "../date"
+require(`../../../db/__tests__/fixtures/ensure-loki`)()
 
 jest.mock(`gatsby-cli/lib/reporter`, () => {
   return {
@@ -15,15 +16,15 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
       return {
         start: jest.fn(),
         setStatus: jest.fn(),
-        end: jest.fn(),
+        end: jest.fn()
       }
     },
     phantomActivity: () => {
       return {
         start: jest.fn(),
-        end: jest.fn(),
+        end: jest.fn()
       }
-    },
+    }
   }
 })
 
@@ -56,7 +57,7 @@ describe(`isDate`, () => {
     `2010-01-30T00:00:00.000Z`,
     `1970-01-01T00:00:00.000001Z`,
     `2012-04-01T00:00:00-05:00`,
-    `2012-11-12T00:00:00+01:00`,
+    `2012-11-12T00:00:00+01:00`
   ])(`should return true for valid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeTruthy()
   })
@@ -78,7 +79,7 @@ describe(`isDate`, () => {
     `1970-01-01 00:00:00 Z`,
     `1970-01-01 000000 Z`,
     `1970-01-01 00:00 Z`,
-    `1970-01-01 00 Z`,
+    `1970-01-01 00 Z`
   ])(`should return true for ISO 8601 (no T, extra space): %s`, dateString => {
     expect(isDate(dateString)).toBeTruthy()
   })
@@ -130,7 +131,7 @@ describe(`isDate`, () => {
     {},
     ``,
     ` `,
-    `2012-04-01T00:basketball`,
+    `2012-04-01T00:basketball`
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeFalsy()
   })
@@ -163,7 +164,7 @@ describe(`looksLikeADate`, () => {
     `2010-01-30T00:00:00.000Z`,
     `1970-01-01T00:00:00.000001Z`,
     `2012-04-01T00:00:00-05:00`,
-    `2012-11-12T00:00:00+01:00`,
+    `2012-11-12T00:00:00+01:00`
   ])(`should return true for valid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -185,7 +186,7 @@ describe(`looksLikeADate`, () => {
     `1970-01-01 00:00:00 Z`,
     `1970-01-01 000000 Z`,
     `1970-01-01 00:00 Z`,
-    `1970-01-01 00 Z`,
+    `1970-01-01 00 Z`
   ])(`should return true for ISO 8601 (no T, extra space): %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -213,7 +214,7 @@ describe(`looksLikeADate`, () => {
     `2010-01-01T23:60`,
     `2010-01-01T23:59:60`,
     `2010-01-40T23:60+00:00`,
-    `2010-01-40T23:59:60+00:00`,
+    `2010-01-40T23:59:60+00:00`
   ])(`should return true for some valid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -235,7 +236,7 @@ describe(`looksLikeADate`, () => {
     {},
     ``,
     ` `,
-    `2012-04-01T00:basketball`,
+    `2012-04-01T00:basketball`
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeFalsy()
   })
@@ -301,8 +302,8 @@ describe(`dateResolver`, () => {
         invalidDate14: ``,
         invalidDate15: ` `,
         invalidDate16: `2012-04-01T00:basketball`,
-        defaultFormatDate: `2010-01-30T23:59:59.999-07:00`,
-      },
+        defaultFormatDate: `2010-01-30T23:59:59.999-07:00`
+      }
     ]
     nodes.forEach(node =>
       actions.createNode(node, { name: `test` })(store.dispatch)
@@ -403,7 +404,7 @@ describe(`dateResolver`, () => {
     `2018-01-29T23:25:16.019345Z`,
     // Seems to not require nanosecond definition to not fail
     `2018-01-29T23:25:16.019345123+02:00`,
-    `2018-01-29T23:25:16.019345123Z`,
+    `2018-01-29T23:25:16.019345123Z`
   ])(`should return "Jan 29, 2018": %s`, async dateString => {
     const schema = await buildTestSchema()
     const fields = schema.getType(`Test`).getFields()
@@ -413,7 +414,7 @@ describe(`dateResolver`, () => {
         { formatString: `MMM DD, YYYY` },
         withResolverContext({}, schema),
         {
-          fieldName: `date`,
+          fieldName: `date`
         }
       )
     ).toEqual(`Jan 29, 2018`)
@@ -426,7 +427,7 @@ describe(`dateResolver`, () => {
     `2010-01-01T24:01`,
     `2010-01-01T23:60`,
     `2010-01-01T23:59:60`,
-    `2010-01-40T23:59:59.9999`,
+    `2010-01-40T23:59:59.9999`
     // Combine with above statement once we figure out why it passes
     // `2018-08-31T23:25:16.01234567899993+02:00`,
   ])(`should return "Invalid Date": %s`, async dateString => {
@@ -438,7 +439,7 @@ describe(`dateResolver`, () => {
         { formatString: `MMM DD, YYYY` },
         withResolverContext({}, schema),
         {
-          fieldName: `date`,
+          fieldName: `date`
         }
       )
     ).toEqual(`Invalid date`)

--- a/packages/gatsby/src/schema/types/__tests__/date.js
+++ b/packages/gatsby/src/schema/types/__tests__/date.js
@@ -15,15 +15,15 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
       return {
         start: jest.fn(),
         setStatus: jest.fn(),
-        end: jest.fn()
+        end: jest.fn(),
       }
     },
     phantomActivity: () => {
       return {
         start: jest.fn(),
-        end: jest.fn()
+        end: jest.fn(),
       }
-    }
+    },
   }
 })
 
@@ -56,7 +56,7 @@ describe(`isDate`, () => {
     `2010-01-30T00:00:00.000Z`,
     `1970-01-01T00:00:00.000001Z`,
     `2012-04-01T00:00:00-05:00`,
-    `2012-11-12T00:00:00+01:00`
+    `2012-11-12T00:00:00+01:00`,
   ])(`should return true for valid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeTruthy()
   })
@@ -78,7 +78,7 @@ describe(`isDate`, () => {
     `1970-01-01 00:00:00 Z`,
     `1970-01-01 000000 Z`,
     `1970-01-01 00:00 Z`,
-    `1970-01-01 00 Z`
+    `1970-01-01 00 Z`,
   ])(`should return true for ISO 8601 (no T, extra space): %s`, dateString => {
     expect(isDate(dateString)).toBeTruthy()
   })
@@ -130,7 +130,7 @@ describe(`isDate`, () => {
     {},
     ``,
     ` `,
-    `2012-04-01T00:basketball`
+    `2012-04-01T00:basketball`,
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(isDate(dateString)).toBeFalsy()
   })
@@ -163,7 +163,7 @@ describe(`looksLikeADate`, () => {
     `2010-01-30T00:00:00.000Z`,
     `1970-01-01T00:00:00.000001Z`,
     `2012-04-01T00:00:00-05:00`,
-    `2012-11-12T00:00:00+01:00`
+    `2012-11-12T00:00:00+01:00`,
   ])(`should return true for valid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -185,7 +185,7 @@ describe(`looksLikeADate`, () => {
     `1970-01-01 00:00:00 Z`,
     `1970-01-01 000000 Z`,
     `1970-01-01 00:00 Z`,
-    `1970-01-01 00 Z`
+    `1970-01-01 00 Z`,
   ])(`should return true for ISO 8601 (no T, extra space): %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -213,7 +213,7 @@ describe(`looksLikeADate`, () => {
     `2010-01-01T23:60`,
     `2010-01-01T23:59:60`,
     `2010-01-40T23:60+00:00`,
-    `2010-01-40T23:59:60+00:00`
+    `2010-01-40T23:59:60+00:00`,
   ])(`should return true for some valid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeTruthy()
   })
@@ -235,7 +235,7 @@ describe(`looksLikeADate`, () => {
     {},
     ``,
     ` `,
-    `2012-04-01T00:basketball`
+    `2012-04-01T00:basketball`,
   ])(`should return false for invalid ISO 8601: %s`, dateString => {
     expect(looksLikeADate(dateString)).toBeFalsy()
   })
@@ -301,8 +301,8 @@ describe(`dateResolver`, () => {
         invalidDate14: ``,
         invalidDate15: ` `,
         invalidDate16: `2012-04-01T00:basketball`,
-        defaultFormatDate: `2010-01-30T23:59:59.999-07:00`
-      }
+        defaultFormatDate: `2010-01-30T23:59:59.999-07:00`,
+      },
     ]
     nodes.forEach(node =>
       actions.createNode(node, { name: `test` })(store.dispatch)
@@ -403,7 +403,7 @@ describe(`dateResolver`, () => {
     `2018-01-29T23:25:16.019345Z`,
     // Seems to not require nanosecond definition to not fail
     `2018-01-29T23:25:16.019345123+02:00`,
-    `2018-01-29T23:25:16.019345123Z`
+    `2018-01-29T23:25:16.019345123Z`,
   ])(`should return "Jan 29, 2018": %s`, async dateString => {
     const schema = await buildTestSchema()
     const fields = schema.getType(`Test`).getFields()
@@ -413,7 +413,7 @@ describe(`dateResolver`, () => {
         { formatString: `MMM DD, YYYY` },
         withResolverContext({}, schema),
         {
-          fieldName: `date`
+          fieldName: `date`,
         }
       )
     ).toEqual(`Jan 29, 2018`)
@@ -426,7 +426,7 @@ describe(`dateResolver`, () => {
     `2010-01-01T24:01`,
     `2010-01-01T23:60`,
     `2010-01-01T23:59:60`,
-    `2010-01-40T23:59:59.9999`
+    `2010-01-40T23:59:59.9999`,
     // Combine with above statement once we figure out why it passes
     // `2018-08-31T23:25:16.01234567899993+02:00`,
   ])(`should return "Invalid Date": %s`, async dateString => {
@@ -438,7 +438,7 @@ describe(`dateResolver`, () => {
         { formatString: `MMM DD, YYYY` },
         withResolverContext({}, schema),
         {
-          fieldName: `date`
+          fieldName: `date`,
         }
       )
     ).toEqual(`Invalid date`)

--- a/packages/gatsby/src/schema/types/__tests__/sort-and-filter.js
+++ b/packages/gatsby/src/schema/types/__tests__/sort-and-filter.js
@@ -18,7 +18,7 @@ const {
   GraphQLInputObjectType,
   Kind,
 } = require(`graphql`)
-const { GraphQLDate } = require(`../date`)
+import { GraphQLDate } from "../date"
 const { GraphQLJSON } = require(`graphql-compose`)
 
 const getInferredFields = fields => {

--- a/packages/gatsby/src/schema/types/date.ts
+++ b/packages/gatsby/src/schema/types/date.ts
@@ -99,7 +99,7 @@ const ISO_8601_FORMAT = [
   `YYYY-[W]WW-E`,
   `YYYY[W]WWE`,
   `YYYY-DDDD`,
-  `YYYYDDDD`
+  `YYYYDDDD`,
 ]
 
 export const GraphQLDate = new GraphQLScalarType({
@@ -111,7 +111,7 @@ export const GraphQLDate = new GraphQLScalarType({
   parseValue: String,
   parseLiteral(ast): string | undefined {
     return ast.kind === Kind.STRING ? ast.value : undefined
-  }
+  },
 })
 
 const momentFormattingTokens = /(\[[^[]*\])|(\\)?([Hh]mm(ss)?|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|Qo?|YYYYYY|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g
@@ -130,7 +130,7 @@ const momentFormattingRegexes = {
   WW: `\\d{2}`,
   "[W]": `W`,
   ".": `\\.`,
-  Z: `(Z|[+-]\\d\\d(?::?\\d\\d)?)`
+  Z: `(Z|[+-]\\d\\d(?::?\\d\\d)?)`,
 }
 const ISO_8601_FORMAT_AS_REGEX = ISO_8601_FORMAT.map(format => {
   const matchedFormat = format.match(momentFormattingTokens)
@@ -155,7 +155,7 @@ const ISO_8601_FORMAT_LENGTHS = [
       // we add count of +01 & +01:00
       return acc.concat([val.length, val.length + 3, val.length + 5])
     }, [])
-  )
+  ),
 ]
 
 // lets imagine these formats: YYYY-MM-DDTHH & YYYY-MM-DD HHmmss.SSSSSS Z
@@ -213,7 +213,7 @@ const formatDate = ({
   fromNow,
   difference,
   formatString,
-  locale = `en`
+  locale = `en`,
 }: IFormatDateArgs): string | number => {
   const normalizedDate = JSON.parse(JSON.stringify(date))
   if (formatString) {
@@ -250,13 +250,13 @@ export const getDateResolver = (
         \`date(formatString: "YYYY MMMM DD")\`.
         See https://momentjs.com/docs/#/displaying/format/
         for documentation for different tokens.`,
-        defaultValue: formatString
+        defaultValue: formatString,
       },
       fromNow: {
         type: `Boolean`,
         description: oneLine`
         Returns a string generated with Moment.js' \`fromNow\` function`,
-        defaultValue: fromNow
+        defaultValue: fromNow,
       },
       difference: {
         type: `String`,
@@ -265,27 +265,27 @@ export const getDateResolver = (
         Defaults to "milliseconds" but you can also pass in as the
         measurement "years", "months", "weeks", "days", "hours", "minutes",
         and "seconds".`,
-        defaultValue: difference
+        defaultValue: difference,
       },
       locale: {
         type: `String`,
         description: oneLine`
         Configures the locale Moment.js will use to format the date.`,
-        defaultValue: locale
-      }
+        defaultValue: locale,
+      },
     },
     async resolve(source, args, context, info): ReturnType<DateResolver> {
       const resolver = fieldConfig.resolve || context.defaultFieldResolver
       const date = await resolver(source, args, context, {
         ...info,
         from: options.from || info.from,
-        fromNode: options.from ? options.fromNode : info.fromNode
+        fromNode: options.from ? options.fromNode : info.fromNode,
       })
       if (date == null) return null
 
       return Array.isArray(date)
         ? date.map(d => formatDate({ date: d, ...args }))
         : formatDate({ date, ...args })
-    }
+    },
   }
 }

--- a/packages/gatsby/src/schema/types/filter.js
+++ b/packages/gatsby/src/schema/types/filter.js
@@ -9,7 +9,7 @@ const {
 const { addDerivedType } = require(`./derived-types`)
 const { InputTypeComposer } = require(`graphql-compose`)
 const { GraphQLJSON } = require(`graphql-compose`)
-const { GraphQLDate } = require(`./date`)
+import { GraphQLDate } from "./date"
 
 const SEARCHABLE_ENUM = {
   SEARCHABLE: `SEARCHABLE`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Part of #21995 
<!-- Write a brief description of the changes introduced by this PR -->

I migrated `types/date.js` to typescript.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

#21995 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
