### PR TITLE
docs: update programmatically-creating-pages.md to remove inconsistency

### DIFF
--- a/docs/docs/mdx/programmatically-creating-pages.md
+++ b/docs/docs/mdx/programmatically-creating-pages.md
@@ -274,13 +274,17 @@ component should look like:
 ```jsx:title=src/components/posts-page-layout.js
 import React from "react"
 import { graphql } from "gatsby"
+import { MDXProvider } from "@mdx-js/react"
 import { MDXRenderer } from "gatsby-plugin-mdx"
+import { Link } from "gatsby"
 
 export default function PageTemplate({ data: { mdx } }) {
   return (
     <div>
       <h1>{mdx.frontmatter.title}</h1>
-      <MDXRenderer>{mdx.body}</MDXRenderer>
+      <MDXProvider components={shortcodes}>
+        <MDXRenderer>{mdx.body}</MDXRenderer>
+      </MDXProvider>
     </div>
   )
 }


### PR DESCRIPTION
## Description

There is a slight inconsistency in the docs for the final steps of the `Make a template for your posts` section. 

The docs have separated this section into two steps (creating an MDX layout component + adding a GraphQL query) but when showing the completed component code (`src/components/posts-page-layout.js`)  the component is missing some imports and the `<MDXProvider>` component that were present in the first step of this section.

## Related Link

- [https://www.gatsbyjs.org/docs/mdx/programmatically-creating-pages/#make-a-template-for-your-posts](https://www.gatsbyjs.org/docs/mdx/programmatically-creating-pages/#make-a-template-for-your-posts)