### PR TITLE
fix(gatsby-plugin-mdx): pass on proper `modules` option value to babel

### DIFF
--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -150,7 +150,7 @@ ${code}`
           {
             useBuiltIns: `entry`,
             corejs: 2,
-            modules: `false`,
+            modules: false,
           },
         ],
       ],


### PR DESCRIPTION
The `modules` option for Babel must be a boolean, not a string.