### PR TITLE
gatsby-plugin-typescipt: support decorators. Fix #18847.

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -29,6 +29,7 @@ module.exports = {
         isTSX: true, // defaults to false
         jsxPragma: `jsx`, // defaults to "React"
         allExtensions: true, // defaults to false
+        decoratorsOptions: { legacy: true }  // options for @babel/plugin-proposal-decorators; defaults to none
       },
     },
   ],

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -29,7 +29,7 @@ module.exports = {
         isTSX: true, // defaults to false
         jsxPragma: `jsx`, // defaults to "React"
         allExtensions: true, // defaults to false
-        decoratorsOptions: { legacy: true }  // options for @babel/plugin-proposal-decorators; defaults to none
+        decoratorsOptions: { legacy: true },  // options for @babel/plugin-proposal-decorators; defaults to none
       },
     },
   ],

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -11,6 +11,7 @@
   ],
   "dependencies": {
     "@babel/core": "^7.9.6",
+    "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "@babel/plugin-proposal-numeric-separator": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -16,7 +16,7 @@ function onCreateBabelConfig({ actions }, options) {
   })
   actions.setBabelPlugin({
     name: require.resolve(`@babel/plugin-proposal-decorators`),
-    options: options && options.decoratorsOptions
+    options: options && options.decoratorsOptions,
   })
 }
 

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -14,6 +14,10 @@ function onCreateBabelConfig({ actions }, options) {
   actions.setBabelPlugin({
     name: require.resolve(`@babel/plugin-proposal-numeric-separator`),
   })
+  actions.setBabelPlugin({
+    name: require.resolve(`@babel/plugin-proposal-decorators`),
+    options: options && options.decoratorsOptions
+  })
 }
 
 function onCreateWebpackConfig({ actions, loaders }) {


### PR DESCRIPTION
## Description

This PR adds support for decorators to to [gatsby-plugin-typescript](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript), with an option for the `legacy` syntax.

### Documentation

Updated the plugin's README to explain the new option.

## Related Issues

#18847.