### PR TITLE
Missing comma in gatsby-transformer-remark README

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -23,7 +23,7 @@ plugins: [
       // GitHub Flavored Markdown mode (default: true)
       gfm: true,
       // Calculate timeToRead in minutes using word count, sanitized html, and raw Markdown content. (default: wordCount / 265)
-      timeToRead: (wordCount, html, rawMD) => wordCount / 42
+      timeToRead: (wordCount, html, rawMD) => wordCount / 42,
       // Plugins configs
       plugins: [],
     },


### PR DESCRIPTION
In the "How to use" section there is an example of what you might put in your gatsby-config.js file.  There is a missing comma at the end of the `timeToRead` value.

(First pull request, hope I'm doing this right.)

## Description

This simply adds the comma to the end of the line in the README example.

### Documentation

This is a documentation only change.
