### PR TITLE
fix(gatsby): Mark plugin parameter as optional for actions

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1100,7 +1100,7 @@ export interface Actions {
   /** @see https://www.gatsbyjs.org/docs/actions/#createFieldExtension */
   createFieldExtension(
     extension: object,
-    plugin: ActionPlugin,
+    plugin?: ActionPlugin,
     traceId?: string
   ): void
 }

--- a/packages/gatsby/src/redux/actions/restricted.js
+++ b/packages/gatsby/src/redux/actions/restricted.js
@@ -22,7 +22,7 @@ const actions = {}
  */
 actions.addThirdPartySchema = (
   { schema }: { schema: GraphQLSchema },
-  plugin: Plugin,
+  plugin?: Plugin,
   traceId?: string
 ) => {
   return {
@@ -181,7 +181,7 @@ actions.createTypes = (
     | GraphQLOutputType
     | GatsbyGraphQLType
     | Array<string | GraphQLOutputType | GatsbyGraphQLType>,
-  plugin: Plugin,
+  plugin?: Plugin,
   traceId?: string
 ) => {
   return {
@@ -299,7 +299,7 @@ actions.printTypeDefinitions = (
     exclude?: { types?: Array<string>, plugins?: Array<string> },
     withFieldTypes?: boolean,
   },
-  plugin: Plugin,
+  plugin?: Plugin,
   traceId?: string
 ) => {
   return {
@@ -347,7 +347,7 @@ actions.printTypeDefinitions = (
  */
 actions.createResolverContext = (
   context: object,
-  plugin: Plugin,
+  plugin?: Plugin,
   traceId?: string
 ) => dispatch => {
   if (!context || typeof context !== `object`) {

--- a/packages/gatsby/src/redux/actions/restricted.js
+++ b/packages/gatsby/src/redux/actions/restricted.js
@@ -239,7 +239,7 @@ import type GraphQLFieldExtensionDefinition from "../../schema/extensions"
  */
 actions.createFieldExtension = (
   extension: GraphQLFieldExtensionDefinition,
-  plugin: Plugin,
+  plugin?: Plugin,
   traceId?: string
 ) => (dispatch, getState) => {
   const { name } = extension || {}


### PR DESCRIPTION
## Description

It would be great to have the plugin argument optional, to avoid workaround like:

```js
api.actions.createFieldExtension({
name: "TestType",
extend: () => ({
  resolve: () => "resolved"
})
}, 
{name: "plugin name"} // Forced to be passed in typescript
```

Showcase:
* https://github.com/Simply007/gatsby-kontent-packages/blob/master/packages/gatsby-source-kontent/src/createSchemaCustomization.items.ts#L81