### PR TITLE
feat(www): Meta title support

### DIFF
--- a/docs/blog/2020-04-29-incredimental-builds/index.md
+++ b/docs/blog/2020-04-29-incredimental-builds/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Gatsby Cloud Incremental Builds: More like *Incredimental* Builds!"
+title: "Incredimental Builds"
+seoTitle: "Gatsby's Incremental Builds: A Closer Look"
 date: 2020-04-29
 author: "Josh Comeau"
 excerpt: "A deeper look at Gatsby's recent announcement, how it changes the game for content editors, and what it means for the future."

--- a/docs/contributing/docs-and-blog-components.md
+++ b/docs/contributing/docs-and-blog-components.md
@@ -219,6 +219,10 @@ You can read more about writing in Markdown in the [Markdown syntax guide](/docs
 
 #### Blog Posts
 
+- `seoTitle` (string)
+
+  If provided, this value will overwrite the `title` for the blog post's `og:title` and `<title>`. This is useful for SEO, as it lets us target specific relevant keywords, without needing to change the page's primary visible title.
+
 - `date` (string)
 
   The blog post's date in the format of `YYYY-MM-DD`.

--- a/www/src/components/__tests__/blog-post-metadata.js
+++ b/www/src/components/__tests__/blog-post-metadata.js
@@ -16,6 +16,7 @@ const basePost = {
   },
   frontmatter: {
     title: "My first Gatsby blog post!",
+    seoTitle: "How to write a Gatsby blog post",
     rawDate: 12345,
     author: {
       id: "Kyle Mathews",
@@ -82,5 +83,35 @@ it("populates the author info and published time", () => {
   expect(content.metaTags).toContainEqual({
     property: "article:published_time",
     content: 12345,
+  })
+})
+
+it("uses the seoTitle when available", () => {
+  render(<BlogPostMetadata post={basePost} />)
+  const content = Helmet.peek()
+  // TEMP: Verify output in CI
+  console.log("all of the things", JSON.stringify(content, null, 2))
+
+  expect(content.title).toContainEqual({
+    children: "How to write a Gatsby blog post",
+  })
+})
+
+it("uses the default title when seoTitle is not available", () => {
+  const basePostWithoutSeoTitle = {
+    ...basePost,
+    frontmatter: {
+      ...basePost.frontmatter,
+      seoTitle: undefined,
+    },
+  }
+
+  render(<BlogPostMetadata post={basePostWithoutSeoTitle} />)
+  const content = Helmet.peek()
+  // TEMP: Verify output in CI
+  console.log("yasss content title", content.title)
+
+  expect(content.title).toContainEqual({
+    children: "My first Gatsby blog post!",
   })
 })

--- a/www/src/components/__tests__/blog-post-metadata.js
+++ b/www/src/components/__tests__/blog-post-metadata.js
@@ -89,12 +89,8 @@ it("populates the author info and published time", () => {
 it("uses the seoTitle when available", () => {
   render(<BlogPostMetadata post={basePost} />)
   const content = Helmet.peek()
-  // TEMP: Verify output in CI
-  console.log("all of the things", JSON.stringify(content, null, 2))
 
-  expect(content.title).toContainEqual({
-    children: "How to write a Gatsby blog post",
-  })
+  expect(content.title).toEqual("How to write a Gatsby blog post")
 })
 
 it("uses the default title when seoTitle is not available", () => {
@@ -108,10 +104,6 @@ it("uses the default title when seoTitle is not available", () => {
 
   render(<BlogPostMetadata post={basePostWithoutSeoTitle} />)
   const content = Helmet.peek()
-  // TEMP: Verify output in CI
-  console.log("yasss content title", content.title)
 
-  expect(content.title).toContainEqual({
-    children: "My first Gatsby blog post!",
-  })
+  expect(content.title).toEqual("My first Gatsby blog post!")
 })

--- a/www/src/components/blog-post-metadata.js
+++ b/www/src/components/blog-post-metadata.js
@@ -13,6 +13,7 @@ export default function BlogPostMetadata({ post }) {
   const {
     canonicalLink,
     title,
+    seoTitle,
     image,
     author,
     rawDate,
@@ -21,7 +22,7 @@ export default function BlogPostMetadata({ post }) {
   const { siteUrl } = useSiteMetadata()
   return (
     <PageMetadata
-      title={title}
+      title={seoTitle || title}
       description={post.fields.excerpt}
       type="article"
       timeToRead={post.timeToRead}

--- a/www/src/components/blog-post-metadata.js
+++ b/www/src/components/blog-post-metadata.js
@@ -20,6 +20,7 @@ export default function BlogPostMetadata({ post }) {
     twittercard,
   } = post.frontmatter
   const { siteUrl } = useSiteMetadata()
+
   return (
     <PageMetadata
       title={seoTitle || title}

--- a/www/src/components/page-metadata.js
+++ b/www/src/components/page-metadata.js
@@ -60,6 +60,7 @@ export default function PageMetadata({
   const { siteUrl } = useSiteMetadata()
   // <Helmet> doesn't support JSX fragments so we can't bundle the tags based on
   // the property they match up with
+
   return (
     <Helmet>
       {title && <title>{title}</title>}

--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -190,6 +190,7 @@ export const pageQuery = graphql`
       }
       frontmatter {
         title
+        seoTitle
         date(formatString: "MMMM Do YYYY")
         rawDate: date
         canonicalLink


### PR DESCRIPTION
## Description

Adds a new field to frontmatter, `seoTitle`. Uses it in the blog-post template, if provided, instead of the article title.
