### PR TITLE
test(e2e_tests_pnp): check if test should run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,8 @@ jobs:
   e2e_tests_pnp:
     executor: node_10_19
     steps:
+      - checkout
+      - run: ./scripts/assert-changed-files.sh "packages/*|.circleci/*"
       - <<: *attach_to_bootstrap
       - run:
           command: cp -r ./starters/default ./e2e-tests/gatsby-pnp


### PR DESCRIPTION
`bootstrap` job might short circuit using `assert-changed-files` before it persists workspace, in which case `e2e_tests_pnp` wouldn't have be able to restore anything - see https://circleci.com/gh/gatsbyjs/gatsby/395045?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link - in particular "Attaching workspace" step, which says "persisted no files" (that's because "bootstrap" in this workflow never persisted - https://circleci.com/gh/gatsbyjs/gatsby/395024)

This also will skip running those tests on content only changes