### PR TITLE
chore(www): add good adaptive design for iPad

### DIFF
--- a/packages/gatsby-design-tokens/src/breakpoints.js
+++ b/packages/gatsby-design-tokens/src/breakpoints.js
@@ -1,7 +1,7 @@
 const b = {
   xs: `400px`,
   sm: `550px`,
-  md: `750px`,
+  md: `770px`,
   lg: `1000px`,
   xl: `1200px`,
   xxl: `1600px`,


### PR DESCRIPTION
## Description

iPad Mini has menu on the left side of the screen. Very uncomfortable to read. This PR sets mobile design to 770px so that the ipad mini can mobile layout.

## Related Issues

  Fixes [#22401](https://github.com/gatsbyjs/gatsby/issues/22401)