### PR TITLE
fix(gatsby): Update to handle changes to fast refresh webpack plugin

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -627,7 +627,9 @@ export const createWebpackUtils = (
 
   plugins.fastRefresh = (): Plugin =>
     new ReactRefreshWebpackPlugin({
-      disableRefreshCheck: true,
+      overlay: {
+        sockIntegration: `whm`,
+      },
     })
 
   plugins.extractText = (options: any): Plugin =>


### PR DESCRIPTION
## Description

Updates our usage of FastRefresh to a recent breaking change from 0.2 -> 0.3.


## Related Issues

#24078