### PR TITLE
refactor(gatsby-theme-blog): Remove keywords from seo

### DIFF
--- a/packages/gatsby-theme-blog-core/README.md
+++ b/packages/gatsby-theme-blog-core/README.md
@@ -121,6 +121,5 @@ The following are the defined blog post fields based on the node interface in th
 | slug     | String   |
 | date     | Date     |
 | tags     | String[] |
-| keywords | String[] |
 | excerpt  | String   |
 | image    | String   |

--- a/packages/gatsby-theme-blog-core/gatsby-node.js
+++ b/packages/gatsby-theme-blog-core/gatsby-node.js
@@ -52,7 +52,6 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       slug: String!
       date: Date! @dateformat
       tags: [String]!
-      keywords: [String]!
       excerpt: String!
       image: File
   }`)
@@ -70,7 +69,6 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
         },
         date: { type: `Date!`, extensions: { dateformat: {} } },
         tags: { type: `[String]!` },
-        keywords: { type: `[String]!` },
         excerpt: {
           type: `String!`,
           args: {
@@ -139,7 +137,6 @@ exports.onCreateNode = async (
       tags: node.frontmatter.tags || [],
       slug,
       date: node.frontmatter.date,
-      keywords: node.frontmatter.keywords || [],
       image: node.frontmatter.image,
     }
 

--- a/packages/gatsby-theme-blog-core/src/templates/post-query.js
+++ b/packages/gatsby-theme-blog-core/src/templates/post-query.js
@@ -21,7 +21,6 @@ export const query = graphql`
       slug
       title
       tags
-      keywords
       date(formatString: "MMMM DD, YYYY")
       image {
         childImageSharp {

--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -127,6 +127,5 @@ The following are the defined blog post fields based on the node interface in th
 | slug     | String   |
 | date     | Date     |
 | tags     | String[] |
-| keywords | String[] |
 | excerpt  | String   |
 | image    | String   |

--- a/packages/gatsby-theme-blog/src/components/post.js
+++ b/packages/gatsby-theme-blog/src/components/post.js
@@ -23,7 +23,6 @@ const Post = ({
     <SEO
       title={post.title}
       description={post.excerpt}
-      keywords={post.keywords}
       imageSource={post.image?.childImageSharp?.fluid.src}
     />
     <main>

--- a/packages/gatsby-theme-blog/src/components/seo.js
+++ b/packages/gatsby-theme-blog/src/components/seo.js
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-function SEO({ description, lang, meta, keywords = [], title, imageSource }) {
+function SEO({ description, lang, meta, title, imageSource }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -79,16 +79,7 @@ function SEO({ description, lang, meta, keywords = [], title, imageSource }) {
           name: `twitter:description`,
           content: metaDescription,
         },
-      ]
-        .concat(
-          keywords.length > 0
-            ? {
-                name: `keywords`,
-                content: keywords.join(`, `),
-              }
-            : []
-        )
-        .concat(meta)}
+      ].concat(meta)}
     />
   )
 }
@@ -96,14 +87,12 @@ function SEO({ description, lang, meta, keywords = [], title, imageSource }) {
 SEO.defaultProps = {
   lang: `en`,
   meta: [],
-  keywords: [],
 }
 
 SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.array,
-  keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,
 }
 


### PR DESCRIPTION
## Description

The `keywords` meta tag was removed for `gatsby-starter-blog` in https://github.com/gatsbyjs/gatsby/pull/14122 since it's not used by Google, Bing, or Yahoo as discussed in https://github.com/gatsbyjs/gatsby/issues/12454. This removes it in `gatsby-theme-blog` and `gatsby-theme-blog-core`.

### Documentation

No documentation changes necessary.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/12454