### PR TITLE
chore(docs): better example header.js in multiple themes

### DIFF
--- a/docs/tutorial/using-multiple-themes-together.md
+++ b/docs/tutorial/using-multiple-themes-together.md
@@ -373,19 +373,25 @@ Your file structure should look like this:
 
 ```jsx:title=src/gatsby-theme-blog/components/header.js
 import React from "react"
+import { css } from "theme-ui"
 import Navigation from "../../components/navigation" // highlight-line
-;<header>
-  <div
-    css={css({
-      maxWidth: `container`,
-      mx: `auto`,
-      px: 3,
-      pt: 4,
-    })}
-  >
-    <Navigation /> // highlight-line
-  </div>
-</header>
+
+export default () => {
+  return (
+    <header>
+      <div
+        css={css({
+          maxWidth: `container`,
+          mx: `auto`,
+          px: 3,
+          pt: 4,
+        })}
+      >
+        <Navigation /> // highlight-line
+      </div>
+    </header>
+  )
+}
 ```
 
 5. Run `gatsby develop` and test the new navigation component.


### PR DESCRIPTION
This provides an updated header.js component for the multiple themes tutorial that will work - is a functioning component and gets rid of that hanging semi-colon.  This way if someone copy and pastes at least they will get something that works out of the box.

I think this is better than what we have there right now.  Feel free to reject this and close it if you want. I was trying to get rid of that semi-colon and realized in the process that we could give people a "working" component at least.