### PR TITLE
docs: clarify props.location

### DIFF
--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -10,7 +10,7 @@ Sometimes it can be helpful to know exactly what your app's browser URL is at an
 {
   key: 'ac3df4', // does not populate with a HashHistory!
   pathname: '/somepage',
-  search: '?someurlparam=foo&anotherurlparam=bar',
+  search: '?someurlparam=valuestring1&anotherurlparam=valuestring2',
   hash: '#about',
   state: {
     [userDefined]: true

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -4,19 +4,21 @@ title: Location Data from Props
 
 ## What is location data
 
-Sometimes it can be helpful to know exactly what your app's browser URL is at any given stage. Using [@reach/router](https://github.com/reach/router) for [client-side](/docs/glossary#client-side) routing in Gatsby, `location` data represents where the app is currently, where you'd like it to go, and other helpful information. The `location` object is never mutated but `reach@router` makes it helpful to determine when navigation happens.
+Sometimes it can be helpful to know exactly what your app's browser URL is at any given stage. Because Gatsby uses [@reach/router](https://github.com/reach/router) for [client-side](/docs/glossary#client-side) routing, the `location` prop is passed to any component and represents where the app is currently, where you'd like it to go, and other helpful information. The `location` object is never mutated but `reach@router` makes it helpful to determine when navigation happens. Here is a sample `props.location`:
 
 ```js
 {
   key: 'ac3df4', // does not populate with a HashHistory!
   pathname: '/somepage',
-  search: '?someurlquery=searching-string',
+  search: '?someurlparam=foo&anotherurlparam=bar',
   hash: '#about',
   state: {
     [userDefined]: true
   }
 }
 ```
+
+Note that you have to parse the `search` field (the [query string](https://developer.mozilla.org/en-US/docs/Web/API/URL/search)) into individual keys and values yourself.
 
 ### HashHistory
 
@@ -28,8 +30,8 @@ Through client-side routing in Gatsby you can provide a location object instead 
 
 - Providing state to linked components
 - Client-only routes
-- Fetching Data
-- Animation Transition
+- Fetching data
+- Animation transitions
 
 ## Example of providing state to a link component
 
@@ -57,10 +59,6 @@ const SomePageComponent = ({ location }) => {
   )
 }
 ```
-
-## Gatsby advantages
-
-The great thing is you can expect the `location` prop to be available to you on every page thanks to its use of `@reach/router`.
 
 ## Other resources
 


### PR DESCRIPTION
Clarify in https://www.gatsbyjs.org/docs/location-data-from-props/ how the `location` prop is passed, what it contains, and fix some random Title Casing.