### PR TITLE
fix(docs): links in sidebar to vercel

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -75,9 +75,9 @@
             - title: Deploying to Heroku
               link: /docs/deploying-to-heroku/
               breadcrumbTitle: Heroku
-            - title: Deploying to ZEIT Now
-              link: /docs/deploying-to-zeit-now/
-              breadcrumbTitle: ZEIT Now
+            - title: Deploying to Vercel
+              link: /docs/deploying-to-vercel/
+              breadcrumbTitle: Vercel
             - title: Deploying to Cloudflare Workers
               link: /docs/deploying-to-cloudflare-workers/
               breadcrumbTitle: Cloudflare Workers


### PR DESCRIPTION
## Description

changes:

- fix link 

## Related Issues

- #24019 `[Umbrella] Rename Zeit to Vercel`
- #23961 `Rename ZEIT Now to Vercel` 
- #19267 `Add link checker for Gatsby Docs`
