### PR TITLE
chore: fix livestream social sharing

### DIFF
--- a/docs/blog/2020-03-23-introducing-gatsby-web-creators/index.md
+++ b/docs/blog/2020-03-23-introducing-gatsby-web-creators/index.md
@@ -14,7 +14,7 @@ tags:
 
 <img src="./images/octopus.png" alt="octopus" />
 
-[Gatsby Web Creators](https://gatsbyjs.com/gatsby-web-creators) is a free livestream series aimed at curious people aged 13 and up, starting Wednesday, March 25. Twice a week for the next 5 weeks, Gatsby Learning Team members and their special guests will teach the basic skills involved for creating web pages, starting with HTML and CSS, and gradually building up to JavaScript.
+[Gatsby Web Creators](https://gatsbyjs.com/gatsby-web-creators) is a free livestream series aimed at curious people aged 13 and up, starting Wednesday, March 25. For an hour twice a week for the next 5 weeks, Gatsby Learning Team members and their special guests will teach the basic skills involved for creating web pages, starting with HTML and CSS, and gradually building up to JavaScript.
 
 Streaming live on [Twitch](https://twitch.tv/gatsbyjs), we’ll explore how to work with text, images, interactive elements, fancy widgets, custom styling, animation with CSS, playing with browser Developer Tools, and more. We’ll make good use of the time people are spending indoors and online to build up a foundation of skills over the coming weeks, showing how to create accessible web pages tailored to one's interests.
 

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -249,7 +249,7 @@ export const pageQuery = graphql`
         tags
         image {
           childImageSharp {
-            resize(width: 1500, height: 1500) {
+            resize(width: 1500) {
               src
             }
             fluid(maxWidth: 786) {


### PR DESCRIPTION
## Description

Here's hoping this PR fixes the issue I attempted to cover in #22535: this PR removes a query height parameter from the blog post template for images, which was cropping my horizontal image into a square in production and looking generally terrible. When I tested it locally, somehow it wasn't exhibiting the same behavior–you can even see my commit history of playing with this in the last PR.

After talking with the team internally, removing one of the image dimensions should eliminate the awkward cropping. I also made a content update for a question we got regarding the livestream length.

### Documentation

N/A

## Related Issues

N/A