### PR TITLE
fix(gatsby-theme-notes): remove ogImage from query

### DIFF
--- a/packages/gatsby-theme-notes/src/templates/note.js
+++ b/packages/gatsby-theme-notes/src/templates/note.js
@@ -5,13 +5,10 @@ import Note from "../components/note"
 export default Note
 
 export const pageQuery = graphql`
-  query($id: String!, $title: String) {
+  query($id: String!) {
     note: mdx(id: { eq: $id }) {
       id
       body
-    }
-    image: ogImage {
-      src(text: $title)
     }
     site: site {
       siteMetadata {


### PR DESCRIPTION
## Description

In #23229 we removed problematic (`npm audit`) `gatsby-plugin-og-image` from deps and config, but we didn't adjust the code itself to not make use of it. This removes query and allow starter to build.

For reference - https://circleci.com/gh/gatsbyjs/gatsby/387504?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link this is example where bumping `gatsby-theme-notes` to newest version (with removed dependency) breaks the build for `gatsby-starter-theme-notes`

I didn't see any actual usage in theme or our starter - but this might be breaking change to theme, because the `Note.js` (which can be shadowed) no longer will get `image`.

## Related Issues

Follow up to #23229