### PR TITLE
fix(benchmarks): Publish changes in contentful data update script

### DIFF
--- a/benchmarks/source-contentful/bin/site.js
+++ b/benchmarks/source-contentful/bin/site.js
@@ -367,10 +367,11 @@ async function runDataUpdate() {
     limit: 1
   })
 
-  const entry = entries.items[0]
+  let entry = entries.items[0]
   const title = entry.fields.title[locale]
   entry.fields.title[locale] = `${title.substring(0, title.lastIndexOf(` `))} ${Date.now()}`
 
-  await entry.update()
+  entry = await entry.update()
+  await entry.publish()
   console.log(`Updated ${chalk.green(entry.sys.id)}`)
 }


### PR DESCRIPTION
## Description

This PR is a fix for the Contentful benchmark site. Specifically for `data-update` script that is supposed to update a single article in Contentful benchmark. The problem is that we must also `publish` the updated article, otherwise, the change is not visible on a subsequent build.

This PR adds publishing step.
