### PR TITLE
fix(webpack): ensure resolution of react-refresh-webpack-plugin

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -401,6 +401,9 @@ module.exports = async (
           `.cache/react-lifecycles-compat.js`
         ),
         "create-react-context": directoryPath(`.cache/create-react-context.js`),
+        "@pmmmwh/react-refresh-webpack-plugin": path.dirname(
+          require.resolve(`@pmmmwh/react-refresh-webpack-plugin/package.json`)
+        ),
       },
       plugins: [
         // Those two folders are special and contain gatsby-generated files


### PR DESCRIPTION
## Description

In some cases `@pmmmwh/react-refresh-webpack-plugin` will not be hoisted in root `node_modules`. Because this is imported in `cache-dir` (which is copied to `<project_dir>/.cache`) in https://github.com/gatsbyjs/gatsby/blob/74463e927210bd3b2ff32a1f9d06fd3966a9b82a/packages/gatsby/cache-dir/error-overlay-handler.js#L1

We need to make sure this will be resolved. We do this by nudging webpack to exact location it is installed in (resolving this in `gatsby` package code/context will ensure it because it is `gatsby` package that have it in dependencies - https://github.com/gatsbyjs/gatsby/blob/74463e927210bd3b2ff32a1f9d06fd3966a9b82a/packages/gatsby/package.json#L22)

## Related Issues

Fixes #22250
Fixes #22684
