### PR TITLE
fix(gatsby): call schema rebuild manually on __refresh

### DIFF
--- a/packages/gatsby/src/bootstrap/schema-hot-reloader.ts
+++ b/packages/gatsby/src/bootstrap/schema-hot-reloader.ts
@@ -36,19 +36,28 @@ const maybeRebuildSchema = debounce(async (): Promise<void> => {
   activity.end()
 }, 1000)
 
-const snapshotInferenceMetadata = (): void => {
+function snapshotInferenceMetadata(): void {
   const { inferenceMetadata } = store.getState()
   lastMetadata = cloneDeep(inferenceMetadata)
 }
 
-export const bootstrapSchemaHotReloader = (): void => {
+export function bootstrapSchemaHotReloader(): void {
   // Snapshot inference metadata at the time of the last schema rebuild
   // (even if schema was rebuilt elsewhere)
   // Using the snapshot later to check if inferred types actually changed since the last rebuild
   snapshotInferenceMetadata()
   emitter.on(`SET_SCHEMA`, snapshotInferenceMetadata)
 
+  startSchemaHotReloader()
+}
+
+export function startSchemaHotReloader(): void {
   // Listen for node changes outside of a regular sourceNodes API call,
   // e.g. markdown file update via watcher
   emitter.on(`API_RUNNING_QUEUE_EMPTY`, maybeRebuildSchema)
+}
+
+export function stopSchemaHotReloader(): void {
+  emitter.off(`API_RUNNING_QUEUE_EMPTY`, maybeRebuildSchema)
+  maybeRebuildSchema.cancel()
 }

--- a/packages/gatsby/src/bootstrap/schema-hot-reloader.ts
+++ b/packages/gatsby/src/bootstrap/schema-hot-reloader.ts
@@ -7,7 +7,6 @@ import report from "gatsby-cli/lib/reporter"
 import { IGatsbyState } from "../redux/types"
 
 type TypeMap = IGatsbyState["inferenceMetadata"]["typeMap"]
-type SchemaCustomization = IGatsbyState["schemaCustomization"]
 type InferenceMetadata = IGatsbyState["inferenceMetadata"]
 
 const inferredTypesChanged = (
@@ -19,41 +18,37 @@ const inferredTypesChanged = (
       typeMap[type].dirty && !haveEqualFields(typeMap[type], prevTypeMap[type])
   )
 
-const schemaChanged = (
-  schemaCustomization: SchemaCustomization,
-  lastSchemaCustomization: SchemaCustomization
-): boolean =>
-  [`fieldExtensions`, `printConfig`, `thirdPartySchemas`, `types`].some(
-    key => schemaCustomization[key] !== lastSchemaCustomization[key]
-  )
-
 let lastMetadata: InferenceMetadata
-let lastSchemaCustomization: SchemaCustomization
 
 // API_RUNNING_QUEUE_EMPTY could be emitted multiple types
 // in a short period of time, so debounce seems reasonable
 const maybeRebuildSchema = debounce(async (): Promise<void> => {
-  const { inferenceMetadata, schemaCustomization } = store.getState()
+  const { inferenceMetadata } = store.getState()
 
-  if (
-    !inferredTypesChanged(inferenceMetadata.typeMap, lastMetadata.typeMap) &&
-    !schemaChanged(schemaCustomization, lastSchemaCustomization)
-  ) {
+  if (!inferredTypesChanged(inferenceMetadata.typeMap, lastMetadata.typeMap)) {
     return
   }
 
   const activity = report.activityTimer(`rebuild schema`)
   activity.start()
-  lastMetadata = cloneDeep(inferenceMetadata)
-  lastSchemaCustomization = schemaCustomization
   await rebuild({ parentSpan: activity })
   await updateStateAndRunQueries(false, { parentSpan: activity })
   activity.end()
 }, 1000)
 
-export const bootstrapSchemaHotReloader = (): void => {
-  const { inferenceMetadata, schemaCustomization } = store.getState()
+const snapshotInferenceMetadata = (): void => {
+  const { inferenceMetadata } = store.getState()
   lastMetadata = cloneDeep(inferenceMetadata)
-  lastSchemaCustomization = schemaCustomization
+}
+
+export const bootstrapSchemaHotReloader = (): void => {
+  // Snapshot inference metadata at the time of the last schema rebuild
+  // (even if schema was rebuilt elsewhere)
+  // Using the snapshot later to check if inferred types actually changed since the last rebuild
+  snapshotInferenceMetadata()
+  emitter.on(`SET_SCHEMA`, snapshotInferenceMetadata)
+
+  // Listen for node changes outside of a regular sourceNodes API call,
+  // e.g. markdown file update via watcher
   emitter.on(`API_RUNNING_QUEUE_EMPTY`, maybeRebuildSchema)
 }

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -37,6 +37,7 @@ import { developStatic } from "./develop-static"
 import withResolverContext from "../schema/context"
 import sourceNodes from "../utils/source-nodes"
 import { createSchemaCustomization } from "../utils/create-schema-customization"
+import { rebuild } from "../schema"
 import { websocketManager } from "../utils/websocket-manager"
 import getSslCert from "../utils/get-ssl-cert"
 import { slash } from "gatsby-core-utils"
@@ -214,6 +215,10 @@ async function startServer(program: IProgram): Promise<IServer> {
     await sourceNodes({
       webhookBody: req.body,
     })
+    activity.end()
+    activity = report.activityTimer(`rebuild schema`)
+    activity.start()
+    await rebuild({ parentSpan: activity })
     activity.end()
   }
   app.use(REFRESH_ENDPOINT, express.json())

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -31,13 +31,17 @@ import * as WorkerPool from "../utils/worker/pool"
 import http from "http"
 import https from "https"
 
-import { bootstrapSchemaHotReloader } from "../bootstrap/schema-hot-reloader"
+import {
+  bootstrapSchemaHotReloader,
+  startSchemaHotReloader,
+  stopSchemaHotReloader,
+} from "../bootstrap/schema-hot-reloader"
 import bootstrapPageHotReloader from "../bootstrap/page-hot-reloader"
 import { developStatic } from "./develop-static"
 import withResolverContext from "../schema/context"
 import sourceNodes from "../utils/source-nodes"
 import { createSchemaCustomization } from "../utils/create-schema-customization"
-import { rebuild } from "../schema"
+import { rebuild as rebuildSchema } from "../schema"
 import { websocketManager } from "../utils/websocket-manager"
 import getSslCert from "../utils/get-ssl-cert"
 import { slash } from "gatsby-core-utils"
@@ -204,6 +208,7 @@ async function startServer(program: IProgram): Promise<IServer> {
    **/
   const REFRESH_ENDPOINT = `/__refresh`
   const refresh = async (req: express.Request): Promise<void> => {
+    stopSchemaHotReloader()
     let activity = report.activityTimer(`createSchemaCustomization`, {})
     activity.start()
     await createSchemaCustomization({
@@ -218,8 +223,9 @@ async function startServer(program: IProgram): Promise<IServer> {
     activity.end()
     activity = report.activityTimer(`rebuild schema`)
     activity.start()
-    await rebuild({ parentSpan: activity })
+    await rebuildSchema({ parentSpan: activity })
     activity.end()
+    startSchemaHotReloader()
   }
   app.use(REFRESH_ENDPOINT, express.json())
   app.post(REFRESH_ENDPOINT, (req, res) => {


### PR DESCRIPTION
## Description

**tl;dr** This PR fixes an issue with schema rebuilding in `__refresh` endpoint by moving rebuild call from schema hot reloader directly to `__refresh` controller.

#### Some Details

Schema rebuilding (introduced in #19092) is triggered in two situations:

1. When `__refresh` endpoint is hit
2. When nodes change outside of `sourceNodes` API, usually via some watcher (e.g. when editing a file)

Originally we handled both cases in a single `schemaHotReloader` which listened for a special event `API_RUNNING_QUEUE_EMPTY` and tried rebuilding the schema if needed.

But the `API_RUNNING_QUEUE_EMPTY` event proved to be problematic for `__refresh`. The expected sequence of actions in `__refresh`:

1. Call `createSchemaCustomization`
2. Call `sourceNodes`
3. Rebuild schema

But `createSchemaCustomization` trigger `API_RUNNING_QUEUE_EMPTY` too. So schema rebuilding could occur between 1 and 2 (and in practice - sometimes in the middle of 2). It broke develop in some setups.

#### This PR

This PR separates the handling of the two original use-cases. So now we call rebuild in `__refresh` explicitly after `sourceNodes`. But keep using `API_RUNNING_QUEUE_EMPTY` to handle node updates that occur outside of the `sourceNodes` hook.

This also made `schemaHotReloader` a bit simpler because now it triggers only on node changes, not on schema customization changes.

## Related Issues

Discovered this problem internally on gatsbyjs.com website.
