### PR TITLE
maintenance(www): get rid of unused isSingle prop on sidebar

### DIFF
--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -75,7 +75,6 @@ class Accordion extends React.Component {
       onLinkClick,
       onSectionTitleClick,
       openSectionHash,
-      isSingle,
       disableAccordions,
     } = this.props
     const uid = `item_` + this.state.uid
@@ -93,30 +92,28 @@ class Accordion extends React.Component {
           transition: t =>
             `all ${t.transition.speed.fast} ${t.transition.curve.default}`,
           mt: t =>
-            item.level === 0 && disableAccordions && !isSingle
+            item.level === 0 && disableAccordion
               ? `${t.space[4]} !important`
               : false,
-          ...(item.level === 0 &&
-            !isSingle && {
-              "::before": {
-                content: `" "`,
-                position: `absolute`,
-                borderTopWidth: `1px`,
-                borderTopStyle: `solid`,
-                borderColor: `ui.border`,
-                left: t =>
-                  (isParentOfActiveItem && isExpanded) ||
-                  (isActive && isExpanded)
-                    ? 0
-                    : t.space[6],
-                right: 0,
-                top: 0,
-              },
-              ":after": {
-                top: `auto`,
-                bottom: -1,
-              },
-            }),
+          ...(item.level === 0 && {
+            "::before": {
+              content: `" "`,
+              position: `absolute`,
+              borderTopWidth: `1px`,
+              borderTopStyle: `solid`,
+              borderColor: `ui.border`,
+              left: t =>
+                (isParentOfActiveItem && isExpanded) || (isActive && isExpanded)
+                  ? 0
+                  : t.space[6],
+              right: 0,
+              top: 0,
+            },
+            ":after": {
+              top: `auto`,
+              bottom: -1,
+            },
+          }),
         }}
       >
         <ItemWithSubitems

--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -92,7 +92,7 @@ class Accordion extends React.Component {
           transition: t =>
             `all ${t.transition.speed.fast} ${t.transition.curve.default}`,
           mt: t =>
-            item.level === 0 && disableAccordion
+            item.level === 0 && disableAccordions
               ? `${t.space[4]} !important`
               : false,
           ...(item.level === 0 && {

--- a/www/src/components/sidebar/item.js
+++ b/www/src/components/sidebar/item.js
@@ -23,7 +23,6 @@ const Item = ({
   onLinkClick,
   onSectionTitleClick,
   ui,
-  isSingle,
   disableAccordions,
 }) => {
   const itemRef = useCallback(
@@ -62,7 +61,6 @@ const Item = ({
           onLinkClick={onLinkClick}
           openSectionHash={openSectionHash}
           onSectionTitleClick={onSectionTitleClick}
-          isSingle={isSingle}
           disableAccordions={disableAccordions}
         />
       ) : (

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -196,8 +196,6 @@ class SidebarBody extends Component {
     const { i18n, closeSidebar, itemList, location } = this.props
     const { openSectionHash, activeItemLink, activeItemParents } = this.state
 
-    const isSingle = itemList.filter(item => item.level === 0).length === 1
-
     return (
       <section
         aria-label={i18n._(t`Secondary Navigation`)}
@@ -290,7 +288,6 @@ class SidebarBody extends Component {
                 onLinkClick={closeSidebar}
                 onSectionTitleClick={this._toggleSection}
                 openSectionHash={openSectionHash}
-                isSingle={isSingle}
                 disableAccordions={this.props.disableAccordions}
               />
             ))}


### PR DESCRIPTION
From what I can tell, the `isSingle` prop only affects things if you have a sidebar that has only one top-level item… which none of the sidebars do.