### PR TITLE
fix(www): responsive ui of buttons on blog page

### DIFF
--- a/www/src/templates/tags.js
+++ b/www/src/templates/tags.js
@@ -1,6 +1,8 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import React from "react"
+import styled from "@emotion/styled"
+import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 import { graphql } from "gatsby"
 import { TiTags as TagsIcon, TiArrowRight } from "react-icons/ti"
 
@@ -23,6 +25,16 @@ const preferSpacedTag = tags => {
   return tags[0]
 }
 
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  ${mediaQueries.xs} {
+    flex-direction: row;
+  }
+`
+
 const Tags = ({ pageContext, data }) => {
   const { tags } = pageContext
   const { nodes, totalCount } = data.allMdx
@@ -40,26 +52,28 @@ const Tags = ({ pageContext, data }) => {
         )}`}
       />
       <h1>{tagHeader}</h1>
-      <Button
-        variant="small"
-        key="blog-post-view-all-tags-button"
-        to="/blog/tags"
-      >
-        View all tags <TagsIcon />
-      </Button>
-      {doc ? (
-        <React.Fragment>
-          <span css={{ margin: 5 }} />
-          <Button
-            variant="small"
-            secondary
-            key={`view-tag-docs-button`}
-            to={doc}
-          >
-            Read the documentation <TiArrowRight />
-          </Button>
-        </React.Fragment>
-      ) : null}
+      <ButtonWrapper>
+        <Button
+          variant="small"
+          key="blog-post-view-all-tags-button"
+          to="/blog/tags"
+        >
+          View all tags <TagsIcon />
+        </Button>
+        {doc ? (
+          <React.Fragment>
+            <span css={{ margin: 5 }} />
+            <Button
+              variant="small"
+              secondary
+              key={`view-tag-docs-button`}
+              to={doc}
+            >
+              Read the documentation <TiArrowRight />
+            </Button>
+          </React.Fragment>
+        ) : null}
+      </ButtonWrapper>
       {nodes.map(node => (
         <BlogPostPreviewItem
           post={node}


### PR DESCRIPTION
## Description

UI of buttons on blog page is broken on devices having width less than 400px

1. Go to Gatsby website on a mobile device having width less than 400px.
2. Go to Blog Page of the Gatsby website.
3. Click on the **View all Tags** button.
4. Click on the **themes** tag from popular tags
5. **The View all tags** and **Read the documentation** buttons are touching each other 

### Screenshot(s)

#### Bug
![bug-blog-page](https://user-images.githubusercontent.com/17913905/82137205-947a0480-9833-11ea-98e2-7584455b976e.png)

#### Bug Fix
![bug-fix-blog-page](https://user-images.githubusercontent.com/17913905/82137210-a6f43e00-9833-11ea-9781-432a416c864f.png)
