### PR TITLE
Add separate social image field

### DIFF
--- a/packages/gatsby-theme-blog-core/gatsby-node.js
+++ b/packages/gatsby-theme-blog-core/gatsby-node.js
@@ -56,6 +56,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       excerpt: String!
       image: File
       imageAlt: String
+      socialImage: File
   }`)
 
   createTypes(
@@ -87,6 +88,9 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
         },
         imageAlt: {
           type: `String`,
+        },
+        socialImage: {
+          type: 'File',
         },
         body: {
           type: `String!`,
@@ -145,6 +149,7 @@ exports.onCreateNode = async (
       date: node.frontmatter.date,
       keywords: node.frontmatter.keywords || [],
       image: node.frontmatter.image,
+      socialImage: node.frontmatter.socialImage
     }
 
     const mdxBlogPostId = createNodeId(`${node.id} >>> MdxBlogPost`)

--- a/packages/gatsby-theme-blog-core/src/templates/post-query.js
+++ b/packages/gatsby-theme-blog-core/src/templates/post-query.js
@@ -31,6 +31,13 @@ export const query = graphql`
         }
       }
       imageAlt
+      socialImage {
+        childImageSharp {
+          fluid {
+            ...GatsbyImageSharpFluid
+          }
+        }
+      }
     }
     previous: blogPost(id: { eq: $previousId }) {
       id

--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -120,14 +120,15 @@ module.exports = {
 
 The following are the defined blog post fields based on the node interface in the schema
 
-| Field    | Type     |
-| -------- | -------- |
-| id       | String   |
-| title    | String   |
-| body     | String   |
-| slug     | String   |
-| date     | Date     |
-| tags     | String[] |
-| keywords | String[] |
-| excerpt  | String   |
-| image    | String   |
+| Field       | Type     |
+| ----------- | -------- |
+| id          | String   |
+| title       | String   |
+| body        | String   |
+| slug        | String   |
+| date        | Date     |
+| tags        | String[] |
+| keywords    | String[] |
+| excerpt     | String   |
+| image       | String   |
+| socialImage | String   |

--- a/packages/gatsby-theme-blog/src/components/post.js
+++ b/packages/gatsby-theme-blog/src/components/post.js
@@ -24,7 +24,11 @@ const Post = ({
     <SEO
       title={post.title}
       description={post.excerpt}
-      imageSource={post.image?.childImageSharp?.fluid.src}
+      imageSource={
+        post.socialImage
+          ? post.socialImage?.childImageSharp?.fluid.src
+          : post.image?.childImageSharp?.fluid.src
+      }
       keywords={post.keywords}
     />
     <main>


### PR DESCRIPTION
As mentioned by @ehowey (https://github.com/gatsbyjs/gatsby/issues/23640#issuecomment-623853743) users may prefer a social image that differs from their featured image. This PR adds an additional field. If no image is found, the social image defaults to the featured image.