### PR TITLE
fix(docs): change gatsby-config mention for global CSS import

### DIFF
--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -100,7 +100,7 @@ export default () => <Layout>Hello world!</Layout>
 
 ```javascript:title=gatsby-config.js
 module.exports = {
-  plugins: [`gatsby-plugin-styled-components`]
+  plugins: [`gatsby-plugin-styled-components`],
 }
 ```
 
@@ -326,7 +326,7 @@ npm install --save gatsby-plugin-emotion @emotion/core @emotion/styled
 
 ```javascript:title=gatsby-config.js
 module.exports = {
-  plugins: [`gatsby-plugin-emotion`]
+  plugins: [`gatsby-plugin-emotion`],
 }
 ```
 
@@ -343,7 +343,7 @@ export default () => (
     <p
       css={{
         background: "pink",
-        color: "blue"
+        color: "blue",
       }}
     >
       This page is using Emotion.

--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -32,7 +32,7 @@ p {
 import "./src/styles/global.css"
 ```
 
-> **Note:** You can also make use of `require('./src/styles/global.css')` to import the global CSS file in your `gatsby-config.js` file.
+> **Note:** You can also make use of `require('./src/styles/global.css')` to import the global CSS file in your `gatsby-browser.js` file.
 
 3. Run `gatsby-develop` to observe the global styling being applied across your site.
 
@@ -100,7 +100,7 @@ export default () => <Layout>Hello world!</Layout>
 
 ```javascript:title=gatsby-config.js
 module.exports = {
-  plugins: [`gatsby-plugin-styled-components`],
+  plugins: [`gatsby-plugin-styled-components`]
 }
 ```
 
@@ -326,7 +326,7 @@ npm install --save gatsby-plugin-emotion @emotion/core @emotion/styled
 
 ```javascript:title=gatsby-config.js
 module.exports = {
-  plugins: [`gatsby-plugin-emotion`],
+  plugins: [`gatsby-plugin-emotion`]
 }
 ```
 
@@ -343,7 +343,7 @@ export default () => (
     <p
       css={{
         background: "pink",
-        color: "blue",
+        color: "blue"
       }}
     >
       This page is using Emotion.


### PR DESCRIPTION
## Description

There was a small part in the `styling-css` recipe docs that was misleading.  It stated you could `require()` your CSS in `gatsby-config` to use it globally in your site.  This just changes it to say `gatsby-browser` instead of `gatsby-config`.

## Related Issues

Closes #23236
Related: #23039