### PR TITLE
fix(docs): change VERCEL to Vercel

### DIFF
--- a/docs/blog/2019-01-01-publish-multiple-gatsby-sites/index.md
+++ b/docs/blog/2019-01-01-publish-multiple-gatsby-sites/index.md
@@ -461,7 +461,7 @@ Hopefully what I’ve said makes more sense with the code in front of us. The `s
 
 ### Vercel
 
-Vercel is a tool created by VERCEL that makes the process of deploying Node applications simple. Vercel has recently released updates to the way they deploy static websites. Fortunately our Gatsby packages build to static sites, so it’s a win for us.
+Vercel is a tool created by Vercel that makes the process of deploying Node applications simple. Vercel has recently released updates to the way they deploy static websites. Fortunately our Gatsby packages build to static sites, so it’s a win for us.
 
 If you haven’t used Vercel before, then go-ahead and [get started](https://vercel.com/home#features). This will install the `Vercel CLI` and get a free account created, things we need for the tutorial. The getting started page also has a brief FAQs section that’s well worth reading.
 

--- a/docs/docs/deploying-to-vercel.md
+++ b/docs/docs/deploying-to-vercel.md
@@ -6,7 +6,7 @@ title: Deploying to Vercel
 
 This guide will show you how to get started in a few quick steps:
 
-## Step 1: Installing VERCEL CLI
+## Step 1: Installing Vercel CLI
 
 To install their command-line interface with [npm](https://www.npmjs.com/), run the following command:
 


### PR DESCRIPTION
changes:
- fix brand name casing: VERCEL to Vercel


## Related Issues

- #24019 `[Umbrella] Rename Zeit to Vercel`

