### PR TITLE
Correct WordPress Demo Site URL

### DIFF
--- a/docs/tutorial/wordpress-image-tutorial.md
+++ b/docs/tutorial/wordpress-image-tutorial.md
@@ -4,7 +4,7 @@ title: "Adding Images to a WordPress Site"
 
 ## What this tutorial covers:
 
-In this tutorial, you will install the several image plugins and components in order to pull image data from a WordPress account into your Gatsby site and render that data. This [Gatsby + WordPress demo site](https://using-wordpress.gatsbyjs.org/sample-post-1) shows you a sample of what you’re going to be building in this tutorial, although in this tutorial you’ll just focus on adding images.
+In this tutorial, you will install the several image plugins and components in order to pull image data from a WordPress account into your Gatsby site and render that data. This [Gatsby + WordPress demo site](https://using-wordpress.gatsbyjs.org/) shows you a sample of what you’re going to be building in this tutorial, although in this tutorial you’ll just focus on adding images.
 
 ## Why go through this tutorial?
 


### PR DESCRIPTION
## Description

This PR resolves the issue with the broken demo link on the 'Adding Images to a WordPress Site' tutorial page.

### Documentation

Not applicable.

## Related Issues

n/a.
