### PR TITLE
perf(gatsby): include node counts in output after sourcing steps

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -23,6 +23,7 @@ import { getConfigFile } from "./get-config-file"
 const tracer = require(`opentracing`).globalTracer()
 import { preferDefault } from "./prefer-default"
 import { removeStaleJobs } from "./remove-stale-jobs"
+const reporter = require(`gatsby-cli/lib/reporter`)
 
 // Show stack trace on unhandled promises.
 process.on(`unhandledRejection`, (reason, p) => {
@@ -445,6 +446,13 @@ module.exports = async (args: BootstrapArgs) => {
   })
   activity.start()
   await require(`../utils/source-nodes`).default({ parentSpan: activity.span })
+  reporter.verbose(
+    `Now have ${store.getState().nodes.size} nodes with ${
+      store.getState().nodesByType.size
+    } types: [${[...store.getState().nodesByType.entries()]
+      .map(([type, nodes]) => type + `:` + nodes.size)
+      .join(`, `)}]`
+  )
   activity.end()
 
   // Create Schema.
@@ -485,6 +493,13 @@ module.exports = async (args: BootstrapArgs) => {
       parentSpan: activity.span,
     },
     { activity }
+  )
+  reporter.verbose(
+    `Now have ${store.getState().nodes.size} nodes with ${
+      store.getState().nodesByType.size
+    } types, and ${
+      store.getState().nodesByType?.get(`SitePage`).size
+    } SitePage nodes`
   )
   activity.end()
 


### PR DESCRIPTION
This will help to triage many sites. If node count is high, certain problems are obvious. Also helps with triaging sites on sources that generate an excessive amount of nodes unexpectedly.

```
success createSchemaCustomization - 0.008s
success source and transform nodes - 29.579s - Now have 100128 nodes with 7 types: [SitePage:1, SitePlugin:22, Site:1, SiteBuildMetadata:1, Directory:1, File:101, IfscCsv:100001]
success building schema - 0.337s
success createPages - 42.945s - Now have 200129 nodes with 7 types: [SitePage:100002, SitePlugin:22, Site:1, SiteBuildMetadata:1, Directory:1, File:101, IfscCsv:100001]
success createPagesStatefully - 0.058s
```
