### PR TITLE
feat(gatsby-plugin-benchmark-reporting): allow arbitrary restart

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -17,6 +17,9 @@ const BENCHMARK_REPORTING_URL =
 
 // Track the last received `api` because not all events in this plugin will receive one
 let lastApi
+// Current benchmark state, if any. If none then create one on next lifecycle.
+let benchMeta
+
 function reportInfo(...args) {
   ;(lastApi ? lastApi.reporter : console).info(...args)
 }
@@ -272,6 +275,21 @@ class BenchMeta {
   }
 }
 
+function init(lifecycle) {
+  if (!benchMeta) {
+    benchMeta = new BenchMeta()
+    // This should be set in the gatsby-config of the site when enabling this plugin
+    reportInfo(
+      `gatsby-plugin-benchmark-reporting: Will post benchmark data to: ${
+        BENCHMARK_REPORTING_URL || `the CLI`
+      }`
+    )
+
+    benchMeta.markStart()
+    benchMeta.markDataPoint(lifecycle)
+  }
+}
+
 process.on(`exit`, () => {
   if (!benchMeta.flushed) {
     // This is probably already a non-zero exit as otherwise node should wait for the last promise to complete
@@ -285,36 +303,36 @@ process.on(`exit`, () => {
   }
 })
 
-const benchMeta = new BenchMeta()
-
 async function onPreInit(api) {
   lastApi = api
-  // This should be set in the gatsby-config of the site when enabling this plugin
-  reportInfo(
-    `gatsby-plugin-benchmark-reporting: Will post benchmark data to: ${
-      BENCHMARK_REPORTING_URL || `the CLI`
-    }`
-  )
-
-  benchMeta.markStart()
+  init(`onPreInit`)
   benchMeta.markDataPoint(`preInit`)
 }
 
 async function onPreBootstrap(api) {
   lastApi = api
+  init(`preBootstrap`)
   benchMeta.markDataPoint(`preBootstrap`)
 }
 
 async function onPreBuild(api) {
   lastApi = api
+  init(`preBuild`)
   benchMeta.markDataPoint(`preBuild`)
 }
 
 async function onPostBuild(api) {
+  if (!benchMeta) {
+    // Ignore. Don't start measuring on this event.
+    return
+  }
+
   lastApi = api
 
   benchMeta.markDataPoint(`postBuild`)
-  return benchMeta.markEnd()
+  await benchMeta.markEnd()
+
+  benchMeta = undefined
 }
 
 module.exports = { onPreInit, onPreBootstrap, onPreBuild, onPostBuild }

--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -286,7 +286,6 @@ function init(lifecycle) {
     )
 
     benchMeta.markStart()
-    benchMeta.markDataPoint(lifecycle)
   }
 }
 
@@ -305,7 +304,7 @@ process.on(`exit`, () => {
 
 async function onPreInit(api) {
   lastApi = api
-  init(`onPreInit`)
+  init(`preInit`)
   benchMeta.markDataPoint(`preInit`)
 }
 


### PR DESCRIPTION
This change allows the benchmark reporter to start benchmarking arbitarily after a previous run finished, without having to explicitly request it. This allows us to benchmark incremental builds more reliably, which don't necessarily trigger all the events.
