### PR TITLE
fix(www/dark-mode-toggle): title and aria-label[object Object] issue

### DIFF
--- a/www/src/components/dark-mode-toggle.js
+++ b/www/src/components/dark-mode-toggle.js
@@ -133,7 +133,7 @@ function DarkModeToggle({ i18n }) {
     event.preventDefault()
     setColorMode(isDark ? `light` : `dark`)
   }
-  const label = isDark ? t`Activate light mode` : t`Activate dark mode`
+  const label = i18n._(isDark ? t`Activate light mode` : t`Activate dark mode`)
 
   return (
     <IconWrapper


### PR DESCRIPTION
## Description
This fixes incorrect title and aria-label issue of dark mode toggle button
![image](https://user-images.githubusercontent.com/3725386/77236172-ef99cd00-6bdd-11ea-9846-db876bd9be26.png)

Related: https://github.com/gatsbyjs/gatsby/pull/21633

Note that I haven't tested this fix locally yet because `gatsby develop` in `www` is taking too much time on my PC.