### PR TITLE
chore: pin version of gatsby-plugin-mdx

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -34,7 +34,7 @@
     "gatsby-plugin-layout": "^1.3.0",
     "gatsby-plugin-mailchimp": "^2.2.3",
     "gatsby-plugin-manifest": "^2.4.0",
-    "gatsby-plugin-mdx": "^1.2.0",
+    "gatsby-plugin-mdx": "1.2.1",
     "gatsby-plugin-netlify": "^2.3.0",
     "gatsby-plugin-netlify-cache": "^0.1.0",
     "gatsby-plugin-nprogress": "^2.3.0",


### PR DESCRIPTION
## Description

Pins version of gatsby-plugin-mdx to avoid OOMing issues caused by generating HTML for timeToRead.

"Fixes" #23614, but temporarily until we fix the underlying issue.

## Related Issues

Relates to #23614