### PR TITLE
fix (scripts/i18n) Add label to the sync PR even if no conflicts

### DIFF
--- a/scripts/i18n/sync.js
+++ b/scripts/i18n/sync.js
@@ -256,6 +256,7 @@ async function syncTranslationRepo(code) {
     body: syncPRBody(),
     maintainerCanModify: true,
   })
+  await addLabelToPullRequest(syncPR, syncLabel)
 
   // if we successfully publish the PR, pull again and create a new PR --
   shell.exec(`git checkout master`)
@@ -332,9 +333,6 @@ async function syncTranslationRepo(code) {
     maintainerCanModify: true,
     draft: true,
   })
-
-  logger.info(`Adding ${syncLabelName} labels to created pull requests...`)
-  await addLabelToPullRequest(syncPR, syncLabel)
   await addLabelToPullRequest(conflictsPR, syncLabel)
 }
 


### PR DESCRIPTION
Add the `sync` label even when the conflicts PR isn't created.