### PR TITLE
chore(gatsby): Improve graphql type definitions in BuildArgs

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -957,7 +957,13 @@ interface ActionOptions {
 }
 
 export interface BuildArgs extends ParentSpanPluginArgs {
-  graphql: Function
+  graphql<TData, TVariables = any>(
+    query: string,
+    variables?: TVariables
+  ): Promise<{
+    errors?: any
+    data?: TData
+  }>
 }
 
 export interface Actions {


### PR DESCRIPTION
## Description

Instead of `Function` expose some more detail of `graphql` to allow for type safety.
Same as #14575 just for `onPreBuild`, `onPostBuild`.