### PR TITLE
Improve renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,15 @@
     "starters/**",
     "examples/**",
   ],
+  ignorePaths: [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**",
+  ],
   major: {
     masterIssueApproval: true,
   },

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,7 +10,6 @@
     ":disablePeerDependencies",
     ":maintainLockFilesDisabled",
     ":disableRateLimiting",
-    ":rebaseStalePrs",
   ],
   includePaths: [
     "package.json",

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,8 +18,21 @@
   semanticCommitScope: null,
   prHourlyLimit: 0,
   packageRules: [
+    // these rules define group names
     {
-      groupName: "minor updates in packages",
+      groupName: "packages",
+      paths: ["package.json", "packages/**"],
+    },
+    {
+      groupName: "www",
+      paths: ["www/package.json"],
+    },
+    {
+      groupName: "starters and examples",
+      paths: ["starters/**", "examples/**"],
+    },
+    // these rules define dependencies that we have special handling for
+    {
       updateTypes: ["minor"],
       excludePackageNames: [
         // below is list of packages that use 0.X version range, any minor bump there can contain breaking changes, so we just ignore minor bumps for those packages and will need to bump them manually
@@ -79,21 +92,14 @@
       ],
     },
     {
-      groupName: "patch updates in packages",
-      updateTypes: ["patch"],
-    },
-    {
       depTypeList: ["engines"],
       enabled: false,
     },
     {
-      groupName: "updates in starters",
-      paths: ["starters/**"],
-      updateTypes: ["patch"],
-    },
-    {
-      groupName: "type updates",
+      groupName: "types",
       packagePatterns: ["^@types"],
+      // only upgrade types with approval as they can break transitives
+      masterIssueApproval: true,
     },
   ],
   timezone: "GMT",

--- a/renovate.json5
+++ b/renovate.json5
@@ -16,6 +16,11 @@
     "**/tests/**",
     "**/__fixtures__/**",
   ],
+  hostRules: [
+    {
+      timeout: 60000,
+    },
+  ],
   major: {
     masterIssueApproval: true,
   },

--- a/renovate.json5
+++ b/renovate.json5
@@ -60,9 +60,78 @@
         "react-docgen",
       ],
     },
+    // we need to replicate this so that it goes to a separate group
     {
       // minor updates in packages <1.0.0 - need master issue approval
       // not grouped
+      groupName: "packages (<1.0.0 minor)",
+      paths: ["package.json", "packages/**"],
+      masterIssueApproval: true,
+      updateTypes: ["minor"],
+      packageNames: [
+        // below is list of packages that use 0.X version range, any minor bump there can contain breaking changes, so we just ignore minor bumps for those packages and will need to bump them manually
+        "@reach/skip-nav",
+        "@theme-ui/prism",
+        "@theme-ui/typography",
+        "axios",
+        "babel-preset-gatsby",
+        "sharp",
+        "gatsby-plugin-theme-ui",
+        "graphiql-explorer",
+        "guess-webpack",
+        "jest-silent-reporter",
+        "js-combinatorics",
+        "jscodeshift",
+        "mini-css-extract-plugin",
+        "react-refresh",
+        "scroll-behavior",
+        "theme-ui",
+        "webpack-stats-plugin",
+        "xlsx",
+        "zipkin",
+        "zipkin-transport-http",
+        // below is list of packages that we use alpha/beta/next/canary, where it's not really safe to bump automatically and need extra caution
+        "react-docgen",
+      ],
+    },
+    {
+      // minor updates in packages <1.0.0 - need master issue approval
+      // not grouped
+      groupName: "www (<1.0.0 minor)",
+      paths: ["www/package.json"],
+      masterIssueApproval: true,
+      updateTypes: ["minor"],
+      packageNames: [
+        // below is list of packages that use 0.X version range, any minor bump there can contain breaking changes, so we just ignore minor bumps for those packages and will need to bump them manually
+        "@reach/skip-nav",
+        "@theme-ui/prism",
+        "@theme-ui/typography",
+        "axios",
+        "babel-preset-gatsby",
+        "sharp",
+        "gatsby-plugin-theme-ui",
+        "graphiql-explorer",
+        "guess-webpack",
+        "jest-silent-reporter",
+        "js-combinatorics",
+        "jscodeshift",
+        "mini-css-extract-plugin",
+        "react-refresh",
+        "scroll-behavior",
+        "theme-ui",
+        "webpack-stats-plugin",
+        "xlsx",
+        "zipkin",
+        "zipkin-transport-http",
+        // below is list of packages that we use alpha/beta/next/canary, where it's not really safe to bump automatically and need extra caution
+        "react-docgen",
+      ],
+    },
+    {
+      // minor updates in packages <1.0.0 - need master issue approval
+      // not grouped
+      groupName: "starters and examples (<1.0.0 minor)",
+      paths: ["starters/**", "examples/**"],
       masterIssueApproval: true,
       updateTypes: ["minor"],
       packageNames: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,17 @@
 {
-  extends: ["config:base", ":disablePeerDependencies"],
+  extends: [
+    ":separateMajorReleases",
+    ":combinePatchMinorReleases",
+    ":ignoreUnstable",
+    ":prImmediately",
+    ":semanticPrefixFixDepsChoreOthers",
+    ":updateNotScheduled",
+    ":automergeDisabled",
+    ":disablePeerDependencies",
+    ":maintainLockFilesDisabled",
+    ":disableRateLimiting",
+    ":rebaseStalePrs",
+  ],
   includePaths: [
     "package.json",
     "packages/**",
@@ -16,16 +28,10 @@
     "**/tests/**",
     "**/__fixtures__/**",
   ],
-  hostRules: [
-    {
-      timeout: 60000,
-    },
-  ],
   major: {
     masterIssueApproval: true,
   },
   masterIssue: true,
-  rebaseStalePrs: false,
   ignoreDeps: ["react", "react-dom"],
   rangeStrategy: "bump",
   bumpVersion: null,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Update renovate config so that:

1. We have clear update groups (packages/www/starters+examples), remove unnecessary groups.
2. Dependency rules apply to all groups
3. We don't update @types by default

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
