### PR TITLE
feat(docs): page on migrating remark -> mdx

### DIFF
--- a/docs/docs/mdx/migrate-remark-to-mdx.md
+++ b/docs/docs/mdx/migrate-remark-to-mdx.md
@@ -2,15 +2,15 @@
 title: Migrating Remark to MDX
 ---
 
-For people who already have an existing blog using gatsby-transformer-remark, but want to use MDX, you can swap out the remark transformer plugin with gatsby-plugin-mdx and touch little code otherwise.
+For people who already have an existing blog using `gatsby-transformer-remark` but want to use MDX, you can swap out the Remark transformer plugin with `gatsby-plugin-mdx` and touch little code otherwise.
 
 ## Prerequisites
 
-- An existing site that builds pages using `gatsby-transformer-remark` ([gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog) will be used as a reference in this guide).
+- An existing Gatsby site that builds pages using `gatsby-transformer-remark` ([gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog) will be used as a reference in this guide)
 
 ## Adding in gatsby-plugin-mdx
 
-Add gatsby-plugin-mdx (and its peer dependencies) to your package.json and remove gatsby-transformer-remark.
+Add the `gatsby-plugin-mdx` plugin (and its peer dependencies) to your `package.json` file and remove the `gatsby-transformer-remark` plugin.
 
 ```shell
 npm install @mdx-js/mdx @mdx-js/react gatsby-plugin-mdx
@@ -19,7 +19,7 @@ npm remove gatsby-transformer-remark
 
 ## Replacing gatsby-transformer-remark with gatsby-plugin-mdx
 
-In your gatsby-config.js file, replace gatsby-transformer-remark with gatsby-plugin-mdx. All sub-plugins of gatsby-transformer-remark can still work with gatsby-plugin-mdx by updating the plugins option to gatsbyRemarkPlugins.
+In your `gatsby-config.js` file, replace `gatsby-transformer-remark` with `gatsby-plugin-mdx`. Most sub-plugins of `gatsby-transformer-remark` can still work with `gatsby-plugin-mdx` by updating the plugins option to `gatsbyRemarkPlugins`.
 
 ```diff:title=gatsby-config.js
 {
@@ -55,9 +55,11 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 +  if (node.internal.type === `Mdx`) {
 ```
 
-## Update File Extension
+## Update file extensions
 
-Where your markdown files live, change the file extension to `.mdx`.
+Where your Markdown files live, changing their individual file extensions from `.md` to `.mdx` will  pick them up with the new configuration. Or:
+
+Alternatively, you can tell `gatsby-plugin-mdx`...
 
 Also, you can tell `gatsby-plugin-mdx` to accept both `md` and `mdx` files by adding the `extensions` option in your gatsby-config entry.
 
@@ -70,19 +72,19 @@ Also, you can tell `gatsby-plugin-mdx` to accept both `md` and `mdx` files by ad
   },
 ```
 
-Now with this addition, gatsby-plugin-mdx will see files that end with both `.mdx` or `.md`.
+Now with this addition, `gatsby-plugin-mdx` will see files that end with both `.mdx` or `.md`.
 
 ## Update usage in pages
 
-Similar to gatsby-node, whenever you use `allMarkdownRemark` in a GraphQL query, change it to `allMdx`.
+Similar to `gatsby-node.js`, wherever you use `allMarkdownRemark` in a GraphQL query, change it to `allMdx`.
 
-Then in your blogpost template, to render the MDX, pull in the `MDXRenderer` react component from `gatsby-plugin-mdx`.
+Then in your blogpost template, to render the MDX, pull in the `MDXRenderer` React component from `gatsby-plugin-mdx`.
 
 ```js:title=src/templates/blog-post.js
 import { MDXRenderer } from "gatsby-plugin-mdx"
 ```
 
-And in the graphql query, change the `html` field in `mdx` to `body`.
+And in the GraphQL query, change the `html` field in `mdx` to `body`.
 
 ```graphql:title=src/templates/blog-post.js
 mdx(fields: { slug: { eq: $slug } }) {
@@ -106,9 +108,9 @@ const post = data.mdx
 +<MDXRenderer>{post.body}</MDXRenderer>
 ```
 
-## Update markdown files that includes HTML
+## Update Markdown files that include HTML code
 
-As MDX uses [JSX](/docs/glossary/jsx/) instead of HTML, examine anywhere you put in HTML and make sure that it is valid JSX.
+As MDX uses [JSX](/docs/glossary/jsx/) instead of HTML, examine anywhere you put in HTML and make sure that it is valid JSX. There might be some reserved words that need to be modified, or attributes to convert to camelCase.
 
 For instance, any HTML component with the `class` attribute needs to be changed to `className`.
 
@@ -117,7 +119,7 @@ For instance, any HTML component with the `class` attribute needs to be changed 
 +<span className="highlight">Hello World</span>
 ```
 
-## Additional Resources:
+## Additional resources
 
 - Follow [Importing and Using Components in MDX](/docs/mdx/importing-and-using-components) to find out how you can insert React components in your MDX files.
 - Follow [Using MDX Plugins](/docs/mdx/plugins/) on how to add and use Gatsby Remark or Remark plugins to your MDX site.

--- a/docs/docs/mdx/migrate-remark-to-mdx.md
+++ b/docs/docs/mdx/migrate-remark-to-mdx.md
@@ -4,6 +4,10 @@ title: Migrating Remark to MDX
 
 For people who already have an existing blog using gatsby-transformer-remark, but want to use MDX, you can swap out the remark transformer plugin with gatsby-plugin-mdx and touch little code otherwise.
 
+## Prerequisites
+
+- An existing site that builds pages using `gatsby-transformer-remark` ([gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog) will be used as a reference in this guide).
+
 ## Adding in gatsby-plugin-mdx
 
 Add gatsby-plugin-mdx (and its peer dependencies) to your package.json and remove gatsby-transformer-remark.
@@ -74,13 +78,13 @@ Similar to gatsby-node, whenever you use `allMarkdownRemark` in a GraphQL query,
 
 Then in your blogpost template, to render the MDX, pull in the `MDXRenderer` react component from `gatsby-plugin-mdx`.
 
-```js
+```js:title=src/templates/blog-post.js
 import { MDXRenderer } from "gatsby-plugin-mdx"
 ```
 
 And in the graphql query, change the `html` field in `mdx` to `body`.
 
-```graphql
+```graphql:title=src/templates/blog-post.js
 mdx(fields: { slug: { eq: $slug } }) {
   id
   excerpt(pruneLength: 160)
@@ -93,7 +97,7 @@ mdx(fields: { slug: { eq: $slug } }) {
 
 And finally swap out the component with `dangerouslySetInnerHTML` to a `MDXRenderer` component:
 
-```diff
+```diff:title=src/templates/blog-post.js
 const post = data.mdx
 
 // ...
@@ -102,6 +106,18 @@ const post = data.mdx
 +<MDXRenderer>{post.body}</MDXRenderer>
 ```
 
-## What's next?
+## Update markdown files that includes HTML
 
-Go check out the [Importing and Using Components in MDX guide](/docs/mdx/importing-and-using-components) to find out how you can insert React components in your MDX files.
+As MDX uses [JSX](/docs/glossary/jsx/) instead of HTML, examine anywhere you put in HTML and make sure that it is valid JSX.
+
+For instance, any HTML component with the `class` attribute needs to be changed to `className`.
+
+```diff
+-<span class="highlight">Hello World</span>
++<span className="highlight">Hello World</span>
+```
+
+## Additional Resources:
+
+- Follow [Importing and Using Components in MDX](/docs/mdx/importing-and-using-components) to find out how you can insert React components in your MDX files.
+- Follow [Using MDX Plugins](/docs/mdx/plugins/) on how to add and use Gatsby Remark or Remark plugins to your MDX site.

--- a/docs/docs/mdx/migrate-remark-to-mdx.md
+++ b/docs/docs/mdx/migrate-remark-to-mdx.md
@@ -30,6 +30,23 @@ In your `gatsby-config.js` file, replace `gatsby-transformer-remark` with `gatsb
 +   gatsbyRemarkPlugins: [
 ```
 
+### Update file extensions
+
+Where your Markdown files live, changing their individual file extensions from `.md` to `.mdx` will pick them up with the new configuration.
+
+Alternatively, you can tell `gatsby-plugin-mdx` to accept both `md` and `mdx` files by adding the `extensions` option in your gatsby-config entry.
+
+```js:title=gatsby-config.js
+  {
+    resolve: `gatsby-plugin-mdx`,
+    options: {
+      extensions: [`.md`, `.mdx`], // highlight-line
+    },
+  },
+```
+
+Now with this addition, `gatsby-plugin-mdx` will see files that end with both `.mdx` or `.md`.
+
 ## Update gatsby-node.js
 
 In the `createPages` API call, when you query for `allMarkdownRemark`, replace it with `allMdx`.
@@ -54,25 +71,6 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 -  if (node.internal.type === `MarkdownRemark`) {
 +  if (node.internal.type === `Mdx`) {
 ```
-
-## Update file extensions
-
-Where your Markdown files live, changing their individual file extensions from `.md` to `.mdx` will  pick them up with the new configuration. Or:
-
-Alternatively, you can tell `gatsby-plugin-mdx`...
-
-Also, you can tell `gatsby-plugin-mdx` to accept both `md` and `mdx` files by adding the `extensions` option in your gatsby-config entry.
-
-```js:title=gatsby-config.js
-  {
-    resolve: `gatsby-plugin-mdx`,
-    options: {
-      extensions: [`.md`, `.mdx`], // highlight-line
-    },
-  },
-```
-
-Now with this addition, `gatsby-plugin-mdx` will see files that end with both `.mdx` or `.md`.
 
 ## Update usage in pages
 

--- a/docs/docs/mdx/migrate-remark-to-mdx.md
+++ b/docs/docs/mdx/migrate-remark-to-mdx.md
@@ -1,0 +1,86 @@
+---
+title: Migrating Remark to MDX
+---
+
+For people who already have an existing blog using gatsby-transformer-remark, but want to use MDX, you can swap out the remark transformer plugin with gatsby-plugin-mdx and touch little code otherwise.
+
+## Adding in gatsby-plugin-mdx
+
+Add gatsby-plugin-mdx (and its peer dependencies) to your package.json and remove gatsby-transformer-remark.
+
+```shell
+npm install @mdx-js/mdx @mdx-js/react gatsby-plugin-mdx
+npm remove gatsby-transformer-remark
+```
+
+## Update gatsby-config.js
+
+In your gatsby-config.js file, replace gatsby-transformer-remark with gatsby-plugin-mdx and update the plugins option with gatsbyRemarkPlugins:
+
+```diff
+{
+- resolve: `gatsby-transformer-remark`
++ resolve: `gatsby-plugin-mdx`
+  options: {
+-   plugins: [
++   gatsbyRemarkPlugins: [
+```
+
+## Update gatsby-node.js
+
+In the `createPages` API call, when you query for `allMarkdownRemark`, replace it with `allMdx`.
+
+Also, update `onCreateNode` which creates the blog post slugs to watch for the node type of `Mdx` instead of `MarkdownRemark`.
+
+## Update File Extension
+
+Where your markdown files live, change the file extension to `.mdx`.
+
+Also, you can tell `gatsby-plugin-mdx` to accept both `md` and `mdx` files by adding the `extensions` option in your gatsby-config entry.
+
+```js
+  {
+    resolve: `gatsby-plugin-mdx`,
+    options: {
+      extensions: [`.md`, `.mdx`], // highlight-line
+    },
+  },
+```
+
+## Update usage in pages
+
+Similar to gatsby-node, whenever you use `allMarkdownRemark` in a GraphQL query, change it to `allMdx`.
+
+Then in your blogpost template, to render the MDX, pull in the `MDXRenderer` react component from `gatsby-plugin-mdx`.
+
+```js
+import { MDXRenderer } from "gatsby-plugin-mdx"
+```
+
+And in the graphql query, change the `html` field in `mdx` to `body`.
+
+```graphql
+mdx(fields: { slug: { eq: $slug } }) {
+  id
+  excerpt(pruneLength: 160)
+  body
+  frontmatter {
+    ...
+  }
+}
+```
+
+And finally swap out the component with `dangerouslySetInnerHTML` to a `MDXRenderer` component:
+
+```diff
+const post = data.mdx
+
+// ...
+
+-<section dangerouslySetInnerHTML={{ __html: post.html }} />
++<MDXRenderer>{post.body}</MDXRenderer>
+```
+
+## What's next?
+
+Go check out the [Importing and Using Components in MDX guide](/docs/mdx/importing-and-using-components) to find out how you can insert React components in your MDX files.

--- a/docs/docs/mdx/migrate-remark-to-mdx.md
+++ b/docs/docs/mdx/migrate-remark-to-mdx.md
@@ -13,11 +13,11 @@ npm install @mdx-js/mdx @mdx-js/react gatsby-plugin-mdx
 npm remove gatsby-transformer-remark
 ```
 
-## Update gatsby-config.js
+## Replacing gatsby-transformer-remark with gatsby-plugin-mdx
 
-In your gatsby-config.js file, replace gatsby-transformer-remark with gatsby-plugin-mdx and update the plugins option with gatsbyRemarkPlugins:
+In your gatsby-config.js file, replace gatsby-transformer-remark with gatsby-plugin-mdx. All sub-plugins of gatsby-transformer-remark can still work with gatsby-plugin-mdx by updating the plugins option to gatsbyRemarkPlugins.
 
-```diff
+```diff:title=gatsby-config.js
 {
 - resolve: `gatsby-transformer-remark`
 + resolve: `gatsby-plugin-mdx`
@@ -30,7 +30,26 @@ In your gatsby-config.js file, replace gatsby-transformer-remark with gatsby-plu
 
 In the `createPages` API call, when you query for `allMarkdownRemark`, replace it with `allMdx`.
 
+```diff:title=gatsby-node.js
+const result = await graphql(
+  `
+    {
+-     allMarkdownRemark(
++     allMdx(
+        sort: { fields: [frontmatter___date], order: DESC }
+        limit: 1000
+      ) {
+```
+
 Also, update `onCreateNode` which creates the blog post slugs to watch for the node type of `Mdx` instead of `MarkdownRemark`.
+
+```diff:title=gatsby-node.js
+exports.onCreateNode = ({ node, actions, getNode }) => {
+  const { createNodeField } = actions
+
+-  if (node.internal.type === `MarkdownRemark`) {
++  if (node.internal.type === `Mdx`) {
+```
 
 ## Update File Extension
 
@@ -38,7 +57,7 @@ Where your markdown files live, change the file extension to `.mdx`.
 
 Also, you can tell `gatsby-plugin-mdx` to accept both `md` and `mdx` files by adding the `extensions` option in your gatsby-config entry.
 
-```js
+```js:title=gatsby-config.js
   {
     resolve: `gatsby-plugin-mdx`,
     options: {
@@ -46,6 +65,8 @@ Also, you can tell `gatsby-plugin-mdx` to accept both `md` and `mdx` files by ad
     },
   },
 ```
+
+Now with this addition, gatsby-plugin-mdx will see files that end with both `.mdx` or `.md`.
 
 ## Update usage in pages
 
@@ -63,7 +84,7 @@ And in the graphql query, change the `html` field in `mdx` to `body`.
 mdx(fields: { slug: { eq: $slug } }) {
   id
   excerpt(pruneLength: 160)
-  body
+  body // highlight-line
   frontmatter {
     ...
   }

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -361,6 +361,8 @@
               link: /docs/mdx/programmatically-creating-pages/
             - title: Using MDX Plugins
               link: /docs/mdx/plugins/
+            - title: Migrating Remark to MDX
+              link: /docs/mdx/migrate-remark-to-mdx/
             - title: Markdown Syntax
               link: /docs/mdx/markdown-syntax/
         - title: Adding Testing


### PR DESCRIPTION
## Description

A documentation page on migrating a Gatsby site using gatsby-transformer-remark to use MDX.

## Related Issues

Closes #23502