### PR TITLE
fix(gatsby): Fix dirty check for schema rebuilding

### DIFF
--- a/packages/gatsby/src/schema/infer/__tests__/inference-metadata.ts
+++ b/packages/gatsby/src/schema/infer/__tests__/inference-metadata.ts
@@ -1148,9 +1148,10 @@ describe(`Type change detection`, () => {
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(false)
     metadata.dirty = false
 
+    // Deleting is expected to restore initial metadata state
     metadata = deleteOne({ relatedNode___NODE: `added` }, metadata)
     expect(metadata.dirty).toEqual(true)
-    expect(haveEqualFields(metadata, initialMetadata)).toEqual(false)
+    expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
   })
 
   it(`does not detect when the same node added to the relatedNode field`, () => {
@@ -1165,9 +1166,10 @@ describe(`Type change detection`, () => {
     expect(haveEqualFields(metadata, initialMetadata)).toEqual(false)
     metadata.dirty = false
 
+    // Deleting is expected to restore initial metadata state
     metadata = deleteOne({ relatedNodeList___NODE: [`added`] }, metadata)
     expect(metadata.dirty).toEqual(true)
-    expect(haveEqualFields(metadata, initialMetadata)).toEqual(false)
+    expect(haveEqualFields(metadata, initialMetadata)).toEqual(true)
   })
 
   it(`does not detect when the same node added to the relatedNodeList field`, () => {

--- a/packages/gatsby/src/schema/infer/inference-metadata.ts
+++ b/packages/gatsby/src/schema/infer/inference-metadata.ts
@@ -391,10 +391,12 @@ const descriptorsAreEqual = (
           descriptor?.relatedNode?.nodes,
           otherDescriptor?.relatedNode?.nodes
         )
+        // Must be present in both descriptors or absent in both
+        // in order to be considered equal
         return nodeIds.every(
           id =>
-            descriptor?.relatedNode?.nodes[id] &&
-            otherDescriptor?.relatedNode?.nodes[id]
+            Boolean(descriptor?.relatedNode?.nodes[id]) ===
+            Boolean(otherDescriptor?.relatedNode?.nodes[id])
         )
       }
       case `relatedNodeList`: {
@@ -404,8 +406,8 @@ const descriptorsAreEqual = (
         )
         return nodeIds.every(
           id =>
-            descriptor?.relatedNodeList?.nodes[id] &&
-            otherDescriptor?.relatedNodeList?.nodes[id]
+            Boolean(descriptor?.relatedNodeList?.nodes[id]) ===
+            Boolean(otherDescriptor?.relatedNodeList?.nodes[id])
         )
       }
       default:


### PR DESCRIPTION
## Description

This is basically a follow up for #23472 which contained a bug resulting in false positives for schema dirty checking (in some edge cases).

### Documentation
N/A

## Related Issues
Fixes #23633 