### PR TITLE
fix(gatsby-recipes): format code blocks without indentation as that makes copy/paste difficult

### DIFF
--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -205,9 +205,8 @@ const components = {
       language = props.className.split(`-`)[1]
     }
     const children = hicat(props.children.trim(), { lang: language })
-    const regex = /^/gm
 
-    const ansi = children.ansi.replace(regex, `··  `)
+    const ansi = `\`\`\`${language}\n${children.ansi}\n\`\`\``
 
     return (
       <Div marginBottom={1}>


### PR DESCRIPTION
Another try on https://github.com/gatsbyjs/gatsby/pull/23996

<img width="653" alt="Screen Shot 2020-05-13 at 5 32 55 PM" src="https://user-images.githubusercontent.com/71047/81879747-7913ae80-9540-11ea-957e-3aeed6651eaa.png">
