### PR TITLE
fix(optimize-hook-destructuring): handle skipped items

### DIFF
--- a/packages/babel-preset-gatsby/src/__tests__/optimize-hook-destructuring.js
+++ b/packages/babel-preset-gatsby/src/__tests__/optimize-hook-destructuring.js
@@ -36,4 +36,16 @@ describe(`optimize-hook-destructuring`, () => {
       `"\\"use strict\\";var _react=require(\\"react\\");const{0:count,1:setCount}=(0,_react.useState)(0);"`
     )
   })
+
+  it(`should handle skipped items`, () => {
+    const input = trim`
+      import { useState } from 'react';
+      const [, setCount] = useState(0);
+    `
+
+    expect(() => babel(input)).not.toThrow()
+    expect(babel(input)).toMatchInlineSnapshot(
+      `"\\"use strict\\";var _react=require(\\"react\\");const{1:setCount}=(0,_react.useState)(0);"`
+    )
+  })
 })

--- a/packages/babel-preset-gatsby/src/optimize-hook-destructuring.ts
+++ b/packages/babel-preset-gatsby/src/optimize-hook-destructuring.ts
@@ -52,8 +52,14 @@ export default function ({
       if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return
 
       path.parent.id = t.objectPattern(
-        path.parent.id.elements.map((element, i) =>
-          t.objectProperty(t.numericLiteral(i), element!)
+        path.parent.id.elements.reduce(
+          (acc: BabelTypes.ObjectProperty[], element, i) => {
+            if (element) {
+              acc.push(t.objectProperty(t.numericLiteral(i), element))
+            }
+            return acc
+          },
+          []
         )
       )
     },


### PR DESCRIPTION
## Description

This fixes hook destructuring for cases when some elements are skipped - for example:
```
const [, setCount] = useState(0);
```

## Related Issues

Fixes #23413
