### PR TITLE
Update benchmark cron schedule and machine type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -590,7 +590,7 @@ workflows:
       - benchmark_markdown_table_32768
     triggers:
       - schedule:
-          cron: 12 3 * * *
+          cron: 22 16 * * *
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,7 +430,6 @@ jobs:
   benchmark_markdown_id_512:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_id
@@ -442,7 +441,6 @@ jobs:
   benchmark_markdown_id_4096:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_id
@@ -454,7 +452,6 @@ jobs:
   benchmark_markdown_id_8192:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_id
@@ -466,7 +463,6 @@ jobs:
   benchmark_markdown_id_32768:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_id
@@ -478,7 +474,6 @@ jobs:
   benchmark_markdown_slug_512:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_slug
@@ -490,7 +485,6 @@ jobs:
   benchmark_markdown_slug_4096:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_slug
@@ -502,7 +496,6 @@ jobs:
   benchmark_markdown_slug_8192:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_slug
@@ -514,7 +507,6 @@ jobs:
   benchmark_markdown_slug_32768:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_slug
@@ -526,7 +518,6 @@ jobs:
   benchmark_markdown_table_512:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_table
@@ -538,7 +529,6 @@ jobs:
   benchmark_markdown_table_4096:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_table
@@ -550,7 +540,6 @@ jobs:
   benchmark_markdown_table_8192:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_table
@@ -562,7 +551,6 @@ jobs:
   benchmark_markdown_table_32768:
     docker:
       - image: "circleci/node:12"
-    resource_class: xlarge
     steps:
       - run-benchmark:
           working_directory: benchmarks/markdown_table/benchmarks/markdown_table


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This updates

- The CircleCI benchmark cron schedule to match that of other platforms for consistency.
- The machine type to use the default machine type to match using defaults in other platforms for consistency. https://circleci.com/docs/2.0/configuration-reference/#docker-executor

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

n/a

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

n/a
