### PR TITLE
chore(gatsby): Migrate utils/worker/child to TypeScript

### DIFF
--- a/packages/gatsby/src/utils/worker/child.js
+++ b/packages/gatsby/src/utils/worker/child.js
@@ -1,8 +1,0 @@
-// Note: this doesn't check for conflicts between module exports
-import { getFilePath } from "./page-data"
-import { renderHTML } from "./render-html"
-
-module.exports = {
-  getFilePath,
-  renderHTML,
-}

--- a/packages/gatsby/src/utils/worker/child.ts
+++ b/packages/gatsby/src/utils/worker/child.ts
@@ -1,0 +1,3 @@
+// Note: this doesn't check for conflicts between module exports
+export { getFilePath } from "./page-data"
+export { renderHTML } from "./render-html"


### PR DESCRIPTION
## Description

Migrate `src/utils/worker/child` to TypeScript

## Related Issues

Related to #21995