### PR TITLE
ci: add mdx benchmark to cronjob, adjust content source in remark benchmarks to differentiate mdx and remark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,6 +571,50 @@ jobs:
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 
+  benchmark_mdx_512:
+    docker:
+      - image: "circleci/node:12"
+    steps:
+      - run-benchmark:
+          working_directory: benchmarks/mdx
+          NUM_PAGES: "512"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/mdx
+          BENCHMARK_SITE_TYPE: BLOG
+
+  benchmark_mdx_4096:
+    docker:
+      - image: "circleci/node:12"
+    steps:
+      - run-benchmark:
+          working_directory: benchmarks/mdx
+          NUM_PAGES: "4096"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/mdx
+          BENCHMARK_SITE_TYPE: BLOG
+
+  benchmark_mdx_8192:
+    docker:
+      - image: "circleci/node:12"
+    steps:
+      - run-benchmark:
+          working_directory: benchmarks/mdx
+          NUM_PAGES: "8192"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/mdx
+          BENCHMARK_SITE_TYPE: BLOG
+
+  benchmark_mdx_32768:
+    docker:
+      - image: "circleci/node:12"
+    steps:
+      - run-benchmark:
+          working_directory: benchmarks/mdx
+          NUM_PAGES: "32768"
+          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/mdx
+          BENCHMARK_SITE_TYPE: BLOG
+
 workflows:
   version: 2
 
@@ -588,6 +632,10 @@ workflows:
       - benchmark_markdown_table_4096
       - benchmark_markdown_table_8192
       - benchmark_markdown_table_32768
+      - benchmark_mdx_512
+      - benchmark_mdx_4096
+      - benchmark_mdx_8192
+      - benchmark_mdx_32768
     triggers:
       - schedule:
           cron: 22 16 * * *

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,7 +446,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_id
           NUM_PAGES: "512"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_id
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -457,7 +457,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_id
           NUM_PAGES: "4096"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_id
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -468,7 +468,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_id
           NUM_PAGES: "8192"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_id
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -479,7 +479,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_id
           NUM_PAGES: "32768"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_id
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -490,7 +490,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_slug
           NUM_PAGES: "512"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_slug
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -501,7 +501,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_slug
           NUM_PAGES: "4096"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_slug
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -512,7 +512,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_slug
           NUM_PAGES: "8192"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_slug
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -523,7 +523,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_slug
           NUM_PAGES: "32768"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_slug
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -534,7 +534,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_table
           NUM_PAGES: "512"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -545,7 +545,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_table
           NUM_PAGES: "4096"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -556,7 +556,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_table
           NUM_PAGES: "8192"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 
@@ -567,7 +567,7 @@ jobs:
       - run-benchmark:
           working_directory: benchmarks/markdown_table/benchmarks/markdown_table
           NUM_PAGES: "32768"
-          BENCHMARK_CONTENT_SOURCE: MDX
+          BENCHMARK_CONTENT_SOURCE: MARKDOWN
           BENCHMARK_REPO_NAME: gatsbyjs/gatsby/benchmarks/markdown_table
           BENCHMARK_SITE_TYPE: BLOG
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,7 +10,7 @@ The standard interface for running a benchmark is:
 cd {benchmark directory}
 export NUM_PAGES={n}
 npm install
-gatsby build
+npm run build / gatsby build
 ```
 
 If a specific benchmark needs to perform some code generation (e.g. `markdown_id`),

--- a/benchmarks/mdx/README.md
+++ b/benchmarks/mdx/README.md
@@ -1,25 +1,13 @@
 # MDX Benchmark
 
-This Gatsby site generates MDX files and downloads sample images on postinstall and places them in `src/articles`. In order for that to work, the env var `BENCHMARK_LEVEL` needs to be set to a number when you call `yarn` to install, so:
+Benchmark for MDX pages.
+Mock data is generated during the dependency installation step.
+The number of pages generated is read from `NUM_PAGES=` (defaults to `512`).
 
 ```
-BENCHMARK_LEVEL=1 yarn
-
-gatsby build
+$ export NUM_PAGES=1024
+$ yarn install    # or npm install
+$ gatsby build    # or npm run build
 ```
-
-If you see "Error: Expected an integer but received: " then you did not set the level env var.
 
 This will not use an external source for data while building, but will download some remote images while installing.
-
-# Levels
-
-The `BENCHMARK_LEVEL` is the amount of times to multiply 512 by 2. The level is used to determine how many articles to generate.
-
-Level 1 = 512
-
-Level 2 = 1024
-
-Level 3 = 2048
-
-etc.

--- a/benchmarks/mdx/package.json
+++ b/benchmarks/mdx/package.json
@@ -9,7 +9,7 @@
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
-    "postinstall": "npx willit --type=\"mdx\" --level=${BENCHMARK_LEVEL}",
+    "postinstall": "del-cli src/articles && gatsby clean && willit --type=mdx --num-pages=${NUM_PAGES:-512}",
     "start": "npm run develop",
     "serve": "gatsby serve"
   },
@@ -17,6 +17,7 @@
     "sharp": "0.25.1"
   },
   "dependencies": {
+    "del-cli": "^3.0.0",
     "@mdx-js/mdx": "^1.5.7",
     "@mdx-js/react": "^1.5.7",
     "dotenv": "^8.2.0",
@@ -34,11 +35,12 @@
   "devDependencies": {
     "cross-env": "^7.0.0",
     "gatsby-plugin-benchmark-reporting": "*",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "willit": "^0.0.3"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/benchmark/mdx"
+    "url": "https://github.com/gatsbyjs/gatsby/tree/master/benchmarks/mdx"
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"


### PR DESCRIPTION
## Description

Update MDX benchmarks to match "normal" benchmark interface.
Add jobs to CirlceCI.