### PR TITLE
Add Gatsby Days LA video 11

### DIFF
--- a/docs/blog/2020-04-15-LA-2020-estevez/index.md
+++ b/docs/blog/2020-04-15-LA-2020-estevez/index.md
@@ -1,0 +1,19 @@
+---
+title: 'Gatsby Days LA 2020 Video 11: Building Accessible Components (Without First Reading Docs for Days)'
+date: 2020-04-15
+author: Greg Thomas
+excerpt: "New York Times Senior Software Engineer Yuraima Estevez shows how developers can improve the accessibility of websites in three “easy” steps that do not involve days of documentation reading."
+tags:
+- gatsby-days
+- community
+- accessibility
+- documentation
+- diversity-and-inclusion
+---
+_Welcome to the Gatsby Days 2020 Video Blog: Los Angeles Edition. In this series of eleven videos, you can catch up with all the wit and wisdom shared at the presentations from our February community gathering in LA. If you weren’t able to make it in person, these videos are the next best thing to owning a time machine! (Though owning a time machine would be super cool for sure, joining us at our next Gatsby Days—currently scheduled as a virtual event June 2nd-3rd—would be pretty awesome, too 💜.  Follow [Gatsby on Twitter](https://twitter.com/gatsbyjs) to keep up with when registration starts, speaker announcements and other developments)._
+
+Yuraima Estevez is a senior software engineer tech lead at the New York Times who is passionate about building open source tools and enabling empathetic web development. At Gatsby Days LA 2020, Yuraima focused on accessibility. To realize the power of the web’s universality, developers must build sites that are accessible to people with disabilities. But doing so can be challenging, especially when there is a ton of documentation to sort through.
+
+Yuraima believes that building accessible components can help streamline progress toward delivering accessible sites. Learn how you can increase accessibility and improve support for assistive technologies as you are building components through three “easy” steps: using semantic HTML whenever possible, employing ARIA (Accessible Rich Internet Applications) attributes, and integrating keyboard navigation capabilities. Adopting this three-step approach also makes much more efficient use of available documentation.
+
+[![TL;DR for Accessible Components - Yuraima Estevez - Gatsby Days LA 2020](https://res.cloudinary.com/marcomontalbano/image/upload/v1586365251/video_to_markdown/images/youtube--Qu3HuUKLNh8-c05b58ac6eb4c4700831b2b3070cd403.jpg)](https://www.youtube.com/watch?v=Qu3HuUKLNh8&t=1s "TL;DR for Accessible Components - Yuraima Estevez - Gatsby Days LA 2020")

--- a/docs/blog/2020-04-15-LA-2020-estevez/index.md
+++ b/docs/blog/2020-04-15-LA-2020-estevez/index.md
@@ -1,16 +1,17 @@
 ---
-title: 'Gatsby Days LA 2020 Video 11: Building Accessible Components (Without First Reading Docs for Days)'
+title: "Gatsby Days LA 2020 Video 11: Building Accessible Components (Without First Reading Docs for Days)"
 date: 2020-04-15
 author: Greg Thomas
 excerpt: "New York Times Senior Software Engineer Yuraima Estevez shows how developers can improve the accessibility of websites in three “easy” steps that do not involve days of documentation reading."
 tags:
-- gatsby-days
-- community
-- accessibility
-- documentation
-- diversity-and-inclusion
+  - gatsby-days
+  - community
+  - accessibility
+  - documentation
+  - diversity-and-inclusion
 ---
-_Welcome to the Gatsby Days 2020 Video Blog: Los Angeles Edition. In this series of eleven videos, you can catch up with all the wit and wisdom shared at the presentations from our February community gathering in LA. If you weren’t able to make it in person, these videos are the next best thing to owning a time machine! (Though owning a time machine would be super cool for sure, joining us at our next Gatsby Days—currently scheduled as a virtual event June 2nd-3rd—would be pretty awesome, too 💜.  Follow [Gatsby on Twitter](https://twitter.com/gatsbyjs) to keep up with when registration starts, speaker announcements and other developments)._
+
+_Welcome to the Gatsby Days 2020 Video Blog: Los Angeles Edition. In this series of eleven videos, you can catch up with all the wit and wisdom shared at the presentations from our February community gathering in LA. If you weren’t able to make it in person, these videos are the next best thing to owning a time machine! (Though owning a time machine would be super cool for sure, joining us at our next Gatsby Days—currently scheduled as a virtual event June 2nd-3rd—would be pretty awesome, too 💜. Follow [Gatsby on Twitter](https://twitter.com/gatsbyjs) to keep up with when registration starts, speaker announcements and other developments)._
 
 Yuraima Estevez is a senior software engineer tech lead at the New York Times who is passionate about building open source tools and enabling empathetic web development. At Gatsby Days LA 2020, Yuraima focused on accessibility. To realize the power of the web’s universality, developers must build sites that are accessible to people with disabilities. But doing so can be challenging, especially when there is a ton of documentation to sort through.
 


### PR DESCRIPTION
Last one! Gatsby Days LA video 11 to run on April 15th, Yuraima Estevez on building accessible components.