### PR TITLE
docs(recipes): add a screencast for generating a plugin with the plugin starter

### DIFF
--- a/docs/docs/recipes/working-with-plugins.md
+++ b/docs/docs/recipes/working-with-plugins.md
@@ -59,6 +59,11 @@ _The instructions found in the README of the plugin you're using can you help yo
 
 If you want to create your own plugin you can get started with the Gatsby plugin starter.
 
+<EggheadEmbed
+  lessonLink="https://egghead.io/lessons/gatsby-get-started-writing-a-gatsby-plugin-using-the-plugin-starter"
+  lessonTitle="Get started writing a Gatsby plugin using the plugin starter"
+/>
+
 ### Prerequisites
 
 - An existing [Gatsby site](/docs/quick-start/) with a `gatsby-config.js` file


### PR DESCRIPTION
## Description

Adds an Egghead video for the new plugin recipe on generating a new plugin with the plugin starter. This is a follow up to #22517 where I made the first screencast for installing plugins.

## Related Issues

_None_
