### PR TITLE
fix(gatsby): Use `moveSync` over `renameSync` to fix cross mount cases

### DIFF
--- a/packages/gatsby/src/redux/__tests__/index.js
+++ b/packages/gatsby/src/redux/__tests__/index.js
@@ -16,7 +16,7 @@ jest.mock(`fs-extra`, () => {
       mockWrittenContent.set(file, content)
     ),
     readFileSync: jest.fn(file => mockWrittenContent.get(file)),
-    renameSync: jest.fn((from, to) => {
+    moveSync: jest.fn((from, to) => {
       // This will only work for folders if they are always the full prefix
       // of the file... (that goes for both input dirs). That's the case here.
       if (mockWrittenContent.has(to)) {

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -4,9 +4,9 @@ import v8 from "v8"
 import {
   existsSync,
   mkdtempSync,
+  moveSync, // Note: moveSync over renameSync because /tmp may be on other mount
   readFileSync,
   removeSync,
-  renameSync,
   writeFileSync,
 } from "fs-extra"
 import { IGatsbyNode, ICachedReduxState } from "./types"
@@ -131,7 +131,7 @@ function safelyRenameToBak(reduxCacheFolder: string): string {
     ++suffixCounter
     bakName = reduxCacheFolder + tmpSuffix + suffixCounter
   }
-  renameSync(reduxCacheFolder, bakName)
+  moveSync(reduxCacheFolder, bakName)
 
   return bakName
 }
@@ -157,7 +157,7 @@ export function writeToCache(contents: ICachedReduxState): void {
   }
 
   // The redux cache folder should now not exist so we can rename our tmp to it
-  renameSync(tmpDir, reduxCacheFolder)
+  moveSync(tmpDir, reduxCacheFolder)
 
   // Now try to yolorimraf the old cache folder
   try {


### PR DESCRIPTION
This PR is a copy of https://github.com/gatsbyjs/gatsby/pull/23005 by @drmats + a fix for the test cases. Copy paste from that PR:

## Description

Using `fs.renameSync(oldpath, newpath)` throws `EXDEV: cross-device link not permitted` error when `oldpath` and `newpath` are not on the same mounted filesystem. [`moveSync()`](https://github.com/jprichardson/node-fs-extra/blob/master/lib/move-sync/move-sync.js) from `fs-extra` package addresses this.

This patch uses it to rename redux cache directory.

## Related Issues

Fixes #22999 

