### PR TITLE
chore(source-wikipedia): ugrade dependencies

### DIFF
--- a/packages/gatsby-source-wikipedia/package.json
+++ b/packages/gatsby-source-wikipedia/package.json
@@ -29,8 +29,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.9.6",
-    "axios": "^0.19.2"
+    "bluebird": "^3.7.2",
+    "node-fetch": "^2.6.0",
+    "query-string": "^6.12.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/gatsby-source-wikipedia/src/fetch.js
+++ b/packages/gatsby-source-wikipedia/src/fetch.js
@@ -1,9 +1,8 @@
 const Promise = require(`bluebird`)
-var querystring = require(`querystring`)
-var axios = require(`axios`)
+const queryString = require(`query-string`)
+const fetch = require(`node-fetch`)
 
-var apiBase = `https://en.wikipedia.org/w/api.php?`
-var viewBase = `https://en.m.wikipedia.org/wiki/`
+const apiBase = `https://en.wikipedia.org/w/api.php?`
 
 const fetchNodesFromSearch = ({ query, limit = 15 }) =>
   search({ query, limit }).then(results =>
@@ -22,19 +21,18 @@ const fetchNodesFromSearch = ({ query, limit = 15 }) =>
   )
 
 const getMetaData = name =>
-  axios(
-    apiBase +
-      querystring.stringify({
-        action: `query`,
-        titles: name,
-        format: `json`,
-        redirects: `resolve`,
-        prop: `extracts|revisions`,
-        explaintext: 1,
-        exsentences: 1,
-      })
+  fetch(
+    `${apiBase}${queryString.stringify({
+      action: `query`,
+      titles: name,
+      format: `json`,
+      redirects: `resolve`,
+      prop: `extracts|revisions`,
+      explaintext: 1,
+      exsentences: 1,
+    })}`
   )
-    .then(r => r.data)
+    .then(response => response.json())
     .then(data => {
       var page = data.query.pages[Object.keys(data.query.pages)[0]]
 
@@ -57,17 +55,16 @@ const getMetaData = name =>
     })
 
 const search = ({ query, limit }) =>
-  axios(
-    apiBase +
-      querystring.stringify({
-        action: `opensearch`,
-        search: query,
-        format: `json`,
-        redirects: `resolve`,
-        limit,
-      })
+  fetch(
+    `${apiBase}${queryString.stringify({
+      action: `opensearch`,
+      search: query,
+      format: `json`,
+      redirects: `resolve`,
+      limit,
+    })}`
   )
-    .then(r => r.data)
+    .then(response => response.json())
     .then(([term, pageTitles, descriptions, urls]) =>
       pageTitles.map((title, i) => {
         return {
@@ -79,8 +76,10 @@ const search = ({ query, limit }) =>
     )
 
 const getArticle = name =>
-  axios(viewBase + name + `?action=render`).then(r =>
-    r.data.replace(/\/\/en\.wikipedia\.org\/wiki\//g, `/wiki/`)
-  )
+  fetch(`https://en.m.wikipedia.org/wiki/${name}?action=render`)
+    .then(res => res.text())
+    .then(pageContent =>
+      pageContent.replace(/\/\/en\.wikipedia\.org\/wiki\//g, `/wiki/`)
+    )
 
 module.exports = { fetchNodesFromSearch, getMetaData, getArticle, search }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
- remove `@babel/runtime` useless dependency
- add missing `bluebird` dependency (used in package but not listed)
- remove usage of `axios` to use `node-fetch` which seems to be most used fetch lib in packages
   -  💡We may need to harmonize usage of fetching libs
- `querystring` is sadly not maintained now and `query-string` is used in many packages 
  - 💡We may need to harmonize queryString libs in the monorepo
  - add it to dependencies

💡I could add some test with jest in a dedicated PR
💡I could add option to load wikipedia depending on local

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
