### PR TITLE
fix(gatsby-recipes): Raise an error when an unknown resource is used

### DIFF
--- a/packages/gatsby-recipes/src/__snapshots__/validate-recipe.test.js.snap
+++ b/packages/gatsby-recipes/src/__snapshots__/validate-recipe.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validate module validates recipes with resource declarations validates File declarations 1`] = `
+Array [
+  Object {
+    "resource": "File",
+    "resourceDeclaration": Object {
+      "contentz": "yo",
+      "path": "super-duper.md",
+    },
+    "step": 2,
+    "validationError": [ValidationError: "contentz" is not allowed],
+  },
+]
+`;
+
+exports[`validate module validates recipes with resource declarations validates File declarations 2`] = `[ValidationError: "contentz" is not allowed]`;
+
+exports[`validate module validates recipes with resource declarations validates NPMPackage declarations 1`] = `
+Array [
+  Object {
+    "resource": "NPMPackage",
+    "resourceDeclaration": Object {
+      "namez": "wee-package",
+    },
+    "step": 1,
+    "validationError": [ValidationError: child "name" fails because ["name" is required]. "namez" is not allowed],
+  },
+]
+`;

--- a/packages/gatsby-recipes/src/validate-recipe.js
+++ b/packages/gatsby-recipes/src/validate-recipe.js
@@ -7,6 +7,15 @@ module.exports = plan => {
       plan.map((step, i) =>
         Object.keys(step).map(key =>
           step[key].map(resourceDeclaration => {
+            if (!resources[key]) {
+              return {
+                step: i,
+                resource: key,
+                resourceDeclaration,
+                validationError: `Unknown resource ${key}`,
+              }
+            }
+
             if (resources[key] && !resources[key].validate) {
               console.log(`${key} is missing an exported validate function`)
               return undefined

--- a/packages/gatsby-recipes/src/validate-recipe.test.js
+++ b/packages/gatsby-recipes/src/validate-recipe.test.js
@@ -9,15 +9,23 @@ describe(`validate module validates recipes with resource declarations`, () => {
     ]
     const validationResponse = validateRecipe(recipe)
     expect(validationResponse[0].validationError).toBeTruthy()
-    //expect(validationResponse).toMatchSnapshot()
-    //expect(validationResponse[0].validationError).toMatchSnapshot()
+    expect(validationResponse).toMatchSnapshot()
+    expect(validationResponse[0].validationError).toMatchSnapshot()
   })
 
-  // it(`validates NPMPackage declarations`, () => {
-  //   const recipe = [{}, { NPMPackage: [{ namez: `wee-package` }] }]
-  //   const validationResponse = validateRecipe(recipe)
-  //   expect(validationResponse).toMatchSnapshot()
-  // })
+  it(`validates NPMPackage declarations`, () => {
+    const recipe = [{}, { NPMPackage: [{ namez: `wee-package` }] }]
+    const validationResponse = validateRecipe(recipe)
+    expect(validationResponse).toMatchSnapshot()
+  })
+
+  it(`returns errors for unknown resources`, () => {
+    const recipe = [{ Fake: [{}] }]
+
+    const result = validateRecipe(recipe)[0]
+
+    expect(result.validationError).toMatch(`Unknown resource Fake`)
+  })
 
   it(`returns empty array if there's no errors`, () => {
     const recipe = [


### PR DESCRIPTION
Currently, if you attempt to use an unknown component/resource in your recipe it silently fails. This will make it more obvious if you make a typo or use a component we don't currently support.