### PR TITLE
fix(gatsby): Collect nested webpack compilation stats errors

### DIFF
--- a/packages/gatsby/src/commands/build-javascript.ts
+++ b/packages/gatsby/src/commands/build-javascript.ts
@@ -1,5 +1,6 @@
 import { Span } from "opentracing"
 import webpack from "webpack"
+import flatMap from "lodash/flatMap"
 
 import webpackConfig from "../utils/webpack.config"
 
@@ -32,7 +33,7 @@ export const buildProductionBundle = async (
       if (stats.hasErrors()) {
         const flattenStatsErrors = (stats: webpack.Stats): Error[] => [
           ...stats.compilation.errors,
-          ...stats.compilation.children.flatMap(child =>
+          ...flatMap(stats.compilation.children, child =>
             flattenStatsErrors(child.getStats())
           ),
         ]

--- a/packages/gatsby/src/commands/build-javascript.ts
+++ b/packages/gatsby/src/commands/build-javascript.ts
@@ -30,7 +30,13 @@ export const buildProductionBundle = async (
       reportWebpackWarnings(stats)
 
       if (stats.hasErrors()) {
-        return reject(stats.compilation.errors)
+        const flattenStatsErrors = (stats: webpack.Stats): Error[] => [
+          ...stats.compilation.errors,
+          ...stats.compilation.children.flatMap(child =>
+            flattenStatsErrors(child.getStats())
+          ),
+        ]
+        return reject(flattenStatsErrors(stats))
       }
 
       return resolve(stats)


### PR DESCRIPTION
## Description

`gatsby build` doesn't propagate all relevant errors up to its error reporter. webpack's stats `hasErrors()` is a child compilation aware call, thus, so too should be gatsby's error stats error collector

### Documentation

n/a

## Related Issues

closes #22597