### PR TITLE
[docs] add explanation to why icons not cached by offline & manifest plugin

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -299,7 +299,7 @@ module.exports = {
 #### Using with gatsby-plugin-offline
 
 If using this plugin with `gatsby-plugin-offline` you may find that your icons are not cached.
-The solution is setting your gatsby config with this
+In order to solve this, update your `gatsby-config.js` as follows:
 
 ```js
 {

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -302,6 +302,7 @@ If using this plugin with `gatsby-plugin-offline` you may find that your icons a
 In order to solve this, update your `gatsby-config.js` as follows:
 
 ```js
+// gatsby-config.js
 {
    resolve: 'gatsby-plugin-manifest',
    options: {

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -298,7 +298,7 @@ module.exports = {
 
 #### Using with gatsby-plugin-offline
 
-There is an issue in gatsby where when you use this plugin with gatsby-plugin-offline, the icons is not cached.
+If using this plugin with `gatsby-plugin-offline` you may find that your icons are not cached.
 The solution is setting your gatsby config with this
 
 ```js

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -321,7 +321,7 @@ In order to solve this, update your `gatsby-config.js` as follows:
 ```
 
 Updating `cache_busting_mode` is necessary. Otherwise, workbox will break while attempting to find the cached URLs. 
-And the `globPatterns` is there so offline will cache everything.
+Adding the `globPatterns` makes sure that the offline plugin will cache everything.
 
 #### Remove `theme-color` meta tag
 

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -320,7 +320,7 @@ In order to solve this, update your `gatsby-config.js` as follows:
 }
 ```
 
-The `cache_busting_mode` is there since the query parameter cache busting would break workbox since it could never find the cached URLS.
+Updating `cache_busting_mode` is necessary. Otherwise, workbox will break while attempting to find the cached URLs. 
 And the `globPatterns` is there so offline will cache everything.
 
 #### Remove `theme-color` meta tag

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -320,7 +320,7 @@ In order to solve this, update your `gatsby-config.js` as follows:
 }
 ```
 
-Updating `cache_busting_mode` is necessary. Otherwise, workbox will break while attempting to find the cached URLs. 
+Updating `cache_busting_mode` is necessary. Otherwise, workbox will break while attempting to find the cached URLs.
 Adding the `globPatterns` makes sure that the offline plugin will cache everything.
 
 #### Remove `theme-color` meta tag

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -296,6 +296,32 @@ module.exports = {
 }
 ```
 
+#### Using with gatsby-plugin-offline
+
+There is an issue in gatsby where when you use this plugin with gatsby-plugin-offline, the icons is not cached.
+The solution is setting your gatsby config with this
+
+```js
+{
+   resolve: 'gatsby-plugin-manifest',
+   options: {
+      icon: 'icon.svg',
+      cache_busting_mode: 'none'
+   }
+},
+{
+   resolve: 'gatsby-plugin-offline',
+   options: {
+      workboxConfig: {
+         globPatterns: ['**/*']
+      }
+   }
+}
+```
+
+The `cache_busting_mode` is there since the query parameter cache busting would break workbox since it could never find the cached URLS.
+And the `globPatterns` is there so offline will cache everything.
+
 #### Remove `theme-color` meta tag
 
 By default a `<meta content={theme_color} name="theme-color" />` tag is inserted into the html output. This can be problematic if you want to programmatically control that tag (e.g. when implementing light/dark themes in your project). You can set `theme_color_in_head` plugin option to `false` to opt-out of this behavior.

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -214,3 +214,29 @@ Alternatively you can have a look at the `/public/index.html` file in your proje
 ### App shell and server logs
 
 Server logs (like from [Netlify analytics](https://www.netlify.com/products/analytics/)) may show a large number of pageviews to a route like `/offline-plugin-app-shell-fallback/index.html`, this is a result of `gatsby-plugin-offline` adding an [app shell](https://developers.google.com/web/fundamentals/architecture/app-shell) to the page. The app shell is a minimal amount of user interface that can be cached offline for reliable performance loading on repeat visits. The shell can be loaded from the cache, and the content of the site loaded into the shell by the service worker.
+
+### Using with gatsby-plugin-manifest
+
+There is an issue with gatsby currently where this plugin will not cache icons when used with gatsby-plugin-manifest.
+You can set your gatsby config to be like this
+
+```js
+{
+   resolve: 'gatsby-plugin-manifest',
+   options: {
+      icon: 'icon.svg',
+      cache_busting_mode: 'none'
+   }
+},
+{
+   resolve: 'gatsby-plugin-offline',
+   options: {
+      workboxConfig: {
+         globPatterns: ['**/*']
+      }
+   }
+}
+```
+
+The `cache_busting_mode` is there since the query parameter cache busting would break workbox since it could never find the cached URLS.
+And the `globPatterns` is there so offline will cache everything.

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -217,10 +217,11 @@ Server logs (like from [Netlify analytics](https://www.netlify.com/products/anal
 
 ### Using with gatsby-plugin-manifest
 
-There is an issue with gatsby currently where this plugin will not cache icons when used with gatsby-plugin-manifest.
-You can set your gatsby config to be like this
+If using this plugin with `gatsby-plugin-manifest` you may find that your icons are not cached.
+In order to solve this, update your `gatsby-config.js` as follows:
 
 ```js
+// gatsby-config.js
 {
    resolve: 'gatsby-plugin-manifest',
    options: {
@@ -238,5 +239,5 @@ You can set your gatsby config to be like this
 }
 ```
 
-The `cache_busting_mode` is there since the query parameter cache busting would break workbox since it could never find the cached URLS.
-And the `globPatterns` is there so offline will cache everything.
+Updating `cache_busting_mode` is necessary. Otherwise, workbox will break while attempting to find the cached URLs.
+Adding the `globPatterns` makes sure that the offline plugin will cache everything.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I added the documentation describing why icons not cached when using gatsby-plugin-manifest with gatsby-plugin-offline.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->
Documented in gatsby-plugin-offline & gatsby-plugin-manifest
## Related Issues
This PR will close #19870 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
