### PR TITLE
fix(www): Fix sidebar expansion behavior

### DIFF
--- a/www/src/components/sidebar/__tests__/sidebar.js
+++ b/www/src/components/sidebar/__tests__/sidebar.js
@@ -93,6 +93,10 @@ describe("sidebar", () => {
 
   describe("initialization", () => {
     it("opens sections with active items", () => {
+      // Render a page
+      renderSidebar("/plot-summary/").unmount()
+      // Render another page and make sure that its section is open even if
+      // a falsy value was stored in local storage
       const { queryByText } = renderSidebar("/characters/jay-gatsby/")
       expect(queryByText("Jay Gatsby")).toBeInTheDocument()
     })

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -101,10 +101,11 @@ function Sidebar({
   )
 
   // Merge hash in local storage and the derived hash from props
+  // so that all sections open in either hash are open
   const initialHash = (() => {
     const { openSectionHash = {} } = readLocalStorage(sidebarKey)
     for (const [key, isOpen] of Object.entries(derivedHash)) {
-      openSectionHash[key] = openSectionHash[key] ?? isOpen
+      openSectionHash[key] = openSectionHash[key] || isOpen
     }
     return openSectionHash
   })()


### PR DESCRIPTION
## Overview

Follow-up to #23301.

* Use `||` instead of `??` for proper resolution.
* Modified a test to account for the bug before.

The implemented solution resulted in a bug where clicking on a link won't expand the hierarchy for that link if coming from another page. To repro, go to any page on the gatsby docs and go to a different page in a different hierarchy (for example, from /docs/recipes/ to /docs/reference-guides).