### PR TITLE
fix(gatsby-link): drop custom innerRef typing and reuse one from @reach/router

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -6,7 +6,6 @@ export interface GatsbyLinkProps<TState> extends LinkProps<TState> {
   activeClassName?: string
   /** Inline styles for when this Link is active */
   activeStyle?: object
-  innerRef?: Function
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
   /** Class the link as highlighted if there is a partial match via a the `to` being prefixed to the current url */
   partiallyActive?: boolean

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.8.7",
-    "@types/reach__router": "^1.3.0",
+    "@types/reach__router": "^1.3.3",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4061,10 +4061,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/reach__router@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.0.tgz#4c05a947ccecca05c72bb335a0f7bb43fec12446"
-  integrity sha512-0aL79bFPJzJOJOOMZm2301ErQVaveBdpW88uuavXymUlcYIAOCmI1ujJ2XLH6Mzn76O94eQCHIl1FDzNNKJCYA==
+"@types/reach__router@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.3.tgz#cec4095219dce6eca2daf22399bb3b6bc28c1baf"
+  integrity sha512-HTHMGJLdH3czgPP1nHF82y+TYLV1KSh1qYeezqHNDNuESBy55ij1LCn8jDYFeKCuAxm0gd9J25zyYy7mhOcgOw==
   dependencies:
     "@types/history" "*"
     "@types/react" "*"


### PR DESCRIPTION
## Description

Recent PR to `@types/reach__router` added `innerRef` typing ( https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43367 ):

```ts
innerRef?: React.RefCallback<HTMLAnchorElement>;
```

which is incompatible with `innerRef` that we have:

```ts
innerRef?: Function
```

and this is causing following error (we extend `@reach/router`'s `Link` props):

```
node_modules/gatsby-link/index.d.ts:4:18 - error TS2430: Interface 'GatsbyLinkProps<TState>' incorrectly extends interface 'LinkProps<TState>'.
  Types of property 'innerRef' are incompatible.
    Type 'Function | undefined' is not assignable to type '((instance: HTMLAnchorElement | null) => void) | RefObject<HTMLAnchorElement> | null | undefined'.
      Type 'Function' is not assignable to type '((instance: HTMLAnchorElement | null) => void) | RefObject<HTMLAnchorElement> | null | undefined'.
        Property 'current' is missing in type 'Function' but required in type 'RefObject<HTMLAnchorElement>'.

4 export interface GatsbyLinkProps<TState> extends LinkProps<TState> {
                   ~~~~~~~~~~~~~~~

  node_modules/@types/react/index.d.ts:86:18
    86         readonly current: T | null;
                        ~~~~~~~
    'current' is declared here.


Found 1 error.
```

## Related Issues

Closes https://github.com/gatsbyjs/gatsby/issues/22754
Closes https://github.com/gatsbyjs/gatsby/issues/22706