### PR TITLE
recipes: Improve providers

### DIFF
--- a/packages/gatsby/src/recipes/providers/fs/file.js
+++ b/packages/gatsby/src/recipes/providers/fs/file.js
@@ -12,21 +12,15 @@ const fileExists = ({ root }, { path: filePath }) => {
   }
 }
 
-const create = async ({ root }, { path: filePath, content, overwrite }) => {
+const create = async ({ root }, { path: filePath, content }) => {
   const fullPath = path.join(root, filePath)
   const { dir } = path.parse(fullPath)
-
-  const alreadyExists = await fileExists({ root }, { path: filePath })
-
-  if (alreadyExists && !overwrite) {
-    return
-  }
 
   await mkdirp(dir)
   await fs.writeFile(fullPath, content)
 }
 
-const update = (context, cmd) => create(context, { ...cmd, overwrite: true })
+const update = create
 
 const read = async ({ root }, { path: filePath }) => {
   const fullPath = path.join(root, filePath)

--- a/packages/gatsby/src/recipes/providers/fs/file.js
+++ b/packages/gatsby/src/recipes/providers/fs/file.js
@@ -1,11 +1,6 @@
-const fs = require(`fs`)
+const fs = require(`fs-extra`)
 const path = require(`path`)
-const { promisify } = require(`util`)
 const mkdirp = require(`mkdirp`)
-
-const readFile = promisify(fs.readFile)
-const writeFile = promisify(fs.writeFile)
-const destroyFile = promisify(fs.unlink)
 
 const fileExists = ({ root }, { path: filePath }) => {
   const fullPath = path.join(root, filePath)
@@ -28,21 +23,21 @@ const create = async ({ root }, { path: filePath, content, overwrite }) => {
   }
 
   await mkdirp(dir)
-  await writeFile(fullPath, content)
+  await fs.writeFile(fullPath, content)
 }
 
 const update = (context, cmd) => create(context, { ...cmd, overwrite: true })
 
 const read = async ({ root }, { path: filePath }) => {
   const fullPath = path.join(root, filePath)
-  const content = await readFile(fullPath, `utf8`)
+  const content = await fs.readFile(fullPath, `utf8`)
 
   return { content }
 }
 
 const destroy = async ({ root }, { path: filePath }) => {
   const fullPath = path.join(root, filePath)
-  await destroyFile(fullPath)
+  await fs.unlink(fullPath)
 }
 
 module.exports.exists = fileExists

--- a/packages/gatsby/src/recipes/providers/fs/file.test.js
+++ b/packages/gatsby/src/recipes/providers/fs/file.test.js
@@ -1,0 +1,48 @@
+const file = require(`./file`)
+
+const root = __dirname
+const content = `Hello, world!`
+
+test(`create writes a file, but does not overwrite by default`, async () => {
+  const filePath = `bar.txt`
+
+  await file.create({ root }, { path: filePath, content })
+  await file.create({ root }, { path: filePath, content: `new content!` })
+
+  const result = await file.read({ root }, { path: filePath })
+
+  expect(result.content).toEqual(content)
+
+  await file.destroy({ root }, { path: filePath })
+})
+
+test(`create overwrites a file when overwrite=true`, async () => {
+  const filePath = `bar.txt`
+  const newContent = `new content!`
+
+  await file.create({ root }, { path: filePath, content })
+  await file.create(
+    { root },
+    { path: filePath, content: newContent, overwrite: true }
+  )
+
+  const result = await file.read({ root }, { path: filePath })
+
+  expect(result.content).toEqual(newContent)
+
+  await file.destroy({ root }, { path: filePath })
+})
+
+test(`update overwrites a file`, async () => {
+  const filePath = `bar.txt`
+  const newContent = `new content!`
+
+  await file.create({ root }, { path: filePath, content })
+  await file.update({ root }, { path: filePath, content: newContent })
+
+  const result = await file.read({ root }, { path: filePath })
+
+  expect(result.content).toEqual(newContent)
+
+  await file.destroy({ root }, { path: filePath })
+})

--- a/packages/gatsby/src/recipes/providers/fs/file.test.js
+++ b/packages/gatsby/src/recipes/providers/fs/file.test.js
@@ -3,32 +3,14 @@ const file = require(`./file`)
 const root = __dirname
 const content = `Hello, world!`
 
-test(`create writes a file, but does not overwrite by default`, async () => {
+test(`create writes a file`, async () => {
   const filePath = `bar.txt`
 
   await file.create({ root }, { path: filePath, content })
-  await file.create({ root }, { path: filePath, content: `new content!` })
 
   const result = await file.read({ root }, { path: filePath })
 
   expect(result.content).toEqual(content)
-
-  await file.destroy({ root }, { path: filePath })
-})
-
-test(`create overwrites a file when overwrite=true`, async () => {
-  const filePath = `bar.txt`
-  const newContent = `new content!`
-
-  await file.create({ root }, { path: filePath, content })
-  await file.create(
-    { root },
-    { path: filePath, content: newContent, overwrite: true }
-  )
-
-  const result = await file.read({ root }, { path: filePath })
-
-  expect(result.content).toEqual(newContent)
 
   await file.destroy({ root }, { path: filePath })
 })

--- a/packages/gatsby/src/recipes/providers/gatsby/fixtures/gatsby-config.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/fixtures/gatsby-config.js
@@ -1,5 +1,4 @@
 const redish = `#c5484d`
-
 module.exports = {
   siteMetadata: {
     title: `Bricolage`,
@@ -63,8 +62,7 @@ module.exports = {
         display: `minimal-ui`,
       },
     },
-    `gatsby-plugin-offline`,
-    // `gatsby-plugin-preact`,
+    `gatsby-plugin-offline`, // `gatsby-plugin-preact`,
     `gatsby-plugin-react-helmet`,
   ],
 }

--- a/packages/gatsby/src/recipes/providers/gatsby/plugin.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/plugin.js
@@ -19,24 +19,28 @@ const isDefaultExport = node => {
 }
 
 const getValueFromLiteral = node => {
-  if (node.type === 'StringLiteral') {
+  if (node.type === `StringLiteral`) {
     return node.value
   }
 
-  if (node.type === 'TemplateLiteral') {
+  if (node.type === `TemplateLiteral`) {
     return node.quasis[0].value.raw
   }
+
+  return null
 }
 
 const getNameForPlugin = node => {
-  if (node.type === 'StringLiteral' || node.type === 'TemplateLiteral') {
+  if (node.type === `StringLiteral` || node.type === `TemplateLiteral`) {
     return getValueFromLiteral(node)
   }
 
-  if (node.type === 'ObjectExpression') {
-    const resolve = node.properties.find(p => p.key.name  === 'resolve')
+  if (node.type === `ObjectExpression`) {
+    const resolve = node.properties.find(p => p.key.name === `resolve`)
     return resolve ? getValueFromLiteral(resolve.value) : null
   }
+
+  return null
 }
 
 const addPluginToConfig = (src, pluginName) => {

--- a/packages/gatsby/src/recipes/providers/gatsby/plugin.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/plugin.js
@@ -1,4 +1,4 @@
-const fs = require(`fs`)
+const fs = require(`fs-extra`)
 const path = require(`path`)
 const babel = require(`@babel/core`)
 
@@ -66,25 +66,25 @@ const getPluginsFromConfig = src => {
   return getPlugins.state
 }
 
-const create = ({ root }, { name }) => {
+const create = async ({ root }, { name }) => {
   const configPath = path.join(root, `gatsby-config.js`)
-  const configSrc = fs.readFileSync(configPath)
+  const configSrc = await fs.readFile(configPath, `utf8`)
 
   const code = addPluginToConfig(configSrc, name)
 
-  fs.writeFileSync(configPath, code)
+  await fs.writeFile(configPath, code)
 }
 
-const read = ({ root }) => {
+const read = async ({ root }) => {
   const configPath = path.join(root, `gatsby-config.js`)
-  const configSrc = fs.readFileSync(configPath)
+  const configSrc = await fs.readFile(configPath, `utf8`)
 
   return getPluginsFromConfig(configSrc)
 }
 
-const destroy = ({ root }, { name }) => {
+const destroy = async ({ root }, { name }) => {
   const configPath = path.join(root, `gatsby-config.js`)
-  const configSrc = fs.readFileSync(configPath)
+  const configSrc = await fs.readFile(configPath, `utf8`)
 
   const addPlugins = new BabelPluginAddPluginsToGatsbyConfig({
     pluginOrThemeName: name,
@@ -95,7 +95,7 @@ const destroy = ({ root }, { name }) => {
     plugins: [addPlugins.plugin],
   })
 
-  fs.writeFileSync(configPath, code)
+  await fs.writeFile(configPath, code)
 }
 
 class BabelPluginAddPluginsToGatsbyConfig {
@@ -124,7 +124,7 @@ class BabelPluginAddPluginsToGatsbyConfig {
               }
             } else {
               plugins.value.elements = plugins.value.elements.filter(
-                node => node.value !== pluginOrThemeName
+                node => getNameForPlugin(node) !== pluginOrThemeName
               )
             }
 

--- a/packages/gatsby/src/recipes/providers/gatsby/plugin.test.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/plugin.test.js
@@ -1,14 +1,33 @@
 const fs = require(`fs`)
 const path = require(`path`)
 
-const { addPluginToConfig } = require(`./plugin`)
+const { addPluginToConfig, getPluginsFromConfig } = require(`./plugin`)
 
 const CONFIG_PATH = path.join(__dirname, `./fixtures/gatsby-config.js`)
 
-test(`babel plugin to get list of plugins and their options!`, () => {
+test(`adds a plugin to a gatsby config`, () => {
   const src = fs.readFileSync(CONFIG_PATH, `utf8`)
 
   const result = addPluginToConfig(src, `gatsby-plugin-foo`)
 
-  expect(result).toMatch(`gatsby-plugin-foo`)
+  expect(getPluginsFromConfig(result)).toContain(`gatsby-plugin-foo`)
+})
+
+test(`retrieves plugins from a config`, () => {
+  const src = fs.readFileSync(CONFIG_PATH, `utf8`)
+
+  const result = getPluginsFromConfig(src)
+
+  expect(result).toEqual([
+    "gatsby-source-filesystem",
+    "gatsby-transformer-sharp",
+    "gatsby-plugin-emotion",
+    "gatsby-plugin-typography",
+    "gatsby-transformer-remark",
+    "gatsby-plugin-sharp",
+    "gatsby-plugin-google-analytics",
+    "gatsby-plugin-manifest",
+    "gatsby-plugin-offline",
+    "gatsby-plugin-react-helmet"
+  ])
 })

--- a/packages/gatsby/src/recipes/providers/gatsby/plugin.test.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/plugin.test.js
@@ -19,15 +19,15 @@ test(`retrieves plugins from a config`, () => {
   const result = getPluginsFromConfig(src)
 
   expect(result).toEqual([
-    "gatsby-source-filesystem",
-    "gatsby-transformer-sharp",
-    "gatsby-plugin-emotion",
-    "gatsby-plugin-typography",
-    "gatsby-transformer-remark",
-    "gatsby-plugin-sharp",
-    "gatsby-plugin-google-analytics",
-    "gatsby-plugin-manifest",
-    "gatsby-plugin-offline",
-    "gatsby-plugin-react-helmet"
+    `gatsby-source-filesystem`,
+    `gatsby-transformer-sharp`,
+    `gatsby-plugin-emotion`,
+    `gatsby-plugin-typography`,
+    `gatsby-transformer-remark`,
+    `gatsby-plugin-sharp`,
+    `gatsby-plugin-google-analytics`,
+    `gatsby-plugin-manifest`,
+    `gatsby-plugin-offline`,
+    `gatsby-plugin-react-helmet`,
   ])
 })

--- a/packages/gatsby/src/recipes/providers/gatsby/plugin.test.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/plugin.test.js
@@ -1,33 +1,35 @@
-const fs = require(`fs`)
 const path = require(`path`)
 
-const { addPluginToConfig, getPluginsFromConfig } = require(`./plugin`)
+const plugin = require(`./plugin`)
 
-const CONFIG_PATH = path.join(__dirname, `./fixtures/gatsby-config.js`)
+const root = path.join(__dirname, `./fixtures`)
+const name = `gatsby-plugin-foo`
 
-test(`adds a plugin to a gatsby config`, () => {
-  const src = fs.readFileSync(CONFIG_PATH, `utf8`)
+describe(`gatsby-config`, () => {
+  test(`adds a plugin to a gatsby config`, async () => {
+    await plugin.create({ root }, { name })
 
-  const result = addPluginToConfig(src, `gatsby-plugin-foo`)
+    const result = await plugin.read({ root })
 
-  expect(getPluginsFromConfig(result)).toContain(`gatsby-plugin-foo`)
-})
+    expect(result).toContain(`gatsby-plugin-foo`)
 
-test(`retrieves plugins from a config`, () => {
-  const src = fs.readFileSync(CONFIG_PATH, `utf8`)
+    await plugin.destroy({ root }, { name })
+  })
 
-  const result = getPluginsFromConfig(src)
+  test(`retrieves plugins from a config`, async () => {
+    const result = await plugin.read({ root })
 
-  expect(result).toEqual([
-    `gatsby-source-filesystem`,
-    `gatsby-transformer-sharp`,
-    `gatsby-plugin-emotion`,
-    `gatsby-plugin-typography`,
-    `gatsby-transformer-remark`,
-    `gatsby-plugin-sharp`,
-    `gatsby-plugin-google-analytics`,
-    `gatsby-plugin-manifest`,
-    `gatsby-plugin-offline`,
-    `gatsby-plugin-react-helmet`,
-  ])
+    expect(result).toEqual([
+      `gatsby-source-filesystem`,
+      `gatsby-transformer-sharp`,
+      `gatsby-plugin-emotion`,
+      `gatsby-plugin-typography`,
+      `gatsby-transformer-remark`,
+      `gatsby-plugin-sharp`,
+      `gatsby-plugin-google-analytics`,
+      `gatsby-plugin-manifest`,
+      `gatsby-plugin-offline`,
+      `gatsby-plugin-react-helmet`,
+    ])
+  })
 })

--- a/packages/gatsby/src/recipes/providers/gatsby/shadow-file.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/shadow-file.js
@@ -26,7 +26,7 @@ const create = async ({ root }, { theme, path: filePath }) => {
   const fullPath = path.join(root, filePath)
   const { dir } = path.parse(fullPath)
 
-  if (fileExists(fullPath)) {
+  if (fileExists({ root }, { path: filePath })) {
     return
   }
 

--- a/packages/gatsby/src/recipes/providers/gatsby/shadow-file.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/shadow-file.js
@@ -1,11 +1,16 @@
 const path = require(`path`)
-const fs = require(`fs`)
-const { promisify } = require(`util`)
+const fs = require(`fs-extra`)
 const mkdirp = require(`mkdirp`)
 
-const readFile = promisify(fs.readFile)
-const writeFile = promisify(fs.writeFile)
-const destroyFile = promisify(fs.unlink)
+const fileExists = ({ root }, { path: filePath }) => {
+  const fullPath = path.join(root, filePath)
+  try {
+    fs.accessSync(fullPath, fs.constants.F_OK)
+    return true
+  } catch (e) {
+    return false
+  }
+}
 
 const create = async ({ root }, { theme, path: filePath }) => {
   const relativePathInTheme = filePath.replace(theme + `/`, ``)
@@ -16,13 +21,17 @@ const create = async ({ root }, { theme, path: filePath }) => {
     relativePathInTheme
   )
 
-  const contents = await readFile(fullFilePathToShadow, `utf8`)
+  const contents = await fs.readFile(fullFilePathToShadow, `utf8`)
 
   const fullPath = path.join(root, filePath)
   const { dir } = path.parse(fullPath)
 
+  if (fileExists(fullPath)) {
+    return
+  }
+
   await mkdirp(dir)
-  await writeFile(fullPath, contents)
+  await fs.writeFile(fullPath, contents)
 }
 
 const read = async ({ root }, { theme, path: filePath }) => {
@@ -34,13 +43,13 @@ const read = async ({ root }, { theme, path: filePath }) => {
     relativePathInTheme
   )
 
-  const contents = await readFile(fullFilePathToShadow, `utf8`)
+  const contents = await fs.readFile(fullFilePathToShadow, `utf8`)
   return contents
 }
 
-const destroy = async ({ root }, { theme, path: filePath }) => {
+const destroy = async ({ root }, { path: filePath }) => {
   const fullPath = path.join(root, filePath)
-  await destroyFile(fullPath)
+  await fs.unlink(fullPath)
 }
 
 module.exports.create = create

--- a/packages/gatsby/src/recipes/providers/gatsby/shadow-file.js
+++ b/packages/gatsby/src/recipes/providers/gatsby/shadow-file.js
@@ -2,16 +2,6 @@ const path = require(`path`)
 const fs = require(`fs-extra`)
 const mkdirp = require(`mkdirp`)
 
-const fileExists = ({ root }, { path: filePath }) => {
-  const fullPath = path.join(root, filePath)
-  try {
-    fs.accessSync(fullPath, fs.constants.F_OK)
-    return true
-  } catch (e) {
-    return false
-  }
-}
-
 const create = async ({ root }, { theme, path: filePath }) => {
   const relativePathInTheme = filePath.replace(theme + `/`, ``)
   const fullFilePathToShadow = path.join(
@@ -25,10 +15,6 @@ const create = async ({ root }, { theme, path: filePath }) => {
 
   const fullPath = path.join(root, filePath)
   const { dir } = path.parse(fullPath)
-
-  if (fileExists({ root }, { path: filePath })) {
-    return
-  }
 
   await mkdirp(dir)
   await fs.writeFile(fullPath, contents)

--- a/packages/gatsby/src/recipes/todo.md
+++ b/packages/gatsby/src/recipes/todo.md
@@ -24,9 +24,9 @@
 - [ ] Select input supported recipes
 - [ ] Make port selection dynamic
 - [ ] Move parsing to the server
-- [ ] Use `fs-extra`
+- [x] Use `fs-extra`
 - [x] Don't overwrite files by default
-- [ ] Don't shadow existing files (overwrite)
+- [x] Don't shadow existing files (overwrite)
 - [x] Handle object style plugins
 - [x] Improve gatsby-config test
 

--- a/packages/gatsby/src/recipes/todo.md
+++ b/packages/gatsby/src/recipes/todo.md
@@ -23,10 +23,7 @@
 - [ ] Step by step design
 - [ ] Select input supported recipes
 - [ ] Make port selection dynamic
-- [ ] Move parsing to the server
 - [x] Use `fs-extra`
-- [x] Don't overwrite files by default
-- [x] Don't shadow existing files (overwrite)
 - [x] Handle object style plugins
 - [x] Improve gatsby-config test
 - [ ] use yarn/npm based on the user config
@@ -34,3 +31,4 @@
 ## Near-ish future
 
 - [ ] Make a proper "Config" provider to add recipes dir, store data, etc.
+- [ ] Move parsing to the server

--- a/packages/gatsby/src/recipes/todo.md
+++ b/packages/gatsby/src/recipes/todo.md
@@ -23,8 +23,13 @@
 - [ ] Step by step design
 - [ ] Select input supported recipes
 - [ ] Make port selection dynamic
+- [ ] Move parsing to the server
+- [ ] Use `fs-extra`
+- [x] Don't overwrite files by default
+- [ ] Don't shadow existing files (overwrite)
+- [x] Handle object style plugins
+- [x] Improve gatsby-config test
 
 ## Near-ish future
 
 - [ ] Make a proper "Config" provider to add recipes dir, store data, etc.
-- [ ] Client sends the MDX file to the server (maybe?)


### PR DESCRIPTION
Begins to address some feedback by not overwriting files by default, handling object style plugins in the config, using `fs-extra` and adding more thorough tests.