### PR TITLE
Fix issue with gatsby-plugin-mdx not picking up gatsbyRemarkPlugins

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -4,6 +4,7 @@ const grayMatter = require(`gray-matter`)
 const unified = require(`unified`)
 const babel = require(`@babel/core`)
 const { createRequireFromPath, slash } = require(`gatsby-core-utils`)
+const { interopDefault } = require(`../utils/interop-default`)
 
 const {
   isImport,
@@ -158,6 +159,29 @@ ${contentWithoutFrontmatter}`
       return fileNode
     } else {
       return rawGetNode(id)
+    }
+  }
+
+  /**
+   * Support gatsby-remark parser plugins
+   */
+  for (let plugin of options.gatsbyRemarkPlugins) {
+    debug(`requiring`, plugin.resolve)
+    const requiredPlugin = interopDefault(require(plugin.resolve))
+    debug(`required`, plugin)
+    if (_.isFunction(requiredPlugin.setParserPlugins)) {
+      for (let parserPlugin of requiredPlugin.setParserPlugins(
+        plugin.options || {}
+      )) {
+        if (_.isArray(parserPlugin)) {
+          const [parser, parserPluginOptions] = parserPlugin
+          debug(`adding remarkPlugin with options`, plugin, parserPluginOptions)
+          options.remarkPlugins.push([parser, parserPluginOptions])
+        } else {
+          debug(`adding remarkPlugin`, plugin)
+          options.remarkPlugins.push(parserPlugin)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #21866.

## Description

`gatsby-plugin-mdx` was not picking up (some?) plugins that were given in `gatsbyRemarkPlugins`. This adds the logic to do so in `mdx-loader` used by webpack.

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/21866
