### PR TITLE
fix(gatsby-plugin-sharp): Apply transformArgs on compressJpg and compressWebP

### DIFF
--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -165,12 +165,12 @@ exports.processFile = (file, transforms, options = {}) => {
       }
 
       if (options.useMozJpeg && transformArgs.toFormat === `jpg`) {
-        await compressJpg(clonedPipeline, outputPath, args)
+        await compressJpg(clonedPipeline, outputPath, transformArgs)
         return transform
       }
 
       if (transformArgs.toFormat === `webp`) {
-        await compressWebP(clonedPipeline, outputPath, args)
+        await compressWebP(clonedPipeline, outputPath, transformArgs)
         return transform
       }
 


### PR DESCRIPTION
## Description

Currently the `defaultQuality` is not being applied when compressing jpg or webp as the wrong args are used.

### Documentation

https://www.gatsbyjs.org/packages/gatsby-plugin-sharp/

## Related Issues

Fixes #13807