### PR TITLE
maintenance (scripts/i18n) Create run-all i18n script

### DIFF
--- a/scripts/i18n/README.md
+++ b/scripts/i18n/README.md
@@ -70,3 +70,13 @@ When run, the script will:
 - Pulls the latest version of `gatsby-i18n-source`.
 - Creates a "sync" pull request that updates all files that do not contain conflicts from the merge.
 - Creates a "conflicts" pull request that contains all merge conflicts, with instructions on how to resolve them.
+
+### `run-all`
+
+Usage:
+
+```shell
+yarn run-all [script name]
+```
+
+The `run-all` script runs the script provided in the argument across all languages for which there are translations of gatbyjs.org, listed in /www/src/i18n.json.

--- a/scripts/i18n/package.json
+++ b/scripts/i18n/package.json
@@ -4,6 +4,7 @@
   "description": "Scripts for gatsby internationalization",
   "scripts": {
     "create": "node ./create.js",
+    "run-all": "node ./run-all.js",
     "sync": "node ./sync.js",
     "update-source": "node ./update-source.js"
   },

--- a/scripts/i18n/run-all.js
+++ b/scripts/i18n/run-all.js
@@ -1,10 +1,16 @@
 // Run the provided script on all valid repos
 const fs = require(`fs`)
+const log4js = require(`log4js`)
 const shell = require(`shelljs`)
+let logger = log4js.getLogger(`run-all`)
 
 require(`dotenv`).config()
 
 function runAll(script) {
+  if (!script) {
+    logger.error(`Please provide a script name`)
+    process.exit(1)
+  }
   const langs = JSON.parse(fs.readFileSync(`../../www/i18n.json`))
   for (const { code } of langs) {
     shell.exec(`yarn ${script} ${code}`)

--- a/scripts/i18n/run-all.js
+++ b/scripts/i18n/run-all.js
@@ -8,7 +8,7 @@ require(`dotenv`).config()
 
 function runAll(script) {
   if (!script) {
-    logger.error(`Please provide a script name`)
+    logger.error(`Usage: yarn run-all <script-name>`)
     process.exit(1)
   }
   const langs = JSON.parse(fs.readFileSync(`../../www/i18n.json`))

--- a/scripts/i18n/run-all.js
+++ b/scripts/i18n/run-all.js
@@ -1,0 +1,15 @@
+// Run the provided script on all valid repos
+const fs = require(`fs`)
+const shell = require(`shelljs`)
+
+require(`dotenv`).config()
+
+function runAll(script) {
+  const langs = JSON.parse(fs.readFileSync(`../../www/i18n.json`))
+  for (const { code } of langs) {
+    shell.exec(`yarn ${script} ${code}`)
+  }
+}
+
+const [script] = process.argv.slice(2)
+runAll(script)


### PR DESCRIPTION
Create a run-all script that runs a script using every language code as a param. This is needed so that we can run the `sync` script across all the different languages.

TODO:

* parallelization

Depends on: #22617 