### PR TITLE
docs: fix language codes

### DIFF
--- a/docs/docs/loading-plugins-from-your-local-plugins-folder.md
+++ b/docs/docs/loading-plugins-from-your-local-plugins-folder.md
@@ -49,7 +49,7 @@ _The [`onPreInit` API](/docs/node-apis/#onPreInit) is the first Node API called 
 
 Then, when running your site in develop or build mode, you should see "Testing..." logged in your terminal:
 
-```sh
+```shell
 success open and validate gatsby-configs - 0.051s
 success load plugins - 1.047s
 Testing... // highlight-line

--- a/examples/using-multiple-local-plugins/README.md
+++ b/examples/using-multiple-local-plugins/README.md
@@ -8,25 +8,25 @@ The actual Gatsby site to run is in the `gatsby-site-using-local-plugins` folder
 
 Navigate into the `gatsby-site-using-local-plugins` project directory with this command:
 
-```sh
+```shell
 cd gatsby-site-using-local-plugins
 ```
 
 You'll need to install dependencies for the site by running:
 
-```sh
+```shell
 npm install
 ```
 
 Then run `gatsby develop`:
 
-```sh
+```shell
 gatsby develop
 ```
 
 In your command line output, you should then see the text listed below. This text is showing how the code for each plugin is run sequentially thanks to the Node API implemented.
 
-```sh
+```shell
 $ gatsby develop
 success open and validate gatsby-configs - 0.051s
 success load plugins - 1.047s
@@ -63,7 +63,7 @@ module.exports = {
 
 And then run:
 
-```sh:title=gatsby-site-using-multiple-local-plugins
+```shell:title=gatsby-site-using-multiple-local-plugins
 npm link ../gatsby-plugin-console-log-c
 ```
 

--- a/examples/using-plugin-options/README.md
+++ b/examples/using-plugin-options/README.md
@@ -5,20 +5,21 @@ This is an example repository demonstrating how to add options to a plugin you'v
 ## Running the example
 
 In this directory, be sure to install dependencies for Gatsby:
+ell
 
-```sh
+```shell
 npm install
 ```
 
 Then run `gatsby develop`:
 
-```sh
+```shell
 gatsby develop
 ```
 
 In your command line output, you should then see the text listed below. This text is showing how the code for each plugin is run sequentially thanks to the Node API implemented.
 
-```sh
+```shell
 $ gatsby develop
 success open and validate gatsby-configs - 0.034s
 success load plugins - 0.050s


### PR DESCRIPTION
Looks like prism doesn't like `sh`, so changing those mentions to `shell`.