### PR TITLE
add Storybook (js) to recipes

### DIFF
--- a/packages/gatsby-recipes/recipes/storybook-js.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-js.mdx
@@ -65,4 +65,4 @@ Add Storybook npm scripts
 
 ## You're all done!
 
-Before your run Storybook make sure you run gatsby develop or gatsby build. This is so GraphQL data is available in Storybook
+Before your run Storybook make sure you run `gatsby develop` or `gatsby build`. This ensures that Gatsby's GraphQL data is available in Storybook.

--- a/packages/gatsby-recipes/recipes/storybook-js.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-js.mdx
@@ -1,0 +1,68 @@
+# Add Storybook to Gatsby project
+
+[Storybook](https://storybook.js.org/) is an open source tool for developing UI components in isolation for React, Vue, and Angular. It makes building stunning UIs organized and efficient.
+
+---
+
+Install babel plugins and presets
+
+<NPMPackage name="babel-loader" />
+<NPMPackage name="@babel/preset-react" />
+<NPMPackage name="@babel/preset-env" />
+<NPMPackage name="@babel/plugin-proposal-class-properties" />
+<NPMPackage name="babel-plugin-remove-graphql-queries" />
+<NPMPackage name="babel-plugin-react-docgen" />
+
+---
+
+Install Storybook React NPM packages and addons
+
+<NPMPackage name="@storybook/react" />
+<NPMPackage name="@storybook/addon-actions" />
+<NPMPackage name="@storybook/addon-docs" />
+
+---
+
+Create JavaScript Storybook webpack config (main.js)
+
+<File
+  path="./.storybook/main.js"
+  content="https://raw.githubusercontent.com/PaulieScanlon/gatsby-recipe-storybook-js/master/recipe/main.js"
+/>
+
+---
+
+Configure Storybook / Gatsby Link settings (preview.js)
+
+<File
+  path="./.storybook/preview.js"
+  content="https://raw.githubusercontent.com/PaulieScanlon/gatsby-recipe-storybook-js/master/recipe/preview.js"
+/>
+
+---
+
+Create example JavaScript Link .stories
+
+<File
+  path="./src/components/Link.stories.js"
+  content="https://raw.githubusercontent.com/PaulieScanlon/gatsby-recipe-storybook-js/master/recipe/Link.stories.js"
+/>
+
+---
+
+Add Storybook npm scripts
+
+<NPMScript
+  name="storybook"
+  command="NODE_ENV=production start-storybook -s ./public -p 6006 --ci"
+/>
+<NPMScript
+  name="build-storybook"
+  command="NODE_ENV=production build-storybook"
+/>
+
+---
+
+## You're all done!
+
+Before your run Storybook make sure you run gatsby develop or gatsby build. This is so GraphQL data is available in Storybook

--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -129,6 +129,10 @@ const RecipesList = ({ setRecipe }) => {
       label: `Add React Helmet`,
       value: `gatsby-plugin-react-helmet.mdx`,
     },
+    {
+      label: `Add Storybook - JavaScript`,
+      value: `storybook-js.mdx`,
+    },
     // TODO remaining recipes
   ]
 


### PR DESCRIPTION
## Description

This PR adds a recipe to`packages/gatsby-recipes`. 

The recipe adds Storybook (js) to your Gatsby project. I've named this recipe `storybook-js` as it'll _**only**_ create the Webpack config required for Storybook to work with **JavaScript** Gatsby projects. 

There are some linked "template" files that live on my GitHub... not sure where you're planning on hosting supporting files for recipes so i'm happy to change that if you have feedback?

I have a second recipe in the making which creates the correct Webpack required for Storybook to work with **TypeScript** Gatsby projects.

### Documentation

More info can be found in the [GitHub repo](https://github.com/PaulieScanlon/gatsby-recipe-storybook-js) repo, and I wrote a short blog post explaining how it works [here](https://paulie.dev/posts/2020/04/gatsby-recipe-storybook-js/)

This PR is loosely related to this [issue](https://github.com/gatsbyjs/gatsby/pull/21378) regarding Storybook v5 docs but hopefully this recipe will be able to co-exist with the documentation. I've only deviated slightly on the Webpack config mentioned in the docs so that it'll work with yarn workspaces _and_ a standard repo setup... which i believe the current documented approach does not, but i might be wrong.