### PR TITLE
fix(gatsby-link): replace current path in history rather than pushing it

### DIFF
--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -159,6 +159,53 @@ describe(`<Link />`, () => {
     getReplace()(`/some-path`)
     expect(global.___replace).toHaveBeenCalledWith(`/some-path`)
   })
+
+  describe(`uses push or replace adequately`, () => {
+    it(`respects force disabling replace`, () => {
+      const to = `/`
+      getNavigate()
+      const { link } = setup({ linkProps: { to, replace: false } })
+      link.click()
+
+      expect(
+        global.___navigate
+      ).toHaveBeenCalledWith(`${global.__BASE_PATH__}${to}`, { replace: false })
+    })
+
+    it(`respects force enabling replace`, () => {
+      const to = `/courses`
+      getNavigate()
+      const { link } = setup({ linkProps: { to, replace: true } })
+      link.click()
+
+      expect(
+        global.___navigate
+      ).toHaveBeenCalledWith(`${global.__BASE_PATH__}${to}`, { replace: true })
+    })
+
+    it(`does not replace history when navigating away`, () => {
+      const to = `/courses`
+      getNavigate()
+      const { link } = setup({ linkProps: { to } })
+      link.click()
+
+      expect(global.___navigate).toHaveBeenCalledWith(
+        `${global.__BASE_PATH__}${to}`,
+        {}
+      )
+    })
+
+    it(`does replace history when navigating on the same page`, () => {
+      const to = `/`
+      getNavigate()
+      const { link } = setup({ linkProps: { to } })
+      link.click()
+
+      expect(
+        global.___navigate
+      ).toHaveBeenCalledWith(`${global.__BASE_PATH__}${to}`, { replace: true })
+    })
+  })
 })
 
 describe(`withPrefix`, () => {
@@ -275,8 +322,12 @@ describe(`state`, () => {
     const { link } = setup({ linkProps: { state } })
     link.click()
 
-    expect(
-      global.___navigate
-    ).toHaveBeenCalledWith(`${global.__BASE_PATH__}${to}`, { state })
+    expect(global.___navigate).toHaveBeenCalledWith(
+      `${global.__BASE_PATH__}${to}`,
+      {
+        replace: true,
+        state,
+      }
+    )
   })
 })

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -169,9 +169,15 @@ class GatsbyLink extends React.Component {
           ) {
             e.preventDefault()
 
+            let shouldReplace = replace
+            const isCurrent = encodeURI(to) === window.location.pathname
+            if (typeof replace !== `boolean` && isCurrent) {
+              shouldReplace = true
+            }
+
             // Make sure the necessary scripts and data are
             // loaded before continuing.
-            navigate(to, { state, replace })
+            navigate(to, { state, replace: shouldReplace })
           }
 
           return true


### PR DESCRIPTION
Hello!
I'd like to start by thanking you for this awesome project.
Sorry if this contribution doesn't match the guidelines, but I hope I understood them well.

## Description

This change makes `<GatsbyLink>` ask `navigate` to use replaceState rather than pushState when navigating on a link that is the current page. This fixes an issue where a history item would be pushed multiple times for the current page, while this is not the expected behaviour.

If a developer forced "replace" using the prop, their choice takes priority.

This uses the same technique as @reach/router when they fixed it upstream: https://github.com/reach/router/commit/11e9ed615c5752cfa1265a998c51a9bb478c857a

I did not copy the
```
const { key, ...restState } = { ...location.state };
shouldReplace = shallowCompare({ ...state }, restState);
```
part, because I do not understand it.

I also added some tests.

Note: I did not manage to get unit tests to run on my computer (either by using Node 10, 12, 13 or 14, or even trying on all 3 operating systems). They didn't work in the linked gitpod either.

That said, I tested the changes in gatsby-link using `yarn jest` in its folder.

### Documentation

I don't believe this needs documentation other than updating the changelog

## Related Issues

Fixes #22124 
