### PR TITLE
feat(gatsby): Warn when pageContext is over 500k

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -246,7 +246,16 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
       }
     }
   }
-
+  
+  //sends a warning if pageContext exceeds approx 500kb limit
+  const contextSize = JSON.stringify(page.context).length;
+  if(contextSize > 500000){
+    msg = `page contextSize was greater than 500kb`
+    report.warn(
+        chalk.bold.yellow(msg)
+        )
+  }
+  
   // Check if a component is set.
   if (!page.component) {
     if (process.env.NODE_ENV !== `test`) {

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -247,13 +247,6 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
     }
   }
 
-  //sends a warning if pageContext exceeds approx 500kb limit
-  const contextSize = JSON.stringify(page.context).length
-  if (contextSize > 500000) {
-    msg = `page contextSize was greater than 500kb`
-    report.warn(chalk.bold.yellow(msg))
-  }
-
   // Check if a component is set.
   if (!page.component) {
     if (process.env.NODE_ENV !== `test`) {

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -246,16 +246,14 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
       }
     }
   }
-  
+
   //sends a warning if pageContext exceeds approx 500kb limit
-  const contextSize = JSON.stringify(page.context).length;
-  if(contextSize > 500000){
+  const contextSize = JSON.stringify(page.context).length
+  if (contextSize > 500000) {
     msg = `page contextSize was greater than 500kb`
-    report.warn(
-        chalk.bold.yellow(msg)
-        )
+    report.warn(chalk.bold.yellow(msg))
   }
-  
+
   // Check if a component is set.
   if (!page.component) {
     if (process.env.NODE_ENV !== `test`) {

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -91,7 +91,7 @@ function guessSafeChunkSize(values: [string, IGatsbyNode][]): number {
     maxSize = Math.max(size, maxSize)
   }
   
-  //Sends a warning once if any of the chunckSizes exceeds approx 500kb limit
+  //Sends a warning once if any of the chunkSizes exceeds approx 500kb limit
   if(warnFlag){
     report.warn(`page context was greater than 500kb`);
   }

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -81,9 +81,19 @@ function guessSafeChunkSize(values: [string, IGatsbyNode][]): number {
   const valueCount = values.length
   const step = Math.max(1, Math.ceil(valueCount / nodesToTest))
   let maxSize = 0
+  let warnFlag = false;
+
   for (let i = 0; i < valueCount; i += step) {
     const size = v8.serialize(values[i]).length
+    if (size > 500000) {
+      warnFlag = true;
+    }
     maxSize = Math.max(size, maxSize)
+  }
+  
+  //Sends a warning once if any of the chunckSizes exceeds approx 500kb limit
+  if(warnFlag){
+    report.warn(`page context was greater than 500kb`);
   }
 
   // Max size of a Buffer is 2gb (yeah, we're assuming 64bit system)

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -89,7 +89,7 @@ function guessSafeChunkSize(values: [string, IGatsbyNode][]): number {
   // Sends a warning once if any of the chunkSizes exceeds approx 500kb limit
   if (maxSize > 500000) {
     report.warn(
-      `The size of least one page context exceeded 500kb, this could lead to degraded performance. Consider putting less data in the page context.`
+      `The size of at least one page context chunk exceeded 500kb, which could lead to degraded performance. Consider putting less data in the page context.`
     )
   }
 

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -81,7 +81,6 @@ function guessSafeChunkSize(values: [string, IGatsbyNode][]): number {
   const valueCount = values.length
   const step = Math.max(1, Math.ceil(valueCount / nodesToTest))
   let maxSize = 0
-  
   for (let i = 0; i < valueCount; i += step) {
     const size = v8.serialize(values[i]).length
     maxSize = Math.max(size, maxSize)
@@ -89,7 +88,9 @@ function guessSafeChunkSize(values: [string, IGatsbyNode][]): number {
   
   // Sends a warning once if any of the chunkSizes exceeds approx 500kb limit
   if (maxSize > 500000) {
-    report.warn(`page context was greater than 500kb`);
+    report.warn(
+      `The size of least one page context exceeded 500kb, this could lead to degraded performance. Consider putting less data in the page context.`
+    )
   }
 
   // Max size of a Buffer is 2gb (yeah, we're assuming 64bit system)

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -81,18 +81,14 @@ function guessSafeChunkSize(values: [string, IGatsbyNode][]): number {
   const valueCount = values.length
   const step = Math.max(1, Math.ceil(valueCount / nodesToTest))
   let maxSize = 0
-  let warnFlag = false;
-
+  
   for (let i = 0; i < valueCount; i += step) {
     const size = v8.serialize(values[i]).length
-    if (size > 500000) {
-      warnFlag = true;
-    }
     maxSize = Math.max(size, maxSize)
   }
   
-  //Sends a warning once if any of the chunkSizes exceeds approx 500kb limit
-  if(warnFlag){
+  // Sends a warning once if any of the chunkSizes exceeds approx 500kb limit
+  if (maxSize > 500000) {
     report.warn(`page context was greater than 500kb`);
   }
 

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -85,7 +85,7 @@ function guessSafeChunkSize(values: [string, IGatsbyNode][]): number {
     const size = v8.serialize(values[i]).length
     maxSize = Math.max(size, maxSize)
   }
-  
+
   // Sends a warning once if any of the chunkSizes exceeds approx 500kb limit
   if (maxSize > 500000) {
     report.warn(


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

updated public.js to send a warning when pageContext exceeds approx 500kb limit

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues


  Fixes #14213

