### PR TITLE
fix(gatsby-recipes): remove gatsby-transformer-remark package from mdx-images recipe

### DIFF
--- a/packages/gatsby-recipes/recipes/mdx-images.mdx
+++ b/packages/gatsby-recipes/recipes/mdx-images.mdx
@@ -1,0 +1,89 @@
+# Setup images in MDX with Gatsby
+
+This recipe installs and configures all
+the necessary NPM packages & Gatsby Plugins
+to enable inline-images in MDX and MD files.
+
+Based on https://www.gatsbyjs.org/docs/working-with-images-in-markdown/
+
+---
+Install NPM Packages 
+
+<NPMPackage
+  name="gatsby-source-filesystem"
+/>
+<NPMPackage
+  name="gatsby-plugin-mdx"
+/>
+<NPMPackage
+  name="@mdx-js/mdx"
+/>
+<NPMPackage
+  name="@mdx-js/react"
+/>
+
+---
+
+<NPMPackage
+  name="gatsby-image"
+/>
+<NPMPackage
+  name="gatsby-plugin-sharp"
+/>
+<NPMPackage
+  name="gatsby-transformer-sharp"
+/>
+<NPMPackage
+  name="gatsby-remark-images"
+/>
+
+---
+Install Gatsby Plugins
+
+First, add `gatsby-source-filesystem` to read images from the src/images
+directory.
+
+<GatsbyPlugin
+  name="gatsby-source-filesystem"
+  key="src/images"
+  options={{
+    name: `MDXImages`,
+    path: `src/images/`,
+  }}
+/>
+
+---
+
+Next, add `gatsby-plugin-sharp`, `gatsby-transformer-sharp`, and `gatsby-transformer-remark` 
+to handle image processing.
+
+<GatsbyPlugin
+  name="gatsby-plugin-sharp"
+/>
+<GatsbyPlugin
+  name="gatsby-transformer-sharp"
+/>
+<GatsbyPlugin
+  name="gatsby-transformer-remark"
+/>
+---
+
+Finally, configure `gatsby-plugin-mdx` to resolve images in MDX files.
+
+<GatsbyPlugin 
+  name="gatsby-plugin-mdx" 
+  options={{
+    gatsbyRemarkPlugins: [
+      {
+        resolve: `gatsby-remark-images`,
+        options: {
+          maxWidth: 1200,
+        }
+      }
+    ]
+  }}
+/>
+
+---
+
+All set! You're ready to start adding images to MDX pages.

--- a/packages/gatsby-recipes/recipes/mdx-images.mdx
+++ b/packages/gatsby-recipes/recipes/mdx-images.mdx
@@ -34,6 +34,9 @@ Install NPM Packages
   name="gatsby-transformer-sharp"
 />
 <NPMPackage
+  name="gatsby-transformer-remark"
+/>
+<NPMPackage
   name="gatsby-remark-images"
 />
 

--- a/packages/gatsby-recipes/recipes/mdx-images.mdx
+++ b/packages/gatsby-recipes/recipes/mdx-images.mdx
@@ -34,9 +34,6 @@ Install NPM Packages
   name="gatsby-transformer-sharp"
 />
 <NPMPackage
-  name="gatsby-transformer-remark"
-/>
-<NPMPackage
   name="gatsby-remark-images"
 />
 
@@ -65,9 +62,6 @@ to handle image processing.
 />
 <GatsbyPlugin
   name="gatsby-transformer-sharp"
-/>
-<GatsbyPlugin
-  name="gatsby-transformer-remark"
 />
 ---
 


### PR DESCRIPTION
 ## Description

(My) tests are flaky--this pull request adds a missing dependency. 

### Question

The CLI throws an error if `/src/images/` doesn't exist (i.e., after running this recipe in an empty `hello-world` project.) Is this okay?