### PR TITLE
chore(monorepo): bump decompress in yarn.lock 

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8310,8 +8310,9 @@ decompress-unzip@^4.0.1:
     yauzl "^2.4.2"
 
 decompress@^4.0.0, decompress@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.1.tgz#007f55cc6a62c055afa37c07eb6a4ee1b773f118"
+  integrity sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==
   dependencies:
     decompress-tar "^4.0.0"
     decompress-tarbz2 "^4.0.0"


### PR DESCRIPTION
## Description

Update `decompress` to fix a vulnerability that causes warnings in audits.

### Documentation

[Quoted from npm](https://www.npmjs.com/advisories/1217):

> ### Overview
> Versions of `decompress` prior to 4.2.1 are vulnerable to Arbitrary File Write. The package fails to prevent extraction of files with relative paths, allowing attackers to write to any folder in the system by including filenames containing `../`.
> ### Remediation
> Upgrade to version 4.2.1 or later.

## Related Issues

Fixes #21791
