### PR TITLE
fix(gatsby-plugin-google-gtag): OutboundLink Forward Ref

### DIFF
--- a/packages/gatsby-plugin-google-gtag/src/index.js
+++ b/packages/gatsby-plugin-google-gtag/src/index.js
@@ -1,9 +1,10 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-function OutboundLink(props) {
+const OutboundLink = React.forwardRef(({ children, ...props }, ref) => {
   return (
     <a
+      ref={ref}
       {...props}
       onClick={e => {
         if (typeof props.onClick === `function`) {

--- a/packages/gatsby-plugin-google-gtag/src/index.js
+++ b/packages/gatsby-plugin-google-gtag/src/index.js
@@ -7,9 +7,9 @@ const OutboundLink = React.forwardRef(({ children, ...props }, ref) => (
     {...props}
     onClick={e => {
       if (typeof props.onClick === `function`) {
-        props.onClick(e);
+        props.onClick(e)
       }
-      let redirect = true;
+      let redirect = true
       if (
         e.button !== 0 ||
         e.altKey ||
@@ -18,10 +18,10 @@ const OutboundLink = React.forwardRef(({ children, ...props }, ref) => (
         e.shiftKey ||
         e.defaultPrevented
       ) {
-        redirect = false;
+        redirect = false
       }
       if (props.target && props.target.toLowerCase() !== `_self`) {
-        redirect = false;
+        redirect = false
       }
       if (window.gtag) {
         window.gtag(`event`, `click`, {
@@ -30,17 +30,17 @@ const OutboundLink = React.forwardRef(({ children, ...props }, ref) => (
           transport_type: redirect ? `beacon` : ``,
           event_callback: function() {
             if (redirect) {
-              document.location = props.href;
+              document.location = props.href
             }
           },
-        });
+        })
       } else {
         if (redirect) {
-          document.location = props.href;
+          document.location = props.href
         }
       }
 
-      return false;
+      return false
     }}
   >
     {children}

--- a/packages/gatsby-plugin-google-gtag/src/index.js
+++ b/packages/gatsby-plugin-google-gtag/src/index.js
@@ -1,53 +1,51 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const OutboundLink = React.forwardRef(({ children, ...props }, ref) => {
-  return (
-    <a
-      ref={ref}
-      {...props}
-      onClick={e => {
-        if (typeof props.onClick === `function`) {
-          props.onClick(e);
+const OutboundLink = React.forwardRef(({ children, ...props }, ref) => (
+  <a
+    ref={ref}
+    {...props}
+    onClick={e => {
+      if (typeof props.onClick === `function`) {
+        props.onClick(e);
+      }
+      let redirect = true;
+      if (
+        e.button !== 0 ||
+        e.altKey ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.shiftKey ||
+        e.defaultPrevented
+      ) {
+        redirect = false;
+      }
+      if (props.target && props.target.toLowerCase() !== `_self`) {
+        redirect = false;
+      }
+      if (window.gtag) {
+        window.gtag(`event`, `click`, {
+          event_category: `outbound`,
+          event_label: props.href,
+          transport_type: redirect ? `beacon` : ``,
+          event_callback: function() {
+            if (redirect) {
+              document.location = props.href;
+            }
+          },
+        });
+      } else {
+        if (redirect) {
+          document.location = props.href;
         }
-        let redirect = true;
-        if (
-          e.button !== 0 ||
-          e.altKey ||
-          e.ctrlKey ||
-          e.metaKey ||
-          e.shiftKey ||
-          e.defaultPrevented
-        ) {
-          redirect = false;
-        }
-        if (props.target && props.target.toLowerCase() !== `_self`) {
-          redirect = false;
-        }
-        if (window.gtag) {
-          window.gtag(`event`, `click`, {
-            event_category: `outbound`,
-            event_label: props.href,
-            transport_type: redirect ? `beacon` : ``,
-            event_callback: function() {
-              if (redirect) {
-                document.location = props.href;
-              }
-            },
-          });
-        } else {
-          if (redirect) {
-            document.location = props.href;
-          }
-        }
+      }
 
-        return false;
-      }}
-    >
-      {children}
-    </a>
-  );
-});
+      return false;
+    }}
+  >
+    {children}
+  </a>
+))
 
 OutboundLink.propTypes = {
   href: PropTypes.string,

--- a/packages/gatsby-plugin-google-gtag/src/index.js
+++ b/packages/gatsby-plugin-google-gtag/src/index.js
@@ -8,9 +8,9 @@ const OutboundLink = React.forwardRef(({ children, ...props }, ref) => {
       {...props}
       onClick={e => {
         if (typeof props.onClick === `function`) {
-          props.onClick(e)
+          props.onClick(e);
         }
-        let redirect = true
+        let redirect = true;
         if (
           e.button !== 0 ||
           e.altKey ||
@@ -19,10 +19,10 @@ const OutboundLink = React.forwardRef(({ children, ...props }, ref) => {
           e.shiftKey ||
           e.defaultPrevented
         ) {
-          redirect = false
+          redirect = false;
         }
         if (props.target && props.target.toLowerCase() !== `_self`) {
-          redirect = false
+          redirect = false;
         }
         if (window.gtag) {
           window.gtag(`event`, `click`, {
@@ -31,21 +31,23 @@ const OutboundLink = React.forwardRef(({ children, ...props }, ref) => {
             transport_type: redirect ? `beacon` : ``,
             event_callback: function() {
               if (redirect) {
-                document.location = props.href
+                document.location = props.href;
               }
             },
-          })
+          });
         } else {
           if (redirect) {
-            document.location = props.href
+            document.location = props.href;
           }
         }
 
-        return false
+        return false;
       }}
-    />
-  )
-}
+    >
+      {children}
+    </a>
+  );
+});
 
 OutboundLink.propTypes = {
   href: PropTypes.string,


### PR DESCRIPTION
## Description

update gatsby-plugin-google-gtag OutboundLink component to forward ref onto DOM element.

## Related Issues
Fixes #22704
