### PR TITLE
perf(www): Change the way child items are hidden in the docs sidebar

### DIFF
--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -139,42 +139,43 @@ class Accordion extends React.Component {
           uid={uid}
           disableAccordions={disableAccordions}
         />
-        <ul
-          id={uid}
-          sx={{
-            display: isExpanded ? `block` : `none`,
-            listStyle: `none`,
-            margin: 0,
-            position: `relative`,
-            ...(item.ui === `steps` && {
-              "&:after": {
-                backgroundColor: `ui.border`,
-                bottom: 0,
-                content: `''`,
-                left: 27,
-                position: `absolute`,
-                top: 0,
-                width: 1,
-              },
-            }),
-          }}
-        >
-          {item.items.map(subitem => (
-            <Item
-              activeItemLink={activeItemLink}
-              activeItemParents={activeItemParents}
-              createLink={createLink}
-              item={subitem}
-              key={subitem.title}
-              location={location}
-              onLinkClick={onLinkClick}
-              isExpanded={isExpanded}
-              onSectionTitleClick={onSectionTitleClick}
-              openSectionHash={openSectionHash}
-              ui={item.ui}
-            />
-          ))}
-        </ul>
+        {isExpanded && (
+          <ul
+            id={uid}
+            sx={{
+              listStyle: `none`,
+              margin: 0,
+              position: `relative`,
+              ...(item.ui === `steps` && {
+                "&:after": {
+                  backgroundColor: `ui.border`,
+                  bottom: 0,
+                  content: `''`,
+                  left: 27,
+                  position: `absolute`,
+                  top: 0,
+                  width: 1,
+                },
+              }),
+            }}
+          >
+            {item.items.map(subitem => (
+              <Item
+                activeItemLink={activeItemLink}
+                activeItemParents={activeItemParents}
+                createLink={createLink}
+                item={subitem}
+                key={subitem.title}
+                location={location}
+                onLinkClick={onLinkClick}
+                isExpanded={isExpanded}
+                onSectionTitleClick={onSectionTitleClick}
+                openSectionHash={openSectionHash}
+                ui={item.ui}
+              />
+            ))}
+          </ul>
+        )}
       </li>
     )
   }


### PR DESCRIPTION
##  Description

Change the sidebar accordion to use JSX conditionals instead of `display: none` to hide child nodes.

## Motivation

This makes the docs page more "snappy" when switching between pages (when the sidebar isn't fully expanded) since the page does not need to load the full sidebar hierarchy.