### PR TITLE
chore(starters): add gatsby-starter-typescript-eslint

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5993,8 +5993,10 @@
   repo: https://github.com/neo/gatsby-starter-typescript-eslint
   description: A clean Gatsby starter with TypeScript and ESLint
   tags:
+    - Language:TypeScript
+    - Linting
+  features:
     - TypeScript
     - ESLint
     - Prettier
-  features:
-    - ESLint that works with TypeScript and Prettier
+    - `typescript-eslint`

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5989,3 +5989,12 @@
     - Pagination
     - SEO
     - Phone browser Support
+- url: https://gatsby-starter-typescript-eslint.now.sh/
+  repo: https://github.com/neo/gatsby-starter-typescript-eslint
+  description: A clean Gatsby starter with TypeScript and ESLint
+  tags:
+    - TypeScript
+    - ESLint
+    - Prettier
+  features:
+    - ESLint that works with TypeScript and Prettier


### PR DESCRIPTION
## Description

Adding a starter that works with `typescript-eslint`

## Related Issues

Related to #18983