### PR TITLE
Add redirect for Vercel docs

### DIFF
--- a/www/redirects.yaml
+++ b/www/redirects.yaml
@@ -15,7 +15,9 @@
 - fromPath: /docs/community/ # Moved "Community" page from /docs/community to /contributing/community
   toPath: /contributing/community/
 - fromPath: /docs/deploying-to-now/
-  toPath: /docs/deploying-to-zeit-now/
+  toPath: /docs/deploying-to-vercel/
+- fromPath: /docs/deploying-to-zeit-now/
+  toPath: /docs/deploying-to-vercel/
 - fromPath: /docs/pair-programming/
   toPath: /contributing/pair-programming/
 - fromPath: /docs/how-to-create-an-issue/


### PR DESCRIPTION
PR #23961 renamed `/docs/deploying-to-zeit-now/` to `/docs/deploying-to-vercel/`. This adds a redirect.