### PR TITLE
fix(docs): Change md to markdown iin code language blocks

### DIFF
--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -171,7 +171,7 @@ There are embedded examples in a few places in the docs (like the [GraphQL Refer
 To write a new GraphQL example, a Codesandbox project with a Gatsby site can be opened at its server container link, for example: [https://711808k40x.sse.codesandbox.io/](https://711808k40x.sse.codesandbox.io/). Because Codesandbox is running a Gatsby site in [`develop` mode instead of `build` mode](/docs/overview-of-the-gatsby-build-process/) you can navigate to GraphiQL by adding `/___graphql` to the link. Write an example query, and when you have a query you are satisfied with, the query fields and names will be saved as URL parameters so you can share the link. Copy the URL and use it as the `src` of an iframe:
 
 <!-- prettier-ignore -->
-```mdx
+```markdown
 Here's an example of a GraphQL query inline:
 
 <iframe src="https://711808k40x.sse.codesandbox.io/___graphql?query=query%20TitleQuery%20%7B%0A%20%20site%20%7B%0A%20%20%20%20siteMetadata%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false&operationName=TitleQuery" /> // highlight-line

--- a/docs/contributing/translation/style-guide.md
+++ b/docs/contributing/translation/style-guide.md
@@ -24,13 +24,13 @@ Use soft line wraps for paragraphs:
 
 ✅ DO:
 
-```md
+```markdown
 No intuito de promover um ambiente aberto e acolhedor, nós, como contribuidores e mantenedores, nos comprometemos em tornar a participação em nossos projetos e em nossa comunidade o mais livre de assédio para todos, independentemente da idade, corpo, tamanho, deficiência, etnia, identidade ou expressão de gênero, nível de experiência, nacionalidade, aparência, raça, religião ou identidade e orientação sexual.
 ```
 
 ❌ DON'T:
 
-```md
+```markdown
 No intuito de promover um ambiente aberto e acolhedor, nós, como contribuidores e mantenedores,
 nos comprometemos em tornar a participação em nossos projetos e em nossa comunidade o mais livre
 de assédio para todos, independentemente da idade, corpo, tamanho, deficiência, etnia, identidade

--- a/docs/tutorial/using-multiple-themes-together.md
+++ b/docs/tutorial/using-multiple-themes-together.md
@@ -88,7 +88,7 @@ Behind the scenes, the two themes created content folders in the root directory 
 
 Create a new file in `/content/posts`, like this one:
 
-```mdx:title=content/posts/hello-posts.md
+```markdown:title=content/posts/hello-posts.md
 ---
 title: My first blog post
 date: 2020-02-15
@@ -101,7 +101,7 @@ Multiple themes are great!
 
 Create a new file in `/content/notes`, like this one:
 
-```mdx:title=content/note/hello-notes.md
+```markdown:title=content/note/hello-notes.md
 ---
 title: My first note
 date: 2020-02-20
@@ -241,7 +241,7 @@ module.exports = {
 
 3. Test it out by adding a Youtube video to one of your blog posts:
 
-```mdx:title=content/posts/video-post.md
+```markdown:title=content/posts/video-post.md
 ---
 title: Jason and Jackson Talk Themes
 date: 2020-02-21

--- a/rfcs/text/0011-move-rfcs-to-monorepo.md
+++ b/rfcs/text/0011-move-rfcs-to-monorepo.md
@@ -43,13 +43,13 @@ This will be how we teach the RFC process. We _may_ publish this to gatsbyjs.org
 
 This Markdown file will be the source from which all RFCs are created. It will look like the following:
 
-```md
+```markdown
 ---
 title: "RFC Template"
 date: YYYY-MM-DD
 status: "IN_REVIEW" | "MERGED" | "PUBLISHED"
 # optional fields, e.g. that can be added when merging
-issue: 
+issue:
 ---
 
 # Summary


### PR DESCRIPTION
## Description
- Change `md` to `markdown` regarding the [code style guides to prefer `markdown`](https://www.gatsbyjs.org/contributing/gatsby-style-guide/#code-formatting-type-tab)
- Change `mdx` to `markdown` when there's no MDX involved

## Related links
https://www.gatsbyjs.org/contributing/gatsby-style-guide/#code-formatting-type-tab