### PR TITLE
feat(benchmarks): Add script to update 1 Contentful article (for benchmarking data updates)

### DIFF
--- a/benchmarks/source-contentful/.env.example
+++ b/benchmarks/source-contentful/.env.example
@@ -5,7 +5,7 @@ BENCHMARK_DATASOURCE_LOCAL_PATH='/path/to/benchmark/_dataset
 # Required for `yarn setup`
 BENCHMARK_SITE_ID='site1'
 
-# Required for `yarn setup` script only
+# Required for `yarn setup` and `yarn data-update`
 BENCHMARK_CONTENTFUL_MANAGEMENT_TOKEN=''
 
 # Required for `yarn build`

--- a/benchmarks/source-contentful/README.md
+++ b/benchmarks/source-contentful/README.md
@@ -32,3 +32,10 @@ Use following approach to fix those:
 1. Copy `.env.example` to `.env.production`
 2. Set `BENCHMARK_CONTENTFUL_SPACE_ID` and `BENCHMARK_CONTENTFUL_ACCESS_TOKEN` variables
 3. Run `yarn build`
+
+## Update data
+
+1. Copy `.env.example` to `.env.production`
+2. Set `BENCHMARK_CONTENTFUL_SPACE_ID` and `BENCHMARK_CONTENTFUL_MANAGEMENT_TOKEN`
+   variables
+3. Run `yarn data-update`

--- a/benchmarks/source-contentful/bin/site.js
+++ b/benchmarks/source-contentful/bin/site.js
@@ -51,6 +51,13 @@ yargs
       runFixBrokenImages(ids).catch(console.error)
     },
   })
+  .command({
+    command: "data-update",
+    desc: `Update random article (to trigger Contentful webhook)`,
+    handler: () => {
+      runDataUpdate().catch(console.error)
+    },
+  })
   .demandCommand(1)
   .help().argv
 
@@ -350,4 +357,20 @@ async function runFixBrokenImages(ids) {
   const { env } = await createClient()
   console.log(`Fixing ${chalk.yellow(ids.length)} broken images`)
   await updateAssets({ env, assetIds: new Set(ids) })
+}
+
+async function runDataUpdate() {
+  const { env } = await createClient()
+
+  const entries = await env.getEntries({
+    content_type: 'article',
+    limit: 1
+  })
+
+  const entry = entries.items[0]
+  const title = entry.fields.title[locale]
+  entry.fields.title[locale] = `${title.substring(0, title.lastIndexOf(` `))} ${Date.now()}`
+
+  await entry.update()
+  console.log(`Updated ${chalk.green(entry.sys.id)}`)
 }

--- a/benchmarks/source-contentful/package.json
+++ b/benchmarks/source-contentful/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "gatsby clean",
     "build": "gatsby build",
-    "data-update": "ts-node scripts/data-update.ts",
+    "data-update": "cross-env NODE_ENV=production node bin/site.js data-update",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "serve": "gatsby serve",

--- a/benchmarks/source-contentful/scripts/data-update.ts
+++ b/benchmarks/source-contentful/scripts/data-update.ts
@@ -1,1 +1,0 @@
-// noop for now, but will be created later.


### PR DESCRIPTION
## Description

Script for benchmarking data updates for Contentful.

Someone has added a skeleton for this script in the past but I didn't use it because we already have scripting infra in this benchmark. It was way easier to re-use it instead of writing it again.

Also, there are two commits here, first one was just a minor refactoring. The feature commit is: https://github.com/gatsbyjs/gatsby/commit/cb3c47fa4bd4a2fd51da69c7663e9391897084b0 (easier to review)

### Documentation

Added notes in README.md on how to use it.
