### PR TITLE
fix(gatsby): improve async commons chunking

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -530,10 +530,13 @@ module.exports = async (
           reuseExistingChunk: true,
         },
         commons: {
+          // only bundle non-async modules
+          chunks: `initial`,
           name: `commons`,
-          // if a chunk is used on all components we put it in commons
-          minChunks: componentsCount,
+          // if a chunk is used on all components we put it in commons (we need at least 2 components)
+          minChunks: Math.max(componentsCount, 2),
           priority: 20,
+          reuseExistingChunk: true,
         },
         // If a chunk is used in at least 2 components we create a separate chunk
         shared: {


### PR DESCRIPTION
## Description

Improves commons chunking:
- only combine modules that are requested initially (no require.ensure or import() statements)
- Make sure to only create a commons chunk when we have 2 or more pages.

## Related Issues

Fixes #22749