### PR TITLE
fix(docs): add webpack - brand names, code language, code fences

### DIFF
--- a/docs/docs/add-custom-webpack-config.md
+++ b/docs/docs/add-custom-webpack-config.md
@@ -12,7 +12,7 @@ Gatsby does multiple webpack builds with somewhat different configuration. Gatsb
 
 1.  develop: when running the `gatsby develop` command. Has configuration for hot reloading and CSS injection into page
 2.  develop-html: same as develop but without react-hmre in the babel config for rendering the HTML component.
-3.  build-javascript: production JavaScript and CSS build. Creates route JS bundles as well as common chunks for JS and CSS.
+3.  build-javascript: production JavaScript and CSS build. Creates route JavaScript bundles as well as common chunks for JavaScript and CSS.
 4.  build-html: production build static HTML pages
 
 Check [webpack.config.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js) for the source.
@@ -77,13 +77,13 @@ You can always find more information on _resolve_ and other options in the offic
 
 ### Importing non-webpack tools using `yarn`
 
-Note that using absolute imports only applies to webpack resolutions and will not work for other tools, e.g. eslint or typescript.
-But if you are using yarn, then the best practice is to set up your imports in package.json as shown below:
+Note that using absolute imports only applies to webpack resolutions and will not work for other tools, e.g. ESLint or TypeScript.
+But if you are using yarn, then the best practice is to set up your imports in `package.json` as shown below:
 
-```js
+```json::title=package.json
 {
   "dependencies": {
-      "hooks": "link:./src/hooks",
+    "hooks": "link:./src/hooks"
   }
 }
 ```

--- a/docs/docs/add-custom-webpack-config.md
+++ b/docs/docs/add-custom-webpack-config.md
@@ -80,7 +80,7 @@ You can always find more information on _resolve_ and other options in the offic
 Note that using absolute imports only applies to webpack resolutions and will not work for other tools, e.g. ESLint or TypeScript.
 But if you are using yarn, then the best practice is to set up your imports in `package.json` as shown below:
 
-```json::title=package.json
+```json:title=package.json
 {
   "dependencies": {
     "hooks": "link:./src/hooks"


### PR DESCRIPTION
## Description

changes: 
- brandnames:
  - eslint -> ESLint
  - typesscript -> TypeScript
  - JS -> JavaScript
- file name in code fences
- fix code language
- add title to code block

## Related Issues

- #22750 `Added doc for absolute import from gatsby eslint rules or other tools` 