### PR TITLE
docs: remove references to squarespace from features comparison

### DIFF
--- a/docs/features/gatsby-cms-specs.csv
+++ b/docs/features/gatsby-cms-specs.csv
@@ -47,8 +47,8 @@ Documentation,Tutorials and guides,Introductory tutorial,3,3,3,Read an introduct
 ,,Adding authentication,3,3,3,Read a guide with a set of instructions to add authentication providers to gate access to your application.
 ,,Adding SEO,3,3,3,Read a guide with a set of instructions to perform search engine optimization for your application.
 Ecosystem,Ecosystem,Component ecosystem,3,3,3,"Leverage an existing component ecosystem such as React’s, which includes out-of-the-box component libraries and curated sets such as JSCoach."
-,,Hosted option,2,2,2,"Plug your application into static hosts such as Netlify, Render, or surge.sh. WordPress and Squarespace include built-in hosting."
-,,Themes ecosystem,2,3,3,"Leverage a theme ecosystem with various options for your application to take on a custom look and feel. Jekyll has themes, and WordPress and Squarespace offer default theme selection."
+,,Hosted option,2,2,2,"Plug your application into static hosts such as Netlify, Render, or surge.sh."
+,,Themes ecosystem,2,3,3,"Leverage a theme ecosystem with various options for your application to take on a custom look and feel. Jekyll has themes, and WordPress offers default theme selection."
 ,Integrations,OOTB integrations with 20+ other systems,3,3,3,Leverage a framework that has integrations off the shelf with more than 20 other systems.
 ,,OOTB integrations with 50+ other systems,3,3,3,Leverage a framework that has integrations off the shelf with more than 50 other systems.
 ,Community,Pairing program,3,1,1,Collaborate with other developers on an individual basis in a community that offers a pairing program for mentorship.


### PR DESCRIPTION

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Squarespace is mentioned nowhere else in the features comparison. Not clear what it is doing here. 
Also Stating that wordpress includes built-in hosting is confusing. Wordpress.com is a paid service that offers hosting but it isn't 'built-in' to wordpress. Wordpress and Drupal must be hosted. It's not really an option not to. This category makes more sense for the JAMstack comparison than it does for the CMS one.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

_None_