### PR TITLE
chore(gatsby): count sift hits in telemetry

### DIFF
--- a/packages/gatsby/src/query/graphql-runner.ts
+++ b/packages/gatsby/src/query/graphql-runner.ts
@@ -28,6 +28,7 @@ interface IGraphQLRunnerStats {
   totalRunQuery: number
   totalPluralRunQuery: number
   totalIndexHits: number
+  totalSiftHits: number
   totalNonSingleFilters: number
   comparatorsUsed: Map<string, number>
   uniqueFilterPaths: Set<string>
@@ -41,6 +42,7 @@ interface IGraphQLRunnerStatResults {
   totalRunQuery: number
   totalPluralRunQuery: number
   totalIndexHits: number
+  totalSiftHits: number
   totalNonSingleFilters: number
   comparatorsUsed: Array<{ comparator: string; amount: number }>
   uniqueFilterPaths: number
@@ -89,6 +91,7 @@ export default class GraphQLRunner {
         totalRunQuery: 0,
         totalPluralRunQuery: 0,
         totalIndexHits: 0,
+        totalSiftHits: 0,
         totalNonSingleFilters: 0,
         comparatorsUsed: new Map(),
         uniqueFilterPaths: new Set(),
@@ -141,6 +144,7 @@ export default class GraphQLRunner {
         totalRunQuery: this.stats.totalRunQuery,
         totalPluralRunQuery: this.stats.totalPluralRunQuery,
         totalIndexHits: this.stats.totalIndexHits,
+        totalSiftHits: this.stats.totalSiftHits,
         totalNonSingleFilters: this.stats.totalNonSingleFilters,
         comparatorsUsed: comparatorsUsedObj,
         uniqueFilterPaths: this.stats.uniqueFilterPaths.size,

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -458,8 +458,8 @@ const applyFilters = (
     resolvedFields
   )
 
-  if (!siftResult || siftResult.length === 0) {
-    if (stats) {
+  if (stats) {
+    if (!siftResult || siftResult.length === 0) {
       stats.totalSiftHits++
     }
   }

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -451,7 +451,20 @@ const applyFilters = (
     return result
   }
 
-  return filterWithSift(filters, firstOnly, nodeTypeNames, resolvedFields)
+  const siftResult = filterWithSift(
+    filters,
+    firstOnly,
+    nodeTypeNames,
+    resolvedFields
+  )
+
+  if (!siftResult || siftResult.length === 0) {
+    if (stats) {
+      stats.totalSiftHits++
+    }
+  }
+
+  return siftResult
 }
 
 const filterToStats = (


### PR DESCRIPTION
We want to know how frequent the fast indexes fail to find anything when they're actually supposed to find something. This is currently not tracked and leads to skewed/incomplete results. By counting how frequent Sift finds something when fast indexes fail or bail, we can get more relevant insight into how well fast indexes are actually performing, and/or whether we need to start thinking about eliminating Sift altogether to prevent having to fall back on it for empty sets. tbd.
