### PR TITLE
fix(gatsby-remark-autolink-headers): include scroll-margin in getTargetOffset

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
@@ -12,9 +12,9 @@ const getTargetOffset = hash => {
       let clientTop =
         document.documentElement.clientTop || document.body.clientTop || 0
       let computedStyles = window.getComputedStyle(element)
-      let scrollMarginTop = 
-        computedStyles.getPropertyValue(`scroll-margin-top`) || 
-        computedStyles.getPropertyValue(`scroll-snap-margin-top`) || 
+      let scrollMarginTop =
+        computedStyles.getPropertyValue(`scroll-margin-top`) ||
+        computedStyles.getPropertyValue(`scroll-snap-margin-top`) ||
         `0px`
 
       return (

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
@@ -11,9 +11,12 @@ const getTargetOffset = hash => {
         document.body.scrollTop
       let clientTop =
         document.documentElement.clientTop || document.body.clientTop || 0
-      let scrollMarginTop = window
-        .getComputedStyle(element)
-        .getPropertyValue("scroll-margin-top")
+      let computedStyles = window.getComputedStyle(element)
+      let scrollMarginTop = 
+        computedStyles.getPropertyValue(`scroll-margin-top`) || 
+        computedStyles.getPropertyValue(`scroll-snap-margin-top`) || 
+        `0px`
+
       return (
         element.getBoundingClientRect().top +
         scrollTop -

--- a/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-browser.js
@@ -11,8 +11,15 @@ const getTargetOffset = hash => {
         document.body.scrollTop
       let clientTop =
         document.documentElement.clientTop || document.body.clientTop || 0
+      let scrollMarginTop = window
+        .getComputedStyle(element)
+        .getPropertyValue("scroll-margin-top")
       return (
-        element.getBoundingClientRect().top + scrollTop - clientTop - offsetY
+        element.getBoundingClientRect().top +
+        scrollTop -
+        parseInt(scrollMarginTop, 10) -
+        clientTop -
+        offsetY
       )
     }
   }


### PR DESCRIPTION
## Description

This PR improves the `getTargetOffset` calculation to include a potential `scroll-margin-top` to enable controlling the scroll offset on the component level via CSS.

### Documentation

No docs exist for this, afaik.

## Related Issues

None.
