### PR TITLE
chore(gatsby): migrate status reducer to TypeScript

### DIFF
--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -24,6 +24,7 @@ Object {
   "pageDataStats": Map {},
   "staticQueryComponents": Map {},
   "status": Object {
+    "PLUGINS_HASH": "",
     "plugins": Object {},
   },
   "webpackCompilationHash": "",
@@ -86,6 +87,7 @@ Object {
   "pageDataStats": Map {},
   "staticQueryComponents": Map {},
   "status": Object {
+    "PLUGINS_HASH": "",
     "plugins": Object {},
   },
   "webpackCompilationHash": "",

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/status.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/status.js.snap
@@ -12,4 +12,4 @@ Object {
 
 exports[`Status actions/reducer throws an error if status isn't an object 1`] = `"You must pass an object into setPluginStatus. What was passed in was \\"test job\\""`;
 
-exports[`Status actions/reducer throws an error if the plugin name isn't set 1`] = `"Cannot read property 'name' of undefined"`;
+exports[`Status actions/reducer throws an error if the plugin name isn't set 1`] = `"You can't set plugin status without a plugin"`;

--- a/packages/gatsby/src/redux/__tests__/status.js
+++ b/packages/gatsby/src/redux/__tests__/status.js
@@ -1,5 +1,6 @@
+import { statusReducer } from "../reducers/status"
+
 const { actions } = require(`../actions`)
-const statusReducer = require(`../reducers/status`)
 
 Date.now = jest.fn(() => 1482363367071)
 

--- a/packages/gatsby/src/redux/reducers/index.js
+++ b/packages/gatsby/src/redux/reducers/index.js
@@ -2,6 +2,7 @@ const reduxNodes = require(`./nodes`)
 const lokiNodes = require(`../../db/loki/nodes`).reducer
 import { redirectsReducer } from "./redirects"
 import { staticQueryComponentsReducer } from "./static-query-components"
+import { statusReducer } from "./status"
 import { webpackCompilationHashReducer } from "./webpack-compilation-hash"
 import { reducer as logReducer } from "gatsby-cli/lib/reporter/redux/reducer"
 
@@ -55,7 +56,7 @@ module.exports = {
   config: require(`./config`),
   pages: require(`./pages`),
   schema: require(`./schema`),
-  status: require(`./status`),
+  status: statusReducer,
   componentDataDependencies: require(`./component-data-dependencies`),
   components: require(`./components`),
   staticQueryComponents: staticQueryComponentsReducer,

--- a/packages/gatsby/src/redux/reducers/status.ts
+++ b/packages/gatsby/src/redux/reducers/status.ts
@@ -1,16 +1,25 @@
-const _ = require(`lodash`)
+import _ from "lodash"
+import { ActionsUnion, IGatsbyState } from "../types"
 
-module.exports = (state = { plugins: {} }, action) => {
+const defaultState: IGatsbyState["status"] = {
+  PLUGINS_HASH: ``,
+  plugins: {},
+}
+
+export const statusReducer = (
+  state: IGatsbyState["status"] = defaultState,
+  action: ActionsUnion
+): IGatsbyState["status"] => {
   switch (action.type) {
     case `DELETE_CACHE`:
-      return { plugins: {} }
+      return defaultState
     case `UPDATE_PLUGINS_HASH`:
       return {
         ...state,
         PLUGINS_HASH: action.payload,
       }
     case `SET_PLUGIN_STATUS`:
-      if (!action.plugin && !action.plugin.name) {
+      if (!action.plugin || !action.plugin?.name) {
         throw new Error(`You can't set plugin status without a plugin`)
       }
       if (!_.isObject(action.payload)) {

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -130,7 +130,7 @@ export interface IGatsbyState {
   pages: Map<string, IGatsbyPage>
   schema: GraphQLSchema
   status: {
-    plugins: {}
+    plugins: Record<string, IGatsbyPlugin>
     PLUGINS_HASH: Identifier
   }
   componentDataDependencies: {
@@ -224,7 +224,9 @@ export type ActionsUnion =
   | ICreateFieldExtension
   | IPrintTypeDefinitions
   | IRemoveStaticQuery
+  | ISetPluginStatusAction
   | ISetWebpackCompilationHashAction
+  | IUpdatePluginsHashAction
 
 export interface ICreatePageDependencyAction {
   type: `CREATE_COMPONENT_DEPENDENCY`
@@ -382,4 +384,18 @@ export interface IRemoveStaticQuery {
 export interface ISetWebpackCompilationHashAction {
   type: `SET_WEBPACK_COMPILATION_HASH`
   payload: IGatsbyState["webpackCompilationHash"]
+}
+
+export interface IUpdatePluginsHashAction {
+  type: `UPDATE_PLUGINS_HASH`
+  payload: Identifier
+}
+
+export interface ISetPluginStatusAction {
+  type: `SET_PLUGIN_STATUS`
+  plugin: IGatsbyPlugin
+  payload: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any
+  }
 }

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -208,23 +208,23 @@ export interface ICachedReduxState {
 }
 
 export type ActionsUnion =
+  | IAddThirdPartySchema
+  | ICreateFieldExtension
   | ICreatePageDependencyAction
+  | ICreateTypes
   | IDeleteCacheAction
   | IDeleteComponentDependenciesAction
-  | IReplaceComponentQueryAction
-  | IReplaceStaticQueryAction
+  | IPageQueryRunAction
+  | IPrintTypeDefinitions
   | IQueryExtractedAction
-  | IQueryExtractionGraphQLErrorAction
   | IQueryExtractedBabelSuccessAction
   | IQueryExtractionBabelErrorAction
-  | ISetProgramStatusAction
-  | IPageQueryRunAction
-  | IAddThirdPartySchema
-  | ICreateTypes
-  | ICreateFieldExtension
-  | IPrintTypeDefinitions
+  | IQueryExtractionGraphQLErrorAction
   | IRemoveStaticQuery
+  | IReplaceComponentQueryAction
+  | IReplaceStaticQueryAction
   | ISetPluginStatusAction
+  | ISetProgramStatusAction
   | ISetWebpackCompilationHashAction
   | IUpdatePluginsHashAction
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This commit migrates the status reducer to TypeScript by adding the relevant types for each actions.

In order to make sense of the condition protecting the `SET_PLUGIN_STATUS` action, I had to transform the `&&` operator to `||`. Without this change, the typecheck would fail. But in the end, it should not change the behaviour of this early-termination.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to #21995