### PR TITLE
fix(gatsby-source-graphql): Convert ts to plain js until better times

### DIFF
--- a/packages/gatsby-source-graphql/src/batching/__tests__/dataloader-link.js
+++ b/packages/gatsby-source-graphql/src/batching/__tests__/dataloader-link.js
@@ -1,14 +1,13 @@
-import { parse } from "graphql"
-import { execute } from "apollo-link"
-import { createDataloaderLink } from "../dataloader-link"
+const { parse } = require(`graphql`)
+const { execute } = require(`apollo-link`)
+const { createDataloaderLink } = require(`../dataloader-link`)
 
 const sampleQuery = parse(`{ foo }`)
 const expectedSampleQueryResult = { data: { foo: `bar` } }
 
-// eslint-disable-next-line @typescript-eslint/camelcase
 const fetchResult = { data: { gatsby0_foo: `bar` } }
 
-const makeFetch = (expectedResult: any = fetchResult): jest.Mock<any> =>
+const makeFetch = (expectedResult = fetchResult) =>
   jest.fn(() =>
     Promise.resolve({
       json: () => Promise.resolve(expectedResult),
@@ -23,7 +22,7 @@ describe(`createDataloaderLink`, () => {
     })
     const observable = execute(link, { query: sampleQuery })
     observable.subscribe({
-      next: (result: any) => {
+      next: result => {
         expect(result).toEqual(expectedSampleQueryResult)
         done()
       },

--- a/packages/gatsby-source-graphql/src/batching/__tests__/merge-queries.js
+++ b/packages/gatsby-source-graphql/src/batching/__tests__/merge-queries.js
@@ -1,5 +1,5 @@
-import { print, parse } from "graphql"
-import { IQuery, merge, resolveResult } from "../merge-queries"
+const { print, parse } = require(`graphql`)
+const { merge, resolveResult } = require(`../merge-queries`)
 
 describe(`Query merging`, () => {
   it(`merges simple queries`, () => {
@@ -213,7 +213,7 @@ describe(`Resolving merged query results`, () => {
   })
 
   it(`throws on unexpected results`, () => {
-    const shouldThrow = (): void => {
+    const shouldThrow = () => {
       resolveResult({
         data: {
           gatsby0_foo: `foo`,
@@ -225,10 +225,8 @@ describe(`Resolving merged query results`, () => {
   })
 })
 
-type QueryFixture = [string, object]
-
-function fromFixtures(fixtures: QueryFixture[]): IQuery[] {
-  return fixtures.map(([query, variables]: QueryFixture) => {
+function fromFixtures(fixtures) {
+  return fixtures.map(([query, variables]) => {
     return {
       query: parse(query),
       variables,


### PR DESCRIPTION
## Description

Convert files using Typescript back to vanilla JS in `gatsby-source-graphql`. The reason for this is that the decision has not been made yet if we want to convert plugins to Typescript (as this would make contributions harder).

So the usage of Typescript in `gatsby-source-graphql` was a bit premature as we don't have a common build configuration for Typescript in plugins.

## Related Issues

Fixes #22785