### PR TITLE
fix(gatsby-plugin-manifest): remove fs from ssr

### DIFF
--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -1,10 +1,10 @@
-jest.mock(`fs`, () => {
-  return {
-    readFileSync: jest.fn().mockImplementation(() => `someIconImage`),
-  }
-})
+const { onPreInit } = require(`../gatsby-node`)
+const { onRenderBody: ssrOnRenderBody } = require(`../gatsby-ssr`)
 
-const { onRenderBody } = require(`../gatsby-ssr`)
+const onRenderBody = (args, pluginOptions) => {
+  onPreInit({}, pluginOptions)
+  return ssrOnRenderBody(args, pluginOptions)
+}
 
 let headComponents
 const setHeadComponents = args => (headComponents = headComponents.concat(args))

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -1,3 +1,9 @@
+jest.mock(`fs`, () => {
+  return {
+    readFileSync: jest.fn().mockImplementation(() => `someIconImage`),
+  }
+})
+
 const { onPreInit } = require(`../gatsby-node`)
 const { onRenderBody: ssrOnRenderBody } = require(`../gatsby-ssr`)
 
@@ -9,6 +15,7 @@ const onRenderBody = (args, pluginOptions) => {
 let headComponents
 const setHeadComponents = args => (headComponents = headComponents.concat(args))
 
+const defaultIcon = `pretend/this/exists.png`
 const ssrArgs = {
   setHeadComponents,
   pathname: `/`,
@@ -25,7 +32,7 @@ describe(`gatsby-plugin-manifest`, () => {
     global.__PATH_PREFIX__ = `/path-prefix`
 
     onRenderBody(ssrArgs, {
-      icon: true,
+      icon: defaultIcon,
       theme_color: `#000000`,
     })
 
@@ -73,7 +80,7 @@ describe(`gatsby-plugin-manifest`, () => {
 
     it(`Does not add a "theme_color" meta tag to head if "theme_color" option is not provided.`, () => {
       onRenderBody(ssrArgs, {
-        icon: true,
+        icon: defaultIcon,
         include_favicon: false,
         cache_busting_mode: false,
         legacy: false,
@@ -83,7 +90,7 @@ describe(`gatsby-plugin-manifest`, () => {
 
     it(`Adds "icon" and "manifest" links and "theme_color" meta tag to head`, () => {
       onRenderBody(ssrArgs, {
-        icon: true,
+        icon: defaultIcon,
         theme_color: `#000000`,
       })
       expect(headComponents).toMatchSnapshot()
@@ -127,7 +134,7 @@ describe(`gatsby-plugin-manifest`, () => {
     describe(`Does create legacy links`, () => {
       it(`if "legacy" not specified in automatic mode`, () => {
         onRenderBody(ssrArgs, {
-          icon: true,
+          icon: defaultIcon,
           theme_color: `#000000`,
           include_favicon: false,
           cache_busting_mode: `none`,
@@ -138,7 +145,7 @@ describe(`gatsby-plugin-manifest`, () => {
 
       it(`if "legacy" not specified in hybrid mode.`, () => {
         onRenderBody(ssrArgs, {
-          icon: true,
+          icon: defaultIcon,
           theme_color: `#000000`,
           icons: [
             {
@@ -161,7 +168,6 @@ describe(`gatsby-plugin-manifest`, () => {
 
       it(`if "legacy" not specified in manual mode.`, () => {
         onRenderBody(ssrArgs, {
-          icon: false,
           icons: [
             {
               src: `/favicons/android-chrome-48x48.png`,
@@ -182,7 +188,7 @@ describe(`gatsby-plugin-manifest`, () => {
     describe(`Does not create legacy links`, () => {
       it(`If "legacy" options is false and in automatic`, () => {
         onRenderBody(ssrArgs, {
-          icon: true,
+          icon: defaultIcon,
           legacy: false,
           include_favicon: false,
           cache_busting_mode: false,
@@ -192,7 +198,6 @@ describe(`gatsby-plugin-manifest`, () => {
 
       it(`If "legacy" options is false and in manual mode`, () => {
         onRenderBody(ssrArgs, {
-          icon: false,
           theme_color: `#000000`,
           legacy: false,
           icons: [
@@ -213,7 +218,7 @@ describe(`gatsby-plugin-manifest`, () => {
 
       it(`If "legacy" options is false and in hybrid mode`, () => {
         onRenderBody(ssrArgs, {
-          icon: true,
+          icon: defaultIcon,
           legacy: false,
           icons: [
             {
@@ -238,7 +243,6 @@ describe(`gatsby-plugin-manifest`, () => {
   describe(`Cache Busting`, () => {
     it(`doesn't add cache busting in manual mode`, () => {
       onRenderBody(ssrArgs, {
-        icon: false,
         icons: [
           {
             src: `/favicons/android-chrome-48x48.png`,
@@ -257,17 +261,17 @@ describe(`gatsby-plugin-manifest`, () => {
     })
 
     it(`doesn't add cache busting if "cache_busting_mode" option is set to none`, () => {
-      onRenderBody(ssrArgs, { icon: true, cache_busting_mode: `none` })
+      onRenderBody(ssrArgs, { icon: defaultIcon, cache_busting_mode: `none` })
       expect(headComponents).toMatchSnapshot()
     })
 
     it(`Does file name cache busting if "cache_busting_mode" option is set to name`, () => {
-      onRenderBody(ssrArgs, { icon: true, cache_busting_mode: `name` })
+      onRenderBody(ssrArgs, { icon: defaultIcon, cache_busting_mode: `name` })
       expect(headComponents).toMatchSnapshot()
     })
 
     it(`Does query cache busting if "cache_busting_mode" option is set to query`, () => {
-      onRenderBody(ssrArgs, { icon: true, cache_busting_mode: `query` })
+      onRenderBody(ssrArgs, { icon: defaultIcon, cache_busting_mode: `query` })
       expect(headComponents).toMatchSnapshot()
     })
 
@@ -280,8 +284,8 @@ describe(`gatsby-plugin-manifest`, () => {
   describe(`Favicon`, () => {
     it(`Adds link favicon tag if "include_favicon" is set to true`, () => {
       onRenderBody(ssrArgs, {
-        icon: true,
-        include_favicon: true,
+        icon: defaultIcon,
+        include_favicon: defaultIcon,
         legacy: false,
         cache_busting_mode: `none`,
       })
@@ -290,7 +294,7 @@ describe(`gatsby-plugin-manifest`, () => {
 
     it(`Does not add a link favicon if "include_favicon" option is set to false`, () => {
       onRenderBody(ssrArgs, {
-        icon: true,
+        icon: defaultIcon,
         include_favicon: false,
         legacy: false,
         cache_busting_mode: `none`,
@@ -300,7 +304,6 @@ describe(`gatsby-plugin-manifest`, () => {
 
     it(`Does not add a link favicon if in manual mode`, () => {
       onRenderBody(ssrArgs, {
-        icon: false,
         icons: [
           {
             src: `/favicons/android-chrome-48x48.png`,
@@ -333,7 +336,7 @@ describe(`gatsby-plugin-manifest`, () => {
 
     it(`Add crossOrigin when 'crossOrigin' is anonymous`, () => {
       onRenderBody(ssrArgs, {
-        icon: true,
+        icon: defaultIcon,
         crossOrigin: `anonymous`,
         legacy: false,
         include_favicon: false,
@@ -344,7 +347,7 @@ describe(`gatsby-plugin-manifest`, () => {
 
     it(`Does not add crossOrigin when 'crossOrigin' is blank`, () => {
       onRenderBody(ssrArgs, {
-        icon: true,
+        icon: defaultIcon,
         legacy: false,
         include_favicon: false,
         cache_busting_mode: `none`,

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -1,5 +1,5 @@
-import fs from "fs"
-import path from "path"
+import * as fs from "fs"
+import * as path from "path"
 import sharp from "./safe-sharp"
 import { createContentDigest, cpuCoreCount, slash } from "gatsby-core-utils"
 import {
@@ -45,20 +45,33 @@ async function generateIcon(icon, srcIcon) {
 async function checkCache(cache, icon, srcIcon, srcIconDigest, callback) {
   const cacheKey = createContentDigest(`${icon.src}${srcIcon}${srcIconDigest}`)
 
-  let created = cache.get(cacheKey, srcIcon)
-
+  const created = cache.get(cacheKey, srcIcon)
   if (!created) {
     cache.set(cacheKey, true)
 
     try {
-      // console.log(`creating icon`, icon.src, srcIcon)
       await callback(icon, srcIcon)
     } catch (e) {
       cache.set(cacheKey, false)
       throw e
     }
-  } else {
-    // console.log(`icon exists`, icon.src, srcIcon)
+  }
+}
+
+/**
+ * Setup pluginOption defaults
+ */
+exports.onPreInit = (_, pluginOptions) => {
+  pluginOptions.cache_busting_mode = pluginOptions.cache_busting_mode ?? `query`
+  pluginOptions.include_favicon = pluginOptions.include_favicon ?? true
+  pluginOptions.legacy = pluginOptions.legacy ?? true
+  pluginOptions.theme_color_in_head = pluginOptions.theme_color_in_head ?? true
+  pluginOptions.cacheDigest = null
+
+  if (pluginOptions.cache_busting_mode !== `none`) {
+    pluginOptions.cacheDigest = createContentDigest(
+      fs.readFileSync(pluginOptions.icon)
+    )
   }
 }
 
@@ -69,6 +82,7 @@ exports.onPostBootstrap = async (
   const activity = reporter.activityTimer(`Build manifest and related icons`, {
     parentSpan,
   })
+
   activity.start()
 
   let cache = new Map()
@@ -172,7 +186,7 @@ const makeManifest = async ({
   })
 
   // Only auto-generate icons if a src icon is defined.
-  if (icon !== undefined) {
+  if (typeof icon !== `undefined`) {
     // Check if the icon exists
     if (!doesIconExist(icon)) {
       throw new Error(

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -68,7 +68,7 @@ exports.onPreInit = (_, pluginOptions) => {
   pluginOptions.theme_color_in_head = pluginOptions.theme_color_in_head ?? true
   pluginOptions.cacheDigest = null
 
-  if (pluginOptions.cache_busting_mode !== `none`) {
+  if (pluginOptions.cache_busting_mode !== `none` && pluginOptions.icon) {
     pluginOptions.cacheDigest = createContentDigest(
       fs.readFileSync(pluginOptions.icon)
     )


### PR DESCRIPTION
## Description

gatsby-ssr was using `fs` to get `contentdigest` of the icon to use as cacheKey. If we want to move to a distributed world. Fs shouldn't run in ssr mode.

### Documentation

Only internal stuff has changed so no need for updates
