### PR TITLE
fix(gatsby): fix dirty check for inference metadata with related nodes

### DIFF
--- a/packages/gatsby/src/schema/infer/__tests__/inference-metadata.ts
+++ b/packages/gatsby/src/schema/infer/__tests__/inference-metadata.ts
@@ -1145,12 +1145,12 @@ describe(`Type change detection`, () => {
     // add/delete to such fields as mutations
     let metadata = addOne({ relatedNode___NODE: `added` })
     expect(metadata.dirty).toEqual(true)
-    expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
+    expect(haveEqualFields(metadata, initialMetadata)).toEqual(false)
     metadata.dirty = false
 
     metadata = deleteOne({ relatedNode___NODE: `added` }, metadata)
     expect(metadata.dirty).toEqual(true)
-    expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
+    expect(haveEqualFields(metadata, initialMetadata)).toEqual(false)
   })
 
   it(`does not detect when the same node added to the relatedNode field`, () => {
@@ -1162,12 +1162,12 @@ describe(`Type change detection`, () => {
   it(`detects on any change of the relatedNodeList field`, () => {
     let metadata = addOne({ relatedNodeList___NODE: [`added`] })
     expect(metadata.dirty).toEqual(true)
-    expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
+    expect(haveEqualFields(metadata, initialMetadata)).toEqual(false)
     metadata.dirty = false
 
     metadata = deleteOne({ relatedNodeList___NODE: [`added`] }, metadata)
     expect(metadata.dirty).toEqual(true)
-    expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
+    expect(haveEqualFields(metadata, initialMetadata)).toEqual(false)
   })
 
   it(`does not detect when the same node added to the relatedNodeList field`, () => {

--- a/packages/gatsby/src/schema/infer/build-example-data.ts
+++ b/packages/gatsby/src/schema/infer/build-example-data.ts
@@ -142,17 +142,11 @@ const prepareConflictExamples = (
   }
   const reportedValueMapper = (typeName: ValueType): unknown => {
     if (typeName === `relatedNode`) {
-      // See FIXME in ./inference-metadata.ts
-      // eslint-disable-next-line
-      // @ts-ignore
-      const { nodes } = descriptor.relatedNode
+      const { nodes } = descriptor.relatedNode ?? { nodes: {} }
       return Object.keys(nodes).find(key => nodes[key] > 0)
     }
     if (typeName === `relatedNodeList`) {
-      // See FIXME in ./inference-metadata.ts
-      // eslint-disable-next-line
-      // @ts-ignore
-      const { nodes } = descriptor.relatedNodeList
+      const { nodes } = descriptor.relatedNodeList ?? { nodes: {} }
       return Object.keys(nodes).filter(key => nodes[key] > 0)
     }
     if (typeName === `object`) {
@@ -174,7 +168,7 @@ const prepareConflictExamples = (
 
   if (isArrayItem) {
     // Differentiate conflict examples by node they were first seen in.
-    // See Caveats section in the header of this file
+    // See Caveats section in the header of the ./inference-metadata.ts
     const groups = groupBy(
       conflictingTypes,
       type => descriptor[type]?.first || ``

--- a/packages/gatsby/src/schema/infer/inference-metadata.ts
+++ b/packages/gatsby/src/schema/infer/inference-metadata.ts
@@ -352,8 +352,8 @@ const updateValueDescriptor = (
 }
 
 const mergeObjectKeys = (
-  dpropsKeysA: ITypeInfoObject["dprops"] = {},
-  dpropsKeysB: ITypeInfoObject["dprops"] = {}
+  dpropsKeysA: object = {},
+  dpropsKeysB: object = {}
 ): string[] => {
   const dprops = Object.keys(dpropsKeysA)
   const otherProps = Object.keys(dpropsKeysB)
@@ -386,12 +386,27 @@ const descriptorsAreEqual = (
           )
         )
       }
-      case `relatedNode`:
+      case `relatedNode`: {
+        const nodeIds = mergeObjectKeys(
+          descriptor?.relatedNode?.nodes,
+          otherDescriptor?.relatedNode?.nodes
+        )
+        return nodeIds.every(
+          id =>
+            descriptor?.relatedNode?.nodes[id] &&
+            otherDescriptor?.relatedNode?.nodes[id]
+        )
+      }
       case `relatedNodeList`: {
-        // eslint-disable-next-line
-        // @ts-ignore
-        // FIXME See comment: https://github.com/gatsbyjs/gatsby/pull/23264#discussion_r410908538
-        return isEqual(descriptor?.nodes, otherDescriptor?.nodes)
+        const nodeIds = mergeObjectKeys(
+          descriptor?.relatedNodeList?.nodes,
+          otherDescriptor?.relatedNodeList?.nodes
+        )
+        return nodeIds.every(
+          id =>
+            descriptor?.relatedNodeList?.nodes[id] &&
+            otherDescriptor?.relatedNodeList?.nodes[id]
+        )
       }
       default:
         return true


### PR DESCRIPTION
## Description

We've caught a small bug while converting inference metadata to Typescript in #23539 
It affects dirty checking of the schema when a referenced node changes (when using `___NODE` convention)

Before this PR changes to referenced nodes are not detected, after this PR those changes are detected by Gatsby (and schema is rebuilt if actually dirty)

## Related Issues
#23264
#23389