### PR TITLE
fix(gatsby-plugin-mdx): Use getNodesByType for plugin transformation

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
@@ -74,7 +74,10 @@ describe(`mdx-loader`, () => {
           }
         },
         query: {
-          getNodes() {
+          getNodes(_type) {
+            return fixtures.map(([, node]) => node)
+          },
+          getNodesByType(_type) {
             return fixtures.map(([, node]) => node)
           },
           pluginOptions: {},

--- a/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -13,7 +13,7 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
   gatsbyRemarkPlugins,
   mdxNode,
   getNode,
-  getNodes,
+  getNodesByType,
   reporter,
   cache,
   pathPrefix,
@@ -39,7 +39,7 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
       }
   }
 
-  fileNodes = getNodes().filter(n => n.internal.type === `File`)
+  fileNodes = getNodesByType(`File`)
 
   // return list of remarkPlugins
   const userPlugins = gatsbyRemarkPlugins


### PR DESCRIPTION
Since getSourcePluginsAsRemarkPlugins is called on
every MDX file, the getNodes call became expensive
at scale with thousands of MDX files.

This was encountered when attempting to find
underlying issues for #22521. @pvdz had a hunch that
node traversal may be a culprit. This doesn't fully
address all underlying performance issues but
is a quick win.

8k MDX pages: 440s => 350s
16k MDX pages: 1100s => 750s