### PR TITLE
feat(gatsby-image): ability to add className to actual image

### DIFF
--- a/docs/docs/gatsby-image.md
+++ b/docs/docs/gatsby-image.md
@@ -353,6 +353,7 @@ After you've made a query, you can pass additional options to the gatsby-image c
 | `className`            | `string` / `object` | Passed to the wrapper element. Object is needed to support Glamor's css prop                                                  |
 | `style`                | `object`            | Spread into the default styles of the wrapper element                                                                         |
 | `imgStyle`             | `object`            | Spread into the default styles of the actual `img` element                                                                    |
+| `imgClassName`         | `string`            | A class that is passed to the actual `img` element                                                                            |
 | `placeholderStyle`     | `object`            | Spread into the default styles of the placeholder `img` element                                                               |
 | `placeholderClassName` | `string`            | A class that is passed to the placeholder `img` element                                                                       |
 | `backgroundColor`      | `string` / `bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string.   |

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -400,6 +400,7 @@ While you could achieve a similar effect with plain CSS media queries, `gatsby-i
 | `className`            | `string` / `object` | Passed to the wrapper element. Object is needed to support Glamor's css prop                                                                  |
 | `style`                | `object`            | Spread into the default styles of the wrapper element                                                                                         |
 | `imgStyle`             | `object`            | Spread into the default styles of the actual `img` element                                                                                    |
+| `imgClassName`         | `string`            | A class that is passed to the actual `img` element                                                                                            |
 | `placeholderStyle`     | `object`            | Spread into the default styles of the placeholder `img` element                                                                               |
 | `placeholderClassName` | `string`            | A class that is passed to the placeholder `img` element                                                                                       |
 | `backgroundColor`      | `string` / `bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string.                   |

--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -38,6 +38,7 @@ interface GatsbyImageProps {
   crossOrigin?: string | boolean
   style?: object
   imgStyle?: object
+  imgClassName?: string
   placeholderStyle?: object
   placeholderClassName?: string
   backgroundColor?: string | boolean

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -253,10 +253,11 @@ const noscriptImg = props => {
     : ``
   const loading = props.loading ? `loading="${props.loading}" ` : ``
   const draggable = props.draggable ? `draggable="${props.draggable}" ` : ``
+  const className = props.imgClassName ? `class="${props.imgClassName}" ` : ``
 
   const sources = generateNoscriptSources(props.imageVariants)
 
-  return `<picture>${sources}<img ${loading}${width}${height}${sizes}${srcSet}${src}${alt}${title}${crossOrigin}${draggable}style="position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/></picture>`
+  return `<picture>${sources}<img ${loading}${width}${height}${sizes}${srcSet}${src}${alt}${title}${crossOrigin}${draggable}${className}style="position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/></picture>`
 }
 
 // Earlier versions of gatsby-image during the 2.x cycle did not wrap
@@ -427,6 +428,7 @@ class Image extends React.Component {
       className,
       style = {},
       imgStyle = {},
+      imgClassName,
       placeholderStyle = {},
       placeholderClassName,
       fluid,
@@ -556,6 +558,7 @@ class Image extends React.Component {
                 itemProp={itemProp}
                 loading={loading}
                 draggable={draggable}
+                className={imgClassName}
               />
             </picture>
           )}
@@ -570,6 +573,7 @@ class Image extends React.Component {
                   loading,
                   ...image,
                   imageVariants,
+                  imgClassName,
                 }),
               }}
             />
@@ -661,6 +665,7 @@ class Image extends React.Component {
                 itemProp={itemProp}
                 loading={loading}
                 draggable={draggable}
+                className={imgClassName}
               />
             </picture>
           )}
@@ -675,6 +680,7 @@ class Image extends React.Component {
                   loading,
                   ...image,
                   imageVariants,
+                  imgClassName,
                 }),
               }}
             />
@@ -741,6 +747,7 @@ Image.propTypes = {
   crossOrigin: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   style: PropTypes.object,
   imgStyle: PropTypes.object,
+  imgClassName: PropTypes.string,
   placeholderStyle: PropTypes.object,
   placeholderClassName: PropTypes.string,
   backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),


### PR DESCRIPTION
## Description

This pull requests introduce the ability to add `className` to the actual `<img>` element.

This fixes #24159

Example 
```
<Img
  fluid={data['profilePic'].childImageSharp.fluid}
  alt={`Ben Shi`}
  className={'avatar'}
  imgClassName={'u-photo'}
/>
```

### Documentation

Updated documentation in gatsby-image README
