### PR TITLE
chore(gatsby): properly typed return types of replaceHydrateFunction

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Renderer } from "react-dom"
 import { EventEmitter } from "events"
 import { WindowLocation, NavigateFn } from "@reach/router"
 import { createContentDigest } from "gatsby-core-utils"
@@ -537,11 +538,7 @@ export interface GatsbyBrowser {
     args: ReplaceComponentRendererArgs,
     options: PluginOptions
   ): any
-  replaceHydrateFunction?(args: BrowserPluginArgs, options: PluginOptions): (
-    element: React.DOMElement<React.DOMAttributes<Element>, Element>,
-    container: Element,
-    callback: () => {}
-  ) => void
+  replaceHydrateFunction?(args: BrowserPluginArgs, options: PluginOptions): Renderer
   shouldUpdateScroll?(args: ShouldUpdateScrollArgs, options: PluginOptions): any
   wrapPageElement?(
     args: WrapPageElementBrowserArgs,

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -537,7 +537,11 @@ export interface GatsbyBrowser {
     args: ReplaceComponentRendererArgs,
     options: PluginOptions
   ): any
-  replaceHydrateFunction?(args: BrowserPluginArgs, options: PluginOptions): any
+  replaceHydrateFunction?(args: BrowserPluginArgs, options: PluginOptions): (
+    element: React.DOMElement<React.DOMAttributes<Element>, Element>,
+    container: Element,
+    callback: () => {}
+  ) => void
   shouldUpdateScroll?(args: ShouldUpdateScrollArgs, options: PluginOptions): any
   wrapPageElement?(
     args: WrapPageElementBrowserArgs,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR add extra type definition for `replaceHydrateFunction` function in Gatsby Browser API which will not cause return type of this function to call explicit `any` type error

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

This PR doe not require docs, it's type improvements

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
