### PR TITLE
Don't list all options in docs

### DIFF
--- a/docs/docs/recipes/working-with-themes.md
+++ b/docs/docs/recipes/working-with-themes.md
@@ -36,6 +36,8 @@ npm install gatsby-theme-blog
 
 Follow the instructions found in the README of the theme you're using to determine what configuration it requires.
 
+> To learn how to further customize the blog theme, check out the available configuration options in the [Gatsby-theme-blog Documentation](/packages/gatsby-theme-blog/#theme-options).
+
 ```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [
@@ -44,9 +46,6 @@ module.exports = {
       options: {
         /*
         - basePath defaults to `/`
-        - contentPath defaults to `content/posts`
-        - assetPath defaults to `content/assets`
-        - mdx defaults to `true`
         */
         basePath: `/blog`,
       },
@@ -56,8 +55,6 @@ module.exports = {
 ```
 
 4. Run `gatsby develop`, the theme should now be running on your site. In this case with the blog theme configured with the `basePath` to `"/blog"`, it should be available at `http://localhost:8000/blog`.
-
-> To learn how to further customize a theme, check out the available paths on [Gatsby-theme-blog Documentation](/packages/gatsby-theme-blog/#theme-options).
 
 ### Additional resources
 

--- a/docs/docs/themes/using-a-gatsby-theme.md
+++ b/docs/docs/themes/using-a-gatsby-theme.md
@@ -20,7 +20,7 @@ npm install --save gatsby-theme-blog
 
 Depending on the theme, there may be theme options that can be configured via `gatsby-config.js`.
 
-For example, `gatsby-theme-blog` can take in 4 potential options: `basePath`, `contentPath`, `assetPath`, and `mdx`. These options are also documented in the [theme's README](/packages/gatsby-theme-blog/) file.
+For example, `gatsby-theme-blog` can take a number of different options. All of them are documented in the [theme's README](/packages/gatsby-theme-blog/) file.
 
 ```javascript:title=gatsby-config.js
 module.exports = {
@@ -30,14 +30,8 @@ module.exports = {
       options: {
         /*
         - basePath defaults to `/`
-        - contentPath defaults to `content/posts`
-        - assetPath defaults to `content/assets`
-        - mdx defaults to `true`
         */
         basePath: `/blog`,
-        contentPath: `content/blogPosts`,
-        assetPath: `content/blogAssets`,
-        mdx: false,
       },
     },
   ],


### PR DESCRIPTION
Adding all the theme options to comments in docs creates technical debt. This changes that pattern and highlights the README section that lists them.