### PR TITLE
Always set the webpack target as "web"

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -464,7 +464,7 @@ module.exports = async (
     // and server (see
     // https://github.com/defunctzombie/package-browser-field-spec); setting
     // the target tells webpack which file to include, ie. browser vs main.
-    target: stage === `build-html` || stage === `develop-html` ? `node` : `web`,
+    target: `web`,
 
     devtool: getDevtool(),
     // Turn off performance hints as we (for now) don't want to show the normal


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Gatsby does not have a node runtime so it doesn't make sense for it be compiling webpack bundles expecting a server environment. Various packages (like superagent) that have a server build included are rendered unbundleable because of this due to lack of globals like `require` in the browser.

### Documentation

n/a

## Related Issues

Fixes #2615 

