### PR TITLE
chore(gatsby): Convert babel-parse-to-ast to TypeScript

### DIFF
--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -1,10 +1,10 @@
 // @flow
-const fs = require(`fs`)
-const traverse = require(`@babel/traverse`).default
-const get = require(`lodash/get`)
-const { codeFrameColumns } = require(`@babel/code-frame`)
-const { babelParseToAst } = require(`../utils/babel-parse-to-ast`)
-const report = require(`gatsby-cli/lib/reporter`)
+import fs from "fs"
+import traverse from "@babel/traverse"
+import get from "lodash/get"
+import { codeFrameColumns } from "@babel/code-frame"
+import { babelParseToAst } from "../utils/babel-parse-to-ast"
+import report from "gatsby-cli/lib/reporter"
 
 import { testRequireError } from "../utils/test-require-error"
 

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -67,7 +67,6 @@ Array [
         "column": 0,
         "line": 6,
       },
-      "filename": true,
       "start": Position {
         "column": 33,
         "line": 2,
@@ -144,7 +143,6 @@ query PageQueryName {
         "column": 0,
         "line": 6,
       },
-      "filename": true,
       "start": Position {
         "column": 26,
         "line": 2,
@@ -221,7 +219,6 @@ query PageQueryIndirect {
         "column": 0,
         "line": 6,
       },
-      "filename": true,
       "start": Position {
         "column": 26,
         "line": 2,
@@ -294,7 +291,6 @@ query PageQueryIndirect2 {
         "column": 0,
         "line": 6,
       },
-      "filename": true,
       "start": Position {
         "column": 31,
         "line": 2,
@@ -371,7 +367,6 @@ query {
         "column": 48,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 19,
         "line": 4,
@@ -440,7 +435,6 @@ query {
         "column": 26,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 19,
         "line": 4,
@@ -513,7 +507,6 @@ query {
         "column": 48,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 19,
         "line": 4,
@@ -582,7 +575,6 @@ query {
         "column": 26,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 19,
         "line": 4,
@@ -655,7 +647,6 @@ query {
         "column": 48,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 19,
         "line": 4,
@@ -728,7 +719,6 @@ query {
         "column": 60,
         "line": 8,
       },
-      "filename": true,
       "start": Position {
         "column": 33,
         "line": 8,
@@ -873,7 +863,6 @@ query {
         "column": 0,
         "line": 9,
       },
-      "filename": true,
       "start": Position {
         "column": 35,
         "line": 2,
@@ -966,7 +955,6 @@ query {
         "column": 0,
         "line": 14,
       },
-      "filename": true,
       "start": Position {
         "column": 33,
         "line": 10,
@@ -1093,7 +1081,6 @@ query {
         "column": 0,
         "line": 12,
       },
-      "filename": true,
       "start": Position {
         "column": 22,
         "line": 4,
@@ -1251,7 +1238,6 @@ query {
         "column": 69,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 22,
         "line": 4,
@@ -1401,7 +1387,6 @@ query {
         "column": 82,
         "line": 5,
       },
-      "filename": true,
       "start": Position {
         "column": 33,
         "line": 5,
@@ -1474,7 +1459,6 @@ query {
         "column": 67,
         "line": 3,
       },
-      "filename": true,
       "start": Position {
         "column": 38,
         "line": 3,
@@ -1547,7 +1531,6 @@ query {
         "column": 67,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 38,
         "line": 4,
@@ -1620,7 +1603,6 @@ query {
         "column": 81,
         "line": 3,
       },
-      "filename": true,
       "start": Position {
         "column": 52,
         "line": 3,
@@ -1693,7 +1675,6 @@ query {
         "column": 82,
         "line": 3,
       },
-      "filename": true,
       "start": Position {
         "column": 53,
         "line": 3,
@@ -1843,7 +1824,6 @@ query {
         "column": 69,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 22,
         "line": 4,
@@ -1912,7 +1892,6 @@ query {
         "column": 51,
         "line": 3,
       },
-      "filename": true,
       "start": Position {
         "column": 38,
         "line": 3,
@@ -1981,7 +1960,6 @@ query {
         "column": 32,
         "line": 4,
       },
-      "filename": true,
       "start": Position {
         "column": 19,
         "line": 4,

--- a/packages/gatsby/src/utils/babel-parse-to-ast.ts
+++ b/packages/gatsby/src/utils/babel-parse-to-ast.ts
@@ -1,12 +1,10 @@
-import * as parser from "@babel/parser"
+import { parse, ParserOptions } from "@babel/parser"
 import { File } from "@babel/types"
 
-const PARSER_OPTIONS = {
+const PARSER_OPTIONS: ParserOptions = {
   allowImportExportEverywhere: true,
   allowReturnOutsideFunction: true,
   allowSuperOutsideMethod: true,
-  sourceType: `unambigious`,
-  sourceFilename: true,
   plugins: [
     `jsx`,
     `flow`,
@@ -43,13 +41,13 @@ const PARSER_OPTIONS = {
   ],
 }
 
-export function getBabelParserOptions(filePath: string): object {
+export function getBabelParserOptions(filePath: string): ParserOptions {
   // Flow and TypeScript plugins can't be enabled simultaneously
   if (/\.tsx?/.test(filePath)) {
     const { plugins } = PARSER_OPTIONS
     return {
       ...PARSER_OPTIONS,
-      plugins: plugins.map(plugin =>
+      plugins: plugins!.map(plugin =>
         plugin === `flow` ? `typescript` : plugin
       ),
     }
@@ -58,5 +56,5 @@ export function getBabelParserOptions(filePath: string): object {
 }
 
 export function babelParseToAst(contents: string, filePath: string): File {
-  return parser.parse(contents, getBabelParserOptions(filePath))
+  return parse(contents, getBabelParserOptions(filePath))
 }

--- a/packages/gatsby/src/utils/babel-parse-to-ast.ts
+++ b/packages/gatsby/src/utils/babel-parse-to-ast.ts
@@ -5,6 +5,7 @@ const PARSER_OPTIONS: ParserOptions = {
   allowImportExportEverywhere: true,
   allowReturnOutsideFunction: true,
   allowSuperOutsideMethod: true,
+  sourceType: `unambiguous`,
   plugins: [
     `jsx`,
     `flow`,

--- a/packages/gatsby/src/utils/babel-parse-to-ast.ts
+++ b/packages/gatsby/src/utils/babel-parse-to-ast.ts
@@ -1,5 +1,5 @@
-/* @flow */
-const parser = require(`@babel/parser`)
+import * as parser from "@babel/parser"
+import { File } from "@babel/types"
 
 const PARSER_OPTIONS = {
   allowImportExportEverywhere: true,
@@ -43,7 +43,7 @@ const PARSER_OPTIONS = {
   ],
 }
 
-export function getBabelParserOptions(filePath: string) {
+export function getBabelParserOptions(filePath: string): object {
   // Flow and TypeScript plugins can't be enabled simultaneously
   if (/\.tsx?/.test(filePath)) {
     const { plugins } = PARSER_OPTIONS
@@ -57,6 +57,6 @@ export function getBabelParserOptions(filePath: string) {
   return PARSER_OPTIONS
 }
 
-export function babelParseToAst(contents: string, filePath: string) {
+export function babelParseToAst(contents: string, filePath: string): File {
   return parser.parse(contents, getBabelParserOptions(filePath))
 }


### PR DESCRIPTION
## Description

Convert `src/utils/babel-parse-to-ast.js` to TypeScript.

I could not use `ParserOptions` Interface exported by `@babel/parser` to declare the return value of the getBabelParserOptions function. 

Because the `ParserOptions` interface and `PARSER_OPTIONS` declared in the `babel-parse-to-ast.js` file are incompatible.

So instead of `ParserOptions` interface, I temporarily declared the return value of the `getBabelParserOptions` function as `object` type.

## Related Issues

Related to #21995 
