### PR TITLE
chore(gatsby): Update filter tests

### DIFF
--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -272,10 +272,7 @@ it(`should use the cache argument`, async () => {
   if (IS_LOKI) return
 
   const filtersCache = new Map()
-  const [result] = await runFilterOnCache(
-    { hair: { eq: 2 } },
-    filtersCache
-  )
+  const [result] = await runFilterOnCache({ hair: { eq: 2 } }, filtersCache)
 
   // Validate answer
   expect(result.length).toEqual(1)
@@ -283,18 +280,20 @@ it(`should use the cache argument`, async () => {
 
   // Confirm cache is not ignored
   expect(filtersCache.size === 1).toBe(true)
-  filtersCache.forEach((
-    filterCache /*: FilterCache */,
-    //cacheKey /*: FilterCacheKey */
-  ) => {
-    // This test will change when the composition of the FilterCache changes
-    // For now it should be a Map of values to Set of nodes
-    expect(filterCache instanceof Object).toBe(true)
-    expect(filterCache.byValue instanceof Map).toBe(true)
-    expect(filterCache.meta instanceof Object).toBe(true)
-    // There ought to be at least one value mapped (probably more, shrug)
-    expect(filterCache.byValue.size >= 1).toBe(true)
-  })
+  filtersCache.forEach(
+    (
+      filterCache /*: FilterCache */
+      //cacheKey /*: FilterCacheKey */
+    ) => {
+      // This test will change when the composition of the FilterCache changes
+      // For now it should be a Map of values to Set of nodes
+      expect(filterCache instanceof Object).toBe(true)
+      expect(filterCache.byValue instanceof Map).toBe(true)
+      expect(filterCache.meta instanceof Object).toBe(true)
+      // There ought to be at least one value mapped (probably more, shrug)
+      expect(filterCache.byValue.size >= 1).toBe(true)
+    }
+  )
 })
 
 // Make sure to test fast filters (with cache) and Sift (without cache)
@@ -438,7 +437,9 @@ it(`should use the cache argument`, async () => {
           const needle = 2 // Note: `id` is a numstr
           const [result, allNodes] = await runFilter({ id: { ne: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.id !== needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.id !== needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.id).not.toEqual(needle))
         })
@@ -457,7 +458,9 @@ it(`should use the cache argument`, async () => {
           const needle = true
           const [result, allNodes] = await runFilter({ boolean: { ne: true } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.boolean !== needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.boolean !== needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.boolean).not.toEqual(needle))
         })
@@ -468,7 +471,9 @@ it(`should use the cache argument`, async () => {
             waxOnly: { foo: { ne: true } },
           })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.waxOnly?.foo !== needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.waxOnly?.foo !== needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.waxOnly?.foo).not.toEqual(needle))
         })
@@ -491,7 +496,9 @@ it(`should use the cache argument`, async () => {
           const [result, allNodes] = await runFilter({ nil: { ne: needle } })
 
           // Should only return nodes who do have the property, not set to null
-          expect(result?.length).toEqual(allNodes.filter(node => node.nil !== needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.nil !== needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.nil).not.toEqual(needle))
         })
@@ -512,18 +519,28 @@ it(`should use the cache argument`, async () => {
             waxOnly: { bar: { baz: { ne: needle } } },
           })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.waxOnly?.bar?.baz !== needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.waxOnly?.bar?.baz !== needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.waxOnly?.bar?.baz).not.toEqual(needle))
+          result.forEach(node =>
+            expect(node.waxOnly?.bar?.baz).not.toEqual(needle)
+          )
         })
 
         it(`handles the ne operator for array field values`, async () => {
           const needle = 1
-          const [result, allNodes] = await runFilter({ anArray: { ne: needle } })
+          const [result, allNodes] = await runFilter({
+            anArray: { ne: needle },
+          })
 
-          expect(result?.length).toEqual(allNodes.filter(node => !node.anArray?.includes(needle)).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => !node.anArray?.includes(needle)).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.anArray?.includes(needle)).not.toEqual(true))
+          result.forEach(node =>
+            expect(node.anArray?.includes(needle)).not.toEqual(true)
+          )
         })
       })
 
@@ -532,7 +549,9 @@ it(`should use the cache argument`, async () => {
           const needle = 1
           const [result, allNodes] = await runFilter({ hair: { lt: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.hair < needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.hair < needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.hair < needle).toEqual(true))
         })
@@ -540,21 +559,33 @@ it(`should use the cache argument`, async () => {
         async function confirmPosition(allNodes, needle) {
           if (IS_LOKI) return
 
-          const result = await runQuery({filter:{ exh: { lt: needle } }}, createFiltersCache(), allNodes)
+          const result = await runQuery(
+            { filter: { exh: { lt: needle } } },
+            createFiltersCache(),
+            allNodes
+          )
 
           // Just check whether the reported count is equal to the actual count
           // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
-          expect((result?.length ?? 0)).toEqual(allNodes.filter(node => node.exh < needle).length)
+          expect(result?.length ?? 0).toEqual(
+            allNodes.filter(node => node.exh < needle).length
+          )
         }
 
-        ;['uneven', 'even'].forEach(count => {
-          describe('positional checks for count=' + count, () => {
-            for (let i=0; i<5; i += 0.5) {
-              it('should be able to lt anywhere in an array i=' + i.toFixed(1), async () => {
-                // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
-                // This checks the ordered search, to check before, on every, between, and after each position in the list
-                await confirmPosition(count === 'even' ? makeNodesEven() : makeNodesUneven(), i)
-              })
+        ;[`uneven`, `even`].forEach(count => {
+          describe(`positional checks for count=` + count, () => {
+            for (let i = 0; i < 5; i += 0.5) {
+              it(
+                `should be able to lt anywhere in an array i=` + i.toFixed(1),
+                async () => {
+                  // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
+                  // This checks the ordered search, to check before, on every, between, and after each position in the list
+                  await confirmPosition(
+                    count === `even` ? makeNodesEven() : makeNodesUneven(),
+                    i
+                  )
+                }
+              )
             }
           })
         })
@@ -564,10 +595,12 @@ it(`should use the cache argument`, async () => {
           // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
-          const needle = '1.5'
+          const needle = `1.5`
           const [result, allNodes] = await runFilter({ float: { lt: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.float < needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.float < needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.float < needle).toEqual(true))
         })
@@ -581,7 +614,9 @@ it(`should use the cache argument`, async () => {
           // Nothing is lt null so zero nodes should match
           // (Note: this is different from `lte`, which does return nulls here!)
           expect(result).toEqual(null)
-          expect(allNodes.filter(node => node.nil === needle).length).toBeGreaterThan(0) // They should _exist_...
+          expect(
+            allNodes.filter(node => node.nil === needle).length
+          ).toBeGreaterThan(0) // They should _exist_...
         })
       })
 
@@ -590,7 +625,9 @@ it(`should use the cache argument`, async () => {
           const needle = 1
           const [result, allNodes] = await runFilter({ hair: { lte: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.hair <= needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.hair <= needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.hair <= needle).toEqual(true))
         })
@@ -598,21 +635,33 @@ it(`should use the cache argument`, async () => {
         async function confirmPosition(allNodes, needle) {
           if (IS_LOKI) return
 
-          const result = await runQuery({filter:{ exh: { lte: needle } }}, createFiltersCache(), allNodes)
+          const result = await runQuery(
+            { filter: { exh: { lte: needle } } },
+            createFiltersCache(),
+            allNodes
+          )
 
           // Just check whether the reported count is equal to the actual count
           // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
-          expect((result?.length ?? 0)).toEqual(allNodes.filter(node => node.exh <= needle).length)
+          expect(result?.length ?? 0).toEqual(
+            allNodes.filter(node => node.exh <= needle).length
+          )
         }
 
-        ;['uneven', 'even'].forEach(count => {
-          describe('positional checks for count=' + count, () => {
-            for (let i=0; i<5; i += 0.5) {
-              it('should be able to lte anywhere in an array i=' + i.toFixed(1), async () => {
-                // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
-                // This checks the ordered search, to check before, on every, between, and after each position in the list
-                await confirmPosition(count === 'even' ? makeNodesEven() : makeNodesUneven(), i)
-              })
+        ;[`uneven`, `even`].forEach(count => {
+          describe(`positional checks for count=` + count, () => {
+            for (let i = 0; i < 5; i += 0.5) {
+              it(
+                `should be able to lte anywhere in an array i=` + i.toFixed(1),
+                async () => {
+                  // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
+                  // This checks the ordered search, to check before, on every, between, and after each position in the list
+                  await confirmPosition(
+                    count === `even` ? makeNodesEven() : makeNodesUneven(),
+                    i
+                  )
+                }
+              )
             }
           })
         })
@@ -622,10 +671,12 @@ it(`should use the cache argument`, async () => {
           // Here 1.5 exists but only as number. However, `1.5 <= '1.5' === true`
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
-          const needle = '1.5'
+          const needle = `1.5`
           const [result, allNodes] = await runFilter({ float: { lte: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.float <= needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.float <= needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.float <= needle).toEqual(true))
         })
@@ -637,7 +688,9 @@ it(`should use the cache argument`, async () => {
           const [result, allNodes] = await runFilter({ nil: { lte: needle } })
 
           // lte null matches null but no nodes without the property (NULL)
-          expect(result?.length).toEqual(allNodes.filter(node => node.nil === needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.nil === needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.nil === needle).toEqual(true))
         })
@@ -648,7 +701,9 @@ it(`should use the cache argument`, async () => {
           const needle = 1
           const [result, allNodes] = await runFilter({ hair: { gt: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.hair > needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.hair > needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.hair > needle).toEqual(true))
         })
@@ -656,21 +711,33 @@ it(`should use the cache argument`, async () => {
         async function confirmPosition(allNodes, needle) {
           if (IS_LOKI) return
 
-          const result = await runQuery({filter:{ exh: { gt: needle } }}, createFiltersCache(), allNodes)
+          const result = await runQuery(
+            { filter: { exh: { gt: needle } } },
+            createFiltersCache(),
+            allNodes
+          )
 
           // Just check whether the reported count is equal to the actual count
           // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
-          expect((result?.length ?? 0)).toEqual(allNodes.filter(node => node.exh > needle).length)
+          expect(result?.length ?? 0).toEqual(
+            allNodes.filter(node => node.exh > needle).length
+          )
         }
 
-        ;['uneven', 'even'].forEach(count => {
-          describe('positional checks for count=' + count, () => {
-            for (let i=0; i<5; i += 0.5) {
-              it('should be able to gt anywhere in an array i=' + i.toFixed(1), async () => {
-                // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
-                // This checks the ordered search, to check before, on every, between, and after each position in the list
-                await confirmPosition(count === 'even' ? makeNodesEven() : makeNodesUneven(), i)
-              })
+        ;[`uneven`, `even`].forEach(count => {
+          describe(`positional checks for count=` + count, () => {
+            for (let i = 0; i < 5; i += 0.5) {
+              it(
+                `should be able to gt anywhere in an array i=` + i.toFixed(1),
+                async () => {
+                  // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
+                  // This checks the ordered search, to check before, on every, between, and after each position in the list
+                  await confirmPosition(
+                    count === `even` ? makeNodesEven() : makeNodesUneven(),
+                    i
+                  )
+                }
+              )
             }
           })
         })
@@ -680,10 +747,12 @@ it(`should use the cache argument`, async () => {
           // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
-          const needle = '1.5'
+          const needle = `1.5`
           const [result, allNodes] = await runFilter({ float: { gt: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.float > needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.float > needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.float > needle).toEqual(true))
         })
@@ -697,7 +766,9 @@ it(`should use the cache argument`, async () => {
           // Nothing is gt null so zero nodes should match
           // (Note: this is different from `gte`, which does return nulls here!)
           expect(result).toEqual(null)
-          expect(allNodes.filter(node => node.nil === needle).length).toBeGreaterThan(0) // They should _exist_...
+          expect(
+            allNodes.filter(node => node.nil === needle).length
+          ).toBeGreaterThan(0) // They should _exist_...
         })
       })
 
@@ -706,7 +777,9 @@ it(`should use the cache argument`, async () => {
           const needle = 1
           const [result, allNodes] = await runFilter({ hair: { gte: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.hair >= needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.hair >= needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.hair >= needle).toEqual(true))
         })
@@ -714,21 +787,33 @@ it(`should use the cache argument`, async () => {
         async function confirmPosition(allNodes, needle) {
           if (IS_LOKI) return
 
-          const result = await runQuery({filter:{ exh: { gte: needle } }}, createFiltersCache(), allNodes)
+          const result = await runQuery(
+            { filter: { exh: { gte: needle } } },
+            createFiltersCache(),
+            allNodes
+          )
 
           // Just check whether the reported count is equal to the actual count
           // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
-          expect((result?.length ?? 0)).toEqual(allNodes.filter(node => node.exh >= needle).length)
+          expect(result?.length ?? 0).toEqual(
+            allNodes.filter(node => node.exh >= needle).length
+          )
         }
 
-        ;['uneven', 'even'].forEach(count => {
-          describe('positional checks for count=' + count, () => {
-            for (let i=0; i<5; i += 0.5) {
-              it('should be able to gte anywhere in an array i=' + i.toFixed(1), async () => {
-                // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
-                // This checks the ordered search, to check before, on every, between, and after each position in the list
-                await confirmPosition(count === 'even' ? makeNodesEven() : makeNodesUneven(), i)
-              })
+        ;[`uneven`, `even`].forEach(count => {
+          describe(`positional checks for count=` + count, () => {
+            for (let i = 0; i < 5; i += 0.5) {
+              it(
+                `should be able to gte anywhere in an array i=` + i.toFixed(1),
+                async () => {
+                  // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
+                  // This checks the ordered search, to check before, on every, between, and after each position in the list
+                  await confirmPosition(
+                    count === `even` ? makeNodesEven() : makeNodesUneven(),
+                    i
+                  )
+                }
+              )
             }
           })
         })
@@ -738,10 +823,12 @@ it(`should use the cache argument`, async () => {
           // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
-          const needle = '1.5'
+          const needle = `1.5`
           const [result, allNodes] = await runFilter({ float: { gte: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.float >= needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.float >= needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.float >= needle).toEqual(true))
         })
@@ -753,7 +840,9 @@ it(`should use the cache argument`, async () => {
           const [result, allNodes] = await runFilter({ nil: { gte: needle } })
 
           // gte null matches null but no nodes without the property (NULL)
-          expect(result?.length).toEqual(allNodes.filter(node => node.nil === needle).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.nil === needle).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.nil === needle).toEqual(true))
         })
@@ -767,20 +856,30 @@ it(`should use the cache argument`, async () => {
             name: { regex: needleStr },
           })
 
-          expect(result?.length).toEqual(allNodes.filter(node => needleRex.test(node.name)).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => needleRex.test(node.name)).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(needleRex.test(node.name)).toEqual(true))
+          result.forEach(node =>
+            expect(needleRex.test(node.name)).toEqual(true)
+          )
         })
 
         it(`handles the regex operator with i-flag`, async () => {
           // Note: needle is different from checked because `new RegExp('/a/i')` does _not_ work
           const needleRex = /^the.*wax/i
-          const needleStr = '/^the.*wax/i'
-          const [result, allNodes] = await runFilter({ name: { regex: needleStr } })
+          const needleStr = `/^the.*wax/i`
+          const [result, allNodes] = await runFilter({
+            name: { regex: needleStr },
+          })
 
-          expect(result?.length).toEqual(allNodes.filter(node => needleRex.test(node.name)).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => needleRex.test(node.name)).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(needleRex.test(node.name)).toEqual(true))
+          result.forEach(node =>
+            expect(needleRex.test(node.name)).toEqual(true)
+          )
         })
 
         it(`handles the nested regex operator`, async () => {
@@ -790,9 +889,17 @@ it(`should use the cache argument`, async () => {
             nestedRegex: { field: { regex: needleStr } },
           })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.nestedRegex && needleRex.test(node.nestedRegex.field)).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(
+              node => node.nestedRegex && needleRex.test(node.nestedRegex.field)
+            ).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nestedRegex && needleRex.test(node.nestedRegex.field)).toEqual(true))
+          result.forEach(node =>
+            expect(
+              node.nestedRegex && needleRex.test(node.nestedRegex.field)
+            ).toEqual(true)
+          )
         })
 
         it(`does not match double quote for string without it`, async () => {
@@ -801,7 +908,7 @@ it(`should use the cache argument`, async () => {
           const [result, allNodes] = await runFilter({ name: { regex: `/"/` } })
 
           expect(result).toEqual(null)
-          expect(allNodes.filter(node => node.name === '"').length).toEqual(0)
+          expect(allNodes.filter(node => node.name === `"`).length).toEqual(0)
         })
       })
 
@@ -812,18 +919,26 @@ it(`should use the cache argument`, async () => {
             string: { in: needle },
           })
 
-          expect(result?.length).toEqual(allNodes.filter(node => needle.includes(node.string)).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => needle.includes(node.string)).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(needle.includes(node.string)).toEqual(true))
+          result.forEach(node =>
+            expect(needle.includes(node.string)).toEqual(true)
+          )
         })
 
         it(`handles the in operator for ints`, async () => {
           const needle = [0, 2]
           const [result, allNodes] = await runFilter({ index: { in: needle } })
 
-          expect(result?.length).toEqual(allNodes.filter(node => needle.includes(node.index)).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => needle.includes(node.index)).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(needle.includes(node.index)).toEqual(true))
+          result.forEach(node =>
+            expect(needle.includes(node.index)).toEqual(true)
+          )
         })
 
         it(`handles the in operator for floats`, async () => {
@@ -832,9 +947,13 @@ it(`should use the cache argument`, async () => {
             float: { in: needle },
           })
 
-          expect(result?.length).toEqual(allNodes.filter(node => needle.includes(node.float)).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => needle.includes(node.float)).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(needle.includes(node.float)).toEqual(true))
+          result.forEach(node =>
+            expect(needle.includes(node.float)).toEqual(true)
+          )
         })
 
         it(`handles the in operator for just null`, async () => {
@@ -844,9 +963,14 @@ it(`should use the cache argument`, async () => {
 
           // Do not include the nodes without a `nil` property
           // May not have the property, or must be null
-          expect(result?.length).toEqual(allNodes.filter(node => node.nil === undefined || node.nil === null).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.nil === undefined || node.nil === null)
+              .length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil === undefined || node.nil === null).toEqual(true))
+          result.forEach(node =>
+            expect(node.nil === undefined || node.nil === null).toEqual(true)
+          )
         })
 
         it(`handles the in operator for double null`, async () => {
@@ -858,9 +982,14 @@ it(`should use the cache argument`, async () => {
 
           // Do not include the nodes without a `nil` property
           // May not have the property, or must be null
-          expect(result?.length).toEqual(allNodes.filter(node => node.nil === undefined || node.nil === null).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.nil === undefined || node.nil === null)
+              .length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil === undefined || node.nil === null).toEqual(true))
+          result.forEach(node =>
+            expect(node.nil === undefined || node.nil === null).toEqual(true)
+          )
         })
 
         it(`handles the in operator for null in int and null`, async () => {
@@ -869,9 +998,14 @@ it(`should use the cache argument`, async () => {
           const [result, allNodes] = await runFilter({ nil: { in: [5, null] } })
 
           // Include the nodes without a `nil` property
-          expect(result?.length).toEqual(allNodes.filter(node => node.nil === undefined || node.nil === null).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.nil === undefined || node.nil === null)
+              .length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil === undefined || node.nil === null).toEqual(true))
+          result.forEach(node =>
+            expect(node.nil === undefined || node.nil === null).toEqual(true)
+          )
         })
 
         it(`handles the in operator for int in int and null`, async () => {
@@ -880,9 +1014,22 @@ it(`should use the cache argument`, async () => {
           })
 
           // Include the nodes without a `index` property (there aren't any)
-          expect(result?.length).toEqual(allNodes.filter(node => node.index === undefined || node.index === null || node.index === 2).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(
+              node =>
+                node.index === undefined ||
+                node.index === null ||
+                node.index === 2
+            ).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.index === undefined || node.index === null || node.index === 2).toEqual(true))
+          result.forEach(node =>
+            expect(
+              node.index === undefined ||
+                node.index === null ||
+                node.index === 2
+            ).toEqual(true)
+          )
         })
 
         it(`handles the in operator for booleans`, async () => {
@@ -890,7 +1037,9 @@ it(`should use the cache argument`, async () => {
             boolean: { in: [true] },
           })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.boolean === true).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.boolean === true).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
           result.forEach(node => expect(node.boolean === true).toEqual(true))
         })
@@ -902,9 +1051,13 @@ it(`should use the cache argument`, async () => {
           // The first one has a 5, the second one does not have a 5, the third does
           // not have the property at all (NULL). It should return the first and last.
           // (If the target value has `null` then the third should be omitted)
-          expect(result?.length).toEqual(allNodes.filter(node => node.anArray?.includes(5)).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.anArray?.includes(5)).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.anArray?.includes(5)).toEqual(true))
+          result.forEach(node =>
+            expect(node.anArray?.includes(5)).toEqual(true)
+          )
         })
 
         it(`handles the in operator for array some elements`, async () => {
@@ -915,9 +1068,16 @@ it(`should use the cache argument`, async () => {
           })
 
           // Same as the test for just `[5]`. 20 and 300 do not appear anywhere.
-          expect(result?.length).toEqual(allNodes.filter(node => node.anArray?.some(n => needle.includes(n))).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node => node.anArray?.some(n => needle.includes(n)))
+              .length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.anArray && needle.some(n => node.anArray.includes(n))).toEqual(true))
+          result.forEach(node =>
+            expect(
+              node.anArray && needle.some(n => node.anArray.includes(n))
+            ).toEqual(true)
+          )
         })
 
         it(`handles the nested in operator for array of strings`, async () => {
@@ -926,9 +1086,18 @@ it(`should use the cache argument`, async () => {
             frontmatter: { tags: { in: needle } },
           })
 
-          expect(result?.length).toEqual(allNodes.filter(node => node.frontmatter.tags?.some(n => needle.includes(n))).length)
+          expect(result?.length).toEqual(
+            allNodes.filter(node =>
+              node.frontmatter.tags?.some(n => needle.includes(n))
+            ).length
+          )
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.frontmatter?.tags && needle.some(n => node.frontmatter.tags.includes(n))).toEqual(true))
+          result.forEach(node =>
+            expect(
+              node.frontmatter?.tags &&
+                needle.some(n => node.frontmatter.tags.includes(n))
+            ).toEqual(true)
+          )
         })
       })
 
@@ -955,7 +1124,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator on the second element`, async () => {
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -976,7 +1145,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`should return only one node if elemMatch hits multiples`, async () => {
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -1001,7 +1170,7 @@ it(`should use the cache argument`, async () => {
         it(`ignores the elemMatch operator on a partial sub tree`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -1015,7 +1184,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator for array of objects (1)`, async () => {
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             data: {
               tags: {
                 elemMatch: {
@@ -1038,7 +1207,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator for array of objects (2)`, async () => {
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             data: {
               tags: {
                 elemMatch: {
@@ -1063,7 +1232,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on boolean field`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             boolean: {
               elemMatch: {
                 eq: true,
@@ -1079,7 +1248,7 @@ it(`should use the cache argument`, async () => {
         it(`skips nodes without the field for elemMatch on boolean`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             boolSecondOnly: {
               elemMatch: {
                 eq: false,
@@ -1095,7 +1264,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on string field`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             string: {
               elemMatch: {
                 eq: `a`,
@@ -1111,7 +1280,7 @@ it(`should use the cache argument`, async () => {
         it(`should return all nodes for elemMatch on non-arrays too`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             name: {
               elemMatch: {
                 eq: `The Mad Wax`,
@@ -1129,7 +1298,7 @@ it(`should use the cache argument`, async () => {
         it(`skips nodes without the field for elemMatch on string`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             strSecondOnly: {
               elemMatch: {
                 eq: `needle`,
@@ -1145,7 +1314,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on number field`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             float: {
               elemMatch: {
                 eq: 1.5,
@@ -1161,7 +1330,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$nin`, () => {
         it(`handles the nin operator for array [5]`, async () => {
-          const [result, ] = await runFilter({ anArray: { nin: [5] } })
+          const [result] = await runFilter({ anArray: { nin: [5] } })
 
           // Since the array does not contain `null`, the query should also return the
           // nodes that do not have the field at all (NULL).
@@ -1180,7 +1349,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for array [null]`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             nullArray: { nin: [null] },
           })
 
@@ -1192,7 +1361,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for strings`, async () => {
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             string: { nin: [`b`, `c`] },
           })
 
@@ -1204,7 +1373,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for ints`, async () => {
-          const [result, ] = await runFilter({ index: { nin: [0, 2] } })
+          const [result] = await runFilter({ index: { nin: [0, 2] } })
 
           expect(result.length).toEqual(1)
           result.forEach(node => {
@@ -1214,7 +1383,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for floats`, async () => {
-          const [result, ] = await runFilter({ float: { nin: [1.5] } })
+          const [result] = await runFilter({ float: { nin: [1.5] } })
 
           expect(result.length).toEqual(2)
           result.forEach(node => {
@@ -1224,7 +1393,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for booleans`, async () => {
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             boolean: { nin: [true, null] },
           })
 
@@ -1240,7 +1409,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for double null`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             nil: { nin: [null, null] },
           })
 
@@ -1256,7 +1425,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for null in int+null`, async () => {
           if (IS_LOKI) return
 
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             nil: { nin: [5, null] },
           })
 
@@ -1270,7 +1439,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for int in int+null`, async () => {
-          const [result, ] = await runFilter({
+          const [result] = await runFilter({
             index: { nin: [2, null] },
           })
 
@@ -1286,7 +1455,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$glob`, () => {
         it(`handles the glob operator`, async () => {
-          const [result, ] = await runFilter({ name: { glob: `*Wax` } })
+          const [result] = await runFilter({ name: { glob: `*Wax` } })
 
           expect(result.length).toEqual(2)
           expect(result[0].name).toEqual(`The Mad Wax`)
@@ -1295,7 +1464,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`date`, () => {
         it(`filters date fields`, async () => {
-          const [result, ] = await runFilter({ date: { ne: null } })
+          const [result] = await runFilter({ date: { ne: null } })
 
           expect(result.length).toEqual(2)
           expect(result[0].index).toEqual(0)

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -244,7 +244,7 @@ it(`should use the cache argument`, async () => {
   if (IS_LOKI) return
 
   const filtersCache = new Map()
-  let [result, allNodes] = await runFilterOnCache(
+  const [result, allNodes] = await runFilterOnCache(
     { hair: { eq: 2 } },
     filtersCache
   )
@@ -282,28 +282,28 @@ it(`should use the cache argument`, async () => {
     describe(`Filter fields`, () => {
       describe(`$eq`, () => {
         it(`handles eq operator with number value`, async () => {
-          let [result, allNodes] = await runFilter({ hair: { eq: 2 } })
+          const [result, allNodes] = await runFilter({ hair: { eq: 2 } })
 
           expect(result.length).toEqual(1)
           expect(result[0].hair).toEqual(2)
         })
 
         it(`handles eq operator with false value`, async () => {
-          let [result, allNodes] = await runFilter({ boolean: { eq: false } })
+          const [result, allNodes] = await runFilter({ boolean: { eq: false } })
 
           expect(result.length).toEqual(1)
           expect(result[0].name).toEqual(`The Mad Wax`)
         })
 
         it(`handles eq operator with 0`, async () => {
-          let [result, allNodes] = await runFilter({ hair: { eq: 0 } })
+          const [result, allNodes] = await runFilter({ hair: { eq: 0 } })
 
           expect(result.length).toEqual(1)
           expect(result[0].hair).toEqual(0)
         })
 
         it(`handles eq operator with null`, async () => {
-          let [result, allNodes] = await runFilter({ nil: { eq: null } })
+          const [result, allNodes] = await runFilter({ nil: { eq: null } })
 
           // Also return nodes that do not have the property at all (NULL in db)
           expect(result.length).toEqual(2)
@@ -311,14 +311,14 @@ it(`should use the cache argument`, async () => {
 
         // grapqhl would never pass on `undefined`
         // it(`handles eq operator with undefined`, async () => {
-        //   let [result, allNodes] = await runFilter({ undef: { eq: undefined } })
+        //   const [result, allNodes] = await runFilter({ undef: { eq: undefined } })
         //
         //   expect(result.length).toEqual(?)
         //   expect(result[0].hair).toEqual(?)
         // })
 
         it(`handles eq operator with serialized array value`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             strArray: { eq: `[5,6,7,8]` },
           })
 
@@ -327,7 +327,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the eq operator for array field values`, async () => {
-          let [result, allNodes] = await runFilter({ anArray: { eq: 5 } })
+          const [result, allNodes] = await runFilter({ anArray: { eq: 5 } })
 
           expect(result.length).toBe(1)
           expect(result[0].index).toBe(1)
@@ -338,20 +338,20 @@ it(`should use the cache argument`, async () => {
         it(`handles ne operator`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ hair: { ne: 2 } })
+          const [result, allNodes] = await runFilter({ hair: { ne: 2 } })
 
           expect(result.length).toEqual(2)
           expect(result[0].hair).toEqual(1)
         })
 
         it(`handles ne: true operator`, async () => {
-          let [result, allNodes] = await runFilter({ boolean: { ne: true } })
+          const [result, allNodes] = await runFilter({ boolean: { ne: true } })
 
           expect(result.length).toEqual(2)
         })
 
         it(`handles nested ne: true operator`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             waxOnly: { foo: { ne: true } },
           })
 
@@ -359,7 +359,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles ne operator with 0`, async () => {
-          let [result, allNodes] = await runFilter({ hair: { ne: 0 } })
+          const [result, allNodes] = await runFilter({ hair: { ne: 0 } })
 
           expect(result.length).toEqual(2)
         })
@@ -367,7 +367,7 @@ it(`should use the cache argument`, async () => {
         it(`handles ne operator with null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ nil: { ne: null } })
+          const [result, allNodes] = await runFilter({ nil: { ne: null } })
 
           // Should only return nodes who do have the property, not set to null
           expect(result.length).toEqual(1)
@@ -376,13 +376,13 @@ it(`should use the cache argument`, async () => {
 
         // grapqhl would never pass on `undefined`
         // it(`handles ne operator with undefined`, async () => {
-        //   let [result, allNodes] = await runFilter({ undef: { ne: undefined } })
+        //   const [result, allNodes] = await runFilter({ undef: { ne: undefined } })
         //
         //   expect(result.length).toEqual(?)
         // })
 
         it(`handles deeply nested ne: true operator`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             waxOnly: { bar: { baz: { ne: true } } },
           })
 
@@ -390,7 +390,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the ne operator for array field values`, async () => {
-          let [result, allNodes] = await runFilter({ anArray: { ne: 1 } })
+          const [result, allNodes] = await runFilter({ anArray: { ne: 1 } })
 
           expect(result.length).toBe(1)
           expect(result[0].index).toBe(2)
@@ -399,7 +399,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$lt`, () => {
         it(`handles lt operator with number`, async () => {
-          let [result, allNodes] = await runFilter({ hair: { lt: 2 } })
+          const [result, allNodes] = await runFilter({ hair: { lt: 2 } })
 
           expect(result.length).toEqual(2)
           result.forEach(r => expect(r.hair <= 2).toBe(true))
@@ -408,7 +408,7 @@ it(`should use the cache argument`, async () => {
         it(`handles lt operator with null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ nil: { lt: null } })
+          const [result, allNodes] = await runFilter({ nil: { lt: null } })
 
           // Nothing is lt null
           expect(result).toEqual(null)
@@ -417,9 +417,9 @@ it(`should use the cache argument`, async () => {
 
       describe(`$lte`, () => {
         it(`handles lte operator with number`, async () => {
-          let [result, allNodes] = await runFilter({ hair: { lte: 1 } })
+          const [result, allNodes] = await runFilter({ hair: { lte: 1 } })
 
-          let actual = allNodes.reduce(
+          const actual = allNodes.reduce(
             (acc, node) => (node.hair <= 1 ? acc + 1 : acc),
             0
           )
@@ -432,9 +432,9 @@ it(`should use the cache argument`, async () => {
         it(`should lte when value is lower than all found values`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ float: { lte: 1 } })
+          const [result, allNodes] = await runFilter({ float: { lte: 1 } })
 
-          let actual = allNodes.reduce(
+          const actual = allNodes.reduce(
             (acc, node) => (node.float <= 1 ? acc + 1 : acc),
             0
           )
@@ -444,9 +444,9 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`should lte when value is in the middle of all found values`, async () => {
-          let [result, allNodes] = await runFilter({ float: { lte: 2 } })
+          const [result, allNodes] = await runFilter({ float: { lte: 2 } })
 
-          let actual = allNodes.reduce(
+          const actual = allNodes.reduce(
             (acc, node) => (node.float <= 2 ? acc + 1 : acc),
             0
           )
@@ -456,9 +456,9 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`should lte when value is higher than all found values`, async () => {
-          let [result, allNodes] = await runFilter({ float: { lte: 5 } })
+          const [result, allNodes] = await runFilter({ float: { lte: 5 } })
 
-          let actual = allNodes.reduce(
+          const actual = allNodes.reduce(
             (acc, node) => (node.float <= 5 ? acc + 1 : acc),
             0
           )
@@ -470,9 +470,9 @@ it(`should use the cache argument`, async () => {
           // Here 1.5 exists but only as number. However, `1.5 <= '1.5' === true`
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
-          let [result, allNodes] = await runFilter({ float: { lte: `1.5` } })
+          const [result, allNodes] = await runFilter({ float: { lte: `1.5` } })
 
-          let actual = allNodes.reduce(
+          const actual = allNodes.reduce(
             (acc, node) => (node.float <= 1.5 ? acc + 1 : acc),
             0
           )
@@ -486,9 +486,9 @@ it(`should use the cache argument`, async () => {
         it(`handles lte operator with null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ nil: { lte: null } })
+          const [result, allNodes] = await runFilter({ nil: { lte: null } })
 
-          let actual = allNodes.reduce(
+          const actual = allNodes.reduce(
             (acc, node) => (node.nil <= null ? acc + 1 : acc),
             0
           )
@@ -503,7 +503,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$gt`, () => {
         it(`handles gt operator with number`, async () => {
-          let [result, allNodes] = await runFilter({ hair: { gt: 0 } })
+          const [result, allNodes] = await runFilter({ hair: { gt: 0 } })
 
           expect(result.length).toEqual(2)
           expect(result[0].hair).toEqual(1)
@@ -513,7 +513,7 @@ it(`should use the cache argument`, async () => {
         it(`handles gt operator with null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ nil: { gt: null } })
+          const [result, allNodes] = await runFilter({ nil: { gt: null } })
 
           // Nothing is gt null
           expect(result).toEqual(null)
@@ -522,9 +522,9 @@ it(`should use the cache argument`, async () => {
 
       describe(`$gte`, () => {
         it(`handles gte operator with number`, async () => {
-          let [result, allNodes] = await runFilter({ hair: { gte: 1 } })
+          const [result, allNodes] = await runFilter({ hair: { gte: 1 } })
 
-          let actual = allNodes.reduce(
+          const actual = allNodes.reduce(
             (acc, node) => (node.hair >= 1 ? acc + 1 : acc),
             0
           )
@@ -537,9 +537,9 @@ it(`should use the cache argument`, async () => {
         it(`handles gte operator with null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ nil: { gte: null } })
+          const [result, allNodes] = await runFilter({ nil: { gte: null } })
 
-          let actual = allNodes.reduce(
+          const actual = allNodes.reduce(
             (acc, node) => (node.nil >= null ? acc + 1 : acc),
             0
           )
@@ -556,7 +556,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$regex`, () => {
         it(`handles the regex operator without flags`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             name: { regex: `/^The.*Wax/` },
           })
 
@@ -566,7 +566,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the regex operator with i-flag`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             name: { regex: `/^the.*wax/i` },
           })
 
@@ -576,7 +576,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nested regex operator`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             nestedRegex: { field: { regex: `/.*/` } },
           })
 
@@ -588,7 +588,7 @@ it(`should use the cache argument`, async () => {
         it(`does not match double quote for string without it`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ name: { regex: `/"/` } })
+          const [result, allNodes] = await runFilter({ name: { regex: `/"/` } })
 
           expect(result).toEqual(null)
         })
@@ -596,7 +596,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$in`, () => {
         it(`handles the in operator for strings`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             string: { in: [`b`, `c`] },
           })
 
@@ -605,7 +605,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for ints`, async () => {
-          let [result, allNodes] = await runFilter({ index: { in: [0, 2] } })
+          const [result, allNodes] = await runFilter({ index: { in: [0, 2] } })
 
           expect(result.length).toEqual(2)
           expect(result[0].index).toEqual(0)
@@ -613,7 +613,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for floats`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             float: { in: [1.5, 2.5] },
           })
 
@@ -625,7 +625,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the in operator for just null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ nil: { in: [null] } })
+          const [result, allNodes] = await runFilter({ nil: { in: [null] } })
 
           // Do not include the nodes without a `nil` property
           expect(result.length).toEqual(2)
@@ -638,7 +638,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the in operator for double null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             nil: { in: [null, null] },
           })
 
@@ -653,7 +653,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the in operator for null in int and null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ nil: { in: [5, null] } })
+          const [result, allNodes] = await runFilter({ nil: { in: [5, null] } })
 
           // Include the nodes without a `nil` property
           expect(result.length).toEqual(2)
@@ -664,7 +664,9 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for int in int and null`, async () => {
-          let [result, allNodes] = await runFilter({ index: { in: [2, null] } })
+          const [result, allNodes] = await runFilter({
+            index: { in: [2, null] },
+          })
 
           // Include the nodes without a `index` property (there aren't any)
           expect(result.length).toEqual(1)
@@ -674,7 +676,9 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for booleans`, async () => {
-          let [result, allNodes] = await runFilter({ boolean: { in: [true] } })
+          const [result, allNodes] = await runFilter({
+            boolean: { in: [true] },
+          })
 
           expect(result.length).toEqual(1)
           expect(result[0].index).toEqual(0)
@@ -682,7 +686,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for array with one element`, async () => {
-          let [result, allNodes] = await runFilter({ anArray: { in: [5] } })
+          const [result, allNodes] = await runFilter({ anArray: { in: [5] } })
 
           // The first one has a 5, the second one does not have a 5, the third does
           // not have the property at all (NULL). It should return the first and last.
@@ -692,7 +696,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for array some elements`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             anArray: { in: [20, 5, 300] },
           })
 
@@ -702,7 +706,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nested in operator for array of strings`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             frontmatter: { tags: { in: [`moo`] } },
           })
 
@@ -713,7 +717,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$elemMatch`, () => {
         it(`handles the elemMatch operator on a proper single tree`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -734,7 +738,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator on the second element`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -755,7 +759,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`should return only one node if elemMatch hits multiples`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -780,7 +784,7 @@ it(`should use the cache argument`, async () => {
         it(`ignores the elemMatch operator on a partial sub tree`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -794,7 +798,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator for array of objects (1)`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             data: {
               tags: {
                 elemMatch: {
@@ -817,7 +821,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator for array of objects (2)`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             data: {
               tags: {
                 elemMatch: {
@@ -842,7 +846,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on boolean field`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             boolean: {
               elemMatch: {
                 eq: true,
@@ -858,7 +862,7 @@ it(`should use the cache argument`, async () => {
         it(`skips nodes without the field for elemMatch on boolean`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             boolSecondOnly: {
               elemMatch: {
                 eq: false,
@@ -874,7 +878,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on string field`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             string: {
               elemMatch: {
                 eq: `a`,
@@ -890,7 +894,7 @@ it(`should use the cache argument`, async () => {
         it(`should return all nodes for elemMatch on non-arrays too`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             name: {
               elemMatch: {
                 eq: `The Mad Wax`,
@@ -908,7 +912,7 @@ it(`should use the cache argument`, async () => {
         it(`skips nodes without the field for elemMatch on string`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             strSecondOnly: {
               elemMatch: {
                 eq: `needle`,
@@ -924,7 +928,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on number field`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             float: {
               elemMatch: {
                 eq: 1.5,
@@ -940,7 +944,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$nin`, () => {
         it(`handles the nin operator for array [5]`, async () => {
-          let [result, allNodes] = await runFilter({ anArray: { nin: [5] } })
+          const [result, allNodes] = await runFilter({ anArray: { nin: [5] } })
 
           // Since the array does not contain `null`, the query should also return the
           // nodes that do not have the field at all (NULL).
@@ -959,7 +963,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for array [null]`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             nullArray: { nin: [null] },
           })
 
@@ -971,7 +975,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for strings`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             string: { nin: [`b`, `c`] },
           })
 
@@ -983,7 +987,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for ints`, async () => {
-          let [result, allNodes] = await runFilter({ index: { nin: [0, 2] } })
+          const [result, allNodes] = await runFilter({ index: { nin: [0, 2] } })
 
           expect(result.length).toEqual(1)
           result.forEach(edge => {
@@ -993,7 +997,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for floats`, async () => {
-          let [result, allNodes] = await runFilter({ float: { nin: [1.5] } })
+          const [result, allNodes] = await runFilter({ float: { nin: [1.5] } })
 
           expect(result.length).toEqual(2)
           result.forEach(edge => {
@@ -1003,7 +1007,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for booleans`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             boolean: { nin: [true, null] },
           })
 
@@ -1019,7 +1023,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for double null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             nil: { nin: [null, null] },
           })
 
@@ -1035,7 +1039,9 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for null in int+null`, async () => {
           if (IS_LOKI) return
 
-          let [result, allNodes] = await runFilter({ nil: { nin: [5, null] } })
+          const [result, allNodes] = await runFilter({
+            nil: { nin: [5, null] },
+          })
 
           // Do not return the node that does not have the field because of `null`
           expect(result.length).toEqual(1)
@@ -1047,7 +1053,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for int in int+null`, async () => {
-          let [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFilter({
             index: { nin: [2, null] },
           })
 
@@ -1063,7 +1069,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$glob`, () => {
         it(`handles the glob operator`, async () => {
-          let [result, allNodes] = await runFilter({ name: { glob: `*Wax` } })
+          const [result, allNodes] = await runFilter({ name: { glob: `*Wax` } })
 
           expect(result.length).toEqual(2)
           expect(result[0].name).toEqual(`The Mad Wax`)
@@ -1072,7 +1078,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`date`, () => {
         it(`filters date fields`, async () => {
-          let [result, allNodes] = await runFilter({ date: { ne: null } })
+          const [result, allNodes] = await runFilter({ date: { ne: null } })
 
           expect(result.length).toEqual(2)
           expect(result[0].index).toEqual(0)

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -407,6 +407,8 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`does not coerce numbers against single-element arrays`, async () => {
+          if (IS_LOKI) return
+
           const needle = `8` // note: `('8' == [8]) === true`
           const [result] = await runFilter({
             singleArray: { eq: needle },

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -275,752 +275,778 @@ it(`should use the cache argument`, async () => {
 
   describe(desc, () => {
     describe(`Filter fields`, () => {
-      it(`handles eq operator with number value`, async () => {
-        let result = await runFilter({ hair: { eq: 2 } })
+      describe(`$eq`, () => {
+        it(`handles eq operator with number value`, async () => {
+          let result = await runFilter({ hair: { eq: 2 } })
 
-        expect(result.length).toEqual(1)
-        expect(result[0].hair).toEqual(2)
-      })
-
-      it(`handles eq operator with false value`, async () => {
-        let result = await runFilter({ boolean: { eq: false } })
-
-        expect(result.length).toEqual(1)
-        expect(result[0].name).toEqual(`The Mad Wax`)
-      })
-
-      it(`handles eq operator with 0`, async () => {
-        let result = await runFilter({ hair: { eq: 0 } })
-
-        expect(result.length).toEqual(1)
-        expect(result[0].hair).toEqual(0)
-      })
-
-      it(`handles eq operator with null`, async () => {
-        let result = await runFilter({ nil: { eq: null } })
-
-        // Also return nodes that do not have the property at all (NULL in db)
-        expect(result.length).toEqual(2)
-      })
-
-      // grapqhl would never pass on `undefined`
-      // it(`handles eq operator with undefined`, async () => {
-      //   let result = await runFilter({ undef: { eq: undefined } })
-      //
-      //   expect(result.length).toEqual(?)
-      //   expect(result[0].hair).toEqual(?)
-      // })
-
-      it(`handles eq operator with serialized array value`, async () => {
-        let result = await runFilter({ strArray: { eq: `[5,6,7,8]` } })
-
-        expect(result.length).toEqual(1)
-        expect(result[0].name).toEqual(`The Mad Wax`)
-      })
-
-      it(`handles ne operator`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ hair: { ne: 2 } })
-
-        expect(result.length).toEqual(2)
-        expect(result[0].hair).toEqual(1)
-      })
-
-      it(`handles ne: true operator`, async () => {
-        let result = await runFilter({ boolean: { ne: true } })
-
-        expect(result.length).toEqual(2)
-      })
-
-      it(`handles nested ne: true operator`, async () => {
-        let result = await runFilter({ waxOnly: { foo: { ne: true } } })
-
-        expect(result.length).toEqual(2)
-      })
-
-      it(`handles ne operator with 0`, async () => {
-        let result = await runFilter({ hair: { ne: 0 } })
-
-        expect(result.length).toEqual(2)
-      })
-
-      it(`handles ne operator with null`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ nil: { ne: null } })
-
-        // Should only return nodes who do have the property, not set to null
-        expect(result.length).toEqual(1)
-        expect(result[0].name).toEqual(`The Mad Max`)
-      })
-
-      // grapqhl would never pass on `undefined`
-      // it(`handles ne operator with undefined`, async () => {
-      //   let result = await runFilter({ undef: { ne: undefined } })
-      //
-      //   expect(result.length).toEqual(?)
-      // })
-
-      it(`handles deeply nested ne: true operator`, async () => {
-        let result = await runFilter({
-          waxOnly: { bar: { baz: { ne: true } } },
+          expect(result.length).toEqual(1)
+          expect(result[0].hair).toEqual(2)
         })
 
-        expect(result.length).toEqual(2)
-      })
+        it(`handles eq operator with false value`, async () => {
+          let result = await runFilter({ boolean: { eq: false } })
 
-      it(`handles lt operator with number`, async () => {
-        let result = await runFilter({ hair: { lt: 2 } })
-
-        expect(result.length).toEqual(2)
-        result.forEach(r => expect(r.hair <= 2).toBe(true))
-      })
-
-      it(`handles lt operator with null`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ nil: { lt: null } })
-
-        // Nothing is lt null
-        expect(result).toEqual(null)
-      })
-
-      it(`handles lte operator with number`, async () => {
-        let result = await runFilter({ hair: { lte: 1 } })
-
-        let actual = nodesAfterLastRunQuery.reduce(
-          (acc, node) => (node.hair <= 1 ? acc + 1 : acc),
-          0
-        )
-
-        expect(actual).not.toBe(0) // Test should keep this invariant!
-        expect(result.length).toEqual(actual)
-        result.forEach(r => expect(r.hair <= 1).toBe(true))
-      })
-
-      it(`should lte when value is lower than all found values`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ float: { lte: 1 } })
-
-        let actual = nodesAfterLastRunQuery.reduce(
-          (acc, node) => (node.float <= 1 ? acc + 1 : acc),
-          0
-        )
-
-        expect(actual).toEqual(0) // Make sure test nodes keep this invariant!
-        expect(result).toEqual(null) // Zero results yields null
-      })
-
-      it(`should lte when value is in the middle of all found values`, async () => {
-        let result = await runFilter({ float: { lte: 2 } })
-
-        let actual = nodesAfterLastRunQuery.reduce(
-          (acc, node) => (node.float <= 2 ? acc + 1 : acc),
-          0
-        )
-
-        expect(result.length).toEqual(actual)
-        result.forEach(r => expect(r.float <= 2).toBe(true))
-      })
-
-      it(`should lte when value is higher than all found values`, async () => {
-        let result = await runFilter({ float: { lte: 5 } })
-
-        let actual = nodesAfterLastRunQuery.reduce(
-          (acc, node) => (node.float <= 5 ? acc + 1 : acc),
-          0
-        )
-
-        expect(result.length).toEqual(actual)
-      })
-
-      it.skip(`should lte when type coercion fails direct value lookup`, async () => {
-        // Here 1.5 exists but only as number. However, `1.5 <= '1.5' === true`
-        // This test checks whether we don't incorrectly assume that if the
-        // value wasn't mapped, that it can't be found.
-        let result = await runFilter({ float: { lte: `1.5` } })
-
-        let actual = nodesAfterLastRunQuery.reduce(
-          (acc, node) => (node.float <= 1.5 ? acc + 1 : acc),
-          0
-        )
-
-        expect(result).not.toBe(undefined)
-        expect(result).not.toBe(null)
-        expect(result.length).toEqual(actual)
-        result.forEach(r => expect(r.float <= 2).toBe(true))
-      })
-
-      it(`handles lte operator with null`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ nil: { lte: null } })
-
-        let actual = nodesAfterLastRunQuery.reduce(
-          (acc, node) => (node.nil <= null ? acc + 1 : acc),
-          0
-        )
-
-        // lte null matches null but no nodes without the property (NULL)
-        expect(actual).not.toBe(0) // Test should keep this invariant!
-        expect(result.length).toEqual(actual)
-        expect(result[0].name).toEqual(`The Mad Wax`)
-        expect(result[0].nil).toEqual(null)
-      })
-
-      it(`handles gt operator with number`, async () => {
-        let result = await runFilter({ hair: { gt: 0 } })
-
-        expect(result.length).toEqual(2)
-        expect(result[0].hair).toEqual(1)
-        expect(result[1].hair).toEqual(2)
-      })
-
-      it(`handles gt operator with null`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ nil: { gt: null } })
-
-        // Nothing is gt null
-        expect(result).toEqual(null)
-      })
-
-      it(`handles gte operator with number`, async () => {
-        let result = await runFilter({ hair: { gte: 1 } })
-
-        let actual = nodesAfterLastRunQuery.reduce(
-          (acc, node) => (node.hair >= 1 ? acc + 1 : acc),
-          0
-        )
-
-        expect(actual).not.toBe(0) // Test invariant should hold
-        expect(result.length).toEqual(actual)
-        result.forEach(r => expect(r.hair >= 1).toBe(true))
-      })
-
-      it(`handles gte operator with null`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ nil: { gte: null } })
-
-        let actual = nodesAfterLastRunQuery.reduce(
-          (acc, node) => (node.nil >= null ? acc + 1 : acc),
-          0
-        )
-
-        // gte null matches null but no nodes without the property (NULL)
-        expect(actual).not.toBe(0) // Test invariant should hold
-        expect(result.length).toEqual(actual)
-        result.forEach(
-          // Note: confirm no `null` is returned for >= null
-          r => expect(r.nil === null).toBe(true)
-        )
-      })
-
-      it(`handles the regex operator without flags`, async () => {
-        let result = await runFilter({ name: { regex: `/^The.*Wax/` } })
-
-        expect(result.length).toEqual(2)
-        expect(result[0].name).toEqual(`The Mad Wax`)
-        expect(result[1].name).toEqual(`The Mad Wax`)
-      })
-
-      it(`handles the regex operator with i-flag`, async () => {
-        let result = await runFilter({ name: { regex: `/^the.*wax/i` } })
-
-        expect(result.length).toEqual(2)
-        expect(result[0].name).toEqual(`The Mad Wax`)
-        expect(result[1].name).toEqual(`The Mad Wax`)
-      })
-
-      it(`handles the nested regex operator`, async () => {
-        let result = await runFilter({
-          nestedRegex: { field: { regex: `/.*/` } },
+          expect(result.length).toEqual(1)
+          expect(result[0].name).toEqual(`The Mad Wax`)
         })
 
-        expect(result.length).toEqual(2)
-        expect(result[0].id).toEqual(`0`)
-        expect(result[1].id).toEqual(`1`)
-      })
+        it(`handles eq operator with 0`, async () => {
+          let result = await runFilter({ hair: { eq: 0 } })
 
-      it(`does not match double quote for string without it`, async () => {
-        if (IS_LOKI) return
+          expect(result.length).toEqual(1)
+          expect(result[0].hair).toEqual(0)
+        })
 
-        let result = await runFilter({ name: { regex: `/"/` } })
+        it(`handles eq operator with null`, async () => {
+          let result = await runFilter({ nil: { eq: null } })
 
-        expect(result).toEqual(null)
-      })
+          // Also return nodes that do not have the property at all (NULL in db)
+          expect(result.length).toEqual(2)
+        })
 
-      it(`handles the in operator for strings`, async () => {
-        let result = await runFilter({ string: { in: [`b`, `c`] } })
+        // grapqhl would never pass on `undefined`
+        // it(`handles eq operator with undefined`, async () => {
+        //   let result = await runFilter({ undef: { eq: undefined } })
+        //
+        //   expect(result.length).toEqual(?)
+        //   expect(result[0].hair).toEqual(?)
+        // })
 
-        expect(result.length).toEqual(2)
-        expect(result[0].index).toEqual(1)
-      })
+        it(`handles eq operator with serialized array value`, async () => {
+          let result = await runFilter({ strArray: { eq: `[5,6,7,8]` } })
 
-      it(`handles the in operator for ints`, async () => {
-        let result = await runFilter({ index: { in: [0, 2] } })
+          expect(result.length).toEqual(1)
+          expect(result[0].name).toEqual(`The Mad Wax`)
+        })
 
-        expect(result.length).toEqual(2)
-        expect(result[0].index).toEqual(0)
-        expect(result[1].index).toEqual(2)
-      })
+        it(`handles the eq operator for array field values`, async () => {
+          const result = await runFilter({ anArray: { eq: 5 } })
 
-      it(`handles the in operator for floats`, async () => {
-        let result = await runFilter({ float: { in: [1.5, 2.5] } })
-
-        expect(result.length).toEqual(2)
-        expect(result[0].index).toEqual(0)
-        expect(result[1].index).toEqual(1)
-      })
-
-      it(`handles the in operator for just null`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ nil: { in: [null] } })
-
-        // Do not include the nodes without a `nil` property
-        expect(result.length).toEqual(2)
-        result.forEach(edge => {
-          // May not have the property, or must be null
-          expect(edge.nil === undefined || edge.nil === null).toBe(true)
+          expect(result.length).toBe(1)
+          expect(result[0].index).toBe(1)
         })
       })
 
-      it(`handles the in operator for double null`, async () => {
-        if (IS_LOKI) return
+      describe(`$ne`, () => {
+        it(`handles ne operator`, async () => {
+          if (IS_LOKI) return
 
-        let result = await runFilter({ nil: { in: [null, null] } })
+          let result = await runFilter({ hair: { ne: 2 } })
 
-        // Do not include the nodes without a `nil` property
-        expect(result.length).toEqual(2)
-        result.forEach(edge => {
-          // May not have the property, or must be null
-          expect(edge.nil === undefined || edge.nil === null).toBe(true)
-        })
-      })
-
-      it(`handles the in operator for null in int and null`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({ nil: { in: [5, null] } })
-
-        // Include the nodes without a `nil` property
-        expect(result.length).toEqual(2)
-        result.forEach(edge => {
-          // May not have the property, or must be null
-          expect(edge.nil === undefined || edge.nil === null).toBe(true)
-        })
-      })
-
-      it(`handles the in operator for int in int and null`, async () => {
-        let result = await runFilter({ index: { in: [2, null] } })
-
-        // Include the nodes without a `index` property (there aren't any)
-        expect(result.length).toEqual(1)
-        result.forEach(edge => {
-          expect(edge.index === 2).toBe(true)
-        })
-      })
-
-      it(`handles the in operator for booleans`, async () => {
-        let result = await runFilter({ boolean: { in: [true] } })
-
-        expect(result.length).toEqual(1)
-        expect(result[0].index).toEqual(0)
-        expect(result[0].boolean).toEqual(true)
-      })
-
-      it(`handles the in operator for array with one element`, async () => {
-        let result = await runFilter({ anArray: { in: [5] } })
-
-        // The first one has a 5, the second one does not have a 5, the third does
-        // not have the property at all (NULL). It should return the first and last.
-        // (If the target value has `null` then the third should be omitted)
-        expect(result.length).toEqual(1)
-        expect(result[0].name).toEqual(`The Mad Wax`)
-      })
-
-      it(`handles the in operator for array some elements`, async () => {
-        let result = await runFilter({ anArray: { in: [20, 5, 300] } })
-
-        // Same as the test for just `[5]`. 20 and 300 do not appear anywhere.
-        expect(result.length).toEqual(1)
-        expect(result[0].name).toEqual(`The Mad Wax`)
-      })
-
-      it(`handles the nested in operator for array of strings`, async () => {
-        let result = await runFilter({ frontmatter: { tags: { in: [`moo`] } } })
-
-        expect(result.length).toEqual(1)
-        expect(result[0].name).toEqual(`The Mad Max`)
-      })
-
-      it(`handles the elemMatch operator on a proper single tree`, async () => {
-        let result = await runFilter({
-          singleElem: {
-            things: {
-              elemMatch: {
-                one: {
-                  two: {
-                    three: { eq: 123 },
-                  },
-                },
-              },
-            },
-          },
+          expect(result.length).toEqual(2)
+          expect(result[0].hair).toEqual(1)
         })
 
-        expect(result.length).toEqual(1)
-        expect(
-          result[0]?.singleElem?.things.some(e => e?.one?.two?.three === 123)
-        ).toEqual(true)
-      })
+        it(`handles ne: true operator`, async () => {
+          let result = await runFilter({ boolean: { ne: true } })
 
-      it(`handles the elemMatch operator on the second element`, async () => {
-        let result = await runFilter({
-          singleElem: {
-            things: {
-              elemMatch: {
-                one: {
-                  five: {
-                    three: { eq: 153 },
-                  },
-                },
-              },
-            },
-          },
+          expect(result.length).toEqual(2)
         })
 
-        expect(result.length).toEqual(1)
-        // Should contain the entire array even only one matched
-        expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
-        expect(result[0].singleElem.things[1].one.five.three).toEqual(153)
-      })
+        it(`handles nested ne: true operator`, async () => {
+          let result = await runFilter({ waxOnly: { foo: { ne: true } } })
 
-      it(`should return only one node if elemMatch hits multiples`, async () => {
-        let result = await runFilter({
-          singleElem: {
-            things: {
-              elemMatch: {
-                one: {
-                  two: {
-                    three: { lt: 1000 }, // one match is 123, the other 404
-                  },
-                },
-              },
-            },
-          },
+          expect(result.length).toEqual(2)
         })
 
-        // The `elemMatch` operator only returns the first nodde that matches so
-        // even though the `lt 1000` would match two elements in the `things` array
-        // it will return one node.
-        expect(result.length).toEqual(1)
-        expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
-        expect(result[0].singleElem.things[2].one.two.three).toEqual(404)
-      })
+        it(`handles ne operator with 0`, async () => {
+          let result = await runFilter({ hair: { ne: 0 } })
 
-      it(`ignores the elemMatch operator on a partial sub tree`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({
-          singleElem: {
-            things: {
-              elemMatch: {
-                three: { eq: 123 },
-              },
-            },
-          },
+          expect(result.length).toEqual(2)
         })
 
-        expect(result).toEqual(null)
-      })
+        it(`handles ne operator with null`, async () => {
+          if (IS_LOKI) return
 
-      it(`handles the elemMatch operator for array of objects (1)`, async () => {
-        let result = await runFilter({
-          data: {
-            tags: {
-              elemMatch: {
-                tag: {
-                  document: {
-                    elemMatch: {
-                      data: {
-                        tag: { eq: `Gatsby` },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
+          let result = await runFilter({ nil: { ne: null } })
+
+          // Should only return nodes who do have the property, not set to null
+          expect(result.length).toEqual(1)
+          expect(result[0].name).toEqual(`The Mad Max`)
         })
 
-        expect(result.length).toEqual(1)
-        expect(result[0].index).toEqual(2)
-      })
+        // grapqhl would never pass on `undefined`
+        // it(`handles ne operator with undefined`, async () => {
+        //   let result = await runFilter({ undef: { ne: undefined } })
+        //
+        //   expect(result.length).toEqual(?)
+        // })
 
-      it(`handles the elemMatch operator for array of objects (2)`, async () => {
-        let result = await runFilter({
-          data: {
-            tags: {
-              elemMatch: {
-                tag: {
-                  document: {
-                    elemMatch: {
-                      data: {
-                        tag: { eq: `Design System` },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        })
-
-        expect(result.length).toEqual(1)
-        expect(result[0].index).toEqual(2)
-      })
-
-      it(`works for elemMatch on boolean field`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({
-          boolean: {
-            elemMatch: {
-              eq: true,
-            },
-          },
-        })
-
-        // Does NOT contain nodes that do not have the field
-        expect(result.length).toEqual(1)
-        expect(result[0].boolean).toEqual(true)
-      })
-
-      it(`skips nodes without the field for elemMatch on boolean`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({
-          boolSecondOnly: {
-            elemMatch: {
-              eq: false,
-            },
-          },
-        })
-
-        // Does NOT contain nodes that do not have the field so returns 2nd node
-        expect(result.length).toEqual(1)
-        expect(result[0].boolSecondOnly).toEqual(false)
-      })
-
-      it(`works for elemMatch on string field`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({
-          string: {
-            elemMatch: {
-              eq: `a`,
-            },
-          },
-        })
-
-        // Does NOT contain nodes that do not have the field
-        expect(result.length).toEqual(1)
-        expect(result[0].string).toEqual(`a`)
-      })
-
-      it(`should return all nodes for elemMatch on non-arrays too`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({
-          name: {
-            elemMatch: {
-              eq: `The Mad Wax`,
-            },
-          },
-        })
-
-        // Can return more than one node
-        // Does NOT contain nodes that do not have the field
-        expect(result.length).toEqual(2)
-        expect(result[0].name).toEqual(`The Mad Wax`)
-        expect(result[1].name).toEqual(`The Mad Wax`)
-      })
-
-      it(`skips nodes without the field for elemMatch on string`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({
-          strSecondOnly: {
-            elemMatch: {
-              eq: `needle`,
-            },
-          },
-        })
-
-        // Does NOT contain nodes that do not have the field so returns 2nd node
-        expect(result.length).toEqual(1)
-        expect(result[0].strSecondOnly).toEqual(`needle`)
-      })
-
-      it(`works for elemMatch on number field`, async () => {
-        if (IS_LOKI) return
-
-        let result = await runFilter({
-          float: {
-            elemMatch: {
-              eq: 1.5,
-            },
-          },
-        })
-
-        // Does NOT contain nodes that do not have the field
-        expect(result.length).toEqual(1)
-        expect(result[0].float).toEqual(1.5)
-      })
-
-      it(`handles the nin operator for array [5]`, async () => {
-        let result = await runFilter({ anArray: { nin: [5] } })
-
-        // Since the array does not contain `null`, the query should also return the
-        // nodes that do not have the field at all (NULL).
-
-        expect(result.length).toEqual(2)
-        // Either does not exist or does not contain
-        result
-          .filter(edge => edge.anArray !== undefined)
-          .forEach(edge => {
-            // In this test, if the property exists it should be an array
-            expect(Array.isArray(edge.anArray)).toBe(true)
-            expect(edge.anArray.includes(5)).toBe(false)
+        it(`handles deeply nested ne: true operator`, async () => {
+          let result = await runFilter({
+            waxOnly: { bar: { baz: { ne: true } } },
           })
-      })
 
-      it(`handles the nin operator for array [null]`, async () => {
-        if (IS_LOKI) return
+          expect(result.length).toEqual(2)
+        })
 
-        let result = await runFilter({ nullArray: { nin: [null] } })
+        it(`handles the ne operator for array field values`, async () => {
+          const result = await runFilter({ anArray: { ne: 1 } })
 
-        // Since the array contains `null`, the query should NOT return the
-        // nodes that do not have the field at all (NULL).
-
-        expect(result.length).toEqual(1)
-        expect(result[0].nullArray.includes(null)).toBe(false)
-      })
-
-      it(`handles the nin operator for strings`, async () => {
-        let result = await runFilter({ string: { nin: [`b`, `c`] } })
-
-        expect(result.length).toEqual(1)
-        result.forEach(edge => {
-          expect(edge.string).not.toEqual(`b`)
-          expect(edge.string).not.toEqual(`c`)
+          expect(result.length).toBe(1)
+          expect(result[0].index).toBe(2)
         })
       })
 
-      it(`handles the nin operator for ints`, async () => {
-        let result = await runFilter({ index: { nin: [0, 2] } })
+      describe(`$lt`, () => {
+        it(`handles lt operator with number`, async () => {
+          let result = await runFilter({ hair: { lt: 2 } })
 
-        expect(result.length).toEqual(1)
-        result.forEach(edge => {
-          expect(edge.index).not.toEqual(0)
-          expect(edge.index).not.toEqual(2)
+          expect(result.length).toEqual(2)
+          result.forEach(r => expect(r.hair <= 2).toBe(true))
+        })
+
+        it(`handles lt operator with null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { lt: null } })
+
+          // Nothing is lt null
+          expect(result).toEqual(null)
         })
       })
 
-      it(`handles the nin operator for floats`, async () => {
-        let result = await runFilter({ float: { nin: [1.5] } })
+      describe(`$lte`, () => {
+        it(`handles lte operator with number`, async () => {
+          let result = await runFilter({ hair: { lte: 1 } })
 
-        expect(result.length).toEqual(2)
-        result.forEach(edge => {
-          // Might not have the property (-> undefined), must not be 1.5
-          expect(edge.float).not.toEqual(1.5)
+          let actual = nodesAfterLastRunQuery.reduce(
+            (acc, node) => (node.hair <= 1 ? acc + 1 : acc),
+            0
+          )
+
+          expect(actual).not.toBe(0) // Test should keep this invariant!
+          expect(result.length).toEqual(actual)
+          result.forEach(r => expect(r.hair <= 1).toBe(true))
+        })
+
+        it(`should lte when value is lower than all found values`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ float: { lte: 1 } })
+
+          let actual = nodesAfterLastRunQuery.reduce(
+            (acc, node) => (node.float <= 1 ? acc + 1 : acc),
+            0
+          )
+
+          expect(actual).toEqual(0) // Make sure test nodes keep this invariant!
+          expect(result).toEqual(null) // Zero results yields null
+        })
+
+        it(`should lte when value is in the middle of all found values`, async () => {
+          let result = await runFilter({ float: { lte: 2 } })
+
+          let actual = nodesAfterLastRunQuery.reduce(
+            (acc, node) => (node.float <= 2 ? acc + 1 : acc),
+            0
+          )
+
+          expect(result.length).toEqual(actual)
+          result.forEach(r => expect(r.float <= 2).toBe(true))
+        })
+
+        it(`should lte when value is higher than all found values`, async () => {
+          let result = await runFilter({ float: { lte: 5 } })
+
+          let actual = nodesAfterLastRunQuery.reduce(
+            (acc, node) => (node.float <= 5 ? acc + 1 : acc),
+            0
+          )
+
+          expect(result.length).toEqual(actual)
+        })
+
+        it.skip(`should lte when type coercion fails direct value lookup`, async () => {
+          // Here 1.5 exists but only as number. However, `1.5 <= '1.5' === true`
+          // This test checks whether we don't incorrectly assume that if the
+          // value wasn't mapped, that it can't be found.
+          let result = await runFilter({ float: { lte: `1.5` } })
+
+          let actual = nodesAfterLastRunQuery.reduce(
+            (acc, node) => (node.float <= 1.5 ? acc + 1 : acc),
+            0
+          )
+
+          expect(result).not.toBe(undefined)
+          expect(result).not.toBe(null)
+          expect(result.length).toEqual(actual)
+          result.forEach(r => expect(r.float <= 2).toBe(true))
+        })
+
+        it(`handles lte operator with null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { lte: null } })
+
+          let actual = nodesAfterLastRunQuery.reduce(
+            (acc, node) => (node.nil <= null ? acc + 1 : acc),
+            0
+          )
+
+          // lte null matches null but no nodes without the property (NULL)
+          expect(actual).not.toBe(0) // Test should keep this invariant!
+          expect(result.length).toEqual(actual)
+          expect(result[0].name).toEqual(`The Mad Wax`)
+          expect(result[0].nil).toEqual(null)
         })
       })
 
-      it(`handles the nin operator for booleans`, async () => {
-        let result = await runFilter({ boolean: { nin: [true, null] } })
+      describe(`$gt`, () => {
+        it(`handles gt operator with number`, async () => {
+          let result = await runFilter({ hair: { gt: 0 } })
 
-        // Do not return the node that does not have the field because of `null`
-        expect(result.length).toEqual(1)
-        result.forEach(edge => {
-          // Must have the property, must not be true nor null
-          expect(edge.boolean !== undefined).toBe(true)
-          expect(edge.boolean !== true && edge.boolean !== null).toBe(true)
+          expect(result.length).toEqual(2)
+          expect(result[0].hair).toEqual(1)
+          expect(result[1].hair).toEqual(2)
+        })
+
+        it(`handles gt operator with null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { gt: null } })
+
+          // Nothing is gt null
+          expect(result).toEqual(null)
         })
       })
 
-      it(`handles the nin operator for double null`, async () => {
-        if (IS_LOKI) return
+      describe(`$gte`, () => {
+        it(`handles gte operator with number`, async () => {
+          let result = await runFilter({ hair: { gte: 1 } })
 
-        let result = await runFilter({ nil: { nin: [null, null] } })
+          let actual = nodesAfterLastRunQuery.reduce(
+            (acc, node) => (node.hair >= 1 ? acc + 1 : acc),
+            0
+          )
 
-        // Do not return the node that does not have the field because of `null`
-        expect(result.length).toEqual(1)
-        result.forEach(edge => {
-          // Must have the property, must not be null
-          expect(edge.nil !== undefined).toBe(true)
-          expect(edge.nil !== null).toBe(true)
+          expect(actual).not.toBe(0) // Test invariant should hold
+          expect(result.length).toEqual(actual)
+          result.forEach(r => expect(r.hair >= 1).toBe(true))
+        })
+
+        it(`handles gte operator with null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { gte: null } })
+
+          let actual = nodesAfterLastRunQuery.reduce(
+            (acc, node) => (node.nil >= null ? acc + 1 : acc),
+            0
+          )
+
+          // gte null matches null but no nodes without the property (NULL)
+          expect(actual).not.toBe(0) // Test invariant should hold
+          expect(result.length).toEqual(actual)
+          result.forEach(
+            // Note: confirm no `null` is returned for >= null
+            r => expect(r.nil === null).toBe(true)
+          )
         })
       })
 
-      it(`handles the nin operator for null in int+null`, async () => {
-        if (IS_LOKI) return
+      describe(`$regex`, () => {
+        it(`handles the regex operator without flags`, async () => {
+          let result = await runFilter({ name: { regex: `/^The.*Wax/` } })
 
-        let result = await runFilter({ nil: { nin: [5, null] } })
+          expect(result.length).toEqual(2)
+          expect(result[0].name).toEqual(`The Mad Wax`)
+          expect(result[1].name).toEqual(`The Mad Wax`)
+        })
 
-        // Do not return the node that does not have the field because of `null`
-        expect(result.length).toEqual(1)
-        result.forEach(edge => {
-          // Must have the property, must not be 5 nor null
-          expect(edge.nil !== undefined).toBe(true)
-          expect(edge.nil !== 5 && edge.nil !== null).toBe(true)
+        it(`handles the regex operator with i-flag`, async () => {
+          let result = await runFilter({ name: { regex: `/^the.*wax/i` } })
+
+          expect(result.length).toEqual(2)
+          expect(result[0].name).toEqual(`The Mad Wax`)
+          expect(result[1].name).toEqual(`The Mad Wax`)
+        })
+
+        it(`handles the nested regex operator`, async () => {
+          let result = await runFilter({
+            nestedRegex: { field: { regex: `/.*/` } },
+          })
+
+          expect(result.length).toEqual(2)
+          expect(result[0].id).toEqual(`0`)
+          expect(result[1].id).toEqual(`1`)
+        })
+
+        it(`does not match double quote for string without it`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ name: { regex: `/"/` } })
+
+          expect(result).toEqual(null)
         })
       })
 
-      it(`handles the nin operator for int in int+null`, async () => {
-        let result = await runFilter({ index: { nin: [2, null] } })
+      describe(`$in`, () => {
+        it(`handles the in operator for strings`, async () => {
+          let result = await runFilter({ string: { in: [`b`, `c`] } })
 
-        // Do not return the node that does not have the field because of `null`
-        expect(result.length).toEqual(2)
-        result.forEach(edge => {
-          // Must have the property, must not be 2 nor null
-          expect(edge.index !== undefined).toBe(true)
-          expect(edge.index !== 2 && edge.index !== null).toBe(true)
+          expect(result.length).toEqual(2)
+          expect(result[0].index).toEqual(1)
+        })
+
+        it(`handles the in operator for ints`, async () => {
+          let result = await runFilter({ index: { in: [0, 2] } })
+
+          expect(result.length).toEqual(2)
+          expect(result[0].index).toEqual(0)
+          expect(result[1].index).toEqual(2)
+        })
+
+        it(`handles the in operator for floats`, async () => {
+          let result = await runFilter({ float: { in: [1.5, 2.5] } })
+
+          expect(result.length).toEqual(2)
+          expect(result[0].index).toEqual(0)
+          expect(result[1].index).toEqual(1)
+        })
+
+        it(`handles the in operator for just null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { in: [null] } })
+
+          // Do not include the nodes without a `nil` property
+          expect(result.length).toEqual(2)
+          result.forEach(edge => {
+            // May not have the property, or must be null
+            expect(edge.nil === undefined || edge.nil === null).toBe(true)
+          })
+        })
+
+        it(`handles the in operator for double null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { in: [null, null] } })
+
+          // Do not include the nodes without a `nil` property
+          expect(result.length).toEqual(2)
+          result.forEach(edge => {
+            // May not have the property, or must be null
+            expect(edge.nil === undefined || edge.nil === null).toBe(true)
+          })
+        })
+
+        it(`handles the in operator for null in int and null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { in: [5, null] } })
+
+          // Include the nodes without a `nil` property
+          expect(result.length).toEqual(2)
+          result.forEach(edge => {
+            // May not have the property, or must be null
+            expect(edge.nil === undefined || edge.nil === null).toBe(true)
+          })
+        })
+
+        it(`handles the in operator for int in int and null`, async () => {
+          let result = await runFilter({ index: { in: [2, null] } })
+
+          // Include the nodes without a `index` property (there aren't any)
+          expect(result.length).toEqual(1)
+          result.forEach(edge => {
+            expect(edge.index === 2).toBe(true)
+          })
+        })
+
+        it(`handles the in operator for booleans`, async () => {
+          let result = await runFilter({ boolean: { in: [true] } })
+
+          expect(result.length).toEqual(1)
+          expect(result[0].index).toEqual(0)
+          expect(result[0].boolean).toEqual(true)
+        })
+
+        it(`handles the in operator for array with one element`, async () => {
+          let result = await runFilter({ anArray: { in: [5] } })
+
+          // The first one has a 5, the second one does not have a 5, the third does
+          // not have the property at all (NULL). It should return the first and last.
+          // (If the target value has `null` then the third should be omitted)
+          expect(result.length).toEqual(1)
+          expect(result[0].name).toEqual(`The Mad Wax`)
+        })
+
+        it(`handles the in operator for array some elements`, async () => {
+          let result = await runFilter({ anArray: { in: [20, 5, 300] } })
+
+          // Same as the test for just `[5]`. 20 and 300 do not appear anywhere.
+          expect(result.length).toEqual(1)
+          expect(result[0].name).toEqual(`The Mad Wax`)
+        })
+
+        it(`handles the nested in operator for array of strings`, async () => {
+          let result = await runFilter({
+            frontmatter: { tags: { in: [`moo`] } },
+          })
+
+          expect(result.length).toEqual(1)
+          expect(result[0].name).toEqual(`The Mad Max`)
         })
       })
 
-      it(`handles the glob operator`, async () => {
-        let result = await runFilter({ name: { glob: `*Wax` } })
+      describe(`$elemMatch`, () => {
+        it(`handles the elemMatch operator on a proper single tree`, async () => {
+          let result = await runFilter({
+            singleElem: {
+              things: {
+                elemMatch: {
+                  one: {
+                    two: {
+                      three: { eq: 123 },
+                    },
+                  },
+                },
+              },
+            },
+          })
 
-        expect(result.length).toEqual(2)
-        expect(result[0].name).toEqual(`The Mad Wax`)
+          expect(result.length).toEqual(1)
+          expect(
+            result[0]?.singleElem?.things.some(e => e?.one?.two?.three === 123)
+          ).toEqual(true)
+        })
+
+        it(`handles the elemMatch operator on the second element`, async () => {
+          let result = await runFilter({
+            singleElem: {
+              things: {
+                elemMatch: {
+                  one: {
+                    five: {
+                      three: { eq: 153 },
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          expect(result.length).toEqual(1)
+          // Should contain the entire array even only one matched
+          expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
+          expect(result[0].singleElem.things[1].one.five.three).toEqual(153)
+        })
+
+        it(`should return only one node if elemMatch hits multiples`, async () => {
+          let result = await runFilter({
+            singleElem: {
+              things: {
+                elemMatch: {
+                  one: {
+                    two: {
+                      three: { lt: 1000 }, // one match is 123, the other 404
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          // The `elemMatch` operator only returns the first nodde that matches so
+          // even though the `lt 1000` would match two elements in the `things` array
+          // it will return one node.
+          expect(result.length).toEqual(1)
+          expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
+          expect(result[0].singleElem.things[2].one.two.three).toEqual(404)
+        })
+
+        it(`ignores the elemMatch operator on a partial sub tree`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({
+            singleElem: {
+              things: {
+                elemMatch: {
+                  three: { eq: 123 },
+                },
+              },
+            },
+          })
+
+          expect(result).toEqual(null)
+        })
+
+        it(`handles the elemMatch operator for array of objects (1)`, async () => {
+          let result = await runFilter({
+            data: {
+              tags: {
+                elemMatch: {
+                  tag: {
+                    document: {
+                      elemMatch: {
+                        data: {
+                          tag: { eq: `Gatsby` },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          expect(result.length).toEqual(1)
+          expect(result[0].index).toEqual(2)
+        })
+
+        it(`handles the elemMatch operator for array of objects (2)`, async () => {
+          let result = await runFilter({
+            data: {
+              tags: {
+                elemMatch: {
+                  tag: {
+                    document: {
+                      elemMatch: {
+                        data: {
+                          tag: { eq: `Design System` },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          expect(result.length).toEqual(1)
+          expect(result[0].index).toEqual(2)
+        })
+
+        it(`works for elemMatch on boolean field`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({
+            boolean: {
+              elemMatch: {
+                eq: true,
+              },
+            },
+          })
+
+          // Does NOT contain nodes that do not have the field
+          expect(result.length).toEqual(1)
+          expect(result[0].boolean).toEqual(true)
+        })
+
+        it(`skips nodes without the field for elemMatch on boolean`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({
+            boolSecondOnly: {
+              elemMatch: {
+                eq: false,
+              },
+            },
+          })
+
+          // Does NOT contain nodes that do not have the field so returns 2nd node
+          expect(result.length).toEqual(1)
+          expect(result[0].boolSecondOnly).toEqual(false)
+        })
+
+        it(`works for elemMatch on string field`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({
+            string: {
+              elemMatch: {
+                eq: `a`,
+              },
+            },
+          })
+
+          // Does NOT contain nodes that do not have the field
+          expect(result.length).toEqual(1)
+          expect(result[0].string).toEqual(`a`)
+        })
+
+        it(`should return all nodes for elemMatch on non-arrays too`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({
+            name: {
+              elemMatch: {
+                eq: `The Mad Wax`,
+              },
+            },
+          })
+
+          // Can return more than one node
+          // Does NOT contain nodes that do not have the field
+          expect(result.length).toEqual(2)
+          expect(result[0].name).toEqual(`The Mad Wax`)
+          expect(result[1].name).toEqual(`The Mad Wax`)
+        })
+
+        it(`skips nodes without the field for elemMatch on string`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({
+            strSecondOnly: {
+              elemMatch: {
+                eq: `needle`,
+              },
+            },
+          })
+
+          // Does NOT contain nodes that do not have the field so returns 2nd node
+          expect(result.length).toEqual(1)
+          expect(result[0].strSecondOnly).toEqual(`needle`)
+        })
+
+        it(`works for elemMatch on number field`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({
+            float: {
+              elemMatch: {
+                eq: 1.5,
+              },
+            },
+          })
+
+          // Does NOT contain nodes that do not have the field
+          expect(result.length).toEqual(1)
+          expect(result[0].float).toEqual(1.5)
+        })
       })
 
-      it(`filters date fields`, async () => {
-        let result = await runFilter({ date: { ne: null } })
+      describe(`$nin`, () => {
+        it(`handles the nin operator for array [5]`, async () => {
+          let result = await runFilter({ anArray: { nin: [5] } })
 
-        expect(result.length).toEqual(2)
-        expect(result[0].index).toEqual(0)
-        expect(result[1].index).toEqual(2)
+          // Since the array does not contain `null`, the query should also return the
+          // nodes that do not have the field at all (NULL).
+
+          expect(result.length).toEqual(2)
+          // Either does not exist or does not contain
+          result
+            .filter(edge => edge.anArray !== undefined)
+            .forEach(edge => {
+              // In this test, if the property exists it should be an array
+              expect(Array.isArray(edge.anArray)).toBe(true)
+              expect(edge.anArray.includes(5)).toBe(false)
+            })
+        })
+
+        it(`handles the nin operator for array [null]`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nullArray: { nin: [null] } })
+
+          // Since the array contains `null`, the query should NOT return the
+          // nodes that do not have the field at all (NULL).
+
+          expect(result.length).toEqual(1)
+          expect(result[0].nullArray.includes(null)).toBe(false)
+        })
+
+        it(`handles the nin operator for strings`, async () => {
+          let result = await runFilter({ string: { nin: [`b`, `c`] } })
+
+          expect(result.length).toEqual(1)
+          result.forEach(edge => {
+            expect(edge.string).not.toEqual(`b`)
+            expect(edge.string).not.toEqual(`c`)
+          })
+        })
+
+        it(`handles the nin operator for ints`, async () => {
+          let result = await runFilter({ index: { nin: [0, 2] } })
+
+          expect(result.length).toEqual(1)
+          result.forEach(edge => {
+            expect(edge.index).not.toEqual(0)
+            expect(edge.index).not.toEqual(2)
+          })
+        })
+
+        it(`handles the nin operator for floats`, async () => {
+          let result = await runFilter({ float: { nin: [1.5] } })
+
+          expect(result.length).toEqual(2)
+          result.forEach(edge => {
+            // Might not have the property (-> undefined), must not be 1.5
+            expect(edge.float).not.toEqual(1.5)
+          })
+        })
+
+        it(`handles the nin operator for booleans`, async () => {
+          let result = await runFilter({ boolean: { nin: [true, null] } })
+
+          // Do not return the node that does not have the field because of `null`
+          expect(result.length).toEqual(1)
+          result.forEach(edge => {
+            // Must have the property, must not be true nor null
+            expect(edge.boolean !== undefined).toBe(true)
+            expect(edge.boolean !== true && edge.boolean !== null).toBe(true)
+          })
+        })
+
+        it(`handles the nin operator for double null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { nin: [null, null] } })
+
+          // Do not return the node that does not have the field because of `null`
+          expect(result.length).toEqual(1)
+          result.forEach(edge => {
+            // Must have the property, must not be null
+            expect(edge.nil !== undefined).toBe(true)
+            expect(edge.nil !== null).toBe(true)
+          })
+        })
+
+        it(`handles the nin operator for null in int+null`, async () => {
+          if (IS_LOKI) return
+
+          let result = await runFilter({ nil: { nin: [5, null] } })
+
+          // Do not return the node that does not have the field because of `null`
+          expect(result.length).toEqual(1)
+          result.forEach(edge => {
+            // Must have the property, must not be 5 nor null
+            expect(edge.nil !== undefined).toBe(true)
+            expect(edge.nil !== 5 && edge.nil !== null).toBe(true)
+          })
+        })
+
+        it(`handles the nin operator for int in int+null`, async () => {
+          let result = await runFilter({ index: { nin: [2, null] } })
+
+          // Do not return the node that does not have the field because of `null`
+          expect(result.length).toEqual(2)
+          result.forEach(edge => {
+            // Must have the property, must not be 2 nor null
+            expect(edge.index !== undefined).toBe(true)
+            expect(edge.index !== 2 && edge.index !== null).toBe(true)
+          })
+        })
       })
 
-      it(`handles the eq operator for array field values`, async () => {
-        const result = await runFilter({ anArray: { eq: 5 } })
+      describe(`$glob`, () => {
+        it(`handles the glob operator`, async () => {
+          let result = await runFilter({ name: { glob: `*Wax` } })
 
-        expect(result.length).toBe(1)
-        expect(result[0].index).toBe(1)
+          expect(result.length).toEqual(2)
+          expect(result[0].name).toEqual(`The Mad Wax`)
+        })
       })
 
-      it(`handles the ne operator for array field values`, async () => {
-        const result = await runFilter({ anArray: { ne: 1 } })
+      describe(`date`, () => {
+        it(`filters date fields`, async () => {
+          let result = await runFilter({ date: { ne: null } })
 
-        expect(result.length).toBe(1)
-        expect(result[0].index).toBe(2)
+          expect(result.length).toEqual(2)
+          expect(result[0].index).toEqual(0)
+          expect(result[1].index).toEqual(2)
+        })
       })
     })
 

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -272,7 +272,7 @@ it(`should use the cache argument`, async () => {
   if (IS_LOKI) return
 
   const filtersCache = new Map()
-  const [result, allNodes] = await runFilterOnCache(
+  const [result] = await runFilterOnCache(
     { hair: { eq: 2 } },
     filtersCache
   )
@@ -285,7 +285,7 @@ it(`should use the cache argument`, async () => {
   expect(filtersCache.size === 1).toBe(true)
   filtersCache.forEach((
     filterCache /*: FilterCache */,
-    cacheKey /*: FilterCacheKey */
+    //cacheKey /*: FilterCacheKey */
   ) => {
     // This test will change when the composition of the FilterCache changes
     // For now it should be a Map of values to Set of nodes
@@ -409,7 +409,7 @@ it(`should use the cache argument`, async () => {
 
         it(`does not coerce numbers against single-element arrays`, async () => {
           const needle = `8` // note: `('8' == [8]) === true`
-          const [result, allNodes] = await runFilter({
+          const [result] = await runFilter({
             singleArray: { eq: needle },
           })
 
@@ -448,7 +448,7 @@ it(`should use the cache argument`, async () => {
           if (IS_LOKI) return
 
           const needle = `2` // Note: `id` is a numstr
-          const [result, allNodes] = await runFilter({ id: { hair: needle } })
+          const [result] = await runFilter({ id: { hair: needle } })
 
           expect(result).toEqual(null)
         })
@@ -634,12 +634,12 @@ it(`should use the cache argument`, async () => {
           if (IS_LOKI) return
 
           const needle = null
-          const [result, allNodes] = await runFilter({ nil: { lte: null } })
+          const [result, allNodes] = await runFilter({ nil: { lte: needle } })
 
           // lte null matches null but no nodes without the property (NULL)
-          expect(result?.length).toEqual(allNodes.filter(node => node.nil === null).length)
+          expect(result?.length).toEqual(allNodes.filter(node => node.nil === needle).length)
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil === null).toEqual(true))
+          result.forEach(node => expect(node.nil === needle).toEqual(true))
         })
       })
 
@@ -750,12 +750,12 @@ it(`should use the cache argument`, async () => {
           if (IS_LOKI) return
 
           const needle = null
-          const [result, allNodes] = await runFilter({ nil: { gte: null } })
+          const [result, allNodes] = await runFilter({ nil: { gte: needle } })
 
           // gte null matches null but no nodes without the property (NULL)
-          expect(result?.length).toEqual(allNodes.filter(node => node.nil === null).length)
+          expect(result?.length).toEqual(allNodes.filter(node => node.nil === needle).length)
           expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil === null).toEqual(true))
+          result.forEach(node => expect(node.nil === needle).toEqual(true))
         })
       })
 
@@ -934,7 +934,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$elemMatch`, () => {
         it(`handles the elemMatch operator on a proper single tree`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -955,7 +955,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator on the second element`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -976,7 +976,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`should return only one node if elemMatch hits multiples`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -1001,7 +1001,7 @@ it(`should use the cache argument`, async () => {
         it(`ignores the elemMatch operator on a partial sub tree`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -1015,7 +1015,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator for array of objects (1)`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             data: {
               tags: {
                 elemMatch: {
@@ -1038,7 +1038,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator for array of objects (2)`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             data: {
               tags: {
                 elemMatch: {
@@ -1063,7 +1063,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on boolean field`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             boolean: {
               elemMatch: {
                 eq: true,
@@ -1079,7 +1079,7 @@ it(`should use the cache argument`, async () => {
         it(`skips nodes without the field for elemMatch on boolean`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             boolSecondOnly: {
               elemMatch: {
                 eq: false,
@@ -1095,7 +1095,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on string field`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             string: {
               elemMatch: {
                 eq: `a`,
@@ -1111,7 +1111,7 @@ it(`should use the cache argument`, async () => {
         it(`should return all nodes for elemMatch on non-arrays too`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             name: {
               elemMatch: {
                 eq: `The Mad Wax`,
@@ -1129,7 +1129,7 @@ it(`should use the cache argument`, async () => {
         it(`skips nodes without the field for elemMatch on string`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             strSecondOnly: {
               elemMatch: {
                 eq: `needle`,
@@ -1145,7 +1145,7 @@ it(`should use the cache argument`, async () => {
         it(`works for elemMatch on number field`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             float: {
               elemMatch: {
                 eq: 1.5,
@@ -1161,7 +1161,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$nin`, () => {
         it(`handles the nin operator for array [5]`, async () => {
-          const [result, allNodes] = await runFilter({ anArray: { nin: [5] } })
+          const [result, ] = await runFilter({ anArray: { nin: [5] } })
 
           // Since the array does not contain `null`, the query should also return the
           // nodes that do not have the field at all (NULL).
@@ -1180,7 +1180,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for array [null]`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             nullArray: { nin: [null] },
           })
 
@@ -1192,7 +1192,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for strings`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             string: { nin: [`b`, `c`] },
           })
 
@@ -1204,7 +1204,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for ints`, async () => {
-          const [result, allNodes] = await runFilter({ index: { nin: [0, 2] } })
+          const [result, ] = await runFilter({ index: { nin: [0, 2] } })
 
           expect(result.length).toEqual(1)
           result.forEach(node => {
@@ -1214,7 +1214,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for floats`, async () => {
-          const [result, allNodes] = await runFilter({ float: { nin: [1.5] } })
+          const [result, ] = await runFilter({ float: { nin: [1.5] } })
 
           expect(result.length).toEqual(2)
           result.forEach(node => {
@@ -1224,7 +1224,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for booleans`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             boolean: { nin: [true, null] },
           })
 
@@ -1240,7 +1240,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for double null`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             nil: { nin: [null, null] },
           })
 
@@ -1256,7 +1256,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nin operator for null in int+null`, async () => {
           if (IS_LOKI) return
 
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             nil: { nin: [5, null] },
           })
 
@@ -1270,7 +1270,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for int in int+null`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, ] = await runFilter({
             index: { nin: [2, null] },
           })
 
@@ -1286,7 +1286,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$glob`, () => {
         it(`handles the glob operator`, async () => {
-          const [result, allNodes] = await runFilter({ name: { glob: `*Wax` } })
+          const [result, ] = await runFilter({ name: { glob: `*Wax` } })
 
           expect(result.length).toEqual(2)
           expect(result[0].name).toEqual(`The Mad Wax`)
@@ -1295,7 +1295,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`date`, () => {
         it(`filters date fields`, async () => {
-          const [result, allNodes] = await runFilter({ date: { ne: null } })
+          const [result, ] = await runFilter({ date: { ne: null } })
 
           expect(result.length).toEqual(2)
           expect(result[0].index).toEqual(0)


### PR DESCRIPTION
This improves the filter tests. It makes them more rebust and less tightly-coupled with the test data set. It will check for each test whether there were nodes (if some were expected) and, if so, whether they indeed match the filter. Rather than just checking whether `id=1` or something, which may change if somebody changes the data set.

Some new tests were added as well around `null` checks and ordering.

No runtime semantics were changed.