### PR TITLE
Create Brewfile to streamline install on Mac/Linux

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
-# Use `brew bundle` from your command line to install the packages listed below
+# Use `brew bundle` to install the packages listed below
+# Don't have Brew?  Use `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"` to install it.
 # See https://github.com/Homebrew/homebrew-bundle to learn more
 brew "git"
 brew "gatsby-cli"

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,5 @@
+# Use `brew bundle` from your command line to install the packages listed below
+# See https://github.com/Homebrew/homebrew-bundle to learn more
+brew "git"
+brew "gatsby-cli"
+brew "yarn"


### PR DESCRIPTION
## Description

Use Homebrew-Bundle to install Xcode-select, Git, NodeJS, Gatsby-CLI, etc, in one command: brew bundle for Mac OS and Linux.

### Documentation

See [Homebrew-Bundle](https://github.com/Homebrew/homebrew-bundle)

## Related Issues

See #23266
