### PR TITLE
fix(gatsby): don't fail validation on fragments that are not used

### DIFF
--- a/packages/gatsby/src/query/__tests__/query-compiler.js
+++ b/packages/gatsby/src/query/__tests__/query-compiler.js
@@ -958,6 +958,120 @@ describe(`actual compiling`, () => {
     `)
     expect(result).toEqual(new Map())
   })
+
+  it(`doesn't error if unknown type is used in unused fragment`, async () => {
+    const nodes = [
+      createGatsbyDoc(
+        `unusedFragment`,
+        `fragment Foo on ThisTypeSurelyDoesntExistInSchema {
+          field
+        }`
+      ),
+      createGatsbyDoc(
+        `mockFile`,
+        `query mockFileQuery {
+          allPostsJson {
+            nodes {
+              id
+            }
+          }
+        }`
+      ),
+    ]
+
+    const errors = []
+    const result = processQueries({
+      schema,
+      parsedQueries: nodes,
+      addError: e => {
+        errors.push(e)
+      },
+    })
+    expect(errors).toMatchInlineSnapshot(`Array []`)
+    expect(result).toMatchInlineSnapshot(`
+      Map {
+        "mockFile" => Object {
+          "hash": "hash",
+          "isHook": false,
+          "isStaticQuery": false,
+          "name": "mockFileQuery",
+          "originalText": "query mockFileQuery {
+                allPostsJson {
+                  nodes {
+                    id
+                  }
+                }
+              }",
+          "path": "mockFile",
+          "text": "query mockFileQuery {
+        allPostsJson {
+          nodes {
+            id
+          }
+        }
+      }
+      ",
+        },
+      }
+    `)
+  })
+
+  it(`does error if unknown type is used in used fragment`, async () => {
+    const nodes = [
+      createGatsbyDoc(
+        `usedFragment`,
+        `fragment Foo on ThisTypeSurelyDoesntExistInSchema {
+          field
+        }`
+      ),
+      createGatsbyDoc(
+        `mockFile`,
+        `query mockFileQuery {
+          allPostsJson {
+            nodes {
+              ...Foo
+            }
+          }
+        }`
+      ),
+    ]
+
+    const errors = []
+    const result = processQueries({
+      schema,
+      parsedQueries: nodes,
+      addError: e => {
+        errors.push(e)
+      },
+    })
+    expect(errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "context": Object {
+            "sourceMessage": "Unknown type \\"ThisTypeSurelyDoesntExistInSchema\\".
+
+      GraphQL request:1:17
+      1 | fragment Foo on ThisTypeSurelyDoesntExistInSchema {
+        |                 ^
+      2 |           field",
+          },
+          "filePath": "mockFile",
+          "id": "85901",
+          "location": Object {
+            "end": Object {
+              "column": 17,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 17,
+              "line": 1,
+            },
+          },
+        },
+      ]
+    `)
+    expect(result).toEqual(new Map())
+  })
 })
 
 describe(`Extra fields`, () => {

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -20,7 +20,6 @@ const {
   isAbstractType,
   Kind,
   FragmentsOnCompositeTypesRule,
-  KnownTypeNamesRule,
   LoneAnonymousOperationRule,
   PossibleFragmentSpreadsRule,
   ScalarLeafsRule,
@@ -185,7 +184,6 @@ export const processQueries = ({
 
 const preValidationRules = [
   LoneAnonymousOperationRule,
-  KnownTypeNamesRule,
   FragmentsOnCompositeTypesRule,
   VariablesAreInputTypesRule,
   ScalarLeafsRule,


### PR DESCRIPTION
## Description

Just having `gatsby-transformer-sharp` installed (not even in gatsby-config) and not having any image nodes cause query-compiler to fail validation because we use prevalidate rules that include `KnownTypeNamesRule` on every extracted graphql document. This PR removes that rule from prevalidation.

We also later run full validation on constructed document that stitches query and used fragments, so this PR doesn't completely removes it - it just makes sure that we run it only on fragments that are actually used (I added 2 tests to verify it - one for not used fragment that is using unknown type - which passes validation and one for used fragment that is using unknown type which errors out as expected)

`gatsby-transformer-sharp` already define schema for `ImageSharp` so we should not see errors like that when it's actually added to gatsby-config, so this PR is mostly about frustrating issues when package is installed, but not used

--edit - I just noticed to original issue was about contentful and not transformer-sharp ... and for it would also help to use schema customization for generic types like asset (still reasonable thing to do), but this seems to help in other cases (as described above for example)

## Related Issues

Fixes #15397 