### PR TITLE
chore(stale): add "status: triage needed" to exempt labels

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -35,6 +35,7 @@ jobs:
             Thanks again for being part of the Gatsby community! 💪💜
           EXEMPT_ISSUE_LABELS: |
             not stale
+            status: triage needed
       - name: Post slack report
         uses: pullreminders/slack-action@v1.0.7
         env:


### PR DESCRIPTION
This adjust the stalebot to ignore issues labeled with `status: triage needed`

I used README from https://github.com/gatsbyjs/stale to see how to define multiple labels. I didn't test it out myself yet (not sure how stable action and README is)

[ch5876]