### PR TITLE
feat(gatsby-recipes): Create default gatsby-config.js when installing a plugin if one doesn't exist

### DIFF
--- a/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/plugin.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/plugin.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gatsby-plugin resource creates default gatsby-config.js if there isn't one already 1`] = `
+Object {
+  "_message": "Installed gatsby-plugin-foo in gatsby-config.js",
+  "id": "gatsby-plugin-foo",
+  "name": "gatsby-plugin-foo",
+  "options": undefined,
+}
+`;
+
 exports[`gatsby-plugin resource e2e plugin resource test with hello world starter: GatsbyPlugin create 1`] = `
 Object {
   "_message": "Installed gatsby-plugin-foo in gatsby-config.js",

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
@@ -21,6 +21,7 @@ describe(`gatsby-plugin resource`, () => {
   let starterBlogRoot
   let helloWorldRoot
   let configPath
+  let emptyRoot
   beforeAll(async () => {
     tmpDir = await tmp.dir({
       unsafeCleanup: true,
@@ -28,6 +29,8 @@ describe(`gatsby-plugin resource`, () => {
     starterBlogRoot = path.join(tmpDir.path, `gatsby-starter-blog`)
     helloWorldRoot = path.join(tmpDir.path, `gatsby-starter-hello-world`)
     configPath = path.join(helloWorldRoot, `gatsby-config.js`)
+    emptyRoot = path.join(tmpDir.path, `empty-site-directory`)
+    await fs.ensureDir(emptyRoot)
     await fs.ensureDir(starterBlogRoot)
     await fs.copy(STARTER_BLOG_FIXTURE, starterBlogRoot)
     await fs.ensureDir(helloWorldRoot)
@@ -164,6 +167,14 @@ describe(`gatsby-plugin resource`, () => {
 
     const result = getPluginsFromConfig(newConfigSrc)
 
+    expect(result).toMatchSnapshot()
+  })
+
+  test(`creates default gatsby-config.js if there isn't one already`, async () => {
+    const result = await plugin.create(
+      { root: emptyRoot },
+      { name: `gatsby-plugin-foo` }
+    )
     expect(result).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
fixes #23464