### PR TITLE
fix: Add 98124 error to better help with "Can't resolve [...]" errors

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -34,7 +34,11 @@ const errors = {
   },
   "98123": {
     text: (context): string =>
-      `${context.stageLabel} failed\n\n${context.message}`,
+      `${context.stageLabel} failed\n\n${
+        context.message
+      }.\n\nPerhaps you need to install the package${
+        context.packageName ? ` '${context.packageName}'` : ``
+      }?`,
     type: Type.WEBPACK,
     level: Level.ERROR,
   },

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -35,10 +35,14 @@ const errors = {
   "98123": {
     text: (context): string =>
       `${context.stageLabel} failed\n\n${
-        context.message
-      }.\n\nPerhaps you need to install the package${
-        context.packageName ? ` '${context.packageName}'` : ``
-      }?`,
+        context.sourceMessage ?? context.message
+      }`,
+    type: Type.WEBPACK,
+    level: Level.ERROR,
+  },
+  "98124": {
+    text: (context): string =>
+      `${context.stageLabel} failed\n\n${context.sourceMessage}\n\nPerhaps you need to install the package '${context.packageName}'?`,
     type: Type.WEBPACK,
     level: Level.ERROR,
   },

--- a/packages/gatsby/src/utils/webpack-error-utils.ts
+++ b/packages/gatsby/src/utils/webpack-error-utils.ts
@@ -20,7 +20,7 @@ interface ITransformedWebpackError {
     stage: Stage
     stageLabel: StageLabel
     message?: string
-    [key: string]: unknown
+    packageName?: string
   }
 }
 const transformWebpackError = (

--- a/packages/gatsby/src/utils/webpack-error-utils.ts
+++ b/packages/gatsby/src/utils/webpack-error-utils.ts
@@ -20,12 +20,17 @@ interface ITransformedWebpackError {
     stage: Stage
     stageLabel: StageLabel
     message?: string
+    [key: string]: unknown
   }
 }
 const transformWebpackError = (
   stage: keyof typeof stageCodeToReadableLabel,
   webpackError: any
 ): ITransformedWebpackError => {
+  const regex = `Can't resolve \\'(.*?)\\' in \\'(.*?)\\'`
+  const nativeWebpackMessage = webpackError?.error?.message
+  const packageName = nativeWebpackMessage?.match(regex)?.[1]
+
   return {
     id: `98123`,
     filePath: webpackError?.module?.resource,
@@ -38,7 +43,8 @@ const transformWebpackError = (
     context: {
       stage,
       stageLabel: stageCodeToReadableLabel[stage],
-      message: webpackError?.error?.message || webpackError?.message,
+      message: nativeWebpackMessage || webpackError?.message,
+      packageName,
     },
 
     // We use original error to display stack trace for the most part.

--- a/packages/gatsby/src/utils/webpack-error-utils.ts
+++ b/packages/gatsby/src/utils/webpack-error-utils.ts
@@ -72,6 +72,8 @@ const transformWebpackError = (
           stageLabel: stageCodeToReadableLabel[stage],
         },
       }
+
+      break
     }
   }
 


### PR DESCRIPTION
## Description

Paired with @laurieontech on this. Starting point was [her PR](https://github.com/system-ui/theme-ui/blob/14a21cca9c846cf15890f5bf82a9fde3c59db988/packages/gatsby-plugin-theme-ui/gatsby-node.js#L3-L17) on the theme-ui repo that added an error message for missing an install of a package. It showed her error and the generic 98123 webpack error.

So we added a new error 98124 that matches on `Can't resolve [...]` errors and prints out the additional `Perhaps you need to install ...?`.

This PR also changes the `context.message` to `context.sourceMessage` to align it with the rest in the error map.

Adds an error parser to the webpack utils so that the webpack error can be more fine tuned in the future.
