### PR TITLE
fix(gatsby): add generic locationState to types

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -52,7 +52,7 @@ export const prefetchPathname: (path: string) => void
  * export default (props: IndexProps) => {
  *   ..
  */
-export type PageProps<DataType = object, PageContextType = object, LocationState = object> = {
+export type PageProps<DataType = object, PageContextType = object, LocationState = WindowLocation["state"]> = {
   /** The path for this current page */
   path: string
   /** The URI for the current page */

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -52,13 +52,13 @@ export const prefetchPathname: (path: string) => void
  * export default (props: IndexProps) => {
  *   ..
  */
-export type PageProps<DataType = object, PageContextType = object> = {
+export type PageProps<DataType = object, PageContextType = object, LocationState = object> = {
   /** The path for this current page */
   path: string
   /** The URI for the current page */
   uri: string
   /** An extended version of window.document which comes from @react/router */
-  location: WindowLocation
+  location: WindowLocation<LocationState>
   /** A way to handle programmatically controlling navigation */
   navigate: NavigateFn
   /** You can't get passed children as this is the root user-land component */

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -153,6 +153,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/runtime": "^7.9.6",
     "@types/hapi__joi": "^16.0.12",
+    "@types/reach__router": "^1.3.5",
     "@types/socket.io": "^2.1.4",
     "babel-preset-gatsby-package": "^0.4.1",
     "cross-env": "^5.2.1",


### PR DESCRIPTION
## Description

This allows to type location state using and additional TypeScript prop.

### Documentation

Example:

```tsx
interface LocationState {
  // data sent from previous page using <Link to="/page/" state={{foo: "OK"}} />
  foo: string
}

const MyPage: React.FC<PageProps<null, null, LocationState>> = ({ location }) => {
  // location.state.foo is recognized as a string
  return <div>Test: {location.state?.foo}</div>
}
```

## Related Issues

Fixes #23298.

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44081