### PR TITLE
chore(gatsby-source-contentful): drop noop loop

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -468,15 +468,6 @@ exports.createNodesForContentType = ({
         entryNode.sys.contentType = entryItem.sys.contentType
       }
 
-      // Use default locale field.
-      Object.keys(entryItemFields).forEach(entryItemFieldKey => {
-        // Ignore fields with "___node" as they're already handled
-        // and won't be a text field.
-        if (entryItemFieldKey.split(`___`).length > 1) {
-          return
-        }
-      })
-
       // Replace text fields with text nodes so we can process their markdown
       // into HTML.
       Object.keys(entryItemFields).forEach(entryItemFieldKey => {


### PR DESCRIPTION
Git blame (https://github.com/gatsbyjs/gatsby/blame/5d2b510a59e4147c74277ddd2f6d670467f79690/packages/gatsby-source-contentful/src/normalize.js#L472 @KyleAMathews !) is useless here because I suspect the loop used to do something but those lines have actually been stripped and when this happened for the last side effect, the actual loop wasn't cleaned up.

Anyways, this can be dropped. It's not doing anything.