### PR TITLE
perf(www): Close other sections when navigating to a new page

### DIFF
--- a/www/src/components/page-with-sidebar.js
+++ b/www/src/components/page-with-sidebar.js
@@ -29,7 +29,6 @@ export default ({ children, enableScrollSync, location }) => {
         enableScrollSync={enableScrollSync}
         itemList={itemList.items}
         title={itemList.title}
-        sidebarKey={itemList.key}
         disableExpandAll={itemList.disableExpandAll}
         disableAccordions={itemList.disableAccordions}
         key={location.pathname}

--- a/www/src/components/sidebar/__tests__/sidebar.js
+++ b/www/src/components/sidebar/__tests__/sidebar.js
@@ -6,27 +6,6 @@ import Sidebar from "../sidebar"
 import { I18nProvider } from "../../I18nContext"
 import theme from "../../../gatsby-plugin-theme-ui"
 
-class LocalStorageMock {
-  store = {}
-
-  getItem(key) {
-    return this.store[key] ?? null
-  }
-
-  setItem(key, value) {
-    this.store[key] = value
-  }
-
-  clear() {
-    this.store = {}
-  }
-}
-
-Object.defineProperty(window, "localStorage", {
-  value: new LocalStorageMock(),
-  writable: true,
-})
-
 function extendItemList(itemList, parentTitle) {
   for (const item of itemList) {
     if (parentTitle) {
@@ -95,7 +74,6 @@ function renderSidebar(pathname, { activeItemHash } = {}) {
 describe("sidebar", () => {
   let scrollIntoViewMock
   beforeEach(() => {
-    localStorage.clear()
     scrollIntoViewMock = jest.fn()
     // https://github.com/jsdom/jsdom/issues/1695
     window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock
@@ -103,22 +81,8 @@ describe("sidebar", () => {
 
   describe("initialization", () => {
     it("opens sections with active items", () => {
-      // Render a page
-      renderSidebar("/plot-summary/").unmount()
-      // Render another page and make sure that its section is open even if
-      // a falsy value was stored in local storage
       const { queryByText } = renderSidebar("/characters/jay-gatsby/")
       expect(queryByText("Jay Gatsby")).toBeInTheDocument()
-    })
-
-    it("opens sections based on local storage", () => {
-      // Render a page
-      renderSidebar("/characters/jay-gatsby/").unmount()
-      // Render a new page and check that the previous opened section
-      // is still open
-      const { queryByText } = renderSidebar("/plot-summary/")
-      expect(queryByText("Jay Gatsby")).toBeInTheDocument()
-      expect(queryByText("Daisy Buchanan")).not.toBeInTheDocument()
     })
   })
 
@@ -165,7 +129,6 @@ describe("sidebar", () => {
     })
 
     it("does not scroll into view when loaded with a hash", () => {
-      //
       renderSidebar("/themes/", {
         activeItemHash: "the-american-dream",
       })

--- a/www/src/components/sidebar/__tests__/sidebar.js
+++ b/www/src/components/sidebar/__tests__/sidebar.js
@@ -61,7 +61,6 @@ function renderSidebar(pathname, { activeItemHash } = {}) {
       <I18nProvider locale="en">
         <Sidebar
           title="The Great Gatsby"
-          sidebarKey="great-gatsby"
           itemList={extendItemList(itemList)}
           location={{ pathname }}
           activeItemHash={activeItemHash}

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -10,19 +10,6 @@ import getActiveItem from "../../utils/sidebar/get-active-item"
 import getActiveItemParents from "../../utils/sidebar/get-active-item-parents"
 import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
-// Access to global `localStorage` property must be guarded as it
-// fails under iOS private session mode.
-var hasLocalStorage = true
-var testKey = `gatsbyjs.sidebar.testKey`
-var ls
-try {
-  ls = global.localStorage
-  ls.setItem(testKey, `test`)
-  ls.removeItem(testKey)
-} catch (e) {
-  hasLocalStorage = false
-}
-
 function isItemInActiveTree(item, activeItem, activeItemParents) {
   return (
     activeItem.title === item.title ||
@@ -48,19 +35,6 @@ function getOpenItemHash(itemList, activeItem, activeItemParents) {
   return result
 }
 
-function readLocalStorage(key) {
-  if (hasLocalStorage) {
-    return JSON.parse(localStorage.getItem(`gatsbyjs:sidebar:${key}`)) ?? {}
-  }
-  return {}
-}
-
-function writeLocalStorage(key, state) {
-  if (hasLocalStorage) {
-    localStorage.setItem(`gatsbyjs:sidebar:${key}`, JSON.stringify(state))
-  }
-}
-
 const SidebarContext = React.createContext({})
 
 export function useSidebarContext() {
@@ -70,7 +44,6 @@ export function useSidebarContext() {
 export default withI18n()(function Sidebar({
   i18n,
   title,
-  sidebarKey,
   closeSidebar,
   itemList,
   location,
@@ -100,17 +73,7 @@ export default withI18n()(function Sidebar({
 
   // Get the hash where the only open items are
   // the hierarchy defined in props
-  const derivedHash = getOpenItemHash(itemList, activeItem, activeItemParents)
-
-  // Merge hash in local storage and the derived hash from props
-  // so that all sections open in either hash are open
-  const initialHash = (() => {
-    const { openSectionHash = {} } = readLocalStorage(sidebarKey)
-    for (const [key, isOpen] of Object.entries(derivedHash)) {
-      openSectionHash[key] = openSectionHash[key] || isOpen
-    }
-    return openSectionHash
-  })()
+  const initialHash = getOpenItemHash(itemList, activeItem, activeItemParents)
 
   const [openSectionHash, setOpenSectionHash] = React.useState(initialHash)
   const expandAll = Object.values(openSectionHash).every(isOpen => isOpen)
@@ -135,11 +98,6 @@ export default withI18n()(function Sidebar({
       setOpenSectionHash(newOpenSectionHash)
     }
   }
-
-  // Write to local storage whenever the open section hash changes
-  React.useEffect(() => {
-    writeLocalStorage(sidebarKey, { openSectionHash })
-  }, [openSectionHash])
 
   const getItemState = React.useCallback(
     item => ({

--- a/www/src/components/sidebar/sidebar.js
+++ b/www/src/components/sidebar/sidebar.js
@@ -89,10 +89,11 @@ export default withI18n()(function Sidebar({
 
   function toggleExpandAll() {
     if (expandAll) {
-      setOpenSectionHash(derivedHash)
+      // Close everything except the initial open section
+      setOpenSectionHash(initialHash)
     } else {
       const newOpenSectionHash = {}
-      for (const key of Object.keys(derivedHash)) {
+      for (const key of Object.keys(initialHash)) {
         newOpenSectionHash[key] = true
       }
       setOpenSectionHash(newOpenSectionHash)


### PR DESCRIPTION
## Description

Remove local storage functionality from sidebar so that other sections close when navigating to a new page.

## Motivation

The performance of the docs pages is proportional to how many sections in the sidebar are open: when more sidebar sections are open, more nodes need to be loaded into the DOM and everything slows down. With our current local-storage based implementation:

1. navigating to a page opens the section that its in
2. sections that aren't manually closed remain open even when navigating away from the page.

This means as you navigate the docs over time, performance becomes slower as more and more docs sections are opened, unless you manually close the sections you're visiting or click the "Expand All" button and then the "Collapse All" button.