### PR TITLE
fix(gatsby): allow elemMatch on non-arrays, fix tests

### DIFF
--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -431,32 +431,35 @@ function addNodeToBucketWithElemMatch(
   }
 
   // `v` should now be an elemMatch target, probably an array (but maybe not)
-  if (Array.isArray(valueAtCurrentStep)) {
-    // Note: We need to check all elements because the node may need to be added
-    // to multiple buckets (`{a:[{b:3},{b:4}]}`, for `a.elemMatch.b/eq` that
-    // node ends up in buckets for value 3 and 4. This may lead to duplicate
-    // work when elements resolve to the same value, but that can't be helped.
-    valueAtCurrentStep.forEach(elem => {
-      if (nestedQuery.type === `elemMatch`) {
-        addNodeToBucketWithElemMatch(
-          node,
-          elem,
-          nestedQuery,
-          filterCache,
-          resolvedNodesCache
-        )
-      } else {
-        // Now take same route as non-elemMatch filters would take
-        addNodeToFilterCache(
-          node,
-          nestedQuery.path,
-          filterCache,
-          resolvedNodesCache,
-          elem
-        )
-      }
-    })
+  if (!Array.isArray(valueAtCurrentStep)) {
+    // It's possible to `elemMatch` on a non-array so let's support that too
+    valueAtCurrentStep = [valueAtCurrentStep]
   }
+
+  // Note: We need to check all elements because the node may need to be added
+  // to multiple buckets (`{a:[{b:3},{b:4}]}`, for `a.elemMatch.b/eq` that
+  // node ends up in buckets for value 3 and 4. This may lead to duplicate
+  // work when elements resolve to the same value, but that can't be helped.
+  valueAtCurrentStep.forEach(elem => {
+    if (nestedQuery.type === `elemMatch`) {
+      addNodeToBucketWithElemMatch(
+        node,
+        elem,
+        nestedQuery,
+        filterCache,
+        resolvedNodesCache
+      )
+    } else {
+      // Now take same route as non-elemMatch filters would take
+      addNodeToFilterCache(
+        node,
+        nestedQuery.path,
+        filterCache,
+        resolvedNodesCache,
+        elem
+      )
+    }
+  })
 }
 
 const binarySearchAsc = (

--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -270,7 +270,11 @@ export const ensureIndexByQuery = (
   const state = store.getState()
   const resolvedNodesCache = state.resolvedNodesCache
 
-  const filterCache: IFilterCache = { op, byValue: new Map(), meta: {} }
+  const filterCache: IFilterCache = {
+    op,
+    byValue: new Map<FilterValueNullable, Set<IGatsbyNode>>(),
+    meta: {},
+  } as IFilterCache
   filtersCache.set(filterCacheKey, filterCache)
 
   // We cache the subsets of nodes by type, but only one type. So if searching
@@ -361,7 +365,11 @@ export const ensureIndexByElemMatch = (
   const state = store.getState()
   const { resolvedNodesCache } = state
 
-  const filterCache: IFilterCache = { op, byValue: new Map(), meta: {} }
+  const filterCache: IFilterCache = {
+    op,
+    byValue: new Map<FilterValueNullable, Set<IGatsbyNode>>(),
+    meta: {},
+  } as IFilterCache
   filtersCache.set(filterCacheKey, filterCache)
 
   if (nodeTypeNames.length === 1) {
@@ -423,7 +431,6 @@ function addNodeToBucketWithElemMatch(
   }
 
   // `v` should now be an elemMatch target, probably an array (but maybe not)
-
   if (Array.isArray(valueAtCurrentStep)) {
     // Note: We need to check all elements because the node may need to be added
     // to multiple buckets (`{a:[{b:3},{b:4}]}`, for `a.elemMatch.b/eq` that

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -27,6 +27,9 @@ const FAST_OPS = [
   `$gte`,
 ]
 
+// More of a testing mechanic, to verify whether last runSift call used Sift
+let lastFilterUsedSift = false
+
 /**
  * Creates a key for one filterCache inside FiltersCache
  *
@@ -390,6 +393,10 @@ const runFilterAndSort = (args: Object) => {
 
 exports.runSift = runFilterAndSort
 
+exports.didLastFilterUseSift = function _didLastFilterUseSift() {
+  return lastFilterUsedSift
+}
+
 /**
  * Applies filter. First through a simple approach, which is much faster than
  * running sift, but not as versatile and correct. If no nodes were found then
@@ -434,6 +441,8 @@ const applyFilters = (
   }
 
   const result = filterWithoutSift(filters, nodeTypeNames, filtersCache)
+
+  lastFilterUsedSift = false
   if (result) {
     if (stats) {
       stats.totalIndexHits++
@@ -443,6 +452,7 @@ const applyFilters = (
     }
     return result
   }
+  lastFilterUsedSift = true
 
   const siftResult = filterWithSift(
     filters,

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -1,6 +1,10 @@
 const { runQuery: nodesQuery } = require(`../../db/nodes`)
+const { didLastFilterUseSift } = require(`../../redux/run-sift`)
 const { store } = require(`../../redux`)
 const { actions } = require(`../../redux/actions`)
+
+const EXPECT_SIFT = true
+const EXPECT_FAST_FILTER = false
 
 const makeNodesUneven = () => [
   // Note: This is assumed to be an uneven node count
@@ -255,7 +259,12 @@ function resetDb(nodes) {
   )
 }
 
-async function runQuery(queryArgs, filtersCache, nodes = makeNodesUneven()) {
+async function runQuery(
+  queryArgs,
+  filtersCache,
+  nodes = makeNodesUneven(),
+  alwaysSift = !filtersCache
+) {
   resetDb(nodes)
   const { sc, type: gqlType } = makeGqlType(nodes)
   const args = {
@@ -266,21 +275,41 @@ async function runQuery(queryArgs, filtersCache, nodes = makeNodesUneven()) {
     nodeTypeNames: [gqlType.name],
     filtersCache,
   }
-  return await nodesQuery(args)
+
+  let result = await nodesQuery(args)
+
+  // If the filters cache was set, then the test expects fast filters to handle
+  // the query and to skip Sift. If it's not set, then it can't use fast filters
+  // Might revise this when adding tests where we don't expect fast filters to
+  // support it yet..?
+  if (result && result.length) {
+    // Currently, empty results must go through Sift, so ignore those cases here
+    if (alwaysSift) {
+      expect(didLastFilterUseSift()).toBe(true)
+    } else {
+      expect(didLastFilterUseSift()).toBe(!filtersCache)
+    }
+  }
+
+  return result
 }
 
-async function runQuery2(queryArgs, filtersCache) {
+async function runQuery2(queryArgs, filtersCache, alwaysSift) {
   const nodes = makeNodesUneven()
-  return [await runQuery(queryArgs, filtersCache, nodes), nodes]
+  return [await runQuery(queryArgs, filtersCache, nodes, alwaysSift), nodes]
 }
 
-async function runFilterOnCache(filter, filtersCache) {
-  return await runQuery2({ filter }, filtersCache)
+async function runFilterOnCache(filter, filtersCache, alwaysSift) {
+  return await runQuery2({ filter }, filtersCache, alwaysSift)
 }
 
 it(`should use the cache argument`, async () => {
   const filtersCache = new Map()
-  const [result] = await runFilterOnCache({ hair: { eq: 2 } }, filtersCache)
+  const [result] = await runFilterOnCache(
+    { hair: { eq: 2 } },
+    filtersCache,
+    EXPECT_FAST_FILTER
+  )
 
   // Validate answer
   expect(result.length).toEqual(1)
@@ -309,8 +338,14 @@ it(`should use the cache argument`, async () => {
   { desc: `without cache`, cb: () => null }, // Forces no cache, must use Sift
   { desc: `with cache`, cb: () => new Map() },
 ].forEach(({ desc, cb: createFiltersCache }) => {
-  async function runFilter(filter) {
-    return runFilterOnCache(filter, createFiltersCache())
+  async function runFastFilter(filter) {
+    // Assume (and assert) that the query used fast filters if a cache was given
+    return runFilterOnCache(filter, createFiltersCache(), EXPECT_FAST_FILTER)
+  }
+  async function runSlowFilter(filter) {
+    // Assume (and assert) that the query used Sift even if a cache was given
+    // (These are cases we still need to support, at least, before dropping Sift)
+    return runFilterOnCache(filter, createFiltersCache(), EXPECT_SIFT)
   }
 
   describe(desc, () => {
@@ -318,7 +353,9 @@ it(`should use the cache argument`, async () => {
       describe(`$eq`, () => {
         it(`handles eq operator with number value`, async () => {
           const needle = 2
-          const [result, allNodes] = await runFilter({ hair: { eq: needle } })
+          const [result, allNodes] = await runFastFilter({
+            hair: { eq: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.hair === needle).length
@@ -329,7 +366,7 @@ it(`should use the cache argument`, async () => {
 
         it(`handles eq operator with false value`, async () => {
           const needle = false
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFastFilter({
             boolean: { eq: needle },
           })
 
@@ -342,7 +379,9 @@ it(`should use the cache argument`, async () => {
 
         it(`handles eq operator with 0`, async () => {
           const needle = 0
-          const [result, allNodes] = await runFilter({ hair: { eq: needle } })
+          const [result, allNodes] = await runFastFilter({
+            hair: { eq: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.hair === needle).length
@@ -353,7 +392,9 @@ it(`should use the cache argument`, async () => {
 
         it(`handles eq operator with null`, async () => {
           const needle = null // note: this should find nodes with null OR undefined (apparently)
-          const [result, allNodes] = await runFilter({ nil: { eq: needle } })
+          const [result, allNodes] = await runFastFilter({
+            nil: { eq: needle },
+          })
 
           // Also returns nodes that do not have the property at all (NULL in db)
           expect(result?.length).toEqual(
@@ -365,7 +406,7 @@ it(`should use the cache argument`, async () => {
 
         // grapqhl would never pass on `undefined`
         // it(`handles eq operator with undefined`, async () => {
-        //   const [result, allNodes] = await runFilter({ undef: { eq: undefined } })
+        //   const [result, allNodes] = await runFastFilter{ undef: { eq: undefined } })
         //
         //   expect(result.length).toEqual(?)
         //   expect(result[0].hair).toEqual(?)
@@ -373,7 +414,7 @@ it(`should use the cache argument`, async () => {
 
         it(`handles eq operator with serialized array value`, async () => {
           const needle = `[5,6,7,8]`
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runFastFilter({
             strArray: { eq: needle },
           })
 
@@ -386,7 +427,7 @@ it(`should use the cache argument`, async () => {
 
         it(`finds numbers inside arrays`, async () => {
           const needle = 3
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             anArray: { eq: needle },
           })
 
@@ -401,7 +442,7 @@ it(`should use the cache argument`, async () => {
 
         it(`finds numbers inside single-element arrays`, async () => {
           const needle = 8
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             singleArray: { eq: needle },
           })
 
@@ -416,7 +457,7 @@ it(`should use the cache argument`, async () => {
 
         it(`does not coerce numbers against single-element arrays`, async () => {
           const needle = `8` // note: `('8' == [8]) === true`
-          const [result] = await runFilter({
+          const [result] = await runFastFilter({
             singleArray: { eq: needle },
           })
 
@@ -428,7 +469,9 @@ it(`should use the cache argument`, async () => {
       describe(`$ne`, () => {
         it(`handles ne operator`, async () => {
           const needle = 2
-          const [result, allNodes] = await runFilter({ hair: { ne: needle } })
+          const [result, allNodes] = await runSlowFilter({
+            hair: { ne: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.hair !== needle).length
@@ -439,7 +482,7 @@ it(`should use the cache argument`, async () => {
 
         it(`coerces number to string`, async () => {
           const needle = 2 // Note: `id` is a numstr
-          const [result, allNodes] = await runFilter({ id: { ne: needle } })
+          const [result, allNodes] = await runSlowFilter({ id: { ne: needle } })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.id !== needle).length
@@ -451,14 +494,16 @@ it(`should use the cache argument`, async () => {
         // This test causes a stack overflow right now
         it.skip(`dpes not coerce string to number`, async () => {
           const needle = `2` // Note: `id` is a numstr
-          const [result] = await runFilter({ id: { hair: needle } })
+          const [result] = await runSlowFilter({ id: { hair: needle } })
 
           expect(result).toEqual(null)
         })
 
         it(`handles ne operator with true`, async () => {
           const needle = true
-          const [result, allNodes] = await runFilter({ boolean: { ne: true } })
+          const [result, allNodes] = await runSlowFilter({
+            boolean: { ne: true },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.boolean !== needle).length
@@ -469,7 +514,7 @@ it(`should use the cache argument`, async () => {
 
         it(`handles nested ne operator with true`, async () => {
           const needle = true
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             waxOnly: { foo: { ne: true } },
           })
 
@@ -482,7 +527,9 @@ it(`should use the cache argument`, async () => {
 
         it(`handles ne operator with 0`, async () => {
           const needle = 0
-          const [result, allNodes] = await runFilter({ hair: { ne: needle } })
+          const [result, allNodes] = await runSlowFilter({
+            hair: { ne: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.hair !== needle).length
@@ -493,7 +540,9 @@ it(`should use the cache argument`, async () => {
 
         it(`handles ne operator with null`, async () => {
           const needle = 0
-          const [result, allNodes] = await runFilter({ nil: { ne: needle } })
+          const [result, allNodes] = await runSlowFilter({
+            nil: { ne: needle },
+          })
 
           // Should only return nodes who do have the property, not set to null
           expect(result?.length).toEqual(
@@ -505,7 +554,7 @@ it(`should use the cache argument`, async () => {
 
         // grapqhl would never pass on `undefined`
         // it(`handles ne operator with undefined`, async () => {
-        //   const [result, allNodes] = await runFilter({ undef: { ne: undefined } })
+        //   const [result, allNodes] = await runFastFilter({ undef: { ne: undefined } })
         //
         //   expect(result.length).toEqual(?)
         //   expect(result?.length).toEqual(allNodes.filter(node => node.nil !== needle).length)
@@ -515,7 +564,7 @@ it(`should use the cache argument`, async () => {
 
         it(`handles deeply nested ne: true operator`, async () => {
           const needle = true
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             waxOnly: { bar: { baz: { ne: needle } } },
           })
 
@@ -530,7 +579,7 @@ it(`should use the cache argument`, async () => {
 
         it(`handles the ne operator for array field values`, async () => {
           const needle = 1
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             anArray: { ne: needle },
           })
 
@@ -547,7 +596,9 @@ it(`should use the cache argument`, async () => {
       describe(`$lt`, () => {
         it(`handles lt operator with number`, async () => {
           const needle = 1
-          const [result, allNodes] = await runFilter({ hair: { lt: needle } })
+          const [result, allNodes] = await runSlowFilter({
+            hair: { lt: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.hair < needle).length
@@ -560,7 +611,8 @@ it(`should use the cache argument`, async () => {
           const result = await runQuery(
             { filter: { exh: { lt: needle } } },
             createFiltersCache(),
-            allNodes
+            allNodes,
+            EXPECT_SIFT
           )
 
           // Just check whether the reported count is equal to the actual count
@@ -614,7 +666,9 @@ it(`should use the cache argument`, async () => {
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
           const needle = `1.5`
-          const [result, allNodes] = await runFilter({ float: { lt: needle } })
+          const [result, allNodes] = await runSlowFilter({
+            float: { lt: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.float < needle).length
@@ -625,7 +679,10 @@ it(`should use the cache argument`, async () => {
 
         it(`handles lt operator with null`, async () => {
           const needle = null
-          const [result, allNodes] = await runFilter({ nil: { lt: needle } })
+          // Note: Slow filter because it returns an empty result
+          const [result, allNodes] = await runSlowFilter({
+            nil: { lt: needle },
+          })
 
           // Nothing is lt null so zero nodes should match
           // (Note: this is different from `lte`, which does return nulls here!)
@@ -639,7 +696,9 @@ it(`should use the cache argument`, async () => {
       describe(`$lte`, () => {
         it(`handles lte operator with number`, async () => {
           const needle = 1
-          const [result, allNodes] = await runFilter({ hair: { lte: needle } })
+          const [result, allNodes] = await runFastFilter({
+            hair: { lte: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.hair <= needle).length
@@ -706,7 +765,9 @@ it(`should use the cache argument`, async () => {
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
           const needle = `1.5`
-          const [result, allNodes] = await runFilter({ float: { lte: needle } })
+          const [result, allNodes] = await runFastFilter({
+            float: { lte: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.float <= needle).length
@@ -717,7 +778,9 @@ it(`should use the cache argument`, async () => {
 
         it(`handles lte operator with null`, async () => {
           const needle = null
-          const [result, allNodes] = await runFilter({ nil: { lte: needle } })
+          const [result, allNodes] = await runFastFilter({
+            nil: { lte: needle },
+          })
 
           // lte null matches null but no nodes without the property (NULL)
           expect(result?.length).toEqual(
@@ -731,7 +794,9 @@ it(`should use the cache argument`, async () => {
       describe(`$gt`, () => {
         it(`handles gt operator with number`, async () => {
           const needle = 1
-          const [result, allNodes] = await runFilter({ hair: { gt: needle } })
+          const [result, allNodes] = await runSlowFilter({
+            hair: { gt: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.hair > needle).length
@@ -744,7 +809,8 @@ it(`should use the cache argument`, async () => {
           const result = await runQuery(
             { filter: { exh: { gt: needle } } },
             createFiltersCache(),
-            allNodes
+            allNodes,
+            EXPECT_SIFT
           )
 
           // Just check whether the reported count is equal to the actual count
@@ -798,7 +864,9 @@ it(`should use the cache argument`, async () => {
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
           const needle = `1.5`
-          const [result, allNodes] = await runFilter({ float: { gt: needle } })
+          const [result, allNodes] = await runSlowFilter({
+            float: { gt: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.float > needle).length
@@ -809,7 +877,10 @@ it(`should use the cache argument`, async () => {
 
         it(`handles gt operator with null`, async () => {
           const needle = null
-          const [result, allNodes] = await runFilter({ nil: { gt: needle } })
+          // Note: Slow filter because it returns an empty result
+          const [result, allNodes] = await runSlowFilter({
+            nil: { gt: needle },
+          })
 
           // Nothing is gt null so zero nodes should match
           // (Note: this is different from `gte`, which does return nulls here!)
@@ -823,7 +894,9 @@ it(`should use the cache argument`, async () => {
       describe(`$gte`, () => {
         it(`handles gte operator with number`, async () => {
           const needle = 1
-          const [result, allNodes] = await runFilter({ hair: { gte: needle } })
+          const [result, allNodes] = await runFastFilter({
+            hair: { gte: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.hair >= needle).length
@@ -890,7 +963,9 @@ it(`should use the cache argument`, async () => {
           // This test checks whether we don't incorrectly assume that if the
           // value wasn't mapped, that it can't be found.
           const needle = `1.5`
-          const [result, allNodes] = await runFilter({ float: { gte: needle } })
+          const [result, allNodes] = await runFastFilter({
+            float: { gte: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => node.float >= needle).length
@@ -901,7 +976,9 @@ it(`should use the cache argument`, async () => {
 
         it(`handles gte operator with null`, async () => {
           const needle = null
-          const [result, allNodes] = await runFilter({ nil: { gte: needle } })
+          const [result, allNodes] = await runFastFilter({
+            nil: { gte: needle },
+          })
 
           // gte null matches null but no nodes without the property (NULL)
           expect(result?.length).toEqual(
@@ -916,7 +993,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the regex operator without flags`, async () => {
           const needleStr = `/^The.*Wax/`
           const needleRex = /^The.*Wax/
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             name: { regex: needleStr },
           })
 
@@ -933,7 +1010,7 @@ it(`should use the cache argument`, async () => {
           // Note: needle is different from checked because `new RegExp('/a/i')` does _not_ work
           const needleRex = /^the.*wax/i
           const needleStr = `/^the.*wax/i`
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             name: { regex: needleStr },
           })
 
@@ -949,7 +1026,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the nested regex operator`, async () => {
           const needleStr = `/.*/`
           const needleRex = /.*/
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             nestedRegex: { field: { regex: needleStr } },
           })
 
@@ -967,7 +1044,9 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`does not match double quote for string without it`, async () => {
-          const [result, allNodes] = await runFilter({ name: { regex: `/"/` } })
+          const [result, allNodes] = await runFastFilter({
+            name: { regex: `/"/` },
+          })
 
           expect(result).toEqual(null)
           expect(allNodes.filter(node => node.name === `"`).length).toEqual(0)
@@ -977,7 +1056,7 @@ it(`should use the cache argument`, async () => {
       describe(`$in`, () => {
         it(`handles the in operator for strings`, async () => {
           const needle = [`b`, `c`]
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             string: { in: needle },
           })
 
@@ -992,7 +1071,9 @@ it(`should use the cache argument`, async () => {
 
         it(`handles the in operator for ints`, async () => {
           const needle = [0, 2]
-          const [result, allNodes] = await runFilter({ index: { in: needle } })
+          const [result, allNodes] = await runSlowFilter({
+            index: { in: needle },
+          })
 
           expect(result?.length).toEqual(
             allNodes.filter(node => needle.includes(node.index)).length
@@ -1005,7 +1086,7 @@ it(`should use the cache argument`, async () => {
 
         it(`handles the in operator for floats`, async () => {
           const needle = [1.5, 2.5]
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             float: { in: needle },
           })
 
@@ -1019,7 +1100,9 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for just null`, async () => {
-          const [result, allNodes] = await runFilter({ nil: { in: [null] } })
+          const [result, allNodes] = await runSlowFilter({
+            nil: { in: [null] },
+          })
 
           // Do not include the nodes without a `nil` property
           // May not have the property, or must be null
@@ -1034,7 +1117,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for double null`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             nil: { in: [null, null] },
           })
 
@@ -1051,7 +1134,9 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for null in int and null`, async () => {
-          const [result, allNodes] = await runFilter({ nil: { in: [5, null] } })
+          const [result, allNodes] = await runSlowFilter({
+            nil: { in: [5, null] },
+          })
 
           // Include the nodes without a `nil` property
           expect(result?.length).toEqual(
@@ -1065,7 +1150,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for int in int and null`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             index: { in: [2, null] },
           })
 
@@ -1089,7 +1174,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the in operator for booleans`, async () => {
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             boolean: { in: [true] },
           })
 
@@ -1102,7 +1187,9 @@ it(`should use the cache argument`, async () => {
 
         it(`handles the in operator for array with one element`, async () => {
           // Note: `node.anArray` doesn't exist or it's an array of multiple numbers
-          const [result, allNodes] = await runFilter({ anArray: { in: [5] } })
+          const [result, allNodes] = await runSlowFilter({
+            anArray: { in: [5] },
+          })
 
           // The first one has a 5, the second one does not have a 5, the third does
           // not have the property at all (NULL). It should return the first and last.
@@ -1119,7 +1206,7 @@ it(`should use the cache argument`, async () => {
         it(`handles the in operator for array some elements`, async () => {
           // Note: `node.anArray` doesn't exist or it's an array of multiple numbers
           const needle = [20, 5, 300]
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             anArray: { in: needle },
           })
 
@@ -1138,7 +1225,7 @@ it(`should use the cache argument`, async () => {
 
         it(`handles the nested in operator for array of strings`, async () => {
           const needle = [`moo`]
-          const [result, allNodes] = await runFilter({
+          const [result, allNodes] = await runSlowFilter({
             frontmatter: { tags: { in: needle } },
           })
 
@@ -1159,7 +1246,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$elemMatch`, () => {
         it(`handles the elemMatch operator on a proper single tree`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runFastFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -1180,7 +1267,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator on the second element`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runFastFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -1201,7 +1288,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`should return only one node if elemMatch hits multiples`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -1224,7 +1311,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`ignores the elemMatch operator on a partial sub tree`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runFastFilter({
             singleElem: {
               things: {
                 elemMatch: {
@@ -1238,7 +1325,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator for array of objects (1)`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runFastFilter({
             data: {
               tags: {
                 elemMatch: {
@@ -1261,7 +1348,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the elemMatch operator for array of objects (2)`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runFastFilter({
             data: {
               tags: {
                 elemMatch: {
@@ -1284,7 +1371,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`works for elemMatch on boolean field`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             boolean: {
               elemMatch: {
                 eq: true,
@@ -1298,7 +1385,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`skips nodes without the field for elemMatch on boolean`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             boolSecondOnly: {
               elemMatch: {
                 eq: false,
@@ -1312,7 +1399,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`works for elemMatch on string field`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             string: {
               elemMatch: {
                 eq: `a`,
@@ -1326,7 +1413,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`should return all nodes for elemMatch on non-arrays too`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             name: {
               elemMatch: {
                 eq: `The Mad Wax`,
@@ -1342,7 +1429,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`skips nodes without the field for elemMatch on string`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             strSecondOnly: {
               elemMatch: {
                 eq: `needle`,
@@ -1356,7 +1443,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`works for elemMatch on number field`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             float: {
               elemMatch: {
                 eq: 1.5,
@@ -1372,7 +1459,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$nin`, () => {
         it(`handles the nin operator for array [5]`, async () => {
-          const [result] = await runFilter({ anArray: { nin: [5] } })
+          const [result] = await runSlowFilter({ anArray: { nin: [5] } })
 
           // Since the array does not contain `null`, the query should also return the
           // nodes that do not have the field at all (NULL).
@@ -1389,7 +1476,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for array [null]`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             nullArray: { nin: [null] },
           })
 
@@ -1401,7 +1488,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for strings`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             string: { nin: [`b`, `c`] },
           })
 
@@ -1413,7 +1500,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for ints`, async () => {
-          const [result] = await runFilter({ index: { nin: [0, 2] } })
+          const [result] = await runSlowFilter({ index: { nin: [0, 2] } })
 
           expect(result.length).toEqual(1)
           result.forEach(node => {
@@ -1423,7 +1510,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for floats`, async () => {
-          const [result] = await runFilter({ float: { nin: [1.5] } })
+          const [result] = await runSlowFilter({ float: { nin: [1.5] } })
 
           expect(result.length).toEqual(2)
           result.forEach(node => {
@@ -1433,7 +1520,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for booleans`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             boolean: { nin: [true, null] },
           })
 
@@ -1447,7 +1534,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for double null`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             nil: { nin: [null, null] },
           })
 
@@ -1461,7 +1548,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for null in int+null`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             nil: { nin: [5, null] },
           })
 
@@ -1475,7 +1562,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`handles the nin operator for int in int+null`, async () => {
-          const [result] = await runFilter({
+          const [result] = await runSlowFilter({
             index: { nin: [2, null] },
           })
 
@@ -1491,7 +1578,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`$glob`, () => {
         it(`handles the glob operator`, async () => {
-          const [result] = await runFilter({ name: { glob: `*Wax` } })
+          const [result] = await runSlowFilter({ name: { glob: `*Wax` } })
 
           expect(result.length).toEqual(2)
           expect(result[0].name).toEqual(`The Mad Wax`)
@@ -1500,7 +1587,7 @@ it(`should use the cache argument`, async () => {
 
       describe(`date`, () => {
         it(`filters date fields`, async () => {
-          const [result] = await runFilter({ date: { ne: null } })
+          const [result] = await runSlowFilter({ date: { ne: null } })
 
           expect(result.length).toEqual(2)
           expect(result[0].index).toEqual(0)

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -1371,7 +1371,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`works for elemMatch on boolean field`, async () => {
-          const [result] = await runSlowFilter({
+          const [result] = await runFastFilter({
             boolean: {
               elemMatch: {
                 eq: true,
@@ -1385,7 +1385,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`skips nodes without the field for elemMatch on boolean`, async () => {
-          const [result] = await runSlowFilter({
+          const [result] = await runFastFilter({
             boolSecondOnly: {
               elemMatch: {
                 eq: false,
@@ -1399,7 +1399,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`works for elemMatch on string field`, async () => {
-          const [result] = await runSlowFilter({
+          const [result] = await runFastFilter({
             string: {
               elemMatch: {
                 eq: `a`,
@@ -1413,7 +1413,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`should return all nodes for elemMatch on non-arrays too`, async () => {
-          const [result] = await runSlowFilter({
+          const [result] = await runFastFilter({
             name: {
               elemMatch: {
                 eq: `The Mad Wax`,
@@ -1429,7 +1429,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`skips nodes without the field for elemMatch on string`, async () => {
-          const [result] = await runSlowFilter({
+          const [result] = await runFastFilter({
             strSecondOnly: {
               elemMatch: {
                 eq: `needle`,
@@ -1443,7 +1443,7 @@ it(`should use the cache argument`, async () => {
         })
 
         it(`works for elemMatch on number field`, async () => {
-          const [result] = await runSlowFilter({
+          const [result] = await runFastFilter({
             float: {
               elemMatch: {
                 eq: 1.5,


### PR DESCRIPTION
This PR will support fast filters for `elemMatch` on values that aren't arrays. I believe this is an edge case but it turned out that Sift supports doing this and fast filters was not, so this achieves parity on that regard.

This PR will expose a new flag to check whether the previous call to `runSift` (which is sync blocking, despite technically async) went through Sift or only used a fast filter index.

This allows us to get a good overview in the tests which ops and specific routes are using the fast filter and which are using the slow (sift) path. And to confirm that each test will test both sift and fast filters.

Followup to #23348 (and all the fast filter related PR's, I guess)