### PR TITLE
fix(gatsby-remark-prismjs): Update useCommandLine

### DIFF
--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -98,7 +98,7 @@ module.exports = (
     }
 
     const useCommandLine =
-      [`bash`].includes(languageName) &&
+      [`bash`, `shell`].includes(languageName) &&
       (prompt.global ||
         (outputLines && outputLines.length > 0) ||
         promptUserLocal ||


### PR DESCRIPTION
## Description
As @muescha mentioned in https://github.com/gatsbyjs/gatsby/pull/22899#issuecomment-614058668

### Documentation
https://github.com/gatsbyjs/gatsby/blob/2a7cb8c10dff4f847ca8e13db2486ad877c80dfb/packages/gatsby-remark-prismjs/README.md#L209-L210

## Related Issues
#22899
