### PR TITLE
chore(starters): add gatsby-markdown-personal-website

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6069,3 +6069,24 @@
     - Snipcart e-commerce starter
     - Flotiq CMS as a product source
     - Deploy to Heroku
+- url: https://gatsby-markdown-personal-website.netlify.app/
+  repo: https://github.com/SaimirKapaj/gatsby-markdown-personal-website
+  description: Gatsby Markdown Personal Website Starter, using Styled Components, Tailwindcss and Framer Motion.
+  tags:
+    - Blog
+    - Portfolio
+    - Markdown
+    - Styling:Tailwind
+  features:
+    - Markdown
+    - Framer Motion
+    - Page Transition
+    - Styled Components
+    - Tailwind CSS
+    - Removes unused CSS with Purgecss
+    - Font Awesome Icons
+    - Responsive Design
+    - SEO
+    - React Helmet
+    - Offline Support
+    - Gatsby Image


### PR DESCRIPTION
Repo: https://github.com/SaimirKapaj/gatsby-markdown-personal-website
Demo: https://gatsby-markdown-personal-website.netlify.app

Images used in the project are downloaded from https://unsplash.com/

PS. The starter is based on https://github.com/SaimirKapaj/gatsby-markdown-typescript-personal-website starter (from the same author).  