### PR TITLE
fix(recipes): adjust path to layout component

### DIFF
--- a/packages/gatsby-recipes/recipes/gatsby-plugin-layout.mdx
+++ b/packages/gatsby-recipes/recipes/gatsby-plugin-layout.mdx
@@ -30,7 +30,7 @@ Let's also write out a sample layout component to get started with.
 
 <File
     path="src/layouts/index.js"
-    content="https://gist.github.com/JeremyTheModernist/be673e8641c61e6a427124acad1e05da"
+    content="https://gist.githubusercontent.com/JeremyTheModernist/be673e8641c61e6a427124acad1e05da/raw/80afecf73eb494dbfa2318ad7a27825edf9ef16c/index.js"
 />
 
 ---


### PR DESCRIPTION
Update path to layout component to pull source from raw gist instead of the parent page.