### PR TITLE
perf(gatsby): support `elemMatch` as fast filter

### DIFF
--- a/packages/gatsby/src/db/__tests__/fixtures/ensure-loki.js
+++ b/packages/gatsby/src/db/__tests__/fixtures/ensure-loki.js
@@ -4,5 +4,8 @@ module.exports = () => {
   if (backend === `loki`) {
     const lokiDb = require(`../../loki`)
     beforeAll(lokiDb.start)
+    return true
   }
+
+  return false
 }

--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -132,9 +132,9 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
       )
     })
     ;[
-      { desc: `with cache`, cb: () => new Map() }, // Avoids sift for flat filters
+      { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
       { desc: `no cache`, cb: () => null }, // Always goes through sift
-    ].forEach(({ desc, cb: createIndexCache }) => {
+    ].forEach(({ desc, cb: createFiltersCache }) => {
       describe(desc, () => {
         describe(`filters by just id correctly`, () => {
           it(`eq operator`, async () => {
@@ -149,7 +149,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: true,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             const resultMany = await runSift({
@@ -157,7 +157,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: false,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(resultSingular.map(o => o.id)).toEqual([mockNodes()[1].id])
@@ -176,7 +176,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: true,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             const resultMany = await runSift({
@@ -184,7 +184,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: false,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             // `id-1` node is not of queried type, so results should be empty
@@ -204,7 +204,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: true,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             const resultMany = await runSift({
@@ -212,7 +212,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: false,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(resultSingular.map(o => o.id)).toEqual([mockNodes()[2].id])
@@ -228,7 +228,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: true,
               nodeTypeNames: [`NonExistentNodeType`],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
             expect(resultSingular).toEqual([])
           })
@@ -246,7 +246,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: true,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(Array.isArray(resultSingular)).toBe(true)
@@ -268,7 +268,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: false,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(Array.isArray(resultMany)).toBe(true)
@@ -290,7 +290,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: true,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(Array.isArray(resultSingular)).toBe(true)
@@ -312,7 +312,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: false,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(Array.isArray(resultMany)).toBe(true)
@@ -334,7 +334,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: true,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(Array.isArray(resultSingular)).toBe(true)
@@ -352,7 +352,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: false,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(resultMany).toBe(null)
@@ -372,7 +372,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
               queryArgs,
               firstOnly: false,
               nodeTypeNames: [gqlType.name],
-              typedKeyValueIndexes: createIndexCache(),
+              filtersCache: createFiltersCache(),
             })
 
             expect(Array.isArray(resultMany)).toBe(true)

--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -446,7 +446,7 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
       expect(results[0].deep.flat.search.chain).toEqual(300)
     })
 
-    it(`ignores elemMatch`, () => {
+    it(`supports elemMatch`, () => {
       const filter = {
         elemList: {
           $elemMatch: { foo: { $eq: `baz` } },
@@ -459,7 +459,8 @@ if (!process.env.GATSBY_DB_NODES || process.env.GATSBY_DB_NODES === `redux`) {
         new Map()
       )
 
-      expect(result).toBe(undefined)
+      expect(result).not.toBe(undefined)
+      expect(result.length).toBe(2)
     })
   })
 } else {

--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -177,7 +177,7 @@ export const ensureIndexByTypedChain = (
 
   if (nodeTypeNames.length === 1) {
     getNodesByType(nodeTypeNames[0]).forEach(node => {
-      addNodeToFilterCache(node, node, chain, filterCache, resolvedNodesCache)
+      addNodeToFilterCache(node, chain, filterCache, resolvedNodesCache)
     })
   } else {
     // Here we must first filter for the node type
@@ -187,17 +187,17 @@ export const ensureIndexByTypedChain = (
         return
       }
 
-      addNodeToFilterCache(node, node, chain, filterCache, resolvedNodesCache)
+      addNodeToFilterCache(node, chain, filterCache, resolvedNodesCache)
     })
   }
 }
 
 function addNodeToFilterCache(
   node: IGatsbyNode,
-  valueOffset: any,
   chain: Array<string>,
   filterCache: FilterCache,
-  resolvedNodesCache
+  resolvedNodesCache,
+  valueOffset: any = node
 ): void {
   // There can be a filter that targets `__gatsby_resolved` so fix that first
   if (!node.__gatsby_resolved) {
@@ -327,10 +327,10 @@ function addNodeToBucketWithElemMatch(
         // Now take same route as non-elemMatch filters would take
         addNodeToFilterCache(
           node,
-          valueAtCurrentStep,
           nestedQuery.path,
           filterCache,
-          resolvedNodesCache
+          resolvedNodesCache,
+          valueAtCurrentStep
         )
       }
     })

--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -192,13 +192,13 @@ export const ensureIndexByTypedChain = (
   }
 }
 
-const addNodeToFilterCache = (
+function addNodeToFilterCache(
   node: IGatsbyNode,
   valueOffset: any,
   chain: Array<string>,
   filterCache: FilterCache,
   resolvedNodesCache
-): void => {
+): void {
   // There can be a filter that targets `__gatsby_resolved` so fix that first
   if (!node.__gatsby_resolved) {
     const typeName = node.internal.type
@@ -241,7 +241,7 @@ export const ensureIndexByElemMatch = (
   filter: IDbQueryElemMatch,
   nodeTypeNames: Array<string>,
   filtersCache: FiltersCache
-) => {
+): void => {
   // Given an elemMatch filter, generate the cache that contains all nodes that
   // matches a given value for that sub-query
 
@@ -279,13 +279,13 @@ export const ensureIndexByElemMatch = (
   }
 }
 
-const addNodeToBucketWithElemMatch = (
+function addNodeToBucketWithElemMatch(
   node: IGatsbyNode,
   valueAtCurrentStep: any, // Arbitrary step on the path inside the node
   filter: IDbQueryElemMatch,
   filterCache: FilterCache,
   resolvedNodesCache
-) => {
+): void {
   // There can be a filter that targets `__gatsby_resolved` so fix that first
   if (!node.__gatsby_resolved) {
     const typeName = node.internal.type
@@ -315,7 +315,7 @@ const addNodeToBucketWithElemMatch = (
     // node ends up in buckets for value 3 and 4. This may lead to duplicate
     // work when elements resolve to the same value, but that can't be helped.
     valueAtCurrentStep.forEach(elem => {
-      if (nestedQuery.type === "elemMatch") {
+      if (nestedQuery.type === `elemMatch`) {
         addNodeToBucketWithElemMatch(
           node,
           elem,

--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -330,7 +330,7 @@ function addNodeToBucketWithElemMatch(
           nestedQuery.path,
           filterCache,
           resolvedNodesCache,
-          valueAtCurrentStep
+          elem
         )
       }
     })

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -29,6 +29,7 @@ const {
  */
 const createTypedFilterCacheKey = (typeNames, filter) => {
   // Note: while `elemMatch` is a special case, in the key it's just `elemMatch`
+  // (This function is future proof for elemMatch support, won't receive it yet)
   let f = filter
   let comparator = ``
   let paths /*: Array<string>*/ = []

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -29,7 +29,6 @@ const {
  */
 const createTypedFilterCacheKey = (typeNames, filter) => {
   // Note: while `elemMatch` is a special case, in the key it's just `elemMatch`
-  // (This function is future proof for elemMatch support, won't receive it yet)
   let f = filter
   let comparator = ``
   let paths /*: Array<string>*/ = []

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -299,12 +299,11 @@ const collectBucketForElemMatch = (
   }
 
   if (!filtersCache.has(typedKey)) {
-    ensureIndexByElemMatch(typedKey, filter, nodeTypeNames, filterCaches)
+    ensureIndexByElemMatch(typedKey, filter, nodeTypeNames, filtersCache)
   }
 
   const nodesByKeyValue /*: Set<IGatsbyNode> | undefined*/ = getFilterCacheByTypedChain(
     typedKey,
-    comparator,
     targetValue,
     filtersCache
   )
@@ -468,7 +467,7 @@ const filterWithoutSift = (filters, nodeTypeNames, filtersCache) => {
   if (
     filters.some(
       filter =>
-        filter.type === `elemMatch` ||
+        filter.type !== `elemMatch` &&
         ![`$eq`].includes(filter.query.comparator)
     )
   ) {

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -39,6 +39,9 @@ const createTypedFilterCacheKey = (typeNames, filter) => {
     if (f.type === `elemMatch`) {
       let q /*: IDbQueryElemMatch*/ = f
       f = q.nestedQuery
+      // Make distinction between filtering `a.elemMatch.b.eq` and `a.b.eq`
+      // In practice this is unlikely to be an issue, but it might
+      paths.push(`elemMatch`)
     } else {
       let q /*: IDbQueryQuery*/ = f
       comparator = q.query.comparator
@@ -273,6 +276,7 @@ const collectBucketForElemMatch = (
   filtersCache,
   filterCaches
 ) => {
+  // Get comparator and target value for this elemMatch
   let comparator = ``
   let targetValue = null
   let f /*: DbQuery*/ = filter

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -467,7 +467,8 @@ const filterWithoutSift = (filters, nodeTypeNames, filtersCache) => {
   if (
     filters.some(
       filter =>
-        filter.type !== `elemMatch` &&
+        filter.type === `query` && // enabled
+        // filter.type === `elemMatch` || // disabled
         ![`$eq`].includes(filter.query.comparator)
     )
   ) {

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -286,9 +286,9 @@ describe(`NodeModel`, () => {
       })
     })
     ;[
-      { desc: `with cache`, cb: () => new Map() }, // Avoids sift for flat filters
+      { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
       { desc: `no cache`, cb: () => null }, // Always goes through sift
-    ].forEach(({ desc, cb: createIndexCache }) => {
+    ].forEach(({ desc, cb: createFiltersCache }) => {
       describe(`runQuery [${desc}]`, () => {
         it(`returns first result only`, async () => {
           const type = `Post`
@@ -296,7 +296,7 @@ describe(`NodeModel`, () => {
             filter: { frontmatter: { published: { eq: false } } },
           }
           const firstOnly = true
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           const result = await nodeModel.runQuery({
             query,
             firstOnly,
@@ -311,7 +311,7 @@ describe(`NodeModel`, () => {
             filter: { frontmatter: { published: { eq: false } } },
           }
           const firstOnly = false
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           const result = await nodeModel.runQuery({
             query,
             firstOnly,
@@ -328,7 +328,7 @@ describe(`NodeModel`, () => {
             filter: { frontmatter: { published: { eq: false } } },
           }
           const firstOnly = false
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           await nodeModel.runQuery(
             {
               query,
@@ -354,7 +354,7 @@ describe(`NodeModel`, () => {
             filter: { frontmatter: { published: { eq: false } } },
           }
           const firstOnly = false
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           await nodeModel.withContext({ path: `/` }).runQuery({
             query,
             firstOnly,
@@ -377,7 +377,7 @@ describe(`NodeModel`, () => {
             filter: { frontmatter: { published: { eq: false } } },
           }
           const firstOnly = false
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           await nodeModel.runQuery(
             {
               query,
@@ -397,7 +397,7 @@ describe(`NodeModel`, () => {
           const type = `AllFiles`
           const query = {}
           const firstOnly = true
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           const result = nodeModel.runQuery({
             query,
             firstOnly,
@@ -412,7 +412,7 @@ describe(`NodeModel`, () => {
           const type = `TeamMember`
           const query = { name: { ne: null } }
           const firstOnly = true
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           const result = await nodeModel.runQuery({
             query,
             firstOnly,
@@ -429,7 +429,7 @@ describe(`NodeModel`, () => {
             },
           }
           const firstOnly = false
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           const result = await nodeModel.runQuery({
             query,
             firstOnly,
@@ -448,7 +448,7 @@ describe(`NodeModel`, () => {
             },
           }
           const firstOnly = true
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           const result = await nodeModel.runQuery({
             query,
             firstOnly,
@@ -551,11 +551,11 @@ describe(`NodeModel`, () => {
       })
     })
     ;[
-      { desc: `with cache`, cb: () => new Map() }, // Avoids sift for flat filters
+      { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
       { desc: `no cache`, cb: () => null }, // Always goes through sift
-    ].forEach(({ desc, cb: createIndexCache }) => {
+    ].forEach(({ desc, cb: createFiltersCache }) => {
       it(`[${desc}] should not resolve prepared nodes more than once`, async () => {
-        nodeModel.replaceTypeKeyValueCache(createIndexCache())
+        nodeModel.replaceTypeKeyValueCache(createFiltersCache())
         await nodeModel.runQuery(
           {
             query: { filter: { betterTitle: { eq: `foo` } } },
@@ -566,7 +566,7 @@ describe(`NodeModel`, () => {
         )
         expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
         expect(resolveOtherTitleMock.mock.calls.length).toBe(0)
-        nodeModel.replaceTypeKeyValueCache(createIndexCache())
+        nodeModel.replaceTypeKeyValueCache(createFiltersCache())
         await nodeModel.runQuery(
           {
             query: { filter: { betterTitle: { eq: `foo` } } },
@@ -577,7 +577,7 @@ describe(`NodeModel`, () => {
         )
         expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
         expect(resolveOtherTitleMock.mock.calls.length).toBe(0)
-        nodeModel.replaceTypeKeyValueCache(createIndexCache())
+        nodeModel.replaceTypeKeyValueCache(createFiltersCache())
         await nodeModel.runQuery(
           {
             query: {
@@ -590,7 +590,7 @@ describe(`NodeModel`, () => {
         )
         expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
         expect(resolveOtherTitleMock.mock.calls.length).toBe(2)
-        nodeModel.replaceTypeKeyValueCache(createIndexCache())
+        nodeModel.replaceTypeKeyValueCache(createFiltersCache())
         await nodeModel.runQuery(
           {
             query: {
@@ -603,7 +603,7 @@ describe(`NodeModel`, () => {
         )
         expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
         expect(resolveOtherTitleMock.mock.calls.length).toBe(2)
-        nodeModel.replaceTypeKeyValueCache(createIndexCache())
+        nodeModel.replaceTypeKeyValueCache(createFiltersCache())
         await nodeModel.runQuery(
           {
             query: {
@@ -619,7 +619,7 @@ describe(`NodeModel`, () => {
       })
 
       it(`[${desc}] can filter by resolved fields`, async () => {
-        nodeModel.replaceTypeKeyValueCache(createIndexCache())
+        nodeModel.replaceTypeKeyValueCache(createFiltersCache())
         const result = await nodeModel.runQuery(
           {
             query: {
@@ -764,12 +764,12 @@ describe(`NodeModel`, () => {
       })
     })
     ;[
-      { desc: `with index cache`, cb: () => new Map() }, // Avoids sift
-      { desc: `no index cache`, cb: () => null }, // Requires sift
-    ].forEach(({ desc, cb: createIndexCache }) => {
+      { desc: `with cache`, cb: () => new Map() }, // Avoids sift
+      { desc: `no cache`, cb: () => null }, // Requires sift
+    ].forEach(({ desc, cb: createFiltersCache }) => {
       describe(`[${desc}] Tracks nodes returned by queries`, () => {
         it(`Tracks objects when running query without filter`, async () => {
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           const result = await nodeModel.runQuery({
             query: {},
             type: schema.getType(`Test`),
@@ -786,7 +786,7 @@ describe(`NodeModel`, () => {
         })
 
         it(`Tracks objects when running query with filter`, async () => {
-          nodeModel.replaceTypeKeyValueCache(createIndexCache())
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
           const result = await nodeModel.runQuery({
             query: {
               filter: {

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -14,6 +14,8 @@ const makeNodes = () => [
     hair: 1,
     date: `2006-07-22T22:39:53.000Z`,
     anArray: [1, 2, 3, 4],
+    strArray: `["testing", "serialization", "hacks"]`,
+    nullArray: [1, null, 3, 4],
     key: {
       withEmptyArray: [],
     },
@@ -35,9 +37,22 @@ const makeNodes = () => [
       { aString: `some string`, aNumber: 2, anArray: [1, 2] },
     ],
     boolean: true,
+    nil: `not null`,
     nestedRegex: {
       field: `har har`,
     },
+    num_null_not: 1,
+    num_not_null: 1,
+    null_num_not: null,
+    null_not_num: null,
+    str_null_not: `x`,
+    str_not_null: `x`,
+    null_str_not: null,
+    null_not_str: null,
+    obj_null_not: { y: 5 },
+    obj_not_null: { y: 5 },
+    null_obj_not: null,
+    null_not_obj: null,
   },
   {
     id: `1`,
@@ -48,6 +63,8 @@ const makeNodes = () => [
     float: 2.5,
     hair: 2,
     anArray: [1, 2, 5, 4],
+    strArray: `[5,6,7,8]`,
+    nullArray: [1, 3, 4],
     waxOnly: {
       foo: true,
       bar: { baz: true },
@@ -64,18 +81,29 @@ const makeNodes = () => [
       circle: `happy`,
     },
     boolean: false,
-    data: {
-      tags: [
+    nil: null,
+    undef: undefined,
+    singleElem: {
+      things: [
         {
-          tag: {
-            document: [
-              {
-                data: {
-                  tag: `Design System`,
-                },
-                number: 3,
-              },
-            ],
+          one: {
+            two: {
+              three: 123,
+            },
+          },
+        },
+        {
+          one: {
+            five: {
+              three: 153,
+            },
+          },
+        },
+        {
+          one: {
+            two: {
+              three: 404,
+            },
           },
         },
       ],
@@ -83,6 +111,20 @@ const makeNodes = () => [
     nestedRegex: {
       field: ``,
     },
+    strSecondOnly: `needle`,
+    boolSecondOnly: false,
+    num_null_not: null,
+    null_num_not: 1,
+    not_null_num: null,
+    not_num_null: 1,
+    str_null_not: null,
+    null_str_not: `x`,
+    not_null_str: null,
+    not_str_null: `x`,
+    obj_null_not: null,
+    null_obj_not: { y: 5 },
+    not_null_obj: null,
+    not_obj_null: { y: 5 },
   },
   {
     id: `2`,
@@ -132,6 +174,18 @@ const makeNodes = () => [
         },
       ],
     },
+    num_not_null: null,
+    null_not_num: 1,
+    not_null_num: 1,
+    not_num_null: null,
+    str_not_null: null,
+    null_not_str: `x`,
+    not_null_str: `x`,
+    not_str_null: null,
+    obj_not_null: null,
+    null_not_obj: { y: 5 },
+    not_null_obj: { y: 5 },
+    not_obj_null: null,
   },
 ]
 
@@ -179,7 +233,7 @@ async function runFilter(filter) {
 }
 
 describe(`Filter fields`, () => {
-  it(`handles eq operator`, async () => {
+  it(`handles eq operator with number value`, async () => {
     let result = await runFilter({ hair: { eq: 2 } })
 
     expect(result.length).toEqual(1)
@@ -198,6 +252,28 @@ describe(`Filter fields`, () => {
 
     expect(result.length).toEqual(1)
     expect(result[0].hair).toEqual(0)
+  })
+
+  it(`handles eq operator with null`, async () => {
+    let result = await runFilter({ nil: { eq: null } })
+
+    // Also return nodes that do not have the property at all (NULL in db)
+    expect(result.length).toEqual(2)
+  })
+
+  // grapqhl would never pass on `undefined`
+  // it(`handles eq operator with undefined`, async () => {
+  //   let result = await runFilter({ undef: { eq: undefined } })
+  //
+  //   expect(result.length).toEqual(?)
+  //   expect(result[0].hair).toEqual(?)
+  // })
+
+  it(`handles eq operator with serialized array value`, async () => {
+    let result = await runFilter({ strArray: { eq: `[5,6,7,8]` } })
+
+    expect(result.length).toEqual(1)
+    expect(result[0].name).toEqual(`The Mad Wax`)
   })
 
   it(`handles ne operator`, async () => {
@@ -219,6 +295,27 @@ describe(`Filter fields`, () => {
     expect(result.length).toEqual(2)
   })
 
+  it(`handles ne operator with 0`, async () => {
+    let result = await runFilter({ hair: { ne: 0 } })
+
+    expect(result.length).toEqual(2)
+  })
+
+  it(`handles ne operator with null`, async () => {
+    let result = await runFilter({ nil: { ne: null } })
+
+    // Should only return nodes who do have the property, not set to null
+    expect(result.length).toEqual(1)
+    expect(result[0].name).toEqual(`The Mad Max`)
+  })
+
+  // grapqhl would never pass on `undefined`
+  // it(`handles ne operator with undefined`, async () => {
+  //   let result = await runFilter({ undef: { ne: undefined } })
+  //
+  //   expect(result.length).toEqual(?)
+  // })
+
   it(`handles deeply nested ne: true operator`, async () => {
     let result = await runFilter({
       waxOnly: { bar: { baz: { ne: true } } },
@@ -227,7 +324,7 @@ describe(`Filter fields`, () => {
     expect(result.length).toEqual(2)
   })
 
-  it(`handles lt operator`, async () => {
+  it(`handles lt operator with number`, async () => {
     let result = await runFilter({ hair: { lt: 2 } })
 
     expect(result.length).toEqual(2)
@@ -235,7 +332,14 @@ describe(`Filter fields`, () => {
     expect(result[1].hair).toEqual(0)
   })
 
-  it(`handles lte operator`, async () => {
+  it(`handles lt operator with null`, async () => {
+    let result = await runFilter({ nil: { lt: null } })
+
+    // Nothing is lt null
+    expect(result).toEqual(null)
+  })
+
+  it(`handles lte operator with number`, async () => {
     let result = await runFilter({ hair: { lte: 1 } })
 
     expect(result.length).toEqual(2)
@@ -243,7 +347,16 @@ describe(`Filter fields`, () => {
     expect(result[1].hair).toEqual(0)
   })
 
-  it(`handles gt operator`, async () => {
+  it(`handles lte operator with null`, async () => {
+    let result = await runFilter({ nil: { lte: null } })
+
+    // lte null matches null but no nodes without the property (NULL)
+    expect(result.length).toEqual(1)
+    expect(result[0].name).toEqual(`The Mad Wax`)
+    expect(result[0].nil).toEqual(null)
+  })
+
+  it(`handles gt operator with number`, async () => {
     let result = await runFilter({ hair: { gt: 0 } })
 
     expect(result.length).toEqual(2)
@@ -251,7 +364,14 @@ describe(`Filter fields`, () => {
     expect(result[1].hair).toEqual(2)
   })
 
-  it(`handles gte operator`, async () => {
+  it(`handles gt operator with null`, async () => {
+    let result = await runFilter({ nil: { gt: null } })
+
+    // Nothing is gt null
+    expect(result).toEqual(null)
+  })
+
+  it(`handles gte operator with number`, async () => {
     let result = await runFilter({ hair: { gte: 1 } })
 
     expect(result.length).toEqual(2)
@@ -259,27 +379,55 @@ describe(`Filter fields`, () => {
     expect(result[1].hair).toEqual(2)
   })
 
-  it(`handles the regex operator`, async () => {
-    let result = await runFilter({ name: { regex: `/^the.*wax/i` } })
+  it(`handles gte operator with null`, async () => {
+    let result = await runFilter({ nil: { gte: null } })
+
+    // lte null matches null but no nodes without the property (NULL)
+    expect(result.length).toEqual(1)
+    expect(result[0].name).toEqual(`The Mad Wax`)
+    expect(result[0].nil).toEqual(null)
+  })
+
+  it(`handles the regex operator without flags`, async () => {
+    let result = await runFilter({ name: { regex: `/^The.*Wax/` } })
+
     expect(result.length).toEqual(2)
     expect(result[0].name).toEqual(`The Mad Wax`)
+    expect(result[1].name).toEqual(`The Mad Wax`)
+  })
+
+  it(`handles the regex operator with i-flag`, async () => {
+    let result = await runFilter({ name: { regex: `/^the.*wax/i` } })
+
+    expect(result.length).toEqual(2)
+    expect(result[0].name).toEqual(`The Mad Wax`)
+    expect(result[1].name).toEqual(`The Mad Wax`)
   })
 
   it(`handles the nested regex operator`, async () => {
     let result = await runFilter({ nestedRegex: { field: { regex: `/.*/` } } })
+
     expect(result.length).toEqual(2)
     expect(result[0].id).toEqual(`0`)
     expect(result[1].id).toEqual(`1`)
   })
 
+  it(`does not match double quote for string without it`, async () => {
+    let result = await runFilter({ name: { regex: `/"/` } })
+
+    expect(result).toEqual(null)
+  })
+
   it(`handles the in operator for strings`, async () => {
     let result = await runFilter({ string: { in: [`b`, `c`] } })
+
     expect(result.length).toEqual(2)
     expect(result[0].index).toEqual(1)
   })
 
   it(`handles the in operator for ints`, async () => {
     let result = await runFilter({ index: { in: [0, 2] } })
+
     expect(result.length).toEqual(2)
     expect(result[0].index).toEqual(0)
     expect(result[1].index).toEqual(2)
@@ -287,31 +435,165 @@ describe(`Filter fields`, () => {
 
   it(`handles the in operator for floats`, async () => {
     let result = await runFilter({ float: { in: [1.5, 2.5] } })
+
     expect(result.length).toEqual(2)
     expect(result[0].index).toEqual(0)
     expect(result[1].index).toEqual(1)
   })
 
-  it(`handles the in operator for booleans`, async () => {
-    let result = await runFilter({ boolean: { in: [true] } })
-    expect(result.length).toEqual(1) // 2
-    expect(result[0].index).toEqual(0)
-    //    expect(result[1].index).toEqual(2)
+  it(`handles the in operator for just null`, async () => {
+    let result = await runFilter({ nil: { in: [null] } })
+
+    // Do not include the nodes without a `nil` property
+    expect(result.length).toEqual(2)
+    result.forEach(edge => {
+      // May not have the property, or must be null
+      expect(edge.nil === undefined || edge.nil === null).toBe(true)
+    })
   })
 
-  it(`handles the in operator for array`, async () => {
+  it(`handles the in operator for double null`, async () => {
+    let result = await runFilter({ nil: { in: [null, null] } })
+
+    // Do not include the nodes without a `nil` property
+    expect(result.length).toEqual(2)
+    result.forEach(edge => {
+      // May not have the property, or must be null
+      expect(edge.nil === undefined || edge.nil === null).toBe(true)
+    })
+  })
+
+  it(`handles the in operator for null in int and null`, async () => {
+    let result = await runFilter({ nil: { in: [5, null] } })
+
+    // Include the nodes without a `nil` property
+    expect(result.length).toEqual(2)
+    result.forEach(edge => {
+      // May not have the property, or must be null
+      expect(edge.nil === undefined || edge.nil === null).toBe(true)
+    })
+  })
+
+  it(`handles the in operator for int in int and null`, async () => {
+    let result = await runFilter({ index: { in: [2, null] } })
+
+    // Include the nodes without a `index` property (there aren't any)
+    expect(result.length).toEqual(1)
+    result.forEach(edge => {
+      expect(edge.index === 2).toBe(true)
+    })
+  })
+
+  it(`handles the in operator for booleans`, async () => {
+    let result = await runFilter({ boolean: { in: [true] } })
+
+    expect(result.length).toEqual(1)
+    expect(result[0].index).toEqual(0)
+    expect(result[0].boolean).toEqual(true)
+  })
+
+  it(`handles the in operator for array with one element`, async () => {
     let result = await runFilter({ anArray: { in: [5] } })
+
+    // The first one has a 5, the second one does not have a 5, the third does
+    // not have the property at all (NULL). It should return the first and last.
+    // (If the target value has `null` then the third should be omitted)
+    expect(result.length).toEqual(1)
+    expect(result[0].name).toEqual(`The Mad Wax`)
+  })
+
+  it(`handles the in operator for array some elements`, async () => {
+    let result = await runFilter({ anArray: { in: [20, 5, 300] } })
+
+    // Same as the test for just `[5]`. 20 and 300 do not appear anywhere.
     expect(result.length).toEqual(1)
     expect(result[0].name).toEqual(`The Mad Wax`)
   })
 
   it(`handles the nested in operator for array of strings`, async () => {
     let result = await runFilter({ frontmatter: { tags: { in: [`moo`] } } })
-    expect(result).toHaveLength(1)
+
+    expect(result.length).toEqual(1)
     expect(result[0].name).toEqual(`The Mad Max`)
   })
 
-  it(`handles the elemMatch operator for array of objects`, async () => {
+  it(`handles the elemMatch operator on a proper single tree`, async () => {
+    let result = await runFilter({
+      singleElem: {
+        things: {
+          elemMatch: {
+            one: {
+              two: {
+                three: { eq: 123 },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.length).toEqual(1)
+  })
+
+  it(`handles the elemMatch operator on the second element`, async () => {
+    let result = await runFilter({
+      singleElem: {
+        things: {
+          elemMatch: {
+            one: {
+              five: {
+                three: { eq: 153 },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.length).toEqual(1)
+    // Should contain the entire array even only one matched
+    expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
+    expect(result[0].singleElem.things[1].one.five.three).toEqual(153)
+  })
+
+  it(`should return only one node if elemMatch hits multiples`, async () => {
+    let result = await runFilter({
+      singleElem: {
+        things: {
+          elemMatch: {
+            one: {
+              two: {
+                three: { lt: 1000 }, // one match is 123, the other 404
+              },
+            },
+          },
+        },
+      },
+    })
+
+    // The `elemMatch` operator only returns the first nodde that matches so
+    // even though the `lt 1000` would match two elements in the `things` array
+    // it will return one node.
+    expect(result.length).toEqual(1)
+    expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
+    expect(result[0].singleElem.things[2].one.two.three).toEqual(404)
+  })
+
+  it(`ignores the elemMatch operator on a partial sub tree`, async () => {
+    let result = await runFilter({
+      singleElem: {
+        things: {
+          elemMatch: {
+            three: { eq: 123 },
+          },
+        },
+      },
+    })
+
+    expect(result).toEqual(null)
+  })
+
+  it(`handles the elemMatch operator for array of objects (1)`, async () => {
     let result = await runFilter({
       data: {
         tags: {
@@ -353,40 +635,117 @@ describe(`Filter fields`, () => {
       },
     })
 
-    expect(result.length).toEqual(2)
-    expect(result[0].index).toEqual(1)
-    expect(result[1].index).toEqual(2)
+    expect(result.length).toEqual(1)
+    expect(result[0].index).toEqual(2)
   })
 
-  it(`handles the elemMatch operator for array of objects (number)`, async () => {
+  it(`works for elemMatch on boolean field`, async () => {
     let result = await runFilter({
-      data: {
-        tags: {
-          elemMatch: {
-            tag: {
-              document: {
-                elemMatch: {
-                  number: { lt: 4 },
-                },
-              },
-            },
-          },
+      boolean: {
+        elemMatch: {
+          eq: true,
         },
       },
     })
 
+    // Does NOT contain nodes that do not have the field
     expect(result.length).toEqual(1)
-    expect(result[0].index).toEqual(1)
+    expect(result[0].boolean).toEqual(true)
   })
 
-  it(`handles the nin operator for array`, async () => {
+  it(`skips nodes without the field for elemMatch on boolean`, async () => {
+    let result = await runFilter({
+      boolSecondOnly: {
+        elemMatch: {
+          eq: false,
+        },
+      },
+    })
+
+    // Does NOT contain nodes that do not have the field so returns 2nd node
+    expect(result.length).toEqual(1)
+    expect(result[0].boolSecondOnly).toEqual(false)
+  })
+
+  it(`works for elemMatch on string field`, async () => {
+    let result = await runFilter({
+      string: {
+        elemMatch: {
+          eq: `a`,
+        },
+      },
+    })
+
+    // Does NOT contain nodes that do not have the field
+    expect(result.length).toEqual(1)
+    expect(result[0].string).toEqual(`a`)
+  })
+
+  it(`should return all nodes for elemMatch on non-arrays too`, async () => {
+    let result = await runFilter({
+      name: {
+        elemMatch: {
+          eq: `The Mad Wax`,
+        },
+      },
+    })
+
+    // Can return more than one node
+    // Does NOT contain nodes that do not have the field
+    expect(result.length).toEqual(2)
+    expect(result[0].name).toEqual(`The Mad Wax`)
+    expect(result[1].name).toEqual(`The Mad Wax`)
+  })
+
+  it(`skips nodes without the field for elemMatch on string`, async () => {
+    let result = await runFilter({
+      strSecondOnly: {
+        elemMatch: {
+          eq: `needle`,
+        },
+      },
+    })
+
+    // Does NOT contain nodes that do not have the field so returns 2nd node
+    expect(result.length).toEqual(1)
+    expect(result[0].strSecondOnly).toEqual(`needle`)
+  })
+
+  it(`works for elemMatch on number field`, async () => {
+    let result = await runFilter({
+      float: {
+        elemMatch: {
+          eq: 1.5,
+        },
+      },
+    })
+
+    // Does NOT contain nodes that do not have the field
+    expect(result.length).toEqual(1)
+    expect(result[0].float).toEqual(1.5)
+  })
+
+  it(`handles the nin operator for array [5]`, async () => {
     let result = await runFilter({ anArray: { nin: [5] } })
 
-    expect(result.length).toEqual(2)
+    // Since the array does not contain `null`, the query should also return the
+    // nodes that do not have the field at all (NULL).
 
+    expect(result.length).toEqual(2)
     result.forEach(edge => {
-      expect(edge.anArray).not.toEqual(expect.arrayContaining([5]))
+      // Either does not exist or does not contain
+      expect(edge.anArray === undefined || !edge.anArray.includes(5)).toBe(true)
     })
+  })
+
+  it(`handles the nin operator for array [null]`, async () => {
+    let result = await runFilter({ nullArray: { nin: [null] } })
+
+    // Since the array contains `null`, the query should NOT return the
+    // nodes that do not have the field at all (NULL).
+
+    expect(result.length).toEqual(1)
+    expect(result[0].nullArray.includes(null)).toBe(false)
   })
 
   it(`handles the nin operator for strings`, async () => {
@@ -414,6 +773,7 @@ describe(`Filter fields`, () => {
 
     expect(result.length).toEqual(2)
     result.forEach(edge => {
+      // Might not have the property (-> undefined), must not be 1.5
       expect(edge.float).not.toEqual(1.5)
     })
   })
@@ -421,8 +781,49 @@ describe(`Filter fields`, () => {
   it(`handles the nin operator for booleans`, async () => {
     let result = await runFilter({ boolean: { nin: [true, null] } })
 
+    // Do not return the node that does not have the field because of `null`
     expect(result.length).toEqual(1)
-    expect(result[0].boolean).toBe(false)
+    result.forEach(edge => {
+      // Must have the property, must not be true nor null
+      expect(edge.boolean !== undefined).toBe(true)
+      expect(edge.boolean !== true && edge.boolean !== null).toBe(true)
+    })
+  })
+
+  it(`handles the nin operator for double null`, async () => {
+    let result = await runFilter({ nil: { nin: [null, null] } })
+
+    // Do not return the node that does not have the field because of `null`
+    expect(result.length).toEqual(1)
+    result.forEach(edge => {
+      // Must have the property, must not be null
+      expect(edge.nil !== undefined).toBe(true)
+      expect(edge.nil !== null).toBe(true)
+    })
+  })
+
+  it(`handles the nin operator for null in int+null`, async () => {
+    let result = await runFilter({ nil: { nin: [5, null] } })
+
+    // Do not return the node that does not have the field because of `null`
+    expect(result.length).toEqual(1)
+    result.forEach(edge => {
+      // Must have the property, must not be 5 nor null
+      expect(edge.nil !== undefined).toBe(true)
+      expect(edge.nil !== 5 && edge.nil !== null).toBe(true)
+    })
+  })
+
+  it(`handles the nin operator for int in int+null`, async () => {
+    let result = await runFilter({ index: { nin: [2, null] } })
+
+    // Do not return the node that does not have the field because of `null`
+    expect(result.length).toEqual(2)
+    result.forEach(edge => {
+      // Must have the property, must not be 2 nor null
+      expect(edge.index !== undefined).toBe(true)
+      expect(edge.index !== 2 && edge.index !== null).toBe(true)
+    })
   })
 
   it(`handles the glob operator`, async () => {
@@ -456,7 +857,7 @@ describe(`Filter fields`, () => {
 })
 
 describe(`collection fields`, () => {
-  it(`sorts results`, async () => {
+  it(`orders by given field desc with limit`, async () => {
     let result = await runQuery({
       limit: 10,
       sort: {
@@ -466,10 +867,561 @@ describe(`collection fields`, () => {
     })
 
     expect(result.length).toEqual(3)
-    expect(result[0].name).toEqual(`The Mad Wax`)
+    expect(result[0].id).toEqual(`1`)
+    expect(result[1].id).toEqual(`2`)
+    expect(result[2].id).toEqual(`0`)
   })
 
-  it(`sorts results with desc has null fields first`, async () => {
+  describe(`num, null, and nullable order`, () => {
+    // This suite asserts the order of a field that is a number vs a field that
+    // is explicitly set to the value `null`, vs a field that is not set
+    // (which gets NULL in the database). This should do whatever redux does!
+    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
+
+    // node 1  2   3
+    //  - num_null_not    1st node has field set, 2nd set to null, 3rd not set
+    //  - num_not_null    etc
+    //  - null_num_not
+    //  - null_not_num
+    //  - not_null_num
+    //  - not_num_null
+
+    it(`sorts num_null_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`num_null_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts num_null_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`num_null_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts num_not_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`num_not_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts num_not_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`num_not_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts null_num_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_num_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts null_num_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_num_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_num asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_num`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_num desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_num`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_null_num asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_num`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_null_num desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_num`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_num_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_num_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_num_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_num_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+  })
+
+  describe(`string, null, and nullable order`, () => {
+    // This suite asserts the order of a field that is a string vs a field that
+    // is explicitly set to the value `null`, vs a field that is not set
+    // (which gets NULL in the database). This should do whatever redux does!
+    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
+
+    // node 1  2   3
+    //  - str_null_not    1st node has field set, 2nd set to null, 3rd not set
+    //  - str_not_null    etc
+    //  - null_str_not
+    //  - null_not_str
+    //  - not_null_str
+    //  - not_str_null
+
+    it(`sorts str_null_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`str_null_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts str_null_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`str_null_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts str_not_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`str_not_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts str_not_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`str_not_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts null_str_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_str_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts null_str_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_str_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_str asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_str`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_str desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_str`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_null_str asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_str`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_null_str desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_str`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_str_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_str_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_str_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_str_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+  })
+
+  describe(`obj, null, and nullable order`, () => {
+    // This suite asserts the order of a field that is a object vs a field that
+    // is explicitly set to the value `null`, vs a field that is not set
+    // (which gets NULL in the database). This should do whatever redux does!
+    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
+
+    // node 1  2   3
+    //  - obj_null_not    1st node has field set, 2nd set to null, 3rd not set
+    //  - obj_not_null    etc
+    //  - null_obj_not
+    //  - null_not_obj
+    //  - not_null_obj
+    //  - not_obj_null
+
+    it(`sorts obj_null_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`obj_null_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts obj_null_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`obj_null_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts obj_not_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`obj_not_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts obj_not_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`obj_not_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts null_obj_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_obj_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts null_obj_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_obj_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_obj asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_obj`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_obj desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_obj`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_null_obj asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_obj`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_null_obj desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_obj`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_obj_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_obj_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_obj_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_obj_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+  })
+
+  it(`sorts results with desc has null fields first vs obj second`, async () => {
     let result = await runQuery({
       limit: 10,
       sort: {
@@ -478,13 +1430,15 @@ describe(`collection fields`, () => {
       },
     })
 
+    // 0 doesnt have it, 1 has it as an object, 2 has it as null
+
     expect(result.length).toEqual(3)
     expect(result[0].id).toEqual(`0`)
     expect(result[1].id).toEqual(`2`)
     expect(result[2].id).toEqual(`1`)
   })
 
-  it(`sorts results with asc has null fields last`, async () => {
+  it(`sorts results with asc has null fields last vs obj first`, async () => {
     let result = await runQuery({
       limit: 10,
       sort: {
@@ -492,6 +1446,8 @@ describe(`collection fields`, () => {
         order: [`asc`],
       },
     })
+
+    // 0 doesnt have it, 1 has it as an object, 2 has it as null
 
     expect(result.length).toEqual(3)
     expect(result[0].id).toEqual(`1`)

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -214,7 +214,7 @@ function resetDb(nodes) {
   )
 }
 
-async function runQuery(queryArgs) {
+async function runQuery(queryArgs, filtersCache) {
   const nodes = makeNodes()
   resetDb(nodes)
   const { sc, type: gqlType } = makeGqlType(nodes)
@@ -224,1264 +224,1300 @@ async function runQuery(queryArgs) {
     queryArgs,
     gqlComposer: sc,
     nodeTypeNames: [gqlType.name],
+    filtersCache,
   }
   return await nodesQuery(args)
 }
 
-async function runFilter(filter) {
-  return await runQuery({ filter })
+async function runFilterOnCache(filter, filtersCache) {
+  return await runQuery({ filter }, filtersCache)
 }
 
-describe(`Filter fields`, () => {
-  it(`handles eq operator with number value`, async () => {
-    let result = await runFilter({ hair: { eq: 2 } })
+it(`should use the cache argument`, async () => {
+  const filtersCache = new Map()
+  const result = await runFilterOnCache({ hair: { eq: 2 } }, filtersCache)
 
-    expect(result.length).toEqual(1)
-    expect(result[0].hair).toEqual(2)
+  // Validate answer
+  expect(result.length).toEqual(1)
+  expect(result[0].hair).toEqual(2)
+
+  // Confirm cache is not ignored
+  expect(filtersCache.size === 1).toBe(true)
+  filtersCache.forEach((filterCache, cacheKey) => {
+    // This test will change when the composition of the FilterCache changes
+    // For now it should be a Map of values to Set of nodes
+    expect(filterCache instanceof Map).toBe(true)
+    // There ought to be at least one value mapped (probably more, shrug)
+    expect(filterCache.size >= 1).toBe(true)
   })
+})
+
+// Make sure to test fast filters (with cache) and Sift (without cache)
+;[
+  { desc: `without cache`, cb: () => null }, // Forces no cache, must use Sift
+  { desc: `with cache`, cb: () => new Map() },
+].forEach(({ desc, cb: createFiltersCache }) => {
+  async function runFilter(filter) {
+    return runFilterOnCache(filter, createFiltersCache())
+  }
+
+  describe(desc, () => {
+    describe(`Filter fields`, () => {
+      it(`handles eq operator with number value`, async () => {
+        let result = await runFilter({ hair: { eq: 2 } })
 
-  it(`handles eq operator with false value`, async () => {
-    let result = await runFilter({ boolean: { eq: false } })
+        expect(result.length).toEqual(1)
+        expect(result[0].hair).toEqual(2)
+      })
 
-    expect(result.length).toEqual(1)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-  })
+      it(`handles eq operator with false value`, async () => {
+        let result = await runFilter({ boolean: { eq: false } })
 
-  it(`handles eq operator with 0`, async () => {
-    let result = await runFilter({ hair: { eq: 0 } })
+        expect(result.length).toEqual(1)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+      })
+
+      it(`handles eq operator with 0`, async () => {
+        let result = await runFilter({ hair: { eq: 0 } })
+
+        expect(result.length).toEqual(1)
+        expect(result[0].hair).toEqual(0)
+      })
+
+      it(`handles eq operator with null`, async () => {
+        let result = await runFilter({ nil: { eq: null } })
 
-    expect(result.length).toEqual(1)
-    expect(result[0].hair).toEqual(0)
-  })
+        // Also return nodes that do not have the property at all (NULL in db)
+        expect(result.length).toEqual(2)
+      })
 
-  it(`handles eq operator with null`, async () => {
-    let result = await runFilter({ nil: { eq: null } })
+      // grapqhl would never pass on `undefined`
+      // it(`handles eq operator with undefined`, async () => {
+      //   let result = await runFilter({ undef: { eq: undefined } })
+      //
+      //   expect(result.length).toEqual(?)
+      //   expect(result[0].hair).toEqual(?)
+      // })
 
-    // Also return nodes that do not have the property at all (NULL in db)
-    expect(result.length).toEqual(2)
-  })
+      it(`handles eq operator with serialized array value`, async () => {
+        let result = await runFilter({ strArray: { eq: `[5,6,7,8]` } })
 
-  // grapqhl would never pass on `undefined`
-  // it(`handles eq operator with undefined`, async () => {
-  //   let result = await runFilter({ undef: { eq: undefined } })
-  //
-  //   expect(result.length).toEqual(?)
-  //   expect(result[0].hair).toEqual(?)
-  // })
+        expect(result.length).toEqual(1)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+      })
 
-  it(`handles eq operator with serialized array value`, async () => {
-    let result = await runFilter({ strArray: { eq: `[5,6,7,8]` } })
+      it(`handles ne operator`, async () => {
+        let result = await runFilter({ hair: { ne: 2 } })
+
+        expect(result.length).toEqual(2)
+        expect(result[0].hair).toEqual(1)
+      })
 
-    expect(result.length).toEqual(1)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-  })
+      it(`handles ne: true operator`, async () => {
+        let result = await runFilter({ boolean: { ne: true } })
+
+        expect(result.length).toEqual(2)
+      })
 
-  it(`handles ne operator`, async () => {
-    let result = await runFilter({ hair: { ne: 2 } })
+      it(`handles nested ne: true operator`, async () => {
+        let result = await runFilter({ waxOnly: { foo: { ne: true } } })
 
-    expect(result.length).toEqual(2)
-    expect(result[0].hair).toEqual(1)
-  })
+        expect(result.length).toEqual(2)
+      })
+
+      it(`handles ne operator with 0`, async () => {
+        let result = await runFilter({ hair: { ne: 0 } })
+
+        expect(result.length).toEqual(2)
+      })
 
-  it(`handles ne: true operator`, async () => {
-    let result = await runFilter({ boolean: { ne: true } })
+      it(`handles ne operator with null`, async () => {
+        let result = await runFilter({ nil: { ne: null } })
+
+        // Should only return nodes who do have the property, not set to null
+        expect(result.length).toEqual(1)
+        expect(result[0].name).toEqual(`The Mad Max`)
+      })
+
+      // grapqhl would never pass on `undefined`
+      // it(`handles ne operator with undefined`, async () => {
+      //   let result = await runFilter({ undef: { ne: undefined } })
+      //
+      //   expect(result.length).toEqual(?)
+      // })
+
+      it(`handles deeply nested ne: true operator`, async () => {
+        let result = await runFilter({
+          waxOnly: { bar: { baz: { ne: true } } },
+        })
 
-    expect(result.length).toEqual(2)
-  })
+        expect(result.length).toEqual(2)
+      })
 
-  it(`handles nested ne: true operator`, async () => {
-    let result = await runFilter({ waxOnly: { foo: { ne: true } } })
+      it(`handles lt operator with number`, async () => {
+        let result = await runFilter({ hair: { lt: 2 } })
 
-    expect(result.length).toEqual(2)
-  })
+        expect(result.length).toEqual(2)
+        expect(result[0].hair).toEqual(1)
+        expect(result[1].hair).toEqual(0)
+      })
 
-  it(`handles ne operator with 0`, async () => {
-    let result = await runFilter({ hair: { ne: 0 } })
+      it(`handles lt operator with null`, async () => {
+        let result = await runFilter({ nil: { lt: null } })
 
-    expect(result.length).toEqual(2)
-  })
+        // Nothing is lt null
+        expect(result).toEqual(null)
+      })
 
-  it(`handles ne operator with null`, async () => {
-    let result = await runFilter({ nil: { ne: null } })
+      it(`handles lte operator with number`, async () => {
+        let result = await runFilter({ hair: { lte: 1 } })
 
-    // Should only return nodes who do have the property, not set to null
-    expect(result.length).toEqual(1)
-    expect(result[0].name).toEqual(`The Mad Max`)
-  })
+        expect(result.length).toEqual(2)
+        expect(result[0].hair).toEqual(1)
+        expect(result[1].hair).toEqual(0)
+      })
 
-  // grapqhl would never pass on `undefined`
-  // it(`handles ne operator with undefined`, async () => {
-  //   let result = await runFilter({ undef: { ne: undefined } })
-  //
-  //   expect(result.length).toEqual(?)
-  // })
+      it(`handles lte operator with null`, async () => {
+        let result = await runFilter({ nil: { lte: null } })
 
-  it(`handles deeply nested ne: true operator`, async () => {
-    let result = await runFilter({
-      waxOnly: { bar: { baz: { ne: true } } },
-    })
+        // lte null matches null but no nodes without the property (NULL)
+        expect(result.length).toEqual(1)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+        expect(result[0].nil).toEqual(null)
+      })
 
-    expect(result.length).toEqual(2)
-  })
+      it(`handles gt operator with number`, async () => {
+        let result = await runFilter({ hair: { gt: 0 } })
 
-  it(`handles lt operator with number`, async () => {
-    let result = await runFilter({ hair: { lt: 2 } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].hair).toEqual(1)
-    expect(result[1].hair).toEqual(0)
-  })
-
-  it(`handles lt operator with null`, async () => {
-    let result = await runFilter({ nil: { lt: null } })
-
-    // Nothing is lt null
-    expect(result).toEqual(null)
-  })
-
-  it(`handles lte operator with number`, async () => {
-    let result = await runFilter({ hair: { lte: 1 } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].hair).toEqual(1)
-    expect(result[1].hair).toEqual(0)
-  })
-
-  it(`handles lte operator with null`, async () => {
-    let result = await runFilter({ nil: { lte: null } })
-
-    // lte null matches null but no nodes without the property (NULL)
-    expect(result.length).toEqual(1)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-    expect(result[0].nil).toEqual(null)
-  })
-
-  it(`handles gt operator with number`, async () => {
-    let result = await runFilter({ hair: { gt: 0 } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].hair).toEqual(1)
-    expect(result[1].hair).toEqual(2)
-  })
-
-  it(`handles gt operator with null`, async () => {
-    let result = await runFilter({ nil: { gt: null } })
-
-    // Nothing is gt null
-    expect(result).toEqual(null)
-  })
-
-  it(`handles gte operator with number`, async () => {
-    let result = await runFilter({ hair: { gte: 1 } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].hair).toEqual(1)
-    expect(result[1].hair).toEqual(2)
-  })
-
-  it(`handles gte operator with null`, async () => {
-    let result = await runFilter({ nil: { gte: null } })
-
-    // lte null matches null but no nodes without the property (NULL)
-    expect(result.length).toEqual(1)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-    expect(result[0].nil).toEqual(null)
-  })
-
-  it(`handles the regex operator without flags`, async () => {
-    let result = await runFilter({ name: { regex: `/^The.*Wax/` } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-    expect(result[1].name).toEqual(`The Mad Wax`)
-  })
-
-  it(`handles the regex operator with i-flag`, async () => {
-    let result = await runFilter({ name: { regex: `/^the.*wax/i` } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-    expect(result[1].name).toEqual(`The Mad Wax`)
-  })
-
-  it(`handles the nested regex operator`, async () => {
-    let result = await runFilter({ nestedRegex: { field: { regex: `/.*/` } } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].id).toEqual(`0`)
-    expect(result[1].id).toEqual(`1`)
-  })
-
-  it(`does not match double quote for string without it`, async () => {
-    let result = await runFilter({ name: { regex: `/"/` } })
-
-    expect(result).toEqual(null)
-  })
-
-  it(`handles the in operator for strings`, async () => {
-    let result = await runFilter({ string: { in: [`b`, `c`] } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].index).toEqual(1)
-  })
-
-  it(`handles the in operator for ints`, async () => {
-    let result = await runFilter({ index: { in: [0, 2] } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].index).toEqual(0)
-    expect(result[1].index).toEqual(2)
-  })
-
-  it(`handles the in operator for floats`, async () => {
-    let result = await runFilter({ float: { in: [1.5, 2.5] } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].index).toEqual(0)
-    expect(result[1].index).toEqual(1)
-  })
-
-  it(`handles the in operator for just null`, async () => {
-    let result = await runFilter({ nil: { in: [null] } })
-
-    // Do not include the nodes without a `nil` property
-    expect(result.length).toEqual(2)
-    result.forEach(edge => {
-      // May not have the property, or must be null
-      expect(edge.nil === undefined || edge.nil === null).toBe(true)
-    })
-  })
-
-  it(`handles the in operator for double null`, async () => {
-    let result = await runFilter({ nil: { in: [null, null] } })
-
-    // Do not include the nodes without a `nil` property
-    expect(result.length).toEqual(2)
-    result.forEach(edge => {
-      // May not have the property, or must be null
-      expect(edge.nil === undefined || edge.nil === null).toBe(true)
-    })
-  })
-
-  it(`handles the in operator for null in int and null`, async () => {
-    let result = await runFilter({ nil: { in: [5, null] } })
-
-    // Include the nodes without a `nil` property
-    expect(result.length).toEqual(2)
-    result.forEach(edge => {
-      // May not have the property, or must be null
-      expect(edge.nil === undefined || edge.nil === null).toBe(true)
-    })
-  })
-
-  it(`handles the in operator for int in int and null`, async () => {
-    let result = await runFilter({ index: { in: [2, null] } })
-
-    // Include the nodes without a `index` property (there aren't any)
-    expect(result.length).toEqual(1)
-    result.forEach(edge => {
-      expect(edge.index === 2).toBe(true)
-    })
-  })
-
-  it(`handles the in operator for booleans`, async () => {
-    let result = await runFilter({ boolean: { in: [true] } })
-
-    expect(result.length).toEqual(1)
-    expect(result[0].index).toEqual(0)
-    expect(result[0].boolean).toEqual(true)
-  })
-
-  it(`handles the in operator for array with one element`, async () => {
-    let result = await runFilter({ anArray: { in: [5] } })
-
-    // The first one has a 5, the second one does not have a 5, the third does
-    // not have the property at all (NULL). It should return the first and last.
-    // (If the target value has `null` then the third should be omitted)
-    expect(result.length).toEqual(1)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-  })
-
-  it(`handles the in operator for array some elements`, async () => {
-    let result = await runFilter({ anArray: { in: [20, 5, 300] } })
-
-    // Same as the test for just `[5]`. 20 and 300 do not appear anywhere.
-    expect(result.length).toEqual(1)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-  })
-
-  it(`handles the nested in operator for array of strings`, async () => {
-    let result = await runFilter({ frontmatter: { tags: { in: [`moo`] } } })
-
-    expect(result.length).toEqual(1)
-    expect(result[0].name).toEqual(`The Mad Max`)
-  })
-
-  it(`handles the elemMatch operator on a proper single tree`, async () => {
-    let result = await runFilter({
-      singleElem: {
-        things: {
-          elemMatch: {
-            one: {
-              two: {
+        expect(result.length).toEqual(2)
+        expect(result[0].hair).toEqual(1)
+        expect(result[1].hair).toEqual(2)
+      })
+
+      it(`handles gt operator with null`, async () => {
+        let result = await runFilter({ nil: { gt: null } })
+
+        // Nothing is gt null
+        expect(result).toEqual(null)
+      })
+
+      it(`handles gte operator with number`, async () => {
+        let result = await runFilter({ hair: { gte: 1 } })
+
+        expect(result.length).toEqual(2)
+        expect(result[0].hair).toEqual(1)
+        expect(result[1].hair).toEqual(2)
+      })
+
+      it(`handles gte operator with null`, async () => {
+        let result = await runFilter({ nil: { gte: null } })
+
+        // lte null matches null but no nodes without the property (NULL)
+        expect(result.length).toEqual(1)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+        expect(result[0].nil).toEqual(null)
+      })
+
+      it(`handles the regex operator without flags`, async () => {
+        let result = await runFilter({ name: { regex: `/^The.*Wax/` } })
+
+        expect(result.length).toEqual(2)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+        expect(result[1].name).toEqual(`The Mad Wax`)
+      })
+
+      it(`handles the regex operator with i-flag`, async () => {
+        let result = await runFilter({ name: { regex: `/^the.*wax/i` } })
+
+        expect(result.length).toEqual(2)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+        expect(result[1].name).toEqual(`The Mad Wax`)
+      })
+
+      it(`handles the nested regex operator`, async () => {
+        let result = await runFilter({
+          nestedRegex: { field: { regex: `/.*/` } },
+        })
+
+        expect(result.length).toEqual(2)
+        expect(result[0].id).toEqual(`0`)
+        expect(result[1].id).toEqual(`1`)
+      })
+
+      it(`does not match double quote for string without it`, async () => {
+        let result = await runFilter({ name: { regex: `/"/` } })
+
+        expect(result).toEqual(null)
+      })
+
+      it(`handles the in operator for strings`, async () => {
+        let result = await runFilter({ string: { in: [`b`, `c`] } })
+
+        expect(result.length).toEqual(2)
+        expect(result[0].index).toEqual(1)
+      })
+
+      it(`handles the in operator for ints`, async () => {
+        let result = await runFilter({ index: { in: [0, 2] } })
+
+        expect(result.length).toEqual(2)
+        expect(result[0].index).toEqual(0)
+        expect(result[1].index).toEqual(2)
+      })
+
+      it(`handles the in operator for floats`, async () => {
+        let result = await runFilter({ float: { in: [1.5, 2.5] } })
+
+        expect(result.length).toEqual(2)
+        expect(result[0].index).toEqual(0)
+        expect(result[1].index).toEqual(1)
+      })
+
+      it(`handles the in operator for just null`, async () => {
+        let result = await runFilter({ nil: { in: [null] } })
+
+        // Do not include the nodes without a `nil` property
+        expect(result.length).toEqual(2)
+        result.forEach(edge => {
+          // May not have the property, or must be null
+          expect(edge.nil === undefined || edge.nil === null).toBe(true)
+        })
+      })
+
+      it(`handles the in operator for double null`, async () => {
+        let result = await runFilter({ nil: { in: [null, null] } })
+
+        // Do not include the nodes without a `nil` property
+        expect(result.length).toEqual(2)
+        result.forEach(edge => {
+          // May not have the property, or must be null
+          expect(edge.nil === undefined || edge.nil === null).toBe(true)
+        })
+      })
+
+      it(`handles the in operator for null in int and null`, async () => {
+        let result = await runFilter({ nil: { in: [5, null] } })
+
+        // Include the nodes without a `nil` property
+        expect(result.length).toEqual(2)
+        result.forEach(edge => {
+          // May not have the property, or must be null
+          expect(edge.nil === undefined || edge.nil === null).toBe(true)
+        })
+      })
+
+      it(`handles the in operator for int in int and null`, async () => {
+        let result = await runFilter({ index: { in: [2, null] } })
+
+        // Include the nodes without a `index` property (there aren't any)
+        expect(result.length).toEqual(1)
+        result.forEach(edge => {
+          expect(edge.index === 2).toBe(true)
+        })
+      })
+
+      it(`handles the in operator for booleans`, async () => {
+        let result = await runFilter({ boolean: { in: [true] } })
+
+        expect(result.length).toEqual(1)
+        expect(result[0].index).toEqual(0)
+        expect(result[0].boolean).toEqual(true)
+      })
+
+      it(`handles the in operator for array with one element`, async () => {
+        let result = await runFilter({ anArray: { in: [5] } })
+
+        // The first one has a 5, the second one does not have a 5, the third does
+        // not have the property at all (NULL). It should return the first and last.
+        // (If the target value has `null` then the third should be omitted)
+        expect(result.length).toEqual(1)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+      })
+
+      it(`handles the in operator for array some elements`, async () => {
+        let result = await runFilter({ anArray: { in: [20, 5, 300] } })
+
+        // Same as the test for just `[5]`. 20 and 300 do not appear anywhere.
+        expect(result.length).toEqual(1)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+      })
+
+      it(`handles the nested in operator for array of strings`, async () => {
+        let result = await runFilter({ frontmatter: { tags: { in: [`moo`] } } })
+
+        expect(result.length).toEqual(1)
+        expect(result[0].name).toEqual(`The Mad Max`)
+      })
+
+      it(`handles the elemMatch operator on a proper single tree`, async () => {
+        let result = await runFilter({
+          singleElem: {
+            things: {
+              elemMatch: {
+                one: {
+                  two: {
+                    three: { eq: 123 },
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        expect(result.length).toEqual(1)
+      })
+
+      it(`handles the elemMatch operator on the second element`, async () => {
+        let result = await runFilter({
+          singleElem: {
+            things: {
+              elemMatch: {
+                one: {
+                  five: {
+                    three: { eq: 153 },
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        expect(result.length).toEqual(1)
+        // Should contain the entire array even only one matched
+        expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
+        expect(result[0].singleElem.things[1].one.five.three).toEqual(153)
+      })
+
+      it(`should return only one node if elemMatch hits multiples`, async () => {
+        let result = await runFilter({
+          singleElem: {
+            things: {
+              elemMatch: {
+                one: {
+                  two: {
+                    three: { lt: 1000 }, // one match is 123, the other 404
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        // The `elemMatch` operator only returns the first nodde that matches so
+        // even though the `lt 1000` would match two elements in the `things` array
+        // it will return one node.
+        expect(result.length).toEqual(1)
+        expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
+        expect(result[0].singleElem.things[2].one.two.three).toEqual(404)
+      })
+
+      it(`ignores the elemMatch operator on a partial sub tree`, async () => {
+        let result = await runFilter({
+          singleElem: {
+            things: {
+              elemMatch: {
                 three: { eq: 123 },
               },
             },
           },
-        },
-      },
-    })
+        })
 
-    expect(result.length).toEqual(1)
-  })
+        expect(result).toEqual(null)
+      })
 
-  it(`handles the elemMatch operator on the second element`, async () => {
-    let result = await runFilter({
-      singleElem: {
-        things: {
-          elemMatch: {
-            one: {
-              five: {
-                three: { eq: 153 },
-              },
-            },
-          },
-        },
-      },
-    })
-
-    expect(result.length).toEqual(1)
-    // Should contain the entire array even only one matched
-    expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
-    expect(result[0].singleElem.things[1].one.five.three).toEqual(153)
-  })
-
-  it(`should return only one node if elemMatch hits multiples`, async () => {
-    let result = await runFilter({
-      singleElem: {
-        things: {
-          elemMatch: {
-            one: {
-              two: {
-                three: { lt: 1000 }, // one match is 123, the other 404
-              },
-            },
-          },
-        },
-      },
-    })
-
-    // The `elemMatch` operator only returns the first nodde that matches so
-    // even though the `lt 1000` would match two elements in the `things` array
-    // it will return one node.
-    expect(result.length).toEqual(1)
-    expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
-    expect(result[0].singleElem.things[2].one.two.three).toEqual(404)
-  })
-
-  it(`ignores the elemMatch operator on a partial sub tree`, async () => {
-    let result = await runFilter({
-      singleElem: {
-        things: {
-          elemMatch: {
-            three: { eq: 123 },
-          },
-        },
-      },
-    })
-
-    expect(result).toEqual(null)
-  })
-
-  it(`handles the elemMatch operator for array of objects (1)`, async () => {
-    let result = await runFilter({
-      data: {
-        tags: {
-          elemMatch: {
-            tag: {
-              document: {
-                elemMatch: {
-                  data: {
-                    tag: { eq: `Gatsby` },
+      it(`handles the elemMatch operator for array of objects (1)`, async () => {
+        let result = await runFilter({
+          data: {
+            tags: {
+              elemMatch: {
+                tag: {
+                  document: {
+                    elemMatch: {
+                      data: {
+                        tag: { eq: `Gatsby` },
+                      },
+                    },
                   },
                 },
               },
             },
           },
-        },
-      },
-    })
+        })
 
-    expect(result.length).toEqual(1)
-    expect(result[0].index).toEqual(2)
-  })
+        expect(result.length).toEqual(1)
+        expect(result[0].index).toEqual(2)
+      })
 
-  it(`handles the elemMatch operator for array of objects (2)`, async () => {
-    let result = await runFilter({
-      data: {
-        tags: {
-          elemMatch: {
-            tag: {
-              document: {
-                elemMatch: {
-                  data: {
-                    tag: { eq: `Design System` },
+      it(`handles the elemMatch operator for array of objects (2)`, async () => {
+        let result = await runFilter({
+          data: {
+            tags: {
+              elemMatch: {
+                tag: {
+                  document: {
+                    elemMatch: {
+                      data: {
+                        tag: { eq: `Design System` },
+                      },
+                    },
                   },
                 },
               },
             },
           },
-        },
-      },
-    })
+        })
 
-    expect(result.length).toEqual(1)
-    expect(result[0].index).toEqual(2)
-  })
-
-  it(`works for elemMatch on boolean field`, async () => {
-    let result = await runFilter({
-      boolean: {
-        elemMatch: {
-          eq: true,
-        },
-      },
-    })
-
-    // Does NOT contain nodes that do not have the field
-    expect(result.length).toEqual(1)
-    expect(result[0].boolean).toEqual(true)
-  })
-
-  it(`skips nodes without the field for elemMatch on boolean`, async () => {
-    let result = await runFilter({
-      boolSecondOnly: {
-        elemMatch: {
-          eq: false,
-        },
-      },
-    })
-
-    // Does NOT contain nodes that do not have the field so returns 2nd node
-    expect(result.length).toEqual(1)
-    expect(result[0].boolSecondOnly).toEqual(false)
-  })
-
-  it(`works for elemMatch on string field`, async () => {
-    let result = await runFilter({
-      string: {
-        elemMatch: {
-          eq: `a`,
-        },
-      },
-    })
-
-    // Does NOT contain nodes that do not have the field
-    expect(result.length).toEqual(1)
-    expect(result[0].string).toEqual(`a`)
-  })
-
-  it(`should return all nodes for elemMatch on non-arrays too`, async () => {
-    let result = await runFilter({
-      name: {
-        elemMatch: {
-          eq: `The Mad Wax`,
-        },
-      },
-    })
-
-    // Can return more than one node
-    // Does NOT contain nodes that do not have the field
-    expect(result.length).toEqual(2)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-    expect(result[1].name).toEqual(`The Mad Wax`)
-  })
-
-  it(`skips nodes without the field for elemMatch on string`, async () => {
-    let result = await runFilter({
-      strSecondOnly: {
-        elemMatch: {
-          eq: `needle`,
-        },
-      },
-    })
-
-    // Does NOT contain nodes that do not have the field so returns 2nd node
-    expect(result.length).toEqual(1)
-    expect(result[0].strSecondOnly).toEqual(`needle`)
-  })
-
-  it(`works for elemMatch on number field`, async () => {
-    let result = await runFilter({
-      float: {
-        elemMatch: {
-          eq: 1.5,
-        },
-      },
-    })
-
-    // Does NOT contain nodes that do not have the field
-    expect(result.length).toEqual(1)
-    expect(result[0].float).toEqual(1.5)
-  })
-
-  it(`handles the nin operator for array [5]`, async () => {
-    let result = await runFilter({ anArray: { nin: [5] } })
-
-    // Since the array does not contain `null`, the query should also return the
-    // nodes that do not have the field at all (NULL).
-
-    expect(result.length).toEqual(2)
-    result.forEach(edge => {
-      // Either does not exist or does not contain
-      expect(edge.anArray === undefined || !edge.anArray.includes(5)).toBe(true)
-    })
-  })
-
-  it(`handles the nin operator for array [null]`, async () => {
-    let result = await runFilter({ nullArray: { nin: [null] } })
-
-    // Since the array contains `null`, the query should NOT return the
-    // nodes that do not have the field at all (NULL).
-
-    expect(result.length).toEqual(1)
-    expect(result[0].nullArray.includes(null)).toBe(false)
-  })
-
-  it(`handles the nin operator for strings`, async () => {
-    let result = await runFilter({ string: { nin: [`b`, `c`] } })
-
-    expect(result.length).toEqual(1)
-    result.forEach(edge => {
-      expect(edge.string).not.toEqual(`b`)
-      expect(edge.string).not.toEqual(`c`)
-    })
-  })
-
-  it(`handles the nin operator for ints`, async () => {
-    let result = await runFilter({ index: { nin: [0, 2] } })
-
-    expect(result.length).toEqual(1)
-    result.forEach(edge => {
-      expect(edge.index).not.toEqual(0)
-      expect(edge.index).not.toEqual(2)
-    })
-  })
-
-  it(`handles the nin operator for floats`, async () => {
-    let result = await runFilter({ float: { nin: [1.5] } })
-
-    expect(result.length).toEqual(2)
-    result.forEach(edge => {
-      // Might not have the property (-> undefined), must not be 1.5
-      expect(edge.float).not.toEqual(1.5)
-    })
-  })
-
-  it(`handles the nin operator for booleans`, async () => {
-    let result = await runFilter({ boolean: { nin: [true, null] } })
-
-    // Do not return the node that does not have the field because of `null`
-    expect(result.length).toEqual(1)
-    result.forEach(edge => {
-      // Must have the property, must not be true nor null
-      expect(edge.boolean !== undefined).toBe(true)
-      expect(edge.boolean !== true && edge.boolean !== null).toBe(true)
-    })
-  })
-
-  it(`handles the nin operator for double null`, async () => {
-    let result = await runFilter({ nil: { nin: [null, null] } })
-
-    // Do not return the node that does not have the field because of `null`
-    expect(result.length).toEqual(1)
-    result.forEach(edge => {
-      // Must have the property, must not be null
-      expect(edge.nil !== undefined).toBe(true)
-      expect(edge.nil !== null).toBe(true)
-    })
-  })
-
-  it(`handles the nin operator for null in int+null`, async () => {
-    let result = await runFilter({ nil: { nin: [5, null] } })
-
-    // Do not return the node that does not have the field because of `null`
-    expect(result.length).toEqual(1)
-    result.forEach(edge => {
-      // Must have the property, must not be 5 nor null
-      expect(edge.nil !== undefined).toBe(true)
-      expect(edge.nil !== 5 && edge.nil !== null).toBe(true)
-    })
-  })
-
-  it(`handles the nin operator for int in int+null`, async () => {
-    let result = await runFilter({ index: { nin: [2, null] } })
-
-    // Do not return the node that does not have the field because of `null`
-    expect(result.length).toEqual(2)
-    result.forEach(edge => {
-      // Must have the property, must not be 2 nor null
-      expect(edge.index !== undefined).toBe(true)
-      expect(edge.index !== 2 && edge.index !== null).toBe(true)
-    })
-  })
-
-  it(`handles the glob operator`, async () => {
-    let result = await runFilter({ name: { glob: `*Wax` } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].name).toEqual(`The Mad Wax`)
-  })
-
-  it(`filters date fields`, async () => {
-    let result = await runFilter({ date: { ne: null } })
-
-    expect(result.length).toEqual(2)
-    expect(result[0].index).toEqual(0)
-    expect(result[1].index).toEqual(2)
-  })
-
-  it(`handles the eq operator for array field values`, async () => {
-    const result = await runFilter({ anArray: { eq: 5 } })
-
-    expect(result.length).toBe(1)
-    expect(result[0].index).toBe(1)
-  })
-
-  it(`handles the ne operator for array field values`, async () => {
-    const result = await runFilter({ anArray: { ne: 1 } })
-
-    expect(result.length).toBe(1)
-    expect(result[0].index).toBe(2)
-  })
-})
-
-describe(`collection fields`, () => {
-  it(`orders by given field desc with limit`, async () => {
-    let result = await runQuery({
-      limit: 10,
-      sort: {
-        fields: [`frontmatter.blue`],
-        order: [`desc`],
-      },
-    })
-
-    expect(result.length).toEqual(3)
-    expect(result[0].id).toEqual(`1`)
-    expect(result[1].id).toEqual(`2`)
-    expect(result[2].id).toEqual(`0`)
-  })
-
-  describe(`num, null, and nullable order`, () => {
-    // This suite asserts the order of a field that is a number vs a field that
-    // is explicitly set to the value `null`, vs a field that is not set
-    // (which gets NULL in the database). This should do whatever redux does!
-    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
-
-    // node 1  2   3
-    //  - num_null_not    1st node has field set, 2nd set to null, 3rd not set
-    //  - num_not_null    etc
-    //  - null_num_not
-    //  - null_not_num
-    //  - not_null_num
-    //  - not_num_null
-
-    it(`sorts num_null_not asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`num_null_not`],
-          order: [`asc`],
-        },
+        expect(result.length).toEqual(1)
+        expect(result[0].index).toEqual(2)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      it(`works for elemMatch on boolean field`, async () => {
+        let result = await runFilter({
+          boolean: {
+            elemMatch: {
+              eq: true,
+            },
+          },
+        })
 
-    it(`sorts num_null_not desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`num_null_not`],
-          order: [`desc`],
-        },
+        // Does NOT contain nodes that do not have the field
+        expect(result.length).toEqual(1)
+        expect(result[0].boolean).toEqual(true)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      it(`skips nodes without the field for elemMatch on boolean`, async () => {
+        let result = await runFilter({
+          boolSecondOnly: {
+            elemMatch: {
+              eq: false,
+            },
+          },
+        })
 
-    it(`sorts num_not_null asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`num_not_null`],
-          order: [`asc`],
-        },
+        // Does NOT contain nodes that do not have the field so returns 2nd node
+        expect(result.length).toEqual(1)
+        expect(result[0].boolSecondOnly).toEqual(false)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`1`)
-    })
+      it(`works for elemMatch on string field`, async () => {
+        let result = await runFilter({
+          string: {
+            elemMatch: {
+              eq: `a`,
+            },
+          },
+        })
 
-    it(`sorts num_not_null desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`num_not_null`],
-          order: [`desc`],
-        },
+        // Does NOT contain nodes that do not have the field
+        expect(result.length).toEqual(1)
+        expect(result[0].string).toEqual(`a`)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      it(`should return all nodes for elemMatch on non-arrays too`, async () => {
+        let result = await runFilter({
+          name: {
+            elemMatch: {
+              eq: `The Mad Wax`,
+            },
+          },
+        })
 
-    it(`sorts null_num_not asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_num_not`],
-          order: [`asc`],
-        },
+        // Can return more than one node
+        // Does NOT contain nodes that do not have the field
+        expect(result.length).toEqual(2)
+        expect(result[0].name).toEqual(`The Mad Wax`)
+        expect(result[1].name).toEqual(`The Mad Wax`)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      it(`skips nodes without the field for elemMatch on string`, async () => {
+        let result = await runFilter({
+          strSecondOnly: {
+            elemMatch: {
+              eq: `needle`,
+            },
+          },
+        })
 
-    it(`sorts null_num_not desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_num_not`],
-          order: [`desc`],
-        },
+        // Does NOT contain nodes that do not have the field so returns 2nd node
+        expect(result.length).toEqual(1)
+        expect(result[0].strSecondOnly).toEqual(`needle`)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`1`)
-    })
+      it(`works for elemMatch on number field`, async () => {
+        let result = await runFilter({
+          float: {
+            elemMatch: {
+              eq: 1.5,
+            },
+          },
+        })
 
-    it(`sorts null_not_num asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_not_num`],
-          order: [`asc`],
-        },
+        // Does NOT contain nodes that do not have the field
+        expect(result.length).toEqual(1)
+        expect(result[0].float).toEqual(1.5)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`1`)
-    })
+      it(`handles the nin operator for array [5]`, async () => {
+        let result = await runFilter({ anArray: { nin: [5] } })
 
-    it(`sorts null_not_num desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_not_num`],
-          order: [`desc`],
-        },
+        // Since the array does not contain `null`, the query should also return the
+        // nodes that do not have the field at all (NULL).
+
+        expect(result.length).toEqual(2)
+        result.forEach(edge => {
+          // Either does not exist or does not contain
+          expect(edge.anArray === undefined || !edge.anArray.includes(5)).toBe(
+            true
+          )
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      it(`handles the nin operator for array [null]`, async () => {
+        let result = await runFilter({ nullArray: { nin: [null] } })
 
-    it(`sorts not_null_num asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_null_num`],
-          order: [`asc`],
-        },
+        // Since the array contains `null`, the query should NOT return the
+        // nodes that do not have the field at all (NULL).
+
+        expect(result.length).toEqual(1)
+        expect(result[0].nullArray.includes(null)).toBe(false)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      it(`handles the nin operator for strings`, async () => {
+        let result = await runFilter({ string: { nin: [`b`, `c`] } })
 
-    it(`sorts not_null_num desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_null_num`],
-          order: [`desc`],
-        },
+        expect(result.length).toEqual(1)
+        result.forEach(edge => {
+          expect(edge.string).not.toEqual(`b`)
+          expect(edge.string).not.toEqual(`c`)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      it(`handles the nin operator for ints`, async () => {
+        let result = await runFilter({ index: { nin: [0, 2] } })
 
-    it(`sorts not_num_null asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_num_null`],
-          order: [`asc`],
-        },
+        expect(result.length).toEqual(1)
+        result.forEach(edge => {
+          expect(edge.index).not.toEqual(0)
+          expect(edge.index).not.toEqual(2)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      it(`handles the nin operator for floats`, async () => {
+        let result = await runFilter({ float: { nin: [1.5] } })
 
-    it(`sorts not_num_null desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_num_null`],
-          order: [`desc`],
-        },
+        expect(result.length).toEqual(2)
+        result.forEach(edge => {
+          // Might not have the property (-> undefined), must not be 1.5
+          expect(edge.float).not.toEqual(1.5)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`1`)
-    })
-  })
+      it(`handles the nin operator for booleans`, async () => {
+        let result = await runFilter({ boolean: { nin: [true, null] } })
 
-  describe(`string, null, and nullable order`, () => {
-    // This suite asserts the order of a field that is a string vs a field that
-    // is explicitly set to the value `null`, vs a field that is not set
-    // (which gets NULL in the database). This should do whatever redux does!
-    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
-
-    // node 1  2   3
-    //  - str_null_not    1st node has field set, 2nd set to null, 3rd not set
-    //  - str_not_null    etc
-    //  - null_str_not
-    //  - null_not_str
-    //  - not_null_str
-    //  - not_str_null
-
-    it(`sorts str_null_not asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`str_null_not`],
-          order: [`asc`],
-        },
+        // Do not return the node that does not have the field because of `null`
+        expect(result.length).toEqual(1)
+        result.forEach(edge => {
+          // Must have the property, must not be true nor null
+          expect(edge.boolean !== undefined).toBe(true)
+          expect(edge.boolean !== true && edge.boolean !== null).toBe(true)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      it(`handles the nin operator for double null`, async () => {
+        let result = await runFilter({ nil: { nin: [null, null] } })
 
-    it(`sorts str_null_not desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`str_null_not`],
-          order: [`desc`],
-        },
+        // Do not return the node that does not have the field because of `null`
+        expect(result.length).toEqual(1)
+        result.forEach(edge => {
+          // Must have the property, must not be null
+          expect(edge.nil !== undefined).toBe(true)
+          expect(edge.nil !== null).toBe(true)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      it(`handles the nin operator for null in int+null`, async () => {
+        let result = await runFilter({ nil: { nin: [5, null] } })
 
-    it(`sorts str_not_null asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`str_not_null`],
-          order: [`asc`],
-        },
+        // Do not return the node that does not have the field because of `null`
+        expect(result.length).toEqual(1)
+        result.forEach(edge => {
+          // Must have the property, must not be 5 nor null
+          expect(edge.nil !== undefined).toBe(true)
+          expect(edge.nil !== 5 && edge.nil !== null).toBe(true)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`1`)
-    })
+      it(`handles the nin operator for int in int+null`, async () => {
+        let result = await runFilter({ index: { nin: [2, null] } })
 
-    it(`sorts str_not_null desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`str_not_null`],
-          order: [`desc`],
-        },
+        // Do not return the node that does not have the field because of `null`
+        expect(result.length).toEqual(2)
+        result.forEach(edge => {
+          // Must have the property, must not be 2 nor null
+          expect(edge.index !== undefined).toBe(true)
+          expect(edge.index !== 2 && edge.index !== null).toBe(true)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      it(`handles the glob operator`, async () => {
+        let result = await runFilter({ name: { glob: `*Wax` } })
 
-    it(`sorts null_str_not asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_str_not`],
-          order: [`asc`],
-        },
+        expect(result.length).toEqual(2)
+        expect(result[0].name).toEqual(`The Mad Wax`)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      it(`filters date fields`, async () => {
+        let result = await runFilter({ date: { ne: null } })
 
-    it(`sorts null_str_not desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_str_not`],
-          order: [`desc`],
-        },
+        expect(result.length).toEqual(2)
+        expect(result[0].index).toEqual(0)
+        expect(result[1].index).toEqual(2)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`1`)
-    })
+      it(`handles the eq operator for array field values`, async () => {
+        const result = await runFilter({ anArray: { eq: 5 } })
 
-    it(`sorts null_not_str asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_not_str`],
-          order: [`asc`],
-        },
+        expect(result.length).toBe(1)
+        expect(result[0].index).toBe(1)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`1`)
+      it(`handles the ne operator for array field values`, async () => {
+        const result = await runFilter({ anArray: { ne: 1 } })
+
+        expect(result.length).toBe(1)
+        expect(result[0].index).toBe(2)
+      })
     })
 
-    it(`sorts null_not_str desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_not_str`],
-          order: [`desc`],
-        },
+    describe(`collection fields`, () => {
+      it(`orders by given field desc with limit`, async () => {
+        let result = await runQuery({
+          limit: 10,
+          sort: {
+            fields: [`frontmatter.blue`],
+            order: [`desc`],
+          },
+        })
+
+        expect(result.length).toEqual(3)
+        expect(result[0].id).toEqual(`1`)
+        expect(result[1].id).toEqual(`2`)
+        expect(result[2].id).toEqual(`0`)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      describe(`num, null, and nullable order`, () => {
+        // This suite asserts the order of a field that is a number vs a field that
+        // is explicitly set to the value `null`, vs a field that is not set
+        // (which gets NULL in the database). This should do whatever redux does!
+        // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
 
-    it(`sorts not_null_str asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_null_str`],
-          order: [`asc`],
-        },
+        // node 1  2   3
+        //  - num_null_not    1st node has field set, 2nd set to null, 3rd not set
+        //  - num_not_null    etc
+        //  - null_num_not
+        //  - null_not_num
+        //  - not_null_num
+        //  - not_num_null
+
+        it(`sorts num_null_not asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`num_null_not`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts num_null_not desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`num_null_not`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts num_not_null asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`num_not_null`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts num_not_null desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`num_not_null`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts null_num_not asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_num_not`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts null_num_not desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_num_not`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts null_not_num asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_not_num`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts null_not_num desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_not_num`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts not_null_num asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_null_num`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts not_null_num desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_null_num`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts not_num_null asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_num_null`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts not_num_null desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_num_null`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`1`)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      describe(`string, null, and nullable order`, () => {
+        // This suite asserts the order of a field that is a string vs a field that
+        // is explicitly set to the value `null`, vs a field that is not set
+        // (which gets NULL in the database). This should do whatever redux does!
+        // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
 
-    it(`sorts not_null_str desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_null_str`],
-          order: [`desc`],
-        },
+        // node 1  2   3
+        //  - str_null_not    1st node has field set, 2nd set to null, 3rd not set
+        //  - str_not_null    etc
+        //  - null_str_not
+        //  - null_not_str
+        //  - not_null_str
+        //  - not_str_null
+
+        it(`sorts str_null_not asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`str_null_not`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts str_null_not desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`str_null_not`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts str_not_null asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`str_not_null`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts str_not_null desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`str_not_null`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts null_str_not asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_str_not`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts null_str_not desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_str_not`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts null_not_str asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_not_str`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts null_not_str desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_not_str`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts not_null_str asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_null_str`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts not_null_str desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_null_str`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts not_str_null asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_str_null`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts not_str_null desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_str_null`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`1`)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      describe(`obj, null, and nullable order`, () => {
+        // This suite asserts the order of a field that is a object vs a field that
+        // is explicitly set to the value `null`, vs a field that is not set
+        // (which gets NULL in the database). This should do whatever redux does!
+        // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
 
-    it(`sorts not_str_null asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_str_null`],
-          order: [`asc`],
-        },
+        // node 1  2   3
+        //  - obj_null_not    1st node has field set, 2nd set to null, 3rd not set
+        //  - obj_not_null    etc
+        //  - null_obj_not
+        //  - null_not_obj
+        //  - not_null_obj
+        //  - not_obj_null
+
+        it(`sorts obj_null_not asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`obj_null_not`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts obj_null_not desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`obj_null_not`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts obj_not_null asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`obj_not_null`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts obj_not_null desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`obj_not_null`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts null_obj_not asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_obj_not`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts null_obj_not desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_obj_not`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts null_not_obj asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_not_obj`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`1`)
+        })
+
+        it(`sorts null_not_obj desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`null_not_obj`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`0`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts not_null_obj asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_null_obj`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`2`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts not_null_obj desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_null_obj`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`1`)
+          expect(result[2].id).toEqual(`2`)
+        })
+
+        it(`sorts not_obj_null asc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_obj_null`],
+              order: [`asc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`1`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`0`)
+        })
+
+        it(`sorts not_obj_null desc`, async () => {
+          let result = await runQuery({
+            sort: {
+              fields: [`not_obj_null`],
+              order: [`desc`],
+            },
+          })
+
+          expect(result.length).toEqual(3)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`2`)
+          expect(result[2].id).toEqual(`1`)
+        })
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      it(`sorts results with desc has null fields first vs obj second`, async () => {
+        let result = await runQuery({
+          limit: 10,
+          sort: {
+            fields: [`waxOnly`],
+            order: [`desc`],
+          },
+        })
 
-    it(`sorts not_str_null desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_str_null`],
-          order: [`desc`],
-        },
+        // 0 doesnt have it, 1 has it as an object, 2 has it as null
+
+        expect(result.length).toEqual(3)
+        expect(result[0].id).toEqual(`0`)
+        expect(result[1].id).toEqual(`2`)
+        expect(result[2].id).toEqual(`1`)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`1`)
-    })
-  })
+      it(`sorts results with asc has null fields last vs obj first`, async () => {
+        let result = await runQuery({
+          limit: 10,
+          sort: {
+            fields: [`waxOnly`],
+            order: [`asc`],
+          },
+        })
 
-  describe(`obj, null, and nullable order`, () => {
-    // This suite asserts the order of a field that is a object vs a field that
-    // is explicitly set to the value `null`, vs a field that is not set
-    // (which gets NULL in the database). This should do whatever redux does!
-    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
+        // 0 doesnt have it, 1 has it as an object, 2 has it as null
 
-    // node 1  2   3
-    //  - obj_null_not    1st node has field set, 2nd set to null, 3rd not set
-    //  - obj_not_null    etc
-    //  - null_obj_not
-    //  - null_not_obj
-    //  - not_null_obj
-    //  - not_obj_null
-
-    it(`sorts obj_null_not asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`obj_null_not`],
-          order: [`asc`],
-        },
+        expect(result.length).toEqual(3)
+        expect(result[0].id).toEqual(`1`)
+        expect(result[1].id).toEqual(`2`)
+        expect(result[2].id).toEqual(`0`)
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`2`)
-    })
+      it(`applies specified sort order, and sorts asc by default`, async () => {
+        let result = await runQuery({
+          limit: 10,
+          sort: {
+            fields: [`frontmatter.blue`, `id`],
+            order: [`desc`], // `id` field will be sorted asc
+          },
+        })
 
-    it(`sorts obj_null_not desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`obj_null_not`],
-          order: [`desc`],
-        },
+        expect(result.length).toEqual(3)
+        expect(result[0].id).toEqual(`1`) // blue = 10010, id = 1
+        expect(result[1].id).toEqual(`2`) // blue = 10010, id = 2
+        expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
       })
 
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`0`)
-    })
+      it(`applies specified sort order per field`, async () => {
+        let result = await runQuery({
+          limit: 10,
+          sort: {
+            fields: [`frontmatter.blue`, `id`],
+            order: [`desc`, `desc`], // `id` field will be sorted desc
+          },
+        })
 
-    it(`sorts obj_not_null asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`obj_not_null`],
-          order: [`asc`],
-        },
+        expect(result.length).toEqual(3)
+        expect(result[0].id).toEqual(`2`) // blue = 10010, id = 2
+        expect(result[1].id).toEqual(`1`) // blue = 10010, id = 1
+        expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
       })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`1`)
     })
-
-    it(`sorts obj_not_null desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`obj_not_null`],
-          order: [`desc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`0`)
-    })
-
-    it(`sorts null_obj_not asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_obj_not`],
-          order: [`asc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`2`)
-    })
-
-    it(`sorts null_obj_not desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_obj_not`],
-          order: [`desc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`1`)
-    })
-
-    it(`sorts null_not_obj asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_not_obj`],
-          order: [`asc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`1`)
-    })
-
-    it(`sorts null_not_obj desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`null_not_obj`],
-          order: [`desc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`0`)
-      expect(result[2].id).toEqual(`2`)
-    })
-
-    it(`sorts not_null_obj asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_null_obj`],
-          order: [`asc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`2`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`0`)
-    })
-
-    it(`sorts not_null_obj desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_null_obj`],
-          order: [`desc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`1`)
-      expect(result[2].id).toEqual(`2`)
-    })
-
-    it(`sorts not_obj_null asc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_obj_null`],
-          order: [`asc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`1`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`0`)
-    })
-
-    it(`sorts not_obj_null desc`, async () => {
-      let result = await runQuery({
-        sort: {
-          fields: [`not_obj_null`],
-          order: [`desc`],
-        },
-      })
-
-      expect(result.length).toEqual(3)
-      expect(result[0].id).toEqual(`0`)
-      expect(result[1].id).toEqual(`2`)
-      expect(result[2].id).toEqual(`1`)
-    })
-  })
-
-  it(`sorts results with desc has null fields first vs obj second`, async () => {
-    let result = await runQuery({
-      limit: 10,
-      sort: {
-        fields: [`waxOnly`],
-        order: [`desc`],
-      },
-    })
-
-    // 0 doesnt have it, 1 has it as an object, 2 has it as null
-
-    expect(result.length).toEqual(3)
-    expect(result[0].id).toEqual(`0`)
-    expect(result[1].id).toEqual(`2`)
-    expect(result[2].id).toEqual(`1`)
-  })
-
-  it(`sorts results with asc has null fields last vs obj first`, async () => {
-    let result = await runQuery({
-      limit: 10,
-      sort: {
-        fields: [`waxOnly`],
-        order: [`asc`],
-      },
-    })
-
-    // 0 doesnt have it, 1 has it as an object, 2 has it as null
-
-    expect(result.length).toEqual(3)
-    expect(result[0].id).toEqual(`1`)
-    expect(result[1].id).toEqual(`2`)
-    expect(result[2].id).toEqual(`0`)
-  })
-
-  it(`applies specified sort order, and sorts asc by default`, async () => {
-    let result = await runQuery({
-      limit: 10,
-      sort: {
-        fields: [`frontmatter.blue`, `id`],
-        order: [`desc`], // `id` field will be sorted asc
-      },
-    })
-
-    expect(result.length).toEqual(3)
-    expect(result[0].id).toEqual(`1`) // blue = 10010, id = 1
-    expect(result[1].id).toEqual(`2`) // blue = 10010, id = 2
-    expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
-  })
-
-  it(`applies specified sort order per field`, async () => {
-    let result = await runQuery({
-      limit: 10,
-      sort: {
-        fields: [`frontmatter.blue`, `id`],
-        order: [`desc`, `desc`], // `id` field will be sorted desc
-      },
-    })
-
-    expect(result.length).toEqual(3)
-    expect(result[0].id).toEqual(`2`) // blue = 10010, id = 2
-    expect(result[1].id).toEqual(`1`) // blue = 10010, id = 1
-    expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
   })
 })

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -1,7 +1,9 @@
 const { runQuery: nodesQuery } = require(`../../db/nodes`)
 const { store } = require(`../../redux`)
 const { actions } = require(`../../redux/actions`)
-require(`../../db/__tests__/fixtures/ensure-loki`)()
+
+// Note: loki does not match redux in certain edge cases in this file
+const IS_LOKI = require(`../../db/__tests__/fixtures/ensure-loki`)()
 
 const makeNodes = () => [
   {
@@ -234,6 +236,9 @@ async function runFilterOnCache(filter, filtersCache) {
 }
 
 it(`should use the cache argument`, async () => {
+  // Loki does not use this system at all
+  if (IS_LOKI) return
+
   const filtersCache = new Map()
   const result = await runFilterOnCache({ hair: { eq: 2 } }, filtersCache)
 
@@ -307,6 +312,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles ne operator`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ hair: { ne: 2 } })
 
         expect(result.length).toEqual(2)
@@ -332,6 +339,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles ne operator with null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { ne: null } })
 
         // Should only return nodes who do have the property, not set to null
@@ -363,6 +372,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles lt operator with null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { lt: null } })
 
         // Nothing is lt null
@@ -378,6 +389,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles lte operator with null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { lte: null } })
 
         // lte null matches null but no nodes without the property (NULL)
@@ -395,6 +408,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles gt operator with null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { gt: null } })
 
         // Nothing is gt null
@@ -410,6 +425,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles gte operator with null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { gte: null } })
 
         // lte null matches null but no nodes without the property (NULL)
@@ -445,6 +462,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`does not match double quote for string without it`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ name: { regex: `/"/` } })
 
         expect(result).toEqual(null)
@@ -474,6 +493,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles the in operator for just null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { in: [null] } })
 
         // Do not include the nodes without a `nil` property
@@ -485,6 +506,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles the in operator for double null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { in: [null, null] } })
 
         // Do not include the nodes without a `nil` property
@@ -496,6 +519,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles the in operator for null in int and null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { in: [5, null] } })
 
         // Include the nodes without a `nil` property
@@ -612,6 +637,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`ignores the elemMatch operator on a partial sub tree`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({
           singleElem: {
             things: {
@@ -672,6 +699,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`works for elemMatch on boolean field`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({
           boolean: {
             elemMatch: {
@@ -686,6 +715,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`skips nodes without the field for elemMatch on boolean`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({
           boolSecondOnly: {
             elemMatch: {
@@ -700,6 +731,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`works for elemMatch on string field`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({
           string: {
             elemMatch: {
@@ -714,6 +747,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`should return all nodes for elemMatch on non-arrays too`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({
           name: {
             elemMatch: {
@@ -730,6 +765,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`skips nodes without the field for elemMatch on string`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({
           strSecondOnly: {
             elemMatch: {
@@ -744,6 +781,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`works for elemMatch on number field`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({
           float: {
             elemMatch: {
@@ -773,6 +812,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles the nin operator for array [null]`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nullArray: { nin: [null] } })
 
         // Since the array contains `null`, the query should NOT return the
@@ -825,6 +866,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles the nin operator for double null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { nin: [null, null] } })
 
         // Do not return the node that does not have the field because of `null`
@@ -837,6 +880,8 @@ it(`should use the cache argument`, async () => {
       })
 
       it(`handles the nin operator for null in int+null`, async () => {
+        if (IS_LOKI) return
+
         let result = await runFilter({ nil: { nin: [5, null] } })
 
         // Do not return the node that does not have the field because of `null`

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -78,14 +78,14 @@ class LocalNodeModel {
    * Replace the cache either with the value passed on (mainly for tests) or
    * an empty new Map.
    *
-   * @param {undefined | Map<string, Map<string, Set<Node>> | Map<string, Node>>} map
+   * @param {undefined | null | FiltersCache} map
    *   (This cached is used in redux/nodes.js and caches a set of buckets (Sets)
    *   of Nodes based on filter and tracks this for each set of types which are
    *   actually queried. If the filter targets `id` directly, only one Node is
-   *   cached instead of a Set of Nodes.
+   *   cached instead of a Set of Nodes. If null, don't create or use a cache.
    */
   replaceTypeKeyValueCache(map = new Map()) {
-    this._typedKeyValueIndexes = map // See redux/nodes.js for usage
+    this._filtersCache = map // See redux/nodes.js for usage
   }
 
   withContext(context) {
@@ -237,7 +237,7 @@ class LocalNodeModel {
       gqlType,
       resolvedFields: fieldsToResolve,
       nodeTypeNames,
-      typedKeyValueIndexes: this._typedKeyValueIndexes,
+      filtersCache: this._filtersCache,
       stats,
     })
 


### PR DESCRIPTION
The filter for `elemMatch` is basically a sub-match on elements of an array. So rather than matching one explicit path, it matches any of the n paths, splitting off at an array. Other than testing paths through each element in an array, it behaves the same as a regular filter. The `elemMatch` filters can be nested.

These filters weren't before optimized and couldn't take the fast index path. This PR changes that.

## This PR improves `elemMatch` perf at scale
# A baseline 50k site went from 42 q/s to 547 q/s
## (or runtime: from 1200s to 90s)

I've modified "the ifsc" benchmark site and added a silly simple array with three elements to the nodes. Then I modified the query to add an `elemMatch` (aside the already existing `eq` filter on `id`) and ran the before-after benchmark on 500, 5.000, 10.000, and 50.000 pages. The results were as stunning as when first introducing the indexed filters :rocket: See below.

This PR refactors the typing a bit, the first couple of commits are refactorings. Then the meat of the commit is there, with a few fixes in followup commits. It also ports an extended query test suite from a research branch. And it modifies the run query tests to test with and without cache. This way we can at least confirm that the results from using fast indexes are identical to not using the fast indexes at all (which is always a fallback, anyways).

Before:

```
CI=1 NBR=1 N=50000 M=8000 yarn bench
success run queries - 1208.516s - 50002/50002 41.37/s
success Building static HTML for pages - 51.533s - 50002/50002 970.30/s
info Done building in 1290.651 sec

CI=1 NBR=1 N=10000 M=8000 yarn bench
success run queries - 40.606s - 10002/10002 246.32/s
success Building static HTML for pages - 11.668s - 10002/10002 857.21/s
info Done building in 60.489 sec

CI=1 NBR=1 N=5000 M=8000 yarn bench
success run queries - 15.147s - 5002/5002 330.23/s
success Building static HTML for pages - 6.432s - 5002/5002 777.71/s
info Done building in 27.066 sec

CI=1 NBR=1 N=500 M=8000 yarn bench
success run queries - 5.034s - 502/502 99.73/s
success Building static HTML for pages - 1.305s - 502/502 384.67/s
success onPostBuild - 0.000s
info Done building in 8.803 sec

CI=1 NBR=1 N=500 M=8000 yarn bench
never ending
```

After:

```
CI=1 NBR=1 N=50000 M=8000 yarn bench
success run queries - 91.352s - 50002/50002 547.35/s
success Building static HTML for pages - 53.323s - 50002/50002 937.73/s
info Done building in 175.43 sec

CI=1 NBR=1 N=10000 M=8000 yarn bench
success run queries - 11.481s - 10002/10002 871.17/s
success Building static HTML for pages - 11.572s - 10002/10002 864.36/s
info Done building in 31.23 sec

CI=1 NBR=1 N=5000 M=8000 yarn bench
success run queries - 8.036s - 5002/5002 622.45/s
success Building static HTML for pages - 6.409s - 5002/5002 780.42/s
info Done building in 19.8 sec

CI=1 NBR=1 N=500 M=8000 yarn bench
success run queries - 4.959s - 502/502 101.23/s
success Building static HTML for pages - 1.312s - 502/502 382.70/s
info Done building in 8.701 sec

CI=1 NBR=1 N=100000 M=8000 yarn bench
success run queries - 501.655s - 100002/100002 199.34/s
success Building static HTML for pages - 99.309s - 100002/100002 1006.98/s
info Done building in 663.366 sec
```