### PR TITLE
Allow, but warn for, pre-release versions of Node

### DIFF
--- a/packages/gatsby-cli/src/__tests__/index.js
+++ b/packages/gatsby-cli/src/__tests__/index.js
@@ -58,6 +58,20 @@ describe(`error handling`, () => {
       expect.stringContaining(`https://gatsby.dev/upgrading-node-js`)
     )
   })
+
+  it(`allows prerelease versions`, () => {
+    const { reporter } = setup(`v15.0.0-pre`)
+
+    expect(reporter.panic).not.toHaveBeenCalled()
+  })
+
+  it(`warns on prerelease versions`, () => {
+    const { reporter } = setup(`v15.0.0-pre`)
+
+    expect(reporter.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`prerelease`)
+    )
+  })
 })
 
 // describe(`deprecation warning`, () => {

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -27,24 +27,29 @@ updateNotifier({ pkg }).notify({ isGlobal: true })
 const MIN_NODE_VERSION = `10.13.0`
 // const NEXT_MIN_NODE_VERSION = `10.13.0`
 
-if (!semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`)) {
+const { version } = process
+
+if (
+  !semver.satisfies(version, `>=${MIN_NODE_VERSION}`, {
+    includePrerelease: true,
+  })
+) {
   report.panic(
     report.stripIndent(`
-      Gatsby requires Node.js ${MIN_NODE_VERSION} or higher (you have ${process.version}).
+      Gatsby requires Node.js ${MIN_NODE_VERSION} or higher (you have ${version}).
       Upgrade Node to the latest stable release: https://gatsby.dev/upgrading-node-js
     `)
   )
 }
 
-// if (!semver.satisfies(process.version, `>=${NEXT_MIN_NODE_VERSION}`)) {
-//   report.warn(
-//     report.stripIndent(`
-//       Node.js ${process.version} has reached End of Life status on 31 December, 2019.
-//       Gatsby will only actively support ${NEXT_MIN_NODE_VERSION} or higher and drop support for Node 8 soon.
-//       Please upgrade Node.js to a currently active LTS release: https://gatsby.dev/upgrading-node-js
-//     `)
-//   )
-// }
+if (semver.prerelease(version)) {
+  report.warn(
+    report.stripIndent(`
+    You are currently using a pre-release version of Node (${version}), which is not supported.
+    You can use this for testing, but we do not recommend it in production. 
+    Before reporting any bugs, please test with a supported version of Node (>=${MIN_NODE_VERSION}).`)
+  )
+}
 
 process.on(`unhandledRejection`, reason => {
   // This will exit the process in newer Node anyway so lets be consistent

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -45,7 +45,7 @@ if (
 if (semver.prerelease(version)) {
   report.warn(
     report.stripIndent(`
-    You are currently using a pre-release version of Node (${version}), which is not supported.
+    You are currently using a prerelease version of Node (${version}), which is not supported.
     You can use this for testing, but we do not recommend it in production. 
     Before reporting any bugs, please test with a supported version of Node (>=${MIN_NODE_VERSION}).`)
   )

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -51,6 +51,16 @@ if (semver.prerelease(version)) {
   )
 }
 
+// if (!semver.satisfies(version, `>=${NEXT_MIN_NODE_VERSION}`)) {
+//   report.warn(
+//     report.stripIndent(`
+//       Node.js ${version} has reached End of Life status on 31 December, 2019.
+//       Gatsby will only actively support ${NEXT_MIN_NODE_VERSION} or higher and drop support for Node 8 soon.
+//       Please upgrade Node.js to a currently active LTS release: https://gatsby.dev/upgrading-node-js
+//     `)
+//   )
+// }
+
 process.on(`unhandledRejection`, reason => {
   // This will exit the process in newer Node anyway so lets be consistent
   // across versions and crash


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Currently the CLI panics if the version of Node does not satisfy the minimum version requirements. As the semver spec says that prerelease versions never satisfy a range requirement, unless specifically included, prerelease verisons of Node cannot be used. This could be useful for testing, so this PR adds the `includePrerelease: true` option for semver, which allows prerelases to satisfy the constraint. It adds a warning if a prerelease version is being used, as we do not support this even if we permit it.

## Related Issues

#23945 