### PR TITLE
fix(docs): add trainling slashes to doc-links.yaml 

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -479,7 +479,7 @@
                 - title: Building an E-commerce Site with Shopify
                   link: /docs/building-an-ecommerce-site-with-shopify/
                 - title: Adding a Shopping Cart with Snipcart
-                  link: /docs/adding-a-shopping-cart-with-snipcart
+                  link: /docs/adding-a-shopping-cart-with-snipcart/
                 - title: Processing Payments with Stripe
                   link: /docs/processing-payments-with-stripe/
                 - title: Processing Payments with Square


### PR DESCRIPTION
## Description

changes:
- unify all links and add trailing slash 

## related issues

- #22628 `chore(docs): Add Snipcart reference guide`