### PR TITLE
fix(docs): add slashes to links in static host yaml

### DIFF
--- a/www/src/data/diagram/static-hosts.yml
+++ b/www/src/data/diagram/static-hosts.yml
@@ -1,7 +1,7 @@
 - title: Netlify
-  url: /docs/deploying-to-netlify
+  url: /docs/deploying-to-netlify/
 - title: AWS Amplify
-  url: /docs/deploying-to-aws-amplify
+  url: /docs/deploying-to-aws-amplify/
 - title: GitHub Pages
   url: /docs/how-gatsby-works-with-github-pages/
 - title: Surge.sh


### PR DESCRIPTION
## Description

changes:
- unify all links and add trailing slash 


## Related Issues

- #24014 `Feature Request: add test for trailing slashes in yaml files with links`