### PR TITLE
fix(docs): TypeScript Example PageProps

### DIFF
--- a/examples/using-typescript/src/pages/404.tsx
+++ b/examples/using-typescript/src/pages/404.tsx
@@ -1,9 +1,12 @@
+import { PageProps } from "gatsby"
 import * as React from "react"
 import Layout from "../components/layout"
 
-export default () => (
+const Error404Page: React.FC<PageProps> = () => (
   <Layout>
     <h1>You are here!</h1>
     <h2>But nothing found for you #404</h2>
   </Layout>
 )
+
+export default Error404Page

--- a/examples/using-typescript/src/pages/index.tsx
+++ b/examples/using-typescript/src/pages/index.tsx
@@ -1,11 +1,11 @@
-import { graphql } from "gatsby"
+import { graphql, PageProps } from "gatsby"
 import * as React from "react"
 import Layout from "../components/layout"
 import Source from "../components/source"
 
 // Please note that you can use https://github.com/dotansimha/graphql-code-generator
 // to generate all types from graphQL schema
-interface IndexPageProps {
+interface IndexPageProps extends PageProps {
   data: {
     site: {
       siteMetadata: {


### PR DESCRIPTION
## Description

Add missing `PageProps` to page interface in typescript example

### Documentation

https://www.gatsbyjs.org/docs/typescript/#example
https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/index.d.ts#L55