### PR TITLE
fix(starters): rename starter-plugin to comply with publish starters script

### DIFF
--- a/starters/gatsby-starter-plugin/README.md
+++ b/starters/gatsby-starter-plugin/README.md
@@ -70,7 +70,7 @@ You should now see a message logged to the console in the preinit phase of the G
 $ gatsby develop
 success open and validate gatsby-configs - 0.033s
 success load plugins - 0.074s
-Loaded gatsby-plugin-minimal
+Loaded gatsby-starter-plugin
 success onPreInit - 0.016s
 ...
 ```

--- a/starters/gatsby-starter-plugin/gatsby-node.js
+++ b/starters/gatsby-starter-plugin/gatsby-node.js
@@ -11,4 +11,4 @@
  *
  * See: https://www.gatsbyjs.org/docs/creating-a-local-plugin/#developing-a-local-plugin-that-is-outside-your-project
  */
-exports.onPreInit = () => console.log("Loaded gatsby-plugin-minimal")
+exports.onPreInit = () => console.log("Loaded gatsby-starter-plugin")

--- a/starters/gatsby-starter-plugin/package.json
+++ b/starters/gatsby-starter-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-plugin-minimal",
+  "name": "gatsby-starter-plugin",
   "version": "1.0.0",
   "description": "A minimal boilerplate for the essential files Gatsby looks for in a plugin",
   "main": "index.js",


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adding the plugin starter broke the `publish-starters` script for not having a name in the `package.json` that matches a repo on the Gatsby org. This change should push to the repo here with new changes (I believe): https://github.com/gatsbyjs/gatsby-starter-plugin

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

https://circleci.com/gh/gatsbyjs/gatsby/360016