### PR TITLE
[Docs] adding additional parameter for Install Visual Studio 2015 Build Tools

### DIFF
--- a/docs/docs/gatsby-on-windows.md
+++ b/docs/docs/gatsby-on-windows.md
@@ -11,7 +11,7 @@ Tools).
 
 The recommended way to setup your build environment on Windows is to install the
 [`windows-build-tools`](https://github.com/felixrieseberg/windows-build-tools)
-package by running `npm install windows-build-tools -g` on an admin PowerShell
+package by running `npm install --global windows-build-tools --vs2015` on an admin PowerShell
 console. Upon installing this package, it downloads and installs Visual C++
 Build Tools 2015, provided free of charge by Microsoft. These tools are required
 to compile popular native modules. It will also install Python 2.7, configuring


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

adding `--vs2015` parameter for install the Visual Studio 2015 Build tools instead of the Visual Studio 2017 ones.
install manualy or via CMD/Powershell

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
windows-build-tools [README.md](https://github.com/felixrieseberg/windows-build-tools/blob/master/README.md) 

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Related to #4694

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
