### PR TITLE
feat(gatsby/dev-404-page): support reading and writing filter to `?filter` query string

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -115,6 +115,7 @@
     "postcss-loader": "^3.0.0",
     "prompts": "^2.3.2",
     "prop-types": "^15.7.2",
+    "query-string": "^6.12.1",
     "raw-loader": "^0.5.1",
     "react-dev-utils": "^4.2.3",
     "react-error-overlay": "^3.0.0",

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types"
 import { graphql, Link } from "gatsby"
 import queryString from "query-string"
 
-
 class Dev404Page extends React.Component {
   static propTypes = {
     data: PropTypes.object,
@@ -17,7 +16,7 @@ class Dev404Page extends React.Component {
     const pagePaths = data.allSitePage.nodes.map(node => node.path)
     const urlState = queryString.parse(location.search)
 
-    const initialPagePathSearchTerms = `urlState.q ? urlState.q : `
+    const initialPagePathSearchTerms = urlState.q ? urlState.q : ``
     this.state = {
       showCustom404: false,
       initPagePaths: pagePaths,

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -14,7 +14,7 @@ class Dev404Page extends React.Component {
     super(props)
     const { data, location } = this.props
     const pagePaths = data.allSitePage.nodes.map(node => node.path)
-    const urlState = queryString.parse(location.search)
+    const urlState = queryString.parse(location.hash)
 
     const initialPagePathSearchTerms = urlState.q ? urlState.q : ``
     this.state = {
@@ -33,8 +33,12 @@ class Dev404Page extends React.Component {
   }
 
   handleSearchTermChange(event) {
+    const searchValue = event.target.value
+
+    this.setSearchUrl(searchValue)
+
     this.setState({
-      pagePathSearchTerms: event.target.value,
+      pagePathSearchTerms: searchValue,
     })
   }
 
@@ -45,6 +49,20 @@ class Dev404Page extends React.Component {
     this.setState({
       pagePaths: tempPagePaths.filter(pagePath => searchTerm.test(pagePath)),
     })
+  }
+
+  setSearchUrl(searchValue) {
+    const { location } = this.props
+
+    if (searchValue) {
+      const hash = queryString.parse(location.hash)
+      hash.q = searchValue
+
+      const newHash = queryString.stringify(hash)
+      location.hash = newHash
+    } else {
+      location.hash = ``
+    }
   }
 
   render() {

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -16,12 +16,16 @@ class Dev404Page extends React.Component {
     const pagePaths = data.allSitePage.nodes.map(node => node.path)
     const urlState = queryString.parse(location.search)
 
-    const initialPagePathSearchTerms = urlState.q ? urlState.q : ``
+    const initialPagePathSearchTerms = urlState.filter ? urlState.filter : ``
+
     this.state = {
       showCustom404: false,
       initPagePaths: pagePaths,
-      pagePaths: pagePaths,
       pagePathSearchTerms: initialPagePathSearchTerms,
+      pagePaths: this.getFilteredPagePaths(
+        pagePaths,
+        initialPagePathSearchTerms
+      ),
     }
     this.showCustom404 = this.showCustom404.bind(this)
     this.handlePagePathSearch = this.handlePagePathSearch.bind(this)
@@ -44,11 +48,18 @@ class Dev404Page extends React.Component {
 
   handlePagePathSearch(event) {
     event.preventDefault()
-    const tempPagePaths = [...this.state.initPagePaths]
-    const searchTerm = new RegExp(`${this.state.pagePathSearchTerms}`)
+    const allPagePaths = [...this.state.initPagePaths]
     this.setState({
-      pagePaths: tempPagePaths.filter(pagePath => searchTerm.test(pagePath)),
+      pagePaths: this.getFilteredPagePaths(
+        allPagePaths,
+        this.state.pagePathSearchTerms
+      ),
     })
+  }
+
+  getFilteredPagePaths(allPagePaths, pagePathSearchTerms) {
+    const searchTerm = new RegExp(`${pagePathSearchTerms}`)
+    return allPagePaths.filter(pagePath => searchTerm.test(pagePath))
   }
 
   setSearchUrl(searchValue) {
@@ -57,7 +68,7 @@ class Dev404Page extends React.Component {
     } = this.props
 
     const searchMap = queryString.parse(search)
-    searchMap.q = searchValue
+    searchMap.filter = searchValue
 
     const newSearch = queryString.stringify(searchMap)
 

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -14,7 +14,7 @@ class Dev404Page extends React.Component {
     super(props)
     const { data, location } = this.props
     const pagePaths = data.allSitePage.nodes.map(node => node.path)
-    const urlState = queryString.parse(location.hash)
+    const urlState = queryString.parse(location.search)
 
     const initialPagePathSearchTerms = urlState.q ? urlState.q : ``
     this.state = {

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -1,6 +1,8 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { graphql, Link } from "gatsby"
+import queryString from "query-string"
+
 
 class Dev404Page extends React.Component {
   static propTypes = {
@@ -11,13 +13,16 @@ class Dev404Page extends React.Component {
 
   constructor(props) {
     super(props)
-    const { data } = this.props
+    const { data, location } = this.props
     const pagePaths = data.allSitePage.nodes.map(node => node.path)
+    const urlState = queryString.parse(location.search)
+
+    const initialPagePathSearchTerms = `urlState.q ? urlState.q : `
     this.state = {
       showCustom404: false,
       initPagePaths: pagePaths,
       pagePaths: pagePaths,
-      pagePathSearchTerms: ``,
+      pagePathSearchTerms: initialPagePathSearchTerms,
     }
     this.showCustom404 = this.showCustom404.bind(this)
     this.handlePagePathSearch = this.handlePagePathSearch.bind(this)

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { graphql, Link } from "gatsby"
+import { graphql, Link, navigate } from "gatsby"
 import queryString from "query-string"
 
 class Dev404Page extends React.Component {
@@ -52,16 +52,17 @@ class Dev404Page extends React.Component {
   }
 
   setSearchUrl(searchValue) {
-    const { location } = this.props
+    const {
+      location: { pathname, search },
+    } = this.props
 
-    if (searchValue) {
-      const hash = queryString.parse(location.hash)
-      hash.q = searchValue
+    const searchMap = queryString.parse(search)
+    searchMap.q = searchValue
 
-      const newHash = queryString.stringify(hash)
-      location.hash = newHash
-    } else {
-      location.hash = ``
+    const newSearch = queryString.stringify(searchMap)
+
+    if (search !== `?${newSearch}`) {
+      navigate(`${pathname}?${newSearch}`, { replace: true })
     }
   }
 


### PR DESCRIPTION
###  Description

This PR includes filtering capabilities to the dev 404 page so it can be linked with custom query string parameters that trigger an initial search.

## Related Issues

Fixes #23617 