### PR TITLE
Changed `{title} expand` to `expand {title}` on aria-label

### DIFF
--- a/www/src/components/sidebar/__tests__/sidebar.js
+++ b/www/src/components/sidebar/__tests__/sidebar.js
@@ -125,13 +125,13 @@ describe("sidebar", () => {
   describe("toggle section", () => {
     it("opens the section if it is not open", () => {
       const { queryByText, getByLabelText } = renderSidebar("/plot-summary/")
-      fireEvent.click(getByLabelText(`Expand Motifs`))
+      fireEvent.click(getByLabelText(`Motifs`))
       expect(queryByText("The Green Light")).toBeInTheDocument()
     })
 
     it("closes the section if it is already opened", () => {
       const { queryByText, getByLabelText } = renderSidebar("/motifs/")
-      fireEvent.click(getByLabelText(`Collapse Motifs`))
+      fireEvent.click(getByLabelText(`Motifs`))
       expect(queryByText("The Green Light")).not.toBeInTheDocument()
     })
   })

--- a/www/src/components/sidebar/__tests__/sidebar.js
+++ b/www/src/components/sidebar/__tests__/sidebar.js
@@ -125,13 +125,13 @@ describe("sidebar", () => {
   describe("toggle section", () => {
     it("opens the section if it is not open", () => {
       const { queryByText, getByLabelText } = renderSidebar("/plot-summary/")
-      fireEvent.click(getByLabelText(`Motifs expand`))
+      fireEvent.click(getByLabelText(`Expand Motifs`))
       expect(queryByText("The Green Light")).toBeInTheDocument()
     })
 
     it("closes the section if it is already opened", () => {
       const { queryByText, getByLabelText } = renderSidebar("/motifs/")
-      fireEvent.click(getByLabelText(`Motifs collapse`))
+      fireEvent.click(getByLabelText(`Collapse Motifs`))
       expect(queryByText("The Green Light")).not.toBeInTheDocument()
     })
   })

--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -168,8 +168,8 @@ const SplitButton = withI18n()(({ i18n, itemRef, item, uid }) => {
         aria-expanded={isExpanded}
         aria-label={
           isExpanded
-            ? i18n._(t`collapse ${item.title}`)
-            : i18n._(t`expand ${item.title}`)
+            ? i18n._(t`Collapse ${item.title}`)
+            : i18n._(t`Expand ${item.title}`)
         }
         sx={{
           ...styles.resetButton,

--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -168,8 +168,8 @@ const SplitButton = withI18n()(({ i18n, itemRef, item, uid }) => {
         aria-expanded={isExpanded}
         aria-label={
           isExpanded
-            ? i18n._(t`${item.title} collapse`)
-            : i18n._(t`${item.title} expand`)
+            ? i18n._(t`collapse ${item.title}`)
+            : i18n._(t`expand ${item.title}`)
         }
         sx={{
           ...styles.resetButton,

--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -1,8 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { t } from "@lingui/macro"
 import { withI18n } from "@lingui/react"
-
 import ChevronSvg from "./chevron-svg"
 import indention from "../../utils/sidebar/indention"
 import ItemLink from "./item-link"

--- a/www/src/components/sidebar/section-title.js
+++ b/www/src/components/sidebar/section-title.js
@@ -166,11 +166,7 @@ const SplitButton = withI18n()(({ i18n, itemRef, item, uid }) => {
       <button
         aria-controls={uid}
         aria-expanded={isExpanded}
-        aria-label={
-          isExpanded
-            ? i18n._(t`Collapse ${item.title}`)
-            : i18n._(t`Expand ${item.title}`)
-        }
+        aria-label={i18n._(item.title)}
         sx={{
           ...styles.resetButton,
           bottom: 0,


### PR DESCRIPTION
### Changed `{title} expand` to `expand {title}` on aria-label - Closes issue #23948 

Moved the verb "expand" or "compress" to before the title of the element in the aria-label, to make it more clear what the element does.

Fixes #23948
