### PR TITLE
 chore(showcase): add St. Jude Cloud to showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -10517,3 +10517,15 @@
   featured: false
   main_url: https://mishal23.github.io/
   url: https://mishal23.github.io/
+- title: St. Jude Cloud
+  url: https://www.stjude.cloud
+  main_url: https://www.stjude.cloud
+  description: >
+    Pediatric cancer data sharing ecosystem by St. Jude Children's Research Hospital.
+  categories:
+    - Science
+    - Technology
+    - Nonprofit
+    - Data
+    - Healthcare
+  featured: false


### PR DESCRIPTION
## Description

Adds [St. Jude Cloud](https://www.stjude.cloud) to the Gatsby showcase.

### Documentation

N/A

## Related Issues

N/A