### PR TITLE
fix(gatsby): Set a timeout of 15 seconds on queries

### DIFF
--- a/packages/gatsby/src/query/queue.js
+++ b/packages/gatsby/src/query/queue.js
@@ -10,6 +10,7 @@ const createBaseOptions = () => {
     concurrent: Number(process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) || 4,
     // eslint-disable-next-line new-cap
     store: FastMemoryStore(),
+    maxTimeout: 15000,
   }
 }
 


### PR DESCRIPTION
Query resolvers can hang indefinitely right now which can be confusing to debug as there's no indication of what's happening.

With a timeout set, eventually the hanging query will fail with an error like this which should help people figure out where to investigate.

<img width="404" alt="Screen Shot 2020-04-11 at 10 43 35 PM" src="https://user-images.githubusercontent.com/71047/79060741-9f8eb300-7c3d-11ea-8060-eb80c9e38ac7.png">

From investigation of https://github.com/gatsbyjs/gatsby/issues/23033