### PR TITLE
fix(docs): add trainling slash to doc-links.yaml

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -379,7 +379,7 @@
             - title: Visual Testing with Storybook
               link: /docs/visual-testing-with-storybook/
         - title: TypeScript
-          link: /docs/typescript
+          link: /docs/typescript/
         - title: Debugging Gatsby
           link: /docs/debugging/
           breadcrumbTitle: Debugging


### PR DESCRIPTION
## Description

changes:
- unify all links and add trailing slash 

## related issues

- #23547 `feature(gatsby): Support TypeScript by default by compiling TS files`