### PR TITLE
docs: replaced <Header/> with <header/>

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -196,7 +196,7 @@ export default function Header() {
 }
 ```
 
-3. Modify the `about.js` file to import the `Header` component. Replace the `h1` markup with `<Header />`:
+3. Modify the `about.js` file to import the `header` component. Replace the `h1` markup with `<header />`:
 
 ```jsx:title=src/pages/about.js
 import React from "react"
@@ -205,7 +205,7 @@ import Header from "../components/header" // highlight-line
 export default function About() {
   return (
     <div style={{ color: `teal` }}>
-      <Header /> {/* highlight-line */}
+      <header /> {/* highlight-line */}
       <p>Such wow. Very React.</p>
     </div>
   )


### PR DESCRIPTION
Header as the component name is not working now when the actual page in components is created as header.js, now its working with header.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
