### PR TITLE
fix (www) Fix mobile nav bar text

### DIFF
--- a/www/src/components/navigation-mobile.js
+++ b/www/src/components/navigation-mobile.js
@@ -75,7 +75,7 @@ const MobileNavigation = ({ i18n }) => (
       <MobileNavItem
         linkTo={`/${id}/`}
         key={id}
-        text={i18n._(text)}
+        label={i18n._(text)}
         icon={icon}
       />
     ))}


### PR DESCRIPTION
## Description

Fix the text not showing up on mobile navigation

Before:

![gatsby homepage without labels on mobile navigation](https://user-images.githubusercontent.com/1278991/79148962-3ad97280-7d7b-11ea-9b9b-9274c3690082.png)


After:

<img width="306" alt="gatsby homepage with labels on mobile navigation" src="https://user-images.githubusercontent.com/1278991/79148982-462c9e00-7d7b-11ea-99ad-20e6613ae3ea.png">
