### PR TITLE
fix(docs): Lowercase Node

### DIFF
--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -12,9 +12,9 @@ As an example consider the following code snippet in a `gatsby-node.js` file:
 const { createFilePath } = require("gatsby-source-filesystem")
 
 exports.onCreateNode = args => {
-  const { actions, Node } = args
+  const { actions, node } = args
 
-  if (Node.internal.type === "MarkdownRemark") {
+  if (node.internal.type === "MarkdownRemark") {
     const { createNodeField } = actions
 
     const value = createFilePath({ node, getNode })
@@ -47,8 +47,8 @@ const { createFilePath } = require("gatsby-source-filesystem")
 
 exports.onCreateNode = args => {
   console.log(args) // highlight-line
-  const { actions, Node } = args
-  if (Node.internal.type === "MarkdownRemark") {
+  const { actions, node } = args
+  if (node.internal.type === "MarkdownRemark") {
     const { createNodeField } = actions
 
     const value = createFilePath({ node, getNode })


### PR DESCRIPTION
## Description

Fixed `Debugging the Build Process` documentation by making `Node` lowercase

### Documentation

## Related Issues