### PR TITLE
fix(docs): add correct email

### DIFF
--- a/docs/contributing/where-to-participate.md
+++ b/docs/contributing/where-to-participate.md
@@ -4,7 +4,7 @@ title: Where to Participate in the Community
 
 We want contributing to Gatsby to be fun, enjoyable, and educational for anyone and everyone. If you're interested in participating in the Gatsby.js community, contributions go far beyond pull requests and commits. We are thrilled to receive a variety of other contributions including the following:
 
-- Blogging, speaking about, or creating tutorials about one of Gatsby's many features. Mention [@gatsbyjs on Twitter](https://twitter.com/gatsbyjs) and/or email marcy [at] gatsbyjs [dot] com so we can give pointers and tips (if you want them 😄) and help you spread the word. Please add your blog posts and videos of talks to our [Awesome Gatsby](/docs/awesome-gatsby-resources/) page.
+- Blogging, speaking about, or creating tutorials about one of Gatsby's many features. Mention [@gatsbyjs on Twitter](https://twitter.com/gatsbyjs) and/or email marcy@gatsbyjs.com so we can give pointers and tips (if you want them 😄) and help you spread the word. Please add your blog posts and videos of talks to our [Awesome Gatsby](/docs/awesome-gatsby-resources/) page.
 - Presenting at meetups and conferences about your Gatsby projects. Your unique challenges and successes in building things with Gatsby can provide great speaking material. We'd love to review your talk abstract/CFP, so get in touch with us if you'd like some help!
 - [Submitting new feature ideas through an RFC](/blog/2018-04-06-introducing-gatsby-rfc-process/)
 - Submitting new documentation; titles in the side navigation on [docs](/docs) which are lighter in color on gatsbyjs.org are stubs and need contributions


### PR DESCRIPTION
## Description

In this PR, I've fixed the email syntax issue or typo under where-to-participate page.
Replaced marcy [at] gatsbyjs [dot] with marcy@gatsbyjs.com
https://www.gatsbyjs.org/contributing/where-to-participate/

@gatsbyjs/learning Kindly review it & approve :)
Thanks !
