### PR TITLE
(chore) add seoTitle to ButterCMS blog post

### DIFF
--- a/docs/blog/2020-05-05-Butter-CMS-case-study/index.md
+++ b/docs/blog/2020-05-05-Butter-CMS-case-study/index.md
@@ -3,6 +3,7 @@ title: "Faster, Easier and Also in French: ButterCMS + Gatsby drive Car Loans Ca
 author: Jake Lumetta
 date: 2020-05-05
 excerpt: "CarLoansCanada.com’s growing marketplace team needed to make their content marketing leaner and meaner. They tuned up their performance with a new website built on Gatsby paired with supremely easy content management from headless ButterCMS."
+seoTitle: "ButterCMS & Gatsby Case Study - Car Loans Canada"
 tags:
   - case-studies
   - performance


### PR DESCRIPTION
This change makes the meta title match searches for "ButterCMS Gatsby", a term I found while doing SEO research for ButterCMS topics