### PR TITLE
chore(gatsby): Convert babel-parse-to-ast.js to typescript

### DIFF
--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -3,7 +3,7 @@ const fs = require(`fs`)
 const traverse = require(`@babel/traverse`).default
 const get = require(`lodash/get`)
 const { codeFrameColumns } = require(`@babel/code-frame`)
-const { babelParseToAst } = require(`../utils/babel-parse-to-ast`)
+import { babelParseToAst } from "../utils/babel-parse-to-ast"
 const report = require(`gatsby-cli/lib/reporter`)
 
 const testRequireError = require(`../utils/test-require-error`).default

--- a/packages/gatsby/src/utils/babel-parse-to-ast.ts
+++ b/packages/gatsby/src/utils/babel-parse-to-ast.ts
@@ -1,5 +1,5 @@
-/* @flow */
-const parser = require(`@babel/parser`)
+import * as parser from "@babel/parser"
+import { File } from "@babel/types"
 
 const PARSER_OPTIONS = {
   allowImportExportEverywhere: true,
@@ -43,7 +43,7 @@ const PARSER_OPTIONS = {
   ],
 }
 
-export function getBabelParserOptions(filePath: string) {
+export function getBabelParserOptions(filePath: string): object {
   // Flow and TypeScript plugins can't be enabled simultaneously
   if (/\.tsx?/.test(filePath)) {
     const { plugins } = PARSER_OPTIONS
@@ -57,6 +57,6 @@ export function getBabelParserOptions(filePath: string) {
   return PARSER_OPTIONS
 }
 
-export function babelParseToAst(contents: string, filePath: string) {
+export function babelParseToAst(contents: string, filePath: string): File {
   return parser.parse(contents, getBabelParserOptions(filePath))
 }


### PR DESCRIPTION
## Description

Convert `src/utils/babel-parse-to-ast.js` to TypeScript.

I could not use `ParserOptions` Interface exported by `@babel/parser` to declare the return value of the getBabelParserOptions function. 

Because the `ParserOptions` interface and `PARSER_OPTIONS` declared in the `babel-parse-to-ast.js` file are incompatible.

So instead of `ParserOptions` interface, I temporarily declared the return value of the `getBabelParserOptions` function as `object` type.

## Related Issues

Related to #21995 
