### PR TITLE
chore(gatsby-transformer-remark): Re-Add `utils` to .gitignore

### DIFF
--- a/packages/gatsby-transformer-remark/.gitignore
+++ b/packages/gatsby-transformer-remark/.gitignore
@@ -1,3 +1,3 @@
 /*.js
 !index.js
-utils
+/utils

--- a/packages/gatsby-transformer-remark/.gitignore
+++ b/packages/gatsby-transformer-remark/.gitignore
@@ -1,2 +1,3 @@
 /*.js
 !index.js
+utils


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/19763/files removed `utils` from the .gitignore.

But now a `yarn bootstrap` will yield build files in a commit:

![image](https://user-images.githubusercontent.com/16143594/80578094-44640b00-8a08-11ea-88a5-67c6dc92d9c4.png)
