### PR TITLE
[gatsby-remark-images] Use Babel, and fallback to Cheerio

### DIFF
--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -7,7 +7,11 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
+    "@babel/generator": "^7.8.4",
+    "@babel/parser": "^7.8.4",
     "@babel/runtime": "^7.8.7",
+    "@babel/traverse": "^7.8.4",
+    "@babel/types": "^7.8.3",
     "chalk": "^2.4.2",
     "cheerio": "^1.0.0-rc.3",
     "gatsby-core-utils": "^1.1.1",

--- a/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
@@ -173,7 +173,38 @@ exports[`it leaves linked HTML img tags alone 1`] = `
 </a>"
 `;
 
+exports[`it leaves linked HTML img tags alone within JSX 1`] = `
+"<a href=\\"https://example.org\\">
+  <span
+      class=\\"gatsby-resp-image-wrapper\\"
+      style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
+    >
+      <span
+    class=\\"gatsby-resp-image-background-image\\"
+    style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/png;base64,iVBORw'); background-size: cover; display: block;\\"
+  ></span>
+  <img
+        class=\\"gatsby-resp-image-image\\"
+        alt=\\"this image already has a link\\"
+        title=\\"this image already has a link\\"
+        src=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg\\"
+        srcset=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg, not-a-real-dir/images/this-image-already-has-a-link.jpeg\\"
+        sizes=\\"(max-width: 650px) 100vw, 650px\\"
+        style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;\\"
+        loading=\\"lazy\\"
+      />
+    </span>
+</a>"
+`;
+
 exports[`it leaves single-line linked HTML img tags alone 1`] = `
+"<span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\">
+      <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url(&apos;data:image/png;base64,iVBORw&apos;); background-size: cover; display: block;\\"></span>
+  <img class=\\"gatsby-resp-image-image\\" alt=\\"this image already has a link\\" title=\\"this image already has a link\\" src=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg\\" srcset=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg, not-a-real-dir/images/this-image-already-has-a-link.jpeg\\" sizes=\\"(max-width: 650px) 100vw, 650px\\" style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;\\" loading=\\"lazy\\">
+    </span>"
+`;
+
+exports[`it leaves single-line linked HTML img tags alone within JSX 1`] = `
 "<span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\">
       <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url(&apos;data:image/png;base64,iVBORw&apos;); background-size: cover; display: block;\\"></span>
   <img class=\\"gatsby-resp-image-image\\" alt=\\"this image already has a link\\" title=\\"this image already has a link\\" src=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg\\" srcset=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg, not-a-real-dir/images/this-image-already-has-a-link.jpeg\\" sizes=\\"(max-width: 650px) 100vw, 650px\\" style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;\\" loading=\\"lazy\\">
@@ -198,7 +229,7 @@ exports[`it transforms HTML img tags with query strings 1`] = `
     </span>"
 `;
 
-exports[`it transforms HTML img tags within React 1`] = `
+exports[`it transforms HTML img tags within JSX 1`] = `
 "<Component attr={func()}>
   <span
       class=\\"gatsby-resp-image-wrapper\\"

--- a/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
@@ -198,6 +198,38 @@ exports[`it transforms HTML img tags with query strings 1`] = `
     </span>"
 `;
 
+exports[`it transforms HTML img tags within React 1`] = `
+"<Component attr={func()}>
+  <span
+      class=\\"gatsby-resp-image-wrapper\\"
+      style=\\"position: relative; display: block; margin-left: auto; margin-right: auto;  max-width: 300px;\\"
+    >
+      <a
+    class=\\"gatsby-resp-image-link\\"
+    href=\\"not-a-real-dir/image/my-image.jpeg\\"
+    style=\\"display: block\\"
+    target=\\"_blank\\"
+    rel=\\"noopener\\"
+  >
+    <span
+    class=\\"gatsby-resp-image-background-image\\"
+    style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/png;base64,iVBORw'); background-size: cover; display: block;\\"
+  ></span>
+  <img
+        class=\\"gatsby-resp-image-image\\"
+        alt=\\"my image\\"
+        title=\\"my image\\"
+        src=\\"not-a-real-dir/image/my-image.jpeg\\"
+        srcset=\\"not-a-real-dir/image/my-image.jpeg, not-a-real-dir/image/my-image.jpeg\\"
+        sizes=\\"(max-width: 650px) 100vw, 650px\\"
+        style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;\\"
+        loading=\\"lazy\\"
+      />
+  </a>
+    </span>
+</Component>"
+`;
+
 exports[`it transforms image references in markdown 1`] = `
 "<span
       class=\\"gatsby-resp-image-wrapper\\"

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -12,15 +12,15 @@ jest.mock(`gatsby-plugin-sharp`, () => {
         src: file.absolutePath,
         srcSet: `${file.absolutePath}, ${file.absolutePath}`,
         sizes: `(max-width: ${args.maxWidth}px) 100vw, ${args.maxWidth}px`,
-        base64: `data:image/png;base64,iVBORw`,
+        base64: `data:image/png;base64,iVBORw`
       })
     },
     traceSVG: mockTraceSVG,
     stats() {
       return Promise.resolve({
-        isTransparent: true,
+        isTransparent: true
       })
-    },
+    }
   }
 })
 
@@ -36,12 +36,12 @@ const plugin = require(`../`)
 const remark = new Remark().data(`settings`, {
   commonmark: true,
   footnotes: true,
-  pedantic: true,
+  pedantic: true
 })
 
 const createNode = content => {
   const node = {
-    id: 1234,
+    id: 1234
   }
 
   const markdownNode = {
@@ -51,13 +51,13 @@ const createNode = content => {
     internal: {
       content,
       contentDigest: `some-hash`,
-      type: `MarkdownRemark`,
-    },
+      type: `MarkdownRemark`
+    }
   }
 
   markdownNode.frontmatter = {
     title: ``, // always include a title
-    parent: node.id,
+    parent: node.id
   }
 
   return markdownNode
@@ -68,20 +68,20 @@ const createPluginOptions = (content, imagePaths = `/`) => {
   return {
     files: [].concat(imagePaths).map(imagePath => {
       return {
-        absolutePath: queryString.parseUrl(`${dirName}/${imagePath}`).url,
+        absolutePath: queryString.parseUrl(`${dirName}/${imagePath}`).url
       }
     }),
     markdownNode: createNode(content),
     markdownAST: remark.parse(content),
     getNode: () => {
       return {
-        dir: dirName,
+        dir: dirName
       }
     },
     compiler: {
       parseString: remark.parse.bind(remark),
-      generateHTML: node => hastToHTML(toHAST(node)),
-    },
+      generateHTML: node => hastToHTML(toHAST(node))
+    }
   }
 }
 
@@ -133,7 +133,7 @@ test(`it transforms images in markdown with the "withWebp" option`, async () => 
   `.trim()
 
   const nodes = await plugin(createPluginOptions(content, imagePath), {
-    withWebp: true,
+    withWebp: true
   })
 
   expect(nodes.length).toBe(1)
@@ -341,6 +341,25 @@ test(`it transforms images in markdown with query strings`, async () => {
   expect(node.value).not.toMatch(`<html>`)
 })
 
+test(`it transforms HTML img tags within React`, async () => {
+  const imagePath = `image/my-image.jpeg`
+
+  const content = `
+<Component attr={func()}>
+  <img src="./${imagePath}" />
+</Component>
+  `.trim()
+
+  const nodes = await plugin(createPluginOptions(content, imagePath))
+
+  expect(nodes.length).toBe(1)
+
+  const node = nodes.pop()
+  expect(node.type).toBe(`html`)
+  expect(node.value).toMatchSnapshot()
+  expect(node.value).not.toMatch(`<html>`)
+})
+
 test(`it uses tracedSVG placeholder when enabled`, async () => {
   const imagePath = `images/my-image.jpeg`
   const content = `
@@ -348,7 +367,7 @@ test(`it uses tracedSVG placeholder when enabled`, async () => {
   `.trim()
 
   const nodes = await plugin(createPluginOptions(content, imagePath), {
-    tracedSVG: { color: `COLOR_AUTO`, turnPolicy: `TURNPOLICY_LEFT` },
+    tracedSVG: { color: `COLOR_AUTO`, turnPolicy: `TURNPOLICY_LEFT` }
   })
 
   expect(nodes.length).toBe(1)
@@ -364,7 +383,7 @@ test(`it uses tracedSVG placeholder when enabled`, async () => {
       // fileArgs cannot be left undefined or traceSVG errors
       fileArgs: expect.any(Object),
       // args containing Potrace constants should be translated to their values
-      args: { color: Potrace.COLOR_AUTO, turnPolicy: Potrace.TURNPOLICY_LEFT },
+      args: { color: Potrace.COLOR_AUTO, turnPolicy: Potrace.TURNPOLICY_LEFT }
     })
   )
 })
@@ -375,7 +394,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: true,
+      showCaptions: true
     })
     expect(nodes.length).toBe(1)
 
@@ -390,7 +409,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: false,
+      showCaptions: false
     })
     expect(nodes.length).toBe(1)
 
@@ -404,7 +423,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [],
+      showCaptions: []
     })
     expect(nodes.length).toBe(1)
 
@@ -418,7 +437,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath})`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: true,
+      showCaptions: true
     })
     expect(nodes.length).toBe(1)
 
@@ -433,7 +452,7 @@ describe(`showCaptions`, () => {
     const content = `![](./${imagePath})`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: true,
+      showCaptions: true
     })
     expect(nodes.length).toBe(1)
 
@@ -447,7 +466,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`alt`, `title`],
+      showCaptions: [`alt`, `title`]
     })
     expect(nodes.length).toBe(1)
 
@@ -462,7 +481,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`title`, `alt`],
+      showCaptions: [`title`, `alt`]
     })
     expect(nodes.length).toBe(1)
 
@@ -477,7 +496,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`alt`],
+      showCaptions: [`alt`]
     })
     expect(nodes.length).toBe(1)
 
@@ -492,7 +511,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`title`],
+      showCaptions: [`title`]
     })
     expect(nodes.length).toBe(1)
 
@@ -507,7 +526,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath})`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`title`, `alt`],
+      showCaptions: [`title`, `alt`]
     })
     expect(nodes.length).toBe(1)
 
@@ -522,7 +541,7 @@ describe(`showCaptions`, () => {
     const content = `![](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`alt`, `title`],
+      showCaptions: [`alt`, `title`]
     })
     expect(nodes.length).toBe(1)
 
@@ -537,7 +556,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath})`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`title`],
+      showCaptions: [`title`]
     })
 
     expect(nodes.length).toBe(1)
@@ -552,7 +571,7 @@ describe(`showCaptions`, () => {
     const content = `![my image](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`alt`],
+      showCaptions: [`alt`]
     })
     expect(nodes.length).toBe(1)
 
@@ -570,7 +589,7 @@ describe(`markdownCaptions`, () => {
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
       showCaptions: true,
-      markdownCaptions: true,
+      markdownCaptions: true
     })
     expect(nodes.length).toBe(1)
 
@@ -586,7 +605,7 @@ describe(`markdownCaptions`, () => {
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
       showCaptions: true,
-      markdownCaptions: false,
+      markdownCaptions: false
     })
     expect(nodes.length).toBe(1)
 
@@ -602,7 +621,7 @@ describe(`markdownCaptions`, () => {
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
       showCaptions: false,
-      markdownCaptions: true,
+      markdownCaptions: true
     })
     expect(nodes.length).toBe(1)
 
@@ -618,7 +637,7 @@ describe(`disableBgImageOnAlpha`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      disableBgImageOnAlpha: false,
+      disableBgImageOnAlpha: false
     })
     expect(nodes.length).toBe(1)
 
@@ -632,7 +651,7 @@ describe(`disableBgImageOnAlpha`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      disableBgImageOnAlpha: true,
+      disableBgImageOnAlpha: true
     })
     expect(nodes.length).toBe(1)
 
@@ -648,7 +667,7 @@ describe(`disableBgImage`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      disableBgImage: false,
+      disableBgImage: false
     })
     expect(nodes.length).toBe(1)
 
@@ -662,7 +681,7 @@ describe(`disableBgImage`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      disableBgImage: true,
+      disableBgImage: true
     })
     expect(nodes.length).toBe(1)
 

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -12,15 +12,15 @@ jest.mock(`gatsby-plugin-sharp`, () => {
         src: file.absolutePath,
         srcSet: `${file.absolutePath}, ${file.absolutePath}`,
         sizes: `(max-width: ${args.maxWidth}px) 100vw, ${args.maxWidth}px`,
-        base64: `data:image/png;base64,iVBORw`
+        base64: `data:image/png;base64,iVBORw`,
       })
     },
     traceSVG: mockTraceSVG,
     stats() {
       return Promise.resolve({
-        isTransparent: true
+        isTransparent: true,
       })
-    }
+    },
   }
 })
 
@@ -36,12 +36,12 @@ const plugin = require(`../`)
 const remark = new Remark().data(`settings`, {
   commonmark: true,
   footnotes: true,
-  pedantic: true
+  pedantic: true,
 })
 
 const createNode = content => {
   const node = {
-    id: 1234
+    id: 1234,
   }
 
   const markdownNode = {
@@ -51,13 +51,13 @@ const createNode = content => {
     internal: {
       content,
       contentDigest: `some-hash`,
-      type: `MarkdownRemark`
-    }
+      type: `MarkdownRemark`,
+    },
   }
 
   markdownNode.frontmatter = {
     title: ``, // always include a title
-    parent: node.id
+    parent: node.id,
   }
 
   return markdownNode
@@ -68,20 +68,20 @@ const createPluginOptions = (content, imagePaths = `/`) => {
   return {
     files: [].concat(imagePaths).map(imagePath => {
       return {
-        absolutePath: queryString.parseUrl(`${dirName}/${imagePath}`).url
+        absolutePath: queryString.parseUrl(`${dirName}/${imagePath}`).url,
       }
     }),
     markdownNode: createNode(content),
     markdownAST: remark.parse(content),
     getNode: () => {
       return {
-        dir: dirName
+        dir: dirName,
       }
     },
     compiler: {
       parseString: remark.parse.bind(remark),
-      generateHTML: node => hastToHTML(toHAST(node))
-    }
+      generateHTML: node => hastToHTML(toHAST(node)),
+    },
   }
 }
 
@@ -133,7 +133,7 @@ test(`it transforms images in markdown with the "withWebp" option`, async () => 
   `.trim()
 
   const nodes = await plugin(createPluginOptions(content, imagePath), {
-    withWebp: true
+    withWebp: true,
   })
 
   expect(nodes.length).toBe(1)
@@ -350,12 +350,17 @@ test(`it transforms HTML img tags within React`, async () => {
 </Component>
   `.trim()
 
-  const nodes = await plugin(createPluginOptions(content, imagePath))
+  const options = createPluginOptions(content, imagePath)
+
+  // MDX should set the block type to jsx.
+  options.markdownAST.children[0].type = `jsx`
+
+  const nodes = await plugin(options)
 
   expect(nodes.length).toBe(1)
 
   const node = nodes.pop()
-  expect(node.type).toBe(`html`)
+  expect(node.type).toBe(`jsx`)
   expect(node.value).toMatchSnapshot()
   expect(node.value).not.toMatch(`<html>`)
 })
@@ -367,7 +372,7 @@ test(`it uses tracedSVG placeholder when enabled`, async () => {
   `.trim()
 
   const nodes = await plugin(createPluginOptions(content, imagePath), {
-    tracedSVG: { color: `COLOR_AUTO`, turnPolicy: `TURNPOLICY_LEFT` }
+    tracedSVG: { color: `COLOR_AUTO`, turnPolicy: `TURNPOLICY_LEFT` },
   })
 
   expect(nodes.length).toBe(1)
@@ -383,7 +388,7 @@ test(`it uses tracedSVG placeholder when enabled`, async () => {
       // fileArgs cannot be left undefined or traceSVG errors
       fileArgs: expect.any(Object),
       // args containing Potrace constants should be translated to their values
-      args: { color: Potrace.COLOR_AUTO, turnPolicy: Potrace.TURNPOLICY_LEFT }
+      args: { color: Potrace.COLOR_AUTO, turnPolicy: Potrace.TURNPOLICY_LEFT },
     })
   )
 })
@@ -394,7 +399,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: true
+      showCaptions: true,
     })
     expect(nodes.length).toBe(1)
 
@@ -409,7 +414,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: false
+      showCaptions: false,
     })
     expect(nodes.length).toBe(1)
 
@@ -423,7 +428,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: []
+      showCaptions: [],
     })
     expect(nodes.length).toBe(1)
 
@@ -437,7 +442,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath})`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: true
+      showCaptions: true,
     })
     expect(nodes.length).toBe(1)
 
@@ -452,7 +457,7 @@ describe(`showCaptions`, () => {
     const content = `![](./${imagePath})`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: true
+      showCaptions: true,
     })
     expect(nodes.length).toBe(1)
 
@@ -466,7 +471,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`alt`, `title`]
+      showCaptions: [`alt`, `title`],
     })
     expect(nodes.length).toBe(1)
 
@@ -481,7 +486,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`title`, `alt`]
+      showCaptions: [`title`, `alt`],
     })
     expect(nodes.length).toBe(1)
 
@@ -496,7 +501,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`alt`]
+      showCaptions: [`alt`],
     })
     expect(nodes.length).toBe(1)
 
@@ -511,7 +516,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`title`]
+      showCaptions: [`title`],
     })
     expect(nodes.length).toBe(1)
 
@@ -526,7 +531,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath})`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`title`, `alt`]
+      showCaptions: [`title`, `alt`],
     })
     expect(nodes.length).toBe(1)
 
@@ -541,7 +546,7 @@ describe(`showCaptions`, () => {
     const content = `![](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`alt`, `title`]
+      showCaptions: [`alt`, `title`],
     })
     expect(nodes.length).toBe(1)
 
@@ -556,7 +561,7 @@ describe(`showCaptions`, () => {
     const content = `![some alt](./${imagePath})`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`title`]
+      showCaptions: [`title`],
     })
 
     expect(nodes.length).toBe(1)
@@ -571,7 +576,7 @@ describe(`showCaptions`, () => {
     const content = `![my image](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      showCaptions: [`alt`]
+      showCaptions: [`alt`],
     })
     expect(nodes.length).toBe(1)
 
@@ -589,7 +594,7 @@ describe(`markdownCaptions`, () => {
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
       showCaptions: true,
-      markdownCaptions: true
+      markdownCaptions: true,
     })
     expect(nodes.length).toBe(1)
 
@@ -605,7 +610,7 @@ describe(`markdownCaptions`, () => {
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
       showCaptions: true,
-      markdownCaptions: false
+      markdownCaptions: false,
     })
     expect(nodes.length).toBe(1)
 
@@ -621,7 +626,7 @@ describe(`markdownCaptions`, () => {
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
       showCaptions: false,
-      markdownCaptions: true
+      markdownCaptions: true,
     })
     expect(nodes.length).toBe(1)
 
@@ -637,7 +642,7 @@ describe(`disableBgImageOnAlpha`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      disableBgImageOnAlpha: false
+      disableBgImageOnAlpha: false,
     })
     expect(nodes.length).toBe(1)
 
@@ -651,7 +656,7 @@ describe(`disableBgImageOnAlpha`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      disableBgImageOnAlpha: true
+      disableBgImageOnAlpha: true,
     })
     expect(nodes.length).toBe(1)
 
@@ -667,7 +672,7 @@ describe(`disableBgImage`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      disableBgImage: false
+      disableBgImage: false,
     })
     expect(nodes.length).toBe(1)
 
@@ -681,7 +686,7 @@ describe(`disableBgImage`, () => {
     const content = `![some alt](./${imagePath} "some title")`
 
     const nodes = await plugin(createPluginOptions(content, imagePath), {
-      disableBgImage: true
+      disableBgImage: true,
     })
     expect(nodes.length).toBe(1)
 

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -52,17 +52,23 @@ module.exports = (
   const definitions = getDefinitions(markdownAST)
 
   // This will allow the use of html image tags
-  // const rawHtmlNodes = select(markdownAST, `html`)
-  let rawHtmlNodes = []
-  visitWithParents(markdownAST, [`html`, `jsx`], (node, ancestors) => {
+  const rawHtmlNodes = []
+  visitWithParents(markdownAST, [`html`], (node, ancestors) => {
     const inLink = ancestors.some(findParentLinks)
 
     rawHtmlNodes.push({ node, inLink })
   })
 
-  // This will only work for markdown syntax image tags
-  let markdownImageNodes = []
+  // This will allow the use of MDX
+  const rawJsxNodes = []
+  visitWithParents(markdownAST, [`jsx`], (node, ancestors) => {
+    const inLink = ancestors.some(findParentLinks)
 
+    rawJsxNodes.push({ node, inLink })
+  })
+
+  // This will only work for markdown syntax image tags
+  const markdownImageNodes = []
   visitWithParents(
     markdownAST,
     [`image`, `imageReference`],
@@ -354,7 +360,7 @@ module.exports = (
     return rawHTML
   }
 
-  return Promise.all(
+  const markdownImageNodesPromise = Promise.all(
     // Simple because there is no nesting in markdown
     markdownImageNodes.map(
       ({ node, inLink }) =>
@@ -407,174 +413,185 @@ module.exports = (
           }
         })
     )
-  ).then(markdownImageNodes =>
-    // HTML image node stuff
-    Promise.all(
-      // Complex because HTML nodes can contain multiple images
-      rawHtmlNodes.map(
-        ({ node, inLink }) =>
-          new Promise((resolve, reject) => {
-            if (!node.value) {
+  )
+
+  async function useBabel(node, inLink) {
+    const ast = parse(node.value, {
+      plugins: [`jsx`, `typescript`],
+      sourceType: `module`,
+    })
+
+    const imagePaths = []
+
+    traverse(ast, {
+      JSXElement(path) {
+        if (path.node.openingElement.name.name === `img`) {
+          imagePaths.push(path)
+        }
+      },
+    })
+
+    if (imagePaths.length === 0) {
+      // No img tags
+      return null
+    }
+
+    let valueChanged = false
+
+    await Promise.all(
+      imagePaths.map(
+        imagePath =>
+          new Promise(async resolve => {
+            // Get the details we need.
+            const getAttributeValue = name => {
+              const attribute = imagePath.node.openingElement.attributes.find(
+                attribute =>
+                  attribute.type === `JSXAttribute` &&
+                  attribute.name.type === `JSXIdentifier` &&
+                  attribute.name.name === name &&
+                  attribute.value.type === `StringLiteral`
+              )
+
+              return attribute && attribute.value.value
+            }
+
+            const url = getAttributeValue(`src`)
+
+            if (!url) {
               return resolve()
             }
 
-            const useBabel = async () => {
-              const ast = parse(node.value, {
-                plugins: [`jsx`, `typescript`],
-                sourceType: `module`,
-              })
+            const fileType = getImageInfo(url).ext
 
-              const imagePaths = []
-
-              traverse(ast, {
-                JSXElement(path) {
-                  if (path.node.openingElement.name.name === `img`) {
-                    imagePaths.push(path)
-                  }
-                },
-              })
-
-              if (imagePaths.length === 0) {
-                // No img tags
-                return resolve()
+            // Ignore gifs as we can't process them,
+            // svgs as they are already responsive by definition
+            if (
+              isRelativeUrl(url) &&
+              fileType !== `gif` &&
+              fileType !== `svg`
+            ) {
+              const formattedImgTag = {
+                alt: getAttributeValue(`alt`),
+                title: getAttributeValue(`title`),
+                url,
               }
 
-              let valueChanged = false
-
-              await Promise.all(
-                imagePaths.map(
-                  imagePath =>
-                    new Promise(async (resolve, reject) => {
-                      // Get the details we need.
-                      const getAttributeValue = name => {
-                        const attribute = imagePath.node.openingElement.attributes.find(
-                          attribute =>
-                            attribute.type === `JSXAttribute` &&
-                            attribute.name.type === `JSXIdentifier` &&
-                            attribute.name.name === name &&
-                            attribute.value.type === `StringLiteral`
-                        )
-
-                        return attribute && attribute.value.value
-                      }
-
-                      const url = getAttributeValue(`src`)
-
-                      if (!url) {
-                        return resolve()
-                      }
-
-                      const fileType = getImageInfo(url).ext
-
-                      // Ignore gifs as we can't process them,
-                      // svgs as they are already responsive by definition
-                      if (
-                        isRelativeUrl(url) &&
-                        fileType !== `gif` &&
-                        fileType !== `svg`
-                      ) {
-                        const formattedImgTag = {
-                          alt: getAttributeValue(`alt`),
-                          title: getAttributeValue(`title`),
-                          url,
-                        }
-
-                        const rawHTML = await generateImagesAndUpdateNode(
-                          formattedImgTag,
-                          resolve,
-                          inLink
-                        )
-
-                        if (rawHTML) {
-                          // Replace the image string
-                          imagePath.replaceWith(types.jsxText(rawHTML))
-                          valueChanged = true
-                        }
-                      }
-
-                      return resolve()
-                    })
-                )
+              const rawHTML = await generateImagesAndUpdateNode(
+                formattedImgTag,
+                resolve,
+                inLink
               )
 
-              if (!valueChanged) {
-                // No need to dump AST
-                return resolve()
+              if (rawHTML) {
+                // Replace the image string
+                imagePath.replaceWith(types.jsxText(rawHTML))
+                valueChanged = true
               }
-
-              let rawHTML = generate(ast, {}, node.value).code
-
-              // Strip the final semicolon
-              rawHTML = rawHTML.slice(0, rawHTML.length - 1)
-
-              // Replace the image node with an inline HTML node.
-              if (node.type !== `jsx`) {
-                node.type = `html`
-              }
-              node.value = rawHTML
-
-              return resolve(node)
             }
 
-            const useCheerio = async () => {
-              const $ = cheerio.load(node.value)
-              if ($(`img`).length === 0) {
-                // No img tags
-                return resolve()
-              }
-
-              let imageRefs = []
-              $(`img`).each(function () {
-                imageRefs.push($(this))
-              })
-
-              for (let thisImg of imageRefs) {
-                // Get the details we need.
-                let formattedImgTag = {}
-                formattedImgTag.url = thisImg.attr(`src`)
-                formattedImgTag.title = thisImg.attr(`title`)
-                formattedImgTag.alt = thisImg.attr(`alt`)
-
-                if (!formattedImgTag.url) {
-                  return resolve()
-                }
-
-                const fileType = getImageInfo(formattedImgTag.url).ext
-
-                // Ignore gifs as we can't process them,
-                // svgs as they are already responsive by definition
-                if (
-                  isRelativeUrl(formattedImgTag.url) &&
-                  fileType !== `gif` &&
-                  fileType !== `svg`
-                ) {
-                  const rawHTML = await generateImagesAndUpdateNode(
-                    formattedImgTag,
-                    resolve,
-                    inLink
-                  )
-
-                  if (rawHTML) {
-                    // Replace the image string
-                    thisImg.replaceWith(rawHTML)
-                  } else {
-                    return resolve()
-                  }
-                }
-              }
-
-              // Replace the image node with an inline HTML node.
-              node.type = `html`
-              node.value = $(`body`).html() // fix for cheerio v1
-
-              return resolve(node)
-            }
-
-            return useBabel().catch(() => useCheerio())
+            return resolve()
           })
       )
-    ).then(htmlImageNodes =>
-      markdownImageNodes.concat(htmlImageNodes).filter(node => !!node)
     )
+
+    if (!valueChanged) {
+      // No need to dump AST
+      return null
+    }
+
+    let rawJSX = generate(ast, {}, node.value).code
+
+    // Strip the final semicolon
+    rawJSX = rawJSX.slice(0, rawJSX.length - 1)
+
+    // Replace the image node with an inline HTML node.
+    node.value = rawJSX
+
+    return node
+  }
+
+  function useCheerio(node, inLink) {
+    return new Promise(async resolve => {
+      const $ = cheerio.load(node.value)
+      if ($(`img`).length === 0) {
+        // No img tags
+        return resolve()
+      }
+
+      let imageRefs = []
+      $(`img`).each(function () {
+        imageRefs.push($(this))
+      })
+
+      for (let thisImg of imageRefs) {
+        // Get the details we need.
+        let formattedImgTag = {}
+        formattedImgTag.url = thisImg.attr(`src`)
+        formattedImgTag.title = thisImg.attr(`title`)
+        formattedImgTag.alt = thisImg.attr(`alt`)
+
+        if (!formattedImgTag.url) {
+          return resolve()
+        }
+
+        const fileType = getImageInfo(formattedImgTag.url).ext
+
+        // Ignore gifs as we can't process them,
+        // svgs as they are already responsive by definition
+        if (
+          isRelativeUrl(formattedImgTag.url) &&
+          fileType !== `gif` &&
+          fileType !== `svg`
+        ) {
+          const rawHTML = await generateImagesAndUpdateNode(
+            formattedImgTag,
+            resolve,
+            inLink
+          )
+
+          if (rawHTML) {
+            // Replace the image string
+            thisImg.replaceWith(rawHTML)
+          } else {
+            return resolve()
+          }
+        }
+      }
+
+      // Replace the image node with an inline HTML node.
+      if (node.type !== `jsx`) {
+        node.type = `html`
+      }
+      node.value = $(`body`).html() // fix for cheerio v1
+
+      return resolve(node)
+    })
+  }
+
+  // HTML image node stuff
+  // Complex because HTML nodes can contain multiple images
+  const rawHtmlNodesPromise = Promise.all(
+    rawHtmlNodes.map(({ node, inLink }) =>
+      node.value ? useCheerio(node, inLink) : Promise.resolve()
+    )
+  )
+
+  const rawJsxNodesPromise = Promise.all(
+    rawJsxNodes.map(({ node, inLink }) =>
+      node.value
+        ? useBabel(node, inLink).catch(() => useCheerio(node, inLink))
+        : Promise.resolve()
+    )
+  )
+
+  return Promise.all([
+    markdownImageNodesPromise,
+    rawHtmlNodesPromise,
+    rawJsxNodesPromise,
+  ]).then(([markdownImageNodes, rawHtmlImageNodes, rawJsxImageNodes]) =>
+    markdownImageNodes
+      .concat(rawHtmlImageNodes)
+      .concat(rawJsxImageNodes)
+      .filter(node => !!node)
   )
 }

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -54,6 +54,10 @@ module.exports = (
   // This will allow the use of html image tags
   const rawHtmlNodes = []
   visitWithParents(markdownAST, [`html`], (node, ancestors) => {
+    if (!node.value) {
+      return
+    }
+
     const inLink = ancestors.some(findParentLinks)
 
     rawHtmlNodes.push({ node, inLink })
@@ -62,6 +66,10 @@ module.exports = (
   // This will allow the use of MDX
   const rawJsxNodes = []
   visitWithParents(markdownAST, [`jsx`], (node, ancestors) => {
+    if (!node.value) {
+      return
+    }
+
     const inLink = ancestors.some(findParentLinks)
 
     rawJsxNodes.push({ node, inLink })
@@ -423,10 +431,25 @@ module.exports = (
 
     const imagePaths = []
 
+    let astLinkCount = 0
     traverse(ast, {
       JSXElement(path) {
         if (path.node.openingElement.name.name === `img`) {
-          imagePaths.push(path)
+          const astInLink = astLinkCount > 0
+          imagePaths.push({
+            imagePath: path,
+            astInLink,
+          })
+        }
+      },
+      JSXOpeningElement(path) {
+        if (path.node.name.name === `a`) {
+          ++astLinkCount
+        }
+      },
+      JSXClosingElement(path) {
+        if (path.node.name.name === `a`) {
+          --astLinkCount
         }
       },
     })
@@ -440,7 +463,7 @@ module.exports = (
 
     await Promise.all(
       imagePaths.map(
-        imagePath =>
+        ({ imagePath, astInLink }) =>
           new Promise(async resolve => {
             // Get the details we need.
             const getAttributeValue = name => {
@@ -479,7 +502,7 @@ module.exports = (
               const rawHTML = await generateImagesAndUpdateNode(
                 formattedImgTag,
                 resolve,
-                inLink
+                inLink || astInLink
               )
 
               if (rawHTML) {
@@ -523,26 +546,25 @@ module.exports = (
         imageRefs.push($(this))
       })
 
-      for (let thisImg of imageRefs) {
-        // Get the details we need.
-        let formattedImgTag = {}
-        formattedImgTag.url = thisImg.attr(`src`)
-        formattedImgTag.title = thisImg.attr(`title`)
-        formattedImgTag.alt = thisImg.attr(`alt`)
+      for (const thisImg of imageRefs) {
+        const url = thisImg.attr(`src`)
 
-        if (!formattedImgTag.url) {
+        if (!url) {
           return resolve()
         }
 
-        const fileType = getImageInfo(formattedImgTag.url).ext
+        const fileType = getImageInfo(url).ext
 
         // Ignore gifs as we can't process them,
         // svgs as they are already responsive by definition
-        if (
-          isRelativeUrl(formattedImgTag.url) &&
-          fileType !== `gif` &&
-          fileType !== `svg`
-        ) {
+        if (isRelativeUrl(url) && fileType !== `gif` && fileType !== `svg`) {
+          // Get the details we need.
+          const formattedImgTag = {
+            url,
+            title: thisImg.attr(`title`),
+            alt: thisImg.attr(`alt`),
+          }
+
           const rawHTML = await generateImagesAndUpdateNode(
             formattedImgTag,
             resolve,
@@ -571,16 +593,18 @@ module.exports = (
   // HTML image node stuff
   // Complex because HTML nodes can contain multiple images
   const rawHtmlNodesPromise = Promise.all(
-    rawHtmlNodes.map(({ node, inLink }) =>
-      node.value ? useCheerio(node, inLink) : Promise.resolve()
-    )
+    rawHtmlNodes.map(({ node, inLink }) => useCheerio(node, inLink))
   )
 
   const rawJsxNodesPromise = Promise.all(
     rawJsxNodes.map(({ node, inLink }) =>
-      node.value
-        ? useBabel(node, inLink).catch(() => useCheerio(node, inLink))
-        : Promise.resolve()
+      useBabel(node, inLink).catch(err => {
+        console.log(
+          `Error while parsing JSX with Babel, using Cheerio fallback.`
+        )
+        console.log(err)
+        return useCheerio(node, inLink)
+      })
     )
   )
 

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -15,6 +15,10 @@ const Promise = require(`bluebird`)
 const cheerio = require(`cheerio`)
 const { slash } = require(`gatsby-core-utils`)
 const chalk = require(`chalk`)
+const { parse } = require(`@babel/parser`)
+const generate = require(`@babel/generator`).default
+const traverse = require(`@babel/traverse`).default
+const types = require(`@babel/types`)
 
 // If the image is relative (not hosted elsewhere)
 // 1. Find the image file
@@ -409,62 +413,164 @@ module.exports = (
       // Complex because HTML nodes can contain multiple images
       rawHtmlNodes.map(
         ({ node, inLink }) =>
-          new Promise(async (resolve, reject) => {
+          new Promise((resolve, reject) => {
             if (!node.value) {
               return resolve()
             }
 
-            const $ = cheerio.load(node.value)
-            if ($(`img`).length === 0) {
-              // No img tags
-              return resolve()
-            }
+            const useBabel = async () => {
+              const ast = parse(node.value, {
+                plugins: [`jsx`, `typescript`],
+                sourceType: `module`,
+              })
 
-            let imageRefs = []
-            $(`img`).each(function () {
-              imageRefs.push($(this))
-            })
+              const imagePaths = []
 
-            for (let thisImg of imageRefs) {
-              // Get the details we need.
-              let formattedImgTag = {}
-              formattedImgTag.url = thisImg.attr(`src`)
-              formattedImgTag.title = thisImg.attr(`title`)
-              formattedImgTag.alt = thisImg.attr(`alt`)
+              traverse(ast, {
+                JSXElement(path) {
+                  if (path.node.openingElement.name.name === `img`) {
+                    imagePaths.push(path)
+                  }
+                },
+              })
 
-              if (!formattedImgTag.url) {
+              if (imagePaths.length === 0) {
+                // No img tags
                 return resolve()
               }
 
-              const fileType = getImageInfo(formattedImgTag.url).ext
+              let valueChanged = false
 
-              // Ignore gifs as we can't process them,
-              // svgs as they are already responsive by definition
-              if (
-                isRelativeUrl(formattedImgTag.url) &&
-                fileType !== `gif` &&
-                fileType !== `svg`
-              ) {
-                const rawHTML = await generateImagesAndUpdateNode(
-                  formattedImgTag,
-                  resolve,
-                  inLink
+              await Promise.all(
+                imagePaths.map(
+                  imagePath =>
+                    new Promise(async (resolve, reject) => {
+                      // Get the details we need.
+                      const getAttributeValue = name => {
+                        const attribute = imagePath.node.openingElement.attributes.find(
+                          attribute =>
+                            attribute.type === `JSXAttribute` &&
+                            attribute.name.type === `JSXIdentifier` &&
+                            attribute.name.name === name &&
+                            attribute.value.type === `StringLiteral`
+                        )
+
+                        return attribute && attribute.value.value
+                      }
+
+                      const url = getAttributeValue(`src`)
+
+                      if (!url) {
+                        return resolve()
+                      }
+
+                      const fileType = getImageInfo(url).ext
+
+                      // Ignore gifs as we can't process them,
+                      // svgs as they are already responsive by definition
+                      if (
+                        isRelativeUrl(url) &&
+                        fileType !== `gif` &&
+                        fileType !== `svg`
+                      ) {
+                        const formattedImgTag = {
+                          alt: getAttributeValue(`alt`),
+                          title: getAttributeValue(`title`),
+                          url,
+                        }
+
+                        const rawHTML = await generateImagesAndUpdateNode(
+                          formattedImgTag,
+                          resolve,
+                          inLink
+                        )
+
+                        if (rawHTML) {
+                          // Replace the image string
+                          imagePath.replaceWith(types.jsxText(rawHTML))
+                          valueChanged = true
+                        }
+                      }
+
+                      return resolve()
+                    })
                 )
+              )
 
-                if (rawHTML) {
-                  // Replace the image string
-                  thisImg.replaceWith(rawHTML)
-                } else {
-                  return resolve()
-                }
+              if (!valueChanged) {
+                // No need to dump AST
+                return resolve()
               }
+
+              let rawHTML = generate(ast, {}, node.value).code
+
+              // Strip the final semicolon
+              rawHTML = rawHTML.slice(0, rawHTML.length - 1)
+
+              // Replace the image node with an inline HTML node.
+              if (node.type !== `jsx`) {
+                node.type = `html`
+              }
+              node.value = rawHTML
+
+              return resolve(node)
             }
 
-            // Replace the image node with an inline HTML node.
-            node.type = `html`
-            node.value = $(`body`).html() // fix for cheerio v1
+            const useCheerio = async () => {
+              const $ = cheerio.load(node.value)
+              if ($(`img`).length === 0) {
+                // No img tags
+                return resolve()
+              }
 
-            return resolve(node)
+              let imageRefs = []
+              $(`img`).each(function () {
+                imageRefs.push($(this))
+              })
+
+              for (let thisImg of imageRefs) {
+                // Get the details we need.
+                let formattedImgTag = {}
+                formattedImgTag.url = thisImg.attr(`src`)
+                formattedImgTag.title = thisImg.attr(`title`)
+                formattedImgTag.alt = thisImg.attr(`alt`)
+
+                if (!formattedImgTag.url) {
+                  return resolve()
+                }
+
+                const fileType = getImageInfo(formattedImgTag.url).ext
+
+                // Ignore gifs as we can't process them,
+                // svgs as they are already responsive by definition
+                if (
+                  isRelativeUrl(formattedImgTag.url) &&
+                  fileType !== `gif` &&
+                  fileType !== `svg`
+                ) {
+                  const rawHTML = await generateImagesAndUpdateNode(
+                    formattedImgTag,
+                    resolve,
+                    inLink
+                  )
+
+                  if (rawHTML) {
+                    // Replace the image string
+                    thisImg.replaceWith(rawHTML)
+                  } else {
+                    return resolve()
+                  }
+                }
+              }
+
+              // Replace the image node with an inline HTML node.
+              node.type = `html`
+              node.value = $(`body`).html() // fix for cheerio v1
+
+              return resolve(node)
+            }
+
+            return useBabel().catch(() => useCheerio())
           })
       )
     ).then(htmlImageNodes =>


### PR DESCRIPTION
## Description

Basically #21782 without the force link/no-link feature I added at the end, which will have its own PR.

With this patch, HTML blocks are parsed and transformed with Cheerio, while JSX blocks use Babel and fallback to Cheerio (i.e. fallback to the current behavior) if Babel fails. None of the tests or of my use cases (external project) fallback to Cheerio. I still let the fallback because I can't guarantee the inputs, but I assume it shouldn't be used.

Still no benchmark done.

### Documentation

I guess a mention on https://www.gatsbyjs.org/docs/working-with-images-in-markdown/#using-the-mdx-plugin should be enough.

## Related Issues

Fixes #19785