### PR TITLE
fix: handle nullish announcementRef to fix client side redirect error

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -174,9 +174,11 @@ class RouteAnnouncer extends React.Component {
         pageName = pageHeadings[0].textContent
       }
       const newAnnouncement = `Navigated to ${pageName}`
-      const oldAnnouncement = this.announcementRef.current.innerText
-      if (oldAnnouncement !== newAnnouncement) {
-        this.announcementRef.current.innerText = newAnnouncement
+      if (this.announcementRef.current) {
+        const oldAnnouncement = this.announcementRef.current.innerText
+        if (oldAnnouncement !== newAnnouncement) {
+          this.announcementRef.current.innerText = newAnnouncement
+        }
       }
     })
   }


### PR DESCRIPTION
## Description

This PR fix error thrown `TypeError: Cannot read property 'innerText' of null` in `navigation.js:177` when doing client side redirect.

### Documentation

No documentation.

## Related Issues

Fixes: https://github.com/gatsbyjs/gatsby/issues/23955
