### PR TITLE
fix(gatsby): update script to generate apis.json to accomodate Typescript

### DIFF
--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -68,5 +68,6 @@ it("generates the expected api output", done => {
         },
       }
     `)
+    done()
   })
 })

--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -1,0 +1,72 @@
+import fs from "fs-extra"
+import childProcess from "child_process"
+import systemPath from "path"
+
+const apiPath = systemPath.join(__dirname, "../../apis.json")
+
+it("generates the expected api output", done => {
+  childProcess.exec("node ../output-api-file.js", async () => {
+    const json = await fs.readJSON(apiPath)
+
+    expect(json).toMatchInlineSnapshot(`
+      Object {
+        "browser": Object {
+          "disableCorePrefetching": Object {},
+          "onClientEntry": Object {},
+          "onInitialClientRender": Object {},
+          "onPostPrefetchPathname": Object {},
+          "onPreRouteUpdate": Object {},
+          "onPrefetchPathname": Object {},
+          "onRouteUpdate": Object {},
+          "onRouteUpdateDelayed": Object {},
+          "onServiceWorkerActive": Object {},
+          "onServiceWorkerInstalled": Object {},
+          "onServiceWorkerRedundant": Object {},
+          "onServiceWorkerUpdateFound": Object {},
+          "onServiceWorkerUpdateReady": Object {},
+          "registerServiceWorker": Object {},
+          "replaceComponentRenderer": Object {
+            "deprecated": true,
+          },
+          "replaceHydrateFunction": Object {},
+          "shouldUpdateScroll": Object {},
+          "wrapPageElement": Object {},
+          "wrapRootElement": Object {},
+        },
+        "node": Object {
+          "createPages": Object {},
+          "createPagesStatefully": Object {},
+          "createResolvers": Object {
+            "version": "2.2.0",
+          },
+          "createSchemaCustomization": Object {
+            "version": "2.12.0",
+          },
+          "generateSideEffects": Object {},
+          "onCreateBabelConfig": Object {},
+          "onCreateDevServer": Object {},
+          "onCreateNode": Object {},
+          "onCreatePage": Object {},
+          "onCreateWebpackConfig": Object {},
+          "onPostBootstrap": Object {},
+          "onPostBuild": Object {},
+          "onPreBootstrap": Object {},
+          "onPreBuild": Object {},
+          "onPreExtractQueries": Object {},
+          "onPreInit": Object {},
+          "preprocessSource": Object {},
+          "resolvableExtensions": Object {},
+          "setFieldsOnGraphQLNodeType": Object {},
+          "sourceNodes": Object {},
+        },
+        "ssr": Object {
+          "onPreRenderHTML": Object {},
+          "onRenderBody": Object {},
+          "replaceRenderer": Object {},
+          "wrapPageElement": Object {},
+          "wrapRootElement": Object {},
+        },
+      }
+    `)
+  })
+})

--- a/packages/gatsby/scripts/output-api-file.js
+++ b/packages/gatsby/scripts/output-api-file.js
@@ -1,49 +1,50 @@
-const path = require('path')
-const documentation = require('documentation')
-const fs = require('fs-extra')
+const path = require("path")
+const documentation = require("documentation")
+const fs = require("fs-extra")
 
 const OUTPUT_FILE_NAME = `apis.json`
 
 async function outputFile() {
-  const apis = await Promise.all([
-    path.join('cache-dir', 'api-ssr-docs.js'),
-    path.join('src', 'utils', 'api-browser-docs.ts'),
-    path.join('src', 'utils', 'api-node-docs.ts')
-  ]
-    .map(filePath => {
+  const apis = await Promise.all(
+    [
+      path.join("cache-dir", "api-ssr-docs.js"),
+      path.join("src", "utils", "api-browser-docs.ts"),
+      path.join("src", "utils", "api-node-docs.ts")
+    ].map(filePath => {
       const resolved = path.resolve(filePath)
-      const [,api] = path.basename(filePath).split('-')
-      return documentation.build(resolved, {
-        shallow: true
-      })
+      const [, api] = path.basename(filePath).split("-")
+      return documentation
+        .build(resolved, {
+          shallow: true
+        })
         .then(contents => {
-          return [
-            contents,
-            api
-          ]
+          return [contents, api]
         })
     })
   )
 
   const output = apis.reduce((merged, [output, api]) => {
-    merged[api] = output.reduce((mergedOutput, doc) => {
-      const isAPI = doc.namespace.startsWith('.')
-      if (isAPI) {
-        const tags = doc.tags.reduce((mergedTags, tag) => {
-          mergedTags[tag.title] = tag.description
-          return mergedTags
-        }, {})
-        mergedOutput[doc.name] = {
-          deprecated: !!tags.deprecated || undefined,
-          version: tags.gatsbyVersion
-        }
+    merged[api] = output.reduce((mergedOutput, doc, i) => {
+      if (doc.kind === "typedef") return mergedOutput
+
+      const tags = doc.tags.reduce((mergedTags, tag) => {
+        mergedTags[tag.title] = tag.description
+        return mergedTags
+      }, {})
+      mergedOutput[doc.name] = {
+        deprecated: !!tags.deprecated || undefined,
+        version: tags.gatsbyVersion
       }
       return mergedOutput
     }, {})
     return merged
   }, {})
 
-  return fs.writeFile(path.resolve(OUTPUT_FILE_NAME), JSON.stringify(output, null, 2), 'utf8')
+  return fs.writeFile(
+    path.resolve(OUTPUT_FILE_NAME),
+    JSON.stringify(output, null, 2),
+    "utf8"
+  )
 }
 
 outputFile()


### PR DESCRIPTION
#23936  Description

A recent TS conversion broke the apis.json script in an unexpected way. Here is how it broke:

- [Currently latest apis.json](https://unpkg.com/gatsby@2.21.24/apis.json)
- [Old working version](https://unpkg.com/gatsby@2.20.0/apis.json)

This fixes the script to make it output the same structure that we currently see in the `Old working version`

## Related Issues

#23688 