### PR TITLE
fix(www): update jsdoc source for actions after typescript migration

### DIFF
--- a/docs/docs/actions.md
+++ b/docs/docs/actions.md
@@ -3,7 +3,7 @@ title: Actions
 description: Documentation on actions and how they help you manipulate state within Gatsby
 jsdoc:
   - "gatsby/src/redux/actions/public.js"
-  - "gatsby/src/redux/actions/restricted.js"
+  - "gatsby/src/redux/actions/restricted.ts"
 contentsHeading: Functions
 ---
 


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/22297 migrated `actions/restricted.js` to `actions/restricted.ts` but our API docs were not updated to use new extension

## Related Issues

fixes #23668