### PR TITLE
chore(docs): Update CloudCallout language

### DIFF
--- a/docs/blog/2020-05-07-gatsby-delivers-impossible-burgers-map/index.md
+++ b/docs/blog/2020-05-07-gatsby-delivers-impossible-burgers-map/index.md
@@ -103,8 +103,7 @@ Check out this [webinar with Gatsby and Contentful](https://www.gatsbyjs.com/imp
 
 <CloudCallout>
   Sites built with Gatsby are fast no matter where they run. But when a Gatsby
-  site runs on Gatsby Cloud, it can make the Kessel run in under 12 parsecs.
-  Find out more:
+  site runs on Gatsby Cloud, its builds get even faster!
 </CloudCallout>
 
 Ashley Geo and David Fonnegra also highlighted the Impossible Foods / Matter Supply partnership in [ImpossibleFoods.com: Combining Gatsby + Contentful for Speed, Scale, and Flexibility](https://www.gatsbyjs.com/impossible-foods-webinar/). Deane Barker highlighted the store locator use-case [in a March 2019 podcast](https://www.ingeniux.com/company/podcast/content-matters-podcast-headless-content-management-with-deane-barker).

--- a/docs/blog/2020-05-12-strapi-instant-content-preview-plugin/index.md
+++ b/docs/blog/2020-05-12-strapi-instant-content-preview-plugin/index.md
@@ -87,6 +87,5 @@ That's it! If everything is working correctly, Strapi will now inform Gatsby Clo
 
 <CloudCallout>
   Sites built with Gatsby are fast no matter where they run. But when a Gatsby
-  site runs on Gatsby Cloud, it can make the Kessel run in under 12 parsecs.
-  Find out more:
+  site runs on Gatsby Cloud, its builds get even faster!
 </CloudCallout>

--- a/docs/contributing/docs-and-blog-components.md
+++ b/docs/contributing/docs-and-blog-components.md
@@ -154,7 +154,7 @@ Rendered, the component looks like this:
 
 <CloudCallout>
   Connect your Gatsby site to Storage Provider for automatic deployments
-</CloudCallout>{" "}
+</CloudCallout>
 
 ### Component Model
 

--- a/docs/contributing/docs-and-blog-components.md
+++ b/docs/contributing/docs-and-blog-components.md
@@ -143,7 +143,7 @@ title: Deploying to Storage Provider
 
 <!-- highlight-start -->
 <CloudCallout>
-  Connect your Gatsby site to Storage Provider for automatic deployments
+  Connect your Gatsby site to Storage Provider for automatic deployments.
 </CloudCallout>
 <!-- highlight-end -->
 ```
@@ -153,7 +153,7 @@ title: Deploying to Storage Provider
 Rendered, the component looks like this:
 
 <CloudCallout>
-  Connect your Gatsby site to Storage Provider for automatic deployments
+  Connect your Gatsby site to Storage Provider for automatic deployments.
 </CloudCallout>
 
 ### Component Model

--- a/docs/docs/deploying-and-hosting.md
+++ b/docs/docs/deploying-and-hosting.md
@@ -8,7 +8,7 @@ Getting your shiny new Gatsby site deployed and accessible is probably the first
 When you build your Gatsby application, the output is static content: HTML, CSS, JavaScript, images, etc. This content is incredibly easy and affordable to host with any provider. We have several guides below for hosting with particular providers, but this list is by no means exhaustive. Whether you're deploying to AWS, Netlify, or something else entirely switching to static content makes deploying a trivial concern.
 
 <CloudCallout>
-  Many of the integrations below, like Netlify and Vercel, are supported on Gatsby Cloud, the best way to deploy Gatsby sites. Reports give you visibility into the performance and SEO of your site, and Gatsby Cloud has a special-built architecture that builds your site 20x faster, often under 10 seconds.
+  Many of the integrations below, like Netlify and Vercel, are supported on Gatsby Cloud, the best way to deploy Gatsby sites. Reports give you visibility into the performance and SEO of your site, and Gatsby Cloud has a special-built architecture that builds your site 20 times faster, often under 10 seconds.
 </CloudCallout>
 <GuideList slug={props.slug} />
 

--- a/docs/docs/deploying-and-hosting.md
+++ b/docs/docs/deploying-and-hosting.md
@@ -8,7 +8,7 @@ Getting your shiny new Gatsby site deployed and accessible is probably the first
 When you build your Gatsby application, the output is static content: HTML, CSS, JavaScript, images, etc. This content is incredibly easy and affordable to host with any provider. We have several guides below for hosting with particular providers, but this list is by no means exhaustive. Whether you're deploying to AWS, Netlify, or something else entirely switching to static content makes deploying a trivial concern.
 
 <CloudCallout>
-  For the best experience deploying Gatsby applications:
+  Many of the integrations below, like Netlify and Vercel, are supported on Gatsby Cloud, the best way to deploy Gatsby sites. Reports give you visibility into the performance and SEO of your site, and Gatsby Cloud has a special-built architecture that builds your site 20x faster, often under 10 seconds.
 </CloudCallout>
 <GuideList slug={props.slug} />
 

--- a/docs/docs/deploying-and-hosting.md
+++ b/docs/docs/deploying-and-hosting.md
@@ -8,7 +8,11 @@ Getting your shiny new Gatsby site deployed and accessible is probably the first
 When you build your Gatsby application, the output is static content: HTML, CSS, JavaScript, images, etc. This content is incredibly easy and affordable to host with any provider. We have several guides below for hosting with particular providers, but this list is by no means exhaustive. Whether you're deploying to AWS, Netlify, or something else entirely switching to static content makes deploying a trivial concern.
 
 <CloudCallout>
-  Many of the integrations below, like Netlify and Vercel, are supported on Gatsby Cloud, the best way to deploy Gatsby sites. Reports give you visibility into the performance and SEO of your site, and Gatsby Cloud has a special-built architecture that builds your site 20 times faster, often under 10 seconds.
+  Many of the integrations below, like Netlify and Vercel, are supported on
+  Gatsby Cloud, the best way to deploy Gatsby sites. Reports give you visibility
+  into the performance and SEO of your site, and Gatsby Cloud has a
+  special-built architecture that builds your site 20 times faster, often under
+  10 seconds.
 </CloudCallout>
 <GuideList slug={props.slug} />
 

--- a/www/src/components/shared/cloud-callout.js
+++ b/www/src/components/shared/cloud-callout.js
@@ -46,9 +46,7 @@ const CloudCallout = ({ narrow = true, children }) => {
   return (
     <CloudCalloutRoot narrow={narrow}>
       <CloudText>{children}</CloudText>
-      Try <OutboundLink href="https://gatsbyjs.com">Gatsby Cloud</OutboundLink>,
-      with CMS and CDN auto-provisioning, performance reports, and 20x faster
-      builds!
+      Try it on <OutboundLink href="https://gatsbyjs.com">Gatsby Cloud</OutboundLink>!
       <Circles dangerouslySetInnerHTML={{ __html: CirclesOrnament }} />
     </CloudCalloutRoot>
   )


### PR DESCRIPTION
## Description

This change is an attempt to update the language around Gatsby Cloud to fit the tone of the docs a little better. We aren't actually using the `CloudCallout` component in too many places and most remain the same because they're quick sentence fragments. I've also updated the two (identical) uses in blog posts. Those are in a separate commit.

## Related Issues

This was an internal request.