### PR TITLE
fix(starters): Upgrade react-helmet in default starter

### DIFF
--- a/starters/default/package-lock.json
+++ b/starters/default/package-lock.json
@@ -6722,11 +6722,6 @@
         }
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -8343,9 +8338,9 @@
       }
     },
     "gatsby-plugin-react-helmet": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.2.1.tgz",
-      "integrity": "sha512-5oarZdVvp3k3keG26eVFagVHLYw7wCGs/MXRYQg8MEyJewU3X4Uc0eo7qu4TM5EIuZ2ekaL14r86RB6RM5TORA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.2.2.tgz",
+      "integrity": "sha512-mPd7gefGIxqAuxFJgDuttR9+DnRLKLrCh61ND1iLSeOp9GoYS/qH8Rhka6fkpmBXOtUVyujzaUthhB/ll/a4RA==",
       "requires": {
         "@babel/runtime": "^7.8.7"
       }
@@ -13638,14 +13633,14 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-helmet": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.1.tgz",
-      "integrity": "sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.0.0.tgz",
+      "integrity": "sha512-My6S4sa0uHN/IuVUn0HFmasW5xj9clTkB9qmMngscVycQ5vVG51Qp44BEvLJ4lixupTwDlU9qX1/sCrMN4AEPg==",
       "requires": {
         "object-assign": "^4.1.1",
-        "prop-types": "^15.5.4",
-        "react-fast-compare": "^2.0.2",
-        "react-side-effect": "^1.1.0"
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^2.0.4",
+        "react-side-effect": "^2.1.0"
       }
     },
     "react-hot-loader": {
@@ -13698,13 +13693,9 @@
       "integrity": "sha512-u5l7fhAJXecWUJzVxzMRU2Zvw8m4QmDNHlTrT5uo3KBlYBhmChd7syAakBoay1yIiVhx/8Fi7a6v6kQZfsw81Q=="
     },
     "react-side-effect": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
-      "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
-      "requires": {
-        "exenv": "^1.2.1",
-        "shallowequal": "^1.0.1"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
     },
     "read": {
       "version": "1.0.7",

--- a/starters/default/package.json
+++ b/starters/default/package.json
@@ -9,14 +9,14 @@
     "gatsby-image": "^2.3.1",
     "gatsby-plugin-manifest": "^2.3.3",
     "gatsby-plugin-offline": "^3.1.2",
-    "gatsby-plugin-react-helmet": "^3.2.1",
+    "gatsby-plugin-react-helmet": "^3.2.2",
     "gatsby-plugin-sharp": "^2.5.3",
     "gatsby-source-filesystem": "^2.2.2",
     "gatsby-transformer-sharp": "^2.4.3",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-helmet": "^5.2.1"
+    "react-helmet": "^6.0.0"
   },
   "devDependencies": {
     "prettier": "^1.19.1"

--- a/starters/default/src/components/seo.js
+++ b/starters/default/src/components/seo.js
@@ -7,7 +7,7 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 function SEO({ description, lang, meta, title }) {


### PR DESCRIPTION
## Description

Remove warning caused by pre-v6 `react-helmet` in default starter (see #17865)

### Documentation

#17865

## Related Issues

Closes #17865

cc @lannonbr