### PR TITLE
Add ./cache to cache paths for gitlab-ci template

### DIFF
--- a/docs/docs/deploying-to-gitlab-pages.md
+++ b/docs/docs/deploying-to-gitlab-pages.md
@@ -45,6 +45,7 @@ image: node:latest
 cache:
   paths:
     - node_modules/
+    - .cache/
 
 pages:
   script:


### PR DESCRIPTION
## Description

It is safe (and recommended!) to cache the `.cache/` directory as per conversation in issue #20285. This PR makes that change.

## Related Issues

Related to #20285