### PR TITLE
fix(gatsby): granular redux cache heuristics for finding large nodes

### DIFF
--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -68,17 +68,20 @@ export const store: Store<IGatsbyState> = configureStore(readState())
 export const saveState = (): void => {
   const state = store.getState()
 
-  return writeToCache({
-    nodes: state.nodes,
-    status: state.status,
-    componentDataDependencies: state.componentDataDependencies,
-    components: state.components,
-    jobsV2: state.jobsV2,
-    staticQueryComponents: state.staticQueryComponents,
-    webpackCompilationHash: state.webpackCompilationHash,
-    pageDataStats: state.pageDataStats,
-    pageData: state.pageData,
-  })
+  return writeToCache(
+    {
+      nodes: state.nodes,
+      status: state.status,
+      componentDataDependencies: state.componentDataDependencies,
+      components: state.components,
+      jobsV2: state.jobsV2,
+      staticQueryComponents: state.staticQueryComponents,
+      webpackCompilationHash: state.webpackCompilationHash,
+      pageDataStats: state.pageDataStats,
+      pageData: state.pageData,
+    },
+    state.nodesByType
+  )
 }
 
 store.subscribe(() => {

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -70,7 +70,7 @@ export function readFromCache(): ICachedReduxState {
   return obj
 }
 
-function guessSafeChunkSize(
+export function guessSafeChunkSize(
   nodesByType: Map<string, Map<string, IGatsbyNode>>
 ): number {
   // Pick a few random elements and measure their size then pick a chunk size
@@ -80,8 +80,9 @@ function guessSafeChunkSize(
 
   const nodesToTest = 11 // Very arbitrary number. Count is per type.
   let maxSize = 1
-  nodesByType.forEach(nodes => {
-    const valueCount = nodes.size
+  nodesByType.forEach((nodesMap: Map<string, IGatsbyNode>) => {
+    const nodes = [...nodesMap.values()]
+    const valueCount = nodes.length
     const step = Math.max(1, Math.ceil(valueCount / nodesToTest))
     for (let i = 0; i < valueCount; i += step) {
       const size = v8.serialize(nodes[i]).length
@@ -145,7 +146,7 @@ export function writeToCache(
   nodesByType: Map<string, Map<string, IGatsbyNode>>
 ): void {
   // Note: this should be a transactional operation. So work in a tmp dir and
-  // make sure the cache cannot be left in a corruptable state due to errors.
+  // make sure the cache cannot be left in a corruptible state due to errors.
 
   const tmpDir = mkdtempSync(path.join(os.tmpdir(), `reduxcache`)) // linux / windows
 


### PR DESCRIPTION
When persisting the redux store, there is a heuristic that will try to roughly determine how big nodes are because there are intrinsic limits to the amount of data we can store in one pass (2gb). This heuristic is currently taking 11 random nodes from the entire pool and using the biggest one to determine the chunk size.

This PR improves the granularity of this check to do this per node type, because certain nodes are intrinsically smaller than others so it hopefully yields more relevant information. I suspect that, ultimately, we could skip all of them and just check the Page type, but we can determine that later.

One downside is that this means sites with many types, like Contentful sites, will probe 11*x nodes now. I don't expect this to be a huge problem, but something noteworthy regardless.

Fixes #23627

This fix will not work with Loki, since that doesn't create the by-type map. Since I'm planning to remove that in the next two weeks I'm probably going to wait with actually getting this PR merged until that happens.