### PR TITLE
navigate returns a Promise

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -205,9 +205,8 @@ export default React.forwardRef((props, ref) => (
   <GatsbyLink innerRef={ref} {...props} />
 ))
 
-export const navigate = (to, options) => {
+export const navigate = (to, options) =>
   window.___navigate(withPrefix(to), options)
-}
 
 export const push = to => {
   showDeprecationWarning(`push`, `navigate`, 3)

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -61,7 +61,7 @@ const navigate = (to, options = {}) => {
   // reset the pathname whitelist
   if (window.___swUpdated) {
     window.location = pathname
-    return
+    return Promise.resolve()
   }
 
   // Start a timer to wait for a second before transitioning and showing a
@@ -73,7 +73,7 @@ const navigate = (to, options = {}) => {
     })
   }, 1000)
 
-  loader.loadPage(pathname).then(pageResources => {
+  return loader.loadPage(pathname).then(pageResources => {
     // If no page resources, then refresh the page
     // Do this, rather than simply `window.location.reload()`, so that
     // pressing the back/forward buttons work - otherwise when pressing
@@ -84,7 +84,7 @@ const navigate = (to, options = {}) => {
       window.history.replaceState({}, ``, location.href)
       window.location = pathname
       clearTimeout(timeoutId)
-      return
+      return null
     }
 
     // If the loaded page has a different compilation hash to the
@@ -109,8 +109,8 @@ const navigate = (to, options = {}) => {
         window.location = pathname
       }
     }
-    reachNavigate(to, options)
     clearTimeout(timeoutId)
+    return reachNavigate(to, options)
   })
 }
 


### PR DESCRIPTION
## Description

Gatsby's `navigate()` function uses `@reach/router`'s `navigate()` function, but the latter returns a _Promise_, while the former does not.

This PR aims to transfer this return value when available, and to be consistent with the typings.

### Documentation

https://www.gatsbyjs.org/docs/gatsby-link/#how-to-use-the-navigate-helper-function
https://reach.tech/router/api/navigate

## Related Issues

Fixes #22151.