### PR TITLE
fix(readme): fix jsx in recipes readme

### DIFF
--- a/packages/gatsby-recipes/README.md
+++ b/packages/gatsby-recipes/README.md
@@ -135,8 +135,8 @@ Installs a Gatsby Plugin in the site's `gatsby-config.js`.
   name="gatsby-source-filesystem"
   key="src/pages"
   options={{
-    name="src pages directory"
-    path="src/pages"
+    name: `src pages directory`,
+    path: `src/pages`,
   }}
 />
 ```


### PR DESCRIPTION
## Description

- fix jsx in readme

## Related Issues

- #23599 `feat(gatsby-recipes): document option support for GatsbyPlugin` 
- #24142 `Reature Request: format check for README.md`
