### PR TITLE
chore(gatsby): Convert pagination to TypeScript

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -28,7 +28,7 @@ const {
   processFieldExtensions,
   internalExtensionNames,
 } = require(`./extensions`)
-const { getPagination } = require(`./types/pagination`)
+import { getPagination } from "./types/pagination"
 const { getSortInput, SORTABLE_ENUM } = require(`./types/sort`)
 const { getFilterInput, SEARCHABLE_ENUM } = require(`./types/filter`)
 const { isGatsbyType, GatsbyGraphQLTypeKind } = require(`./types/type-builders`)

--- a/packages/gatsby/src/schema/types/pagination.ts
+++ b/packages/gatsby/src/schema/types/pagination.ts
@@ -2,6 +2,7 @@ import {
   SchemaComposer,
   ObjectTypeComposer,
   InputTypeComposer,
+  InterfaceTypeComposer,
 } from "graphql-compose"
 
 import { getFieldsEnum } from "./sort"
@@ -29,7 +30,7 @@ const getEdge = ({
   typeComposer,
 }: {
   schemaComposer: SchemaComposer<any>
-  typeComposer: ObjectTypeComposer
+  typeComposer: ObjectTypeComposer | InterfaceTypeComposer
 }): ObjectTypeComposer => {
   const typeName: string = typeComposer.getTypeName() + `Edge`
   addDerivedType({ typeComposer, derivedTypeName: typeName })
@@ -49,19 +50,23 @@ const createPagination = ({
   typeName,
 }: {
   schemaComposer: SchemaComposer<any>
-  typeComposer: ObjectTypeComposer
+  typeComposer: ObjectTypeComposer | InterfaceTypeComposer
+  // TODO: Define the interface for the 'fields' data structure
   fields: Record<string, any>
   typeName: string
 }): ObjectTypeComposer => {
-  const paginationTypeComposer = schemaComposer.getOrCreateOTC(typeName, tc => {
-    tc.addFields({
-      totalCount: `Int!`,
-      edges: [getEdge({ schemaComposer, typeComposer }).getTypeNonNull()],
-      nodes: [typeComposer.getTypeNonNull()],
-      pageInfo: getPageInfo({ schemaComposer }).getTypeNonNull(),
-      ...fields,
-    })
-  })
+  const paginationTypeComposer: ObjectTypeComposer = schemaComposer.getOrCreateOTC(
+    typeName,
+    tc => {
+      tc.addFields({
+        totalCount: `Int!`,
+        edges: [getEdge({ schemaComposer, typeComposer }).getTypeNonNull()],
+        nodes: [typeComposer.getTypeNonNull()],
+        pageInfo: getPageInfo({ schemaComposer }).getTypeNonNull(),
+        ...fields,
+      })
+    }
+  )
   paginationTypeComposer.makeFieldNonNull(`edges`)
   paginationTypeComposer.makeFieldNonNull(`nodes`)
   addDerivedType({ typeComposer, derivedTypeName: typeName })
@@ -73,7 +78,7 @@ const getGroup = ({
   typeComposer,
 }: {
   schemaComposer: SchemaComposer<any>
-  typeComposer: ObjectTypeComposer
+  typeComposer: ObjectTypeComposer | InterfaceTypeComposer
 }): ObjectTypeComposer => {
   const typeName: string = typeComposer.getTypeName() + `GroupConnection`
   const fields = {
@@ -88,7 +93,7 @@ const getPagination = ({
   typeComposer,
 }: {
   schemaComposer: SchemaComposer<any>
-  typeComposer: ObjectTypeComposer
+  typeComposer: ObjectTypeComposer | InterfaceTypeComposer
 }): ObjectTypeComposer => {
   const inputTypeComposer: InputTypeComposer = typeComposer.getInputTypeComposer()
   const typeName: string = typeComposer.getTypeName() + `Connection`
@@ -115,7 +120,7 @@ const getPagination = ({
       resolve: group,
     },
   }
-  const paginationTypeComposer = createPagination({
+  const paginationTypeComposer: ObjectTypeComposer = createPagination({
     schemaComposer,
     typeComposer,
     fields,

--- a/packages/gatsby/src/schema/types/pagination.ts
+++ b/packages/gatsby/src/schema/types/pagination.ts
@@ -1,8 +1,18 @@
-const { getFieldsEnum } = require(`./sort`)
-const { addDerivedType } = require(`./derived-types`)
-const { distinct, group } = require(`../resolvers`)
+import {
+  SchemaComposer,
+  ObjectTypeComposer,
+  InputTypeComposer,
+} from "graphql-compose"
 
-const getPageInfo = ({ schemaComposer }) =>
+import { getFieldsEnum } from "./sort"
+import { addDerivedType } from "./derived-types"
+import { distinct, group } from "../resolvers"
+
+const getPageInfo = ({
+  schemaComposer,
+}: {
+  schemaComposer: SchemaComposer<any>
+}): ObjectTypeComposer =>
   schemaComposer.getOrCreateOTC(`PageInfo`, tc => {
     tc.addFields({
       currentPage: `Int!`,
@@ -14,8 +24,14 @@ const getPageInfo = ({ schemaComposer }) =>
     })
   })
 
-const getEdge = ({ schemaComposer, typeComposer }) => {
-  const typeName = typeComposer.getTypeName() + `Edge`
+const getEdge = ({
+  schemaComposer,
+  typeComposer,
+}: {
+  schemaComposer: SchemaComposer<any>
+  typeComposer: ObjectTypeComposer
+}): ObjectTypeComposer => {
+  const typeName: string = typeComposer.getTypeName() + `Edge`
   addDerivedType({ typeComposer, derivedTypeName: typeName })
   return schemaComposer.getOrCreateOTC(typeName, tc => {
     tc.addFields({
@@ -31,7 +47,12 @@ const createPagination = ({
   typeComposer,
   fields,
   typeName,
-}) => {
+}: {
+  schemaComposer: SchemaComposer<any>
+  typeComposer: ObjectTypeComposer
+  fields: Record<string, any>
+  typeName: string
+}): ObjectTypeComposer => {
   const paginationTypeComposer = schemaComposer.getOrCreateOTC(typeName, tc => {
     tc.addFields({
       totalCount: `Int!`,
@@ -47,8 +68,14 @@ const createPagination = ({
   return paginationTypeComposer
 }
 
-const getGroup = ({ schemaComposer, typeComposer }) => {
-  const typeName = typeComposer.getTypeName() + `GroupConnection`
+const getGroup = ({
+  schemaComposer,
+  typeComposer,
+}: {
+  schemaComposer: SchemaComposer<any>
+  typeComposer: ObjectTypeComposer
+}): ObjectTypeComposer => {
+  const typeName: string = typeComposer.getTypeName() + `GroupConnection`
   const fields = {
     field: `String!`,
     fieldValue: `String`,
@@ -56,9 +83,15 @@ const getGroup = ({ schemaComposer, typeComposer }) => {
   return createPagination({ schemaComposer, typeComposer, fields, typeName })
 }
 
-const getPagination = ({ schemaComposer, typeComposer }) => {
-  const inputTypeComposer = typeComposer.getInputTypeComposer()
-  const typeName = typeComposer.getTypeName() + `Connection`
+const getPagination = ({
+  schemaComposer,
+  typeComposer,
+}: {
+  schemaComposer: SchemaComposer<any>
+  typeComposer: ObjectTypeComposer
+}): ObjectTypeComposer => {
+  const inputTypeComposer: InputTypeComposer = typeComposer.getInputTypeComposer()
+  const typeName: string = typeComposer.getTypeName() + `Connection`
   const fieldsEnumTC = getFieldsEnum({
     schemaComposer,
     typeComposer,
@@ -93,9 +126,4 @@ const getPagination = ({ schemaComposer, typeComposer }) => {
   return paginationTypeComposer
 }
 
-module.exports = {
-  getPageInfo,
-  getEdge,
-  getGroup,
-  getPagination,
-}
+export { getPageInfo, getEdge, getGroup, getPagination }


### PR DESCRIPTION
## Description

This PR converts the `packages/gatsby/src/schema/types/pagination.ts` file to TypeScript and its related import in the `packages/gatsby/src/schema/schema.js` file.

### Documentation

No changes required.

## Related Issues

Related to #21995
