### PR TITLE
fix(gatsby): Throw error on default export in gatsby-ssr/browser

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
@@ -122,6 +122,8 @@ describe(`Resolve module exports`, () => {
     "/export/named/from": `export { Component } from 'react';`,
     "/export/named/as": `const foo = ''; export { foo as bar };`,
     "/export/named/multiple": `const foo = ''; const bar = ''; const baz = ''; export { foo, bar, baz };`,
+    "/export/default": `export default () => {}`,
+    "/export/default/name": `export default foo = () => {}`,
   }
 
   beforeEach(() => {
@@ -207,6 +209,16 @@ describe(`Resolve module exports`, () => {
   it(`Resolves multiple named exports`, () => {
     const result = resolveModuleExports(`/export/named/multiple`, { resolver })
     expect(result).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`Resolves default export`, () => {
+    const result = resolveModuleExports(`/export/default`, { resolver })
+    expect(result).toEqual([`export default`])
+  })
+
+  it(`Resolves default export with name`, () => {
+    const result = resolveModuleExports(`/export/default/name`, { resolver })
+    expect(result).toEqual([`export default foo`])
   })
 
   it(`Resolves exports when using require mode - simple case`, () => {

--- a/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
@@ -123,7 +123,7 @@ describe(`Resolve module exports`, () => {
     "/export/named/as": `const foo = ''; export { foo as bar };`,
     "/export/named/multiple": `const foo = ''; const bar = ''; const baz = ''; export { foo, bar, baz };`,
     "/export/default": `export default () => {}`,
-    "/export/default/name": `export default foo = () => {}`,
+    "/export/default/name": `const foo = () => {}; export default foo`,
   }
 
   beforeEach(() => {

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -75,8 +75,8 @@ const staticallyAnalyzeExports = (modulePath, resolver = require.resolve) => {
     // export default () => {}
     // export default Foo = () => {}
     ExportDefaultDeclaration: function ExportDefaultDeclaration(astPath) {
-      const identifier = get(astPath, `node.declaration.left.name`)
-      const exportName = `export default${identifier ? ` ${identifier}` : ``}`
+      const name = get(astPath, `node.declaration.name`)
+      const exportName = `export default${name ? ` ${name}` : ``}`
       isES6 = true
       exportNames.push(exportName)
     },

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -73,7 +73,7 @@ const staticallyAnalyzeExports = (modulePath, resolver = require.resolve) => {
     },
 
     // export default () => {}
-    // export default Foo = () => {}
+    // const foo = () => {}; export default foo
     ExportDefaultDeclaration: function ExportDefaultDeclaration(astPath) {
       const name = get(astPath, `node.declaration.name`)
       const exportName = `export default${name ? ` ${name}` : ``}`

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -72,6 +72,15 @@ const staticallyAnalyzeExports = (modulePath, resolver = require.resolve) => {
       if (exportName) exportNames.push(exportName)
     },
 
+    // export default () => {}
+    // export default Foo = () => {}
+    ExportDefaultDeclaration: function ExportDefaultDeclaration(astPath) {
+      const identifier = get(astPath, `node.declaration.left.name`)
+      const exportName = `export default${identifier ? ` ${identifier}` : ``}`
+      isES6 = true
+      exportNames.push(exportName)
+    },
+
     AssignmentExpression: function AssignmentExpression(astPath) {
       const nodeLeft = astPath.node.left
 


### PR DESCRIPTION
## Description

See #21382

This change adds an error that then will look like:

```
ERROR #11329 

Your plugins must export known APIs from their gatsby-ssr.js.

See https://www.gatsbyjs.org/docs/ssr-apis/ for the list of Gatsby ssr APIs.

- Your local gatsby-ssr.js is using the API "export default [optional-name]" which is not a known API.
```

IMO the `default export` message should be enough to lead to the right solution.

### Documentation

I couldn't directly find a fitting doc to put this info into, any suggestions?

## Related Issues

Fixes #21382
