### PR TITLE
add Storybook (ts) to recipes

### DIFF
--- a/packages/gatsby-recipes/recipes/storybook-js.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-js.mdx
@@ -4,7 +4,7 @@
 
 ---
 
-Install babel plugins and presets
+Install babel plugins and presets as well as the Storybook React NPM packages and addons
 
 <NPMPackage name="babel-loader" />
 <NPMPackage name="@babel/preset-react" />
@@ -12,10 +12,6 @@ Install babel plugins and presets
 <NPMPackage name="@babel/plugin-proposal-class-properties" />
 <NPMPackage name="babel-plugin-remove-graphql-queries" />
 <NPMPackage name="babel-plugin-react-docgen" />
-
----
-
-Install Storybook React NPM packages and addons
 
 <NPMPackage name="@storybook/react" />
 <NPMPackage name="@storybook/addon-actions" />

--- a/packages/gatsby-recipes/recipes/storybook-ts.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-ts.mdx
@@ -1,0 +1,70 @@
+# Add Storybook to Gatsby project
+
+[Storybook](https://storybook.js.org/) is an open source tool for developing UI components in isolation for React, Vue, and Angular. It makes building stunning UIs organized and efficient.
+
+---
+
+Install TypesScript + babel plugins and presets
+
+<NPMPackage name="typescript" />
+<NPMPackage name="babel-loader" />
+<NPMPackage name="@babel/preset-react" />
+<NPMPackage name="@babel/preset-env" />
+<NPMPackage name="@babel/preset-typescript" />
+<NPMPackage name="@babel/plugin-proposal-class-properties" />
+<NPMPackage name="babel-plugin-remove-graphql-queries" />
+<NPMPackage name="react-docgen-typescript-loader" />
+
+---
+
+Install Storybook React NPM packages and addons
+
+<NPMPackage name="@storybook/react" />
+<NPMPackage name="@storybook/addon-actions" />
+<NPMPackage name="@storybook/addon-docs" />
+
+---
+
+Create custom Storybook webpack config (main.js)
+
+<File
+  path="./.storybook/main.js"
+  content="https://raw.githubusercontent.com/PaulieScanlon/gatsby-recipe-storybook-ts/master/recipe/main.js"
+/>
+
+---
+
+Configure Storybook / Gatsby Link settings (preview.js)
+
+<File
+  path="./.storybook/preview.js"
+  content="https://raw.githubusercontent.com/PaulieScanlon/gatsby-recipe-storybook-ts/master/recipe/preview.js"
+/>
+
+---
+
+Create example Link stories
+
+<File
+  path="./src/components/Link.stories.tsx"
+  content="https://raw.githubusercontent.com/PaulieScanlon/gatsby-recipe-storybook-ts/master/recipe/Link.stories.tsx"
+/>
+
+---
+
+Add Storybook npm scripts
+
+<NPMScript
+  name="storybook"
+  command="NODE_ENV=production start-storybook -s ./public -p 6006 --ci"
+/>
+<NPMScript
+  name="build-storybook"
+  command="NODE_ENV=production build-storybook"
+/>
+
+---
+
+## You're all done!
+
+Before your run Storybook make sure you run `gatsby develop` or `gatsby build`. This ensures that Gatsby's GraphQL data is available in Storybook.

--- a/packages/gatsby-recipes/recipes/storybook-ts.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-ts.mdx
@@ -6,7 +6,7 @@ This recipe adds support for JavaScript and TypeScript components.
 
 ---
 
-Install TypesScript + babel plugins and presets
+Install TypesScript + babel plugins and presets as well as the Storybook React NPM packages and addons
 
 <NPMPackage name="typescript" />
 <NPMPackage name="babel-loader" />
@@ -16,10 +16,6 @@ Install TypesScript + babel plugins and presets
 <NPMPackage name="@babel/plugin-proposal-class-properties" />
 <NPMPackage name="babel-plugin-remove-graphql-queries" />
 <NPMPackage name="react-docgen-typescript-loader" />
-
----
-
-Install Storybook React NPM packages and addons
 
 <NPMPackage name="@storybook/react" />
 <NPMPackage name="@storybook/addon-actions" />

--- a/packages/gatsby-recipes/recipes/storybook-ts.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-ts.mdx
@@ -1,6 +1,8 @@
-# Add Storybook to Gatsby project
+# Add Storybook
 
 [Storybook](https://storybook.js.org/) is an open source tool for developing UI components in isolation for React, Vue, and Angular. It makes building stunning UIs organized and efficient.
+
+This recipe adds support for JavaScript and TypeScript components.
 
 ---
 

--- a/packages/gatsby-recipes/recipes/storybook-ts.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-ts.mdx
@@ -65,4 +65,4 @@ Add Storybook npm scripts
 
 ## You're all done!
 
-Before your run Storybook make sure you run `gatsby develop` or `gatsby build`. This ensures that Gatsby's GraphQL data is available in Storybook.
+Before you run Storybook, make sure you run `gatsby develop` or `gatsby build`. This ensures that Gatsby's GraphQL data is available in Storybook.

--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -133,6 +133,10 @@ const RecipesList = ({ setRecipe }) => {
       label: `Add Storybook - JavaScript`,
       value: `storybook-js.mdx`,
     },
+    {
+      label: `Add Storybook - TypeScript`,
+      value: `storybook-ts.mdx`,
+    },
     // TODO remaining recipes
   ]
 


### PR DESCRIPTION
## Description

This PR adds a recipe to `packages/gatsby-recipes`

The recipe adds Storybook (ts) to your Gatsby project. I've named this recipe `storybook-ts` as it creates the Webpack config required for Storybook to work with **_both_** **JavaScript** and **TypeScript** Gatsby projects. 

There are some linked "template" files that live on my GitHub... not sure where you're planning on hosting supporting files for recipes so i'm happy to change that if you have feedback?

### Documentation

More info can be found in the [GitHub repo](https://github.com/PaulieScanlon/gatsby-recipe-storybook-ts) repo, and I wrote a short blog post explaining how it works [here](https://paulie.dev/posts/2020/05/gatsby-recipe-storybook-ts/)

This PR is related to a previously merged PR for `gatsby-recipe-storybook-js` which can be seen [here](https://github.com/gatsbyjs/gatsby/pull/23665)