### PR TITLE
fix(docs): 404 not found links

### DIFF
--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -6,10 +6,10 @@ We want contributing to Gatsby to be fun, enjoyable, and educational for anyone 
 
 ## Not sure how to start contributing?
 
-If you are worried or don't know where to start, check out our [where to participate](/contributing/where-to-participate/) page. You can reach out with questions to [Marcy Sutton (@marcysutton)](https://twitter.com/marcysutton) or [@GatsbyJS](https://twitter.com/gatsbyjs) on Twitter, and anyone from the Gatsby team on [Discord](https://gatsby.dev/discord). You can also [submit an issue](/contributing/how-to-file-an-issue/) and a maintainer can give you guidance!
+If you are worried or don't know where to start, check out our [where to participate](/docs/contributing/where-to-participate.md) page. You can reach out with questions to [Marcy Sutton (@marcysutton)](https://twitter.com/marcysutton) or [@GatsbyJS](https://twitter.com/gatsbyjs) on Twitter, and anyone from the Gatsby team on [Discord](https://gatsby.dev/discord). You can also [submit an issue](/docs/contributing/how-to-file-an-issue.md) and a maintainer can give you guidance!
 
 ## Pair programming
 
-Gatsby.js offers free [pair programming sessions](/contributing/pair-programming/) to the community, if there's something you'd like to work on together. Get in touch with us if you have a question about contributing or an idea for something to pair on!
+Gatsby.js offers free [pair programming sessions](/docs/contributing/pair-programming.md) to the community, if there's something you'd like to work on together. Get in touch with us if you have a question about contributing or an idea for something to pair on!
 
 <GuideList slug={props.slug} />

--- a/docs/contributing/translation/index.md
+++ b/docs/contributing/translation/index.md
@@ -20,18 +20,18 @@ Currently, the following languages are being translated:
 
 ## Creating a new translation
 
-If you don't see your language in the above list, please see [Starting a new language](/contributing/translation/new-translations/) for how to start up a new translation repository.
+If you don't see your language in the above list, please see [Starting a new language](/contributing/translation/new-translations) for how to start up a new translation repository.
 
 ## Contributing translations
 
-If you do see your language on the list, please see the [translation contributor guide](/contributing/translation/translators/) for information on how to contribute translations in your language.
+If you do see your language on the list, please see the [translation contributor guide](/docs/contributing/translation/translators.md) for information on how to contribute translations in your language.
 
 ## Maintainers
 
-Each translation repo will have at least two maintainers and codeowners that are responsible for the upkeep of the repo. Please see the [Translation Maintainer Guide](/contributing/translation/maintainers/) for information on the responsibilities of translation maintainers.
+Each translation repo will have at least two maintainers and codeowners that are responsible for the upkeep of the repo. Please see the [Translation Maintainer Guide](/docs/contributing/translation/maintainers.md) for information on the responsibilities of translation maintainers.
 
 ## Language-specific channels
 
 Each translation group may want to have a space for maintainers and community members to ask questions and coordinate the project. **[Discord](https://gatsby.dev/discord) is the official channel** and maintainers can have their own private groups if desired. Some groups may elect to use a different platform such as Wechat or Whatsapp, but that will be at your own discretion.
 
-To set up a Discord channel for a translation group (if it doesn't already exist), [ping the Gatsbyjs team](/contributing/how-to-contribute/#not-sure-how-to-start-contributing).
+To set up a Discord channel for a translation group (if it doesn't already exist), [ping the Gatsbyjs team](/docs/contributing/how-to-contribute.md#not-sure-how-to-start-contributing).


### PR DESCRIPTION
## Description 

- Fixed links "translation contributor guide" and "Translation Maintainer Guide" from contributing "index".
