### PR TITLE
fix(gatsby-source-drupal): Verify nodes exist before looping through them

### DIFF
--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -149,8 +149,7 @@ const handleWebhookUpdate = async (
     // if we are inserting new node, we need to update all referenced nodes
     const newNodes = referencedNodesLookup.get(newNode)
     if (typeof newNodes !== `undefined`) {
-      const newNodeReferencedNodes = newNodes.map(id => getNode(id))
-      nodesToUpdate.push(...newNodeReferencedNodes)
+      newNodes.forEach(id => nodesToUpdate.push(getNode(id)))
     }
   }
 

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -147,10 +147,11 @@ const handleWebhookUpdate = async (
     nodesToUpdate.push(...addedReferencedNodes)
   } else {
     // if we are inserting new node, we need to update all referenced nodes
-    const newNodeReferencedNodes = referencedNodesLookup
-      .get(newNode)
-      .map(id => getNode(id))
-    nodesToUpdate.push(...newNodeReferencedNodes)
+    const newNodes = referencedNodesLookup.get(newNode)
+    if (typeof newNodes !== `undefined`) {
+      const newNodeReferencedNodes = newNodes.map(id => getNode(id))
+      nodesToUpdate.push(...newNodeReferencedNodes)
+    }
   }
 
   // download file


### PR DESCRIPTION
## Description

There are certain types of entities in Drupal that are sent to the preview server that can not be processed. This adds a check to verify the nodes exist before trying to loop through and process the updates.

## Related Issues

Fixes #22724
