### PR TITLE
fix(gatsby): use scoped requires for theme plugins

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/load.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.js
@@ -164,7 +164,7 @@ const loadPlugins = (config = {}, rootDir = null) => {
         }
       }
 
-      const info = resolvePlugin(plugin.resolve, rootDir)
+      const info = resolvePlugin(plugin.resolve, plugin.parentDir || rootDir)
 
       return {
         ...info,

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/.gitignore
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/gatsby-config.js
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/gatsby-config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [`gatsby-theme-child`],
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/gatsby-config.js
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/gatsby-config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    `gatsby-theme-parent`,
+  ]
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/gatsby-config.js
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/gatsby-config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    `gatsby-plugin-added-by-parent-theme`,
+  ]
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/node_modules/gatsby-plugin-added-by-parent-theme/package.json
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/node_modules/gatsby-plugin-added-by-parent-theme/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "gatsby-plugin-added-by-parent-theme",
+  "main": "package.json",
+  "version": "0.0.1"
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/package.json
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gatsby-theme-parent",
+  "main": "package.json",
+  "version": "0.0.1",
+  "dependencies": {
+    "gatsby-plugin-added-by-parent-theme": "^0.0.1"
+  }
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/package.json
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gatsby-theme-child",
+  "main": "package.json",
+  "version": "0.0.1",
+  "dependencies": {
+    "gatsby-theme-parent": "^0.0.1"
+  }
+}

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/index.js
@@ -1,0 +1,95 @@
+const loadThemes = require(`..`)
+const path = require(`path`)
+
+describe(`loadThemes`, () => {
+  test(`resolves themes and plugins from location of gatsby-config`, async () => {
+    /*
+      Fixture used in this test is structured like this:
+
+      .
+      ├── gatsby-config.js
+      └── node_modules
+          └── gatsby-theme-child
+              ├── gatsby-config.js
+              ├── node_modules
+              │   └── gatsby-theme-parent
+              │       ├── gatsby-config.js
+              │       ├── node_modules
+              │       │   └── gatsby-plugin-added-by-parent-theme
+              │       │       └── package.json
+              │       └── package.json
+              └── package.json
+
+      This make sure we can handle cases when plugins and themes are not hoisted to root "node_modules", as well as simulates requirements for yarn PnP or pnpm
+      (being able to import modules only declared as dependencies of current package).
+    */
+
+    const configFilePath = require.resolve(
+      `./fixtures/resolve-from-config-location/gatsby-config`
+    )
+    const config = require(configFilePath)
+
+    const {
+      config: { plugins },
+      themes,
+    } = await loadThemes(config, {
+      useLegacyThemes: false,
+      configFilePath,
+      rootDir: path.dirname(configFilePath),
+    })
+
+    // implicit assertion - above doesn't throw `Couldn't find the "x" plugin`
+
+    expect(plugins.length).toEqual(3)
+
+    // all nested plugins / themes are found
+    expect(plugins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resolve: `gatsby-theme-child`,
+        }),
+        expect.objectContaining({
+          resolve: `gatsby-theme-parent`,
+        }),
+        expect.objectContaining({
+          resolve: `gatsby-plugin-added-by-parent-theme`,
+        }),
+      ])
+    )
+
+    expect(themes.length).toEqual(3)
+
+    expect(themes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          themeName: `gatsby-theme-child`,
+          // `gatsby-theme-child` is resolved to first level node_modules
+          themeDir: path.dirname(
+            require.resolve(
+              `./fixtures/resolve-from-config-location/node_modules/gatsby-theme-child`
+            )
+          ),
+        }),
+        expect.objectContaining({
+          themeName: `gatsby-theme-parent`,
+          // `gatsby-theme-child` is resolved to second level node_modules
+          themeDir: path.dirname(
+            require.resolve(
+              `./fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent`
+            )
+          ),
+        }),
+
+        expect.objectContaining({
+          themeName: `gatsby-plugin-added-by-parent-theme`,
+          // `gatsby-theme-child` is resolved to third level node_modules
+          themeDir: path.dirname(
+            require.resolve(
+              `./fixtures/resolve-from-config-location/node_modules/gatsby-theme-child/node_modules/gatsby-theme-parent/node_modules/gatsby-plugin-added-by-parent-theme`
+            )
+          ),
+        }),
+      ])
+    )
+  })
+})

--- a/packages/gatsby/src/bootstrap/load-themes/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/index.js
@@ -21,9 +21,7 @@ const resolveTheme = async (
   const themeName = themeSpec.resolve || themeSpec
   let themeDir
   try {
-    const scopedRequire = isMainConfig
-      ? require
-      : createScopedRequire(`${rootDir}/:internal:`)
+    const scopedRequire = createScopedRequire(`${rootDir}/:internal:`)
     // theme is an node-resolvable module
     themeDir = path.dirname(scopedRequire.resolve(themeName))
   } catch (e) {

--- a/packages/gatsby/src/bootstrap/load-themes/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/index.js
@@ -1,4 +1,4 @@
-const { createRequire, createRequireFromPath } = require(`module`)
+const { createRequireFromPath } = require(`gatsby-core-utils`)
 const path = require(`path`)
 const mergeGatsbyConfig = require(`../../utils/merge-gatsby-config`)
 const Promise = require(`bluebird`)
@@ -8,8 +8,6 @@ const preferDefault = require(`../prefer-default`)
 import { getConfigFile } from "../get-config-file"
 const { resolvePlugin } = require(`../load-plugins/load`)
 const reporter = require(`gatsby-cli/lib/reporter`)
-
-const createScopedRequire = createRequire || createRequireFromPath
 
 // get the gatsby-config file for a theme
 const resolveTheme = async (
@@ -21,7 +19,7 @@ const resolveTheme = async (
   const themeName = themeSpec.resolve || themeSpec
   let themeDir
   try {
-    const scopedRequire = createScopedRequire(`${rootDir}/:internal:`)
+    const scopedRequire = createRequireFromPath(`${rootDir}/:internal:`)
     // theme is an node-resolvable module
     themeDir = path.dirname(scopedRequire.resolve(themeName))
   } catch (e) {

--- a/packages/gatsby/src/utils/__tests__/merge-gatsby-config.js
+++ b/packages/gatsby/src/utils/__tests__/merge-gatsby-config.js
@@ -38,22 +38,45 @@ describe(`Merge gatsby config`, () => {
 
   it(`Merging plugins uniqs them, keeping the first occurrence`, () => {
     const basicConfig = {
-      plugins: [`gatsby-plugin-mdx`],
+      plugins: [
+        `gatsby-plugin-mdx`,
+        {
+          resolve: `scoped-plugin`,
+          options: {},
+          parentDir: `/path/to/scoped-basic/parent`,
+        },
+      ],
     }
     const morePlugins = {
       plugins: [
         `a-plugin`,
         `gatsby-plugin-mdx`,
         `b-plugin`,
-        { resolve: `c-plugin`, options: {} },
+        {
+          resolve: `c-plugin`,
+          options: {},
+        },
+        {
+          resolve: `scoped-plugin`,
+          options: {},
+          parentDir: `/path/to/scoped-more/parent`,
+        },
       ],
     }
     expect(mergeGatsbyConfig(basicConfig, morePlugins)).toEqual({
       plugins: [
         `gatsby-plugin-mdx`,
+        {
+          resolve: `scoped-plugin`,
+          options: {},
+          parentDir: `/path/to/scoped-basic/parent`,
+        },
         `a-plugin`,
         `b-plugin`,
-        { resolve: `c-plugin`, options: {} },
+        {
+          resolve: `c-plugin`,
+          options: {},
+        },
       ],
     })
     expect(mergeGatsbyConfig(morePlugins, basicConfig)).toEqual({
@@ -61,7 +84,15 @@ describe(`Merge gatsby config`, () => {
         `a-plugin`,
         `gatsby-plugin-mdx`,
         `b-plugin`,
-        { resolve: `c-plugin`, options: {} },
+        {
+          resolve: `c-plugin`,
+          options: {},
+        },
+        {
+          resolve: `scoped-plugin`,
+          options: {},
+          parentDir: `/path/to/scoped-more/parent`,
+        },
       ],
     })
   })

--- a/packages/gatsby/src/utils/merge-gatsby-config.js
+++ b/packages/gatsby/src/utils/merge-gatsby-config.js
@@ -49,7 +49,7 @@ const howToMerge = {
   byDefault: (a, b) => b || a,
   siteMetadata: (objA, objB) => _.merge({}, objA, objB),
   // plugins are concatenated and uniq'd, so we don't get two of the same plugin value
-  plugins: (a = [], b = [], defaultDir) =>
+  plugins: (a = [], b = []) =>
     _.uniqWith(a.concat(b), (a, b) =>
       _.isEqual(
         _.omit(normalizePluginEntry(a), [`parentDir`]),

--- a/packages/gatsby/src/utils/merge-gatsby-config.js
+++ b/packages/gatsby/src/utils/merge-gatsby-config.js
@@ -52,8 +52,8 @@ const howToMerge = {
   plugins: (a = [], b = []) =>
     _.uniqWith(a.concat(b), (a, b) =>
       _.isEqual(
-        _.omit(normalizePluginEntry(a), [`parentDir`]),
-        _.omit(normalizePluginEntry(b), [`parentDir`])
+        _.pick(normalizePluginEntry(a), [`resolve`, `options`]),
+        _.pick(normalizePluginEntry(b), [`resolve`, `options`])
       )
     ),
   mapping: (objA, objB) => _.merge({}, objA, objB),

--- a/packages/gatsby/src/utils/merge-gatsby-config.js
+++ b/packages/gatsby/src/utils/merge-gatsby-config.js
@@ -49,9 +49,12 @@ const howToMerge = {
   byDefault: (a, b) => b || a,
   siteMetadata: (objA, objB) => _.merge({}, objA, objB),
   // plugins are concatenated and uniq'd, so we don't get two of the same plugin value
-  plugins: (a = [], b = []) =>
+  plugins: (a = [], b = [], defaultDir) =>
     _.uniqWith(a.concat(b), (a, b) =>
-      _.isEqual(normalizePluginEntry(a), normalizePluginEntry(b))
+      _.isEqual(
+        _.omit(normalizePluginEntry(a), [`parentDir`]),
+        _.omit(normalizePluginEntry(b), [`parentDir`])
+      )
     ),
   mapping: (objA, objB) => _.merge({}, objA, objB),
 }


### PR DESCRIPTION
## Description

Because of the nature of package managers like pnpm and yarn 2, there are issues when resolving plugins for themes.

When Gatsby is resolving plugins from themes, it attempts to do a simple `require.resolve()`, which  essentially tries to resolve the package from the current working directory.  In effect, its `require()` method for these theme's plugins is scoped to the current project.  This is okay when using yarn/npm's, because of their hoisting mechanism.

PNPM uses a `node_modules` structure that limits each package to its own assigned dependencies.  If you have a dependency installed in a theme and used in its `gatsby-config`, but you don't have it installed in the consumer project, then the previously mentioned `require.resolve()` will fail miserably.

The same goes for Yarn 2.  Yarn 2 is very strict with its dependencies, and will absolutely _not_ let you `require()` a dependency from another project, while scoped to the current one.

Those issues make it next to impossible to use other (better?) package managers within a Gatsby project.  This is very unfortunate, because it also makes it impossible to use other monorepo managers; some of which are, IMO, better than Lerna/Yarn workspaces.  Even yarn 2 workspaces are better, though maybe not stable yet.  It also fosters a fairly loose set of standards when it comes to dependencies.

If you'd like to see the issue in action, you can check out my reproduction at https://github.com/Js-Brecht/theme-dep-issue.  It is a simple pnpm workspaces repo; `packages/root-project` is the "consumer", while `packages/theme-project` is the theme.  In a perfect world, you should be able to install the dependencies (`pnpm i`), go into `packages/root-project` and run `gatsby build`.  In reality, you see it fail.

## Solution

What this PR does it simply scope the `require()` method for the theme resolution to the "parent directory" of that theme.  Then it links each of that theme's plugins to _the theme's_ directory.  Later, when `loadPlugins()` is run, each plugin can use its `parentDir` as the `rootDir` parameter, so that it can also be resolved relative to the package that owns it.

I can confirm that this works for pnpm, and pnpm workspaces; as a result, it also works with Rush monorepos.  It also fixes the issue for yarn 2, but _not_ yarn 2 workspaces.  That may take some extra work.

## Quality Control/Feedback

I tried to make sure that this would have as little effect beyond the intended scope as possible, but I would really appreciate some feedback from some of you that have a more thorough understanding of Gatsby's internals, and can hopefully foresee any issues that I may have overlooked.

Also, if this doesn't seem like the best method to accomplish this, please let me know.  It seemed like the shortest path.

## Related Issues

I believe this may fix an old, closed (though unresolved) issue: #13707.  The suggestion there was for pnpm/rush to fix the issue, but it's not an issue with them.  The issue is because Gatsby is attempting to resolve dependencies that belong to other packages.