### PR TITLE
chore(starters): Created a Template using Shards UI library

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5716,3 +5716,20 @@
     - SEO optimized
     - Robots.txt
     - OpenGraph structured data
+
+- url: https://shards-gatsby-starter.netlify.com/
+  repo: https://github.com/wcisco17/gatsby-typescript-shards-starter
+  description: Portfolio with Typescript and Shards UI
+  tags:
+    - Language:TypeScript
+    - Portfolio
+    - Netlify
+    - PWA
+    - Styling:Bootstrap
+  features:
+    - Portfollio Starter that includes Shards Ui component library and Typescript generator.
+    - Typescript
+    - Typescript Generator
+    - Styled-Components
+    - Shards UI
+    - Bootstrap


### PR DESCRIPTION
I've been using Shards UI for 3 of my projects now, and I was getting really tired of repeating myself every project. To avoid this redundancy I created a special template that uses all of the standards to start your own Gatsby Project. Those are typescript, styled-components, and a UI framework.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I mostly created this out of frustration from having to recreate the same type of projects every time, I hope it serves everyone in terms of getting up to speed with Shards UI - which is a clean React UI library. Embedded in the starter is typescript, styled-components, and bootstrap.
 
### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->
The documentation should be [here](https://github.com/wcisco17/gatsby-typescript-shards-starter)
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
