### PR TITLE
Use consistent cases for siteUrl in themes

### DIFF
--- a/packages/gatsby-theme-blog-core/README.md
+++ b/packages/gatsby-theme-blog-core/README.md
@@ -94,7 +94,7 @@ module.exports = {
     // Used for SEO
     description: `My site description...`,
     // Used for social links in the root footer
-    siteURL: `https://example.com`,
+    siteUrl: `https://example.com`,
     // Used for resolving images in social cards
     social: [
       {

--- a/packages/gatsby-theme-blog-core/gatsby-config.js
+++ b/packages/gatsby-theme-blog-core/gatsby-config.js
@@ -9,7 +9,7 @@ module.exports = themeOptions => {
       title: `Blog Title Placeholder`,
       author: `Name Placeholder`,
       description: `Description placeholder`,
-      siteURL: 'https://example.com',
+      siteUrl: 'https://example.com',
       social: [
         {
           name: `Twitter`,

--- a/packages/gatsby-theme-blog/README.md
+++ b/packages/gatsby-theme-blog/README.md
@@ -102,7 +102,7 @@ module.exports = {
     // Used for SEO
     description: `My site description...`,
     // Used for social links in the root footer
-    siteURL: `https://example.com`,
+    siteUrl: `https://example.com`,
     // Used for resolving images in social cards
     social: [
       {

--- a/packages/gatsby-theme-blog/src/components/seo.js
+++ b/packages/gatsby-theme-blog/src/components/seo.js
@@ -27,7 +27,7 @@ function SEO({
             title
             description
             author
-            siteURL
+            siteUrl
           }
         }
       }
@@ -36,7 +36,7 @@ function SEO({
 
   const metaDescription = description || site.siteMetadata.description
   const image = imageSource
-    ? `${site.siteMetadata.siteURL}${imageSource}`
+    ? `${site.siteMetadata.siteUrl}${imageSource}`
     : null
   const imageAltText = imageAlt || metaDescription
 


### PR DESCRIPTION
Other plugins and docs make use of site URL in metadata as `siteUrl` rather than `siteURL`. We should be consistent.