### PR TITLE
feat(gatsby-recipes): Improve ongoing summary of steps + add end summary

### DIFF
--- a/packages/gatsby-recipes/recipes/tailwindcss.mdx
+++ b/packages/gatsby-recipes/recipes/tailwindcss.mdx
@@ -1,6 +1,6 @@
 # Setup Gatsby with Tailwindcss
 
-[Tailwindcss](https://tailwindcss.com/) Tailwind CSS is a highly customizable, low-level CSS framework that gives you all of the building blocks you need to build bespoke designs without any annoying opinionated styles you have to fight to override.
+[Tailwind CSS](https://tailwindcss.com/) is a highly customizable, low-level CSS framework that gives you all of the building blocks you need to build bespoke designs without any annoying opinionated styles you have to fight to override.
 
 ---
 

--- a/packages/gatsby-recipes/src/__snapshots__/recipe-machine.test.js.snap
+++ b/packages/gatsby-recipes/src/__snapshots__/recipe-machine.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should store created/changed/deleted resources on the context after applying plan 1`] = `
+Array [
+  Object {
+    "_currentStep": 1,
+    "_message": "Wrote file ./hi.md",
+  },
+  Object {
+    "_currentStep": 1,
+    "_message": "Wrote file ./hi2.md",
+  },
+  Object {
+    "_currentStep": 2,
+    "_message": "Wrote file ./hi3.md",
+  },
+]
+`;

--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -541,7 +541,9 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
         process.nextTick(() => {
           subscriptionClient.close()
           exit()
-          process.stdout.write(`\n\n---\n\n\nThe recipe finished successfully!\n\n`)
+          process.stdout.write(
+            `\n\n---\n\n\nThe recipe finished successfully!\n\n`
+          )
           lodash.flattenDeep(state.context.stepResources).forEach((res, i) => {
             process.stdout.write(`✅ ${res._message}\n`)
           })

--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -259,8 +259,6 @@ log(
   `======================================= ${new Date().toJSON()}`
 )
 
-const PlanContext = React.createContext({})
-
 module.exports = ({ recipe, graphqlPort, projectRoot }) => {
   try {
     const GRAPHQL_ENDPOINT = `http://localhost:${graphqlPort}/graphql`
@@ -391,9 +389,8 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
 
       const isDone = state.value === `done`
 
-      // If we're done, exit.
-      if (state.value === `done`) {
-      }
+      // If we're done with an error, render out error (happens below)
+      // then exit.
       if (state.value === `doneError`) {
         process.nextTick(() => process.exit())
       }
@@ -408,10 +405,6 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
         const isPlan = state.context.plan && state.context.plan.length > 0
         const isPresetPlanState = state.value === `present plan`
         const isRunningStep = state.value === `applyingPlan`
-        const isLastStep =
-          state.context.steps &&
-          state.context.steps.length - 1 === state.context.currentStep
-
         if (isRunningStep) {
           return null
         }
@@ -524,7 +517,7 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
         return <Error width="100%" state={state} />
       }
 
-      let staticMessages = {}
+      const staticMessages = {}
       for (let step = 0; step < state.context.currentStep; step++) {
         staticMessages[step] = [
           {

--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -293,9 +293,9 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
     })
 
     const RecipeInterpreter = () => {
+      const { exit } = useApp()
       // eslint-disable-next-line
       const [localRecipe, setRecipe] = useState(recipe)
-      const { exit } = useApp()
 
       const [subscriptionResponse] = useSubscription(
         {
@@ -343,11 +343,7 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
         if (showRecipesList) {
           return
         }
-        if (key.return && state && state.value === `SUCCESS`) {
-          subscriptionClient.close()
-          exit()
-          process.exit()
-        } else if (key.return) {
+        if (key.return) {
           sendEvent({ event: `CONTINUE` })
         }
       })
@@ -393,9 +389,10 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
       log(`render`, `${renderCount} ${new Date().toJSON()}`)
       renderCount += 1
 
+      const isDone = state.value === `done`
+
       // If we're done, exit.
       if (state.value === `done`) {
-        process.nextTick(() => process.exit())
       }
       if (state.value === `doneError`) {
         process.nextTick(() => process.exit())
@@ -411,22 +408,11 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
         const isPlan = state.context.plan && state.context.plan.length > 0
         const isPresetPlanState = state.value === `present plan`
         const isRunningStep = state.value === `applyingPlan`
-        const isDone = state.value === `done`
         const isLastStep =
           state.context.steps &&
           state.context.steps.length - 1 === state.context.currentStep
 
         if (isRunningStep) {
-          return null
-        }
-
-        if (isDone) {
-          return null
-        }
-
-        // If there's no plan on the last step, just return.
-        if (!isPlan && isLastStep) {
-          process.nextTick(() => process.exit())
           return null
         }
 
@@ -441,7 +427,7 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
         return (
           <Div>
             <Div>
-              <Text bold underline marginBottom={2}>
+              <Text bold italic marginBottom={2}>
                 Proposed changes
               </Text>
             </Div>
@@ -538,31 +524,76 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
         return <Error width="100%" state={state} />
       }
 
+      let staticMessages = {}
+      for (let step = 0; step < state.context.currentStep; step++) {
+        staticMessages[step] = [
+          {
+            type: `mdx`,
+            key: `mdx-${step}`,
+            value: state.context.stepsAsMdx[step],
+          },
+        ]
+      }
+      lodash.flattenDeep(state.context.stepResources).forEach((res, i) => {
+        staticMessages[res._currentStep].push({
+          type: `resource`,
+          key: `finished-stuff-${i}`,
+          value: res._message,
+        })
+      })
+
+      log(`staticMessages`, staticMessages)
+
+      if (isDone) {
+        process.nextTick(() => {
+          subscriptionClient.close()
+          exit()
+          process.stdout.write(`\n\n---\nThe recipe finished successfully!\n\n`)
+          lodash.flattenDeep(state.context.stepResources).forEach((res, i) => {
+            process.stdout.write(`✅ ${res._message}\n`)
+          })
+          process.exit()
+        })
+        // return null
+      }
+
       return (
         <>
           <Div>
             <Static>
-              {lodash.flattenDeep(state.context.stepResources).map((r, i) => (
-                <Text key={`finished-stuff-${i}`}>✅ {r._message}</Text>
-              ))}
+              {Object.keys(staticMessages).map((key, iStep) =>
+                staticMessages[key].map((r, i) => {
+                  if (r.type && r.type === `mdx`) {
+                    return (
+                      <Div key={r.key}>
+                        {iStep === 0 && <Text underline>Completed Steps</Text>}
+                        <Div marginTop={iStep === 0 ? 0 : 1} marginBottom={1}>
+                          {iStep !== 0 && `---`}
+                        </Div>
+                        {iStep !== 0 && <Text>Step {iStep}</Text>}
+                        <MDX components={components}>{r.value}</MDX>
+                      </Div>
+                    )
+                  }
+                  return <Text key={r.key}>✅ {r.value}</Text>
+                })
+              )}
             </Static>
           </Div>
           {state.context.currentStep === 0 && <WelcomeMessage />}
-          {state.context.currentStep > 0 && state.value !== `done` && (
-            <Div>
+          {state.context.currentStep > 0 && !isDone && (
+            <Div marginTop={7}>
               <Text underline bold>
                 Step {state.context.currentStep} /{` `}
                 {state.context.steps.length - 1}
               </Text>
             </Div>
           )}
-          <PlanContext.Provider value={{ planForNextStep: state.plan }}>
-            <MDX components={components}>
-              {state.context.stepsAsMdx[state.context.currentStep]}
-            </MDX>
-            <PresentStep state={state} />
-            <RunningStep state={state} />
-          </PlanContext.Provider>
+          <MDX components={components}>
+            {state.context.stepsAsMdx[state.context.currentStep]}
+          </MDX>
+          {!isDone && <PresentStep state={state} />}
+          {!isDone && <RunningStep state={state} />}
         </>
       )
     }

--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -541,7 +541,7 @@ module.exports = ({ recipe, graphqlPort, projectRoot }) => {
         process.nextTick(() => {
           subscriptionClient.close()
           exit()
-          process.stdout.write(`\n\n---\nThe recipe finished successfully!\n\n`)
+          process.stdout.write(`\n\n---\n\n\nThe recipe finished successfully!\n\n`)
           lodash.flattenDeep(state.context.stepResources).forEach((res, i) => {
             process.stdout.write(`✅ ${res._message}\n`)
           })

--- a/packages/gatsby-recipes/src/graphql.js
+++ b/packages/gatsby-recipes/src/graphql.js
@@ -46,6 +46,7 @@ const applyPlan = ({ recipePath, projectRoot }) => {
       event: state.event,
       state: state.value,
       context: state.context,
+      stepResources: state.context.stepResources,
       plan: state.context.plan,
     })
     if (state.changed) {

--- a/packages/gatsby-recipes/src/recipe-machine.js
+++ b/packages/gatsby-recipes/src/recipe-machine.js
@@ -218,8 +218,14 @@ const recipeMachine = Machine(
       addResourcesToContext: assign((context, event) => {
         if (event.data) {
           const stepResources = context.stepResources || []
+          const messages = event.data.map(e => {
+            return {
+              _message: e._message,
+              _currentStep: context.currentStep,
+            }
+          })
           return {
-            stepResources: stepResources.concat([event.data]),
+            stepResources: stepResources.concat(messages),
           }
         }
         return undefined

--- a/packages/gatsby-recipes/src/recipe-machine.test.js
+++ b/packages/gatsby-recipes/src/recipe-machine.test.js
@@ -210,9 +210,10 @@ it(`should store created/changed/deleted resources on the context after applying
       fs.unlinkSync(path.join(process.cwd(), filePath2))
       fs.unlinkSync(path.join(process.cwd(), filePath3))
 
-      expect(state.context.stepResources[0]).toHaveLength(2)
-      //expect(state.context.stepResources).toMatchSnapshot()
-      expect(state.context.stepResources[1][0]._message).toBeTruthy()
+      expect(state.context.stepResources).toHaveLength(3)
+      expect(state.context.stepResources).toMatchSnapshot()
+      expect(state.context.stepResources[0]._message).toBeTruthy()
+      expect(state.context.stepResources[0]._currentStep).toBeTruthy()
       done()
     }
   })


### PR DESCRIPTION
fixes https://github.com/gatsbyjs/gatsby/issues/23817
fixes https://github.com/gatsbyjs/gatsby/issues/23818
fixes https://github.com/gatsbyjs/gatsby/issues/23603

We previously erased markdown text from recipes after a step was completed which meant that users couldn't reference them again while running the recipe or after.

Also with longer recipes, the step summaries could get lost so we now also print out at the end a list of all actions that were taken.

![new-recipes-ui](https://user-images.githubusercontent.com/71047/81358166-994bf500-908a-11ea-9094-0cad63ce8406.gif)
