### PR TITLE
chore(lint-staged): add `.ts(x)` files to rule running `eslint --fix`

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   ],
   "private": true,
   "lint-staged": {
-    "*.{js,jsx}": [
+    "*.{js,jsx,ts,tsx}": [
       "eslint --cache --ext .js,.jsx,.ts,.tsx --fix",
       "git add"
     ],


### PR DESCRIPTION
Right now our git hooks running `eslint --fix` don't handle typescript files - this should fix it 🤞 