### PR TITLE
fix(docs): added trailing slash to glossary.md

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -78,11 +78,11 @@ A component can include components within it. In fact, [pages](#page) and [templ
 
 The configuration file, `gatsby-config.js` tells Gatsby information about your website. A common option set in config is your sites metadata that can power your SEO meta tags.
 
-### [Content Delivery Network](/docs/glossary/content-delivery-network)
+### [Content Delivery Network](/docs/glossary/content-delivery-network/)
 
 A content delivery network (CDN) is a highly distributed network of servers that stores copies of your content in locations that are closer to your site's visitors. Content delivery networks improve your site's performance by reducing the time needed to complete a network request.
 
-### [Continuous Deployment](/docs/glossary/continuous-deployment)
+### [Continuous Deployment](/docs/glossary/continuous-deployment/)
 
 Continuous deployment (CD) automates the process of releasing changes to your project. A continuous deployment workflow automatically builds and tests your project, and publishes your changes only when they pass the required tests.
 
@@ -104,7 +104,7 @@ A database is a structured collection of data or content. Often a [CMS](#cms) wi
 
 Decoupling describes the separation of different concerns. With [Gatsby](#gatsby) this most commonly means decoupling the [frontend](#frontend) from the [backend](#backend), like with [Decoupled Drupal](https://dri.es/how-to-decouple-drupal-in-2019) or [Headless WordPress](https://www.smashingmagazine.com/2018/10/headless-wordpress-decoupled/).
 
-### [Decoupled Drupal](/docs/glossary/decoupled-drupal)
+### [Decoupled Drupal](/docs/glossary/decoupled-drupal/)
 
 Decoupling refers to the practice of using Drupal as a [headless CMS](#headless-cms). A decoupled Drupal instance functions as a content API that returns JSON for your [frontend](#frontend) to consume.
 
@@ -152,7 +152,7 @@ The [public-facing](#public) interface for your website or app, delivered using 
 
 Gatsby is a modern website framework that builds performance into every website or app by leveraging the latest web technologies such as [React](#react), [GraphQL](#graphql), and modern [JavaScript](#javascript). Gatsby makes it easy to create blazing fast, compelling web experiences without needing to become a performance expert.
 
-### [GraphQL](/docs/glossary/graphql)
+### [GraphQL](/docs/glossary/graphql/)
 
 A [query](#query) language that allows you to pull data into your website or app. It’s the [interface that Gatsby uses](/docs/graphql/) for managing site data.
 
@@ -162,11 +162,11 @@ A [query](#query) language that allows you to pull data into your website or app
 
 A markup language that every web browser is able to understand. It stands for Hypertext Markup Language. [HTML](https://developer.mozilla.org/en-US/docs/Web/HTML) gives your web content a universal informational structure, defining things like headings, paragraphs, and more. It is also key to providing an accessible website.
 
-### [Headless CMS](/docs/glossary/headless-cms)
+### [Headless CMS](/docs/glossary/headless-cms/)
 
 A [CMS](#cms) that only handles the [backend](#backend) content management instead of handling both the backend and [frontend](#frontend). This type of setup is also referred to as [Decoupled](#decoupled).
 
-### [Headless WordPress](/docs/glossary/headless-wordpress)
+### [Headless WordPress](/docs/glossary/headless-wordpress/)
 
 The practice of using JSON returned from the WordPress REST API as a [headless CMS](#headless-cms). It allows you to use WordPress to write and edit content that can be consumed by any client capable of parsing JSON.
 
@@ -194,7 +194,7 @@ Infrastructure As Code is the practice of using configuration files and scripts 
 
 ## J
 
-### [JAMStack](/docs/glossary/jamstack)
+### [JAMStack](/docs/glossary/jamstack/)
 
 JAMStack refers to a modern web architecture using [JavaScript](#javascript), [APIs](#api), and ([HTML](#html)) markup. From [JAMStack.org](https://jamstack.org): "It’s a new way of building websites and apps that delivers better performance, higher security, lower cost of scaling, and a better developer experience."
 
@@ -226,7 +226,7 @@ A way of writing HTML content with plain text, using special characters to denot
 
 ## N
 
-### [npm](/docs/glossary/npm)
+### [npm](/docs/glossary/npm/)
 
 [Node](#node) [package](#package) manager. Allows you to install and update other packages that your project depends on. [Gatsby](#gatsby) and [React](#react) are examples of your project's dependencies. See also: [Yarn](#yarn).
 
@@ -234,7 +234,7 @@ A way of writing HTML content with plain text, using special characters to denot
 
 Gatsby uses [data nodes](/docs/node-interface/) to represent a single piece of data. A [data source](#data-source) will create multiple nodes.
 
-### [Node.js](/docs/glossary/node)
+### [Node.js](/docs/glossary/node/)
 
 A program that lets you run [JavaScript](#javascript) on your computer. Gatsby is powered by Node.
 
@@ -280,7 +280,7 @@ The process of requesting specific data from somewhere. With Gatsby you normally
 
 ## R
 
-### [React](/docs/glossary/react)
+### [React](/docs/glossary/react/)
 
 A code library (written with [JavaScript](#javascript)) for building user interfaces. It’s the framework that [Gatsby](#gatsby) uses to build pages and structure content.
 
@@ -330,7 +330,7 @@ Gatsby [builds](#build) static versions of your page that can be easily [hosted]
 
 It also refers to the `/static` folder which is automatically copied into `/public` on each [build](#build) for files that don't need to be processed by Gatsby but do need to exist in [public](#public).
 
-### [Static Site Generator](/docs/glossary/static-site-generator)
+### [Static Site Generator](/docs/glossary/static-site-generator/)
 
 A software application that creates HTML pages from templates or [components](#component) and a given content source.
 
@@ -362,11 +362,11 @@ A UI refers to a User Interface. In the field of human-computer interaction, a U
 
 ## W
 
-### [webpack](/docs/glossary/webpack)
+### [webpack](/docs/glossary/webpack/)
 
 A [JavaScript](#javascript) application that Gatsby uses to bundle your website's code up. This happens automatically on [build](#build).
 
-### [WPGraphQL](/docs/glossary/wpgraphql)
+### [WPGraphQL](/docs/glossary/wpgraphql/)
 
 A WordPress plugin that adds [GraphQL](#graphql) capabilities to WordPress. It's another way that you can use WordPress as a content source for Gatsby.
 


### PR DESCRIPTION
## Description
**Changes: added trailing slash to helps the user identify the hierarchy of page.**

`Fix: Breadcrumb issue resolved in /docs/docs/glossary.md`

## Related Issues
#20767
#22628
#22933