### PR TITLE
chore(scripts): Add conversion metrics to typecheck command

### DIFF
--- a/scripts/check-ts.js
+++ b/scripts/check-ts.js
@@ -59,9 +59,38 @@ if (filterPackage) {
   }
 }
 
+let totalTsFiles = 0
+let totalJsFiles = 0
+
 packagesWithTs.forEach(project => {
+  const tsFiles = glob.sync(
+    `./packages/${project.split(/.*packages[/\\]/)[1]}/src/**/*.ts`,
+    {
+      root: project,
+      ignore: `**/node_modules/**`,
+    }
+  ).length
+
+  const jsFiles = glob.sync(
+    `./packages/${project.split(/.*packages[/\\]/)[1]}/src/**/*.js`,
+    {
+      root: project,
+      ignore: `**/node_modules/**`,
+    }
+  ).length
+
+  totalTsFiles += tsFiles
+  totalJsFiles += jsFiles
+
+  const percentConverted = Number(
+    ((tsFiles / (jsFiles + tsFiles)) * 100).toFixed(1)
+  )
+
   console.log(
-    `TS Check: Checking ./packages/${project.split(/.*packages[/\\]/)[1]}`
+    `TS Check: Checking ./packages/${project.split(/.*packages[/\\]/)[1]}`,
+    `\n  - TS Files: ${tsFiles}`,
+    `\n  - JS Files: ${jsFiles}`,
+    `\n  - Percent Converted: ${percentConverted}%`
   )
 
   const args = [
@@ -84,3 +113,15 @@ packagesWithTs.forEach(project => {
 })
 
 console.log(`TS Check: Success`)
+
+if (!filterPackage) {
+  const percentConverted = Number(
+    ((totalTsFiles / (totalJsFiles + totalTsFiles)) * 100).toFixed(1)
+  )
+
+  console.log(
+    `  - Total TS Files: ${totalJsFiles}`,
+    `\n  - Total JS Files: ${totalJsFiles}`,
+    `\n  - Percent Converted: ${percentConverted}%`
+  )
+}

--- a/scripts/check-ts.js
+++ b/scripts/check-ts.js
@@ -15,7 +15,8 @@ const execa = require(`execa`)
 
 console.log(`TS Check: Running...`)
 
-const PACKAGES_DIR = path.resolve(__dirname, `../packages`)
+const toAbsolutePath = relativePath => path.join(__dirname, `..`, relativePath)
+const PACKAGES_DIR = toAbsolutePath(`/packages`)
 
 const filterPackage = yargs.argv._[0]
 
@@ -64,19 +65,15 @@ let totalJsFiles = 0
 
 packagesWithTs.forEach(project => {
   const tsFiles = glob.sync(
-    `./packages/${project.split(/.*packages[/\\]/)[1]}/src/**/*.ts`,
-    {
-      root: project,
-      ignore: `**/node_modules/**`,
-    }
+    toAbsolutePath(
+      `./packages/${project.split(/.*packages[/\\]/)[1]}/src/**/*.ts`
+    )
   ).length
 
   const jsFiles = glob.sync(
-    `./packages/${project.split(/.*packages[/\\]/)[1]}/src/**/*.js`,
-    {
-      root: project,
-      ignore: `**/node_modules/**`,
-    }
+    toAbsolutePath(
+      `./packages/${project.split(/.*packages[/\\]/)[1]}/src/**/*.js`
+    )
   ).length
 
   totalTsFiles += tsFiles


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Gives us some context on how our migration is going. `yarn typecheck` will give output like this:

```
TS Check: Running...
TS Check: Checking ./packages/babel-preset-gatsby 
  - TS Files: 1 
  - JS Files: 4 
  - Percent Converted: 20%
TS Check: Checking ./packages/gatsby 
  - TS Files: 82 
  - JS Files: 202 
  - Percent Converted: 28.9%
TS Check: Checking ./packages/gatsby-cli 
  - TS Files: 27 
  - JS Files: 16 
  - Percent Converted: 62.8%
TS Check: Checking ./packages/gatsby-core-utils 
  - TS Files: 16 
  - JS Files: 1 
  - Percent Converted: 94.1%
TS Check: Checking ./packages/gatsby-image 
  - TS Files: 0 
  - JS Files: 3 
  - Percent Converted: 0%
TS Check: Checking ./packages/gatsby-link 
  - TS Files: 0 
  - JS Files: 4 
  - Percent Converted: 0%
TS Check: Success
  - Total TS Files: 230 
  - Total JS Files: 230 
  - Percent Converted: 35.4%
```
