### PR TITLE
docs/glossary: JSX article

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -202,7 +202,7 @@ JAMStack refers to a modern web architecture using [JavaScript](#javascript), [A
 
 A programming language that helps us make the web dynamic and interactive. [JavaScript](https://developer.mozilla.org/en-US/docs/Web/Javascript) is a widely deployed web technology in browsers. It is also used on the server-side with [Node.js](#node). It is an implementation of the [ECMAScript](#ECMAScript) specification.
 
-### JSX
+### [JSX](/docs/glossary/jsx/)
 
 JSX is an extension to JavaScript that allows developers to write HTML and custom components in the same piece of code. The [React team recommends](https://reactjs.org/docs/introducing-jsx.html) using it to describe what a [UI](#UI) should look like. JSX may remind you of a template language, but it comes with the full power of JavaScript. Some important details to note are that because JSX uses JavaScript, some HTML attributes in your markup have to be swapped out to avoid reserved words in JavaScript (things like `htmlFor` and `className`).
 

--- a/docs/docs/glossary/jsx.md
+++ b/docs/docs/glossary/jsx.md
@@ -1,0 +1,38 @@
+---
+title: JSX
+disableTableOfContents: true
+---
+
+Learn what _JSX_ is, and how to use JSX to create React components for your Gatsby site.
+
+## What is JSX?
+
+JSX is an XML-like syntax extension for JavaScript that's used to create React components. It's the recommended way to create components, and a more readable alternative to using [`React.createElement()`](https://reactjs.org/docs/react-api.html#createelement). When you create components for your Gatsby site, you're using JSX.
+
+JSX tags resemble HTML and XML tags, and follow similar rules of grammar. As with [XML](https://www.w3.org/TR/REC-xml/), JSX tags must be closed, either by using a closing tag (e.g.: `<p>` and `</p>`) or by self-closing the tag using `/>`. The following example uses JSX to create a form control and label.
+
+```jsx
+const input = (
+  <div className="form__field">
+    <label htmlFor="my_input">My input</label>
+    <input type="text" id="my_input" name="field_1" value="" required />
+  </div>
+)
+```
+
+JSX looks like HTML, but it's really an alternate way to write JavaScript that describes a user interface. JSX tags represent JavaScript objects such as HTML and SVG elements.
+
+JSX is JavaScript, so HTML and XML attributes that conflict with reserved words in JavaScript have been renamed. As shown in the preceding example, `htmlFor` replaces the `for` attribute, and the `className` attribute replaces `class`.
+
+JSX also uses [camelCase](https://en.wikipedia.org/wiki/Camel_case) for hyphenated and multi-word attributes and CSS properties. For instance, the `tabindex` attribute becomes `tabIndex`, `background-color` becomes `backgroundColor` and the SVG `stroke-width` attribute becomes `strokeWidth`.
+
+It isn't necessary to enclose multi-line JSX in parentheses, but doing so is a good practice. Parentheses reduce the likelihood of errors caused by [automatic semicolon insertion](https://stackoverflow.com/questions/2846283/what-are-the-rules-for-javascripts-automatic-semicolon-insertion-asi).
+
+You can't use JSX by itself. Browsers do not understand it. JSX tags must be converted to standard JavaScript by a [transpiler](https://www.gatsbyjs.org/docs/glossary#transpile). A transpiler is software that converts code from one language or syntax to another. Gatsby and React use [Babel](https://www.gatsbyjs.org/docs/glossary#babel) to transpile JSX into browser-compatible JavaScript.
+
+## Learn more about JSX
+
+- [Introducing JSX](https://reactjs.org/docs/introducing-jsx.html) from the React docs.
+- [JSX In Depth](https://reactjs.org/docs/jsx-in-depth.html) from the React docs.
+- [JSX Specification](https://facebook.github.io/jsx/) (draft)
+- [WTF is JSX](https://jasonformat.com/wtf-is-jsx/)

--- a/docs/docs/glossary/jsx.md
+++ b/docs/docs/glossary/jsx.md
@@ -28,7 +28,7 @@ JSX also uses [camelCase](https://en.wikipedia.org/wiki/Camel_case) for hyphenat
 
 It isn't necessary to enclose multi-line JSX in parentheses, but doing so is a good practice. Parentheses reduce the likelihood of errors caused by [automatic semicolon insertion](https://stackoverflow.com/questions/2846283/what-are-the-rules-for-javascripts-automatic-semicolon-insertion-asi).
 
-You can't use JSX by itself. Browsers do not understand it. JSX tags must be converted to standard JavaScript by a [transpiler](https://www.gatsbyjs.org/docs/glossary#transpile). A transpiler is software that converts code from one language or syntax to another. Gatsby and React use [Babel](https://www.gatsbyjs.org/docs/glossary#babel) to transpile JSX into browser-compatible JavaScript.
+You can't use JSX by itself. Browsers do not understand it. JSX tags must be converted to standard JavaScript by a [transpiler](/docs/glossary#transpile). A transpiler is software that converts code from one language or syntax to another. Gatsby and React use [Babel](/docs/glossary#babel) to transpile JSX into browser-compatible JavaScript.
 
 ## Learn more about JSX
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -781,10 +781,12 @@
           link: /docs/glossary/headless-wordpress/
         - title: Hydration
           link: /docs/glossary/hydration/
-        - title: JAMStack
-          link: /docs/glossary/jamstack/
         - title: Infrastructure as Code
           link: /docs/glossary/infrastructure-as-code/
+        - title: JAMStack
+          link: /docs/glossary/jamstack/
+        - title: JSX
+          link: /docs/glossary/jsx/
         - title: Markdown
           link: /docs/glossary/markdown/
         - title: MDX


### PR DESCRIPTION
Updates docs/docs/glossary, and doc-links.yaml with links to entry.
Fixed alphabetization of Infrastructure as Code and JAMStack.
