### PR TITLE
chore(renovate): Don't renovate types and renovate examples and starters

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -93,7 +93,7 @@
     },
     {
       groupName: "type updates",
-      packagePatters: ["^@types"],
+      packagePatterns: ["^@types"],
     },
   ],
   timezone: "GMT",

--- a/renovate.json5
+++ b/renovate.json5
@@ -79,10 +79,6 @@
       ],
     },
     {
-      groupName: "type updates",
-      packagePatters: ["^@types"],
-    },
-    {
       groupName: "patch updates in packages",
       updateTypes: ["patch"],
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,8 @@
     "package.json",
     "packages/**",
     "www/package.json",
+    "starters/**",
+    "examples/**",
   ],
   major: {
     masterIssueApproval: true,
@@ -88,6 +90,10 @@
       groupName: "updates in starters",
       paths: ["starters/**"],
       updateTypes: ["patch"],
+    },
+    {
+      groupName: "type updates",
+      packagePatters: ["^@types"],
     },
   ],
   timezone: "GMT",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Don't renovate types and renovate examples and starters. We should have starters always up to date.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
