### PR TITLE
Add a note about node creation in `onCreateNode`

### DIFF
--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -122,9 +122,10 @@ exports.sourceNodes = true
  * Called when a new node is created. Plugins wishing to extend or
  * transform nodes created by other plugins should implement this API.
  *
- * If you create a new nodes in `onCreateNode`, remember to set the
- * new nodes' `parent` field to `node.id`. Not doing this will cause 
- * cache issues.
+ * If you create new nodes in `onCreateNode`, remember to set the
+ * the `parent` field to `node.id` when calling
+ * [`createNode`](/docs/actions/#createNode). Not setting the `parent`
+ * will cause cache issues.
  *
  * See also the documentation for [`createNode`](/docs/actions/#createNode)
  * and [`createNodeField`](/docs/actions/#createNodeField)

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -122,8 +122,8 @@ exports.sourceNodes = true
  * Called when a new node is created. Plugins wishing to extend or
  * transform nodes created by other plugins should implement this API.
  *
- * If you create new nodes in `onCreateNode`, remember to set the
- * the `parent` field to `node.id` when calling
+ * If you create new nodes in `onCreateNode`, remember to set the `parent`
+ * field to `node.id` when calling
  * [`createNode`](/docs/actions/#createNode). Not setting the `parent`
  * will cause cache issues.
  *

--- a/packages/gatsby/src/utils/api-node-docs.js
+++ b/packages/gatsby/src/utils/api-node-docs.js
@@ -122,6 +122,10 @@ exports.sourceNodes = true
  * Called when a new node is created. Plugins wishing to extend or
  * transform nodes created by other plugins should implement this API.
  *
+ * If you create a new nodes in `onCreateNode`, remember to set the
+ * new nodes' `parent` field to `node.id`. Not doing this will cause 
+ * cache issues.
+ *
  * See also the documentation for [`createNode`](/docs/actions/#createNode)
  * and [`createNodeField`](/docs/actions/#createNodeField)
  * @example


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I recently had problems with nodes crated in `onCreateNode` not re-creating on subsequent `gatsby develop` runs. In the end, the issue was that I didn't set their `parent` field.

### Documentation

`createNode`'s documentation says:

> If the node is derived from another node, set that node as the parent. Otherwise it can just be null.

I think it's not stressed enought that your derived nodes won't actually get created at all if you forget to add `parent`. So I thought the best place to do this is in the documentation of `onCreateNode` itself.


<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

None
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
