### PR TITLE
fix(gatsby-starter-blog): Remove superfluous text-decoration:none

### DIFF
--- a/starters/blog/src/components/layout.js
+++ b/starters/blog/src/components/layout.js
@@ -19,7 +19,6 @@ const Layout = ({ location, title, children }) => {
         <Link
           style={{
             boxShadow: `none`,
-            textDecoration: `none`,
             color: `inherit`,
           }}
           to={`/`}
@@ -39,7 +38,6 @@ const Layout = ({ location, title, children }) => {
         <Link
           style={{
             boxShadow: `none`,
-            textDecoration: `none`,
             color: `inherit`,
           }}
           to={`/`}


### PR DESCRIPTION
text-decoration: none is already set, earlier in the cascade,
maybe through typography.js?

This css rule has been there since 077cb982 but I can't tell if it was effective then.