### PR TITLE
test(source-npm-package-search): init test

### DIFF
--- a/packages/gatsby-source-npm-package-search/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-source-npm-package-search/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gatsby-source-npm-package-search sourceNodes with readme should create a package node for each search hit 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "id": "readme foo",
+    "internal": Object {
+      "content": "readme",
+      "contentDigest": "digest",
+      "mediaType": "text/markdown",
+      "type": "NPMPackageReadme",
+    },
+    "parent": "plugin foo",
+    "slug": "/packages/en/foo",
+  },
+]
+`;
+
+exports[`gatsby-source-npm-package-search sourceNodes with readme should create readme node for each search hit 1`] = `
+Array [
+  Object {
+    "children": Array [],
+    "created": Date { NaN },
+    "deprecated": "undefined",
+    "id": "plugin foo",
+    "internal": Object {
+      "content": "",
+      "contentDigest": "digest",
+      "type": "NPMPackage",
+    },
+    "modified": Date { NaN },
+    "objectID": "foo",
+    "parent": null,
+    "readme___NODE": "readme foo",
+    "slug": "/packages/foo/",
+    "title": "foo",
+  },
+]
+`;
+
+exports[`gatsby-source-npm-package-search sourceNodes with readme should search with config keywords 1`] = `
+Array [
+  Object {
+    "filters": "(keywords:foo OR keywords:bar)",
+    "hitsPerPage": 1000,
+  },
+]
+`;

--- a/packages/gatsby-source-npm-package-search/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-npm-package-search/src/__tests__/gatsby-node.js
@@ -1,0 +1,82 @@
+const { sourceNodes } = require(`../gatsby-node`)
+const { browse } = require(`../search`)
+const got = require(`got`)
+
+jest.mock(`../search`)
+jest.mock(`got`)
+
+describe(`gatsby-source-npm-package-search`, () => {
+  describe(`sourceNodes`, () => {
+    let boundActionCreators
+    let createNodeId
+    let createContentDigest
+
+    beforeEach(async () => {
+      boundActionCreators = {
+        createNode: jest.fn(),
+      }
+      createNodeId = jest.fn(id => id)
+      createContentDigest = jest.fn(() => `digest`)
+    })
+
+    describe(`with readme`, () => {
+      beforeEach(async () => {
+        browse.mockReturnValue([
+          {
+            objectID: `foo`,
+            readme: `readme`,
+          },
+        ])
+        await sourceNodes(
+          {
+            boundActionCreators,
+            createNodeId,
+            createContentDigest,
+          },
+          {
+            keywords: [`foo`, `bar`],
+          }
+        )
+      })
+
+      it(`should search with config keywords`, () => {
+        expect(browse.mock.calls[0]).toMatchSnapshot()
+      })
+
+      it(`should create a package node for each search hit`, () => {
+        expect(boundActionCreators.createNode.mock.calls[0]).toMatchSnapshot()
+      })
+
+      it(`should create readme node for each search hit`, () => {
+        expect(boundActionCreators.createNode.mock.calls[1]).toMatchSnapshot()
+      })
+    })
+
+    describe(`without readme`, () => {
+      const packageName = `foo`
+      beforeEach(async () => {
+        browse.mockReturnValue([
+          {
+            objectID: packageName,
+          },
+        ])
+        await sourceNodes(
+          {
+            boundActionCreators,
+            createNodeId,
+            createContentDigest,
+          },
+          {
+            keywords: [`foo`, `bar`],
+          }
+        )
+      })
+
+      it(`should fetch readme`, () => {
+        expect(got.get).toBeCalledWith(
+          `https://unpkg.com/${packageName}/README.md`
+        )
+      })
+    })
+  })
+})

--- a/packages/gatsby-source-npm-package-search/src/gatsby-node.js
+++ b/packages/gatsby-source-npm-package-search/src/gatsby-node.js
@@ -1,20 +1,6 @@
-const algoliasearch = require(`algoliasearch`)
 const got = require(`got`)
 const url = require(`url`)
-
-const client = algoliasearch(`OFCNCOG2CU`, `6fbcaeafced8913bf0e4d39f0b541957`)
-var index = client.initIndex(`npm-search`)
-
-function browse({ index, ...params }) {
-  let hits = []
-  const browser = index.browseAll(params)
-
-  return new Promise((resolve, reject) => {
-    browser.on(`result`, content => (hits = hits.concat(content.hits)))
-    browser.on(`end`, () => resolve(hits))
-    browser.on(`error`, err => reject(err))
-  })
-}
+const { browse } = require(`./search`)
 
 exports.sourceNodes = async (
   { boundActionCreators, createNodeId, createContentDigest },
@@ -25,7 +11,6 @@ exports.sourceNodes = async (
   const buildFilter = keywords.map(keyword => `keywords:${keyword}`)
 
   const hits = await browse({
-    index,
     filters: `(${buildFilter.join(` OR `)})`,
     hitsPerPage: 1000,
   })

--- a/packages/gatsby-source-npm-package-search/src/search.js
+++ b/packages/gatsby-source-npm-package-search/src/search.js
@@ -1,0 +1,14 @@
+const algoliasearch = require(`algoliasearch`)
+const client = algoliasearch(`OFCNCOG2CU`, `6fbcaeafced8913bf0e4d39f0b541957`)
+const searchIndex = client.initIndex(`npm-search`)
+
+exports.browse = ({ ...params }) => {
+  let hits = []
+  const browser = searchIndex.browseAll(params)
+
+  return new Promise((resolve, reject) => {
+    browser.on(`result`, content => (hits = hits.concat(content.hits)))
+    browser.on(`end`, () => resolve(hits))
+    browser.on(`error`, err => reject(err))
+  })
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
- Add test with jest on package source-npm-package-search
- need to split algolia search to a dedicate file to be able to mock it nicely
- this package is now covered, I'm ready for the next one
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
