### PR TITLE
Add a hook to gatsby-transformer-json to give an object an id based on fileNode, other transformations

### DIFF
--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -46,6 +46,9 @@ async function onCreateNode(
 
   if (_.isArray(parsedContent)) {
     parsedContent.forEach((obj, i) => {
+      if (pluginOptions && _.isFunction(pluginOptions.onTransformObject)) {
+        pluginOptions.onTransformObject({ fileNode: node, object: obj })
+      }
       transformObject(
         obj,
         obj.id ? String(obj.id) : createNodeId(`${node.id} [${i}] >>> JSON`),
@@ -53,6 +56,9 @@ async function onCreateNode(
       )
     })
   } else if (_.isPlainObject(parsedContent)) {
+    if (pluginOptions && _.isFunction(pluginOptions.onTransformObject)) {
+      pluginOptions.onTransformObject({ fileNode: node, object: parsedContent })
+    }
     transformObject(
       parsedContent,
       parsedContent.id


### PR DESCRIPTION
This is an improvement to `gatsby-transform-json`'s API for improving the file (or other) to JSON node transformation process at bundle building time.

From #2210 @KyleAMathews 

> Not sure this is solvable as Gatsby doesn't keep track of where IDs come from so closing. Perhaps this is something we could warn against in development. Would welcome a PR adding this to gatsby-transformer-json.

This change would add an `onTransformObject` function that would give the plugin consumer an opportunity to set the ID based on a `fileNode` from which the JSON was loaded (and possibly its array index, if you think that makes sense, even though I don't).

I use this in production to set my `id` fields and easily add a `path` property to my JSON I later consume when rendering pages based on it. From production code as an example:

```js
    {
      resolve: `gatsby-transformer-json-hooks`,
      options: {
        onTransformObject: ({ fileNode, object }) => {
          // this is a card JSON
          if (object.hasOwnProperty('fileFormatVersion')) {
            if (!object.id) {
              // Set the id
              object.id = fileNode.base.replace(/.json$/, '')
            }

            // Also set a path on the cards node which corresponds to its URL in the website
            object.path = '/cards/' + object.id
          } else if (object.hasOwnProperty('args0') && object.hasOwnProperty('message0')) {
            // this is a blockly block
            if (!object.id && !!object.type) {
              object.id = object.type
            }
            object.path = '/blocks/' + object.id
          } else if (object.hasOwnProperty('Style') && object.hasOwnProperty('BlockCategoryList')) {
            // this is a toolbox definition
            if (!object.id && !!object.Style) {
              object.id = object.Style;
            }
            object.path = '/toolboxes/' + object.id;
          }
        },
        typeName: ({ node, object, isArray }) => {
          // This is card JSON
          if (object.hasOwnProperty('fileFormatVersion')) {
            return 'Card'
          } else if (object.hasOwnProperty('args0') && object.hasOwnProperty('message0')) {
            // this is a blockly block
            return 'Block'
          } else if (object.hasOwnProperty('Style') && object.hasOwnProperty('BlockCategoryList')) {
            // this is a toolbox definition
            return 'Toolbox'
          }
          return 'Json'
        }
      }
    },
```

Observe at the moment `typeName` is a little redundant. You might want an `actions` with a `setTypeName` in `onTransformObject` here. Not sure what the patterns you prefer are.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
