### PR TITLE
fix(www): fixes the padding issues on homepage for mobile screen sizes

### DIFF
--- a/www/src/components/card.js
+++ b/www/src/components/card.js
@@ -29,9 +29,13 @@ const Card = ({ children }) => (
   >
     <div
       sx={{
-        p: 8,
-        pb: [0, 8],
+        pt: 8,
+        px: 0,
         transform: `translateZ(0)`,
+        [mediaQueries.sm]: {
+          px: 8,
+          py: 8,
+        },
       }}
     >
       {children}

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -9,6 +9,7 @@ import logo from "../assets/monogram.svg"
 import { GraphQLIcon, ReactJSIcon } from "../assets/tech-logos"
 import FuturaParagraph from "./futura-paragraph"
 import TechWithIcon from "./tech-with-icon"
+import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
 const lineAnimation = keyframes({
   to: { strokeDashoffset: 10 },
@@ -218,8 +219,11 @@ const Diagram = () => (
         sx={{
           flex: `1 1 100%`,
           fontFamily: `heading`,
-          p: 6,
+          py: 6,
           textAlign: `center`,
+          [mediaQueries.sm]: {
+            px: 6,
+          },
         }}
       >
         <h1

--- a/www/src/components/homepage/homepage-features.js
+++ b/www/src/components/homepage/homepage-features.js
@@ -16,10 +16,7 @@ const HomepageFeatures = () => (
       flex: `0 1 auto`,
       flexWrap: `wrap`,
       px: 8,
-      pb: 8,
-      [mediaQueries.sm]: {
-        pb: 0,
-      },
+      pb: [8, 0],
     }}
   >
     <Card>

--- a/www/src/components/homepage/homepage-features.js
+++ b/www/src/components/homepage/homepage-features.js
@@ -6,7 +6,6 @@ import Card from "../card"
 import CardHeadline from "../card-headline"
 import TechWithIcon from "../tech-with-icon"
 import FuturaParagraph from "../futura-paragraph"
-import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
 const HomepageFeatures = () => (
   <div

--- a/www/src/components/homepage/homepage-features.js
+++ b/www/src/components/homepage/homepage-features.js
@@ -6,6 +6,7 @@ import Card from "../card"
 import CardHeadline from "../card-headline"
 import TechWithIcon from "../tech-with-icon"
 import FuturaParagraph from "../futura-paragraph"
+import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
 const HomepageFeatures = () => (
   <div
@@ -15,6 +16,10 @@ const HomepageFeatures = () => (
       flex: `0 1 auto`,
       flexWrap: `wrap`,
       px: 8,
+      pb: 8,
+      [mediaQueries.sm]: {
+        pb: 0,
+      },
     }}
   >
     <Card>


### PR DESCRIPTION
## PR

### Description

1. The diagram section of homepage is having extra left and right padding(1.5rem) which is making it very narrow on mobile devices, also inconsistent with the other sections on homepage.
2. The features sections of homepage is also narrow because the cards inside of it are having extra left and right padding(1.5rem).
3. The features section is not having any padding bottom on mobile devices which is making it attached to the divider.

The styles have only been touched for devices with size smaller than **mediaQueries.sm**, others have been untouched.

### Screenshot(s) _(iPhone X)_

#### Diagram section

##### Actual
![homepage-actual](https://user-images.githubusercontent.com/19193724/82324503-62b19b00-99f7-11ea-9a83-61ba2ba5b108.png)

##### Expected
![homepage-expected](https://user-images.githubusercontent.com/19193724/82324543-75c46b00-99f7-11ea-853b-815a4cdbe5cc.png)

#### Features section

##### Actual
![homepage-features-actual-1](https://user-images.githubusercontent.com/19193724/82324515-69d8a900-99f7-11ea-89ff-c9d07f710528.png)

##### Expected
![homepage-features-expected-1](https://user-images.githubusercontent.com/19193724/82324561-7c52e280-99f7-11ea-822b-836bad52bf9c.png)

#### Features section divider

##### Actual
![homepage-features-actual-2](https://user-images.githubusercontent.com/19193724/82324528-70672080-99f7-11ea-996f-e598b6821cc7.png)

##### Expected
![homepage-features-expected-2](https://user-images.githubusercontent.com/19193724/82324568-81179680-99f7-11ea-9c98-d995b72de967.png)

### How to test

1. Go to the homepage on mobile device
2. Scroll down to the diagram and features section
3. The section should not include the extra padding and should not shrink
4. The features sections should have padding-bottom similar to the padding-top

