### PR TITLE
fix(gatsby-recipes): Fix wording in mdx pages recipe

### DIFF
--- a/packages/gatsby-recipes/recipes/mdx-pages.mdx
+++ b/packages/gatsby-recipes/recipes/mdx-pages.mdx
@@ -31,7 +31,7 @@ Install NPM Packages
 
 Install the Gatsby Plugins.
 
-First `gatsby-source-wordpress` to read the MDX files in the src/pages
+First `gatsby-source-filesystem` to read the MDX files in the src/pages
 directory.
 
 <GatsbyPlugin


### PR DESCRIPTION
## Description

Mistake source plugin in recipe docs. Was meant to say `gatsby-source-filesystem` instead `gatsby-source-wordpress`