### PR TITLE
fix(docs): recipe google analytics -  fix 404 link

### DIFF
--- a/docs/docs/recipes/deploying-your-site.md
+++ b/docs/docs/recipes/deploying-your-site.md
@@ -26,7 +26,7 @@ gatsby build
 
 ```js:title=gatsby-config.js
 module.exports = {
-  pathPrefix: `/yourpathprefix`
+  pathPrefix: `/yourpathprefix`,
 }
 ```
 

--- a/docs/docs/recipes/deploying-your-site.md
+++ b/docs/docs/recipes/deploying-your-site.md
@@ -26,7 +26,7 @@ gatsby build
 
 ```js:title=gatsby-config.js
 module.exports = {
-  pathPrefix: `/yourpathprefix`,
+  pathPrefix: `/yourpathprefix`
 }
 ```
 
@@ -143,7 +143,7 @@ Use `gatsby-plugin-google-analytics` to track site activity and provide insights
 
 ### Verify the domain in search.google.com
 
-1. Navigate to the [Google search console](<(https://search.google.com/search-console/not-verified)>) to verify the domain by clicking on **Search Property** > **Add Property**. Type in your domain and press Continue.
+1. Navigate to the [Google search console](https://search.google.com/search-console/not-verified) to verify the domain by clicking on **Search Property** > **Add Property**. Type in your domain and press Continue.
 2. Add a **TXT** record to your DNS configuration. Follow the directions for your provider, or refer to the [Google documentation](https://support.google.com/a/answer/183895?hl=en).
 
 ### Linking the domain to Google Analytics admin


### PR DESCRIPTION
## Description

changes:

- fix 404 link 

## Related Issues

- #22648 `Recipe google analytics` 
- #19267 `Add link checker for Gatsby Docs`