### PR TITLE
Add noop data update scripts for all benchmarks

### DIFF
--- a/benchmarks/markdown_id/package.json
+++ b/benchmarks/markdown_id/package.json
@@ -28,8 +28,10 @@
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1",
     "react-typography": "^0.16.19",
+    "ts-node": "^8.9.0",
     "typeface-merriweather": "0.0.72",
     "typeface-montserrat": "0.0.75",
+    "typescript": "^3.8.3",
     "typography": "^0.16.19",
     "typography-theme-wordpress-2016": "^0.16.19"
   },
@@ -46,6 +48,7 @@
     "bench": "rm -r markdown-pages; NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js; gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "benchnb": "gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "build": "gatsby build",
+    "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/benchmarks/markdown_id/scripts/data-update.ts
+++ b/benchmarks/markdown_id/scripts/data-update.ts
@@ -1,0 +1,1 @@
+// noop for now, but will be created later.

--- a/benchmarks/markdown_slug/package.json
+++ b/benchmarks/markdown_slug/package.json
@@ -28,8 +28,10 @@
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1",
     "react-typography": "^0.16.19",
+    "ts-node": "^8.9.0",
     "typeface-merriweather": "0.0.72",
     "typeface-montserrat": "0.0.75",
+    "typescript": "^3.8.3",
     "typography": "^0.16.19",
     "typography-theme-wordpress-2016": "^0.16.19"
   },
@@ -46,6 +48,7 @@
     "bench": "rm -r markdown-pages; NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js; gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "benchnb": "gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "build": "gatsby build",
+    "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/benchmarks/markdown_slug/scripts/data-update.ts
+++ b/benchmarks/markdown_slug/scripts/data-update.ts
@@ -1,0 +1,1 @@
+// noop for now, but will be created later.

--- a/benchmarks/markdown_table/package.json
+++ b/benchmarks/markdown_table/package.json
@@ -6,13 +6,16 @@
     "bench": "set -x; gatsby clean; NUM_PAGES=${NUM_PAGES:-2000} gatsby build",
     "develop": "gatsby develop",
     "build": "gatsby build",
+    "data-update": "ts-node scripts/data-update.ts",
     "serve": "gatsby serve"
   },
   "dependencies": {
     "gatsby": "^2.19.5",
     "gatsby-transformer-remark": "^2.6.48",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "ts-node": "^8.9.0",
+    "typescript": "^3.8.3"
   },
   "devDependencies": {
     "faker": "^4.1.0",

--- a/benchmarks/markdown_table/scripts/data-update.ts
+++ b/benchmarks/markdown_table/scripts/data-update.ts
@@ -1,0 +1,1 @@
+// noop for now, but will be created later.

--- a/benchmarks/mdx/package.json
+++ b/benchmarks/mdx/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
+    "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "postinstall": "del-cli src/articles && gatsby clean && willit --use-pregenerated-data --type=mdx --num-pages=${NUM_PAGES:-512}",
@@ -27,7 +28,9 @@
     "gatsby-source-filesystem": "^2.2.3",
     "gatsby-transformer-sharp": "^2.4.5",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "ts-node": "^8.9.0",
+    "typescript": "^3.8.3"
   },
   "devDependencies": {
     "cross-env": "^7.0.0",

--- a/benchmarks/mdx/scripts/data-update.ts
+++ b/benchmarks/mdx/scripts/data-update.ts
@@ -1,0 +1,1 @@
+// noop for now, but will be created later.

--- a/benchmarks/source-contentful/package.json
+++ b/benchmarks/source-contentful/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "clean": "gatsby clean",
     "build": "gatsby build",
+    "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "serve": "gatsby serve",
@@ -26,7 +27,9 @@
     "gatsby-source-filesystem": "^2.1.48",
     "gatsby-transformer-sharp": "^2.3.14",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "ts-node": "^8.9.0",
+    "typescript": "^3.8.3"
   },
   "devDependencies": {
     "chalk": "^2.4.2",

--- a/benchmarks/source-contentful/scripts/data-update.ts
+++ b/benchmarks/source-contentful/scripts/data-update.ts
@@ -1,0 +1,1 @@
+// noop for now, but will be created later.

--- a/benchmarks/source-datocms/package.json
+++ b/benchmarks/source-datocms/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
+    "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "serve": "gatsby serve",
@@ -22,7 +23,9 @@
     "gatsby-transformer-sharp": "^2.3.14",
     "lodash.kebabcase": "^4.1.1",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "ts-node": "^8.9.0",
+    "typescript": "^3.8.3"
   },
   "devDependencies": {
     "cross-env": "^7.0.0",

--- a/benchmarks/source-datocms/scripts/data-update.ts
+++ b/benchmarks/source-datocms/scripts/data-update.ts
@@ -1,0 +1,1 @@
+// noop for now, but will be created later.

--- a/benchmarks/source-wordpress/package.json
+++ b/benchmarks/source-wordpress/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
+    "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "serve": "gatsby serve",
@@ -21,7 +22,9 @@
     "gatsby-source-wordpress-experimental": "^0.0.31",
     "gatsby-transformer-sharp": "^2.3.14",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "ts-node": "^8.9.0",
+    "typescript": "^3.8.3"
   },
   "devDependencies": {
     "cross-env": "^7.0.0",

--- a/benchmarks/source-wordpress/scripts/data-update.ts
+++ b/benchmarks/source-wordpress/scripts/data-update.ts
@@ -1,0 +1,1 @@
+// noop for now, but will be created later.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This adds a noop `data-update` script (https://github.com/gatsbyjs/gatsby/blob/67730fdfa8fa1f123a5999a2ddf9834775f7d98b/benchmarks/source-drupal/scripts/data-update.ts) for the remainder of the benchmarks so that we can safely run `npm run data-update` for any of these benchmarks while testing the Drupal example.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

n/a

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

n/a
