### PR TITLE
fix(blog): multilingual sites: fix intend to 2 spaces, split code blocks, add line

### DIFF
--- a/docs/blog/2020-02-19-how-to-build-multilingual-sites-with-gatsby/index.md
+++ b/docs/blog/2020-02-19-how-to-build-multilingual-sites-with-gatsby/index.md
@@ -115,21 +115,23 @@ If your website is not Google Maps, people most likely won't share their locatio
 
 As I mentioned already, the intranet app contains profile pages for all employees. They are generated dynamically because, well, the list of employees is also dynamic. This code piece that sits in `gatsby-node.js`'s `createPages` generates pages in the original implementation:
 
-```js
-query peoplePortalList {
-  allKontentItemPerson() {
-    nodes {
-      elements {
-        urlslug {
-          value
+```jsx
+graphql(`
+  query peoplePortalList {
+    allKontentItemPerson() {
+      nodes {
+        elements {
+          urlslug {
+            value
+          }
         }
       }
     }
   }
-}
-```
+`)
 
-```js
+// ...
+
 for (const person of nodes) {
   createPage({
     path: `employees/${person.elements.urlslug.value}`,

--- a/docs/blog/2020-02-19-how-to-build-multilingual-sites-with-gatsby/index.md
+++ b/docs/blog/2020-02-19-how-to-build-multilingual-sites-with-gatsby/index.md
@@ -65,14 +65,14 @@ Before we jump into code, it's essential to mention plugins. They greatly help w
 
 ```js:title=gatsby-config.js
 {
-     resolve: `gatsby-plugin-i18n`,
-     options: {
-         langKeyDefault: 'en',
-         langKeyForNull: 'en',
-         prefixDefault: false,
-         useLangKeyLayout: false,
-     },
- },
+  resolve: `gatsby-plugin-i18n`,
+  options: {
+    langKeyDefault: 'en',
+    langKeyForNull: 'en',
+    prefixDefault: false,
+    useLangKeyLayout: false,
+  },
+},
 ```
 
 This configuration (in `gatsby-config.js`) tells the plugin to use 'en' as the default language code (`langKeyDefault`, `langKeyForNull`) and no prefix (`prefixDefault`). The last option (`useLangKeyLayout`) specifies that the used layout is language invariant.
@@ -117,26 +117,28 @@ As I mentioned already, the intranet app contains profile pages for all employee
 
 ```js
 query peoplePortalList {
-    allKontentItemPerson() {
-         nodes {
-             elements {
-                 urlslug {
-                     value
-                 }
-             }
-         }
-     }
- }
- ...
- for (const person of nodes) {
-     createPage({
-         path: `employees/${person.elements.urlslug.value}`,
-         component: path.resolve(`./src/templates/person.js`),
-         context: {
-             slug: person.elements.urlslug.value,
-         },
-     });
- }
+  allKontentItemPerson() {
+    nodes {
+      elements {
+        urlslug {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+```js
+for (const person of nodes) {
+  createPage({
+    path: `employees/${person.elements.urlslug.value}`,
+    component: path.resolve(`./src/templates/person.js`),
+    context: {
+      slug: person.elements.urlslug.value,
+    },
+  })
+}
 ```
 
 We will need to adjust both the GraphQL query and the code that generates pages.
@@ -153,16 +155,16 @@ In my case, I am happy with language fallbacks for items that are not translated
 
 ```js
 query PeoplePortalList {
-    allKontentItemPerson() {
-        nodes {
-            elements {
-                urlslug {
-                    value
-                }
-            },
-            preferred_language
+  allKontentItemPerson() {
+    nodes {
+      elements {
+        urlslug {
+          value
         }
+      },
+      preferred_language
     }
+  }
 }
 ```
 
@@ -171,18 +173,20 @@ If you don't want to display items that fallback to parent language, just compar
 Let's define here a new variable `lang` that will hold the language code for the current item's `preferred_language`. I will use it in the `createPage` method call to place the newly generated page on the right URL.
 
 ```js
-let lang = `${person.preferred_language}/`
-if (person.preferred_language === "default") {
-  lang = "/"
+for (const person of nodes) {
+  let lang = `${person.preferred_language}/`
+  if (person.preferred_language === "default") {
+    lang = "/"
+  }
+  createPage({
+    path: `${lang}employees/${person.elements.urlslug.value}`,
+    component: path.resolve(`./src/templates/person.js`),
+    context: {
+      slug: person.elements.urlslug.value,
+      lang: person.preferred_language,
+    },
+  })
 }
-createPage({
-  path: `${lang}employees/${person.elements.urlslug.value}`,
-  component: path.resolve(`./src/templates/person.js`),
-  context: {
-    slug: person.elements.urlslug.value,
-    lang: person.preferred_language,
-  },
-})
 ```
 
 ### Generate Language-specific Static Pages
@@ -218,9 +222,9 @@ I always aim to keep things simple. In my case, the language travels through com
 
 ```js
 function Content({ classes, lang }) {
-    ...
-    <EmployeeList lang={lang} />
-    ...
+  ...
+  <EmployeeList lang={lang} />
+  ...
 }
 ```
 


### PR DESCRIPTION
## Description

changes:

- fix intend to 2 spaces
- split into 2 code blocks for better syntax highlights
- add code line from previous example (for loop), to show where variable `person` comes from

## Related Issues

- #22020 `fix(blog): Building multilingual sites with Gatsby`
- #21517 `(blog) Bulding multilingual sites with Gatsby`