### PR TITLE
fix(gatsby-source-contentful): Use https instead of http when downloading assets

### DIFF
--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -56,7 +56,7 @@ const downloadContentfulAssets = async gatsbyFunctions => {
         )
         return Promise.resolve()
       }
-      const url = `http://${node.file.url.slice(2)}`
+      const url = `https://${node.file.url.slice(2)}`
 
       // Avoid downloading the asset again if it's been cached
       // Note: Contentful Assets do not provide useful metadata


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Update the source url to use `https` instead of `http`. 

### Documentation

As per https://www.contentful.com/developers/docs/references/http-details/ , https is the recommended approach.

## Related Issues

Fixes #24130
