### PR TITLE
chore(benchmark-wordpress): Reuse existing BENCHMARK_WPGRAPHQL_URL env variable

### DIFF
--- a/benchmarks/source-wordpress/README.md
+++ b/benchmarks/source-wordpress/README.md
@@ -2,4 +2,4 @@
 
 This is a benchmark to test a site while sourcing data from a WordPress site
 
-Requires an env variable WPGRAPHQL_URL that points at a WPGraphQL graphql endpoint. The WordPress instances must have WPGatsby installed.
+Requires an env variable BENCHMARK_WPGRAPHQL_URL that points at a WPGraphQL graphql endpoint. The WordPress instances must have WPGatsby installed.

--- a/benchmarks/source-wordpress/scripts/data-update.js
+++ b/benchmarks/source-wordpress/scripts/data-update.js
@@ -8,6 +8,6 @@ require(`dotenv`).config({
 
 const username = process.env.BENCHMARK_WORDPRESS_USERNAME
 const password = process.env.BENCHMARK_WORDPRESS_PASSWORD
-const server = process.env.BENCHMARK_WORDPRESS_BASE_URL
+const server = process.env.BENCHMARK_WPGRAPHQL_URL
 
 update({ username, password, server })

--- a/benchmarks/source-wordpress/scripts/updater.js
+++ b/benchmarks/source-wordpress/scripts/updater.js
@@ -4,12 +4,12 @@ const fetchGraphql = require(`gatsby-source-wordpress-experimental/utils/fetch-g
 const faker = require(`faker`)
 
 const authedWPGQLRequest = async query => {
-  if (!process.env.BENCHMARK_WORDPRESS_BASE_URL) {
-    console.error(`No process.env.BENCHMARK_WORDPRESS_BASE_URL url found`)
+  if (!process.env.BENCHMARK_WPGRAPHQL_URL) {
+    console.error(`No process.env.BENCHMARK_WPGRAPHQL_URL url found`)
     process.exit(1)
   }
   const { errors, data } = await fetchGraphql({
-    url: `${process.env.BENCHMARK_WORDPRESS_BASE_URL}graphql`,
+    url: process.env.BENCHMARK_WPGRAPHQL_URL,
     query,
     headers: {
       Authorization: `Basic ${Buffer.from(
@@ -73,7 +73,7 @@ const getFirstArticle = async () => {
 const update = async ({ username, password, server }) => {
   if (!username || !password || !server) {
     console.error(
-      `You must add the BENCHMARK_WORDPRESS_USERNAME, BENCHMARK_WORDPRESS_PASSWORD and BENCHMARK_WORDPRESS_BASE_URL env variables`
+      `You must add the BENCHMARK_WORDPRESS_USERNAME, BENCHMARK_WORDPRESS_PASSWORD and BENCHMARK_WPGRAPHQL_URL env variables`
     )
     return
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Since this benchmark already relies on a `BENCHMARK_WPGRAPHQL_URL` environment variable we might as well re-use that one in the data-update script instead of having the redundant `BENCHMARK_WORDPRESS_BASE_URL`.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
