### PR TITLE
chore(docs): Remove Milligram category from starters showcase

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -60,7 +60,6 @@ starter:
   - Styling:SCSS
   - Styling:Tailwind
   - Styling:Theme-UI
-  - Styling:Milligram
   - Styling:Other
   - Styling:None
   - Testing

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -5809,7 +5809,7 @@
   tags:
     - AWS
     - Onepage
-    - Styling:Milligram
+    - Styling:Other
   features:
     - Interactive SVG map using D3
     - Responsive design


### PR DESCRIPTION
## Description

Originally added in https://github.com/gatsbyjs/gatsby/pull/22281 but it doesn't warrant its own category as it's not a major library and another Milligram project was already under Styling:Other
