### PR TITLE
fix(docs): Adding a Redux Store to TOC

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -448,6 +448,9 @@
             - title: Adding an RSS Feed
               link: /docs/adding-an-rss-feed/
               breadcrumbTitle: RSS Feed
+            - title: Adding a Redux Store
+              link: /docs/adding-redux-store/
+              breadcrumbTitle: Redux Store
             - title: Adding Page Transitions
               link: /docs/adding-page-transitions/
               breadcrumbTitle: Page Transitions


### PR DESCRIPTION
## Description

changes:

- add page to TOC

note:

- i am not sure if it is the right section in sidebar toc

## Related Issues

- #21688 `docs: gatsby-magic page - Reword redux section for actions emphasis` 
- #19267 `Add link checker for Gatsby Docs`