### PR TITLE
Update a small typo in style guide

### DIFF
--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -142,11 +142,11 @@ When referencing another page within [gatsbyjs.org](https://www.gatsbyjs.org/) h
 ```markdown
 <!-- Good -->
 
-[Gatsby's glossay](/docs/glossary)
+[Gatsby's glossary](/docs/glossary)
 
 <!-- Bad -->
 
-[Gatsby's glossay](https://www.gatsbyjs.org/docs/glossary)
+[Gatsby's glossary](https://www.gatsbyjs.org/docs/glossary)
 ```
 
 Note: Links to Gatsby Cloud/Gatsby Inc. are located at [gatsbyjs.com](https://www.gatsbyjs.com/) and should be referenced using an absolute path (domain included). See also [Referencing Gatsby Cloud](#referencing-gatsby-cloud)


### PR DESCRIPTION
Updated a small typo in a code block within the Gatsby style guide. 
The typo was 'glossay', updated to 'glossary'.

https://www.gatsbyjs.org/contributing/gatsby-style-guide/