### PR TITLE
Fix graphql extraction error

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.js
@@ -43,7 +43,7 @@ export function followVariableDeclarations(binding) {
   const node = binding.path?.node
   if (
     node?.type === `VariableDeclarator` &&
-    node?.id?.type === `Identifier` &&
+    node?.id.type === `Identifier` &&
     node?.init?.type === `Identifier`
   ) {
     return followVariableDeclarations(

--- a/packages/babel-plugin-remove-graphql-queries/src/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.js
@@ -39,6 +39,20 @@ class GraphQLSyntaxError extends Error {
 const isGlobalIdentifier = tag =>
   tag.isIdentifier({ name: `graphql` }) && tag.scope.hasGlobal(`graphql`)
 
+export function followVariableDeclarations(binding) {
+  const node = binding.path?.node
+  if (
+    node?.type === `VariableDeclarator` &&
+    node?.id?.type === `Identifier` &&
+    node?.init?.type === `Identifier`
+  ) {
+    return followVariableDeclarations(
+      binding.path.scope.getBinding(node.init.name)
+    )
+  }
+  return binding
+}
+
 function getTagImport(tag) {
   const name = tag.node.name
   const binding = tag.scope.getBinding(name)
@@ -349,21 +363,6 @@ export default function ({ types: t }) {
             })
           },
         })
-
-        function followVariableDeclarations(binding) {
-          const node = binding.path?.node
-          if (
-            node &&
-            node.type === `VariableDeclarator` &&
-            node.id.type === `Identifier` &&
-            node.init.type === `Identifier`
-          ) {
-            return followVariableDeclarations(
-              binding.path.scope.getBinding(node.init.name)
-            )
-          }
-          return binding
-        }
 
         // Traverse once again for useStaticQuery instances
         path.traverse({

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -45,7 +45,7 @@ function followVariableDeclarations(binding) {
   const node = binding.path?.node
   if (
     node?.type === `VariableDeclarator` &&
-    node?.id?.type === `Identifier` &&
+    node?.id.type === `Identifier` &&
     node?.init?.type === `Identifier`
   ) {
     return followVariableDeclarations(

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -39,6 +39,22 @@ const generateQueryName = ({ def, hash, file }) => {
   return def
 }
 
+// taken from `babel-plugin-remove-graphql-queries`, in the future import from
+// there
+function followVariableDeclarations(binding) {
+  const node = binding.path?.node
+  if (
+    node?.type === `VariableDeclarator` &&
+    node?.id?.type === `Identifier` &&
+    node?.init?.type === `Identifier`
+  ) {
+    return followVariableDeclarations(
+      binding.path.scope.getBinding(node.init.name)
+    )
+  }
+  return binding
+}
+
 function isUseStaticQuery(path) {
   return (
     (path.node.callee.type === `MemberExpression` &&
@@ -343,21 +359,6 @@ async function findGraphQLTags(
           )
 
           documents.push(docInFile)
-        }
-
-        function followVariableDeclarations(binding) {
-          const node = binding.path?.node
-          if (
-            node &&
-            node.type === `VariableDeclarator` &&
-            node.id.type === `Identifier` &&
-            node.init.type === `Identifier`
-          ) {
-            return followVariableDeclarations(
-              binding.path.scope.getBinding(node.init.name)
-            )
-          }
-          return binding
         }
 
         // When a component has a StaticQuery we scan all of its exports and follow those exported variables


### PR DESCRIPTION
## Description

This fixes a bug where the GrahpQL query extractor chokes on particular syntax because of possible `unidentified` fields.

Fixed this by explicit checks on these fields.

## Related Issues

Fixes: #21212
