### PR TITLE
chore(www): Prevent default click behavior on Link mock

### DIFF
--- a/www/__mocks__/gatsby.js
+++ b/www/__mocks__/gatsby.js
@@ -4,17 +4,25 @@ const gatsby = jest.requireActual(`gatsby`)
 module.exports = {
   ...gatsby,
   graphql: jest.fn(),
-  Link: jest.fn().mockImplementation(({ children, to, onClick, id }) =>
-    React.createElement(
+  Link: jest.fn().mockImplementation(({ children, to, onClick, id }) => {
+    // Prevent the default click event to stop a console.error from jsdom.
+    // https://github.com/jsdom/jsdom/issues/2112
+    const onClickWithoutDefault = (ev) => {
+      ev.preventDefault()
+      onClick(ev)
+    }
+
+    return React.createElement(
       `a`,
       {
         href: to,
-        onClick,
+        onClick: onClickWithoutDefault,
         id,
       },
       children
     )
-  ),
+  }),
+
   StaticQuery: jest.fn(),
   useStaticQuery: jest.fn(),
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
When window.location is updated due to a click event on an `a` tag with an
href attribute, jsdom was logging an error to the console even though the tests
were passing.

This wraps the onClick prop passed to the `Link` mock in a function that prevents
the default behavior of the click, so that we can test the onClick
callback's behavior without triggering an update to window.location.

### Documentation

Just test maintenance, no doc updates. 


### Test Output

There's still a warning about using `componentWillMount`, but I think that's coming from `react-side-effect`, which is pulled in by `react-helmet`. `react-helmet` was updated to a new major version a few weeks ago that pulls in a new version of `react-side-effect` which shouldn't have that deprecation warning anymore. I can try pulling in that update too, but I wasn't sure if that was too out of scope for this.


```js
yarn run v1.21.0
$ jest
 PASS  src/components/__tests__/copy.js
 PASS  src/components/code-block/__tests__/index.js
 PASS  src/components/__tests__/banner.js
 PASS  src/components/events/__tests__/event-list.js
 PASS  src/components/__tests__/stub-list.js
 PASS  src/components/__tests__/mdx-link.js
 PASS  src/components/code-block/__tests__/normalize.js
 PASS  src/utils/__tests__/i18n.js
 PASS  src/utils/__tests__/get-csv-features-data.js
 PASS  src/components/__tests__/table-of-contents.js
 PASS  src/utils/__tests__/copy-to-clipboard.js
 PASS  src/components/__tests__/button.js
 PASS  src/templates/__tests__/template-starter-page.js (5.014s)
  ● Console

    console.warn
      Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component
-lifecycles for details.
      
      * Move code with side effects to componentDidMount, and set initial state in the constructor.
      * Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, o
nly the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod renam
e-unsafe-lifecycles` in your project source folder.
      
      Please update the following components: SideEffect(NullComponent)

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:88:30)
      at warn (node_modules/react-dom/cjs/react-dom.development.js:51:5)
      at Object.<anonymous>.ReactStrictModeWarnings.flushPendingUnsafeLifecycleWarnings (node_modules/react-dom/cjs/react-dom.development.js:11371:7)
      at flushRenderPhaseStrictModeWarningsInDEV (node_modules/react-dom/cjs/react-dom.development.js:23112:31)
      at commitRootImpl (node_modules/react-dom/cjs/react-dom.development.js:22396:3)
      at unstable_runWithPriority (node_modules/react-dom/node_modules/scheduler/cjs/scheduler.development.js:653:12)
      at runWithPriority$1 (node_modules/react-dom/cjs/react-dom.development.js:11039:10)
      at commitRoot (node_modules/react-dom/cjs/react-dom.development.js:22381:3)

 PASS  src/components/sidebar/__tests__/sidebar.js (5.227s)

Test Suites: 14 passed, 14 total
Tests:       2 skipped, 62 passed, 64 total
Snapshots:   0 total
Time:        6.851s
Ran all test suites.
✨  Done in 9.61s.
```

## Related Issues
Fixes #23326 