### PR TITLE
fix(using-markdown-pages): Example and docs

### DIFF
--- a/docs/docs/adding-markdown-pages.md
+++ b/docs/docs/adding-markdown-pages.md
@@ -77,13 +77,13 @@ When you create a Markdown file, you can include a set of key value pairs that c
 
 ```markdown:title=src/markdown-pages/post-1.md
 ---
-path: "/blog/my-first-post"
+slug: "/blog/my-first-post"
 date: "2019-05-04"
 title: "My first blog post"
 ---
 ```
 
-What is important in this step is the key pair `path`. The value that is assigned to the key `path` is used in order to navigate to your post.
+What is important in this step is the key pair `slug`. The value that is assigned to the key `slug` is used in order to navigate to your post.
 
 ## Create a page template for the Markdown files
 
@@ -114,12 +114,12 @@ export default function Template({
 }
 
 export const pageQuery = graphql`
-  query($path: String!) {
-    markdownRemark(frontmatter: { path: { eq: $path } }) {
+  query($slug: String!) {
+    markdownRemark(frontmatter: { slug: { eq: $slug } }) {
       html
       frontmatter {
         date(formatString: "MMMM DD, YYYY")
-        path
+        slug
         title
       }
     }
@@ -144,12 +144,10 @@ Use the `graphql` to query Markdown file data as below. Next, use the `createPag
 **NOTE:** Gatsby calls the `createPages` API (if present) at build time with injected parameters, `actions` and `graphql`.
 
 ```javascript:title=gatsby-node.js
-const path = require(`path`)
-
 exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage } = actions
 
-  const blogPostTemplate = path.resolve(`src/templates/blogTemplate.js`)
+  const blogPostTemplate = require.resolve(`./src/templates/blogTemplate.js`)
 
   const result = await graphql(`
     {
@@ -160,7 +158,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
         edges {
           node {
             frontmatter {
-              path
+              slug
             }
           }
         }
@@ -176,9 +174,12 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
 
   result.data.allMarkdownRemark.edges.forEach(({ node }) => {
     createPage({
-      path: node.frontmatter.path,
+      path: node.frontmatter.slug,
       component: blogPostTemplate,
-      context: {}, // additional data can be passed via context
+      context: {
+        // additional data can be passed via context
+        slug: node.frontmatter.slug,
+      },
     })
   })
 }

--- a/examples/using-markdown-pages/gatsby-node.js
+++ b/examples/using-markdown-pages/gatsby-node.js
@@ -1,9 +1,7 @@
-const path = require(`path`)
-
 exports.createPages = ({ actions, graphql }) => {
   const { createPage } = actions
 
-  const blogPostTemplate = path.resolve(`src/templates/blogTemplate.js`)
+  const blogPostTemplate = require.resolve(`./src/templates/blogTemplate.js`)
 
   return graphql(`
     {
@@ -14,7 +12,7 @@ exports.createPages = ({ actions, graphql }) => {
         edges {
           node {
             frontmatter {
-              path
+              slug
             }
           }
         }
@@ -27,9 +25,12 @@ exports.createPages = ({ actions, graphql }) => {
 
     return result.data.allMarkdownRemark.edges.forEach(({ node }) => {
       createPage({
-        path: node.frontmatter.path,
+        path: node.frontmatter.slug,
         component: blogPostTemplate,
-        context: {}, // additional data can be passed via context
+        context: {
+          // additional data can be passed via context
+          slug: node.frontmatter.slug,
+        },
       })
     })
   })

--- a/examples/using-markdown-pages/src/markdown-pages/post-1.md
+++ b/examples/using-markdown-pages/src/markdown-pages/post-1.md
@@ -1,5 +1,7 @@
 ---
-path: "/blog/my-first-post"
+slug: "/blog/my-first-post"
 date: "2019-05-04"
 title: "My first blog post"
 ---
+
+Hello World!

--- a/examples/using-markdown-pages/src/markdown-pages/post-2.md
+++ b/examples/using-markdown-pages/src/markdown-pages/post-2.md
@@ -1,0 +1,7 @@
+---
+slug: "/blog/my-second-post"
+date: "2020-05-07"
+title: "My second blog post"
+---
+
+Hello Universe!

--- a/examples/using-markdown-pages/src/pages/index.js
+++ b/examples/using-markdown-pages/src/pages/index.js
@@ -7,7 +7,11 @@ const IndexPage = () => (
   <Layout>
     <h1>Hi people</h1>
     <p>Welcome to your new Gatsby blog with Markdown pages.</p>
-    <Link to="/blog/my-first-post/">Go to my first Markdown blog post</Link>
+    <p>
+      <Link to="/blog/my-first-post/">Go to my first Markdown blog post</Link>
+      <br />
+      <Link to="/blog/my-second-post/">Go to my second Markdown blog post</Link>
+    </p>
   </Layout>
 )
 

--- a/examples/using-markdown-pages/src/templates/blogTemplate.js
+++ b/examples/using-markdown-pages/src/templates/blogTemplate.js
@@ -21,12 +21,12 @@ export default function Template({
 }
 
 export const pageQuery = graphql`
-  query($path: String!) {
-    markdownRemark(frontmatter: { path: { eq: $path } }) {
+  query($slug: String!) {
+    markdownRemark(frontmatter: { slug: { eq: $slug } }) {
       html
       frontmatter {
         date(formatString: "MMMM DD, YYYY")
-        path
+        slug
         title
       }
     }


### PR DESCRIPTION
## Description

While researching for something else I stumbled upon our docs page: https://www.gatsbyjs.org/docs/adding-markdown-pages/

I recognized that nothing was passed in via `context` which is necessary for the query in the template. So I updated the doc and example.

Moreover, I renamed the frontmatter from `path` to `slug` as the former is not allowed inside `context` - it's a reserved constant.

I also removed the `const path = require('path')` to not confuse people with another "path" variable (used `require.resolve()` instead).

Last but not least I added another blog post example so that the filtering can show.
