### PR TITLE
fix(docs): Add Snipcart reference guide: fix 404 link

### DIFF
--- a/docs/docs/adding-a-shopping-cart-with-snipcart.md
+++ b/docs/docs/adding-a-shopping-cart-with-snipcart.md
@@ -185,7 +185,7 @@ The following quote is from the Snipcart [payment gateway page](https://app.snip
 
 ## Other resources
 
-- [Build an E-commerce Site with Gatsby, DatoCMS, and Snipcart](/docs/tutorial/e-commerce-with-datocms-and-snipcart/) tutorial
+- [Build an E-commerce Site with Gatsby, DatoCMS, and Snipcart](/tutorial/e-commerce-with-datocms-and-snipcart/) tutorial
 - [`gatsby-plugin-snipcart`](/packages/gatsby-plugin-snipcart/)
 - [OneShopper Gatsby starter](/starters/rohitguptab/OneShopper/)
 - Reference guide on [sourcing from Etsy](/docs/sourcing-from-etsy/)


### PR DESCRIPTION
## Description

changes:

- fix 404 link 

## Related Issues

- #22628 `chore(docs): Add Snipcart reference guide` 
- #19267 `Add link checker for Gatsby Docs`