### PR TITLE
Adjust blog title to boost SEO

### DIFF
--- a/docs/blog/2020-04-29-incredimental-builds/index.md
+++ b/docs/blog/2020-04-29-incredimental-builds/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Incredimental Builds"
+title: "Gatsby Cloud Incremental Builds: More like *Incredimental* Builds!"
 date: 2020-04-29
 author: "Josh Comeau"
 excerpt: "A deeper look at Gatsby's recent announcement, how it changes the game for content editors, and what it means for the future."


### PR DESCRIPTION
Changed title in frontmatter because Incredimental Builds on its own was getting missed in SEO