### PR TITLE
fix(gatsby): use moveSync() for renaming redux tmp cache dir (#22999)

### DIFF
--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -6,7 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   removeSync,
-  renameSync,
+  moveSync,
   writeFileSync,
 } from "fs-extra"
 import { IGatsbyNode, ICachedReduxState } from "./types"
@@ -131,7 +131,7 @@ function safelyRenameToBak(reduxCacheFolder: string): string {
     ++suffixCounter
     bakName = reduxCacheFolder + tmpSuffix + suffixCounter
   }
-  renameSync(reduxCacheFolder, bakName)
+  moveSync(reduxCacheFolder, bakName)
 
   return bakName
 }
@@ -157,7 +157,7 @@ export function writeToCache(contents: ICachedReduxState): void {
   }
 
   // The redux cache folder should now not exist so we can rename our tmp to it
-  renameSync(tmpDir, reduxCacheFolder)
+  moveSync(tmpDir, reduxCacheFolder)
 
   // Now try to yolorimraf the old cache folder
   try {


### PR DESCRIPTION
## Description

Using `fs.renameSync(oldpath, newpath)` throws `EXDEV: cross-device link not permitted` error when `oldpath` and `newpath` are not on the same mounted filesystem. [`moveSync()`](https://github.com/jprichardson/node-fs-extra/blob/master/lib/move-sync/move-sync.js) from `fs-extra` package addresses this.

This patch uses it to rename redux cache directory.

## Related Issues

Fixes #22999 
