### PR TITLE
fix(gatsby-source-filesystem): dereference symlinks when copying files with `publicURL`

### DIFF
--- a/packages/gatsby-source-filesystem/src/extend-file-node.js
+++ b/packages/gatsby-source-filesystem/src/extend-file-node.js
@@ -24,14 +24,19 @@ module.exports = ({ type, getNodeAndSavePathDependency, pathPrefix = `` }) => {
         )
 
         if (!fs.existsSync(publicPath)) {
-          fs.copy(details.absolutePath, publicPath, err => {
-            if (err) {
-              console.error(
-                `error copying file from ${details.absolutePath} to ${publicPath}`,
-                err
-              )
+          fs.copy(
+            details.absolutePath,
+            publicPath,
+            { dereference: true },
+            err => {
+              if (err) {
+                console.error(
+                  `error copying file from ${details.absolutePath} to ${publicPath}`,
+                  err
+                )
+              }
             }
-          })
+          )
         }
 
         return `${pathPrefix}/static/${fileName}`


### PR DESCRIPTION
## Description

I have some larger assets in one of my Gatsby projects that I pull in with gatsby-source-filesystem. Due to the file sizes involved, I want to avoid committing those files to git. Instead I'm using git-annex which replaces the files with relative symbolic links (e.g. `../../../../.git/annex/objects/...`. Currently, gatsby-source-filesystem copies the link itself to the public folder when building the site which breaks the link.

This PR adds the "dereference" option to the copy call which will cause the actual file content to be copied and produce a working build even if symbolic links are involved.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

As far as I am aware it is not documented how symlinks are handled. Not sure if it needs to be, I would expect symlinks to be dereferenced anyways.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

None that I am aware of.
