### PR TITLE
fix(gatsby-sterter-blog -> gatsby-node): exchange next with previous

### DIFF
--- a/starters/blog/gatsby-node.js
+++ b/starters/blog/gatsby-node.js
@@ -35,8 +35,8 @@ exports.createPages = async ({ graphql, actions }) => {
   const posts = result.data.allMarkdownRemark.edges
 
   posts.forEach((post, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const next = index === posts.length - 1 ? null : posts[index + 1].node
+    const previous = index === 0 ? null : posts[index - 1].node
 
     createPage({
       path: post.node.fields.slug,


### PR DESCRIPTION
I just discovered that `next` and `previous` should be swapped.
For example here[https://gatsby-starter-blog-demo.netlify.app/new-beginnings/](https://gatsby-starter-blog-demo.netlify.app/new-beginnings/), this is the first blog post in a list. And when I scroll to bottom, there is a previous link `← My Second Post!` which is logically the next one.