### PR TITLE
fix(gatsby-source-contentful): Move sharp plugin to optional dependencies

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -18,7 +18,6 @@
     "deep-map": "^1.5.0",
     "fs-extra": "^8.1.0",
     "gatsby-core-utils": "^1.2.2",
-    "gatsby-plugin-sharp": "^2.6.3",
     "gatsby-source-filesystem": "^2.3.3",
     "is-online": "^8.3.1",
     "json-stringify-safe": "^5.0.1",
@@ -30,6 +29,9 @@
     "@babel/core": "^7.9.6",
     "babel-preset-gatsby-package": "^0.4.1",
     "cross-env": "^5.2.1"
+  },
+  "optionalDependencies": {
+    "gatsby-plugin-sharp": "^2.6.3"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#readme",
   "keywords": [


### PR DESCRIPTION
fixes #23904

More details can be found in the original report