### PR TITLE
update link to json section

### DIFF
--- a/docs/docs/sourcing-content-from-json-or-yaml.md
+++ b/docs/docs/sourcing-content-from-json-or-yaml.md
@@ -14,7 +14,7 @@ gatsby new gatsby-YAML-JSON-at-buildtime https://github.com/gatsbyjs/gatsby-star
 
 ## Directly import data with YAML
 
-This section starts with YAML data sourcing. If you want to see how to do it using JSON instead, jump to the [next section](#Directly-importing-data-with-JSON).
+This section starts with YAML data sourcing. If you want to see how to do it using JSON instead, jump to the [next section](#directly-import-data-with-json).
 
 ### Add the YAML content
 


### PR DESCRIPTION
## Description

It appears the title of the JSON section changed, so the link to that section is no longer valid. This updates it to make it valid again.

### Documentation

N/A

## Related Issues

N/A
