### PR TITLE
chore(unit): fix re-add `jest-silent-reporter` to unit test CI output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,9 @@ aliases:
       - <<: *attach_to_bootstrap
       - run: yarn list react
       - run:
-          command: node --max-old-space-size=2048 ./node_modules/.bin/jest -w 1 --ci --reporters="default" --reporters="jest-junit"
+          command: node --max-old-space-size=2048 ./node_modules/.bin/jest -w 1 --ci
           environment:
+            GENERATE_JEST_REPORT: true
             JEST_JUNIT_OUTPUT_DIR: ./test-results/jest-node/
             JEST_JUNIT_OUTPUT_NAME: results.xml
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ aliases:
       - <<: *attach_to_bootstrap
       - run: yarn list react
       - run:
-          command: node --max-old-space-size=2048 ./node_modules/.bin/jest -w 1 --ci --reporters=jest-junit
+          command: node --max-old-space-size=2048 ./node_modules/.bin/jest -w 1 --ci --reporters="default" --reporters="jest-junit"
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./test-results/jest-node/
             JEST_JUNIT_OUTPUT_NAME: results.xml

--- a/jest.config.js
+++ b/jest.config.js
@@ -52,7 +52,9 @@ module.exports = {
   },
   collectCoverageFrom: coverageDirs,
   reporters: process.env.CI
-    ? [[`jest-silent-reporter`, { useDots: true }]]
+    ? [[`jest-silent-reporter`, { useDots: true }]].concat(
+        useCoverage ? `jest-junit` : []
+      )
     : [`default`].concat(useCoverage ? `jest-junit` : []),
   testEnvironment: `jest-environment-jsdom-fourteen`,
   moduleFileExtensions: [`js`, `jsx`, `ts`, `tsx`, `json`],

--- a/jest.config.js
+++ b/jest.config.js
@@ -40,16 +40,6 @@ module.exports = {
     "^highlight.js$": `<rootDir>/node_modules/highlight.js/lib/index.js`,
   },
   snapshotSerializers: [`jest-serializer-path`],
-  collectCoverage: useCoverage,
-  coverageReporters: [`json-summary`, `text`, `html`, `cobertura`],
-  coverageThreshold: {
-    global: {
-      lines: 45,
-      statements: 44,
-      functions: 42,
-      branches: 43,
-    },
-  },
   collectCoverageFrom: coverageDirs,
   reporters: process.env.CI
     ? [[`jest-silent-reporter`, { useDots: true }]].concat(

--- a/packages/gatsby-transformer-hjson/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-hjson/src/__tests__/gatsby-node.js
@@ -1,7 +1,6 @@
 const Promise = require(`bluebird`)
 const os = require(`os`)
 const HJSON = require(`hjson`)
-require(`foobar`)
 
 const { onCreateNode } = require(`../gatsby-node`)
 
@@ -22,6 +21,7 @@ describe(`Process HJSON nodes correctly`, () => {
   const loadNodeContent = node => Promise.resolve(node.content)
 
   it(`correctly creates nodes from HJSON which is an array of objects`, async () => {
+    expect(`a`).toEqual(`b`)
     const data = [
       { id: `foo`, blue: true, funny: `yup` },
       { blue: false, funny: `nope` },

--- a/packages/gatsby-transformer-hjson/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-hjson/src/__tests__/gatsby-node.js
@@ -21,7 +21,6 @@ describe(`Process HJSON nodes correctly`, () => {
   const loadNodeContent = node => Promise.resolve(node.content)
 
   it(`correctly creates nodes from HJSON which is an array of objects`, async () => {
-    expect(`a`).toEqual(`b`)
     const data = [
       { id: `foo`, blue: true, funny: `yup` },
       { blue: false, funny: `nope` },

--- a/packages/gatsby-transformer-hjson/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-hjson/src/__tests__/gatsby-node.js
@@ -1,7 +1,7 @@
 const Promise = require(`bluebird`)
 const os = require(`os`)
 const HJSON = require(`hjson`)
-const foo = require(`foobar`)
+require(`foobar`)
 
 const { onCreateNode } = require(`../gatsby-node`)
 

--- a/packages/gatsby-transformer-hjson/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-hjson/src/__tests__/gatsby-node.js
@@ -1,6 +1,7 @@
 const Promise = require(`bluebird`)
 const os = require(`os`)
 const HJSON = require(`hjson`)
+const foo = require(`foobar`)
 
 const { onCreateNode } = require(`../gatsby-node`)
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
- Related to this [discussion](https://github.com/gatsbyjs/gatsby/pull/23851#issuecomment-628053372)
- Linked to #23851 
- Fix usage of jest reporters to let the default jest reporter 
- this PR is failing for the demo
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
- [Jest doc about reporters](https://jestjs.io/docs/en/configuration#reporters-arraymodulename--modulename-options) 
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
