### PR TITLE
fix(gatsby-source-contentful): use request url for base64 image cache key

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -55,7 +55,7 @@ const getBase64Image = imageProps => {
 
   // Note: sha1 is unsafe for crypto but okay for this particular case
   const shasum = crypto.createHash(`sha1`)
-  shasum.update(`requestUrl`)
+  shasum.update(`${requestUrl}`)
   const urlSha = shasum.digest(`hex`)
 
   // TODO: Find the best place for this step. This is definitely not it.

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -55,7 +55,7 @@ const getBase64Image = imageProps => {
 
   // Note: sha1 is unsafe for crypto but okay for this particular case
   const shasum = crypto.createHash(`sha1`)
-  shasum.update(`${requestUrl}`)
+  shasum.update(requestUrl)
   const urlSha = shasum.digest(`hex`)
 
   // TODO: Find the best place for this step. This is definitely not it.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Noticed a problem after upgrading to gatsby-source-contentful@2.2.5 where all our images were using the same base64 placeholder. I managed to track down the source of the issue to #22551 where caching was introduced but the cache key was the same for all images since it was based on the string `requestUrl` instead of the interpolation `${requestUrl}`.

## Related Issues

Related to #22551
