### PR TITLE
docs: added details signifying that node fields can be arbitrary

### DIFF
--- a/docs/docs/data-fetching.md
+++ b/docs/docs/data-fetching.md
@@ -93,7 +93,6 @@ It is important to note that node fields can indeed be arbitrary. The `nameWithO
 
 This node created manually could be retrieved with a query like this:
 
-
 ```graphql
 query {
   example {

--- a/docs/docs/data-fetching.md
+++ b/docs/docs/data-fetching.md
@@ -74,7 +74,7 @@ exports.sourceNodes = async ({
   const resultData = await result.json()
   // create node for build time data example in the docs
   createNode({
-    //nameWithOwner and url are arbitrary fields from the data
+    // nameWithOwner and url are arbitrary fields from the data
     nameWithOwner: resultData.full_name,
     url: resultData.html_url,
     // required fields

--- a/docs/docs/data-fetching.md
+++ b/docs/docs/data-fetching.md
@@ -89,7 +89,7 @@ exports.sourceNodes = async ({
 }
 ```
 
-It is important to note that node fields can indeed be arbitrary. The nameWithOwner and url fields from above are examples of this.
+It is important to note that node fields can indeed be arbitrary. The `nameWithOwner` and `url` fields from above are examples of this.
 
 This node created manually could be retrieved with a query like this:
 

--- a/docs/docs/data-fetching.md
+++ b/docs/docs/data-fetching.md
@@ -74,6 +74,7 @@ exports.sourceNodes = async ({
   const resultData = await result.json()
   // create node for build time data example in the docs
   createNode({
+    //nameWithOwner and url are arbitrary fields from the data
     nameWithOwner: resultData.full_name,
     url: resultData.html_url,
     // required fields
@@ -88,7 +89,10 @@ exports.sourceNodes = async ({
 }
 ```
 
+It is important to note that node fields can indeed be arbitrary. The nameWithOwner and url fields from above are examples of this.
+
 This node created manually could be retrieved with a query like this:
+
 
 ```graphql
 query {


### PR DESCRIPTION
## Description
The changes introduced by this PR include some changes that were asked to be made 
to the https://www.gatsbyjs.org/docs/data-fetching/ page. One change was to add a comment
in the code example stating that the nameWithOwner and url fields are arbitrary fields from the data, and another change was to add a line explicitly stating that node fields can be arbitrary.

### Documentation
This issue is concerned with the Gatsby GraphQL docs and is located on this [page](https://www.gatsbyjs.org/docs/data-fetching/)

## Related Issues
Addresses #21962 
