### PR TITLE
fix(gatsby-recipes): link to the raw gist of .estlintrc.js

### DIFF
--- a/packages/gatsby-recipes/recipes/eslint.mdx
+++ b/packages/gatsby-recipes/recipes/eslint.mdx
@@ -32,7 +32,7 @@ Install necessary packages
 
 <File
   path=".eslintrc.js"
-  content='https://gist.github.com/KyleAMathews/5c4cfa4f58cc2707094f3ae5048e72f6'/>
+  content='https://gist.githubusercontent.com/KyleAMathews/5c4cfa4f58cc2707094f3ae5048e72f6/raw/5a57b14ccc957c8d21c4c6b2f10bba9d179254a1/.estlintrc.js'/>
 
 ---
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Like it mentioned [here](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-recipes#props-4), the content url of `<File />` should be to the raw of a gist instead.

## Related Issues

Related to #22991
