### PR TITLE
fix(docs): Remove unnecessary import in PrivateRoute example

### DIFF
--- a/docs/tutorial/authentication-tutorial.md
+++ b/docs/tutorial/authentication-tutorial.md
@@ -259,7 +259,7 @@ Though the routing is working now, you still can access all routes without restr
 To check if a user can access the content, you can wrap the restricted content inside a PrivateRoute component:
 
 ```jsx:title=src/components/privateRoute.js
-import React, { Component } from "react"
+import React from "react"
 import { navigate } from "gatsby"
 import { isLoggedIn } from "../services/auth"
 


### PR DESCRIPTION
## Description

This removes an unnecessary import of `Component` from React in the `PrivateRoute` [section](https://www.gatsbyjs.org/tutorial/authentication-tutorial/#controlling-private-routes) of the authentication tutorial.

## Related Issues

Fixes #23721
