### PR TITLE
fix(i18n/update-source): handle single quotes in commit messages

### DIFF
--- a/scripts/i18n/update-source.js
+++ b/scripts/i18n/update-source.js
@@ -88,7 +88,13 @@ async function updateSourceRepo() {
   logger.info(`Committing changes`)
   shell.exec(`git add .`)
 
-  if (shell.exec(`git commit -m '${commitMessage}' > /dev/null`).code !== 0) {
+  // need to "escape" single quotes in commit message
+  // http://blog.stvjam.es/2016/11/using-quotes-in-git-command-line-commit-messages/#Using-Single-Quotes
+  if (
+    shell.exec(
+      `git commit -m '${commitMessage.replace(/'/g, `'\\''`)}' > /dev/null`
+    ).code !== 0
+  ) {
     logger.error(`Failed to commit to ${sourceRepo}`)
     process.exit(1)
   }


### PR DESCRIPTION
Fixes problems when commit message in master contains single quotes - like https://github.com/gatsbyjs/gatsby/commit/091194bd469cd5d670e46331f6a52afadc633a05 - which caused https://circleci.com/gh/gatsbyjs/gatsby/395925?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link