### PR TITLE
fix(gatsby-dev-cli): fix `set-path-to-repo` command after yargs bump

### DIFF
--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -16,7 +16,7 @@ const argv = require(`yargs`)
   .nargs(`s`, 0)
   .describe(`s`, `Scan once. Do not start file watch`)
   .alias(`p`, `set-path-to-repo`)
-  .nargs(`p`, 0)
+  .nargs(`p`, 1)
   .describe(
     `p`,
     `Set path to Gatsby repository.


### PR DESCRIPTION
We were misusing `.nargs` function previously but it worked, but recent `yargs` bump cause it to fail now.

https://github.com/yargs/yargs/blob/master/docs/api.md#nargskey-count

> The number of arguments that should be consumed after a key. This can be a useful hint to prevent parsing ambiguity.

`set-path-to-repo` requires one argument, otherwise it turns into boolean switch