### PR TITLE
fix(gatsby-plugin-react-helmet): allow the use of `react-helmet@6`

### DIFF
--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -36,7 +36,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^2.0.0",
-    "react-helmet": "^5.1.3"
+    "react-helmet": "^5.1.3 || ^6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Version `6.0.0` of `react-helmet` was just released:
https://www.npmjs.com/package/react-helmet 

Currently, installing `gatsby-plugin-react-helmet` alongside `react-helmet@6.0.0` causes the following warning:

```
warning " > gatsby-plugin-react-helmet@3.2.1" has incorrect peer dependency "react-helmet@^5.1.3".
```

This `peerDependency` can be bumped to support both versions as the only breaking change for v6 is the removal of the default export in favour of the named export, as explained in the [upgrade guide](https://github.com/nfl/react-helmet/wiki/Upgrade-from-5.x.x----6.x.x-beta).

`gatsby-plugin-react-helmet` already uses the named export thanks to a commit (99b57c1484f5876751829d81674a34996f627b6b) by @Ehesp which explains the same rationale. This commit just brings the `package.json` into alignment.

### Documentation

Already updated in 99b57c1484f5876751829d81674a34996f627b6b

## Related Issues

Related to #10578
