### PR TITLE
adding .gitfilter spec file

### DIFF
--- a/packages/.gitfilterspec
+++ b/packages/.gitfilterspec
@@ -1,0 +1,18 @@
+# Only the paths listed in the file will be downloaded when performing a
+# partial clone using `git clone --filter=sparse:oid=packages/.gitfilterspec`
+
+# Explicitly include filterspec needed to configure sparse checkout with
+# git config --local core.sparsecheckout true
+# git show master:packages/.gitfilterspec >> .git/info/sparse-checkout
+
+
+# careful looks like you need to enable Sparse checkout to prevent downloading more files when checking out different branches / PRs
+# read documentation here https://docs.gitlab.com/ee/topics/git/partial_clone.html
+
+
+packages/.gitfilterspec
+
+# packages folder
+packages/
+
+# Dependencies n/a


### PR DESCRIPTION
### Description
this .gitfilterspec is a step towards implementing feature from issue #23652 

however, I believe there are local configurations that need to be made on each client.

for example
- "git clone" needs "--filter=sparse:oid=packages/.gitfilterspec"
- "git fetch" needs "--filter=sparse:oid=packages/.gitfilterspec"
but likewise, checkout also needs to be configured to not download folders and files that are outside the filterspec.

anyway not sure the best way to finish this implementation to make it easier for people to configure this. not that much of a git expert sorry

### Documentation
- [gitlab partial_clone](https://docs.gitlab.com/ee/topics/git/partial_clone.html)
- [git documentation on partial clone](https://git-scm.com/docs/partial-clone/en)
## Related Issues
Addresses  #23652 
