### PR TITLE
refactor: migrate graphql-runner into TypeScript

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -537,7 +537,11 @@ export interface GatsbyBrowser {
     args: ReplaceComponentRendererArgs,
     options: PluginOptions
   ): any
-  replaceHydrateFunction?(args: BrowserPluginArgs, options: PluginOptions): any
+  replaceHydrateFunction?(args: BrowserPluginArgs, options: PluginOptions): (
+    element: React.DOMElement<React.DOMAttributes<Element>, Element>,
+    container: Element,
+    callback: () => {}
+  ) => void
   shouldUpdateScroll?(args: ShouldUpdateScrollArgs, options: PluginOptions): any
   wrapPageElement?(
     args: WrapPageElementBrowserArgs,

--- a/packages/gatsby/src/bootstrap/graphql-runner.ts
+++ b/packages/gatsby/src/bootstrap/graphql-runner.ts
@@ -1,14 +1,21 @@
-const stackTrace = require(`stack-trace`)
+import stackTrace from 'stack-trace'
+import { Store } from 'redux'
 
-const GraphQLRunner = require(`../query/graphql-runner`).default
-const errorParser = require(`../query/error-parser`).default
+import GraphQLRunner from '../query/graphql-runner'
+import errorParser from '../query/error-parser'
 
-const { emitter } = require(`../redux`)
+import { emitter } from '../redux'
+import { IGatsbyState } from '../redux/types'
+import { Reporter } from '../..'
 
-module.exports = (store, reporter) => {
+import { ExecutionResult, Source } from '../../graphql'
+import { ExecutionResultDataDefault } from 'graphql/execution/execute'
+
+const graphQLRunner = (store: Store<IGatsbyState>, reporter: Reporter): (query: string | Source, context: Record<string, any>) => Promise<ExecutionResult<ExecutionResultDataDefault>> => {
   // TODO: Move tracking of changed state inside GraphQLRunner itself. https://github.com/gatsbyjs/gatsby/issues/20941
   let runner = new GraphQLRunner(store)
-  ;[
+  
+  const eventTypes: string[] = [
     `DELETE_CACHE`,
     `CREATE_NODE`,
     `DELETE_NODE`,
@@ -17,11 +24,14 @@ module.exports = (store, reporter) => {
     `SET_SCHEMA`,
     `ADD_FIELD_TO_NODE`,
     `ADD_CHILD_NODE_TO_PARENT_NODE`,
-  ].forEach(eventType => {
-    emitter.on(eventType, event => {
+  ]
+  
+  eventTypes.forEach(type => {
+    emitter.on(type, () => {
       runner = new GraphQLRunner(store)
     })
   })
+
   return (query, context) =>
     runner.query(query, context).then(result => {
       if (result.errors) {
@@ -30,15 +40,15 @@ module.exports = (store, reporter) => {
             // Find the file where graphql was called.
             const file = stackTrace
               .parse(e)
-              .find(file => /createPages/.test(file.functionName))
+              .find(file => /createPages/.test(file.getFunctionName()))
 
             if (file) {
               const structuredError = errorParser({
                 message: e.message,
                 location: {
-                  start: { line: file.lineNumber, column: file.columnNumber },
+                  start: { line: file.getLineNumber(), column: file.getColumnNumber() },
                 },
-                filePath: file.fileName,
+                filePath: file.getFileName(),
               })
               structuredError.context = {
                 ...structuredError.context,
@@ -60,3 +70,5 @@ module.exports = (store, reporter) => {
       return result
     })
 }
+
+export default graphQLRunner

--- a/packages/gatsby/src/types.ts
+++ b/packages/gatsby/src/types.ts
@@ -2,7 +2,7 @@ export interface IMatch {
   id: string
   context: {
     sourceMessage: string
-    [key: string]: string
+    [key: string]: string | boolean
   }
   error?: Error | undefined
   [key: string]: unknown


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

There's some changes in `IMatch` type because it originally says that context key data type can be only string `[key: string]: string` but context in line 55 of `graphql-runner.ts`data is in `boolean` type.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
