### PR TITLE
fix(gatsby): add maxAsyncRequests to infinity to reduce bundle size

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -527,6 +527,7 @@ module.exports = async (
           },
           priority: 30,
           minChunks: 1,
+          reuseExistingChunk: true,
         },
         commons: {
           name: `commons`,

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -527,16 +527,12 @@ module.exports = async (
           },
           priority: 30,
           minChunks: 1,
-          reuseExistingChunk: true,
         },
         commons: {
-          // only bundle non-async modules
-          chunks: `initial`,
           name: `commons`,
           // if a chunk is used on all components we put it in commons (we need at least 2 components)
           minChunks: Math.max(componentsCount, 2),
           priority: 20,
-          reuseExistingChunk: true,
         },
         // If a chunk is used in at least 2 components we create a separate chunk
         shared: {
@@ -568,6 +564,11 @@ module.exports = async (
           enforce: true,
         },
       },
+      // We load our pages async through async-requires, maxInitialRequests doesn't have an effect on chunks derived from page components.
+      // By default webpack has set maxAsyncRequests to 6, in some cases this isn't enough an actually makes the bundle size blow up.
+      // We've set maxAsyncRequests to Infinity to negate this. This could potentionally exceed the 25 initial requests that we set before
+      // sadly I do not have a better solution.
+      maxAsyncRequests: Infinity,
       maxInitialRequests: 25,
       minSize: 20000,
     }


### PR DESCRIPTION

## Description

Granular chunks was bound by async requests of 6, this could lead to bundle bloat. I had to set it to Infinity to make sure we never hit that limit. One downside is that the limit of initial 25 requests can be broken now. I'm pretty sure this will hardly happen.

## Related Issues
Fixes https://github.com/gatsbyjs/gatsby/issues/23221
Fixes https://github.com/gatsbyjs/gatsby/issues/23402
