### PR TITLE
fix: incorrect typedef parsing for interfaces

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`transformer-react-doc-gen: onCreateNode Complex example should handle members should handle type unions 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Complex example should handle members should handle type unions 1`] = `
 Object {
   "elements": Array [
     Object {
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`transformer-react-doc-gen: onCreateNode Complex example should handle typedefs should handle type applications 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Complex example should handle typedefs should handle type applications 1`] = `
 Object {
   "children": Array [
     "documentationJS documentationJS node_1 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"}] line 12 path #[{\\"name\\":\\"ObjectType\\",\\"kind\\":\\"typedef\\"},{\\"fieldName\\":\\"properties\\",\\"fieldIndex\\":0}] line 3--DocumentationJSComponentDescription--comment.description",
@@ -52,12 +52,12 @@ Object {
 }
 `;
 
-exports[`transformer-react-doc-gen: onCreateNode Simple example should extract out a description, params, and examples: description content 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: description content 1`] = `
 "A pretty cool jsdoc example
 "
 `;
 
-exports[`transformer-react-doc-gen: onCreateNode Simple example should extract out a description, params, and examples: example 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: example 1`] = `
 Object {
   "description": "const apple = require('apple')
 apple()",
@@ -68,9 +68,9 @@ apple()",
 }
 `;
 
-exports[`transformer-react-doc-gen: onCreateNode Simple example should extract out a description, params, and examples: param description 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: param description 1`] = `
 "A nice crispy apple
 "
 `;
 
-exports[`transformer-react-doc-gen: onCreateNode Simple example should extract out a description, params, and examples: param name 1`] = `"paramName"`;
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: param name 1`] = `"paramName"`;

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/same-name.ts
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/same-name.ts
@@ -1,0 +1,14 @@
+
+/**
+ * The actual type
+ */
+export declare interface Foo {
+  (props: any): JSX.Element | null;
+}
+
+/**
+ * The Main Thing here
+ */
+const Foo: Foo = () => null;
+
+

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
@@ -2,7 +2,7 @@ import groupBy from "lodash/groupBy"
 import path from "path"
 import gatsbyNode from "../gatsby-node"
 
-describe(`transformer-react-doc-gen: onCreateNode`, () => {
+describe(`gatsby-transformer-documentationjs: onCreateNode`, () => {
   let createdNodes, updatedNodes
   const createNodeId = jest.fn(id => id)
   const createContentDigest = jest.fn().mockReturnValue(`content-digest`)
@@ -360,5 +360,9 @@ describe(`transformer-react-doc-gen: onCreateNode`, () => {
       await run(getFileNode(`code.js`))
       expect(createdNodes.length).toBeGreaterThan(0)
     })
+  })
+
+  it(`doesn't cause a stack overflow for nodes of the same name`, () => {
+    expect(run(getFileNode(`same-name.ts`))).resolves.toBeUndefined()
   })
 })

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -218,18 +218,18 @@ exports.onCreateNode = async ({ node, actions, ...helpers }) => {
       }
 
       const index = documentationJson.findIndex(
-        (docsJson) =>
+        docsJson =>
           docsJson.name === typeName &&
-          [`interface`, `typedef`, `constant`].includes(docsJson.kind),
-      );
+          [`interface`, `typedef`, `constant`].includes(docsJson.kind)
+      )
 
-      const isCycle = parent === documentationJson[index];
+      const isCycle = parent === documentationJson[index]
       if (isCycle) {
         helpers.reporter.warn(
-          `Unexpected cycle detected creating DocumentationJS nodes for file:\n\n\t${node.absolutePath}\n\nFor type: ${typeName}`,
-        );
+          `Unexpected cycle detected creating DocumentationJS nodes for file:\n\n\t${node.absolutePath}\n\nFor type: ${typeName}`
+        )
       }
-      
+
       if (index !== -1 && !isCycle) {
         return prepareNodeForDocs(documentationJson[index], {
           commentNumber: index,
@@ -241,21 +241,21 @@ exports.onCreateNode = async ({ node, actions, ...helpers }) => {
 
     const tryToAddTypeDef = (type, parent) => {
       if (type.applications) {
-        type.applications.forEach(t => tryToAddTypeDef(t, parent));
+        type.applications.forEach(t => tryToAddTypeDef(t, parent))
       }
 
       if (type.expression) {
-        tryToAddTypeDef(type.expression, parent);
+        tryToAddTypeDef(type.expression, parent)
       }
 
       if (type.elements) {
-        type.elements.forEach(t => tryToAddTypeDef(t, parent));
+        type.elements.forEach(t => tryToAddTypeDef(t, parent))
       }
 
       if (type.type === `NameExpression` && type.name) {
-        type.typeDef___NODE = getNodeIDForType(type.name, parent);
+        type.typeDef___NODE = getNodeIDForType(type.name, parent)
       }
-    };
+    }
 
     /**
      * Prepare Gatsby node from JsDoc object.


### PR DESCRIPTION
## Description

Wasn't finding typedefs for interfaces with the same name as the typed thing; e.g.

```ts
interface Foo {}
const Foo: Foo
```

Also adds a guard and more helpful error when unavoidable loops occur due to type naming
