### PR TITLE
docs: unescape dollar signs in free swag details

### DIFF
--- a/docs/contributing/contributor-swag.md
+++ b/docs/contributing/contributor-swag.md
@@ -17,8 +17,8 @@ If you’ve contributed in other ways, such as giving talks about Gatsby, teachi
 ## Details about free swag
 
 - We will send one item from our [swag store](https://store.gatsbyjs.org/) per swag tier
-- Tier 1 swag includes most items \$10 and under
-- Tier 2 swag includes most items \$26 and under
+- Tier 1 swag includes most items $10 and under
+- Tier 2 swag includes most items $26 and under
 - Not all items are eligible due to high cost to create the swag. We’ll make it clear which items are not eligible
 - There’s a limit of one free swag item per swag tier
 - Shipping is free worldwide

--- a/docs/contributing/contributor-swag.md
+++ b/docs/contributing/contributor-swag.md
@@ -16,6 +16,8 @@ If you’ve contributed in other ways, such as giving talks about Gatsby, teachi
 
 ## Details about free swag
 
+<!-- The entire bulleted list must be prettier-ignored to prevent Prettier from escaping the dollar signs -->
+<!-- prettier-ignore -->
 - We will send one item from our [swag store](https://store.gatsbyjs.org/) per swag tier
 - Tier 1 swag includes most items $10 and under
 - Tier 2 swag includes most items $26 and under


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The backslashes next to the "$" characters disappear when viewing this document's rendered HTML on GitHub or in VS Code's Markdown preview...But they looked odd on gatsbyjs.org.

I promise I'm not making this change *just* to unlock Tier 2 swag 👀

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
