### PR TITLE
chore(docs): 🧹 Remove trailing spaces

### DIFF
--- a/docs/docs/creating-a-source-plugin.md
+++ b/docs/docs/creating-a-source-plugin.md
@@ -265,7 +265,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       author: Author @link(from: "author.name" by: "name") // highlight-line
       # ... other fields
     }
-    
+
     type Author implements Node {
       name: String!
       post: Post @link // highlight-line

--- a/rfcs/text/0011-move-rfcs-to-monorepo.md
+++ b/rfcs/text/0011-move-rfcs-to-monorepo.md
@@ -49,7 +49,7 @@ title: "RFC Template"
 date: YYYY-MM-DD
 status: "IN_REVIEW" | "MERGED" | "PUBLISHED"
 # optional fields, e.g. that can be added when merging
-issue: 
+issue:
 ---
 
 # Summary


### PR DESCRIPTION
## Description

Small fix to remove trailing spaces from two Markdown files on two lines.

