### PR TITLE
fix(docs): typescript - 404

### DIFF
--- a/docs/docs/typescript.md
+++ b/docs/docs/typescript.md
@@ -26,7 +26,7 @@ The example above uses the power of TypeScript, in combination with exported typ
 
 ## Other resources
 
-TypeScript integration is supported through automatically including [`gatsby-plugin-typescript`](/plugins/gatsby-plugin-typescript). Visit that link to see configuration options and limitations of this setup.
+TypeScript integration is supported through automatically including [`gatsby-plugin-typescript`](/packages/gatsby-plugin-typescript/). Visit that link to see configuration options and limitations of this setup.
 
 If you are new to TypeScript, check out these other resources to learn more:
 


### PR DESCRIPTION
## Description

changes:

- fix 404 link 

## Related Issues

- #23547 `feature(gatsby): Support TypeScript by default by compiling TS files`
- #19267 `Add link checker for Gatsby Docs`