### PR TITLE
feat(gatsby-plugin-sass): Allow miniCssExtract to accept options

### DIFF
--- a/packages/gatsby-plugin-sass/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-sass/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -280,7 +280,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / No options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -294,7 +294,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / No options 1`] = `
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -333,7 +333,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / PostCss plugins 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
@@ -347,7 +347,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / PostCss plugins 1`] = `
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
@@ -386,7 +386,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / Sass options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -404,7 +404,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / Sass options 1`] = `
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -447,7 +447,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / css-loader options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -461,7 +461,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / css-loader options 1`] = `
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"camelCase\\":false,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -500,7 +500,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / sass rule modules test opt
                 Object {
                   "test": /\\\\\\.global\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -514,7 +514,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / sass rule modules test opt
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -553,7 +553,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / sass rule test options 1`]
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -567,7 +567,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / sass rule test options 1`]
                 Object {
                   "test": /\\\\\\.global\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -606,7 +606,7 @@ exports[`gatsby-plugin-sass Stage: develop / No options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -620,7 +620,7 @@ exports[`gatsby-plugin-sass Stage: develop / No options 1`] = `
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -659,7 +659,7 @@ exports[`gatsby-plugin-sass Stage: develop / PostCss plugins 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
@@ -673,7 +673,7 @@ exports[`gatsby-plugin-sass Stage: develop / PostCss plugins 1`] = `
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
@@ -712,7 +712,7 @@ exports[`gatsby-plugin-sass Stage: develop / Sass options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -730,7 +730,7 @@ exports[`gatsby-plugin-sass Stage: develop / Sass options 1`] = `
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -773,7 +773,7 @@ exports[`gatsby-plugin-sass Stage: develop / css-loader options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -787,7 +787,7 @@ exports[`gatsby-plugin-sass Stage: develop / css-loader options 1`] = `
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"camelCase\\":false,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -826,7 +826,7 @@ exports[`gatsby-plugin-sass Stage: develop / sass rule modules test options 1`] 
                 Object {
                   "test": /\\\\\\.global\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -840,7 +840,7 @@ exports[`gatsby-plugin-sass Stage: develop / sass rule modules test options 1`] 
                 Object {
                   "test": /\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -879,7 +879,7 @@ exports[`gatsby-plugin-sass Stage: develop / sass rule test options 1`] = `
                 Object {
                   "test": /\\\\\\.module\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({\\"hmr\\":false})",
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
@@ -893,7 +893,7 @@ exports[`gatsby-plugin-sass Stage: develop / sass rule test options 1`] = `
                 Object {
                   "test": /\\\\\\.global\\\\\\.s\\(a\\|c\\)ss\\$/,
                   "use": Array [
-                    "miniCssExtract",
+                    "miniCssExtract({})",
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {

--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -7,7 +7,7 @@ describe(`gatsby-plugin-sass`, () => {
 
   // loaders "mocks"
   const loaders = {
-    miniCssExtract: () => `miniCssExtract`,
+    miniCssExtract: args => `miniCssExtract(${JSON.stringify(args)})`,
     css: args => `css(${JSON.stringify(args)})`,
     postcss: args => `postcss(${JSON.stringify(args)})`,
     null: () => `null`,

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -5,6 +5,7 @@ exports.onCreateWebpackConfig = (
   {
     cssLoaderOptions = {},
     postCssPlugins,
+    miniCssExtractOptions = {},
     useResolveUrlLoader,
     sassRuleTest,
     sassRuleModulesTest,
@@ -28,7 +29,7 @@ exports.onCreateWebpackConfig = (
     use: isSSR
       ? [loaders.null()]
       : [
-          loaders.miniCssExtract(),
+          loaders.miniCssExtract(miniCssExtractOptions),
           loaders.css({ ...cssLoaderOptions, importLoaders: 2 }),
           loaders.postcss({ plugins: postCssPlugins }),
           sassLoader,
@@ -37,7 +38,8 @@ exports.onCreateWebpackConfig = (
   const sassRuleModules = {
     test: sassRuleModulesTest || /\.module\.s(a|c)ss$/,
     use: [
-      !isSSR && loaders.miniCssExtract({ hmr: false }),
+      !isSSR &&
+        loaders.miniCssExtract({ ...miniCssExtractOptions, hmr: false }),
       loaders.css({ ...cssLoaderOptions, modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       sassLoader,


### PR DESCRIPTION
This is PR #18889 by @tmilewski but I needed to rebase it and so I just copied the few changes manually and created this PR. Original description:

## Description

This PR allows for `miniCssExtract` to accept options from `gatsby-plugin-sass`.

## Related Issues

None