### PR TITLE
fix(www): sidebar bullets indention for steps

### DIFF
--- a/www/src/components/sidebar/accordion.js
+++ b/www/src/components/sidebar/accordion.js
@@ -64,7 +64,11 @@ export default function Accordion({ itemRef, item }) {
           }}
         >
           {item.items.map(subitem => (
-            <Item item={subitem} key={subitem.title} />
+            <Item
+              item={subitem}
+              key={subitem.title}
+              isSteps={item.ui === `steps`}
+            />
           ))}
         </ul>
       )}

--- a/www/src/components/sidebar/item-link.js
+++ b/www/src/components/sidebar/item-link.js
@@ -102,7 +102,7 @@ export default function ItemLink({ item, overrideCSS, isSteps }) {
         {isSteps && (
           <span
             sx={{
-              bg: `white`,
+              bg: `ui.border`,
               borderColor: `ui.border`,
               borderRadius: 6,
               borderStyle: `solid`,

--- a/www/src/components/sidebar/item-link.js
+++ b/www/src/components/sidebar/item-link.js
@@ -12,7 +12,7 @@ const bulletSize = 8
 const bulletSizeActive = 100
 const bulletOffsetTop = `1.3em`
 
-export default function ItemLink({ item, overrideCSS }) {
+export default function ItemLink({ item, overrideCSS, isSteps }) {
   const { onLinkClick, getItemState } = useSidebarContext()
   const { isActive, inActiveTree } = getItemState(item)
 
@@ -20,8 +20,7 @@ export default function ItemLink({ item, overrideCSS }) {
   const title = _getTitle(item.title, isDraft)
 
   const level = item.level
-  const indent =
-    item.parentUi === `steps` ? indention(level + 1) : indention(level)
+  const indent = isSteps ? indention(level + 1) : indention(level)
 
   return (
     <span
@@ -75,7 +74,7 @@ export default function ItemLink({ item, overrideCSS }) {
           "&:before, &:after": {
             content: `''`,
             left: t =>
-              level === 0 || (level === 1 && item.parentUi !== `steps`)
+              level === 0 || (level === 1 && !isSteps)
                 ? `calc(${indent} - ${t.space[4]})`
                 : `calc(${indent} - ${t.space[6]})`,
             top: bulletOffsetTop,
@@ -100,7 +99,7 @@ export default function ItemLink({ item, overrideCSS }) {
         onClick={onLinkClick}
         to={item.link}
       >
-        {item.parentUi === `steps` && (
+        {isSteps && (
           <span
             sx={{
               bg: `white`,

--- a/www/src/components/sidebar/item-link.js
+++ b/www/src/components/sidebar/item-link.js
@@ -20,7 +20,8 @@ export default function ItemLink({ item, overrideCSS }) {
   const title = _getTitle(item.title, isDraft)
 
   const level = item.level
-  const indent = item.ui === `steps` ? indention(level + 1) : indention(level)
+  const indent =
+    item.parentUi === `steps` ? indention(level + 1) : indention(level)
 
   return (
     <span
@@ -74,7 +75,7 @@ export default function ItemLink({ item, overrideCSS }) {
           "&:before, &:after": {
             content: `''`,
             left: t =>
-              level === 0 || (level === 1 && item.ui !== `steps`)
+              level === 0 || (level === 1 && item.parentUi !== `steps`)
                 ? `calc(${indent} - ${t.space[4]})`
                 : `calc(${indent} - ${t.space[6]})`,
             top: bulletOffsetTop,
@@ -99,7 +100,7 @@ export default function ItemLink({ item, overrideCSS }) {
         onClick={onLinkClick}
         to={item.link}
       >
-        {item.ui === `steps` && (
+        {item.parentUi === `steps` && (
           <span
             sx={{
               bg: `white`,

--- a/www/src/components/sidebar/item.js
+++ b/www/src/components/sidebar/item.js
@@ -4,7 +4,7 @@ import Accordion from "./accordion"
 import ItemLink from "./item-link"
 import { useSidebarContext } from "./sidebar"
 
-const Item = ({ item }) => {
+const Item = ({ item, isSteps }) => {
   const { getItemState } = useSidebarContext()
   const { isActive } = getItemState(item)
   const itemRef = React.useRef(null)
@@ -21,7 +21,7 @@ const Item = ({ item }) => {
   } else {
     return (
       <li ref={itemRef}>
-        <ItemLink item={item} />
+        <ItemLink item={item} isSteps={isSteps} />
       </li>
     )
   }

--- a/www/src/utils/sidebar/item-list.js
+++ b/www/src/utils/sidebar/item-list.js
@@ -11,22 +11,20 @@ const createHash = link => {
   return index >= 0 ? link.substr(index + 1) : false
 }
 
-const extendItem = (items, parentTitle, parentUi, level) => {
+const extendItem = (items, parentTitle, level) => {
   items.forEach(item => {
     item.hash = createHash(item.link)
     item.parentTitle = parentTitle
-    if (parentUi) item.parentUi = parentUi
     item.level = level || 1
 
-    if (item.items)
-      extendItem(item.items, item.title, item.parentUi, item.level + 1)
+    if (item.items) extendItem(item.items, item.title, item.level + 1)
   })
 }
 
 const extendItemList = itemList => {
   itemList.forEach(section => {
     section.level = 0
-    if (section.items) extendItem(section.items, section.title, section.ui)
+    if (section.items) extendItem(section.items, section.title)
   })
   return itemList
 }

--- a/www/src/utils/sidebar/item-list.js
+++ b/www/src/utils/sidebar/item-list.js
@@ -11,20 +11,22 @@ const createHash = link => {
   return index >= 0 ? link.substr(index + 1) : false
 }
 
-const extendItem = (items, parentTitle, level) => {
+const extendItem = (items, parentTitle, parentUi, level) => {
   items.forEach(item => {
     item.hash = createHash(item.link)
     item.parentTitle = parentTitle
+    if (parentUi) item.parentUi = parentUi
     item.level = level || 1
 
-    if (item.items) extendItem(item.items, item.title, item.level + 1)
+    if (item.items)
+      extendItem(item.items, item.title, item.parentUi, item.level + 1)
   })
 }
 
 const extendItemList = itemList => {
   itemList.forEach(section => {
     section.level = 0
-    if (section.items) extendItem(section.items, section.title)
+    if (section.items) extendItem(section.items, section.title, section.ui)
   })
   return itemList
 }


### PR DESCRIPTION
## Description

Fixes indentation of sidebar bullets when parent link has `ui: steps`-property (i.e. in Tutorials section). For this I used a new prop called `parentUi` which is set on items.

Result looks like this:
![Screenshot from 2020-05-15 22-56-20](https://user-images.githubusercontent.com/4885581/82095743-f3d6f800-96ff-11ea-93ec-d46ea8284d43.png)

## Related Issues

Fixes #24093 
