### PR TITLE
fix(babel-preset-gatsby): remove prop-types in production for dependencies

### DIFF
--- a/packages/babel-preset-gatsby/src/dependencies.ts
+++ b/packages/babel-preset-gatsby/src/dependencies.ts
@@ -3,7 +3,7 @@
 
 import path from "path"
 
-interface PresetOptions {
+interface IPresetOptions {
   stage?: "build-javascript" | "build-html" | "develop" | "develop-html"
 }
 
@@ -11,7 +11,7 @@ interface PresetOptions {
 // via require.resolve
 // This function has a better inference than would be beneficial to type, and it's relatively easy to grok.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export default (_, options: PresetOptions = {}) => {
+export default (_, options: IPresetOptions = {}) => {
   const absoluteRuntimePath = path.dirname(
     require.resolve(`@babel/runtime/package.json`)
   )

--- a/packages/babel-preset-gatsby/src/dependencies.ts
+++ b/packages/babel-preset-gatsby/src/dependencies.ts
@@ -3,14 +3,21 @@
 
 import path from "path"
 
+interface PresetOptions {
+  stage?: "build-javascript" | "build-html" | "develop" | "develop-html"
+}
+
 // export default is required here because it is passed directly to webpack
 // via require.resolve
 // This function has a better inference than would be beneficial to type, and it's relatively easy to grok.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export default () => {
+export default (_, options: PresetOptions = {}) => {
   const absoluteRuntimePath = path.dirname(
     require.resolve(`@babel/runtime/package.json`)
   )
+
+  // TODO(v3): Remove process.env.GATSBY_BUILD_STAGE, needs to be passed as an option
+  const stage = options.stage || process.env.GATSBY_BUILD_STAGE || `test`
 
   return {
     // Babel assumes ES Modules, which isn't safe until CommonJS
@@ -53,6 +60,13 @@ export default () => {
       ],
       // Adds syntax support for import()
       require.resolve(`@babel/plugin-syntax-dynamic-import`),
-    ],
+      stage === `build-javascript` && [
+        // Remove PropTypes from production build
+        require.resolve(`babel-plugin-transform-react-remove-prop-types`),
+        {
+          removeImport: true,
+        },
+      ],
+    ].filter(Boolean),
   }
 }

--- a/packages/babel-preset-gatsby/src/dependencies.ts
+++ b/packages/babel-preset-gatsby/src/dependencies.ts
@@ -11,7 +11,7 @@ interface IPresetOptions {
 // via require.resolve
 // This function has a better inference than would be beneficial to type, and it's relatively easy to grok.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export default (_, options: IPresetOptions = {}) => {
+export default (_?: unknown, options: IPresetOptions = {}) => {
   const absoluteRuntimePath = path.dirname(
     require.resolve(`@babel/runtime/package.json`)
   )

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
@@ -14,7 +14,12 @@ Object {
         "compact": false,
         "configFile": false,
         "presets": Array [
-          "<PROJECT_ROOT>/packages/babel-preset-gatsby/dependencies.js",
+          Array [
+            "<PROJECT_ROOT>/packages/babel-preset-gatsby/dependencies.js",
+            Object {
+              "stage": "develop",
+            },
+          ],
         ],
         "sourceMaps": false,
       },

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -352,7 +352,14 @@ export const createWebpackUtils = (
         babelrc: false,
         configFile: false,
         compact: false,
-        presets: [require.resolve(`babel-preset-gatsby/dependencies`)],
+        presets: [
+          [
+            require.resolve(`babel-preset-gatsby/dependencies`),
+            {
+              stage,
+            },
+          ],
+        ],
         // If an error happens in a package, it's possible to be
         // because it was compiled. Thus, we don't want the browser
         // debugger to show the original code. Instead, the code


### PR DESCRIPTION
## Description

Apply `babel-plugin-transform-react-remove-prop-types` for dependencies (similar to how we do it in https://github.com/gatsbyjs/gatsby/blob/05151c006974b7636b00f0cd608fac89ddaa1c08/packages/babel-preset-gatsby/src/index.js#L106-L112 already for `src` and themes

This was mostly copy & paste from `index.js` file (with addition of passing `stage` option to this preset)

## Related Issues

Discovered in https://github.com/gatsbyjs/gatsby/issues/23550 (but doesn't fix it)
