### PR TITLE
fix(telemetry): fix isTrackingEnabled always truthy

### DIFF
--- a/packages/gatsby-telemetry/src/__tests__/telemetry.js
+++ b/packages/gatsby-telemetry/src/__tests__/telemetry.js
@@ -14,4 +14,10 @@ describe(`Telemetry`, () => {
     expect(eventStore).toHaveBeenCalledTimes(1)
     expect(eventStore.mock.instances[0].addEvent).toHaveBeenCalledTimes(1)
   })
+
+  it(`Doesn't add event to store if telemetry is turned off`, () => {
+    telemetry.trackingEnabled = false
+    telemetry.trackActivity(`demo`)
+    expect(eventStore.mock.instances[0].addEvent).not.toHaveBeenCalled()
+  })
 })

--- a/packages/gatsby-telemetry/src/__tests__/telemetry.js
+++ b/packages/gatsby-telemetry/src/__tests__/telemetry.js
@@ -15,7 +15,7 @@ describe(`Telemetry`, () => {
     expect(eventStore.mock.instances[0].addEvent).toHaveBeenCalledTimes(1)
   })
 
-  it(`Doesn't add event to store if telemetry is turned off`, () => {
+  it(`Doesn't add event to store if telemetry tracking is turned off`, () => {
     telemetry.trackingEnabled = false
     telemetry.trackActivity(`demo`)
     expect(eventStore.mock.instances[0].addEvent).not.toHaveBeenCalled()

--- a/packages/gatsby-telemetry/src/index.js
+++ b/packages/gatsby-telemetry/src/index.js
@@ -28,7 +28,7 @@ module.exports = {
   startBackgroundUpdate: _ => {
     setTimeout(tick, interval)
   },
-  isTrackingEnabled: () => instance.isTrackingEnabled,
+  isTrackingEnabled: () => instance.isTrackingEnabled(),
   aggregateStats: data => instance.aggregateStats(data),
   addSiteMeasurement: (event, obj) => instance.addSiteMeasurement(event, obj),
   expressMiddleware: source => (req, res, next) => {


### PR DESCRIPTION
Fixed the isTrackingEnabled being exported as a function returning a function instead of a function returning a value

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
As #22531 mentions, the telemetry module is exporting a _function that returns a function_ instead of a _function that returns a boolean value_.
I've gone through the entire codebase, we don't use it as a returning function anywhere.

Also, added a minor test for `telemetry.js`
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #22531