### PR TITLE
fix(gatsby-cli): Fix recipes cli invocation

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -342,15 +342,11 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
   cli.command({
     command: `recipes [recipe]`,
     describe: `[EXPERIMENTAL] Run a recipe`,
-    handler: handlerP(({ recipe }: yargs.Arguments) => {
-      if (typeof recipe !== `string`) {
-        throw new Error(
-          `Error: gatsby recipes needs to be called with a specific recipe`
-        )
+    handler: handlerP(
+      async ({ recipe }: yargs.Arguments<{ recipe: string | undefined }>) => {
+        await recipesHandler(recipe)
       }
-
-      recipesHandler(recipe)
-    }),
+    ),
   })
 }
 

--- a/packages/gatsby-cli/src/recipes.ts
+++ b/packages/gatsby-cli/src/recipes.ts
@@ -4,7 +4,9 @@ import * as path from "path"
 import * as fs from "fs"
 import detectPort from "detect-port"
 
-export async function recipesHandler(recipe: string): Promise<void> {
+export async function recipesHandler(
+  recipe: string | undefined
+): Promise<void> {
   // We don't really care what port is used for GraphQL as it's
   // generally only for code to code communication or debugging.
   const graphqlPort = await detectPort(4000)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

We broke gatsby recipes with our recent TS conversion. This fixes it.

## Related Issues

Fixes #24198