### PR TITLE
Webfont option for blog theme

### DIFF
--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -68,6 +68,7 @@ module.exports = {
 | `mdxOtherwiseConfigured` | `false`          | Set this flag `true` if `gatsby-plugin-mdx` is already configured for your site.                                                                                   |
 | `disableThemeUiStyling`  | `false`          | Set this flag `true` if you want to use the blog theme without `gatsby-plugin-theme-ui` styles. Note that styles within the components you can shadow still exist. |
 | `excerptLength`          | `140`            | Length of the auto-generated excerpt of a blog post                                                                                                                |
+| `webfontURL`             | `''`             | URL for the webfont you'd like to include. Be sure that your local theme does not override it.                                                                     |
 
 #### Example configuration
 

--- a/packages/gatsby-theme-blog/gatsby-node.js
+++ b/packages/gatsby-theme-blog/gatsby-node.js
@@ -3,19 +3,21 @@ exports.createSchemaCustomization = ({ actions }) => {
 
   createTypes(`
     type BlogThemeConfig implements Node {
-      disableThemeUiStyling: Boolean
+      disableThemeUiStyling: Boolean,
+      webfontURL: String,
     }
   `)
 }
 
 exports.sourceNodes = (
   { actions, createContentDigest },
-  { disableThemeUiStyling = false }
+  { disableThemeUiStyling = false, webfontURL = '' }
 ) => {
   const { createNode } = actions
 
   const blogThemeConfig = {
     disableThemeUiStyling,
+    webfontURL,
   }
 
   createNode({

--- a/packages/gatsby-theme-blog/src/components/layout.js
+++ b/packages/gatsby-theme-blog/src/components/layout.js
@@ -1,21 +1,30 @@
 import React from "react"
 import { css, Styled } from "theme-ui"
 import Header from "./header"
+import useBlogThemeConfig from "../hooks/configOptions"
 
-export default ({ children, ...props }) => (
-  <Styled.root>
-    <Header {...props} />
-    <div>
-      <div
-        css={css({
-          maxWidth: `container`,
-          mx: `auto`,
-          px: 3,
-          py: 4,
-        })}
-      >
-        {children}
+export default ({ children, ...props }) => {
+  const blogThemeConfig = useBlogThemeConfig()
+  const { webfontURL } = blogThemeConfig
+
+  return (
+    <Styled.root>
+      <head>
+        <link rel="stylesheet" href={webfontURL} />
+      </head>
+      <Header {...props} />
+      <div>
+        <div
+          css={css({
+            maxWidth: `container`,
+            mx: `auto`,
+            px: 3,
+            py: 4,
+          })}
+        >
+          {children}
+        </div>
       </div>
-    </div>
-  </Styled.root>
-)
+    </Styled.root>
+  )
+}

--- a/packages/gatsby-theme-blog/src/components/layout.js
+++ b/packages/gatsby-theme-blog/src/components/layout.js
@@ -2,6 +2,7 @@ import React from "react"
 import { css, Styled } from "theme-ui"
 import Header from "./header"
 import useBlogThemeConfig from "../hooks/configOptions"
+import Helmet from "react-helmet"
 
 export default ({ children, ...props }) => {
   const blogThemeConfig = useBlogThemeConfig()
@@ -9,9 +10,9 @@ export default ({ children, ...props }) => {
 
   return (
     <Styled.root>
-      <head>
+      <Helmet>
         <link rel="stylesheet" href={webfontURL} />
-      </head>
+      </Helmet>
       <Header {...props} />
       <div>
         <div

--- a/packages/gatsby-theme-blog/src/hooks/configOptions.js
+++ b/packages/gatsby-theme-blog/src/hooks/configOptions.js
@@ -5,6 +5,7 @@ const useBlogThemeConfig = () => {
     query {
       blogThemeConfig(id: { eq: "gatsby-theme-blog-config" }) {
         disableThemeUiStyling
+        webfontURL
       }
     }
   `)


### PR DESCRIPTION
Allow users to include a webfont URL in their options that will be included in their head tag.

There may be a more performant way to do this.