### PR TITLE
chore(docs): Be more vocal about not doing type checking

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-typescript
 
-Provides drop-in support for TypeScript and TSX.
+Allows Gatsby to build TypeScript and TSX files. Does NOT run type checking during build (see Caveats).
 
 ## Install
 
@@ -10,6 +10,7 @@ Provides drop-in support for TypeScript and TSX.
 
 1.  Include the plugin in your `gatsby-config.js` file.
 1.  Write your components in TSX or TypeScript.
+1.  Run TypeScript directly or with a build tool.
 1.  You're good to go.
 
 `gatsby-config.js`


### PR DESCRIPTION
## Description

I hope this isn't too heavy-handed, but I think that philosophically, this plugin doesn't provide "support" for typescript at all, it just disables it. Typescript _is_ type checking! I admit I don't fully understand the scope of this plugin, but I'm aware of a great number of people on unrelated projects who thought gatsby was doing type checking on build after installing this plugin.

### Documentation

This is it :)

## Related Issues

Native TypeScript support #18983