### PR TITLE
fix(docs): breadcrumb issue with RFC process section in docs/contributing

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -14,6 +14,6 @@ Below you'll find guides on the Gatsby.js community, code of conduct, and how to
 - [Code of Conduct](/contributing/code-of-conduct/): Read about what we expect from everyone participating in Gatsby.js to make it the most friendly and welcoming community.
 - [Gatsby Style Guide](/contributing/gatsby-style-guide/): The art of contributing to Gatsby, a.k.a. the detailed requirements that will make it more likely your contribution is accepted with minimal changes.
 - [How to Contribute](/contributing/how-to-contribute/): How to get the most out of your Gatsby.js contributing experience, including GitHub management tips, setup instructions for docs and code contributions, and more.
-- [RFC process](/contributing/rfc-process): Learn how the Gatsby.js team manages bigger changes, by way of a “Request-for-comment” process on GitHub.
+- [RFC process](/contributing/rfc-process/): Learn how the Gatsby.js team manages bigger changes, by way of a “Request-for-comment” process on GitHub.
 
 <EmailCaptureForm signupMessage="Want to keep up with the latest tips &amp; tricks? Subscribe to our newsletter!" />


### PR DESCRIPTION
## Description
**Changes: added trailing slash to helps the user identify the hierarchy of page.**

`Fix: Breadcrumb issue with RFC process section resolved in /docs/contributing/index.md`

Related Issues
#20767