### PR TITLE
chore(benchmarks): Ensure all source and md[x] benchmarks have a clean command

### DIFF
--- a/benchmarks/markdown_id/package.json
+++ b/benchmarks/markdown_id/package.json
@@ -46,11 +46,11 @@
     "bench": "rm -r markdown-pages; NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js; gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "benchnb": "gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "build": "gatsby build",
+    "clean": "gatsby clean",
     "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
     "postinstall": "del-cli markdown-pages && gatsby clean && NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js"
   }

--- a/benchmarks/markdown_slug/package.json
+++ b/benchmarks/markdown_slug/package.json
@@ -46,11 +46,11 @@
     "bench": "rm -r markdown-pages; NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js; gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "benchnb": "gatsby clean; node --max_old_space_size=2000 node_modules/.bin/gatsby build",
     "build": "gatsby build",
+    "clean": "gatsby clean",
     "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
     "postinstall": "del-cli markdown-pages && gatsby clean && NUM_PAGES=${NUM_PAGES:-2000} node md.generate.js"
   }

--- a/benchmarks/markdown_table/package.json
+++ b/benchmarks/markdown_table/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "bench": "set -x; gatsby clean; NUM_PAGES=${NUM_PAGES:-2000} gatsby build",
+    "clean": "gatsby clean",
     "develop": "gatsby develop",
     "build": "gatsby build",
     "data-update": "ts-node scripts/data-update.ts",

--- a/benchmarks/md/package.json
+++ b/benchmarks/md/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
+    "clean": "gatsby clean",
     "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",

--- a/benchmarks/mdx/package.json
+++ b/benchmarks/mdx/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
+    "clean": "gatsby clean",
     "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",

--- a/benchmarks/source-contentful/package.json
+++ b/benchmarks/source-contentful/package.json
@@ -5,9 +5,9 @@
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {
-    "clean": "gatsby clean",
     "build": "gatsby build",
     "data-update": "cross-env NODE_ENV=production node bin/site.js data-update",
+    "clean": "gatsby clean",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "serve": "gatsby serve",

--- a/benchmarks/source-datocms/package.json
+++ b/benchmarks/source-datocms/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
+    "clean": "gatsby clean",
     "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",

--- a/benchmarks/source-drupal/package.json
+++ b/benchmarks/source-drupal/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
+    "clean": "gatsby clean",
     "data-update": "ts-node scripts/data-update.ts",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",

--- a/benchmarks/source-wordpress/package.json
+++ b/benchmarks/source-wordpress/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "build:send": "cross-env BENCHMARK_REPORTING_URL=true gatsby build",
+    "clean": "gatsby clean",
     "data-update": "node scripts/data-update.js",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adds a clean command to all markdown, mdx and source benchmarks.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
