### PR TITLE
refactor(gatsby-theme-blog-core): Use more semantic HTML for articles

### DIFF
--- a/packages/gatsby-theme-blog/src/components/post-footer.js
+++ b/packages/gatsby-theme-blog/src/components/post-footer.js
@@ -14,30 +14,32 @@ const Footer = ({ previous, next }) => (
     <Styled.hr />
     <Bio />
     {(previous || next) && (
-      <Flex
-        as="ul"
-        css={css({
-          flexWrap: `wrap`,
-          justifyContent: `space-between`,
-          listStyle: `none`,
-          padding: 0,
-        })}
-      >
-        <li>
-          {previous && (
-            <Styled.a as={Link} to={previous.slug} rel="prev">
-              ← {previous.title}
-            </Styled.a>
-          )}
-        </li>
-        <li>
-          {next && (
-            <Styled.a as={Link} to={next.slug} rel="next">
-              {next.title} →
-            </Styled.a>
-          )}
-        </li>
-      </Flex>
+      <nav>
+        <Flex
+          as="ul"
+          css={css({
+            flexWrap: `wrap`,
+            justifyContent: `space-between`,
+            listStyle: `none`,
+            padding: 0,
+          })}
+        >
+          <li>
+            {previous && (
+              <Styled.a as={Link} to={previous.slug} rel="prev">
+                ← {previous.title}
+              </Styled.a>
+            )}
+          </li>
+          <li>
+            {next && (
+              <Styled.a as={Link} to={next.slug} rel="next">
+                {next.title} →
+              </Styled.a>
+            )}
+          </li>
+        </Flex>
+      </nav>
     )}
   </footer>
 )

--- a/packages/gatsby-theme-blog/src/components/post-footer.js
+++ b/packages/gatsby-theme-blog/src/components/post-footer.js
@@ -14,32 +14,30 @@ const Footer = ({ previous, next }) => (
     <Styled.hr />
     <Bio />
     {(previous || next) && (
-      <nav>
-        <Flex
-          as="ul"
-          css={css({
-            flexWrap: `wrap`,
-            justifyContent: `space-between`,
-            listStyle: `none`,
-            padding: 0,
-          })}
-        >
-          <li>
-            {previous && (
-              <Styled.a as={Link} to={previous.slug} rel="prev">
-                ← {previous.title}
-              </Styled.a>
-            )}
-          </li>
-          <li>
-            {next && (
-              <Styled.a as={Link} to={next.slug} rel="next">
-                {next.title} →
-              </Styled.a>
-            )}
-          </li>
-        </Flex>
-      </nav>
+      <Flex
+        as="ul"
+        css={css({
+          flexWrap: `wrap`,
+          justifyContent: `space-between`,
+          listStyle: `none`,
+          padding: 0,
+        })}
+      >
+        <li>
+          {previous && (
+            <Styled.a as={Link} to={previous.slug} rel="prev">
+              ← {previous.title}
+            </Styled.a>
+          )}
+        </li>
+        <li>
+          {next && (
+            <Styled.a as={Link} to={next.slug} rel="next">
+              {next.title} →
+            </Styled.a>
+          )}
+        </li>
+      </Flex>
     )}
   </footer>
 )

--- a/packages/gatsby-theme-blog/src/components/post-link.js
+++ b/packages/gatsby-theme-blog/src/components/post-link.js
@@ -3,25 +3,29 @@ import { Styled, jsx } from "theme-ui"
 import { Link } from "gatsby"
 
 const PostLink = ({ title, slug, date, excerpt }) => (
-  <div>
-    <Styled.h2
-      sx={{
-        mb: 1,
-      }}
-    >
-      <Styled.a
-        as={Link}
+  <article>
+    <header>
+      <Styled.h2
         sx={{
-          textDecoration: `none`,
+          mb: 1,
         }}
-        to={slug}
       >
-        {title || slug}
-      </Styled.a>
-    </Styled.h2>
-    <small>{date}</small>
-    <Styled.p>{excerpt}</Styled.p>
-  </div>
+        <Styled.a
+          as={Link}
+          sx={{
+            textDecoration: `none`,
+          }}
+          to={slug}
+        >
+          {title || slug}
+        </Styled.a>
+      </Styled.h2>
+      <small>{date}</small>
+    </header>
+    <section>
+      <Styled.p>{excerpt}</Styled.p>
+    </section>
+  </article>
 )
 
 export default PostLink

--- a/packages/gatsby-theme-blog/src/components/post.js
+++ b/packages/gatsby-theme-blog/src/components/post.js
@@ -27,9 +27,15 @@ const Post = ({
       imageSource={post.image?.childImageSharp?.fluid.src}
     />
     <main>
-      <PostTitle>{post.title}</PostTitle>
-      <PostDate>{post.date}</PostDate>
-      <MDXRenderer>{post.body}</MDXRenderer>
+      <article>
+        <header>
+          <PostTitle>{post.title}</PostTitle>
+          <PostDate>{post.date}</PostDate>
+        </header>
+        <section>
+          <MDXRenderer>{post.body}</MDXRenderer>
+        </section>
+      </article>
     </main>
     <PostFooter {...{ previous, next }} />
   </Layout>


### PR DESCRIPTION
## Description

HTML for `gatsby-starter-blog` was updated in https://github.com/gatsbyjs/gatsby/pull/16557. This ports those same changes to `gatsby-theme-blog`. The original description of the changes,

> - Wrap whole blog post in `<article>`
> - Wrap blog post header details in `<header>`.
> - Wrap blog post content itself with `<section>`.
> - Wrap footer navigation to next/previous posts in `<nav>`.

> As I was looking at tweaking some of the blog post rendering for my new site using Gatsby, I noticed that the markup used in the blog starter didn't seem to be using as semantic a markup set as it could be. This PR should theoretically make the markup more accessible to screen readers, etc, although I've not had a chance to personally verify this.

### Documentation

No documentation changes necessary.

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/23314 and https://github.com/gatsbyjs/gatsby/pull/16557