### PR TITLE
fix(gatsby-cli): Improve wording for 98124 error message

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -42,7 +42,7 @@ const errors = {
   },
   "98124": {
     text: (context): string =>
-      `${context.stageLabel} failed\n\n${context.sourceMessage}\n\nPerhaps you need to install the package '${context.packageName}'?`,
+      `${context.stageLabel} failed\n\n${context.sourceMessage}\n\nIf you're trying to use a package make sure that '${context.packageName}' is installed. If you're trying to use a local file make sure that the path is correct.`,
     type: Type.WEBPACK,
     level: Level.ERROR,
   },


### PR DESCRIPTION
## Description

I recently added the 98124 error. However, it's also thrown when people require local files and it fails. So it would say something like `Perhaps you need to install the package '../../content/image.png'?`. This update accounts for that.
