### PR TITLE
chore(gatsby-react-router-scroll): Migrate package to Typescript

### DIFF
--- a/packages/gatsby-react-router-scroll/.babelrc
+++ b/packages/gatsby-react-router-scroll/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package", { "browser": true }]],
+  "overrides": [
+    {
+      "test": ["**/*.ts", "**/*.tsx"],
+      "plugins": [["@babel/plugin-transform-typescript", { "isTSX": true }]]
+    }
+  ]
 }

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
+    "@types/warning": "^3.0.0",
     "babel-plugin-dev-expression": "^0.2.2",
     "babel-preset-gatsby-package": "^0.3.1",
     "cross-env": "^5.2.1"

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -23,7 +23,7 @@
     "gatsby"
   ],
   "license": "MIT",
-  "main": "index.js",
+  "main": "dist/index.js",
   "peerDependencies": {
     "@reach/router": "^1.0",
     "gatsby": "^2.0.0",
@@ -36,9 +36,9 @@
     "directory": "packages/gatsby-react-router-scroll"
   },
   "scripts": {
-    "build": "babel src --out-dir . --ignore **/__tests__",
+    "build": "babel src --out-dir ./dist/ --ignore **/__tests__ --extensions \".ts,.js,.tsx\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore **/__tests__"
+    "watch": "babel -w src --out-dir ./dist/ --ignore **/__tests__ --extensions \".ts,.js,.tsx\""
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -8,12 +8,14 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",
-    "scroll-behavior": "^0.9.12",
+    "scroll-behavior": "^0.10.0",
     "warning": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
+    "@babel/plugin-transform-typescript": "^7.9.4",
+    "@types/reach__router": "^1.3.1",
     "@types/warning": "^3.0.0",
     "babel-plugin-dev-expression": "^0.2.2",
     "babel-preset-gatsby-package": "^0.3.1",

--- a/packages/gatsby-react-router-scroll/src/index.js
+++ b/packages/gatsby-react-router-scroll/src/index.js
@@ -1,4 +1,0 @@
-import ScrollBehaviorContext from "./ScrollBehaviorContext"
-import ScrollContainer from "./ScrollContainer"
-exports.ScrollContainer = ScrollContainer
-exports.ScrollContext = ScrollBehaviorContext

--- a/packages/gatsby-react-router-scroll/src/index.ts
+++ b/packages/gatsby-react-router-scroll/src/index.ts
@@ -1,0 +1,2 @@
+export { ScrollContext } from "./scroll-context"
+export { ScrollContainer } from "./scroll-container"

--- a/packages/gatsby-react-router-scroll/src/scroll-container.ts
+++ b/packages/gatsby-react-router-scroll/src/scroll-container.ts
@@ -2,11 +2,16 @@ import React, { ReactChildren } from "react"
 import ReactDOM from "react-dom"
 import warning from "warning"
 import PropTypes from "prop-types"
-import { ScrollContext, IShouldUpdateScroll } from "./scroll-context"
+import {
+  ScrollContext,
+  IShouldUpdateScroll,
+  IHistory,
+  ScrollTarget,
+} from "./scroll-context"
 
 interface IScrollContainerProps {
   scrollKey: string
-  shouldUpdateScroll: IShouldUpdateScroll
+  shouldUpdateScroll: IShouldUpdateScroll<IHistory>
   children: ReactChildren
 }
 
@@ -65,7 +70,7 @@ export class ScrollContainer extends React.Component<IScrollContainerProps> {
     this.context.scrollBehavior.unregisterElement(this.scrollKey)
   }
 
-  shouldUpdateScroll = (prevRouterProps, routerProps): boolean => {
+  shouldUpdateScroll = (prevRouterProps, routerProps): boolean | ScrollTarget => {
     const { shouldUpdateScroll } = this.props
     if (!shouldUpdateScroll) {
       return true

--- a/packages/gatsby-react-router-scroll/src/scroll-container.ts
+++ b/packages/gatsby-react-router-scroll/src/scroll-container.ts
@@ -70,7 +70,10 @@ export class ScrollContainer extends React.Component<IScrollContainerProps> {
     this.context.scrollBehavior.unregisterElement(this.scrollKey)
   }
 
-  shouldUpdateScroll = (prevRouterProps, routerProps): boolean | ScrollTarget => {
+  shouldUpdateScroll = (
+    prevRouterProps,
+    routerProps
+  ): boolean | ScrollTarget => {
     const { shouldUpdateScroll } = this.props
     if (!shouldUpdateScroll) {
       return true

--- a/packages/gatsby-react-router-scroll/src/scroll-container.ts
+++ b/packages/gatsby-react-router-scroll/src/scroll-container.ts
@@ -1,22 +1,28 @@
-import React from "react"
+import React, { ReactChildren } from "react"
 import ReactDOM from "react-dom"
 import warning from "warning"
 import PropTypes from "prop-types"
+import { ScrollContext } from "./scroll-context"
 
-const propTypes = {
-  scrollKey: PropTypes.string.isRequired,
-  shouldUpdateScroll: PropTypes.func,
-  children: PropTypes.element.isRequired,
+interface IScrollContainerProps {
+  scrollKey: string
+  shouldUpdateScroll: any
+  children: ReactChildren
 }
 
-const contextTypes = {
-  // This is necessary when rendering on the client. However, when rendering on
-  // the server, this container will do nothing, and thus does not require the
-  // scroll behavior context.
-  scrollBehavior: PropTypes.object,
+interface IScrollContainerContext {
+  scrollBehavior: ScrollContext
 }
 
-class ScrollContainer extends React.Component {
+export class ScrollContainer extends React.Component<IScrollContainerProps> {
+  static contextTypes = {
+    scrollBehavior: PropTypes.object,
+  }
+  context!: IScrollContainerContext
+
+  scrollKey: string
+  domNode: Element | Text | null | undefined
+
   constructor(props, context) {
     super(props, context)
 
@@ -25,7 +31,7 @@ class ScrollContainer extends React.Component {
     this.scrollKey = props.scrollKey
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.context.scrollBehavior.registerElement(
       this.props.scrollKey,
       ReactDOM.findDOMNode(this), // eslint-disable-line react/no-find-dom-node
@@ -39,7 +45,7 @@ class ScrollContainer extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps): void {
     warning(
       prevProps.scrollKey === this.props.scrollKey,
       `<ScrollContainer> does not support changing scrollKey.`
@@ -55,11 +61,11 @@ class ScrollContainer extends React.Component {
     }
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     this.context.scrollBehavior.unregisterElement(this.scrollKey)
   }
 
-  shouldUpdateScroll = (prevRouterProps, routerProps) => {
+  shouldUpdateScroll = (prevRouterProps, routerProps): boolean => {
     const { shouldUpdateScroll } = this.props
     if (!shouldUpdateScroll) {
       return true
@@ -73,12 +79,7 @@ class ScrollContainer extends React.Component {
     )
   }
 
-  render() {
+  render(): ReactChildren {
     return this.props.children
   }
 }
-
-ScrollContainer.propTypes = propTypes
-ScrollContainer.contextTypes = contextTypes
-
-export default ScrollContainer

--- a/packages/gatsby-react-router-scroll/src/scroll-container.ts
+++ b/packages/gatsby-react-router-scroll/src/scroll-container.ts
@@ -2,28 +2,24 @@ import React, { ReactChildren } from "react"
 import ReactDOM from "react-dom"
 import warning from "warning"
 import PropTypes from "prop-types"
-import {
-  ScrollContext,
-  IShouldUpdateScroll,
-  IHistory,
-  ScrollTarget,
-} from "./scroll-context"
+import { ShouldUpdateScroll, ScrollTarget } from "scroll-behavior"
+import { ScrollContext, IHistory } from "./scroll-context"
 
-interface IScrollContainerProps {
+interface IProps {
   scrollKey: string
-  shouldUpdateScroll: IShouldUpdateScroll<IHistory>
+  shouldUpdateScroll: ShouldUpdateScroll<IHistory>
   children: ReactChildren
 }
 
-interface IScrollContainerContext {
+interface IContext {
   scrollBehavior: ScrollContext
 }
 
-export class ScrollContainer extends React.Component<IScrollContainerProps> {
+export class ScrollContainer extends React.Component<IProps> {
   static contextTypes = {
     scrollBehavior: PropTypes.object,
   }
-  context!: IScrollContainerContext
+  context!: IContext
 
   scrollKey: string
   domNode: Element | Text | null | undefined

--- a/packages/gatsby-react-router-scroll/src/scroll-container.ts
+++ b/packages/gatsby-react-router-scroll/src/scroll-container.ts
@@ -2,11 +2,11 @@ import React, { ReactChildren } from "react"
 import ReactDOM from "react-dom"
 import warning from "warning"
 import PropTypes from "prop-types"
-import { ScrollContext } from "./scroll-context"
+import { ScrollContext, IShouldUpdateScroll } from "./scroll-context"
 
 interface IScrollContainerProps {
   scrollKey: string
-  shouldUpdateScroll: any
+  shouldUpdateScroll: IShouldUpdateScroll
   children: ReactChildren
 }
 

--- a/packages/gatsby-react-router-scroll/src/scroll-context.ts
+++ b/packages/gatsby-react-router-scroll/src/scroll-context.ts
@@ -1,40 +1,30 @@
 import React, { ReactChildren } from "react"
-import ScrollBehavior from "scroll-behavior"
+import ScrollBehavior, {
+  LocationBase,
+  ScrollTarget,
+  ShouldUpdateScroll,
+} from "scroll-behavior"
 import PropTypes from "prop-types"
-import { globalHistory as history } from "@reach/router/lib/history"
+import { globalHistory as history, History } from "@reach/router"
 import { SessionStorage } from "./state-storage"
 
-// A copy of the not-exposed interface in scroll-behavior
-export interface ILocationBase {
-  action: "PUSH" | string
-  hash?: string
-}
-
-export type ScrollPosition = [number, number]
-
-export type ScrollTarget = ScrollPosition | string | boolean | null | undefined
-
-export interface IShouldUpdateScroll<TContext> {
-  (prevContext: TContext | null, context: TContext): ScrollTarget
-}
-
 export interface IHistory {
-  location: ILocationBase
-  history: history
+  location?: LocationBase
+  history?: History
 }
 
-interface IScrollBehaviorProps {
-  shouldUpdateScroll: IShouldUpdateScroll<IHistory>
+interface IProps {
+  shouldUpdateScroll: ShouldUpdateScroll<IHistory>
   children: ReactChildren
-  location: ILocationBase
+  location: LocationBase
 }
 
-interface IScrollBehaviorContextContext {
+interface IContext {
   scrollBehavior: ScrollContext
 }
 
-export class ScrollContext extends React.Component<IScrollBehaviorProps, {}> {
-  scrollBehavior: ScrollBehavior<history, history>
+export class ScrollContext extends React.Component<IProps, {}> {
+  scrollBehavior: ScrollBehavior<LocationBase, IHistory>
   static childContextTypes = {
     scrollBehavior: PropTypes.object.isRequired,
   }
@@ -45,12 +35,12 @@ export class ScrollContext extends React.Component<IScrollBehaviorProps, {}> {
     this.scrollBehavior = new ScrollBehavior({
       addTransitionHook: history.listen,
       stateStorage: new SessionStorage(),
-      getCurrentLocation: (): ILocationBase => this.props.location,
+      getCurrentLocation: (): LocationBase => this.props.location,
       shouldUpdateScroll: this.shouldUpdateScroll,
     })
   }
 
-  getChildContext(): IScrollBehaviorContextContext {
+  getChildContext(): IContext {
     return {
       scrollBehavior: this,
     }
@@ -100,7 +90,7 @@ export class ScrollContext extends React.Component<IScrollBehaviorProps, {}> {
   registerElement = (
     key: string,
     element: Element | Text | null,
-    shouldUpdateScroll: IShouldUpdateScroll<IHistory>
+    shouldUpdateScroll: ShouldUpdateScroll<IHistory>
   ): void => {
     this.scrollBehavior.registerElement(
       key,

--- a/packages/gatsby-react-router-scroll/src/scroll-context.ts
+++ b/packages/gatsby-react-router-scroll/src/scroll-context.ts
@@ -10,8 +10,14 @@ export interface ILocationBase {
   hash?: string
 }
 
+export type ScrollTarget = ScrollPosition | string | boolean | null | undefined
+
+export interface IShouldUpdateScroll<TContext> {
+  (prevContext: TContext | null, context: TContext): ScrollTarget
+}
+
 interface IScrollBehaviorProps {
-  shouldUpdateScroll: any
+  shouldUpdateScroll: IShouldUpdateScroll
   children: ReactChildren
   location: ILocationBase
 }
@@ -84,7 +90,7 @@ export class ScrollContext extends React.Component<IScrollBehaviorProps, {}> {
   registerElement = (
     key: string,
     element: Element | Text | null,
-    shouldUpdateScroll: any
+    shouldUpdateScroll: IShouldUpdateScroll
   ): void => {
     this.scrollBehavior.registerElement(
       key,

--- a/packages/gatsby-react-router-scroll/src/scroll-context.ts
+++ b/packages/gatsby-react-router-scroll/src/scroll-context.ts
@@ -10,14 +10,21 @@ export interface ILocationBase {
   hash?: string
 }
 
+export type ScrollPosition = [number, number]
+
 export type ScrollTarget = ScrollPosition | string | boolean | null | undefined
 
 export interface IShouldUpdateScroll<TContext> {
   (prevContext: TContext | null, context: TContext): ScrollTarget
 }
 
+export interface IHistory {
+  location: ILocationBase
+  history: history
+}
+
 interface IScrollBehaviorProps {
-  shouldUpdateScroll: IShouldUpdateScroll
+  shouldUpdateScroll: IShouldUpdateScroll<IHistory>
   children: ReactChildren
   location: ILocationBase
 }
@@ -68,12 +75,15 @@ export class ScrollContext extends React.Component<IScrollBehaviorProps, {}> {
     this.scrollBehavior.stop()
   }
 
-  getRouterProps(): { location: ILocationBase; history: history } {
+  getRouterProps(): IHistory {
     const { location } = this.props
     return { location, history }
   }
 
-  shouldUpdateScroll = (prevRouterProps, routerProps): boolean => {
+  shouldUpdateScroll = (
+    prevRouterProps,
+    routerProps
+  ): boolean | ScrollTarget => {
     const { shouldUpdateScroll } = this.props
     if (!shouldUpdateScroll) {
       return true
@@ -90,7 +100,7 @@ export class ScrollContext extends React.Component<IScrollBehaviorProps, {}> {
   registerElement = (
     key: string,
     element: Element | Text | null,
-    shouldUpdateScroll: IShouldUpdateScroll
+    shouldUpdateScroll: IShouldUpdateScroll<IHistory>
   ): void => {
     this.scrollBehavior.registerElement(
       key,

--- a/packages/gatsby-react-router-scroll/src/state-storage.ts
+++ b/packages/gatsby-react-router-scroll/src/state-storage.ts
@@ -1,9 +1,9 @@
-import { ILocationBase } from "./scroll-context";
+import { ILocationBase } from "./scroll-context"
 
 const STATE_KEY_PREFIX = `@@scroll|`
 const GATSBY_ROUTER_SCROLL_STATE = `___GATSBY_REACT_ROUTER_SCROLL`
 
-type ScrollPosition = [number, number];
+type ScrollPosition = [number, number]
 
 interface ILocation extends ILocationBase {
   key?: string

--- a/packages/gatsby-react-router-scroll/src/state-storage.ts
+++ b/packages/gatsby-react-router-scroll/src/state-storage.ts
@@ -1,16 +1,16 @@
-import { ILocationBase, ScrollPosition } from "./scroll-context"
+import { LocationBase, ScrollPosition } from "scroll-behavior"
 
 const STATE_KEY_PREFIX = `@@scroll|`
 const GATSBY_ROUTER_SCROLL_STATE = `___GATSBY_REACT_ROUTER_SCROLL`
 
-interface ILocation extends ILocationBase {
+interface ILocation extends LocationBase {
   key?: string
   pathname?: string
 }
 
 export class SessionStorage {
   read(
-    location: ILocation,
+    location: LocationBase,
     key: string | null
   ): ScrollPosition | null | undefined {
     const stateKey = SessionStorage.getStateKey(location, key)
@@ -36,7 +36,7 @@ export class SessionStorage {
     }
   }
 
-  save(location: ILocation, key: string | null, value): void {
+  save(location: LocationBase, key: string | null, value): void {
     const stateKey = SessionStorage.getStateKey(location, key)
     const storedValue = JSON.stringify(value)
 
@@ -56,7 +56,7 @@ export class SessionStorage {
     }
   }
 
-  static getStateKey(location: ILocation, key: string | null): string {
+  static getStateKey(location: ILocation, key?: string | null): string {
     const locationKey = location.key || location.pathname
     const stateKeyBase = `${STATE_KEY_PREFIX}${locationKey}`
     return key === null || typeof key === `undefined`

--- a/packages/gatsby-react-router-scroll/src/state-storage.ts
+++ b/packages/gatsby-react-router-scroll/src/state-storage.ts
@@ -1,9 +1,7 @@
-import { ILocationBase } from "./scroll-context"
+import { ILocationBase, ScrollPosition } from "./scroll-context"
 
 const STATE_KEY_PREFIX = `@@scroll|`
 const GATSBY_ROUTER_SCROLL_STATE = `___GATSBY_REACT_ROUTER_SCROLL`
-
-type ScrollPosition = [number, number]
 
 interface ILocation extends ILocationBase {
   key?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -4178,6 +4178,11 @@
     "@types/unist" "*"
     "@types/vfile-message" "*"
 
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
+
 "@types/webpack-sources@*":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.5.tgz#be47c10f783d3d6efe1471ff7f042611bd464a92"


### PR DESCRIPTION
## Description

Migrates `gatsby-react-router-scroll` to Typescript
Enforced other rules provided by prettier

## Related Issues

Related to #21995 