### PR TITLE
Update blog-core 

### DIFF
--- a/packages/gatsby-theme-blog-core/src/components/bio-content.js
+++ b/packages/gatsby-theme-blog-core/src/components/bio-content.js
@@ -1,0 +1,12 @@
+import React, { Fragment } from "react"
+/**
+ * Shadow me to add your own bio content
+ */
+
+export default () => (
+  <Fragment>
+    Words by <a href="http://example.com/">Jane Doe</a>.
+    <br />
+    Change me. This is all quite default.
+  </Fragment>
+)

--- a/packages/gatsby-theme-blog-core/src/components/bio.js
+++ b/packages/gatsby-theme-blog-core/src/components/bio.js
@@ -1,0 +1,53 @@
+/**
+ * Bio component that queries for data
+ * with Gatsby's StaticQuery component
+ *
+ * See: https://www.gatsbyjs.org/docs/static-query/
+ */
+
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+import Image from "gatsby-image"
+import BioContent from "./bio-content"
+
+const Bio = () => {
+  const data = useStaticQuery(bioQuery)
+  const {
+    site: {
+      siteMetadata: { author },
+    },
+    avatar,
+  } = data
+
+  return (
+    <>
+      {avatar ? (
+        <Image fixed={avatar.childImageSharp.fixed} alt={author} />
+      ) : (
+        <div role="presentation" />
+      )}
+      <div>
+        <BioContent />
+      </div>
+    </>
+  )
+}
+
+const bioQuery = graphql`
+  query BioQuery {
+    site {
+      siteMetadata {
+        author
+      }
+    }
+    avatar: file(absolutePath: { regex: "/avatar.(jpeg|jpg|gif|png)/" }) {
+      childImageSharp {
+        fixed(width: 48, height: 48) {
+          ...GatsbyImageSharpFixed
+        }
+      }
+    }
+  }
+`
+
+export default Bio

--- a/packages/gatsby-theme-blog-core/src/components/header.js
+++ b/packages/gatsby-theme-blog-core/src/components/header.js
@@ -13,7 +13,7 @@ const Title = ({ children, location }) => {
     )
   } else {
     return (
-      <h3 as="p">
+      <h3>
         <Link to={`/`}>{children}</Link>
       </h3>
     )

--- a/packages/gatsby-theme-blog-core/src/components/header.js
+++ b/packages/gatsby-theme-blog-core/src/components/header.js
@@ -1,0 +1,33 @@
+import React from "react"
+import { Link } from "gatsby"
+import Bio from "../components/bio"
+
+const rootPath = `${__PATH_PREFIX__}/`
+
+const Title = ({ children, location }) => {
+  if (location.pathname === rootPath) {
+    return (
+      <h1>
+        <Link to={`/`}>{children}</Link>
+      </h1>
+    )
+  } else {
+    return (
+      <h3 as="p">
+        <Link to={`/`}>{children}</Link>
+      </h3>
+    )
+  }
+}
+
+export default ({ children, title, ...props }) => (
+  <header>
+    <div>
+      <div>
+        <Title {...props}>{title}</Title>
+        {children}
+      </div>
+      {props.location.pathname === rootPath && <Bio />}
+    </div>
+  </header>
+)

--- a/packages/gatsby-theme-blog-core/src/components/headings.js
+++ b/packages/gatsby-theme-blog-core/src/components/headings.js
@@ -1,0 +1,36 @@
+import React from "react"
+
+// from https://octicons.github.com/icon/link/
+const LinkIcon = props => (
+  <svg
+    {...props}
+    viewBox="0 0 16 16"
+    width="16"
+    height="16"
+    fill="currentcolor"
+    aria-hidden="true"
+  >
+    <path
+      fillRule="evenodd"
+      d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"
+    />
+  </svg>
+)
+
+const heading = Tag => props => (
+  <Tag {...props}>
+    <a href={`#${props.id}`}>
+      <LinkIcon />
+    </a>
+    {props.children}
+  </Tag>
+)
+
+export default {
+  h1: heading(`h1`),
+  h2: heading(`h2`),
+  h3: heading(`h3`),
+  h4: heading(`h4`),
+  h5: heading(`h5`),
+  h6: heading(`h6`),
+}

--- a/packages/gatsby-theme-blog-core/src/components/home-footer.js
+++ b/packages/gatsby-theme-blog-core/src/components/home-footer.js
@@ -1,0 +1,23 @@
+import React, { Fragment } from "react"
+
+const Footer = ({ socialLinks }) => (
+  <footer>
+    © {new Date().getFullYear()}, Powered by
+    {` `}
+    <a href="https://www.gatsbyjs.org">Gatsby</a>
+    {` `}&bull;{` `}
+    {socialLinks.map((platform, i, arr) => (
+      <Fragment key={platform.url}>
+        <a href={platform.url} target="_blank" rel="noopener noreferrer">
+          {platform.name}
+        </a>
+        {arr.length - 1 !== i && (
+          <Fragment>
+            {` `}&bull;{` `}
+          </Fragment>
+        )}
+      </Fragment>
+    ))}
+  </footer>
+)
+export default Footer

--- a/packages/gatsby-theme-blog-core/src/components/layout.js
+++ b/packages/gatsby-theme-blog-core/src/components/layout.js
@@ -1,0 +1,11 @@
+import React from "react"
+import Header from "./header"
+
+export default ({ children, ...props }) => (
+  <root>
+    <Header {...props} />
+    <div>
+      <div>{children}</div>
+    </div>
+  </root>
+)

--- a/packages/gatsby-theme-blog-core/src/components/post-footer.js
+++ b/packages/gatsby-theme-blog-core/src/components/post-footer.js
@@ -1,0 +1,31 @@
+import React from "react"
+import { Link } from "gatsby"
+
+import Bio from "../components/bio"
+
+const Footer = ({ previous, next }) => (
+  <footer>
+    <hr />
+    <Bio />
+    {(previous || next) && (
+      <>
+        <li>
+          {previous && (
+            <Link to={previous.slug} rel="prev">
+              ← {previous.title}
+            </Link>
+          )}
+        </li>
+        <li>
+          {next && (
+            <Link to={next.slug} rel="next">
+              {next.title} →
+            </Link>
+          )}
+        </li>
+      </>
+    )}
+  </footer>
+)
+
+export default Footer

--- a/packages/gatsby-theme-blog-core/src/components/post.js
+++ b/packages/gatsby-theme-blog-core/src/components/post.js
@@ -1,3 +1,30 @@
 import React from "react"
 
-export default props => <pre>{JSON.stringify(props.data, null, 2)}</pre>
+import PostFooter from "../components/post-footer"
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+import { MDXRenderer } from "gatsby-plugin-mdx"
+
+const Post = ({
+  data: {
+    post,
+    site: {
+      siteMetadata: { title },
+    },
+  },
+  location,
+  previous,
+  next,
+}) => (
+  <Layout location={location} title={title}>
+    <SEO title={post.title} description={post.excerpt} />
+    <main>
+      <h1>{post.title}</h1>
+      <p>{post.date}</p>
+      <MDXRenderer>{post.body}</MDXRenderer>
+    </main>
+    <PostFooter {...{ previous, next }} />
+  </Layout>
+)
+
+export default Post

--- a/packages/gatsby-theme-blog-core/src/components/posts.js
+++ b/packages/gatsby-theme-blog-core/src/components/posts.js
@@ -1,3 +1,32 @@
-import React from "react"
+import React, { Fragment } from "react"
+import { Link } from "gatsby"
 
-export default props => <pre>{JSON.stringify(props.data, null, 2)}</pre>
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+import Footer from "../components/home-footer"
+
+const Posts = ({ location, posts, siteTitle, socialLinks }) => (
+  <Layout location={location} title={siteTitle}>
+    <main>
+      {posts.map(({ node }) => {
+        const title = node.title || node.slug
+        const keywords = node.keywords || []
+        return (
+          <Fragment key={node.slug}>
+            <SEO title="Home" keywords={keywords} />
+            <div>
+              <h2>
+                <Link to={node.slug}>{title}</Link>
+              </h2>
+              <small>{node.date}</small>
+              <p>{node.excerpt}</p>
+            </div>
+          </Fragment>
+        )
+      })}
+    </main>
+    <Footer socialLinks={socialLinks} />
+  </Layout>
+)
+
+export default Posts

--- a/packages/gatsby-theme-blog-core/src/components/posts.js
+++ b/packages/gatsby-theme-blog-core/src/components/posts.js
@@ -10,10 +10,9 @@ const Posts = ({ location, posts, siteTitle, socialLinks }) => (
     <main>
       {posts.map(({ node }) => {
         const title = node.title || node.slug
-        const keywords = node.keywords || []
         return (
           <Fragment key={node.slug}>
-            <SEO title="Home" keywords={keywords} />
+            <SEO title="Home" />
             <div>
               <h2>
                 <Link to={node.slug}>{title}</Link>

--- a/packages/gatsby-theme-blog-core/src/components/seo.js
+++ b/packages/gatsby-theme-blog-core/src/components/seo.js
@@ -1,0 +1,98 @@
+/**
+ * SEO component that queries for data with
+ *  Gatsby's useStaticQuery React hook
+ *
+ * See: https://www.gatsbyjs.org/docs/use-static-query/
+ */
+
+import React from "react"
+import PropTypes from "prop-types"
+import Helmet from "react-helmet"
+import { useStaticQuery, graphql } from "gatsby"
+
+function SEO({ description, lang, meta, keywords, title }) {
+  const { site } = useStaticQuery(
+    graphql`
+      query {
+        site {
+          siteMetadata {
+            title
+            description
+            author
+          }
+        }
+      }
+    `
+  )
+
+  const metaDescription = description || site.siteMetadata.description
+
+  return (
+    <Helmet
+      htmlAttributes={{
+        lang,
+      }}
+      title={title}
+      titleTemplate={`%s | ${site.siteMetadata.title}`}
+      meta={[
+        {
+          name: `description`,
+          content: metaDescription,
+        },
+        {
+          property: `og:title`,
+          content: title,
+        },
+        {
+          property: `og:description`,
+          content: metaDescription,
+        },
+        {
+          property: `og:type`,
+          content: `website`,
+        },
+        {
+          name: `twitter:card`,
+          content: `summary`,
+        },
+        {
+          name: `twitter:creator`,
+          content: site.siteMetadata.author,
+        },
+        {
+          name: `twitter:title`,
+          content: title,
+        },
+        {
+          name: `twitter:description`,
+          content: metaDescription,
+        },
+      ]
+        .concat(
+          keywords.length > 0
+            ? {
+                name: `keywords`,
+                content: keywords.join(`, `),
+              }
+            : []
+        )
+        .concat(meta)}
+    />
+  )
+}
+
+SEO.defaultProps = {
+  lang: `en`,
+  meta: [],
+  keywords: [],
+}
+
+SEO.propTypes = {
+  description: PropTypes.string,
+  lang: PropTypes.string,
+  meta: PropTypes.array,
+  keywords: PropTypes.arrayOf(PropTypes.string),
+  title: PropTypes.string.isRequired,
+}
+
+export default SEO

--- a/packages/gatsby-theme-blog-core/src/components/seo.js
+++ b/packages/gatsby-theme-blog-core/src/components/seo.js
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-function SEO({ description, lang, meta, keywords, title }) {
+function SEO({ description, lang, meta, title }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -67,16 +67,7 @@ function SEO({ description, lang, meta, keywords, title }) {
           name: `twitter:description`,
           content: metaDescription,
         },
-      ]
-        .concat(
-          keywords.length > 0
-            ? {
-                name: `keywords`,
-                content: keywords.join(`, `),
-              }
-            : []
-        )
-        .concat(meta)}
+      ].concat(meta)}
     />
   )
 }
@@ -84,14 +75,12 @@ function SEO({ description, lang, meta, keywords, title }) {
 SEO.defaultProps = {
   lang: `en`,
   meta: [],
-  keywords: [],
 }
 
 SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.array,
-  keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,
 }
 

--- a/packages/gatsby-theme-blog-core/src/templates/post-query.js
+++ b/packages/gatsby-theme-blog-core/src/templates/post-query.js
@@ -1,7 +1,19 @@
 import { graphql } from "gatsby"
-import PostPage from "../components/post"
+import Post from "../components/post"
+import React from "react"
 
-export default PostPage
+export default ({ location, data }) => {
+  const { blogPost, previous, next } = data
+
+  return (
+    <Post
+      data={{ ...data, post: blogPost }}
+      location={location}
+      previous={previous}
+      next={next}
+    />
+  )
+}
 
 export const query = graphql`
   query PostPageQuery($id: String!, $previousId: String, $nextId: String) {

--- a/packages/gatsby-theme-blog-core/src/templates/posts-query.js
+++ b/packages/gatsby-theme-blog-core/src/templates/posts-query.js
@@ -1,7 +1,19 @@
 import { graphql } from "gatsby"
-import PostsPage from "../components/posts"
+import React from "react"
 
-export default PostsPage
+import Posts from "../components/posts"
+
+export default ({ location, data }) => {
+  const { site, allBlogPost } = data
+  return (
+    <Posts
+      location={location}
+      posts={allBlogPost.edges}
+      siteTitle={site.siteMetadata.title}
+      socialLinks={site.siteMetadata.social}
+    />
+  )
+}
 
 export const query = graphql`
   query PostsQuery {

--- a/packages/gatsby-theme-blog/src/components/post-link.js
+++ b/packages/gatsby-theme-blog/src/components/post-link.js
@@ -3,25 +3,29 @@ import { Styled, jsx } from "theme-ui"
 import { Link } from "gatsby"
 
 const PostLink = ({ title, slug, date, excerpt }) => (
-  <div>
-    <Styled.h2
-      sx={{
-        mb: 1,
-      }}
-    >
-      <Styled.a
-        as={Link}
+  <article>
+    <header>
+      <Styled.h2
         sx={{
-          textDecoration: `none`,
+          mb: 1,
         }}
-        to={slug}
       >
-        {title || slug}
-      </Styled.a>
-    </Styled.h2>
-    <small>{date}</small>
-    <Styled.p>{excerpt}</Styled.p>
-  </div>
+        <Styled.a
+          as={Link}
+          sx={{
+            textDecoration: `none`,
+          }}
+          to={slug}
+        >
+          {title || slug}
+        </Styled.a>
+      </Styled.h2>
+      <small>{date}</small>
+    </header>
+    <section>
+      <Styled.p>{excerpt}</Styled.p>
+    </section>
+  </article>
 )
 
 export default PostLink

--- a/packages/gatsby-theme-blog/src/components/post.js
+++ b/packages/gatsby-theme-blog/src/components/post.js
@@ -27,9 +27,15 @@ const Post = ({
       imageSource={post.image?.childImageSharp?.fluid.src}
     />
     <main>
-      <PostTitle>{post.title}</PostTitle>
-      <PostDate>{post.date}</PostDate>
-      <MDXRenderer>{post.body}</MDXRenderer>
+      <article>
+        <header>
+          <PostTitle>{post.title}</PostTitle>
+          <PostDate>{post.date}</PostDate>
+        </header>
+        <section>
+          <MDXRenderer>{post.body}</MDXRenderer>
+        </section>
+      </article>
     </main>
     <PostFooter {...{ previous, next }} />
   </Layout>


### PR DESCRIPTION
After discussions about re-architecture, moving forward the gatsby-theme-blog-core 2.0 version will be more than just the data layer. It will act as a semantic HTML unstyled blog implementation.

This is the initial PR for that functionality which will be merged into the larger #23351 PR.

Note that functionality in #23353 will live in blog-core going forward, but is not included here just yet.