### PR TITLE
fix(gatsby-plugin-netlify): Add missing space in error message

### DIFF
--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -234,7 +234,7 @@ const validateUserOptions = (pluginOptions, reporter) => headers => {
   if (!_.isFunction(pluginOptions.transformHeaders)) {
     throw new Error(
       `The "transformHeaders" option to gatsby-plugin-netlify must be a function ` +
-        `that returns a array of header strings. ` +
+        `that returns an array of header strings. ` +
         `Check your gatsby-config.js.`
     )
   }

--- a/packages/gatsby-plugin-netlify/src/build-headers-program.js
+++ b/packages/gatsby-plugin-netlify/src/build-headers-program.js
@@ -234,7 +234,7 @@ const validateUserOptions = (pluginOptions, reporter) => headers => {
   if (!_.isFunction(pluginOptions.transformHeaders)) {
     throw new Error(
       `The "transformHeaders" option to gatsby-plugin-netlify must be a function ` +
-        `that returns a array of header strings.` +
+        `that returns a array of header strings. ` +
         `Check your gatsby-config.js.`
     )
   }


### PR DESCRIPTION
Minor change that adds a missing space in transformHeader check error message