### PR TITLE
fix: Ensure component order is deterministic

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/__tests__/requires-writer.js
@@ -326,4 +326,29 @@ describe(`requires-writer`, () => {
       })
     })
   })
+
+  describe(`getComponents`, () => {
+    it(`should return components in a deterministic order`, () => {
+      const pagesInput = generatePagesState([
+        {
+          component: `component1`,
+          componentChunkName: `chunkName1`,
+          matchPath: `matchPath1`,
+          path: `/path1`,
+        },
+        {
+          component: `component2`,
+          componentChunkName: `chunkName2`,
+          path: `/path2`,
+        },
+      ])
+
+      const pages = [...pagesInput.values()]
+      const pagesReversed = [...pagesInput.values()].reverse()
+
+      expect(requiresWriter.getComponents(pages)).toEqual(
+        requiresWriter.getComponents(pagesReversed)
+      )
+    })
+  })
 })

--- a/packages/gatsby/src/bootstrap/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/requires-writer.js
@@ -255,4 +255,5 @@ module.exports = {
   writeAll,
   resetLastHash,
   startListener,
+  getComponents,
 }

--- a/packages/gatsby/src/bootstrap/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/requires-writer.js
@@ -52,6 +52,7 @@ const getComponents = pages =>
   _(pages)
     .map(pickComponentFields)
     .uniqBy(c => c.componentChunkName)
+    .orderBy(c => c.componentChunkName)
     .value()
 
 /**


### PR DESCRIPTION
## Description

Ensure component order - and therefore the build hash - is deterministic when writing out `.cache/async-requires.js`. When using page build optimisation, this ensures pages are not rebuilt when no content or code has changed.

## Related Issues

Fixes #22964 
