### PR TITLE
Add missing letter at gatsby-plugin-sitemap docs

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -61,7 +61,7 @@ plugins: [
           }
 
           allSitePage {
-            node {
+            nodes {
               path
             }
           }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Adds a missing letter at the `nodes` word on the [`gatsby-plugin-sitemap`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap)