### PR TITLE
chore(gatsby): migrate derived-types to TypeScript

### DIFF
--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -6,7 +6,7 @@ const report = require(`gatsby-cli/lib/reporter`)
 
 import { isFile } from "./is-file"
 import { isDate } from "../types/date"
-const { addDerivedType } = require(`../types/derived-types`)
+import { addDerivedType } from "../types/derived-types"
 import { is32BitInteger } from "../../utils/is-32-bit-integer"
 const { getNode, getNodes } = require(`../../redux/nodes`)
 

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -43,7 +43,7 @@ const {
   parseTypeDef,
   reportParsingError,
 } = require(`./types/type-defs`)
-const { clearDerivedTypes } = require(`./types/derived-types`)
+import { clearDerivedTypes } from "./types/derived-types"
 const { printTypeDefinitions } = require(`./print`)
 
 const buildSchema = async ({

--- a/packages/gatsby/src/schema/types/derived-types.ts
+++ b/packages/gatsby/src/schema/types/derived-types.ts
@@ -29,9 +29,37 @@
  *   user explicitly defines `FooFields` type (via `createTypes` call) it won't be considered
  *   a derived type
  */
-const { ObjectTypeComposer, InterfaceTypeComposer } = require(`graphql-compose`)
+import {
+  ObjectTypeComposer,
+  InterfaceTypeComposer,
+  ScalarTypeComposer,
+  SchemaComposer,
+  InputTypeComposer,
+  EnumTypeComposer,
+  UnionTypeComposer,
+} from "graphql-compose"
 
-const clearDerivedTypes = ({ schemaComposer, typeComposer }) => {
+type AllTypeComposer =
+  | ObjectTypeComposer
+  | InputTypeComposer
+  | EnumTypeComposer
+  | InterfaceTypeComposer
+  | UnionTypeComposer
+  | ScalarTypeComposer
+
+const getDerivedTypes = ({
+  typeComposer,
+}: {
+  typeComposer: AllTypeComposer
+}): any => typeComposer.getExtension(`derivedTypes`) || new Set()
+
+export const clearDerivedTypes = ({
+  schemaComposer,
+  typeComposer,
+}: {
+  schemaComposer: SchemaComposer<any>
+  typeComposer: AllTypeComposer
+}): void => {
   const derivedTypes = getDerivedTypes({ typeComposer })
 
   for (const typeName of derivedTypes.values()) {
@@ -50,15 +78,13 @@ const clearDerivedTypes = ({ schemaComposer, typeComposer }) => {
   typeComposer.setExtension(`derivedTypes`, new Set())
 }
 
-const addDerivedType = ({ typeComposer, derivedTypeName }) => {
+export const addDerivedType = ({
+  typeComposer,
+  derivedTypeName,
+}: {
+  typeComposer: AllTypeComposer
+  derivedTypeName: string
+}): void => {
   const derivedTypes = getDerivedTypes({ typeComposer })
   typeComposer.setExtension(`derivedTypes`, derivedTypes.add(derivedTypeName))
-}
-
-const getDerivedTypes = ({ typeComposer }) =>
-  typeComposer.getExtension(`derivedTypes`) || new Set()
-
-module.exports = {
-  clearDerivedTypes,
-  addDerivedType,
 }

--- a/packages/gatsby/src/schema/types/derived-types.ts
+++ b/packages/gatsby/src/schema/types/derived-types.ts
@@ -51,7 +51,7 @@ const getDerivedTypes = ({
   typeComposer,
 }: {
   typeComposer: AllTypeComposer
-}): any => typeComposer.getExtension(`derivedTypes`) || new Set()
+}): Set<string> => typeComposer.getExtension(`derivedTypes`) || new Set()
 
 export const clearDerivedTypes = ({
   schemaComposer,

--- a/packages/gatsby/src/schema/types/filter.js
+++ b/packages/gatsby/src/schema/types/filter.js
@@ -6,7 +6,7 @@ const {
   GraphQLList,
   isSpecifiedScalarType,
 } = require(`graphql`)
-const { addDerivedType } = require(`./derived-types`)
+import { addDerivedType } from "./derived-types"
 const { InputTypeComposer } = require(`graphql-compose`)
 const { GraphQLJSON } = require(`graphql-compose`)
 import { GraphQLDate } from "./date"

--- a/packages/gatsby/src/schema/types/sort.js
+++ b/packages/gatsby/src/schema/types/sort.js
@@ -6,7 +6,7 @@ const {
   GraphQLInputObjectType,
   GraphQLList,
 } = require(`graphql`)
-const { addDerivedType } = require(`./derived-types`)
+import { addDerivedType } from "./derived-types"
 
 const SORTABLE_ENUM = {
   SORTABLE: `SORTABLE`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Part of #21995 
<!-- Write a brief description of the changes introduced by this PR -->

I migrated `derived-types.js` to TS.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

#21995 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
