### PR TITLE
docs: add egghead video for installing plugins

### DIFF
--- a/docs/docs/recipes/working-with-plugins.md
+++ b/docs/docs/recipes/working-with-plugins.md
@@ -11,6 +11,11 @@ Found a plugin you'd like to use in your project? Awesome! You can configure it 
 
 > If you'd like to take a look at available plugins, check out the [plugin library](/plugins).
 
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-install-and-use-a-plugin-in-a-gatsby-site"
+  lessonTitle="Install and use a plugin in a Gatsby site"
+/>
+
 ### Prerequisites
 
 - An existing [Gatsby site](/docs/quick-start/) with a `gatsby-config.js` file


### PR DESCRIPTION

## Description

Adds an Egghead video for the new plugin recipes on installing and using a plugin in a Gatsby site. (I'll probably get around to adding another one for using the plugin starter soon)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

_None_