### PR TITLE
Make a note about duplicate behavior in theme authoring

### DIFF
--- a/docs/tutorial/building-a-theme.md
+++ b/docs/tutorial/building-a-theme.md
@@ -1047,6 +1047,8 @@ exports.createPages = async ({ actions, graphql, reporter }, options) => {
 }
 ```
 
+Note that the example above sets default values for `options`. This behavior was also included in the prior `gatsby-config.js` example. You only need to set default values once, but both mechanisms for doing so are valid.
+
 > 💡 Up till now, you've mostly worked in the `gatsby-theme-events` space. Because you've converted the theme to use a function export, you can no longer run the theme on its own. The function export in `gatsby-config.js` is only supported for themes. From now on you'll be running `site` -- the Gatsby site consuming `gatsby-theme-events`, instead. Gatsby sites still require the object export in `gatsby-config.js`.
 
 Test out this new options-setting by making some adjustments to `site`.


### PR DESCRIPTION
This was born out of a community question. Our example code for theme authoring sets default values in gatsby-config and gatsby-node. Both options are valid, but a theme author only needs to do one. Adding a note to that effect.