### PR TITLE
chore(gatsby): migrate static-query-components reducer to TypeScript

### DIFF
--- a/packages/gatsby/src/redux/reducers/index.js
+++ b/packages/gatsby/src/redux/reducers/index.js
@@ -1,6 +1,7 @@
 const reduxNodes = require(`./nodes`)
 const lokiNodes = require(`../../db/loki/nodes`).reducer
 import { redirectsReducer } from "./redirects"
+import { staticQueryComponentsReducer } from "./static-query-components"
 import { reducer as logReducer } from "gatsby-cli/lib/reporter/redux/reducer"
 
 const backend = process.env.GATSBY_DB_NODES || `redux`
@@ -56,7 +57,7 @@ module.exports = {
   status: require(`./status`),
   componentDataDependencies: require(`./component-data-dependencies`),
   components: require(`./components`),
-  staticQueryComponents: require(`./static-query-components`),
+  staticQueryComponents: staticQueryComponentsReducer,
   jobs: require(`./jobs`),
   jobsV2: require(`./jobsv2`),
   webpack: require(`./webpack`),

--- a/packages/gatsby/src/redux/reducers/static-query-components.ts
+++ b/packages/gatsby/src/redux/reducers/static-query-components.ts
@@ -1,4 +1,9 @@
-module.exports = (state = new Map(), action) => {
+import { ActionsUnion, IGatsbyState } from "../types"
+
+export const staticQueryComponentsReducer = (
+  state: IGatsbyState["staticQueryComponents"] = new Map(),
+  action: ActionsUnion
+): IGatsbyState["staticQueryComponents"] => {
   switch (action.type) {
     case `DELETE_CACHE`:
       return new Map()

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -81,6 +81,14 @@ export interface IGatsbyPluginContext {
   [key: string]: (...args: any[]) => any
 }
 
+export interface IGatsbyStaticQueryComponents {
+  name: string
+  componentPath: SystemPath
+  id: Identifier
+  query: string
+  hash: string
+}
+
 type GatsbyNodes = Map<string, IGatsbyNode>
 
 export interface IGatsbyState {
@@ -139,14 +147,8 @@ export interface IGatsbyState {
     }
   >
   staticQueryComponents: Map<
-    number,
-    {
-      name: string
-      componentPath: SystemPath
-      id: Identifier
-      query: string
-      hash: string
-    }
+    IGatsbyStaticQueryComponents["id"],
+    IGatsbyStaticQueryComponents
   >
   // @deprecated
   jobs: {
@@ -207,6 +209,7 @@ export interface ICachedReduxState {
 
 export type ActionsUnion =
   | ICreatePageDependencyAction
+  | IDeleteCacheAction
   | IDeleteComponentDependenciesAction
   | IReplaceComponentQueryAction
   | IReplaceStaticQueryAction
@@ -220,6 +223,7 @@ export type ActionsUnion =
   | ICreateTypes
   | ICreateFieldExtension
   | IPrintTypeDefinitions
+  | IRemoveStaticQuery
 
 export interface ICreatePageDependencyAction {
   type: `CREATE_COMPONENT_DEPENDENCY`
@@ -358,4 +362,18 @@ export interface ICreateResolverContext {
 export interface ICreateRedirectAction {
   type: `CREATE_REDIRECT`
   payload: IRedirect
+}
+
+export interface IDeleteCacheAction {
+  type: `DELETE_CACHE`
+}
+
+export interface IReplaceStaticQueryAction {
+  type: `REPLACE_STATIC_QUERY`
+  payload: IGatsbyStaticQueryComponents
+}
+
+export interface IRemoveStaticQuery {
+  type: `REMOVE_STATIC_QUERY`
+  payload: IGatsbyStaticQueryComponents["id"]
 }


### PR DESCRIPTION
## Description

This commit migrates the `static-query-components` reducer to TypeScript with few adjustments to the existing IGatsbyState interface.

The main adjustment is the update of the type of the key used for the map storing each static query from `number` to `string`.
This change reflect the fact that the key is described as being the `id` field of the interface, and this field is described as a `string` in the object definition.

## Related Issues

Relates to #21995 