### PR TITLE
fix(gatsby-cli): Fix console methods incorrectly handling falsy values

### DIFF
--- a/packages/gatsby-cli/src/reporter/__tests__/patch-console.ts
+++ b/packages/gatsby-cli/src/reporter/__tests__/patch-console.ts
@@ -27,4 +27,22 @@ describe(`patchConsole`, () => {
 
     expect(reporter.log).toBeCalledWith(`bar 1`)
   })
+
+  it("handles normal values", () => {
+    console.log(1)
+    console.log(0)
+    console.log(true)
+    console.log(false)
+    console.log([1, true, false, {}])
+    console.log({ 1: 1, true: true, false: "false", obj: {} })
+
+    expect(reporter.log.mock.calls[0][0]).toBe(`1`)
+    expect(reporter.log.mock.calls[1][0]).toBe(`0`)
+    expect(reporter.log.mock.calls[2][0]).toBe(`true`)
+    expect(reporter.log.mock.calls[3][0]).toBe(`false`)
+    expect(reporter.log.mock.calls[4][0]).toBe("[ 1, true, false, {} ]")
+    expect(reporter.log.mock.calls[5][0]).toBe(
+      "{ '1': 1, true: true, false: 'false', obj: {} }"
+    )
+  })
 })

--- a/packages/gatsby-cli/src/reporter/__tests__/patch-console.ts
+++ b/packages/gatsby-cli/src/reporter/__tests__/patch-console.ts
@@ -4,45 +4,57 @@ import { reporter as gatsbyReporter } from "../reporter"
 describe(`patchConsole`, () => {
   const reporter = {
     log: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
   }
+
   patchConsole((reporter as unknown) as typeof gatsbyReporter)
+  ;[`info`, `log`, `warn`].forEach(method => {
+    describe(method, () => {
+      beforeEach(reporter[method].mockReset)
 
-  beforeEach(reporter.log.mockReset)
+      it(`handles an empty call`, () => {
+        console[method]()
 
-  it(`handles an empty call`, () => {
-    console.log()
+        expect(reporter[method]).toBeCalledWith(``)
+      })
 
-    // intentionally empty arguments
-    expect(reporter.log).toBeCalledWith()
-  })
+      it(`handles multiple arguments`, () => {
+        console[method](`foo`, `bar`, `baz`)
 
-  it(`handles multiple arguments`, () => {
-    console.log(`foo`, `bar`, `baz`)
+        expect(reporter[method]).toBeCalledWith(`foo bar baz`)
+      })
 
-    expect(reporter.log).toBeCalledWith(`foo bar baz`)
-  })
+      it(`handles formatting`, () => {
+        console[method](`%s %d`, `bar`, true)
 
-  it(`handles formatting`, () => {
-    console.log(`%s %d`, `bar`, true)
+        expect(reporter[method]).toBeCalledWith(`bar 1`)
+      })
 
-    expect(reporter.log).toBeCalledWith(`bar 1`)
-  })
+      it(`handles normal values`, () => {
+        console[method](1)
+        console[method](0)
+        console[method](true)
+        console[method](false)
+        console[method]([1, true, false, {}])
+        console[method]({ 1: 1, true: true, false: `false`, obj: {} })
 
-  it("handles normal values", () => {
-    console.log(1)
-    console.log(0)
-    console.log(true)
-    console.log(false)
-    console.log([1, true, false, {}])
-    console.log({ 1: 1, true: true, false: "false", obj: {} })
+        expect(reporter[method].mock.calls[0][0]).toBe(`1`)
+        expect(reporter[method].mock.calls[1][0]).toBe(`0`)
+        expect(reporter[method].mock.calls[2][0]).toBe(`true`)
+        expect(reporter[method].mock.calls[3][0]).toBe(`false`)
+        expect(reporter[method].mock.calls[4][0]).toBe(`[ 1, true, false, {} ]`)
+        expect(reporter[method].mock.calls[5][0]).toBe(
+          `{ '1': 1, true: true, false: 'false', obj: {} }`
+        )
+      })
 
-    expect(reporter.log.mock.calls[0][0]).toBe(`1`)
-    expect(reporter.log.mock.calls[1][0]).toBe(`0`)
-    expect(reporter.log.mock.calls[2][0]).toBe(`true`)
-    expect(reporter.log.mock.calls[3][0]).toBe(`false`)
-    expect(reporter.log.mock.calls[4][0]).toBe("[ 1, true, false, {} ]")
-    expect(reporter.log.mock.calls[5][0]).toBe(
-      "{ '1': 1, true: true, false: 'false', obj: {} }"
-    )
+      it(`handles undefined variables`, () => {
+        let a
+        console[method](a)
+
+        expect(reporter[method]).toBeCalledWith(``)
+      })
+    })
   })
 })

--- a/packages/gatsby-cli/src/reporter/patch-console.ts
+++ b/packages/gatsby-cli/src/reporter/patch-console.ts
@@ -6,26 +6,17 @@ import util from "util"
 import { reporter as gatsbyReporter } from "./reporter"
 
 export const patchConsole = (reporter: typeof gatsbyReporter): void => {
-  console.log = (format?: any, ...args: any[]): void => {
-    if (format !== undefined) {
-      reporter.log(util.format(format, ...args))
-      return
-    }
-    reporter.log()
+  console.log = (...args: any[]): void => {
+    const [format, ...rest] = args
+    reporter.log(util.format(format === undefined ? `` : format, ...rest))
   }
-  console.warn = (format?: any, ...args: any[]): void => {
-    if (format !== undefined) {
-      reporter.warn(util.format(format, ...args))
-      return
-    }
-    reporter.warn()
+  console.warn = (...args: any[]): void => {
+    const [format, ...rest] = args
+    reporter.warn(util.format(format === undefined ? `` : format, ...rest))
   }
-  console.info = (format?: any, ...args: any[]): void => {
-    if (format !== undefined) {
-      reporter.info(util.format(format, ...args))
-      return
-    }
-    reporter.info()
+  console.info = (...args: any[]): void => {
+    const [format, ...rest] = args
+    reporter.info(util.format(format === undefined ? `` : format, ...rest))
   }
   console.error = (format: any, ...args: any[]): void => {
     reporter.error(util.format(format, ...args))

--- a/packages/gatsby-cli/src/reporter/patch-console.ts
+++ b/packages/gatsby-cli/src/reporter/patch-console.ts
@@ -6,22 +6,22 @@ import util from "util"
 import { reporter as gatsbyReporter } from "./reporter"
 
 export const patchConsole = (reporter: typeof gatsbyReporter): void => {
-  console.log = (format: any, ...args: any[]): void => {
-    if (format) {
+  console.log = (format?: any, ...args: any[]): void => {
+    if (format !== undefined) {
       reporter.log(util.format(format, ...args))
       return
     }
     reporter.log()
   }
-  console.warn = (format: any, ...args: any[]): void => {
-    if (format) {
+  console.warn = (format?: any, ...args: any[]): void => {
+    if (format !== undefined) {
       reporter.warn(util.format(format, ...args))
       return
     }
     reporter.warn()
   }
-  console.info = (format: any, ...args: any[]): void => {
-    if (format) {
+  console.info = (format?: any, ...args: any[]): void => {
+    if (format !== undefined) {
       reporter.info(util.format(format, ...args))
       return
     }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This is a follow up to #23000 where I incorrectly handled falsy values.
