### PR TITLE
fix(gatsby-transform-json): improve json parse error so it's easier to locate problematic content

### DIFF
--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -45,7 +45,7 @@ async function onCreateNode(
   let parsedContent
   try {
     parsedContent = JSON.parse(content)
-  } catch() {
+  } catch {
     throw new Error(`Unable to parse JSON: ${node.absolutePath}`)
   }
 

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -46,7 +46,8 @@ async function onCreateNode(
   try {
     parsedContent = JSON.parse(content)
   } catch {
-    throw new Error(`Unable to parse JSON: ${node.absolutePath}`)
+    const hint = node.absolutePath ? `file ${node.absolutePath}` : `in node ${node.id}`
+    throw new Error(`Unable to parse JSON: ${hint}`)
   }
 
   if (_.isArray(parsedContent)) {

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -46,7 +46,8 @@ async function onCreateNode(
   try {
     parsedContent = JSON.parse(content)
   } catch {
-    const hint = node.absolutePath ? `file ${node.absolutePath}` : `in node ${node.id}`
+    const hint = node.absolutePath 
+      ? `file ${node.absolutePath}` : `in node ${node.id}`
     throw new Error(`Unable to parse JSON: ${hint}`)
   }
 

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -47,7 +47,8 @@ async function onCreateNode(
     parsedContent = JSON.parse(content)
   } catch {
     const hint = node.absolutePath
-      ? `file ${node.absolutePath}` : `in node ${node.id}`
+      ? `file ${node.absolutePath}`
+      : `in node ${node.id}`
     throw new Error(`Unable to parse JSON: ${hint}`)
   }
 

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -42,7 +42,12 @@ async function onCreateNode(
   }
 
   const content = await loadNodeContent(node)
-  const parsedContent = JSON.parse(content)
+  let parsedContent
+  try {
+    parsedContent = JSON.parse(content)
+  } catch() {
+    throw new Error(`Unable to parse JSON: ${node.absolutePath}`)
+  }
 
   if (_.isArray(parsedContent)) {
     parsedContent.forEach((obj, i) => {

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -46,7 +46,7 @@ async function onCreateNode(
   try {
     parsedContent = JSON.parse(content)
   } catch {
-    const hint = node.absolutePath 
+    const hint = node.absolutePath
       ? `file ${node.absolutePath}` : `in node ${node.id}`
     throw new Error(`Unable to parse JSON: ${hint}`)
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

It was previously difficult to locate a json file with a syntax error in it, this patch improves the error message to include the path.

### Before

![Screen Shot 2020-05-07 at 10 51 46 PM](https://user-images.githubusercontent.com/2461547/81515829-acf59680-92ea-11ea-8494-837fed03cf3a.png)

### After

![Screen Shot 2020-05-10 at 6 15 16 PM](https://user-images.githubusercontent.com/2461547/81515858-c991ce80-92ea-11ea-84f6-3112953b186e.png)
