### PR TITLE
Add `-` to end of second `gatsby-theme` prefix str

### DIFF
--- a/docs/docs/themes/conventions.md
+++ b/docs/docs/themes/conventions.md
@@ -7,7 +7,7 @@ As methodologies for building Gatsby Themes begin to formalize and standardize, 
 ## Naming
 
 It's required to prefix themes with `gatsby-theme-`. So if you'd like to name your theme "awesome" you
-can name it `gatsby-theme-awesome` and place that as the `name` key in your `package.json`. Prefixing themes with `gatsby-theme` enables Gatsby in identifying theme packages for compilation.
+can name it `gatsby-theme-awesome` and place that as the `name` key in your `package.json`. Prefixing themes with `gatsby-theme-` enables Gatsby in identifying theme packages for compilation.
 
 ## Initializing required directories
 


### PR DESCRIPTION
The maximal prefix is `gatsby-theme-` so make sure both instances of that string include the final `-` for consistency.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
