### PR TITLE
chore(benchmarks): Don't pin gatsby-plugin-benchmark-reporting version

### DIFF
--- a/benchmarks/md/package.json
+++ b/benchmarks/md/package.json
@@ -23,7 +23,7 @@
     "front-matter": "^3.1.0",
     "gatsby": "^2.20.23",
     "gatsby-image": "^2.3.3",
-    "gatsby-plugin-benchmark-reporting": "0.1.3",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-plugin-page-creator": "^2.2.2",
     "gatsby-plugin-sharp": "^2.4.12",
     "gatsby-remark-images": "^3.2.3",

--- a/benchmarks/mdx/package.json
+++ b/benchmarks/mdx/package.json
@@ -25,7 +25,7 @@
     "front-matter": "^3.1.0",
     "gatsby": "^2.20.23",
     "gatsby-image": "^2.3.3",
-    "gatsby-plugin-benchmark-reporting": "0.1.3",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-plugin-mdx": "^1.1.8",
     "gatsby-plugin-page-creator": "^2.2.2",
     "gatsby-plugin-sharp": "^2.4.12",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I don't think there's any reason we want to pin these benchmarks to an older version of the reporting plugin, and this version doesn't work with refresh.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
