### PR TITLE
feat(gatsby-source-wordpress) Add ability to specify status for posts and pages

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -119,6 +119,8 @@ module.exports = {
         },
         // Set how many simultaneous requests are sent at once.
         concurrentRequests: 10,
+        // Set which post and page statuses to retrieve if authenticated
+        status: "publish,draft",
         // Set WP REST API routes whitelists
         // and blacklists using glob patterns.
         // Defaults to whitelist the routes shown

--- a/packages/gatsby-source-wordpress/src/fetch.js
+++ b/packages/gatsby-source-wordpress/src/fetch.js
@@ -54,6 +54,7 @@ async function fetch({
   _includedRoutes,
   _excludedRoutes,
   _restApiRoutePrefix,
+  _status,
   typePrefix,
   refactoredEntityTypes,
 }) {
@@ -173,6 +174,7 @@ Fetching the JSON data from ${validRoutes.length} valid API Routes...
           _cookies,
           _accessToken,
           _concurrentRequests,
+          _status,
         })
       )
       if (_verbose) console.log(``)
@@ -259,6 +261,7 @@ async function fetchData({
   _cookies,
   _accessToken,
   _concurrentRequests,
+  _status,
 }) {
   const { type, url, optionPageId } = route
 
@@ -282,6 +285,7 @@ async function fetchData({
     _accessToken,
     _verbose,
     _concurrentRequests,
+    _status,
   })
 
   let entities = []
@@ -325,6 +329,7 @@ async function fetchData({
               _auth,
               _cookies,
               _accessToken,
+              _status,
             })
           )
         }
@@ -342,6 +347,7 @@ async function fetchData({
             _auth,
             _accessToken,
             _cookies,
+            _status,
           })
         )
       }
@@ -385,6 +391,7 @@ async function getPages(
     _accessToken,
     _concurrentRequests,
     _verbose,
+    _status,
   },
   page = 1
 ) {
@@ -397,6 +404,9 @@ async function getPages(
         url: `${url}?${querystring.stringify({
           per_page: _perPage,
           page: page,
+          ...(_status && (url.includes(`/pages`) || url.includes(`/posts`))
+            ? { status: _status }
+            : {}),
         })}`,
       }
 

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -26,6 +26,7 @@ let _normalizer
 let _normalizers
 let _keepMediaSizes
 let _restApiRoutePrefix
+let _status
 
 exports.sourceNodes = async (
   {
@@ -56,6 +57,7 @@ exports.sourceNodes = async (
     normalizers,
     keepMediaSizes = false,
     restApiRoutePrefix = `wp-json`,
+    status,
   }
 ) => {
   const { createNode, touchNode } = actions
@@ -76,6 +78,7 @@ exports.sourceNodes = async (
   _restApiRoutePrefix = restApiRoutePrefix
   _normalizer = normalizer
   _normalizers = normalizers
+  _status = status
 
   let entities = await fetch({
     baseUrl,
@@ -92,6 +95,7 @@ exports.sourceNodes = async (
     _excludedRoutes,
     _keepMediaSizes,
     _restApiRoutePrefix,
+    _status,
     typePrefix,
     refactoredEntityTypes,
   })


### PR DESCRIPTION
## Description

Adds the ability to specify which post and page statuses to retrieve. For example `publish,draft` can be specified which can help with building a preview version of the site.

### Documentation

Added relevant documentation in the existing README: `packages/gatsby-source-wordpress/README.md`

## Related Issues

Related to: #10982