### PR TITLE
gatsby-source-graphql: Add babel typescript plugin and specify ts extension in build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -23,3 +23,4 @@ packages/*/*.js
 packages/gatsby-plugin-preload-fonts/prepare/*.js
 packages/gatsby-image/withIEPolyfill/index.js
 packages/gatsby/cache-dir/commonjs/**/*
+packages/gatsby-source-graphql/batching/*.js

--- a/packages/gatsby-source-graphql/.babelrc
+++ b/packages/gatsby-source-graphql/.babelrc
@@ -1,5 +1,11 @@
 {
   "presets": [
     ["babel-preset-gatsby-package"]
+  ],
+  "overrides": [
+    {
+      "test": ["**/*.ts"],
+      "plugins": [["@babel/plugin-transform-typescript"]]
+    }
   ]
 }

--- a/packages/gatsby-source-graphql/.gitignore
+++ b/packages/gatsby-source-graphql/.gitignore
@@ -1,3 +1,3 @@
 /*.js
-/batching/*.js
+/batching/**/*.js
 yarn.lock

--- a/packages/gatsby-source-graphql/.npmignore
+++ b/packages/gatsby-source-graphql/.npmignore
@@ -32,3 +32,4 @@ flow-typed
 coverage
 decls
 examples
+__tests__

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -39,9 +39,9 @@
     "directory": "packages/gatsby-source-graphql"
   },
   "scripts": {
-    "build": "babel src --out-dir . --ignore **/__tests__ --extensions \".ts,.js\"",
+    "build": "babel src --out-dir . --ignore /**/__tests__ --extensions \".ts,.js\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore **/__tests__ --extensions \".ts,.js\""
+    "watch": "babel -w src --out-dir . --ignore /**/__tests__ --extensions \".ts,.js\""
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.7",
+    "@babel/plugin-transform-typescript": "^7.9.4",
     "babel-preset-gatsby-package": "^0.3.1",
     "cross-env": "^5.2.1"
   },
@@ -38,9 +39,9 @@
     "directory": "packages/gatsby-source-graphql"
   },
   "scripts": {
-    "build": "babel src --out-dir . --ignore **/__tests__",
+    "build": "babel src --out-dir . --ignore **/__tests__ --extensions \".ts,.js\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore **/__tests__"
+    "watch": "babel -w src --out-dir . --ignore **/__tests__ --extensions \".ts,.js\""
   },
   "engines": {
     "node": ">=10.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,6 +1580,15 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-typescript" "^7.8.3"
 
+"@babel/plugin-transform-typescript@^7.9.4":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.4.tgz#4bb4dde4f10bbf2d787fce9707fb09b483e33359"
+  integrity sha512-yeWeUkKx2auDbSxRe8MusAG+n4m9BFY/v+lPjmQDgOFX5qnySkUY5oXzkp6FwPdsYqnKay6lorXYdC0n3bZO7w==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-typescript" "^7.8.3"
+
 "@babel/plugin-transform-unicode-regex@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This adds the `.ts` extension to the `npm run build` command so that babel doesn't only transform `.js` files in the `src` directory.

This also adds the `@babel/plugin-transform-typescript` babel plugin in the .babelrc so that `.ts` files are parsed correctly by babel.

I ran `npm publish --dry-run` to make sure the out files from the batching/*.ts files ended up in the package.

```
npm publish --dry-run

> gatsby-source-graphql@2.3.1 prepare .
> cross-env NODE_ENV=production npm run build


> gatsby-source-graphql@2.3.1 build /Users/zolokar/projects/gatsby/packages/gatsby-source-graphql
> babel src --out-dir . --ignore **/__tests__ --extensions ".ts,.js"

Successfully compiled 11 files with Babel.
npm notice 
npm notice 📦  gatsby-source-graphql@2.3.1
npm notice === Tarball Contents === 
npm notice 178B   .babelrc                   
npm notice 2.7kB  batching/dataloader-link.js
npm notice 2.6kB  gatsby-node.js             
npm notice 13B    index.js                   
npm notice 10.7kB batching/merge-queries.js  
npm notice 1.0kB  transforms.js              
npm notice 1.4kB  package.json               
npm notice 16.1kB CHANGELOG.md               
npm notice 9.4kB  README.md                  
npm notice === Tarball Details === 
npm notice name:          gatsby-source-graphql                   
npm notice version:       2.3.1                                   
npm notice package size:  10.7 kB                                 
npm notice unpacked size: 44.1 kB                                 
npm notice shasum:        65d77890da6496a98a09a0300ee559afd550364c
npm notice integrity:     sha512-x3Ub+ztY+rGSt[...]i7RdX+lF5FuyA==
npm notice total files:   9                                       
npm notice 
+ gatsby-source-graphql@2.3.1
```

### Documentation

This shouldn't require a docs update.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes #22785
