### PR TITLE
feat(gatsby): Add total count to pageInfo

### DIFF
--- a/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
@@ -889,6 +889,7 @@ type PageInfo {
   itemCount: Int!
   pageCount: Int!
   perPage: Int
+  totalCount: Int!
 }
 
 type Query {

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
@@ -889,6 +889,7 @@ type PageInfo {
   itemCount: Int!
   pageCount: Int!
   perPage: Int
+  totalCount: Int!
 }
 
 type Query {

--- a/packages/gatsby/src/schema/__tests__/pagination.js
+++ b/packages/gatsby/src/schema/__tests__/pagination.js
@@ -28,6 +28,7 @@ describe(`Paginate query results`, () => {
       itemCount: 2,
       pageCount: 2,
       perPage: 2,
+      totalCount: 4,
     })
   })
 
@@ -42,6 +43,7 @@ describe(`Paginate query results`, () => {
       itemCount: 2,
       pageCount: 3,
       perPage: 2,
+      totalCount: 4,
     })
   })
 
@@ -56,6 +58,7 @@ describe(`Paginate query results`, () => {
       itemCount: 2,
       pageCount: 2,
       perPage: 2,
+      totalCount: 4,
     })
   })
 
@@ -70,6 +73,7 @@ describe(`Paginate query results`, () => {
       itemCount: 3,
       pageCount: 2,
       perPage: undefined,
+      totalCount: 4,
     })
   })
 
@@ -84,6 +88,7 @@ describe(`Paginate query results`, () => {
       itemCount: 0,
       pageCount: 2,
       perPage: undefined,
+      totalCount: 4,
     })
   })
 
@@ -98,6 +103,7 @@ describe(`Paginate query results`, () => {
       itemCount: 4,
       pageCount: 1,
       perPage: 10,
+      totalCount: 4,
     })
   })
 })

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -198,6 +198,7 @@ export function paginate<NodeType>(
       itemCount: items.length,
       pageCount,
       perPage: limit,
+      totalCount: count,
     },
   }
 }

--- a/packages/gatsby/src/schema/type-definitions.ts
+++ b/packages/gatsby/src/schema/type-definitions.ts
@@ -45,6 +45,7 @@ export interface IGatsbyPageInfo {
   itemCount: number
   pageCount: number
   perPage: number | undefined
+  totalCount: number
 }
 
 export interface IGraphQLSpanTracer {

--- a/packages/gatsby/src/schema/types/pagination.ts
+++ b/packages/gatsby/src/schema/types/pagination.ts
@@ -22,6 +22,7 @@ export const getPageInfo = <TContext = any>({
       itemCount: `Int!`,
       pageCount: `Int!`,
       perPage: `Int`,
+      totalCount: `Int!`,
     })
   })
 


### PR DESCRIPTION
For the uniformity, there is no point of having this not be pageInfo as it might be important to display the pageInfo.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
