### PR TITLE
enhancement(gatsby-design-tokens): improve the color of social links

### DIFF
--- a/packages/gatsby-design-tokens/src/theme-gatsbyjs-org.js
+++ b/packages/gatsby-design-tokens/src/theme-gatsbyjs-org.js
@@ -73,7 +73,7 @@ const c = {
     linkDefault: colorsTokens.grey[70],
     linkActive: colorsTokens.purple[50],
     linkHover: colorsTokens.gatsby,
-    socialLink: colorsTokens.grey[40],
+    socialLink: colorsTokens.grey[50],
   },
   search: {
     suggestionHighlightBackground: colorsTokens.lavender,
@@ -187,7 +187,7 @@ const c = {
         linkActive: colorsTokens.purple[40],
         linkDefault: colorsTokens.whiteFade[60],
         linkHover: colorsTokens.white,
-        socialLink: colorsTokens.grey[60],
+        socialLink: colorsTokens.grey[50],
       },
       themedInput: {
         background: darkBorder,


### PR DESCRIPTION
## Description

Edit the color of the social links to be more accessible, based on [feedback](https://github.com/gatsbyjs/gatsby/pull/22955#issuecomment-613366389) from #22955.

