### PR TITLE
Gatsby Dev Proxy forwards 'complex' HTTP calls like DELETE now

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -310,7 +310,7 @@ async function startServer(program: IDevelopArgs): Promise<IServer> {
           )
           .pipe(res)
       })
-    })
+    }, cors())
   }
 
   await apiRunnerNode(`onCreateDevServer`, { app })


### PR DESCRIPTION
This PR as per the issue I opened yesterday: https://github.com/gatsbyjs/gatsby/issues/24165

Gatsby offers proxy functionality while in dev so if React needs to call, say, a RESTful api to fetch data, no special dev configuration is needed beyond updating `gatsby-config.js` with the proxy's location.

However, Gatsby's proxy does not include the cors middleware, which means the proxy fails for any proxied DELETE (and PUT and PATCH) requests. It will work for GET and POST and I think OPTIONS. Not sure about the others.

So the proxy is only half-functional right now.

## Description

The fix is a few keystrokes: you add `cors()` to the proxied requests when initialized. That's what I've done in this PR.

I have not written any tests because I'm not sure where to put them. However, there do not appear to be any tests written for the proxy functionality right now. So possibly no one cares about providing any tests for the proxy functionality anyway and it can be merged?

At the issue above, I have a couple links to the relevant Gatsby documentation about this proxy, plus the Express documentation (Gatsby uses Express under the hood) explaining why you need to enable this for DELETE/PUT/PATCH request proxying.

### Documentation

Here is the relevant Gatsby doc: https://www.gatsbyjs.org/docs/api-proxy/

There does not appear to be anything that needs updating. It's silent on the issue of different HTTP verbs, so it implies it should already work for all proxying (and with this PR, it does).

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/24165
