### PR TITLE
fix(gatsby-plugin-sharp): trim option failed

### DIFF
--- a/packages/gatsby-plugin-sharp/src/plugin-options.js
+++ b/packages/gatsby-plugin-sharp/src/plugin-options.js
@@ -58,7 +58,7 @@ exports.createTransformObject = args => {
     jpegProgressive: args.jpegProgressive || generalArgs.jpegProgressive,
     grayscale: args.grayscale || generalArgs.grayscale,
     rotate: args.rotate,
-    trim: !!args.trim,
+    trim: args.trim ? args.trim : undefined,
     duotone: args.duotone ? args.duotone : null,
     fit: args.fit,
     background: args.background,


### PR DESCRIPTION
### Description

The validation of Sharp's trim option is wrong, it turns `trim` into a boolean instead of keeping it float.

### Error
<img width="1057" alt="Capture d’écran 2020-04-10 à 13 49 55" src="https://user-images.githubusercontent.com/6873926/78990473-cdd59b00-7b36-11ea-8767-62478777b160.png">


### Query to reproduce

```graphql
    allEntity {
      nodes {
        logo {
          file {
            childImageSharp {
              fixed(height: 70, trim: 10) {
                ...GatsbyImageSharpFixed
              }
            }
          }
        }
      }
    }
```