### PR TITLE
chore(gatsby-cli): use `gatsby clean` in tests to test `gatsby clean`

### DIFF
--- a/integration-tests/gatsby-cli/__tests__/build.js
+++ b/integration-tests/gatsby-cli/__tests__/build.js
@@ -1,4 +1,4 @@
-import { GatsbyCLI, removeFolder } from "../test-helpers"
+import { GatsbyCLI } from "../test-helpers"
 
 const MAX_TIMEOUT = 2147483647
 jest.setTimeout(MAX_TIMEOUT)

--- a/integration-tests/gatsby-cli/__tests__/build.js
+++ b/integration-tests/gatsby-cli/__tests__/build.js
@@ -6,10 +6,8 @@ jest.setTimeout(MAX_TIMEOUT)
 describe(`gatsby build`, () => {
   const cwd = `gatsby-sites/gatsby-build`
 
-  beforeAll(() => removeFolder(`${cwd}/.cache`))
-  beforeAll(() => removeFolder(`${cwd}/public`))
-  afterAll(() => removeFolder(`${cwd}/.cache`))
-  afterAll(() => removeFolder(`${cwd}/public`))
+  beforeAll(() => GatsbyCLI.from(cwd).invoke(`clean`))
+  afterAll(() => GatsbyCLI.from(cwd).invoke(`clean`))
 
   it(`creates a built gatsby site`, () => {
     const [code, logs] = GatsbyCLI.from(cwd).invoke(`build`)

--- a/integration-tests/gatsby-cli/__tests__/develop.js
+++ b/integration-tests/gatsby-cli/__tests__/develop.js
@@ -13,10 +13,8 @@ jest.setTimeout(MAX_TIMEOUT)
 describe(`gatsby develop`, () => {
   const cwd = `gatsby-sites/gatsby-develop`
 
-  beforeAll(() => removeFolder(`${cwd}/.cache`))
-  beforeAll(() => removeFolder(`${cwd}/public`))
-  afterAll(() => removeFolder(`${cwd}/.cache`))
-  afterAll(() => removeFolder(`${cwd}/public`))
+  beforeAll(() => GatsbyCLI.from(cwd).invoke(`clean`))
+  afterAll(() => GatsbyCLI.from(cwd).invoke(`clean`))
 
   it(`starts a gatsby site on port 8000`, async () => {
     // 1. Start the `gatsby develop` command

--- a/integration-tests/gatsby-cli/__tests__/develop.js
+++ b/integration-tests/gatsby-cli/__tests__/develop.js
@@ -1,6 +1,5 @@
 import spawn from "cross-spawn"
-import { GatsbyCLI, removeFolder } from "../test-helpers"
-import strip from "strip-ansi"
+import { GatsbyCLI } from "../test-helpers"
 
 const timeout = seconds =>
   new Promise(resolve => {
@@ -21,7 +20,7 @@ describe(`gatsby develop`, () => {
     const [childProcess, getLogs] = GatsbyCLI.from(cwd).invokeAsync(`develop`)
 
     // 2. Wait for the build process to finish
-    await timeout(30)
+    await timeout(10)
 
     // 3. kill the `gatsby develop` command so we can get logs
     spawn.sync("kill", [childProcess.pid])


### PR DESCRIPTION
## Description

I was going to write tests for gatsby clean, but then I realized I had before and after hooks doing what gatsby clean does. So now instead, we just invoke that command. It's sort of an implicit test on `gatsby clean`

There's also a few other micro clean ups in there.