### PR TITLE
fix: add hint about prune length for records

### DIFF
--- a/docs/docs/adding-search-with-algolia.md
+++ b/docs/docs/adding-search-with-algolia.md
@@ -89,7 +89,6 @@ ALGOLIA_ADMIN_KEY=insertValue
 The `queries` allow you to grab the data you want Algolia to index directly from Gatsby's GraphQL layer by exporting from `src/utils/algolia.js` an array of objects, each containing a required GraphQL query and an optional index name, transformer function and settings object.
 
 > Note: You can see that the excerpts below are pruned to 5000 characters. This is because by default Algolia has an upper bound of 10KB for an index entry. If you hit this boundary, you'll be presented with an error looking like this: "AlgoliaSearchError: Record at the position XX objectID=xx-xx-xx-xx-xx is too big size=10356 bytes. Contact us if you need an extended quota". So make sure that your overall record is less than this limit.
- 
 
 ```js:title=src/utils/algolia.js
 const pageQuery = `{

--- a/docs/docs/adding-search-with-algolia.md
+++ b/docs/docs/adding-search-with-algolia.md
@@ -88,6 +88,9 @@ ALGOLIA_ADMIN_KEY=insertValue
 
 The `queries` allow you to grab the data you want Algolia to index directly from Gatsby's GraphQL layer by exporting from `src/utils/algolia.js` an array of objects, each containing a required GraphQL query and an optional index name, transformer function and settings object.
 
+> Note: You can see that the excerpts below are pruned to 5000 characters. This is because by default Algolia has an upper bound of 10KB for an index entry. If you hit this boundary, you'll be presented with an error looking like this: "AlgoliaSearchError: Record at the position XX objectID=xx-xx-xx-xx-xx is too big size=10356 bytes. Contact us if you need an extended quota". So make sure that your overall record is less than this limit.
+ 
+
 ```js:title=src/utils/algolia.js
 const pageQuery = `{
   pages: allMarkdownRemark(

--- a/docs/docs/adding-search-with-algolia.md
+++ b/docs/docs/adding-search-with-algolia.md
@@ -88,7 +88,7 @@ ALGOLIA_ADMIN_KEY=insertValue
 
 The `queries` allow you to grab the data you want Algolia to index directly from Gatsby's GraphQL layer by exporting from `src/utils/algolia.js` an array of objects, each containing a required GraphQL query and an optional index name, transformer function and settings object.
 
-> Note: You can see that the excerpts below are pruned to 5000 characters. This is because by default Algolia has an upper bound of 10KB for an index entry. If you hit this boundary, you'll be presented with an error looking like this: "AlgoliaSearchError: Record at the position XX objectID=xx-xx-xx-xx-xx is too big size=10356 bytes. Contact us if you need an extended quota". So make sure that your overall record is less than this limit.
+> Note: The excerpts below are pruned to 5000 characters. This is because, by default, Algolia has an upper bound of 10KB for an index entry. If you hit this boundary, you'll be presented with an error like this: `AlgoliaSearchError: Record at the position XX objectID=xx-xx-xx-xx-xx is too big size=10356 bytes. Contact us if you need an extended quota`. Make sure that your overall record is within this limit.
 
 ```js:title=src/utils/algolia.js
 const pageQuery = `{


### PR DESCRIPTION
## Description

Added a hint about why we prune excerpts and Algolia's default record limit.