### PR TITLE
fix(www): remove comments that are causing builds to fail

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -516,10 +516,6 @@ export const createWebpackUtils = (
    */
   const plugins = { ...builtinPlugins } as PluginUtils
 
-  /**
-   * Minify JavaScript code without regard for IE8. Attempts
-   * to parallelize the work to save time. Generally only add in Production
-   */
   plugins.minifyJs = ({
     terserOptions,
     ...options
@@ -622,10 +618,6 @@ export const createWebpackUtils = (
       disableRefreshCheck: true,
     })
 
-  /**
-   * Extracts css requires into a single file;
-   * includes some reasonable defaults
-   */
   plugins.extractText = (options: any): Plugin =>
     new MiniCssExtractPlugin({
       filename: `[name].[contenthash].css`,


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

When #22381 was merged builds started failing for `www` (the docs site). The error looks like this:

```
11:01:06 AM: error { "commentNumber": null, "level": 1, "id": "827a9a3a-6d53-5ec1-bde7-32147298b648", "parent": "ec28ebff-f198-59bc-9d97-9f0662e37679", "children": [ "f923a690-d5e9-5170-a02b-b51a17706ae7", "4bddd280-f7d7-5922-821a-89604b600b2f", "ed3d70f6-d142-5e7b-92f7-29ede823380d" ], "internal": { "type": "DocumentationJs", "contentDigest": "358a5703a82d2d403134479c9cf283fe", "counter": 7689, "owner": "gatsby-transformer-documentationjs" }, "kind": "function", "memberof": "plugins", "name": "minifyJs", "scope": "static", "examples": [], "tags": [], "optional": false, "docsLocation": { "start": { "line": 519, "column": 2 }, "end": { "line": 522, "column": 5 } }, "codeLocation": { "start": { "line": 523, "column": 2 }, "end": { "line": 551, "column": 6 } }, "description___NODE": "f923a690-d5e9-5170-a02b-b51a17706ae7", "params___NODE": [ "4bddd280-f7d7-5922-821a-89604b600b2f" ], "returns___NODE": [ "ed3d70f6-d142-5e7b-92f7-29ede823380d" ], "members": {} } error The node internal.owner field is set automatically by Gatsby and not by plugins
11:01:06 AM: not finished source and transform nodes - 21.021s
11:01:06 AM: ERROR Failed to compile: Error: Exited with code 1
```

This error pointed at the documentationjs transformer and the lines it identified didn't seem problematic, but removing them is enough to fix builds.

The problematic lines are:

https://github.com/gatsbyjs/gatsby/blob/e65eef43570c41c4f49c9e7dd177218702bb7bf5/packages/gatsby/src/utils/webpack-utils.ts#L519-L522
https://github.com/gatsbyjs/gatsby/blob/e65eef43570c41c4f49c9e7dd177218702bb7bf5/packages/gatsby/src/utils/webpack-utils.ts#L625-L628

I'm really not sure why this works or what the transformer is complaining about, so if there's an alternative way to do this I'm all ears!

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

_None_
