### PR TITLE
fix(gatsby-cli): Address an issue that caused empty logs to print undefined

### DIFF
--- a/packages/gatsby-cli/src/reporter/__tests__/patch-console.ts
+++ b/packages/gatsby-cli/src/reporter/__tests__/patch-console.ts
@@ -1,0 +1,30 @@
+import { patchConsole } from "../patch-console"
+import { reporter as gatsbyReporter } from "../reporter"
+
+describe("patchConsole", () => {
+  const reporter = {
+    log: jest.fn(),
+  }
+  patchConsole((reporter as unknown) as typeof gatsbyReporter)
+
+  beforeEach(reporter.log.mockReset)
+
+  it("handles an empty call", () => {
+    console.log()
+
+    // intentionally empty arguments
+    expect(reporter.log).toBeCalledWith()
+  })
+
+  it("handles multiple arguments", () => {
+    console.log("foo", "bar", "baz")
+
+    expect(reporter.log).toBeCalledWith("foo bar baz")
+  })
+
+  it("handles formatting", () => {
+    console.log("%s %d", "bar", true)
+
+    expect(reporter.log).toBeCalledWith("bar 1")
+  })
+})

--- a/packages/gatsby-cli/src/reporter/__tests__/patch-console.ts
+++ b/packages/gatsby-cli/src/reporter/__tests__/patch-console.ts
@@ -1,7 +1,7 @@
 import { patchConsole } from "../patch-console"
 import { reporter as gatsbyReporter } from "../reporter"
 
-describe("patchConsole", () => {
+describe(`patchConsole`, () => {
   const reporter = {
     log: jest.fn(),
   }
@@ -9,22 +9,22 @@ describe("patchConsole", () => {
 
   beforeEach(reporter.log.mockReset)
 
-  it("handles an empty call", () => {
+  it(`handles an empty call`, () => {
     console.log()
 
     // intentionally empty arguments
     expect(reporter.log).toBeCalledWith()
   })
 
-  it("handles multiple arguments", () => {
-    console.log("foo", "bar", "baz")
+  it(`handles multiple arguments`, () => {
+    console.log(`foo`, `bar`, `baz`)
 
-    expect(reporter.log).toBeCalledWith("foo bar baz")
+    expect(reporter.log).toBeCalledWith(`foo bar baz`)
   })
 
-  it("handles formatting", () => {
-    console.log("%s %d", "bar", true)
+  it(`handles formatting`, () => {
+    console.log(`%s %d`, `bar`, true)
 
-    expect(reporter.log).toBeCalledWith("bar 1")
+    expect(reporter.log).toBeCalledWith(`bar 1`)
   })
 })

--- a/packages/gatsby-cli/src/reporter/patch-console.ts
+++ b/packages/gatsby-cli/src/reporter/patch-console.ts
@@ -7,13 +7,13 @@ import { reporter as gatsbyReporter } from "./reporter"
 
 export const patchConsole = (reporter: typeof gatsbyReporter): void => {
   console.log = (format: any, ...args: any[]): void => {
-    reporter.log(util.format(format, ...args))
+    format ? reporter.log(util.format(format, ...args)) : reporter.log()
   }
   console.warn = (format: any, ...args: any[]): void => {
-    reporter.warn(util.format(format, ...args))
+    format ? reporter.warn(util.format(format, ...args)) : reporter.warn()
   }
   console.info = (format: any, ...args: any[]): void => {
-    reporter.info(util.format(format, ...args))
+    format ? reporter.info(util.format(format, ...args)) : reporter.info()
   }
   console.error = (format: any, ...args: any[]): void => {
     reporter.error(util.format(format, ...args))

--- a/packages/gatsby-cli/src/reporter/patch-console.ts
+++ b/packages/gatsby-cli/src/reporter/patch-console.ts
@@ -7,13 +7,25 @@ import { reporter as gatsbyReporter } from "./reporter"
 
 export const patchConsole = (reporter: typeof gatsbyReporter): void => {
   console.log = (format: any, ...args: any[]): void => {
-    format ? reporter.log(util.format(format, ...args)) : reporter.log()
+    if (format) {
+      reporter.log(util.format(format, ...args))
+      return
+    }
+    reporter.log()
   }
   console.warn = (format: any, ...args: any[]): void => {
-    format ? reporter.warn(util.format(format, ...args)) : reporter.warn()
+    if (format) {
+      reporter.warn(util.format(format, ...args))
+      return
+    }
+    reporter.warn()
   }
   console.info = (format: any, ...args: any[]): void => {
-    format ? reporter.info(util.format(format, ...args)) : reporter.info()
+    if (format) {
+      reporter.info(util.format(format, ...args))
+      return
+    }
+    reporter.info()
   }
   console.error = (format: any, ...args: any[]): void => {
     reporter.error(util.format(format, ...args))

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -164,13 +164,13 @@ class Reporter {
     }
   }
 
-  success = (text: string): CreateLogAction =>
+  success = (text?: string): CreateLogAction =>
     reporterActions.createLog({ level: LogLevels.Success, text })
-  info = (text: string): CreateLogAction =>
+  info = (text?: string): CreateLogAction =>
     reporterActions.createLog({ level: LogLevels.Info, text })
-  warn = (text: string): CreateLogAction =>
+  warn = (text?: string): CreateLogAction =>
     reporterActions.createLog({ level: LogLevels.Warning, text })
-  log = (text: string): CreateLogAction =>
+  log = (text?: string): CreateLogAction =>
     reporterActions.createLog({ level: LogLevels.Log, text })
 
   pendingActivity = reporterActions.createPendingActivity


### PR DESCRIPTION

## Description

Fixes gatsby-cli. Currently it's doing this:

```
success run queries - 0.050s - 2/2 39.61/s
undefined
You can now view gatsby-starter-hello-world in the browser.
undefined
  http://localhost:8001/
undefined
View GraphiQL, an in-browser IDE, to explore your site's data and schema
undefined
  http://localhost:8001/___graphql
undefined
Note that the development build is not optimized.
To create a production build, use gatsby build
undefined
success Building development bundle - 3.567s
```

This is because of typescript forcing us to seperate the args, we were then passing undefined into util.format instead of nothing