### PR TITLE
chore(docs) Add Strapi to integration list

### DIFF
--- a/docs/docs/deploying-to-gatsby-cloud.md
+++ b/docs/docs/deploying-to-gatsby-cloud.md
@@ -28,12 +28,12 @@ Gatsby Cloud offers integrations with a wide variety of CMSs. The below CMSs hav
 - Cosmic JS
 - Dato CMS
 - Sanity.io
+- Strapi
 
 If you want to work with a CMS without automatic integration support you still can. There are specific documents available for the below integration points:
 
 - Contentstack
 - Drupal
-- Strapi
 
 In addition, Gatsby Cloud offers a POST endpoint for manually integrating with CMSs that support webhooks.
 


### PR DESCRIPTION
Strapi is now an integration in Gatsby Cloud. This change moves the service to the integration list