### PR TITLE
docs: use PageQuery in gatsby image example snippet

### DIFF
--- a/docs/docs/using-gatsby-image.md
+++ b/docs/docs/using-gatsby-image.md
@@ -83,30 +83,31 @@ module.exports = {
 
 ```jsx:title=src/pages/my-dogs.js
 import React from "react"
-import { useStaticQuery, graphql } from "gatsby" // highlight-line
+import { graphql } from "gatsby" // highlight-line
 import Layout from "../components/layout"
 
-export default () => {
-  // highlight-start
-  const data = useStaticQuery(graphql`
-    query MyQuery {
-      file(relativePath: { eq: "images/corgi.jpg" }) {
-        childImageSharp {
-          # Specify the image processing specifications right in the query.
-          fluid {
-            ...GatsbyImageSharpFluid
-          }
-        }
-      }
-    }
-  `)
-  // highlight-end
+export default ({ data }) => {
   return (
     <Layout>
       <h1>I love my corgi!</h1>
     </Layout>
   )
 }
+
+// highlight-start
+export const query = graphql`
+  query MyQuery {
+    file(relativePath: { eq: "images/corgi.jpg" }) {
+      childImageSharp {
+        # Specify the image processing specifications right in the query.
+        fluid {
+          ...GatsbyImageSharpFluid
+        }
+      }
+    }
+  }
+`
+// highlight-end
 ```
 
 <EggheadEmbed
@@ -118,23 +119,11 @@ export default () => {
 
 ```jsx:title=src/pages/my-dogs.js
 import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
+import { graphql } from "gatsby"
 import Layout from "../components/layout"
 import Img from "gatsby-image" // highlight-line
 
-export default () => {
-  const data = useStaticQuery(graphql`
-    query MyQuery {
-      file(relativePath: { eq: "images/corgi.jpg" }) {
-        childImageSharp {
-          # Specify the image processing specifications right in the query.
-          fluid {
-            ...GatsbyImageSharpFluid
-          }
-        }
-      }
-    }
-  `)
+export default ({ data }) => {
   return (
     <Layout>
       <h1>I love my corgi!</h1>
@@ -147,6 +136,19 @@ export default () => {
     </Layout>
   )
 }
+
+export const query = graphql`
+  query MyQuery {
+    file(relativePath: { eq: "images/corgi.jpg" }) {
+      childImageSharp {
+        # Specify the image processing specifications right in the query.
+        fluid {
+          ...GatsbyImageSharpFluid
+        }
+      }
+    }
+  }
+`
 ```
 
 <EggheadEmbed


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This updates the example snippets on the /docs/using-gatsby-image
documentation page to use PageQueries instead of StaticQueries, because
the example snippets have a src/pages/index.js filename.

The hope is that since the snippet filenames are in the pages directory,
it's more consistent with other documentation to use PageQueries when
in a src/pages/*.js file instead of a StaticQuery, which from the
documentation appears to be used in places like src/components/*.js.

### Screenshots

![image](https://user-images.githubusercontent.com/2539016/78459229-6ae29080-766c-11ea-8d84-a0f77ec493aa.png)

![image](https://user-images.githubusercontent.com/2539016/78459239-7c2b9d00-766c-11ea-981f-1b14e709970a.png)



### Documentation

This documentation exists at https://www.gatsbyjs.org/docs/using-gatsby-image/
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->