### PR TITLE
fix(plugin-sitemap): missing data in query results

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
@@ -137,6 +137,16 @@ describe(`results using non default alternatives`, () => {
             },
           ],
         },
+        otherData: {
+          nodes: [
+            {
+              name: `test`,
+            },
+            {
+              name: `test 2`,
+            },
+          ],
+        },
       },
     }
   }
@@ -161,5 +171,6 @@ describe(`results using non default alternatives`, () => {
     const queryRecords = filterQuery(results, [], ``, customSiteResolver)
 
     expect(queryRecords.site.siteMetadata.siteUrl).toEqual(customUrl)
+    expect(queryRecords).toHaveProperty(`otherData`)
   })
 })

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -20,9 +20,7 @@ export function filterQuery(
     throw new Error(errors.join(`, `))
   }
 
-  // site shouldn't be included in "otherData but isn't needed either."
-  // eslint-disable-next-line no-unused-vars
-  const { allSitePage, site, ...otherData } = data
+  const { allSitePage, ...otherData } = data
 
   let { allPages, originalType } = getNodes(allSitePage)
 
@@ -57,6 +55,7 @@ export function filterQuery(
   siteUrl = withoutTrailingSlash(siteUrl)
 
   return {
+    ...otherData,
     allSitePage: {
       [originalType]:
         originalType === `nodes`
@@ -66,7 +65,6 @@ export function filterQuery(
             }),
     },
     site: { siteMetadata: { siteUrl } },
-    ...otherData,
   }
 }
 

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -14,14 +14,15 @@ export function filterQuery(
   pathPrefix,
   resolveSiteUrl = defaultOptions.resolveSiteUrl
 ) {
-  const {
-    errors,
-    data: { allSitePage, site, ...otherData },
-  } = results
+  const { errors, data } = results
 
   if (errors) {
     throw new Error(errors.join(`, `))
   }
+
+  // site shouldn't be included in "otherData but isn't needed either."
+  // eslint-disable-next-line no-unused-vars
+  const { allSitePage, site, ...otherData } = data
 
   let { allPages, originalType } = getNodes(allSitePage)
 
@@ -44,7 +45,7 @@ export function filterQuery(
 
   // siteUrl Validation
 
-  let siteUrl = resolveSiteUrl(site)
+  let siteUrl = resolveSiteUrl(data)
 
   if (!siteUrl || siteUrl.trim().length == 0) {
     throw new Error(
@@ -104,7 +105,7 @@ export const defaultOptions = {
       }
     })
   },
-  resolveSiteUrl: data => data.siteMetadata.siteUrl,
+  resolveSiteUrl: data => data.site.siteMetadata.siteUrl,
 }
 
 function getNodes(results) {

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -14,13 +14,16 @@ export function filterQuery(
   pathPrefix,
   resolveSiteUrl = defaultOptions.resolveSiteUrl
 ) {
-  const { errors, data } = results
+  const {
+    errors,
+    data: { allSitePage, site, ...otherData },
+  } = results
 
   if (errors) {
     throw new Error(errors.join(`, `))
   }
 
-  let { allPages, originalType } = getNodes(data.allSitePage)
+  let { allPages, originalType } = getNodes(allSitePage)
 
   // Removing excluded paths
   allPages = allPages.filter(
@@ -41,7 +44,7 @@ export function filterQuery(
 
   // siteUrl Validation
 
-  let siteUrl = resolveSiteUrl(data)
+  let siteUrl = resolveSiteUrl(site)
 
   if (!siteUrl || siteUrl.trim().length == 0) {
     throw new Error(
@@ -62,6 +65,7 @@ export function filterQuery(
             }),
     },
     site: { siteMetadata: { siteUrl } },
+    ...otherData,
   }
 }
 
@@ -100,7 +104,7 @@ export const defaultOptions = {
       }
     })
   },
-  resolveSiteUrl: data => data.site.siteMetadata.siteUrl,
+  resolveSiteUrl: data => data.siteMetadata.siteUrl,
 }
 
 function getNodes(results) {


### PR DESCRIPTION
# Description
#21948 broke custom data queries and only passed required data. This PR correctly filter's the required data and passes the other queried data 

## Related Issues
fixes #22703