### PR TITLE
chore(docs): Fix react-helmet named import

### DIFF
--- a/docs/docs/porting-an-html-site-to-gatsby.md
+++ b/docs/docs/porting-an-html-site-to-gatsby.md
@@ -151,7 +151,7 @@ Now you can import the `<Helmet>` component to the `index.js` file and place `<h
 
 ```jsx:title=/gatsby-site/src/pages/index.js
 import React from "react"
-import Helmet from "react-helmet" // highlight-line
+import { Helmet } from "react-helmet" // highlight-line
 
 import "../styles/normalize.css"
 import "../styles/style.css"
@@ -182,7 +182,7 @@ Copy over the `<header>` element contents, changing `<a>` elements to `<Link>` c
 
 ```jsx:title=/gatsby-site/src/pages/index.js
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { Link } from "gatsby" // highlight-line
 
 import "../styles/normalize.css"
@@ -289,7 +289,7 @@ Like in `/src/pages/index.js` the file exports a JavaScript function that return
 
 ```jsx:title=/gatsby-site/src/components/Layout.js
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 
 export default ({ children }) => (
   <>
@@ -304,7 +304,7 @@ The common elements between the `/index.html` and `/who/index.html` files can no
 
 ```jsx:title=/gatsby-site/src/components/Layout.js
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { Link } from "gatsby"
 
 import "../styles/normalize.css"

--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -210,7 +210,7 @@ module.exports = {
 ```jsx:title=src/components/seo.js
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 function SEO({ description, lang, meta, title }) {

--- a/docs/tutorial/seo-and-social-sharing-cards-tutorial/index.md
+++ b/docs/tutorial/seo-and-social-sharing-cards-tutorial/index.md
@@ -47,7 +47,7 @@ Using the power and flexibility of React, you can create a React component to po
 ```jsx:title=src/components/seo.js
 import React from "react"
 // highlight-start
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 // highlight-end
 
@@ -82,7 +82,7 @@ This component doesn't _do_ anything yet, but it's the foundation for a useful, 
 
 ```jsx:title=src/components/seo.js
 import React from "react"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 function SEO({ description, lang, meta }) {
@@ -151,7 +151,7 @@ In addition to SEO for actual _search_ engines you also want those pretty cards 
 ```jsx:title=src/components/seo.js
 import React from "react"
 import PropTypes from "prop-types" // highlight-line
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 // highlight-next-line
@@ -294,7 +294,7 @@ To implement this functionality, you need to do the following:
 ```jsx:title=src/components/seo.js
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 // highlight-next-line


### PR DESCRIPTION
The SEO component code snippet was causing a gatsby build warning and error in my environment. Adding brackets around Helmet resolves the issue.
