### PR TITLE
fix(gatsby): Use tmp dir for tmp redux cache folder

### DIFF
--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import os from "os"
 import v8 from "v8"
 import {
   existsSync,
@@ -139,7 +140,7 @@ export function writeToCache(contents: ICachedReduxState): void {
   // Note: this should be a transactional operation. So work in a tmp dir and
   // make sure the cache cannot be left in a corruptable state due to errors.
 
-  const tmpDir = mkdtempSync(`reduxcache`) // linux / windows
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), `reduxcache`)) // linux / windows
 
   prepareCacheFolder(tmpDir, contents)
 


### PR DESCRIPTION
The path was omitted which led to `cwd()` being used, whatever it was. `gatsby build` is assumed to be called from the project root, and since it should be able to create `.cache` there, it should also create other temp folders there.

Yet, who knows, it may have caused some of the WSL issues we've been seeing (#21982, #22562) and even if it's not, it prevents these tmp dirs from lingering in the project root in case the build gets cancelled prematurely.