### PR TITLE
Fix a11y outline on homepage view all posts button

### DIFF
--- a/www/src/components/homepage/homepage-blog-posts.js
+++ b/www/src/components/homepage/homepage-blog-posts.js
@@ -46,7 +46,6 @@ const PostsColumn = styled(`div`)`
 const ViewAllStyle = styled(HorizontalScrollerItem.withComponent(`div`))`
   display: flex;
   font-family: ${p => p.theme.fonts.heading};
-  overflow: hidden;
   width: auto;
 
   a {


### PR DESCRIPTION
## Description

Hello! This is my very first PR to the gatsby repo and I'm so happy to be able to contribute fixing this one 🥳: #24035

I don't really know why was the div using overflow: hidden but seems that not using it fixes the problem. Let me know if I did something wrong!

Thank you so much! 

## Related Issues
Fixes  #24035
