### PR TITLE
fix(blog): service relief project - link fixes, brand names 

### DIFF
--- a/docs/blog/2020-03-26-service-relief-project/index.md
+++ b/docs/blog/2020-03-26-service-relief-project/index.md
@@ -16,9 +16,9 @@ We woke up and the world was utterly changed. It's easy to be overwhelmed. I sat
 
 State-mandated social distancing shutdowns are being rolled out across the country, closing down bars, entertainment venues, and restaurants - taking the livelihoods of countless service workers with them. "Shelter in place" orders also prevent independent workers like pet sitters and house cleaners from being able to do their jobs. And as independent small businesses classified as "nonessential," like bookstores and art galleries, are forced to close they also find themselves in the same increasingly dire situation.
 
-Wonderfully, though, fundraisers are popping up all over the place to provide some emergency relief. Through them I saw a way to help out':' creating a fast, free and above all easy way for communities to gather local relief fundraisers in a single website, where donors can easily find and contribute. It turns out I wasn't the only one with this idea!
+Wonderfully, though, fundraisers are popping up all over the place to provide some emergency relief. Through them I saw a way to help out: creating a fast, free and above all easy way for communities to gather local relief fundraisers in a single website, where donors can easily find and contribute. It turns out I wasn't the only one with this idea!
 
-**In this post: **
+**In this post:**
 
 - [About the project](#about)
 - [How it all began](#beginnings)
@@ -32,7 +32,7 @@ The Service Relief Project is a boilerplate for launching blazing-fast zero-cost
 
 Here's what it does:
 
-- Generates a static website using [GatsbyJS](https://gatsbyjs.org)
+- Generates a static website using [Gatsby](https://gatsbyjs.org)
 - Uses [Airtable](https://airtable.com) to manage your listings and categories
 - Includes an Airtable form to collect local submissions and add them to Airtable for approval
 - Can be personalized to a city or region without touching a line of code
@@ -42,7 +42,7 @@ Using Gatsby to build and generate a static website based on data from a remote 
 
 In order to provide the ability to launch a zero-cost directory of fundraisers for your local area, we've:
 
-- Open-sourced the [entire project on Github](https://github.com/service-relief)
+- Open-sourced the [entire project on GitHub](https://github.com/service-relief)
 - Written [detailed instructions on how to get started](https://www.servicerelief.us/start/)
 - Released a [Gatsby Starter](https://github.com/service-relief/gatsby-starter-service-relief) and a [Gatsby Theme](https://github.com/service-relief/service-relief/tree/master/themes/gatsby-theme-service-relief)
 - Released a [one-click deployment to Netlify](https://app.netlify.com/start/deploy?repository=https://github.com/service-relief/gatsby-starter-service-relief)
@@ -53,7 +53,7 @@ _This project was inspired by [Chicago Service Relief](https://chicagoservicerel
 
 Here are a few of the sites that have already launched using this project:
 
-- [Seattle Service Relief](http://seattleservicerelief.com/)
+- [Seattle Service Relief](https://seattleservicerelief.com/)
 - [Denver Service Relief](https://denverservicerelief.com/)
 - [Austin Service Relief](https://austinservicerelief.com/)
 - [Sioux Falls Service Relief](https://siouxfallsservicerelief.com/)
@@ -69,7 +69,7 @@ These are unprecedented times, and from my small home office in Omaha, Nebraska 
 
 Drew and I have worked together in the past and I've both built and managed several websites for him over the years. All of them have been powered by [WordPress](https://wordpress.org), but I knew that spinning up another WordPress website was going to be overkill for something this simple.
 
-That's where Gatsby came in. For the Seattle Service Relief site, I generated a new site using LekoArts' [Gatsby Minimal Blog](https://www.gatsbyjs.org/starters/LekoArts/gatsby-starter-minimal-blog/) by running `gatsby new` and customizing a quick site. I had used the same starter on my personal site which helped speed up the process. A few hours later I messaged him back with a link to the live site.
+That's where Gatsby came in. For the Seattle Service Relief site, I generated a new site using LekoArts' [Gatsby Minimal Blog](/starters/LekoArts/gatsby-starter-minimal-blog/) by running `gatsby new` and customizing a quick site. I had used the same starter on my personal site which helped speed up the process. A few hours later I messaged him back with a link to the live site.
 
 ![Text message conversation with Drew where I announced that seattleservicerelief.com was live](./images/conversation-drew-finished-site.png)
 
@@ -106,7 +106,7 @@ _A special thank-you to [Dustin Schau](https://twitter.com/SchauDustin), [Aisha 
 
 Over the next hour and a half, we developed a prototype using the following tool stack:
 
-- Github, for hosting the code of the site
+- GitHub, for hosting the code of the site
 - Airtable, for managing data
 - Gatsby, to generate the site based on Airtable data
 - Netlify, for building and deploying the site
@@ -138,9 +138,9 @@ I'll also be publishing my personal workflow for building and deploying your Ser
 
 Getting the word out to your network is the best way to raise awareness of this project. We'll be listing all published Service Relief websites on [https://www.servicerelief.us/](https://www.servicerelief.us/).
 
-##### 3. Contribute to the project on Github
+##### 3. Contribute to the project on GitHub
 
-We've published this entire [project on Github](https://github.com/service-relief) to open it up for the world to contribute back. Here's what you'll see there:
+We've published this entire [project on GitHub](https://github.com/service-relief) to open it up for the world to contribute back. Here's what you'll see there:
 
 - `service-relief` - this is the monorepo for the entire project, including the ServiceRelief.us website, Gatsby Theme, and Gatsby Starter. You'll want to fork and submit your pull requests against this repository.
 - `gatsby-starter-service-relief` - this is an automatically-generated Gatsby Starter based on the monorepo. When the monorepo is updated, this starter is automatically updated.


### PR DESCRIPTION
## Description

changes:

- Links: remove domain from internal links
- Links: `http` to `https`
- brand names: `GatsbyJS` to `Gatsby`
- brand names: `Github` to `GitHub`
- markdown: remove space for bold markup - to only apply to the line (you see it in github code view with the markdown highlighting in bold)
- changed `help out':'` to `help out:`

## Notes:

- ~~is there a special meaning for this format `help out':'`?~~ 
  answer: it was a typo (https://github.com/gatsbyjs/gatsby/pull/22548#issuecomment-607445467 and see #22727)
- the TOC is broken (see bug: #22728 `markdown anchor links for a header with html`) but this can be a followup PR  

## Related Issues

- #22548 `(blog) service relief project`
- #22728 `markdown anchor links for a header with html`
- #19267 `Add link checker for Gatsby Docs`