### PR TITLE
feat(gatsby-cli): Allow postinstall link to be clicked

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -45,6 +45,7 @@
     "source-map": "0.7.3",
     "stack-trace": "^0.0.10",
     "strip-ansi": "^5.2.0",
+    "terminal-link": "^2.1.1",
     "update-notifier": "^3.0.1",
     "uuid": "3.4.0",
     "yargs": "^12.0.5",

--- a/packages/gatsby-cli/scripts/postinstall.js
+++ b/packages/gatsby-cli/scripts/postinstall.js
@@ -1,9 +1,12 @@
 const chalk = require(`chalk`);
+const terminalLink = require(`terminal-link`);
+
+const cliInfoUrl = `https://www.gatsbyjs.org/docs/gatsby-cli/`
 
 const showSuccessMessage = () => {
   console.log(chalk.green(`Success!\n`));
   console.log(chalk.cyan(`Welcome to the Gatsby CLI! Please visit `) +
-    chalk.underline(`https://www.gatsbyjs.org/docs/gatsby-cli/`) +
+    terminalLink(cliInfoUrl, cliInfoUrl, { fallback: chalk.underline(cliInfoUrl) }) +
     chalk.cyan(` for more information.\n`));
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Allow the link which is displayed during the post-install of `gatsby-cli` to be clicked in supported terminals.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
