### PR TITLE
fix(tutorial): Import react-helmet by name.

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -210,7 +210,7 @@ module.exports = {
 ```jsx:title=src/components/seo.js
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 function SEO({ description, lang, meta, title }) {


### PR DESCRIPTION
The Gatsby tutorials were very helpful to me as a Gatsby newbie. There were some places that got stuck in the tutorial, so let me contribute a little bit.

## Description
Since the react-helmet is exported with a named export, we need to import it by name.

It causes the element type error like this.
```
Error: Element type is invalid: expected a string (for built-in components) or 
a class/function (for composite components) but got: undefined. 
You likely forgot to export your component from the file it's defined in, or 
you might have mixed up default and named imports.
Check the render method of `SEO`.
```

I use `"gatsby": "^2.20.29"`, `"gatsby-plugin-react-helmet": "^3.2.4"` and `"react-helmet": "^6.0.0"`