### PR TITLE
Added Guiding Digital link to Gatsby tutorials section

### DIFF
--- a/docs/docs/awesome-gatsby-resources.md
+++ b/docs/docs/awesome-gatsby-resources.md
@@ -94,6 +94,7 @@ See the [unofficial list of themes](https://gatsbytemplates.io/)
 - [Add a chat widget to your Gatsby blog](https://pusher.com/tutorials/chat-gatsby/)
 - [Headless WordPress: Why Gatsby Should Be Next on Your List of Things to Learn](https://deliciousbrains.com/gatsby-headless-wordpress/)
 - [Gatsby Tutorials \[video series\] — Michael Uloth](https://www.youtube.com/watch?v=jAa1wh5ATm0&list=PLHBEcHVSROXQQhXpNhmiVKKcw72Cc0V-U)
+- [Guiding Digital's "Gatsby" Playlist](https://www.youtube.com/playlist?list=PLlKF6nzQe39fzz4MHc19l8-PtSqyseqok)
 
 ### German
 


### PR DESCRIPTION
Added link to Guiding Digital's "Gatsby" YouTube playlist to the Gatsby tutorials section.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
