### PR TITLE
test(gatsby-transformer-asciidoc): init some tests

### DIFF
--- a/packages/gatsby-transformer-asciidoc/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/__tests__/gatsby-node.js
@@ -1,0 +1,95 @@
+const path = require(`path`)
+const { onCreateNode } = require(`../gatsby-node`)
+
+jest.mock(`asciidoctor`, () => () => {
+  return {
+    load: jest.fn(() => {
+      return {
+        hasRevisionInfo: jest.fn(),
+        getAuthor: jest.fn(),
+        getAttributes: jest.fn(() => {
+          return {}
+        }),
+        getAttribute: jest.fn(),
+        convert: jest.fn(() => `html generated`),
+        getDocumentTitle: jest.fn(() => {
+          return {
+            getCombined: jest.fn(() => `title`),
+            hasSubtitle: jest.fn(() => true),
+            getSubtitle: jest.fn(() => `subtitle`),
+            getMain: jest.fn(() => `main`),
+          }
+        }),
+      }
+    }),
+  }
+})
+
+describe(`gatsby-transformer-asciidoc`, () => {
+  let node
+  let actions
+  let loadNodeContent
+  let createNodeId
+  let createContentDigest
+
+  beforeEach(() => {
+    node = {
+      id: `dummy`,
+      extension: `asciidoc`,
+      dir: path.resolve(__dirname),
+    }
+    actions = {
+      createNode: jest.fn(),
+      createParentChildLink: jest.fn(),
+    }
+    loadNodeContent = jest.fn(node => node)
+    createNodeId = jest.fn(node => node)
+    createContentDigest = jest.fn(() => `digest`)
+  })
+
+  it(`should do nothing when extension is not whitelisted`, async () => {
+    node.extension = `foo`
+    await onCreateNode(
+      { node, actions, loadNodeContent, createNodeId, createContentDigest },
+      {}
+    )
+    expect(actions.createNode).not.toHaveBeenCalled()
+  })
+
+  it(`should enhance available extension`, async () => {
+    node.extension = `ad`
+    await onCreateNode(
+      { node, actions, loadNodeContent, createNodeId, createContentDigest },
+      { fileExtensions: [`ad`] }
+    )
+    expect(actions.createNode).toHaveBeenCalled()
+  })
+
+  it(`should create node based on loaded asciidoc file`, async () => {
+    await onCreateNode(
+      {
+        node,
+        actions,
+        loadNodeContent,
+        createNodeId,
+        createContentDigest,
+      },
+      {}
+    )
+    expect(actions.createNode).toHaveBeenCalledWith({
+      author: null,
+      children: [],
+      document: { main: `main`, subtitle: `subtitle`, title: `title` },
+      html: `html generated`,
+      id: `dummy >>> ASCIIDOC`,
+      internal: {
+        contentDigest: `digest`,
+        mediaType: `text/html`,
+        type: `Asciidoc`,
+      },
+      pageAttributes: {},
+      parent: `dummy`,
+      revision: null,
+    })
+  })
+})


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
- add test on `asciidoc` transformer
- mock `asciidoctor` usage because it was quite complicate to make it work in the jest context
- we could complete with more test in a second time to keep this PR small

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
