### PR TITLE
feat(gatsby-recipes): Allow for basic config objects in plugin resource

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -8,7 +8,10 @@
   },
   "dependencies": {
     "@babel/core": "^7.8.7",
+    "@babel/generator": "^7.9.5",
     "@babel/standalone": "^7.9.5",
+    "@babel/template": "^7.8.6",
+    "@babel/types": "^7.9.5",
     "@hapi/joi": "^15.1.1",
     "@mdx-js/mdx": "^1.5.8",
     "@mdx-js/react": "^1.5.8",

--- a/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/plugin.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/plugin.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "_message": "Installed gatsby-plugin-foo in gatsby-config.js",
   "id": "gatsby-plugin-foo",
   "name": "gatsby-plugin-foo",
+  "options": undefined,
 }
 `;
 
@@ -22,14 +23,20 @@ module.exports = {
 ",
   "describe": "Install gatsby-plugin-foo in gatsby-config.js",
   "diff": "- Original  - 1
-+ Modified  + 1
++ Modified  + 7
 
-@@ -5,6 +5,6 @@
+@@ -5,6 +5,12 @@
    */
   module.exports = {
     /* Your site config here */
 -   plugins: [],
-+   plugins: [\\"gatsby-plugin-foo\\"],
++   plugins: [
++     {
++       resolve: \\"gatsby-plugin-foo\\",
++       options: undefined,
++       __key: \\"gatsby-plugin-foo\\",
++     },
++   ],
   };
 ",
   "id": "gatsby-plugin-foo",
@@ -41,7 +48,13 @@ module.exports = {
  */
 module.exports = {
   /* Your site config here */
-  plugins: [\\"gatsby-plugin-foo\\"],
+  plugins: [
+    {
+      resolve: \\"gatsby-plugin-foo\\",
+      options: undefined,
+      __key: \\"gatsby-plugin-foo\\",
+    },
+  ],
 };
 ",
 }
@@ -54,6 +67,7 @@ Object {
   "_message": "Installed gatsby-plugin-foo in gatsby-config.js",
   "id": "gatsby-plugin-foo",
   "name": "gatsby-plugin-foo",
+  "options": undefined,
 }
 `;
 
@@ -70,7 +84,24 @@ module.exports = {
 };
 ",
   "describe": "Install gatsby-plugin-foo in gatsby-config.js",
-  "diff": "Compared values have no visual difference.",
+  "diff": "- Original  - 1
++ Modified  + 8
+
+@@ -5,6 +5,13 @@
+   */
+  module.exports = {
+    /* Your site config here */
+-   plugins: [\\"gatsby-plugin-foo\\"],
++   plugins: [
++     \\"gatsby-plugin-foo\\",
++     {
++       resolve: \\"gatsby-plugin-foo\\",
++       options: undefined,
++       __key: \\"gatsby-plugin-foo\\",
++     },
++   ],
+  };
+",
   "id": "gatsby-plugin-foo",
   "name": "gatsby-plugin-foo",
   "newState": "/**
@@ -80,7 +111,14 @@ module.exports = {
  */
 module.exports = {
   /* Your site config here */
-  plugins: [\\"gatsby-plugin-foo\\"],
+  plugins: [
+    \\"gatsby-plugin-foo\\",
+    {
+      resolve: \\"gatsby-plugin-foo\\",
+      options: undefined,
+      __key: \\"gatsby-plugin-foo\\",
+    },
+  ],
 };
 ",
 }
@@ -91,6 +129,7 @@ Object {
   "_message": "Installed gatsby-plugin-foo in gatsby-config.js",
   "id": "gatsby-plugin-foo",
   "name": "gatsby-plugin-foo",
+  "options": undefined,
 }
 `;
 
@@ -160,20 +199,24 @@ module.exports = {
         display: \`minimal-ui\`,
       },
     },
-    \`gatsby-plugin-offline\`, // \`gatsby-plugin-preact\`,
+    \`gatsby-plugin-offline\`,
     \`gatsby-plugin-react-helmet\`,
   ],
 };
 ",
   "describe": "Install gatsby-plugin-foo in gatsby-config.js",
   "diff": "- Original  - 0
-+ Modified  + 1
++ Modified  + 5
 
-@@ -64,6 +64,7 @@
+@@ -64,6 +64,11 @@
       },
-      \`gatsby-plugin-offline\`, // \`gatsby-plugin-preact\`,
+      \`gatsby-plugin-offline\`,
       \`gatsby-plugin-react-helmet\`,
-+     \\"gatsby-plugin-foo\\",
++     {
++       resolve: \\"gatsby-plugin-foo\\",
++       options: undefined,
++       __key: \\"gatsby-plugin-foo\\",
++     },
     ],
   };
 ",
@@ -243,9 +286,13 @@ module.exports = {
         display: \`minimal-ui\`,
       },
     },
-    \`gatsby-plugin-offline\`, // \`gatsby-plugin-preact\`,
+    \`gatsby-plugin-offline\`,
     \`gatsby-plugin-react-helmet\`,
-    \\"gatsby-plugin-foo\\",
+    {
+      resolve: \\"gatsby-plugin-foo\\",
+      options: undefined,
+      __key: \\"gatsby-plugin-foo\\",
+    },
   ],
 };
 ",
@@ -259,6 +306,7 @@ Object {
   "_message": "Installed gatsby-plugin-foo in gatsby-config.js",
   "id": "gatsby-plugin-foo",
   "name": "gatsby-plugin-foo",
+  "options": undefined,
 }
 `;
 
@@ -328,14 +376,28 @@ module.exports = {
         display: \`minimal-ui\`,
       },
     },
-    \`gatsby-plugin-offline\`, // \`gatsby-plugin-preact\`,
+    \`gatsby-plugin-offline\`,
     \`gatsby-plugin-react-helmet\`,
     \\"gatsby-plugin-foo\\",
   ],
 };
 ",
   "describe": "Install gatsby-plugin-foo in gatsby-config.js",
-  "diff": "Compared values have no visual difference.",
+  "diff": "- Original  - 0
++ Modified  + 5
+
+@@ -65,6 +65,11 @@
+      \`gatsby-plugin-offline\`,
+      \`gatsby-plugin-react-helmet\`,
+      \\"gatsby-plugin-foo\\",
++     {
++       resolve: \\"gatsby-plugin-foo\\",
++       options: undefined,
++       __key: \\"gatsby-plugin-foo\\",
++     },
+    ],
+  };
+",
   "id": "gatsby-plugin-foo",
   "name": "gatsby-plugin-foo",
   "newState": "const redish = \`#c5484d\`;
@@ -402,11 +464,39 @@ module.exports = {
         display: \`minimal-ui\`,
       },
     },
-    \`gatsby-plugin-offline\`, // \`gatsby-plugin-preact\`,
+    \`gatsby-plugin-offline\`,
     \`gatsby-plugin-react-helmet\`,
     \\"gatsby-plugin-foo\\",
+    {
+      resolve: \\"gatsby-plugin-foo\\",
+      options: undefined,
+      __key: \\"gatsby-plugin-foo\\",
+    },
   ],
 };
 ",
 }
+`;
+
+exports[`gatsby-plugin resource handles config options as an object 1`] = `
+Array [
+  Object {
+    "name": "gatsby-plugin-foo",
+    "options": Object {
+      "bar": "baz",
+      "baz": "qux",
+      "foo": 1,
+      "otherStuff": Array [
+        Object {
+          "bar": Array [
+            Object {
+              "foo": "bar",
+            },
+          ],
+          "foo": "bar2",
+        },
+      ],
+    },
+  },
+]
 `;

--- a/packages/gatsby-recipes/src/providers/gatsby/fixtures/gatsby-starter-blog/gatsby-config.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/fixtures/gatsby-starter-blog/gatsby-config.js
@@ -62,7 +62,7 @@ module.exports = {
         display: `minimal-ui`,
       },
     },
-    `gatsby-plugin-offline`, // `gatsby-plugin-preact`,
+    `gatsby-plugin-offline`,
     `gatsby-plugin-react-helmet`,
   ],
 }

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.js
@@ -1,14 +1,21 @@
 const fs = require(`fs-extra`)
 const path = require(`path`)
 const babel = require(`@babel/core`)
+const t = require(`@babel/types`)
+const declare = require(`@babel/helper-plugin-utils`).declare
 const Joi = require(`@hapi/joi`)
 const glob = require(`glob`)
 const prettier = require(`prettier`)
 
-const declare = require(`@babel/helper-plugin-utils`).declare
-
 const getDiff = require(`../utils/get-diff`)
 const resourceSchema = require(`../resource-schema`)
+
+const isDefaultExport = require(`./utils/is-default-export`)
+const buildPluginNode = require(`./utils/build-plugin-node`)
+const getObjectFromNode = require(`./utils/get-object-from-node`)
+const { getValueFromNode } = require(`./utils/get-object-from-node`)
+const { REQUIRES_KEYS } = require(`./utils/constants`)
+
 const fileExists = filePath => fs.existsSync(filePath)
 
 const listShadowableFilesForTheme = (directory, theme) => {
@@ -30,49 +37,67 @@ const listShadowableFilesForTheme = (directory, theme) => {
   return { shadowedFiles, shadowableFiles }
 }
 
-const isDefaultExport = node => {
-  if (!node || node.type !== `MemberExpression`) {
-    return false
+const getOptionsForPlugin = node => {
+  if (!t.isObjectExpression(node)) {
+    return undefined
   }
 
-  const { object, property } = node
+  const options = node.properties.find(
+    property => property.key.name === `options`
+  )
 
-  if (object.type !== `Identifier` || object.name !== `module`) return false
-  if (property.type !== `Identifier` || property.name !== `exports`)
-    return false
+  if (options) {
+    return getObjectFromNode(options.value)
+  }
 
-  return true
+  return undefined
 }
 
-const getValueFromLiteral = node => {
-  if (node.type === `StringLiteral`) {
-    return node.value
+const getPlugin = node => {
+  const plugin = {
+    name: getNameForPlugin(node),
+    options: getOptionsForPlugin(node),
   }
 
-  if (node.type === `TemplateLiteral`) {
-    return node.quasis[0].value.raw
+  const key = getKeyForPlugin(node)
+
+  if (key) {
+    return { ...plugin, key }
+  }
+
+  return plugin
+}
+
+const getKeyForPlugin = node => {
+  if (t.isObjectExpression(node)) {
+    const key = node.properties.find(p => p.key.name === `__key`)
+
+    return key ? getValueFromNode(key.value) : null
   }
 
   return null
 }
 
 const getNameForPlugin = node => {
-  if (node.type === `StringLiteral` || node.type === `TemplateLiteral`) {
-    return getValueFromLiteral(node)
+  if (t.isStringLiteral(node) || t.isTemplateLiteral(node)) {
+    return getValueFromNode(node)
   }
 
-  if (node.type === `ObjectExpression`) {
+  if (t.isObjectExpression(node)) {
     const resolve = node.properties.find(p => p.key.name === `resolve`)
-    return resolve ? getValueFromLiteral(resolve.value) : null
+
+    return resolve ? getValueFromNode(resolve.value) : null
   }
 
   return null
 }
 
-const addPluginToConfig = (src, pluginName) => {
+const addPluginToConfig = (src, { name, options, key }) => {
   const addPlugins = new BabelPluginAddPluginsToGatsbyConfig({
-    pluginOrThemeName: pluginName,
+    pluginOrThemeName: name,
+    options,
     shouldAdd: true,
+    key,
   })
 
   const { code } = babel.transform(src, {
@@ -94,39 +119,47 @@ const getPluginsFromConfig = src => {
   return getPlugins.state
 }
 
-const create = async ({ root }, { name }) => {
+const create = async ({ root }, { name, options, key }) => {
   const configPath = path.join(root, `gatsby-config.js`)
   const configSrc = await fs.readFile(configPath, `utf8`)
 
   const prettierConfig = await prettier.resolveConfig(root)
 
-  let code = addPluginToConfig(configSrc, name)
+  let code = addPluginToConfig(configSrc, { name, options, key })
   code = prettier.format(code, { ...prettierConfig, parser: `babel` })
 
   await fs.writeFile(configPath, code)
 
-  return await read({ root }, name)
+  return await read({ root }, key || name)
 }
 
 const read = async ({ root }, id) => {
-  const configPath = path.join(root, `gatsby-config.js`)
-  const configSrc = await fs.readFile(configPath, `utf8`)
+  try {
+    const configPath = path.join(root, `gatsby-config.js`)
+    const configSrc = await fs.readFile(configPath, `utf8`)
 
-  const name = getPluginsFromConfig(configSrc).find(name => name === id)
+    const plugin = getPluginsFromConfig(configSrc).find(
+      plugin => plugin.key === id || plugin.name === id
+    )
 
-  if (name) {
-    return { id, name, _message: `Installed ${id} in gatsby-config.js` }
-  } else {
-    return undefined
+    if (plugin) {
+      return { id, ...plugin, _message: `Installed ${id} in gatsby-config.js` }
+    } else {
+      return undefined
+    }
+  } catch (e) {
+    console.log(e)
+    throw e
   }
 }
 
-const destroy = async ({ root }, { name }) => {
+const destroy = async ({ root }, { id, name }) => {
   const configPath = path.join(root, `gatsby-config.js`)
   const configSrc = await fs.readFile(configPath, `utf8`)
 
   const addPlugins = new BabelPluginAddPluginsToGatsbyConfig({
     pluginOrThemeName: name,
+    key: id,
     shouldAdd: false,
   })
 
@@ -139,11 +172,10 @@ const destroy = async ({ root }, { name }) => {
 }
 
 class BabelPluginAddPluginsToGatsbyConfig {
-  constructor({ pluginOrThemeName, shouldAdd }) {
+  constructor({ pluginOrThemeName, shouldAdd, options, key }) {
     this.plugin = declare(api => {
       api.assertVersion(7)
 
-      const { types: t } = api
       return {
         visitor: {
           ExpressionStatement(path) {
@@ -154,17 +186,55 @@ class BabelPluginAddPluginsToGatsbyConfig {
               return
             }
 
-            const plugins = right.properties.find(p => p.key.name === `plugins`)
+            const pluginNodes = right.properties.find(
+              p => p.key.name === `plugins`
+            )
 
             if (shouldAdd) {
-              const pluginNames = plugins.value.elements.map(getNameForPlugin)
-              const exists = pluginNames.includes(pluginOrThemeName)
-              if (!exists) {
-                plugins.value.elements.push(t.stringLiteral(pluginOrThemeName))
+              const plugins = pluginNodes.value.elements.map(getPlugin)
+              const matches = plugins.filter(plugin => {
+                if (!key) {
+                  return plugin.name === pluginOrThemeName
+                }
+
+                return plugin.key === key
+              })
+
+              if (!matches.length) {
+                const pluginNode = buildPluginNode({
+                  name: pluginOrThemeName,
+                  options,
+                  key,
+                })
+
+                pluginNodes.value.elements.push(pluginNode)
+              } else {
+                pluginNodes.value.elements = pluginNodes.value.elements.map(
+                  node => {
+                    const plugin = getPlugin(node)
+
+                    if (plugin.key !== key) {
+                      return node
+                    }
+
+                    return buildPluginNode({
+                      name: pluginOrThemeName,
+                      options,
+                      key,
+                    })
+                  }
+                )
               }
             } else {
-              plugins.value.elements = plugins.value.elements.filter(
-                node => getNameForPlugin(node) !== pluginOrThemeName
+              pluginNodes.value.elements = pluginNodes.value.elements.filter(
+                node => {
+                  const plugin = getPlugin(node)
+                  if (key) {
+                    return plugin.key === key
+                  }
+
+                  return plugin.name === pluginOrThemeName
+                }
               )
             }
 
@@ -196,7 +266,7 @@ class BabelPluginGetPluginsFromGatsbyConfig {
             const plugins = right.properties.find(p => p.key.name === `plugins`)
 
             plugins.value.elements.map(node => {
-              this.state.push(getNameForPlugin(node))
+              this.state.push(getPlugin(node))
             })
           },
         },
@@ -237,18 +307,26 @@ module.exports.all = async ({ root }) => {
 
 const schema = {
   name: Joi.string(),
+  options: Joi.object(),
   shadowableFiles: Joi.array().items(Joi.string()),
   shadowedFiles: Joi.array().items(Joi.string()),
   ...resourceSchema,
 }
 
-const validate = resource =>
-  Joi.validate(resource, schema, { abortEarly: false })
+const validate = resource => {
+  if (REQUIRES_KEYS.includes(resource.name) && !resource.key) {
+    return {
+      error: `${resource.name} requires a key to be set`,
+    }
+  }
+
+  return Joi.validate(resource, schema, { abortEarly: false })
+}
 
 exports.schema = schema
 exports.validate = validate
 
-module.exports.plan = async ({ root }, { id, name }) => {
+module.exports.plan = async ({ root }, { id, key, name, options }) => {
   const fullName = id || name
   const configPath = path.join(root, `gatsby-config.js`)
   const prettierConfig = await prettier.resolveConfig(root)
@@ -257,7 +335,13 @@ module.exports.plan = async ({ root }, { id, name }) => {
     ...prettierConfig,
     parser: `babel`,
   })
-  let newContents = addPluginToConfig(src, fullName)
+
+  let newContents = addPluginToConfig(src, {
+    id,
+    key: id || key,
+    name: fullName,
+    options,
+  })
   newContents = prettier.format(newContents, {
     ...prettierConfig,
     parser: `babel`,

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.js
@@ -320,6 +320,12 @@ const validate = resource => {
     }
   }
 
+  if (resource.key && resource.key === resource.name) {
+    return {
+      error: `${resource.name} requires a key to be different than the plugin name`,
+    }
+  }
+
   return Joi.validate(resource, schema, { abortEarly: false })
 }
 

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
@@ -61,14 +61,87 @@ describe(`gatsby-plugin resource`, () => {
 
   test(`does not add the same plugin twice by default`, async () => {
     const configSrc = await fs.readFile(configPath, `utf8`)
-    const newConfigSrc = addPluginToConfig(
-      configSrc,
-      `gatsby-plugin-react-helmet`
-    )
+    const newConfigSrc = addPluginToConfig(configSrc, {
+      name: `gatsby-plugin-react-helmet`,
+    })
     const plugins = getPluginsFromConfig(newConfigSrc)
 
     const result = [...new Set(plugins)]
 
     expect(result).toEqual(plugins)
+  })
+
+  // A key isn't required for gatsby plugin, but when you want to distinguish
+  // between multiple of the same plugin, you can specify it to target config changes.
+  test(`validates the gatsby-source-filesystem specifies a key`, async () => {
+    const result = plugin.validate({ name: `gatsby-source-filesystem` })
+
+    expect(result.error).toEqual(
+      `gatsby-source-filesystem requires a key to be set`
+    )
+  })
+
+  test(`adds multiple gatsby-source-filesystems and reads with key`, async () => {
+    const context = { root: helloWorldRoot }
+    const fooPlugin = {
+      key: `foo-data-sourcing`,
+      name: `gatsby-source-filesystem`,
+      options: {
+        name: `foo`,
+        path: `foo`,
+      },
+    }
+    const barPlugin = {
+      key: `bar-data-sourcing`,
+      name: `gatsby-source-filesystem`,
+      options: {
+        name: `bar`,
+        path: `bar`,
+      },
+    }
+
+    await plugin.create(context, fooPlugin)
+    await plugin.create(context, barPlugin)
+
+    const barResult = await plugin.read(context, barPlugin.key)
+    const fooResult = await plugin.read(context, fooPlugin.key)
+
+    expect(barResult.key).toEqual(barPlugin.key)
+    expect(fooResult.key).toEqual(fooPlugin.key)
+    expect(barResult.options.name).toEqual(barPlugin.options.name)
+    expect(fooResult.options.name).toEqual(fooPlugin.options.name)
+
+    const newBarResult = await plugin.update(context, {
+      ...barResult,
+      options: { path: `new-bar` },
+    })
+
+    expect(newBarResult.key).toEqual(barPlugin.key)
+    expect(newBarResult.options).toEqual({ path: `new-bar` })
+
+    await plugin.destroy(context, barResult)
+    await plugin.destroy(context, fooResult)
+  })
+
+  test(`handles config options as an object`, async () => {
+    const configSrc = await fs.readFile(configPath, `utf8`)
+    const newConfigSrc = addPluginToConfig(configSrc, {
+      name: `gatsby-plugin-foo`,
+      options: {
+        foo: 1,
+        bar: `baz`,
+        baz: `qux`,
+        otherStuff: [
+          {
+            foo: `bar2`,
+            bar: [{ foo: `bar` }],
+          },
+        ],
+      },
+    })
+
+    const result = getPluginsFromConfig(newConfigSrc)
+
+    expect(result).toMatchSnapshot()
   })
 })

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
@@ -81,6 +81,17 @@ describe(`gatsby-plugin resource`, () => {
     )
   })
 
+  test(`validates the gatsby-source-filesystem specifies a key that isn't equal to the name`, async () => {
+    const result = plugin.validate({
+      name: `gatsby-source-filesystem`,
+      key: `gatsby-source-filesystem`,
+    })
+
+    expect(result.error).toEqual(
+      `gatsby-source-filesystem requires a key to be different than the plugin name`
+    )
+  })
+
   test(`adds multiple gatsby-source-filesystems and reads with key`, async () => {
     const context = { root: helloWorldRoot }
     const fooPlugin = {

--- a/packages/gatsby-recipes/src/providers/gatsby/utils/build-plugin-node.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/utils/build-plugin-node.js
@@ -1,0 +1,18 @@
+const t = require(`@babel/types`)
+const template = require(`@babel/template`).default
+
+module.exports = ({ name, options, key }) => {
+  if (!options && !key) {
+    return t.stringLiteral(name)
+  }
+
+  const pluginWithOptions = template(`
+    const foo = {
+      resolve: '${name}',
+      options: ${JSON.stringify(options, null, 2)},
+      ${key ? `__key: "` + key + `"` : ``}
+    }
+  `)()
+
+  return pluginWithOptions.declarations[0].init
+}

--- a/packages/gatsby-recipes/src/providers/gatsby/utils/build-plugin-node.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/utils/build-plugin-node.test.js
@@ -1,0 +1,55 @@
+const generate = require(`@babel/generator`).default
+
+const buildPluginNode = require(`./build-plugin-node`)
+
+const testPluginNode = obj => {
+  const ast = buildPluginNode(obj)
+
+  return generate(ast).code
+}
+
+test(`build-plugin-node creates a proper AST from JSON object`, () => {
+  const result = testPluginNode({
+    name: `gatsby-plugin-foo`,
+    key: `super-special`,
+    options: {
+      foo: `bar`,
+    },
+  })
+
+  expect(result).toMatchInlineSnapshot(`
+    "{
+      resolve: 'gatsby-plugin-foo',
+      options: {
+        \\"foo\\": \\"bar\\"
+      },
+      __key: \\"super-special\\"
+    }"
+  `)
+})
+
+test(`build-plugin-node does not add a key when it doesn't exist`, () => {
+  const result = testPluginNode({
+    name: `gatsby-plugin-foo`,
+    options: {
+      foo: `bar`,
+    },
+  })
+
+  expect(result).toMatchInlineSnapshot(`
+    "{
+      resolve: 'gatsby-plugin-foo',
+      options: {
+        \\"foo\\": \\"bar\\"
+      }
+    }"
+  `)
+})
+
+test(`build-plugin-node returns a string literal when there are no options or key`, () => {
+  const result = testPluginNode({
+    name: `gatsby-plugin-foo`,
+  })
+
+  expect(result).toMatchInlineSnapshot(`"\\"gatsby-plugin-foo\\""`)
+})

--- a/packages/gatsby-recipes/src/providers/gatsby/utils/constants.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/utils/constants.js
@@ -1,0 +1,3 @@
+const REQUIRES_KEYS = [`gatsby-source-filesystem`, `gatsby-plugin-page-creator`]
+
+module.exports.REQUIRES_KEYS = REQUIRES_KEYS

--- a/packages/gatsby-recipes/src/providers/gatsby/utils/get-object-from-node.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/utils/get-object-from-node.js
@@ -1,0 +1,61 @@
+const generate = require(`@babel/generator`).default
+const t = require(`@babel/types`)
+
+const getKeyNameFromAttribute = node => node.key.name || node.key.value
+
+const unwrapTemplateLiteral = str =>
+  str.trim().replace(/^`/, ``).replace(/`$/, ``)
+
+const isLiteral = node =>
+  t.isLiteral(node) || t.isStringLiteral(node) || t.isNumericLiteral(node)
+
+const getValueFromNode = node => {
+  if (t.isTemplateLiteral(node)) {
+    delete node.leadingComments
+    const literalContents = generate(node).code
+    return unwrapTemplateLiteral(literalContents)
+  }
+
+  if (isLiteral(node)) {
+    return node.value
+  }
+
+  if (node.type === `ArrayExpression`) {
+    return node.elements.map(getObjectFromNode)
+  }
+
+  if (node.type === `ObjectExpression`) {
+    return getObjectFromNode(node)
+  }
+
+  return null
+}
+
+const getObjectFromNode = nodeValue => {
+  if (!nodeValue || !nodeValue.properties) {
+    return getValueFromNode(nodeValue)
+  }
+
+  const props = nodeValue.properties.reduce((acc, curr) => {
+    let value = null
+
+    if (curr.value) {
+      value = getValueFromNode(curr.value)
+    } else if (t.isObjectExpression(curr.value)) {
+      value = curr.value.expression.properties.reduce((acc, curr) => {
+        acc[getKeyNameFromAttribute(curr)] = getObjectFromNode(curr)
+        return acc
+      }, {})
+    } else {
+      throw new Error(`Did not recognize ${curr}`)
+    }
+
+    acc[getKeyNameFromAttribute(curr)] = value
+    return acc
+  }, {})
+
+  return props
+}
+
+module.exports = getObjectFromNode
+module.exports.getValueFromNode = getValueFromNode

--- a/packages/gatsby-recipes/src/providers/gatsby/utils/get-object-from-node.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/utils/get-object-from-node.test.js
@@ -1,0 +1,39 @@
+const template = require(`@babel/template`).default
+
+const getObjectFromNode = require(`./get-object-from-node`)
+
+const buildFixture = () => {
+  const ast = template(`
+    const foo = {
+      foo: \`bar\`,
+      "baz": 123,
+      "qux": [
+        {
+          foo: 'bar'
+        },
+        'baz',
+        12.34
+      ]
+    }
+  `)()
+
+  return ast.declarations[0].init
+}
+
+test(`get-object-from-node return object from AST node`, () => {
+  const result = getObjectFromNode(buildFixture())
+
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "baz": 123,
+      "foo": "bar",
+      "qux": Array [
+        Object {
+          "foo": "bar",
+        },
+        "baz",
+        12.34,
+      ],
+    }
+  `)
+})

--- a/packages/gatsby-recipes/src/providers/gatsby/utils/is-default-export.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/utils/is-default-export.js
@@ -1,0 +1,14 @@
+const t = require(`@babel/types`)
+
+module.exports = node => {
+  if (!node || !t.isMemberExpression(node)) {
+    return false
+  }
+
+  const { object, property } = node
+
+  if (!t.isIdentifier(object) || object.name !== `module`) return false
+  if (!t.isIdentifier(property) || property.name !== `exports`) return false
+
+  return true
+}

--- a/packages/gatsby-recipes/src/providers/resource-schema.js
+++ b/packages/gatsby-recipes/src/providers/resource-schema.js
@@ -1,15 +1,7 @@
 const Joi = require(`@hapi/joi`)
 
-// heh
-// createResource —> when comes from the user
-//   — when there's an ID — it's now "created"
-// read — just grabs it off the same place.
-//
-// This is freakin Gatsby all over again!!!
-
 module.exports = {
-  // ID of a file should be relative to the root of the git repo
-  // or the absolute path if we can't find one
   id: Joi.string(),
+  key: Joi.string(),
   _message: Joi.string(),
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,16 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
+"@babel/generator@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.5.tgz#27f0917741acc41e6eaaced6d68f96c3fa9afaf9"
+  integrity sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==
+  dependencies:
+    "@babel/types" "^7.9.5"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
@@ -479,6 +489,11 @@
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
 
 "@babel/helper-wrap-function@^7.1.0", "@babel/helper-wrap-function@^7.2.0":
   version "7.2.0"
@@ -1928,6 +1943,15 @@
   integrity sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==
   dependencies:
     esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.5.tgz#89231f82915a8a566a703b3b20133f73da6b9444"
+  integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 


### PR DESCRIPTION
Adds initial support for plugin options (#23299). This functionality won't address config options that contain javascript.

~~Before this is deemed truly stable we will also need to implement a resource identifier for the GatsbyPlugin resource because there's no way to handle plugins that are composed together (#23300).~~ This PR now adds support for [keyed values for gatsby plugin config](https://github.com/johno/gatsby/pull/1)

### TODO

- [x] Rebase in test updates for recipes
- [x] Test other babel utils for plugin config