### PR TITLE
feat(gatsby-cli): allow --recursive git url

### DIFF
--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -179,9 +179,14 @@ const clone = async (hostInfo: any, rootPath: string): Promise<void> => {
 
   report.info(`Creating new site from git: ${url}`)
 
-  const args = [`clone`, ...branch, url, rootPath, `--depth=1`].filter(arg =>
-    Boolean(arg)
-  )
+  const args = [
+    `clone`,
+    ...branch,
+    url,
+    rootPath,
+    `--recursive`,
+    `--depth=1`,
+  ].filter(arg => Boolean(arg))
 
   await spawnWithArgs(`git`, args)
 


### PR DESCRIPTION
## Description

We have our gatsby starter (https://github.com/ueno-llc/ueno-gatsby-starter) and one folder is a submodule to another git repository.

### Documentation

It would allow us to pass `--recursive` after the starter-url and be able to clone the git submodule folder.

_**Not ready yet on this part:**_
```
gatsby new my-awesome-submodule-site https://github.com/gatsbyjs/gatsby-starter-blog --recursive
```

or through node with our current usage

```
process.argv[2] = 'new';
process.argv[3] = 'myAwesomeSubmoduleSite';
process.argv[4] = `https://github.com/ueno-llc/ueno-gatsby-starter#master --recursive`;

require('gatsby-cli');
```