### PR TITLE
Revert "fix(gatsby): Set a timeout of 15 seconds on queries"

### DIFF
--- a/packages/gatsby/src/query/queue.js
+++ b/packages/gatsby/src/query/queue.js
@@ -10,7 +10,6 @@ const createBaseOptions = () => {
     concurrent: Number(process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) || 4,
     // eslint-disable-next-line new-cap
     store: FastMemoryStore(),
-    maxTimeout: 15000,
   }
 }
 


### PR DESCRIPTION
Reverts gatsbyjs/gatsby#23036

This breaks builds for several users of Gatsby. In addition, this causes a structured error that isn't defined in a structured error map, causing broken stacktraces.