### PR TITLE
perf(gatsby): replace `mitt` with a modern Map/Set based version of it

### DIFF
--- a/integration-tests/structured-logging/__tests__/to-do.js
+++ b/integration-tests/structured-logging/__tests__/to-do.js
@@ -319,7 +319,7 @@ describe(`develop`, () => {
   // See https://github.com/gatsbyjs/gatsby/issues/18518
   describe.skip(`test preview workflows`, () => {
     let gatsbyProcess
-    const mitt = new EventEmitter()
+    const eventEmitter = new EventEmitter()
     const events = []
     const clearEvents = () => {
       events.splice(0, events.length)
@@ -345,7 +345,7 @@ describe(`develop`, () => {
           msg.action.payload !== `IN_PROGRESS`
         ) {
           setTimeout(() => {
-            mitt.emit(`done`)
+            eventEmitter.emit(`done`)
             done()
           }, 5000)
         }
@@ -391,7 +391,7 @@ describe(`develop`, () => {
             codeWithError
           )
 
-          mitt.once(`done`, () => {
+          eventEmitter.once(`done`, () => {
             done()
           })
         })
@@ -406,7 +406,7 @@ describe(`develop`, () => {
             `git checkout -- ${require.resolve(`../src/pages/index.js`)}`
           )
 
-          mitt.once(`done`, () => {
+          eventEmitter.once(`done`, () => {
             done()
           })
         })
@@ -431,7 +431,7 @@ describe(`develop`, () => {
             }),
           })
 
-          mitt.once(`done`, () => {
+          eventEmitter.once(`done`, () => {
             done()
           })
         })
@@ -453,7 +453,7 @@ describe(`develop`, () => {
             }),
           })
 
-          mitt.once(`done`, () => {
+          eventEmitter.once(`done`, () => {
             done()
           })
         })

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -7,14 +7,14 @@ import {
 } from "redux"
 import _ from "lodash"
 
-import mitt from "mitt"
+import { mett } from "../utils/mett"
 import thunk from "redux-thunk"
 import reducers from "./reducers"
 import { writeToCache, readFromCache } from "./persist"
 import { IGatsbyState, ActionsUnion } from "./types"
 
 // Create event emitter for actions
-export const emitter = mitt()
+export const emitter = mett()
 
 // Read old node data from cache.
 export const readState = (): IGatsbyState => {

--- a/packages/gatsby/src/utils/__tests__/mett.ts
+++ b/packages/gatsby/src/utils/__tests__/mett.ts
@@ -3,9 +3,9 @@ import { mett } from "../mett"
 describe(`mett`, (): void => {
   describe(`regular events`, (): void => {
     it(`can be called multiple times`, (): void => {
-      expect((): void => mett()).not.toThrow()
-      expect((): void => mett()).not.toThrow()
-      expect((): void => mett()).not.toThrow()
+      expect((): unknown => mett()).not.toThrow()
+      expect((): unknown => mett()).not.toThrow()
+      expect((): unknown => mett()).not.toThrow()
     })
 
     it(`returns unique objects`, (): void => {

--- a/packages/gatsby/src/utils/__tests__/mett.ts
+++ b/packages/gatsby/src/utils/__tests__/mett.ts
@@ -1,0 +1,303 @@
+import { mett } from "../mett"
+
+describe(`mett`, () => {
+  describe("regular events", () => {
+    it(`can be called multiple times`, () => {
+      expect(() => mett()).not.toThrow()
+      expect(() => mett()).not.toThrow()
+      expect(() => mett()).not.toThrow()
+    })
+
+    it(`returns unique objects`, () => {
+      expect(mett() !== mett()).toBe(true)
+    })
+
+    it(`can register an event`, () => {
+      const met = mett()
+
+      expect(() => met.on("foo", () => {})).not.toThrow()
+    })
+
+    it(`can remove an added event`, () => {
+      const met = mett()
+      const f = () => {}
+
+      expect(() => met.on("foo", f)).not.toThrow()
+      expect(() => met.off("foo", f)).not.toThrow()
+    })
+
+    it(`calls a registered event handler on emit`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("foo", spy)
+      met.emit("foo", "pass")
+
+      expect(spy).toHaveBeenCalledWith("pass", "foo")
+    })
+
+    it(`does not call a removed event`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("foo", spy)
+      met.off("foo", spy)
+      met.emit("foo", "pass")
+
+      expect(spy).not.toHaveBeenCalledWith("pass", "foo")
+    })
+
+    it(`can remove a handler from an event that did not have it`, () => {
+      const met = mett()
+      const f = () => {}
+
+      expect(() => met.off("foo", f)).not.toThrow()
+    })
+
+    it(`calls an added handler when removed from different event`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("foo", spy)
+      met.off("barr", spy) // NOT the original event
+      met.emit("foo", "pass")
+
+      expect(spy).toHaveBeenCalledWith("pass", "foo")
+    })
+
+    it(`calls handlers in fifo order without removal`, () => {
+      const met = mett()
+      const list = [
+        () => (out += "a"),
+        () => (out += "b"),
+        () => (out += "c"),
+        () => (out += "d"),
+        () => (out += "e"),
+        () => (out += "f"),
+        () => (out += "g"),
+        () => (out += "h"),
+        () => (out += "i"),
+        () => (out += "j"),
+        () => (out += "k"),
+        () => (out += "l"),
+        () => (out += "m"),
+        () => (out += "n"),
+        () => (out += "o"),
+        () => (out += "p"),
+      ]
+
+      list.forEach(f => met.on("foo", f))
+
+      let out = ""
+      met.emit("foo", "pass")
+
+      expect(out).toBe("abcdefghijklmnop")
+    })
+
+    it(`calls handlers in fifo order after removal`, () => {
+      const met = mett()
+      const list = [
+        () => (out += "a"),
+        () => (out += "b"),
+        () => (out += "c"),
+        () => (out += "d"),
+        () => (out += "e"),
+        () => (out += "f"),
+        () => (out += "g"),
+        () => (out += "h"),
+        () => (out += "i"),
+        () => (out += "j"),
+        () => (out += "k"),
+        () => (out += "l"),
+        () => (out += "m"),
+        () => (out += "n"),
+        () => (out += "o"),
+        () => (out += "p"),
+      ]
+
+      list.forEach(f => met.on("foo", f))
+
+      met.off("foo", list[3]) // d
+      met.off("foo", list[8]) // h
+
+      let out = ""
+      met.emit("foo", "pass")
+
+      expect(out).toBe("abcefghjklmnop")
+    })
+
+    it(`calls handlers in fifo order after pingpong`, () => {
+      const met = mett()
+      const list = [
+        () => (out += "a"),
+        () => (out += "b"),
+        () => (out += "c"),
+        () => (out += "d"),
+        () => (out += "e"),
+        () => (out += "f"),
+        () => (out += "g"),
+        () => (out += "h"),
+        () => (out += "i"),
+        () => (out += "j"),
+        () => (out += "k"),
+        () => (out += "l"),
+        () => (out += "m"),
+        () => (out += "n"),
+        () => (out += "o"),
+        () => (out += "p"),
+      ]
+
+      list.forEach(f => met.on("foo", f))
+
+      met.off("foo", list[3]) // d
+      met.off("foo", list[8]) // i
+      met.on("foo", list[8]) // i
+      met.on("foo", list[3]) // d
+
+      let out = ""
+      met.emit("foo", "pass")
+
+      // Note: i before d now
+      expect(out).toBe("abcefghjklmnopid")
+    })
+
+    it(`calls each unique handler only once`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.emit("foo", "pass")
+
+      expect(spy).toHaveBeenCalledWith("pass", "foo")
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it(`should remove a handler even if it was added multiple times`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.off("foo", spy)
+      met.emit("foo", "pass")
+
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+
+    it(`should add-remove-add multiple times and still call handler once`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.off("foo", spy)
+      met.off("foo", spy)
+      met.off("foo", spy)
+      met.off("foo", spy)
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.off("foo", spy)
+      met.off("foo", spy)
+      met.on("foo", spy)
+      met.on("foo", spy)
+      met.emit("foo", "pass")
+
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it(`should allow same handler in different events`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("foo", spy)
+      met.on("bar", spy)
+      met.emit("foo", "pass1")
+      met.emit("bar", "pass2")
+
+      expect(spy).toHaveBeenNthCalledWith(1, "pass1", "foo")
+      expect(spy).toHaveBeenNthCalledWith(2, "pass2", "bar")
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe("star events", () => {
+    it(`should always call star handlers`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("*", spy)
+      met.emit("foo", "pass1")
+      met.emit("bar", "pass2")
+
+      expect(spy).toHaveBeenNthCalledWith(1, "pass1", "foo")
+      expect(spy).toHaveBeenNthCalledWith(2, "pass2", "bar")
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it(`should call same handler twice if registered in star and event`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("bar", spy)
+      met.on("*", spy)
+      met.emit("foo", "pass1")
+      met.emit("bar", "pass2")
+
+      expect(spy).toHaveBeenNthCalledWith(1, "pass1", "foo")
+      expect(spy).toHaveBeenNthCalledWith(2, "pass2", "bar")
+      expect(spy).toHaveBeenNthCalledWith(3, "pass2", "bar")
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
+
+    it(`should not remove handler from star if removed from event`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("foo", spy)
+      met.on("*", spy)
+      met.off("foo", spy)
+      met.emit("foo", "pass")
+
+      expect(spy).toHaveBeenNthCalledWith(1, "pass", "foo")
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it(`should not remove handler from event if removed from star`, () => {
+      const met = mett()
+      const spy = jest.fn()
+
+      met.on("*", spy)
+      met.on("foo", spy)
+      met.off("*", spy)
+      met.emit("foo", "pass")
+
+      expect(spy).toHaveBeenNthCalledWith(1, "pass", "foo")
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it(`should call star handlers after regular handlers`, () => {
+      const met = mett()
+
+      let out = ''
+
+      // Order is relevant here
+      met.on("foo", () => out += 'a')
+      met.on("*", () => out += 'b')
+      // Reverse order
+      met.on("*", () => out += 'c')
+      met.on("foo", () => out += 'd')
+
+      met.emit("foo", "pass")
+
+      // the stars should last, in fifo order otherwise
+      expect(out).toBe('adbc')
+    })
+  })
+})

--- a/packages/gatsby/src/utils/__tests__/mett.ts
+++ b/packages/gatsby/src/utils/__tests__/mett.ts
@@ -1,303 +1,303 @@
 import { mett } from "../mett"
 
-describe(`mett`, () => {
-  describe("regular events", () => {
-    it(`can be called multiple times`, () => {
-      expect(() => mett()).not.toThrow()
-      expect(() => mett()).not.toThrow()
-      expect(() => mett()).not.toThrow()
+describe(`mett`, (): void => {
+  describe(`regular events`, (): void => {
+    it(`can be called multiple times`, (): void => {
+      expect((): void => mett()).not.toThrow()
+      expect((): void => mett()).not.toThrow()
+      expect((): void => mett()).not.toThrow()
     })
 
-    it(`returns unique objects`, () => {
+    it(`returns unique objects`, (): void => {
       expect(mett() !== mett()).toBe(true)
     })
 
-    it(`can register an event`, () => {
+    it(`can register an event`, (): void => {
       const met = mett()
 
-      expect(() => met.on("foo", () => {})).not.toThrow()
+      expect((): void => met.on(`foo`, (): void => {})).not.toThrow()
     })
 
-    it(`can remove an added event`, () => {
+    it(`can remove an added event`, (): void => {
       const met = mett()
-      const f = () => {}
+      const f = (): void => {}
 
-      expect(() => met.on("foo", f)).not.toThrow()
-      expect(() => met.off("foo", f)).not.toThrow()
+      expect((): void => met.on(`foo`, f)).not.toThrow()
+      expect((): void => met.off(`foo`, f)).not.toThrow()
     })
 
-    it(`calls a registered event handler on emit`, () => {
+    it(`calls a registered event handler on emit`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("foo", spy)
-      met.emit("foo", "pass")
+      met.on(`foo`, spy)
+      met.emit(`foo`, `pass`)
 
-      expect(spy).toHaveBeenCalledWith("pass", "foo")
+      expect(spy).toHaveBeenCalledWith(`pass`, `foo`)
     })
 
-    it(`does not call a removed event`, () => {
+    it(`does not call a removed event`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("foo", spy)
-      met.off("foo", spy)
-      met.emit("foo", "pass")
+      met.on(`foo`, spy)
+      met.off(`foo`, spy)
+      met.emit(`foo`, `pass`)
 
-      expect(spy).not.toHaveBeenCalledWith("pass", "foo")
+      expect(spy).not.toHaveBeenCalledWith(`pass`, `foo`)
     })
 
-    it(`can remove a handler from an event that did not have it`, () => {
+    it(`can remove a handler from an event that did not have it`, (): void => {
       const met = mett()
-      const f = () => {}
+      const f = (): void => {}
 
-      expect(() => met.off("foo", f)).not.toThrow()
+      expect((): void => met.off(`foo`, f)).not.toThrow()
     })
 
-    it(`calls an added handler when removed from different event`, () => {
+    it(`calls an added handler when removed from different event`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("foo", spy)
-      met.off("barr", spy) // NOT the original event
-      met.emit("foo", "pass")
+      met.on(`foo`, spy)
+      met.off(`barr`, spy) // NOT the original event
+      met.emit(`foo`, `pass`)
 
-      expect(spy).toHaveBeenCalledWith("pass", "foo")
+      expect(spy).toHaveBeenCalledWith(`pass`, `foo`)
     })
 
-    it(`calls handlers in fifo order without removal`, () => {
+    it(`calls handlers in fifo order without removal`, (): void => {
       const met = mett()
+      let out = ``
       const list = [
-        () => (out += "a"),
-        () => (out += "b"),
-        () => (out += "c"),
-        () => (out += "d"),
-        () => (out += "e"),
-        () => (out += "f"),
-        () => (out += "g"),
-        () => (out += "h"),
-        () => (out += "i"),
-        () => (out += "j"),
-        () => (out += "k"),
-        () => (out += "l"),
-        () => (out += "m"),
-        () => (out += "n"),
-        () => (out += "o"),
-        () => (out += "p"),
+        (): string => (out += `a`),
+        (): string => (out += `b`),
+        (): string => (out += `c`),
+        (): string => (out += `d`),
+        (): string => (out += `e`),
+        (): string => (out += `f`),
+        (): string => (out += `g`),
+        (): string => (out += `h`),
+        (): string => (out += `i`),
+        (): string => (out += `j`),
+        (): string => (out += `k`),
+        (): string => (out += `l`),
+        (): string => (out += `m`),
+        (): string => (out += `n`),
+        (): string => (out += `o`),
+        (): string => (out += `p`),
       ]
 
-      list.forEach(f => met.on("foo", f))
+      list.forEach(f => met.on(`foo`, f))
 
-      let out = ""
-      met.emit("foo", "pass")
+      met.emit(`foo`, `pass`)
 
-      expect(out).toBe("abcdefghijklmnop")
+      expect(out).toBe(`abcdefghijklmnop`)
     })
 
-    it(`calls handlers in fifo order after removal`, () => {
+    it(`calls handlers in fifo order after removal`, (): void => {
       const met = mett()
+      let out = ``
       const list = [
-        () => (out += "a"),
-        () => (out += "b"),
-        () => (out += "c"),
-        () => (out += "d"),
-        () => (out += "e"),
-        () => (out += "f"),
-        () => (out += "g"),
-        () => (out += "h"),
-        () => (out += "i"),
-        () => (out += "j"),
-        () => (out += "k"),
-        () => (out += "l"),
-        () => (out += "m"),
-        () => (out += "n"),
-        () => (out += "o"),
-        () => (out += "p"),
+        (): string => (out += `a`),
+        (): string => (out += `b`),
+        (): string => (out += `c`),
+        (): string => (out += `d`),
+        (): string => (out += `e`),
+        (): string => (out += `f`),
+        (): string => (out += `g`),
+        (): string => (out += `h`),
+        (): string => (out += `i`),
+        (): string => (out += `j`),
+        (): string => (out += `k`),
+        (): string => (out += `l`),
+        (): string => (out += `m`),
+        (): string => (out += `n`),
+        (): string => (out += `o`),
+        (): string => (out += `p`),
       ]
 
-      list.forEach(f => met.on("foo", f))
+      list.forEach(f => met.on(`foo`, f))
 
-      met.off("foo", list[3]) // d
-      met.off("foo", list[8]) // h
+      met.off(`foo`, list[3]) // d
+      met.off(`foo`, list[8]) // h
 
-      let out = ""
-      met.emit("foo", "pass")
+      met.emit(`foo`, `pass`)
 
-      expect(out).toBe("abcefghjklmnop")
+      expect(out).toBe(`abcefghjklmnop`)
     })
 
-    it(`calls handlers in fifo order after pingpong`, () => {
+    it(`calls handlers in fifo order after pingpong`, (): void => {
       const met = mett()
+      let out = ``
       const list = [
-        () => (out += "a"),
-        () => (out += "b"),
-        () => (out += "c"),
-        () => (out += "d"),
-        () => (out += "e"),
-        () => (out += "f"),
-        () => (out += "g"),
-        () => (out += "h"),
-        () => (out += "i"),
-        () => (out += "j"),
-        () => (out += "k"),
-        () => (out += "l"),
-        () => (out += "m"),
-        () => (out += "n"),
-        () => (out += "o"),
-        () => (out += "p"),
+        (): string => (out += `a`),
+        (): string => (out += `b`),
+        (): string => (out += `c`),
+        (): string => (out += `d`),
+        (): string => (out += `e`),
+        (): string => (out += `f`),
+        (): string => (out += `g`),
+        (): string => (out += `h`),
+        (): string => (out += `i`),
+        (): string => (out += `j`),
+        (): string => (out += `k`),
+        (): string => (out += `l`),
+        (): string => (out += `m`),
+        (): string => (out += `n`),
+        (): string => (out += `o`),
+        (): string => (out += `p`),
       ]
 
-      list.forEach(f => met.on("foo", f))
+      list.forEach(f => met.on(`foo`, f))
 
-      met.off("foo", list[3]) // d
-      met.off("foo", list[8]) // i
-      met.on("foo", list[8]) // i
-      met.on("foo", list[3]) // d
+      met.off(`foo`, list[3]) // d
+      met.off(`foo`, list[8]) // i
+      met.on(`foo`, list[8]) // i
+      met.on(`foo`, list[3]) // d
 
-      let out = ""
-      met.emit("foo", "pass")
+      met.emit(`foo`, `pass`)
 
       // Note: i before d now
-      expect(out).toBe("abcefghjklmnopid")
+      expect(out).toBe(`abcefghjklmnopid`)
     })
 
-    it(`calls each unique handler only once`, () => {
+    it(`calls each unique handler only once`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.emit("foo", "pass")
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.emit(`foo`, `pass`)
 
-      expect(spy).toHaveBeenCalledWith("pass", "foo")
+      expect(spy).toHaveBeenCalledWith(`pass`, `foo`)
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it(`should remove a handler even if it was added multiple times`, () => {
+    it(`should remove a handler even if it was added multiple times`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.off("foo", spy)
-      met.emit("foo", "pass")
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.off(`foo`, spy)
+      met.emit(`foo`, `pass`)
 
       expect(spy).toHaveBeenCalledTimes(0)
     })
 
-    it(`should add-remove-add multiple times and still call handler once`, () => {
+    it(`should add-remove-add multiple times and still call handler once`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.off("foo", spy)
-      met.off("foo", spy)
-      met.off("foo", spy)
-      met.off("foo", spy)
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.off("foo", spy)
-      met.off("foo", spy)
-      met.on("foo", spy)
-      met.on("foo", spy)
-      met.emit("foo", "pass")
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.off(`foo`, spy)
+      met.off(`foo`, spy)
+      met.off(`foo`, spy)
+      met.off(`foo`, spy)
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.off(`foo`, spy)
+      met.off(`foo`, spy)
+      met.on(`foo`, spy)
+      met.on(`foo`, spy)
+      met.emit(`foo`, `pass`)
 
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it(`should allow same handler in different events`, () => {
+    it(`should allow same handler in different events`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("foo", spy)
-      met.on("bar", spy)
-      met.emit("foo", "pass1")
-      met.emit("bar", "pass2")
+      met.on(`foo`, spy)
+      met.on(`bar`, spy)
+      met.emit(`foo`, `pass1`)
+      met.emit(`bar`, `pass2`)
 
-      expect(spy).toHaveBeenNthCalledWith(1, "pass1", "foo")
-      expect(spy).toHaveBeenNthCalledWith(2, "pass2", "bar")
+      expect(spy).toHaveBeenNthCalledWith(1, `pass1`, `foo`)
+      expect(spy).toHaveBeenNthCalledWith(2, `pass2`, `bar`)
       expect(spy).toHaveBeenCalledTimes(2)
     })
   })
 
-  describe("star events", () => {
-    it(`should always call star handlers`, () => {
+  describe(`star events`, (): void => {
+    it(`should always call star handlers`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("*", spy)
-      met.emit("foo", "pass1")
-      met.emit("bar", "pass2")
+      met.on(`*`, spy)
+      met.emit(`foo`, `pass1`)
+      met.emit(`bar`, `pass2`)
 
-      expect(spy).toHaveBeenNthCalledWith(1, "pass1", "foo")
-      expect(spy).toHaveBeenNthCalledWith(2, "pass2", "bar")
+      expect(spy).toHaveBeenNthCalledWith(1, `pass1`, `foo`)
+      expect(spy).toHaveBeenNthCalledWith(2, `pass2`, `bar`)
       expect(spy).toHaveBeenCalledTimes(2)
     })
 
-    it(`should call same handler twice if registered in star and event`, () => {
+    it(`should call same handler twice if registered in star and event`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("bar", spy)
-      met.on("*", spy)
-      met.emit("foo", "pass1")
-      met.emit("bar", "pass2")
+      met.on(`bar`, spy)
+      met.on(`*`, spy)
+      met.emit(`foo`, `pass1`)
+      met.emit(`bar`, `pass2`)
 
-      expect(spy).toHaveBeenNthCalledWith(1, "pass1", "foo")
-      expect(spy).toHaveBeenNthCalledWith(2, "pass2", "bar")
-      expect(spy).toHaveBeenNthCalledWith(3, "pass2", "bar")
+      expect(spy).toHaveBeenNthCalledWith(1, `pass1`, `foo`)
+      expect(spy).toHaveBeenNthCalledWith(2, `pass2`, `bar`)
+      expect(spy).toHaveBeenNthCalledWith(3, `pass2`, `bar`)
       expect(spy).toHaveBeenCalledTimes(3)
     })
 
-    it(`should not remove handler from star if removed from event`, () => {
+    it(`should not remove handler from star if removed from event`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("foo", spy)
-      met.on("*", spy)
-      met.off("foo", spy)
-      met.emit("foo", "pass")
+      met.on(`foo`, spy)
+      met.on(`*`, spy)
+      met.off(`foo`, spy)
+      met.emit(`foo`, `pass`)
 
-      expect(spy).toHaveBeenNthCalledWith(1, "pass", "foo")
+      expect(spy).toHaveBeenNthCalledWith(1, `pass`, `foo`)
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it(`should not remove handler from event if removed from star`, () => {
+    it(`should not remove handler from event if removed from star`, (): void => {
       const met = mett()
       const spy = jest.fn()
 
-      met.on("*", spy)
-      met.on("foo", spy)
-      met.off("*", spy)
-      met.emit("foo", "pass")
+      met.on(`*`, spy)
+      met.on(`foo`, spy)
+      met.off(`*`, spy)
+      met.emit(`foo`, `pass`)
 
-      expect(spy).toHaveBeenNthCalledWith(1, "pass", "foo")
+      expect(spy).toHaveBeenNthCalledWith(1, `pass`, `foo`)
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it(`should call star handlers after regular handlers`, () => {
+    it(`should call star handlers after regular handlers`, (): void => {
       const met = mett()
 
-      let out = ''
+      let out = ``
 
       // Order is relevant here
-      met.on("foo", () => out += 'a')
-      met.on("*", () => out += 'b')
+      met.on(`foo`, (): string => (out += `a`))
+      met.on(`*`, (): string => (out += `b`))
       // Reverse order
-      met.on("*", () => out += 'c')
-      met.on("foo", () => out += 'd')
+      met.on(`*`, (): string => (out += `c`))
+      met.on(`foo`, (): string => (out += `d`))
 
-      met.emit("foo", "pass")
+      met.emit(`foo`, `pass`)
 
       // the stars should last, in fifo order otherwise
-      expect(out).toBe('adbc')
+      expect(out).toBe(`adbc`)
     })
   })
 })

--- a/packages/gatsby/src/utils/mett.ts
+++ b/packages/gatsby/src/utils/mett.ts
@@ -1,0 +1,54 @@
+// This is a simple event emitter based on mitt.js
+// It mainly changes the data model to use a Map and Set, rather than a
+// regular object and an array.
+
+type MettHandler<EventName, Payload> = (
+  e: Payload,
+  eventName: EventName
+) => void
+
+interface IMett<EventName, Payload> {
+  on(eventName: EventName, callback: MettHandler<EventName, Payload>): void
+  off(eventName: EventName, callback: MettHandler<EventName, Payload>): void
+  emit(eventName: EventName, e: Payload): void
+}
+
+function mett<EventName = string, Payload = any>(): IMett<EventName, Payload> {
+  const mettEvents: Map<
+    EventName,
+    Set<MettHandler<EventName, Payload>>
+  > = new Map()
+
+  return {
+    on(eventName: EventName, callback: MettHandler<EventName, Payload>): void {
+      const set = mettEvents.get(eventName)
+      if (set) {
+        set.add(callback)
+      } else {
+        mettEvents.set(eventName, new Set([callback]))
+      }
+    },
+    off(eventName: EventName, callback: MettHandler<EventName, Payload>): void {
+      const set = mettEvents.get(eventName)
+      if (set) {
+        set.delete(callback)
+      }
+    },
+    emit(eventName: EventName, e: Payload): void {
+      const setName = mettEvents.get(eventName)
+      if (setName) {
+        setName.forEach(function mettEmitEachC(callback) {
+          callback(e, eventName)
+        })
+      }
+      const setStar = mettEvents.get((`*` as unknown) as EventName)
+      if (setStar) {
+        setStar.forEach(function mettEmitEachStar(n) {
+          n(e, eventName)
+        })
+      }
+    },
+  }
+}
+
+export { mett }

--- a/packages/gatsby/src/utils/mett.ts
+++ b/packages/gatsby/src/utils/mett.ts
@@ -7,13 +7,16 @@ type MettHandler<EventName, Payload> = (
   eventName: EventName
 ) => void
 
-interface IMett<EventName, Payload> {
+interface IMett {
   on(eventName: EventName, callback: MettHandler<EventName, Payload>): void
   off(eventName: EventName, callback: MettHandler<EventName, Payload>): void
   emit(eventName: EventName, e: Payload): void
 }
 
-function mett<EventName = string, Payload = any>(): IMett<EventName, Payload> {
+type EventName = string
+type Payload = any
+
+function mett(): IMett {
   const mettEvents: Map<
     EventName,
     Set<MettHandler<EventName, Payload>>
@@ -41,10 +44,10 @@ function mett<EventName = string, Payload = any>(): IMett<EventName, Payload> {
           callback(e, eventName)
         })
       }
-      const setStar = mettEvents.get((`*` as unknown) as EventName)
+      const setStar = mettEvents.get(`*`)
       if (setStar) {
-        setStar.forEach(function mettEmitEachStar(n) {
-          n(e, eventName)
+        setStar.forEach(function mettEmitEachStar(callback) {
+          callback(e, eventName)
         })
       }
     },


### PR DESCRIPTION
Saves ~25% of the bootstrap at scale for some baseline benchmarks because mitt uses an array to maintain handlers which it splices when removing a handler. When thousands of handlers get added to this array and you splice, things get quite expensive. Using a `Set` instead fixes this problem.

The `mett` code is ready for TypeScript although in this PR it implements the event name as `string` and payload as `any`. In some future somebody probably will want to go through each use of the emitter and define strict eventName+payload type pairs. I expect this not to be very easy but there are ways.
