### PR TITLE
fix(babel-remove-graphql-queries, graphql-skip-limit) Make graphql package version consistent

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -18,7 +18,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.0",
-    "graphql": "^14.1.1"
+    "graphql": "^14.6.0"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",

--- a/packages/graphql-skip-limit/package.json
+++ b/packages/graphql-skip-limit/package.json
@@ -10,14 +10,13 @@
     "@babel/runtime": "^7.8.7"
   },
   "peerDependencies": {
-    "graphql": "^14.1.1"
+    "graphql": "^14.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
     "babel-preset-gatsby-package": "^0.3.1",
-    "cross-env": "^5.2.1",
-    "graphql": "^14.6.0"
+    "cross-env": "^5.2.1"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit#readme",
   "keywords": [

--- a/packages/graphql-skip-limit/package.json
+++ b/packages/graphql-skip-limit/package.json
@@ -16,7 +16,8 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
     "babel-preset-gatsby-package": "^0.3.1",
-    "cross-env": "^5.2.1"
+    "cross-env": "^5.2.1",
+    "graphql": "^14.6.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/graphql-skip-limit#readme",
   "keywords": [


### PR DESCRIPTION
## Description

Make graphql version consistent (2 packages were linking to 4.1.1 instead of 4.6.0), which in some scenarios would cause problems with [yarn version resolution](https://classic.yarnpkg.com/en/docs/selective-version-resolutions).