### PR TITLE
chore(CODEOWNERS): assign `/docs/blog/` to content team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,9 @@
 /docs/                                          @gatsbyjs/learning
 **/README.md                                    @gatsbyjs/learning
 
+# All blog posts must be reviewed by the content team.
+/docs/blog                                      @gatsbyjs/content
+
 # The website auto-deploys, so we need an extra check to avoid shenanigans.
 /www/                                           @gatsbyjs/website
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 **/README.md                                    @gatsbyjs/learning
 
 # All blog posts must be reviewed by the content team.
-/docs/blog                                      @gatsbyjs/content
+/docs/blog/                                     @gatsbyjs/content
 
 # The website auto-deploys, so we need an extra check to avoid shenanigans.
 /www/                                           @gatsbyjs/website


### PR DESCRIPTION
## Description

This moves ownership of blog content on gatsbyjs.org from learning team to content team. There will be some overlap in learning and content team members.

---

Notes about CODEOWNERS ( from https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners ):

> Order is important; the last matching pattern takes the most precedence.

Which means that added rule for `/docs/blog/` below `/docs/` one, will overwrite it, making "content" team sole owner of this part of repository