### PR TITLE
fix(docs): Link to apollo blog

### DIFF
--- a/docs/docs/graphql-concepts.md
+++ b/docs/docs/graphql-concepts.md
@@ -363,7 +363,7 @@ export const query = graphql`
 ## Further reading
 
 - [Why Gatsby Uses GraphQL](/docs/why-gatsby-uses-graphql/)
-- [The Anatomy of a GraphQL Query](https://blog.apollographql.com/the-anatomy-of-a-graphql-query-6dffa9e9e747)
+- [The Anatomy of a GraphQL Query](https://www.apollographql.com/blog/the-anatomy-of-a-graphql-query)
 
 ### Getting started with GraphQL
 


### PR DESCRIPTION
Fixes #23255

Apollo re-did their blog and apparently their redirect doesn't work for this link. So replacing it with the working link.