### PR TITLE
fix(gatsby-source-drupal): added check for node.uri.value prefix

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/file.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/file.json
@@ -22,6 +22,32 @@
            "value" : "public://secondary-image.png"
         }
       }
+    },
+    {
+      "type": "file--file",
+      "id": "file-3",
+      "attributes": {
+        "id": 3,
+        "uuid": "file-3",
+        "filename": "third-image.png",
+        "uri": {
+          "url": "https://files.s3.eu-central-1.amazonaws.com/2020-05/third-image.png",
+          "value" : "s3://third-image.png"
+        }
+      }
+    },
+    {
+      "type": "file--file",
+      "id": "file-4",
+      "attributes": {
+        "id": 2,
+        "uuid": "file-4",
+        "filename": "forth-image.png",
+        "uri": {
+          "url" : "/sites/default/files/forth-image.png",
+          "value" : "private://forth-image.png"
+        }
+      }
     }
   ],
   "links": {}

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/file.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/file.json
@@ -18,7 +18,8 @@
         "uuid": "file-2",
         "filename": "secondary-image.png",
         "uri": {
-          "url" : "/sites/default/files/secondary-image.png"
+          "url" : "/sites/default/files/secondary-image.png",
+           "value" : "public://secondary-image.png"
         }
       }
     }

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -142,19 +142,75 @@ describe(`gatsby-source-drupal`, () => {
     ).toEqual(expect.arrayContaining([createNodeId(`article-1`)]))
   })
 
-  it(`Download files`, () => {
+  it(`Download files without Basic Auth`, () => {
     const urls = [
       `/sites/default/files/main-image.png`,
       `/sites/default/files/secondary-image.png`,
+      `https://files.s3.eu-central-1.amazonaws.com/2020-05/third-image.png`,
+      `/sites/default/files/forth-image.png`,
     ].map(fileUrl => new URL(fileUrl, baseUrl).href)
 
     urls.forEach(url => {
       expect(createRemoteFileNode).toBeCalledWith(
         expect.objectContaining({
           url,
+          auth: {},
         })
       )
     })
+  })
+
+  it(`Download files with Basic Auth`, async () => {
+    const basicAuth = {
+      username: `user`,
+      password: `password`,
+    }
+    await sourceNodes(args, { baseUrl, basicAuth })
+    const urls = [
+      `http://fixture/sites/default/files/main-image.png`,
+      `http://fixture/sites/default/files/secondary-image.png`,
+      `https://files.s3.eu-central-1.amazonaws.com/2020-05/third-image.png`,
+      `/sites/default/files/forth-image.png`,
+    ].map(fileUrl => new URL(fileUrl, baseUrl).href)
+    //first call without basicAuth (no fileSystem defined)
+    //(the first call is actually the 5th because sourceNodes was ran at first with no basicAuth)
+    expect(createRemoteFileNode).toHaveBeenNthCalledWith(
+      5,
+      expect.objectContaining({
+        url: urls[0],
+        auth: {},
+      })
+    )
+    //2nd call with basicAuth (public: fileSystem defined)
+    expect(createRemoteFileNode).toHaveBeenNthCalledWith(
+      6,
+      expect.objectContaining({
+        url: urls[1],
+        auth: {
+          htaccess_pass: `password`,
+          htaccess_user: `user`,
+        },
+      })
+    )
+    //3rd call without basicAuth (s3: fileSystem defined)
+    expect(createRemoteFileNode).toHaveBeenNthCalledWith(
+      7,
+      expect.objectContaining({
+        url: urls[2],
+        auth: {},
+      })
+    )
+    //4th call with basicAuth (private: fileSystem defined)
+    expect(createRemoteFileNode).toHaveBeenNthCalledWith(
+      8,
+      expect.objectContaining({
+        url: urls[3],
+        auth: {
+          htaccess_pass: `password`,
+          htaccess_user: `user`,
+        },
+      })
+    )
   })
 
   describe(`Update webhook`, () => {

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -49,8 +49,9 @@ exports.downloadFile = async (
       // Resolve w/ baseUrl if node.uri isn't absolute.
       const url = new URL(fileUrl, baseUrl)
       // If we have basicAuth credentials, add them to the request.
+      const basicAuthFileSystems = [`public:`, `private:`, `temporary:`]
       const auth =
-        typeof basicAuth === `object` && fileType === `public:`
+        typeof basicAuth === `object` && basicAuthFileSystems.includes(fileType)
           ? {
               htaccess_user: basicAuth.username,
               htaccess_pass: basicAuth.password,

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -43,14 +43,14 @@ exports.downloadFile = async (
         // Support JSON API 2.x file URI format https://www.drupal.org/node/2982209
         fileUrl = node.uri.url
         // get file type from uri prefix ("S3:", "public:", etc.)
-        const uri_prefix = node.uri.value.match(/^\w*:/);
-        fileType = uri_prefix ? uri_prefix[0] : null;
+        const uri_prefix = node.uri.value.match(/^\w*:/)
+        fileType = uri_prefix ? uri_prefix[0] : null
       }
       // Resolve w/ baseUrl if node.uri isn't absolute.
       const url = new URL(fileUrl, baseUrl)
       // If we have basicAuth credentials, add them to the request.
       const auth =
-        (typeof basicAuth === `object` && fileType === 'public:')
+        typeof basicAuth === `object` && fileType === `public:`
           ? {
               htaccess_user: basicAuth.username,
               htaccess_pass: basicAuth.password,

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -35,17 +35,22 @@ exports.downloadFile = async (
   // handle file downloads
   if (isFileNode(node)) {
     let fileNode
+    let fileType
+
     try {
       let fileUrl = node.url
       if (typeof node.uri === `object`) {
         // Support JSON API 2.x file URI format https://www.drupal.org/node/2982209
         fileUrl = node.uri.url
+        // get file type from uri prefix ("S3:", "public:", etc.)
+        const uri_prefix = node.uri.value.match(/^\w*:/);
+        fileType = uri_prefix ? uri_prefix[0] : null;
       }
       // Resolve w/ baseUrl if node.uri isn't absolute.
       const url = new URL(fileUrl, baseUrl)
       // If we have basicAuth credentials, add them to the request.
       const auth =
-        typeof basicAuth === `object`
+        (typeof basicAuth === `object` && fileType === 'public:')
           ? {
               htaccess_user: basicAuth.username,
               htaccess_pass: basicAuth.password,


### PR DESCRIPTION
* if prefix found - allow basicAuth object to include credentials only for files whose prefix is 'public:'
* for other prefixes ('S3:' for example) use an empty auth object
( for use with Drupal's s3fs module, to store images on S3 - without the prefix check sending credentials on the file download request will fail)


## Description

When using a Drupal configuration that stores images on S3 (using s3fs module), the images fail to download when supplying Basic Authentication credentials.
Added a check to remove credentials in that case.

### Documentation


## Related Issues
Fixed #23632

