### PR TITLE
chore(starters): Updated starter URLs due to DNS changes

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1,4 +1,4 @@
-- url: https://gatsby-ghost-balsa-starter.now.sh/
+- url: https://ghost-balsa.draftbox.co/
   repo: https://github.com/draftbox-co/gatsby-ghost-balsa-starter
   description: A Gatsby starter for creating blogs from headless Ghost CMS.
   tags:
@@ -6216,7 +6216,7 @@
     - React Helmet
     - Offline Support
     - Gatsby Image
-- url: https://gatsby-wordpress-balsa-starter.now.sh/
+- url: https://wordpress-balsa.draftbox.co/
   repo: https://github.com/draftbox-co/gatsby-wordpress-balsa-starter
   description: A Gatsby starter for creating blogs from headless WordPress CMS.
   tags:


### PR DESCRIPTION
Hi team, 
Due to DNS changes in our starters, we are making this pull request with updated URLs which points to the continuously updated demo of starters.