### PR TITLE
chore(gatsby): Test sift filtering on date instances (skipped for now)

### DIFF
--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -457,6 +457,33 @@ describe(`NodeModel`, () => {
           expect(result).toBeDefined()
           expect(result.id).toEqual(`post2`)
         })
+
+        // FIXME: Filters on date instances are not supported yet
+        //  SIFT requires such filters to be expressed as Date instances but we
+        //  don't know if date is stored as `Date` instance or `string`
+        //  so can't really do that
+        //  See https://github.com/crcn/sift.js#date-comparison
+        it.skip(`queries date instances in nodes`, async () => {
+          const type = `Post`
+          const query = {
+            filter: {
+              frontmatter: {
+                date: { lte: `2018-01-01T00:00:00Z` },
+              },
+            },
+          }
+          const firstOnly = false
+          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
+          const result = await nodeModel.runQuery({
+            query,
+            firstOnly,
+            type,
+          })
+          expect(result).toBeDefined()
+          expect(result.length).toEqual(2)
+          expect(result[0].id).toEqual(`post2`)
+          expect(result[1].id).toEqual(`post3`)
+        })
       })
     })
 


### PR DESCRIPTION
## Description

Gatsby [allows](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/db/sanitize-node.js#L72) storing `Date` instances in node fields. But `sift` filtering seems to be broken in this case as it requires filters to be passed as `Date` instances ([docs](https://github.com/crcn/sift.js#date-comparison))

The problem is that we don't know how a date field is stored when querying (as `string` or as a `Date` instance). So we can't adjust filters accordingly.

Ideally, we should disallow `Date` instances or always convert them to `string` when sanitizing. But that would be a breaking change.

So, for now, I just added a failing test but we should address it in the next major.
