### PR TITLE
chore(gatsby-benchmark-mdx): update mdx benchmark packages to use pregenerated data

### DIFF
--- a/benchmarks/mdx/package.json
+++ b/benchmarks/mdx/package.json
@@ -33,7 +33,7 @@
     "cross-env": "^7.0.0",
     "gatsby-plugin-benchmark-reporting": "0.1.3",
     "prettier": "2.0.4",
-    "willit": "0.0.7"
+    "willit": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/benchmarks/mdx/package.json
+++ b/benchmarks/mdx/package.json
@@ -9,34 +9,31 @@
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
-    "postinstall": "del-cli src/articles && gatsby clean && willit --type=mdx --num-pages=${NUM_PAGES:-512}",
+    "postinstall": "del-cli src/articles && gatsby clean && willit --use-pregenerated-data --type=mdx --num-pages=${NUM_PAGES:-512}",
     "start": "npm run develop",
     "serve": "gatsby serve"
   },
-  "resolutions": {
-    "sharp": "0.25.1"
-  },
   "dependencies": {
-    "del-cli": "^3.0.0",
     "@mdx-js/mdx": "^1.5.7",
     "@mdx-js/react": "^1.5.7",
+    "del-cli": "^3.0.0",
     "dotenv": "^8.2.0",
-    "gatsby": "^2.19.35",
-    "gatsby-image": "^2.2.40",
-    "gatsby-plugin-mdx": "^1.0.82",
-    "gatsby-plugin-page-creator": "^2.1.45",
+    "gatsby": "^2.20.23",
+    "gatsby-image": "^2.3.3",
+    "gatsby-plugin-mdx": "^1.1.8",
+    "gatsby-plugin-page-creator": "^2.2.2",
     "gatsby-plugin-sharp": "^2.4.12",
-    "gatsby-remark-images": "^3.1.49",
-    "gatsby-source-filesystem": "^2.1.48",
-    "gatsby-transformer-sharp": "^2.3.14",
+    "gatsby-remark-images": "^3.2.3",
+    "gatsby-source-filesystem": "^2.2.3",
+    "gatsby-transformer-sharp": "^2.4.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },
   "devDependencies": {
     "cross-env": "^7.0.0",
-    "gatsby-plugin-benchmark-reporting": "*",
+    "gatsby-plugin-benchmark-reporting": "0.1.3",
     "prettier": "2.0.4",
-    "willit": "*"
+    "willit": "0.0.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR upgrades to the latest `willit` data generator so we can use the `--use-pregenerated-data` flag and keep the mdx benchmark data consistent.