### PR TITLE
Topic/expose graphql source query

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -5,7 +5,15 @@ exports[`Allow alternative import of useStaticQuery 1`] = `
 import * as React from 'react';
 import * as Gatsby from 'gatsby';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = {
+    id: \\"2626356014\\",
+    source: \\"{site { siteMetadata { title }}}\\",
+
+    toString() {
+      return this.id;
+    }
+
+  };
   const siteTitle = staticQueryData.data;
   return React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"
@@ -17,13 +25,29 @@ import * as React from 'react';
 import { StaticQuery } from \\"gatsby\\";
 
 const Test = () => React.createElement(StaticQuery, {
-  query: \\"4279313589\\",
+  query: {
+    id: \\"4279313589\\",
+    source: \\"/n      {/n        site {/n          siteMetadata {/n            title/n          }/n        }/n      }/n      \\",
+
+    toString() {
+      return this.id;
+    }
+
+  },
   render: data => React.createElement(\\"div\\", null, data.site.siteMetadata.title),
   data: staticQueryData
 });
 
 export default Test;
-export const fragment = \\"2962815581\\";"
+export const fragment = {
+  id: \\"2962815581\\",
+  source: \\"/n    fragment MarkdownNodeFragment on MarkdownRemark {/n      html/n    }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
 `;
 
 exports[`Handles closing StaticQuery tag 1`] = `
@@ -31,7 +55,15 @@ exports[`Handles closing StaticQuery tag 1`] = `
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
 export default (() => React.createElement(StaticQuery, {
-  query: \\"2626356014\\",
+  query: {
+    id: \\"2626356014\\",
+    source: \\"{site { siteMetadata { title }}}\\",
+
+    toString() {
+      return this.id;
+    }
+
+  },
   data: staticQueryData
 }, data => React.createElement(\\"div\\", null, data.site.siteMetadata.title)));"
 `;
@@ -50,7 +82,15 @@ export const query = graphql\`
 exports[`Only runs transforms if useStaticQuery is imported from gatsby 1`] = `
 "import * as React from 'react';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = {
+    id: \\"2626356014\\",
+    source: \\"{site { siteMetadata { title }}}\\",
+
+    toString() {
+      return this.id;
+    }
+
+  };
   const siteTitle = useStaticQuery(query);
   return React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"
@@ -58,8 +98,24 @@ export default (() => {
 
 exports[`Removes all gatsby queries 1`] = `
 "export default (() => React.createElement(\\"div\\", null, data.site.siteMetadata.title));
-export const siteMetaQuery = \\"2673797374\\";
-export const query = \\"2589775908\\";"
+export const siteMetaQuery = {
+  id: \\"2673797374\\",
+  source: \\"/n    fragment siteMetaQuery on RootQueryType {/n      site {/n        siteMetadata {/n          title/n        }/n      }/n    }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};
+export const query = {
+  id: \\"2589775908\\",
+  source: \\"/n     {/n       ...siteMetaQuery/n     }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
 `;
 
 exports[`Transformation does not break custom hooks 1`] = `
@@ -84,7 +140,15 @@ export default (() => {
   const data = staticQueryData.data;
   return React.createElement(React.Fragment, null, React.createElement(\\"h1\\", null, data.site.siteMetadata.title), React.createElement(\\"p\\", null, data.site.siteMetadata.description));
 });
-export const query = \\"2626356014\\";"
+export const query = {
+  id: \\"2626356014\\",
+  source: \\"{site { siteMetadata { title }}}\\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
 `;
 
 exports[`Transforms only the call expression in useStaticQuery 1`] = `
@@ -105,7 +169,15 @@ exports[`Transforms queries and preserves destructuring in useStaticQuery 1`] = 
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import * as React from 'react';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = {
+    id: \\"2626356014\\",
+    source: \\"{site { siteMetadata { title }}}\\",
+
+    toString() {
+      return this.id;
+    }
+
+  };
   const {
     site
   } = staticQueryData.data;
@@ -117,7 +189,15 @@ exports[`Transforms queries and preserves variable type in useStaticQuery 1`] = 
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import * as React from 'react';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = {
+    id: \\"2626356014\\",
+    source: \\"{site { siteMetadata { title }}}\\",
+
+    toString() {
+      return this.id;
+    }
+
+  };
   let {
     site
   } = staticQueryData.data;
@@ -129,7 +209,15 @@ exports[`Transforms queries defined in own variable in <StaticQuery> 1`] = `
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
-const query = \\"2626356014\\";
+const query = {
+  id: \\"2626356014\\",
+  source: \\"{site { siteMetadata { title }}}\\",
+
+  toString() {
+    return this.id;
+  }
+
+};
 export default (() => React.createElement(StaticQuery, {
   query: query,
   render: data => React.createElement(\\"div\\", null, data.site.siteMetadata.title),
@@ -141,7 +229,15 @@ exports[`Transforms queries defined in own variable in useStaticQuery 1`] = `
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import * as React from 'react';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = {
+    id: \\"2626356014\\",
+    source: \\"{site { siteMetadata { title }}}\\",
+
+    toString() {
+      return this.id;
+    }
+
+  };
   const siteTitle = staticQueryData.data;
   return React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"
@@ -152,13 +248,31 @@ exports[`Transforms queries in <StaticQuery> 1`] = `
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
 export default (() => React.createElement(StaticQuery, {
-  query: \\"2626356014\\",
+  query: {
+    id: \\"2626356014\\",
+    source: \\"{site { siteMetadata { title }}}\\",
+
+    toString() {
+      return this.id;
+    }
+
+  },
   render: data => React.createElement(\\"div\\", null, data.site.siteMetadata.title),
   data: staticQueryData
 }));"
 `;
 
-exports[`Transforms queries in page components 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`Transforms queries in page components 1`] = `
+"export const query = {
+  id: \\"3687030656\\",
+  source: \\"/n     {/n       site { siteMetadata { title }}/n     }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
+`;
 
 exports[`Transforms queries in useStaticQuery 1`] = `
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
@@ -169,7 +283,17 @@ export default (() => {
 });"
 `;
 
-exports[`allows the global tag 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`allows the global tag 1`] = `
+"export const query = {
+  id: \\"3687030656\\",
+  source: \\"/n     {/n       site { siteMetadata { title }}/n     }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
+`;
 
 exports[`distinguishes between the right tags 1`] = `
 "const foo = styled('div')\`
@@ -195,22 +319,78 @@ const pulse = keyframes\`
       animation-timing-function: ease-out;
     }
   \`;
-export const query = \\"3687030656\\";"
+export const query = {
+  id: \\"3687030656\\",
+  source: \\"/n     {/n       site { siteMetadata { title }}/n     }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
 `;
 
-exports[`handles import aliasing 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`handles import aliasing 1`] = `
+"export const query = {
+  id: \\"3687030656\\",
+  source: \\"/n     {/n       site { siteMetadata { title }}/n     }/n  \\",
 
-exports[`handles require 1`] = `"export const query = \\"3687030656\\";"`;
+  toString() {
+    return this.id;
+  }
 
-exports[`handles require alias 1`] = `"export const query = \\"3687030656\\";"`;
+};"
+`;
 
-exports[`handles require namespace 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`handles require 1`] = `
+"export const query = {
+  id: \\"3687030656\\",
+  source: \\"/n     {/n       site { siteMetadata { title }}/n     }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
+`;
+
+exports[`handles require alias 1`] = `
+"export const query = {
+  id: \\"3687030656\\",
+  source: \\"/n     {/n       site { siteMetadata { title }}/n     }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
+`;
+
+exports[`handles require namespace 1`] = `
+"export const query = {
+  id: \\"3687030656\\",
+  source: \\"/n     {/n       site { siteMetadata { title }}/n     }/n  \\",
+
+  toString() {
+    return this.id;
+  }
+
+};"
+`;
 
 exports[`transforms exported variable queries in <StaticQuery> 1`] = `
 "import staticQueryData from \\"public/static/d/2626356014.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
-export const query = \\"2626356014\\";
+export const query = {
+  id: \\"2626356014\\",
+  source: \\"{site { siteMetadata { title }}}\\",
+
+  toString() {
+    return this.id;
+  }
+
+};
 export default (() => React.createElement(StaticQuery, {
   query: query,
   render: data => React.createElement(\\"div\\", null, data.site.siteMetadata.title),

--- a/packages/babel-plugin-remove-graphql-queries/src/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.js
@@ -167,8 +167,14 @@ function isUseStaticQuery(path) {
       path.get(`callee`).referencesImport(`gatsby`))
   )
 }
-
-function getGraphqlExpression(t, queryHash, source) {
+/**
+ * generateGraphqlExpression.
+ * @param {object} @{link https://babeljs.io/docs/en/babel-types|Babel-types} object for interacting with babel.
+ * @param {string} id hash of the query
+ * @param {string} graphql query text.
+ * @return {object} Ast-object expression with the values id (hash of the query), source (query text) and a toString method returns the id.
+ * */
+function generateGraphqlExpression(t, queryHash, source) {
   return t.objectExpression([
     t.objectProperty(t.identifier(`id`), t.stringLiteral(queryHash)),
     t.objectProperty(t.identifier(`source`), t.stringLiteral(source)),
@@ -257,7 +263,7 @@ export default function({ types: t }) {
 
               // Expose query source
               path2.replaceWith(
-                getGraphqlExpression(t, this.queryHash, this.query)
+                generateGraphqlExpression(t, this.queryHash, this.query)
               )
 
               // Add query
@@ -304,7 +310,9 @@ export default function({ types: t }) {
 
           // Replace the query with the hash of the query.
           // templatePath.replaceWith(t.StringLiteral(queryHash))
-          templatePath.replaceWith(getGraphqlExpression(t, queryHash, text))
+          templatePath.replaceWith(
+            generateGraphqlExpression(t, queryHash, text)
+          )
 
           // traverse upwards until we find top-level JSXOpeningElement or Program
           // this handles exported queries and variable queries
@@ -442,7 +450,7 @@ export default function({ types: t }) {
 
             // Replace the query with the hash of the query.
             // path2.replaceWith(t.StringLiteral(queryHash))
-            path2.replaceWith(getGraphqlExpression(t, queryHash, text))
+            path2.replaceWith(generateGraphqlExpression(t, queryHash, text))
             return null
           },
         })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
One of the plugins used by `gatsby-source-prismic-graphql`, `gatsby-source-graphql-universal` overrides `babel-plugin-remove-graphql-queries.js` so that the queries can be retained within `gatsby-node.js#createPages` can passed to components and re-executed at run-time.

At prismic we re-use graphql queries for previews, but this mechanism for this relies on a "on-the-fly" replacement of the gatsby `babel-plugin-remove-graphql-queries`. Thus we would like to add this feature to gatsby :)


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
Addresses #22919
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
