### PR TITLE
chore(graphql-tools): use upstream graphql-tools v5

### DIFF
--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -12,7 +12,7 @@
     "apollo-link-http": "^1.5.16",
     "dataloader": "^2.0.0",
     "graphql": "^14.6.0",
-    "graphql-tools-fork": "^8.9.6",
+    "graphql-tools": "^5.0.0",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",
     "uuid": "^3.4.0"

--- a/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/__tests__/gatsby-node.js
@@ -1,4 +1,4 @@
-jest.mock(`graphql-tools-fork`, () => {
+jest.mock(`graphql-tools`, () => {
   return {
     transformSchema: jest.fn(),
     introspectSchema: jest.fn(),

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -4,7 +4,7 @@ const {
   transformSchema,
   introspectSchema,
   RenameTypes,
-} = require(`graphql-tools-fork`)
+} = require(`graphql-tools`)
 const { createHttpLink } = require(`apollo-link-http`)
 const nodeFetch = require(`node-fetch`)
 const invariant = require(`invariant`)

--- a/packages/gatsby-source-graphql/src/transforms.js
+++ b/packages/gatsby-source-graphql/src/transforms.js
@@ -4,7 +4,7 @@ const {
   cloneType,
   healSchema,
   visitSchema,
-} = require(`graphql-tools-fork`)
+} = require(`graphql-tools`)
 
 class NamespaceUnderFieldTransform {
   constructor({ typeName, fieldName, resolver }) {


### PR DESCRIPTION
## Description

graphql-tools-fork has been merged into upstream graphql-tools with v5

### Documentation

API is the same.

## Related Issues

Fixes #23002, as issues related to discrepant versions of apollo-link have been fixed upstream.