### PR TITLE
fix(www) Fix translated aria-label for sidebar section toggles

### DIFF
--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -138,9 +138,11 @@ const SplitButton = withI18n()(
       <button
         aria-controls={uid}
         aria-expanded={isExpanded}
-        aria-label={i18n._(
-          isExpanded ? t`${item.title} collapse` : t`${item.title} expand`
-        )}
+        aria-label={
+          isExpanded
+            ? i18n._(t`${item.title} collapse`)
+            : i18n._(t`${item.title} expand`)
+        }
         sx={{
           ...styles.resetButton,
           bottom: 0,

--- a/www/src/data/locales/en/messages.po
+++ b/www/src/data/locales/en/messages.po
@@ -29,7 +29,7 @@ msgstr "Table of Contents"
 msgid "In this section:"
 msgstr "In this section:"
 
-#: src/components/markdown-page-footer.js:24
+#: src/components/markdown-page-footer.js:32
 msgid "<0/> Edit this page on GitHub"
 msgstr "<0/> Edit this page on GitHub"
 
@@ -126,11 +126,11 @@ msgstr "Collapse All"
 msgid "Expand All"
 msgstr "Expand All"
 
-#: src/components/sidebar/section-title.js:142
+#: src/components/sidebar/section-title.js:143
 msgid "{0} collapse"
 msgstr "{0} collapse"
 
-#: src/components/sidebar/section-title.js:142
+#: src/components/sidebar/section-title.js:144
 msgid "{0} expand"
 msgstr "{0} expand"
 

--- a/www/src/data/locales/ja/messages.po
+++ b/www/src/data/locales/ja/messages.po
@@ -29,7 +29,7 @@ msgstr "目次"
 msgid "In this section:"
 msgstr ""
 
-#: src/components/markdown-page-footer.js:24
+#: src/components/markdown-page-footer.js:32
 msgid "<0/> Edit this page on GitHub"
 msgstr ""
 
@@ -126,11 +126,11 @@ msgstr ""
 msgid "Expand All"
 msgstr ""
 
-#: src/components/sidebar/section-title.js:142
+#: src/components/sidebar/section-title.js:143
 msgid "{0} collapse"
 msgstr ""
 
-#: src/components/sidebar/section-title.js:142
+#: src/components/sidebar/section-title.js:144
 msgid "{0} expand"
 msgstr ""
 


### PR DESCRIPTION
## Description

Fix the aria-label for the section toggles in the sidebar. The issue was that the lingui macro wasn't triggering correctly because there was a conditional inside the `i18n._` call.

Before:

<img width="474" alt="HTML node for the sidebar toggle showing an aria-label of '{0} expand'" src="https://user-images.githubusercontent.com/1278991/79267289-ca4f5600-7e4d-11ea-8c0e-e14919f85bff.png">

After:

<img width="477" alt="HTML node of the sidebar toggle showing an aria-label of 'Reference guide expand'" src="https://user-images.githubusercontent.com/1278991/79267301-d0453700-7e4d-11ea-9403-61e310e57d9e.png">
