### PR TITLE
Fix DatoCMS benchmarks

### DIFF
--- a/benchmarks/source-datocms/gatsby-config.js
+++ b/benchmarks/source-datocms/gatsby-config.js
@@ -17,13 +17,13 @@ module.exports = {
         path: `${__dirname}/src/pages/`,
       },
     },
-    {	
+    {
       resolve: `gatsby-source-datocms`,
       options: {
         apiToken: process.env.DATOCMS_API_TOKEN,
         previewMode: false,
         disableLiveReload: false,
-        apiUrl: 'https://site-api.datocms.com',
+        apiUrl: "https://site-api.datocms.com",
       },
     },
   ],

--- a/benchmarks/source-datocms/gatsby-config.js
+++ b/benchmarks/source-datocms/gatsby-config.js
@@ -23,7 +23,7 @@ module.exports = {
         apiToken: process.env.DATOCMS_API_TOKEN,
         previewMode: false,
         disableLiveReload: false,
-        apiUrl: "https://site-api.datocms.com",
+        apiUrl: `https://site-api.datocms.com`,
       },
     },
   ],

--- a/benchmarks/source-datocms/gatsby-node.js
+++ b/benchmarks/source-datocms/gatsby-node.js
@@ -3,8 +3,8 @@ const kebabCase = require(`lodash.kebabcase`)
 exports.onCreateNode = ({ actions, node }) => {
   const { createNodeField } = actions
 
-  if (node.internal.type === "node__article") {
-    createNodeField({ node, name: "slug", value: kebabCase(node.title) })
+  if (node.internal.type === `node__article`) {
+    createNodeField({ node, name: `slug`, value: kebabCase(node.title) })
   }
 }
 

--- a/benchmarks/source-datocms/gatsby-node.js
+++ b/benchmarks/source-datocms/gatsby-node.js
@@ -3,7 +3,7 @@ const kebabCase = require(`lodash.kebabcase`)
 exports.onCreateNode = ({ actions, node }) => {
   const { createNodeField } = actions
 
-  if (node.internal.type === 'node__article') {
+  if (node.internal.type === "node__article") {
     createNodeField({ node, name: "slug", value: kebabCase(node.title) })
   }
 }
@@ -16,7 +16,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       articles: allDatoCmsArticle {
         nodes {
           id
-          path
+          slug
         }
       }
     }
@@ -28,11 +28,11 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 
   result.data.articles.nodes.map(article => {
     createPage({
-      path: article.path,
+      path: article.slug,
       component: require.resolve(`./src/templates/article.js`),
       context: {
         id: article.id,
-      }
+      },
     })
   })
 }

--- a/benchmarks/source-datocms/src/pages/index.js
+++ b/benchmarks/source-datocms/src/pages/index.js
@@ -9,7 +9,7 @@ const Index = ({ data }) => {
       <ul>
         {data.articles.nodes.map(article => (
           <li>
-            <Link to={article.path}>{article.title}</Link>
+            <Link to={article.slug}>{article.title}</Link>
           </li>
         ))}
       </ul>
@@ -29,7 +29,7 @@ export const query = graphql`
     articles: allDatoCmsArticle {
       nodes {
         title
-        path
+        slug
       }
     }
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

- Fixes the DatoCMS benchmarks. There is no `path` available in `allDatoCmsArticle`.
- Auto-formatting

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

n/a

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

n/a
