### PR TITLE
Update data update webhooks env naming

### DIFF
--- a/benchmarks/md/scripts/data-update.ts
+++ b/benchmarks/md/scripts/data-update.ts
@@ -36,10 +36,10 @@ interface IArticleAttributes {
 
   // call webhooks if they exist
   if (
-    process.env.BENCHMARK_UPDATE_WEBHOOKS &&
-    typeof process.env.BENCHMARK_UPDATE_WEBHOOKS === `string`
+    process.env.BENCHMARK_MD_UPDATE_WEBHOOKS &&
+    typeof process.env.BENCHMARK_MD_UPDATE_WEBHOOKS === `string`
   ) {
-    const webhooks = process.env.BENCHMARK_UPDATE_WEBHOOKS.split(`,`)
+    const webhooks = process.env.BENCHMARK_MD_UPDATE_WEBHOOKS.split(`,`)
 
     for (const webhook of webhooks) {
       await fetch(webhook, { method: `POST` })

--- a/benchmarks/mdx/scripts/data-update.ts
+++ b/benchmarks/mdx/scripts/data-update.ts
@@ -36,10 +36,10 @@ interface IArticleAttributes {
 
   // call webhooks if they exist
   if (
-    process.env.BENCHMARK_UPDATE_WEBHOOKS &&
-    typeof process.env.BENCHMARK_UPDATE_WEBHOOKS === `string`
+    process.env.BENCHMARK_MDX_UPDATE_WEBHOOKS &&
+    typeof process.env.BENCHMARK_MDX_UPDATE_WEBHOOKS === `string`
   ) {
-    const webhooks = process.env.BENCHMARK_UPDATE_WEBHOOKS.split(`,`)
+    const webhooks = process.env.BENCHMARK_MDX_UPDATE_WEBHOOKS.split(`,`)
 
     for (const webhook of webhooks) {
       await fetch(webhook, { method: `POST` })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This changes the name of the environment variables for the `md` and `mdx` benchmark webhooks to easily distinguish between them in the various platforms.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

n/a

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

n/a
