### PR TITLE
fix(www): Allow API docs to reference top level TS exports

### DIFF
--- a/www/src/templates/template-api-markdown.js
+++ b/www/src/templates/template-api-markdown.js
@@ -42,7 +42,7 @@ const mergeFunctions = (data, context) => {
 
   const docs = data.jsdoc.nodes.reduce((acc, node) => {
     const doc = node.childrenDocumentationJs
-      .filter(def => def.kind !== `typedef` && def.memberof)
+      .filter(def => def.kind !== `typedef`)
       .map(def => {
         if (!context.apiCalls) {
           // When an api call list is not available, the line numbers from jsdoc


### PR DESCRIPTION
## Description

Currently API docs filter out definitions that do not include a `memberof` field. This is not set in top level exports in TypeScript files, so was causing the Node API docs to go missing.

This PR just removes that filter. I don't _think_ this should include any unexpected definitions.

## Related Issues

Fixes #23857 