### PR TITLE
fix(gatsby-plugin-benchmark-reporting): Fix invalid refernece to var that may be null

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -290,7 +290,7 @@ function init(lifecycle) {
 }
 
 process.on(`exit`, () => {
-  if (!benchMeta.flushed) {
+  if (benchMeta && !benchMeta.flushed) {
     // This is probably already a non-zero exit as otherwise node should wait for the last promise to complete
     reportError(
       `gatsby-plugin-benchmark-reporting error`,


### PR DESCRIPTION
Fixes unchecked global variable reference.