### PR TITLE
chore(starters): add material-kit-react to gatsby

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2061,7 +2061,7 @@
   description: Adaptation of Material Kit React to Gatsby
   tags:
     - Material Kit React
-    - Material UI
+    - Styling:Material
   features:
     - 60 Handcrafted Components
     - 4 Customized Plugins

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2056,3 +2056,13 @@
     - Uses styled-components + styled-system
     - SEO with Sitemap, Schema.org JSONLD, Tags
     - Responsive images with gatsby-image
+- url: https://amazing-jones-e61bda.netlify.app/
+  repo: https://github.com/WebCu/gatsby-material-kit-react
+  description: Adaptation of Material Kit React to Gatsby
+  tags:
+    - Material Kit React
+    - Material UI
+  features:
+    - 60 Handcrafted Components
+    - 4 Customized Plugins
+    - 3 Example Pages

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2060,7 +2060,6 @@
   repo: https://github.com/WebCu/gatsby-material-kit-react
   description: Adaptation of Material Kit React to Gatsby
   tags:
-    - Material Kit React
     - Styling:Material
   features:
     - 60 Handcrafted Components


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add Material Kit React to Gatsby

### Documentation
https://www.creative-tim.com/product/material-kit-react
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
