### PR TITLE
chore(starters): add gatsby-starter-basic-bootstrap

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5834,3 +5834,13 @@
     - CSS-in-Reason support
     - StaticQuery GraphQL support in ReasonML
     - Similar to gatsby-starter-blog
+- url: https://mik3y.github.io/gatsby-starter-basic-bootstrap/
+  repo: https://github.com/mik3y/gatsby-starter-basic-bootstrap
+  description: A barebones starter featuring react-bootstrap and deliberately little else
+  tags:
+    - Styling:Bootstrap
+    - Styling:SCSS
+  features:
+    - Uses react-bootstrap, sass, and little else
+    - Skeleton starter, based on gatsby-starter-default
+    - Optional easy integration of themes from Bootswatch.com


### PR DESCRIPTION
## Description

Nothing earth-shattering here, simply a starter with  *just* react-bootstrap and sass
support. Many other existing starters bring a lot of additional bells and whistles.

Preview: https://mik3y.github.io/gatsby-starter-basic-bootstrap/

### Documentation

https://github.com/mik3y/gatsby-starter-basic-bootstrap#-quick-start
