### PR TITLE
docs: add revert info for gatsby-dev

### DIFF
--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -57,6 +57,18 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
 
   - Note: if you plan to modify packages that are exported from `gatsby` directly, you need to either add those manually to your test sites so that they are listed in `package.json` (e.g. `yarn add gatsby-link`), or specify them explicitly with `gatsby-dev --packages gatsby-link`).
 
+- To revert the cloned code by `gatsby-dev` you can remove the `node_modules` directory or run:
+
+```shell
+git checkout package.json; yarn --force
+```
+
+or
+
+```shell
+git checkout package.json; npm install --force
+```
+
 ### Add tests
 
 - Add tests and code for your changes.

--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -57,16 +57,10 @@ Yarn is a package manager for your code, similar to [NPM](https://www.npmjs.com/
 
   - Note: if you plan to modify packages that are exported from `gatsby` directly, you need to either add those manually to your test sites so that they are listed in `package.json` (e.g. `yarn add gatsby-link`), or specify them explicitly with `gatsby-dev --packages gatsby-link`).
 
-- To revert the cloned code by `gatsby-dev` you can remove the `node_modules` directory or run:
+- If you've recently run `gatsby-dev` your `node_modules` will be out of sync with current published packages. In order to undo this, you can remove the `node_modules` directory or run:
 
 ```shell
 git checkout package.json; yarn --force
-```
-
-or
-
-```shell
-git checkout package.json; npm install --force
 ```
 
 ### Add tests

--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -31,6 +31,20 @@ this program running.
 Typically you'll also want to run `npm run watch` in the Gatsby repo to set up
 watchers to build Gatsby source code.
 
+## revert cloned files
+
+To revert the cloned code by `gatsby-dev` you can remove the `node_modules` directory or run:
+
+```shell
+git checkout package.json; yarn --force
+```
+
+or
+
+```shell
+git checkout package.json; npm install --force
+```
+
 **[Demo Video](https://www.youtube.com/watch?v=D0SwX1MSuas)**
 
 More detailed instruction for setting up your Gatsby development environment can

--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -31,7 +31,7 @@ this program running.
 Typically you'll also want to run `npm run watch` in the Gatsby repo to set up
 watchers to build Gatsby source code.
 
-## revert cloned files
+## Revert to current packages
 
 If you've recently run `gatsby-dev` your `node_modules` will be out of sync with current published packages. In order to undo this, you can remove the `node_modules` directory or run:
 

--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -33,7 +33,7 @@ watchers to build Gatsby source code.
 
 ## revert cloned files
 
-To revert the cloned code by `gatsby-dev` you can remove the `node_modules` directory or run:
+If you've recently run `gatsby-dev` your `node_modules` will be out of sync with current published packages. In order to undo this, you can remove the `node_modules` directory or run:
 
 ```shell
 git checkout package.json; yarn --force


### PR DESCRIPTION
## Description

changes:

- added a "how to revert changes" from `gatsby-dev` (https://github.com/gatsbyjs/gatsby/issues/21027#issuecomment-585361320 and https://github.com/gatsbyjs/gatsby/issues/21027#issuecomment-609612670)


PS:
help on the right wording is welcome

## Related Issues

- fixes #21027 `gatsby-dev-cli: how to remove the installed plugins`