### PR TITLE
chore(gatsby-cli) Add TypeScript definitions for hosted-git-info

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
+    "@types/hosted-git-info": "^3.0.0",
     "babel-preset-gatsby-package": "^0.4.0",
     "cross-env": "^5.2.1"
   },

--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -165,7 +165,10 @@ const copy = async (
 }
 
 // Clones starter from URI.
-const clone = async (hostInfo: any, rootPath: string): Promise<void> => {
+const clone = async (
+  hostInfo: hostedGitInfo,
+  rootPath: string
+): Promise<void> => {
   let url: string
   // Let people use private repos accessed over SSH.
   if (hostInfo.getDefaultRepresentation() === `sshurl`) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3801,6 +3801,11 @@
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.0.tgz#2fac51050c68f7d6f96c5aafc631132522f4aa3f"
 
+"@types/hosted-git-info@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/hosted-git-info/-/hosted-git-info-3.0.0.tgz#4df861ca6bc2846961a69fd45d503fa11571864c"
+  integrity sha512-dYLI2VgU1UTpdigoeLYc8vVpe7kpu3jysLCTUPB9NS1B+7+BdH6XefI4BhB33CNUaBewnxmjy9GPhF4NXOSNew==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"


### PR DESCRIPTION
### Description

They were missing before, adding them improves type safety and
removes one "any" type from the codebase

### Documentation

No changes needed

### Related Issues

Related to #21995 
