### PR TITLE
fix(gatsby-cli): don't fail when using `--log-pages` and/or `--write-to-file`

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -182,16 +182,6 @@ function buildLocalCommands(cli, isLocalSite) {
           default: false,
           describe: `Build site without uglifying JS bundles (for debugging).`,
         })
-        .option(`log-pages`, {
-          type: `boolean`,
-          default: false,
-          describe: `Log the pages that changes since last build (for optimization).`,
-        })
-        .option(`write-to-file`, {
-          type: `boolean`,
-          default: false,
-          describe: `Save the log of changed pages for future comparison (for optimization).`,
-        })
         .option(`profile`, {
           type: `boolean`,
           default: false,
@@ -200,6 +190,20 @@ function buildLocalCommands(cli, isLocalSite) {
         .option(`open-tracing-config-file`, {
           type: `string`,
           describe: `Tracer configuration file (OpenTracing compatible). See https://gatsby.dev/tracing`,
+        })
+        // log-pages and write-to-file are specific to experimental GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES feature
+        // because of that they are hidden from `--help` but still defined so `yargs` know about them
+        .option(`log-pages`, {
+          type: `boolean`,
+          default: false,
+          describe: `Log the pages that changes since last build (only available when using GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES).`,
+          hidden: true,
+        })
+        .option(`write-to-file`, {
+          type: `boolean`,
+          default: false,
+          describe: `Save the log of changed pages for future comparison (only available when using GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES).`,
+          hidden: true,
         }),
     handler: handlerP(
       getCommandHandler(`build`, (args, cmd) => {

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -182,16 +182,16 @@ function buildLocalCommands(cli, isLocalSite) {
           default: false,
           describe: `Build site without uglifying JS bundles (for debugging).`,
         })
-       .option(`log-pages`, {
-         type: `boolean`,
-         default: false,
-         describe: `Log the pages that changes since last build (for optimization).`,
-       })
-       .option(`write-to-file`, {
-         type: `boolean`,
-         default: false,
-         describe: `Save the log of changed pages for future comparison (for optimization).`,
-       })
+        .option(`log-pages`, {
+          type: `boolean`,
+          default: false,
+          describe: `Log the pages that changes since last build (for optimization).`,
+        })
+        .option(`write-to-file`, {
+          type: `boolean`,
+          default: false,
+          describe: `Save the log of changed pages for future comparison (for optimization).`,
+        })
         .option(`profile`, {
           type: `boolean`,
           default: false,

--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -182,6 +182,16 @@ function buildLocalCommands(cli, isLocalSite) {
           default: false,
           describe: `Build site without uglifying JS bundles (for debugging).`,
         })
+       .option(`log-pages`, {
+         type: `boolean`,
+         default: false,
+         describe: `Log the pages that changes since last build (for optimization).`,
+       })
+       .option(`write-to-file`, {
+         type: `boolean`,
+         default: false,
+         describe: `Save the log of changed pages for future comparison (for optimization).`,
+       })
         .option(`profile`, {
           type: `boolean`,
           default: false,


### PR DESCRIPTION
## Description

Resolves #23941 there is no log-pages cli arg option

### Documentation

https://www.gatsbyjs.org/docs/page-build-optimizations-for-incremental-data-changes/

## Related Issues

#23941 