### PR TITLE
chore(docs): Update fadeIn prop to bool

### DIFF
--- a/docs/docs/gatsby-image.md
+++ b/docs/docs/gatsby-image.md
@@ -371,7 +371,7 @@ Here are some usage examples:
 <Img
   fluid={data.file.childImageSharp.fluid}
   alt="Cat taking up an entire chair"
-  fadeIn="false"
+  fadeIn={false}
   className="customImg"
   placeholderStyle={{ `backgroundColor`: `black` }}
   onLoad={() => {


### PR DESCRIPTION
Following this example leads to a console error `Warning: Failed prop type: Invalid prop "fadeIn" of type "string" supplied to "Image", expected "boolean". I updated the example fadeIn prop to a bool from a string.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
