### PR TITLE
Move all benchmark dependencies out of devDependencies

### DIFF
--- a/benchmarks/markdown_id/package.json
+++ b/benchmarks/markdown_id/package.json
@@ -6,8 +6,10 @@
   "author": "PvdZ <pvdz@github>",
   "dependencies": {
     "del-cli": "^3.0.0",
+    "faker": "^4.1.0",
     "gatsby": "^2.19.5",
     "gatsby-image": "^2.2.39",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-plugin-feed": "^2.3.26",
     "gatsby-plugin-google-analytics": "^2.1.34",
     "gatsby-plugin-manifest": "^2.2.38",
@@ -34,10 +36,6 @@
     "typescript": "^3.8.3",
     "typography": "^0.16.19",
     "typography-theme-wordpress-2016": "^0.16.19"
-  },
-  "devDependencies": {
-    "faker": "^4.1.0",
-    "gatsby-plugin-benchmark-reporting": "*"
   },
   "keywords": [
     "gatsby"

--- a/benchmarks/markdown_slug/package.json
+++ b/benchmarks/markdown_slug/package.json
@@ -6,8 +6,10 @@
   "author": "PvdZ <pvdz@github>",
   "dependencies": {
     "del-cli": "^3.0.0",
+    "faker": "^4.1.0",
     "gatsby": "^2.19.5",
     "gatsby-image": "^2.2.39",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-plugin-feed": "^2.3.26",
     "gatsby-plugin-google-analytics": "^2.1.34",
     "gatsby-plugin-manifest": "^2.2.38",
@@ -34,10 +36,6 @@
     "typescript": "^3.8.3",
     "typography": "^0.16.19",
     "typography-theme-wordpress-2016": "^0.16.19"
-  },
-  "devDependencies": {
-    "faker": "^4.1.0",
-    "gatsby-plugin-benchmark-reporting": "*"
   },
   "keywords": [
     "gatsby"

--- a/benchmarks/markdown_table/package.json
+++ b/benchmarks/markdown_table/package.json
@@ -10,16 +10,14 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
+    "faker": "^4.1.0",
     "gatsby": "^2.19.5",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-transformer-remark": "^2.6.48",
+    "gray-matter": "^4.0.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "ts-node": "^8.9.0",
     "typescript": "^3.8.3"
-  },
-  "devDependencies": {
-    "faker": "^4.1.0",
-    "gatsby-plugin-benchmark-reporting": "*",
-    "gray-matter": "^4.0.2"
   }
 }

--- a/benchmarks/mdx/package.json
+++ b/benchmarks/mdx/package.json
@@ -17,10 +17,12 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.5.7",
     "@mdx-js/react": "^1.5.7",
+    "cross-env": "^7.0.0",
     "del-cli": "^3.0.0",
     "dotenv": "^8.2.0",
     "gatsby": "^2.20.23",
     "gatsby-image": "^2.3.3",
+    "gatsby-plugin-benchmark-reporting": "0.1.3",
     "gatsby-plugin-mdx": "^1.1.8",
     "gatsby-plugin-page-creator": "^2.2.2",
     "gatsby-plugin-sharp": "^2.4.12",
@@ -30,13 +32,11 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "ts-node": "^8.9.0",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "willit": "^1.0.0"
   },
   "devDependencies": {
-    "cross-env": "^7.0.0",
-    "gatsby-plugin-benchmark-reporting": "0.1.3",
-    "prettier": "2.0.4",
-    "willit": "^1.0.0"
+    "prettier": "2.0.4"
   },
   "repository": {
     "type": "git",

--- a/benchmarks/source-contentful/package.json
+++ b/benchmarks/source-contentful/package.json
@@ -17,9 +17,12 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
+    "chalk": "^2.4.2",
     "contentful-management": "^5.14.0",
+    "cross-env": "^7.0.0",
     "dotenv": "^8.2.0",
     "gatsby": "^2.19.7",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-image": "^2.2.40",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-source-contentful": "^2.1.88",
@@ -29,14 +32,11 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "ts-node": "^8.9.0",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "chalk": "^2.4.2",
-    "cross-env": "^7.0.0",
-    "gatsby-plugin-benchmark-reporting": "*",
-    "prettier": "2.0.4",
-    "yargs": "^15.3.1"
+    "prettier": "2.0.4"
   },
   "repository": {
     "type": "git",

--- a/benchmarks/source-datocms/package.json
+++ b/benchmarks/source-datocms/package.json
@@ -14,9 +14,11 @@
     "start": "npm run develop"
   },
   "dependencies": {
+    "cross-env": "^7.0.0",
     "dotenv": "^8.2.0",
     "gatsby": "^2.19.7",
     "gatsby-image": "^2.2.40",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-source-datocms": "^2.1.27",
     "gatsby-source-filesystem": "^2.1.48",
@@ -28,8 +30,6 @@
     "typescript": "^3.8.3"
   },
   "devDependencies": {
-    "cross-env": "^7.0.0",
-    "gatsby-plugin-benchmark-reporting": "*",
     "prettier": "2.0.4"
   },
   "repository": {

--- a/benchmarks/source-drupal/package.json
+++ b/benchmarks/source-drupal/package.json
@@ -14,10 +14,12 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
+    "cross-env": "^7.0.0",
     "dotenv": "^8.2.0",
     "faker": "^4.1.0",
     "gatsby": "^2.19.7",
     "gatsby-image": "^2.2.40",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-source-drupal": "^3.3.18",
     "gatsby-source-filesystem": "^2.1.48",
@@ -30,8 +32,6 @@
     "typescript": "^3.8.3"
   },
   "devDependencies": {
-    "cross-env": "^7.0.0",
-    "gatsby-plugin-benchmark-reporting": "*",
     "prettier": "2.0.4"
   },
   "repository": {

--- a/benchmarks/source-wordpress/package.json
+++ b/benchmarks/source-wordpress/package.json
@@ -14,8 +14,11 @@
     "start": "npm run develop"
   },
   "dependencies": {
+    "cross-env": "^7.0.0",
     "dotenv": "^8.2.0",
+    "faker": "^4.1.0",
     "gatsby": "^2.19.35",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-image": "^2.2.40",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-source-filesystem": "^2.1.48",
@@ -25,9 +28,6 @@
     "react-dom": "^16.12.0"
   },
   "devDependencies": {
-    "cross-env": "^7.0.0",
-    "faker": "^4.1.0",
-    "gatsby-plugin-benchmark-reporting": "*",
     "prettier": "2.0.4"
   },
   "repository": {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

We may be running benchmarks in some platforms in a fashion that would not by default install `devDependencies.` Move all necessary packages to `dependencies`.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

n/a

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

n/a
