### PR TITLE
chore(gatsby): migrate schema reducer to TypeScript

### DIFF
--- a/packages/gatsby/src/redux/reducers/index.js
+++ b/packages/gatsby/src/redux/reducers/index.js
@@ -1,6 +1,7 @@
 const reduxNodes = require(`./nodes`)
 const lokiNodes = require(`../../db/loki/nodes`).reducer
 import { redirectsReducer } from "./redirects"
+import { schemaReducer } from "./schema"
 import { staticQueryComponentsReducer } from "./static-query-components"
 import { statusReducer } from "./status"
 import { webpackCompilationHashReducer } from "./webpack-compilation-hash"
@@ -55,7 +56,7 @@ module.exports = {
   flattenedPlugins: require(`./flattened-plugins`),
   config: require(`./config`),
   pages: require(`./pages`),
-  schema: require(`./schema`),
+  schema: schemaReducer,
   status: statusReducer,
   componentDataDependencies: require(`./component-data-dependencies`),
   components: require(`./components`),

--- a/packages/gatsby/src/redux/reducers/schema.js
+++ b/packages/gatsby/src/redux/reducers/schema.js
@@ -1,8 +1,0 @@
-module.exports = (state = {}, action) => {
-  switch (action.type) {
-    case `SET_SCHEMA`:
-      return action.payload
-    default:
-      return state
-  }
-}

--- a/packages/gatsby/src/redux/reducers/schema.ts
+++ b/packages/gatsby/src/redux/reducers/schema.ts
@@ -1,0 +1,13 @@
+import { ActionsUnion, IGatsbyState } from "../types"
+
+export const schemaReducer = (
+  state: IGatsbyState["schema"] | {} = {},
+  action: ActionsUnion
+): IGatsbyState["schema"] | {} => {
+  switch (action.type) {
+    case `SET_SCHEMA`:
+      return action.payload
+    default:
+      return state
+  }
+}

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -225,6 +225,7 @@ export type ActionsUnion =
   | IReplaceStaticQueryAction
   | ISetPluginStatusAction
   | ISetProgramStatusAction
+  | ISetSchemaAction
   | ISetWebpackCompilationHashAction
   | IUpdatePluginsHashAction
 
@@ -398,4 +399,9 @@ export interface ISetPluginStatusAction {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any
   }
+}
+
+export interface ISetSchemaAction {
+  type: `SET_SCHEMA`
+  payload: IGatsbyState["schema"]
 }


### PR DESCRIPTION
## Description

This commit implements the migration of the schema reducer to TypeScript by adding the `SET_SCHEMA` action to the `ActionsUnion` and by adding the basic types from the `IGatsbyState` interface.

## Related Issues

Related to #21995 