### PR TITLE
chore(doc):Re-record Quick Start video to not reference npx, and remove note on doc

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -7,11 +7,10 @@ This quick start is intended for intermediate to advanced developers. For a gent
 ## Use the Gatsby CLI
 
 <EggheadEmbed
-  lessonLink="https://egghead.io/lessons/gatsby-quick-start-with-gatsby-create-develop-and-build-gatsby-sites-from-the-command-line"
+  lessonLink="https://https://egghead.io/lessons/gatsby-quick-start-with-gatsby-from-the-command-line-5bf2403a"
   lessonTitle="Quick Start with Gatsby: Create, Develop, and Build Gatsby Sites From the Command Line"
 />
 
-**Note**: this video uses `npx`, which is a tool to execute an npm package without first installing it. Running the command `npx gatsby new` is the same as running `gatsby new` after installing the gatsby-cli on your computer.
 
 ### Install the Gatsby CLI
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -7,7 +7,7 @@ This quick start is intended for intermediate to advanced developers. For a gent
 ## Use the Gatsby CLI
 
 <EggheadEmbed
-  lessonLink="https://https://egghead.io/lessons/gatsby-quick-start-with-gatsby-from-the-command-line-5bf2403a"
+  lessonLink="https://egghead.io/lessons/gatsby-quick-start-with-gatsby-from-the-command-line-5bf2403a"
   lessonTitle="Quick Start with Gatsby: Create, Develop, and Build Gatsby Sites From the Command Line"
 />
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -11,7 +11,6 @@ This quick start is intended for intermediate to advanced developers. For a gent
   lessonTitle="Quick Start with Gatsby: Create, Develop, and Build Gatsby Sites From the Command Line"
 />
 
-
 ### Install the Gatsby CLI
 
 ```shell


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
This PR replaces the quick-start video in the documentation to not reference `npx`,and remove note in doc for `npx`.  See clubhouse story: https://app.clubhouse.io/gatsbyjs/story/2500/record-new-quick-start-video   
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
https://www.gatsbyjs.org/docs/quick-start/
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
