### PR TITLE
fix: check if location.state is set for filtering

### DIFF
--- a/www/src/views/creators/index.js
+++ b/www/src/views/creators/index.js
@@ -22,7 +22,7 @@ class CreatorsView extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.location.state !== null) {
+    if (this.props.location.state !== null && prevProps.location.state !== null) {
       const filterStateChanged =
         this.props.location.state.filter !== prevProps.location.state.filter
       const isNotFiltered = this.props.location.state.filter === ``


### PR DESCRIPTION
## Description

Added a null check for the location.state of the creators page before filtering which prevents it from crashing. Previously, when using "Skip to main content" componentDidUpdate fired with `location.key = 'initial'` and `location.state` was not set in that case.

## Related Issues

Fixes #24081 
