### PR TITLE
fix(gatsby-plugin-mdx): Truncate non-latin language excerpts correctly

### DIFF
--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -559,6 +559,22 @@ export const pageQuery = graphql`
 `
 ```
 
+## Troubleshooting
+
+### Excerpts for non-latin languages
+
+By default, `excerpt` uses `underscore.string/prune` which doesn't handle non-latin characters ([https://github.com/epeli/underscore.string/issues/418](https://github.com/epeli/underscore.string/issues/418)).
+
+If that is the case, you can set `truncate` option on `excerpt` field, like:
+
+```graphql
+{
+  markdownRemark {
+    excerpt(truncate: true)
+  }
+}
+```
+
 ## License
 
 MIT

--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -1,4 +1,5 @@
 const _ = require(`lodash`)
+const { GraphQLBoolean } = require(`gatsby/graphql`)
 const remark = require(`remark`)
 const english = require(`retext-english`)
 const remark2retext = require(`remark-retext`)
@@ -151,8 +152,12 @@ module.exports = (
             type: `Int`,
             defaultValue: 140,
           },
+          truncate: {
+            type: GraphQLBoolean,
+            defaultValue: false,
+          },
         },
-        async resolve(mdxNode, { pruneLength }) {
+        async resolve(mdxNode, { pruneLength, truncate }) {
           if (mdxNode.excerpt) {
             return Promise.resolve(mdxNode.excerpt)
           }
@@ -166,7 +171,14 @@ module.exports = (
             return
           })
 
-          return prune(excerptNodes.join(` `), pruneLength, `…`)
+          if (!truncate) {
+            return prune(excerptNodes.join(` `), pruneLength, `…`)
+          }
+
+          return _.truncate(excerptNodes.join(` `), {
+            length: pruneLength,
+            omission: `…`,
+          })
         },
       },
       headings: {


### PR DESCRIPTION
## Description

`gatsby-plugin-mdx` fails to truncate non-latin language excerpts correctly. The result is always just whitespace. The reason is the `prune` function from `underscore.string` library that is used by `gatsby-plugin-mdx` . It is a long standing bug of  `underscore.string`: esamattis/underscore.string#418

`gatsby-transformer-remark` had the same issue before: see #6916. Here I literally take the same solution as in the PR for that issue: `truncate` option to use lodash's `truncate` function.

Checked on [`gatsby-starter-blog-mdx`](https://github.com/hagnerd/gatsby-starter-blog-mdx) with `gatsby-dev`.

## Related Issues

#22390
#6916
