### PR TITLE
fix(docs): add missing comma between properties in code example

### DIFF
--- a/docs/docs/sourcing-from-sanity.md
+++ b/docs/docs/sourcing-from-sanity.md
@@ -247,7 +247,7 @@ module.exports = {
       resolve: 'gatsby-source-sanity',
       options: {
         projectId: process.env.SANITY_PROJECT_ID,
-        dataset: process.env.SANITY_DATASET
+        dataset: process.env.SANITY_DATASET,
         token: process.env.SANITY_TOKEN
       }
     }

--- a/docs/docs/sourcing-from-sanity.md
+++ b/docs/docs/sourcing-from-sanity.md
@@ -237,21 +237,21 @@ SANITY_TOKEN = my-super-secret-token
 ```
 
 ```js:title=gatsby-config.js
-require('dotenv').config({
-  path: `.env.${process.env.NODE_ENV}`
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
 })
 
 module.exports = {
   plugins: [
     {
-      resolve: 'gatsby-source-sanity',
+      resolve: "gatsby-source-sanity",
       options: {
         projectId: process.env.SANITY_PROJECT_ID,
         dataset: process.env.SANITY_DATASET,
-        token: process.env.SANITY_TOKEN
-      }
-    }
-  ]
+        token: process.env.SANITY_TOKEN,
+      },
+    },
+  ],
 }
 ```
 


### PR DESCRIPTION
## Description
Fixes an error within an example code block of the sourcing-from-sanity doc.
- Adds missing comma between properties

## Related Issues
None

(It's my first PR here, I hope I did this right!)