### PR TITLE
feat(gatsby-plugin-benchmark-reporter): change type of incremental benchmark after first run

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -20,6 +20,8 @@ let lastApi
 // Current benchmark state, if any. If none then create one on next lifecycle.
 let benchMeta
 
+let nextBuildType = process.env.BENCHMARK_BUILD_TYPE ?? `initial`
+
 function reportInfo(...args) {
   ;(lastApi ? lastApi.reporter : console).info(...args)
 }
@@ -78,7 +80,8 @@ class BenchMeta {
      * extract the configuration from there
      */
 
-    let buildType = process.env.BENCHMARK_BUILD_TYPE
+    let buildType = nextBuildType
+    nextBuildType = process.env.BENCHMARK_BUILD_TYPE_NEXT ?? `DATA_UPDATE`
     const incomingHookBodyEnv = process.env.INCOMING_HOOK_BODY
 
     if (CI_NAME === `netlify` && incomingHookBodyEnv) {


### PR DESCRIPTION
If the benchmark runs more than once in the same session then the type will update to something that can be controlled from an env var with a default of 'DATA_UPDATE'.