### PR TITLE
chore(gatsby-cli): move recipes out of gatsby

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -26,6 +26,7 @@
     "fs-exists-cached": "^1.0.0",
     "fs-extra": "^8.1.0",
     "gatsby-core-utils": "^1.1.2",
+    "gatsby-recipes": "^0.0.6",
     "gatsby-telemetry": "^1.2.4",
     "hosted-git-info": "^3.0.4",
     "is-valid-path": "^0.1.1",

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -13,6 +13,7 @@ const {
   setDefaultTags,
   setTelemetryEnabled,
 } = require(`gatsby-telemetry`)
+const { recipesHandler } = require(`./recipes`)
 
 const handlerP = fn => (...args) => {
   Promise.resolve(fn(...args)).then(
@@ -293,18 +294,11 @@ function buildLocalCommands(cli, isLocalSite) {
       return cmd(args)
     }),
   })
+
   cli.command({
-    command: `recipes`,
+    command: `recipes [recipe]`,
     desc: `[EXPERIMENTAL] Run a recipe`,
-    handler: handlerP(
-      getCommandHandler(`recipes`, (args, cmd) => {
-        cmd(args)
-        // Return an empty promise to prevent handlerP from exiting early.
-        // The recipe command shouldn't ever exit until the user directly
-        // kills it so this is fine.
-        return new Promise(resolve => {})
-      })
-    ),
+    handler: handlerP(({ recipe }) => recipesHandler(recipe)),
   })
 }
 

--- a/packages/gatsby-cli/src/recipes.ts
+++ b/packages/gatsby-cli/src/recipes.ts
@@ -23,23 +23,28 @@ export async function recipesHandler(recipe: string): Promise<void> {
     },
   })
 
+  // eslint-disable-next-line no-unused-expressions
   subprocess.stderr?.on(`data`, data => {
     console.log(data.toString())
   })
-  process.on(`exit`, () =>
+
+  process.on(`exit`, () => {
     subprocess.kill(`SIGTERM`, {
       forceKillAfterTimeout: 2000,
     })
-  )
+  })
+
   // Log server output to a file.
   if (process.env.DEBUG) {
     const logFile = path.resolve(`./recipe-server.log`)
     fs.writeFileSync(logFile, `\n-----\n${new Date().toJSON()}\n`)
     const writeStream = fs.createWriteStream(logFile, { flags: `a` })
+    // eslint-disable-next-line no-unused-expressions
     subprocess.stdout?.pipe(writeStream)
   }
 
   let started = false
+  // eslint-disable-next-line no-unused-expressions
   subprocess.stdout?.on(`data`, () => {
     if (!started) {
       const runRecipe = require(`gatsby-recipes/dist/index.js`)

--- a/packages/gatsby-cli/src/recipes.ts
+++ b/packages/gatsby-cli/src/recipes.ts
@@ -22,7 +22,8 @@ export async function recipesHandler(recipe: string): Promise<void> {
       FORCE_COLOR: `true`,
     },
   })
-  subprocess.stderr.on(`data`, data => {
+
+  subprocess.stderr?.on(`data`, data => {
     console.log(data.toString())
   })
   process.on(`exit`, () =>
@@ -35,11 +36,11 @@ export async function recipesHandler(recipe: string): Promise<void> {
     const logFile = path.resolve(`./recipe-server.log`)
     fs.writeFileSync(logFile, `\n-----\n${new Date().toJSON()}\n`)
     const writeStream = fs.createWriteStream(logFile, { flags: `a` })
-    subprocess.stdout.pipe(writeStream)
+    subprocess.stdout?.pipe(writeStream)
   }
 
   let started = false
-  subprocess.stdout.on(`data`, () => {
+  subprocess.stdout?.on(`data`, () => {
     if (!started) {
       const runRecipe = require(`gatsby-recipes/dist/index.js`)
       runRecipe({ recipe, graphqlPort, projectRoot: process.cwd() })
@@ -47,5 +48,5 @@ export async function recipesHandler(recipe: string): Promise<void> {
     }
   })
 
-  return subprocess
+  return subprocess.then(() => {})
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -77,7 +77,6 @@
     "gatsby-link": "^2.3.3",
     "gatsby-plugin-page-creator": "^2.2.2",
     "gatsby-react-router-scroll": "^2.2.1",
-    "gatsby-recipes": "^0.0.6",
     "gatsby-telemetry": "^1.2.4",
     "glob": "^7.1.6",
     "got": "8.3.2",

--- a/packages/gatsby/src/commands/types.ts
+++ b/packages/gatsby/src/commands/types.ts
@@ -20,7 +20,6 @@ export interface IProgram {
   https?: boolean
   sitePackageJson: PackageJson
   ssl?: ICert
-  _?: any
 }
 
 // @deprecated


### PR DESCRIPTION
## Description

There is no reason to have gatsby-recipes part of gatsby, we should only add it to gatsby-cli.

Waiting for https://github.com/gatsbyjs/gatsby/pull/23188 to be merged