### PR TITLE
[gatsby-plugin-google-analytics] Set nonInteraction param default value to false

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/index.js
+++ b/packages/gatsby-plugin-google-analytics/src/index.js
@@ -82,7 +82,7 @@ function trackCustomEvent({
   action,
   label,
   value,
-  nonInteraction = true,
+  nonInteraction = false,
   transport,
   hitCallback,
   callbackTimeout = 1000,


### PR DESCRIPTION
## Description
Google defines all the tracked events in Google Analytics as interactive per default. In current implementation of plugin the `nonInteraction` parameter of `trackCustomEvent` has default value of `true` which is opposite of default implementation.

To follow the Google documentation `nonInteraction` parameter has to be set to `false`.

### Documentation
[Google Analytics Documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/events#non-interaction_events)