### PR TITLE
fix(gatsby-dev-cli): fix "expected manifest" errors

### DIFF
--- a/packages/gatsby-dev-cli/src/local-npm-registry/index.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/index.js
@@ -53,8 +53,10 @@ exports.publishPackagesLocallyAndInstall = async ({
 
   const versionPostFix = Date.now()
 
+  const newlyPublishedPackageVersions = {}
+
   for (let packageName of packagesToPublish) {
-    await publishPackage({
+    newlyPublishedPackageVersions[packageName] = await publishPackage({
       packageName,
       packagesToPublish,
       root,
@@ -65,5 +67,9 @@ exports.publishPackagesLocallyAndInstall = async ({
 
   const packagesToInstall = _.intersection(packagesToPublish, localPackages)
 
-  await installPackages({ packagesToInstall, yarnWorkspaceRoot })
+  await installPackages({
+    packagesToInstall,
+    yarnWorkspaceRoot,
+    newlyPublishedPackageVersions,
+  })
 }

--- a/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
@@ -4,7 +4,11 @@ const fs = require(`fs-extra`)
 const { promisifiedSpawn } = require(`../utils/promisified-spawn`)
 const { registryUrl } = require(`./verdaccio-config`)
 
-const installPackages = async ({ packagesToInstall, yarnWorkspaceRoot }) => {
+const installPackages = async ({
+  packagesToInstall,
+  yarnWorkspaceRoot,
+  newlyPublishedPackageVersions,
+}) => {
   console.log(
     `Installing packages from local registry:\n${packagesToInstall
       .map(packageAndVersion => ` - ${packageAndVersion}`)
@@ -71,7 +75,10 @@ const installPackages = async ({ packagesToInstall, yarnWorkspaceRoot }) => {
       `yarn`,
       [
         `add`,
-        ...packagesToInstall.map(packageName => `${packageName}@gatsby-dev`),
+        ...packagesToInstall.map(packageName => {
+          const packageVersion = newlyPublishedPackageVersions[packageName]
+          return `${packageName}@${packageVersion}`
+        }),
         `--registry=${registryUrl}`,
         `--exact`,
       ],
@@ -84,6 +91,7 @@ const installPackages = async ({ packagesToInstall, yarnWorkspaceRoot }) => {
     console.log(`Installation complete`)
   } catch (error) {
     console.error(`Installation failed`, error)
+    process.exit(1)
   }
 }
 

--- a/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
@@ -27,6 +27,7 @@ const adjustPackageJson = ({
   versionPostFix,
   packagesToPublish,
   ignorePackageJSONChanges,
+  root,
 }) => {
   // we need to check if package depend on any other package to will be published and
   // adjust version selector to point to dev version of package so local registry is used
@@ -44,8 +45,19 @@ const adjustPackageJson = ({
       monorepoPKGjson.dependencies &&
       monorepoPKGjson.dependencies[packageThatWillBePublished]
     ) {
-      // change to "gatsby-dev" dist tag
-      monorepoPKGjson.dependencies[packageThatWillBePublished] = `gatsby-dev`
+      const currentVersion = JSON.parse(
+        fs.readFileSync(
+          getMonorepoPackageJsonPath({
+            packageName: packageThatWillBePublished,
+            root,
+          }),
+          `utf-8`
+        )
+      ).version
+
+      monorepoPKGjson.dependencies[
+        packageThatWillBePublished
+      ] = `${currentVersion}-dev-${versionPostFix}`
     }
   })
 
@@ -133,6 +145,8 @@ const publishPackage = async ({
 
   uncreateTemporaryNPMRC()
   unadjustPackageJson()
+
+  return newPackageVersion
 }
 
 exports.publishPackage = publishPackage

--- a/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio-config.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio-config.js
@@ -19,6 +19,8 @@ const verdaccioConfig = {
   uplinks: {
     npmjs: {
       url: `https://registry.npmjs.org/`,
+      // default is 2 max_fails - on flaky networks that cause a lot of failed installations
+      max_fails: 10,
     },
   },
 }


### PR DESCRIPTION
I was checking on one instance of "expected manifest" error and seems like in some cases using `dist-tag` over concrete version when installing dependencies was triggering this problem (problem in `yarn` perhaps?). Using concrete versions seems to solve it (at least in reproduction I had).

There are also few QoL improvements:
 - increase request retries for npm registry uplink - on flaky connections (or maybe when npm registry is getting hammered) installation would sometimes fail because of those - this adds bit more resilience
 - don't display those annoying and not actionable "Installation of dependencies after initial scan is not implemented" messages when package.json is being changed by `gatsby-dev` itself while publishing dev versions of packages
 - in case of `yarn` installation failures - exit the process and don't continue - this particulary annoying because of output spam when you don't use `--quiet` you don't actually see that installation failed, and gatsby-dev continued to copy files phase resulting in not installed packages, just copied files in `node_modules`

You try it by installing `qol` canary: `npm i -g gatsby-dev-cli@qol`