### PR TITLE
fix develop command on windows

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -109,7 +109,7 @@ module.exports = async (program: IProgram): Promise<void> => {
   const developPort = await getRandomPort()
 
   const developProcess = new ControllableScript(`
-    const cmd = require("${developProcessPath}");
+    const cmd = require(${JSON.stringify(developProcessPath)});
     const args = ${JSON.stringify({
       ...program,
       port: developPort,

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -109,7 +109,7 @@ module.exports = async (program: IProgram): Promise<void> => {
   const developPort = await getRandomPort()
 
   const developProcess = new ControllableScript(`
-    const cmd = require(developProcessPath);
+    const cmd = require("${developProcessPath}")
     const args = ${JSON.stringify({
       ...program,
       port: developPort,

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -109,7 +109,7 @@ module.exports = async (program: IProgram): Promise<void> => {
   const developPort = await getRandomPort()
 
   const developProcess = new ControllableScript(`
-    const cmd = require("${developProcessPath}")
+    const cmd = require("${developProcessPath}");
     const args = ${JSON.stringify({
       ...program,
       port: developPort,

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -7,7 +7,7 @@ import chokidar from "chokidar"
 import getRandomPort from "detect-port"
 import socket from "socket.io"
 import fs from "fs-extra"
-import { isCI } from "gatsby-core-utils"
+import { isCI, slash } from "gatsby-core-utils"
 import { createServiceLock } from "gatsby-core-utils/dist/service-lock"
 import { startDevelopProxy } from "../utils/develop-proxy"
 import { IProgram } from "./types"
@@ -102,14 +102,14 @@ class ControllableScript {
 let isRestarting
 
 module.exports = async (program: IProgram): Promise<void> => {
-  const developProcessPath = require.resolve(`./develop-process`)
+  const developProcessPath = slash(require.resolve(`./develop-process`))
   // Run the actual develop server on a random port, and the proxy on the program port
   // which users will access
   const proxyPort = program.port
   const developPort = await getRandomPort()
 
   const developProcess = new ControllableScript(`
-    const cmd = require(${JSON.stringify(developProcessPath)});
+    const cmd = require(developProcessPath);
     const args = ${JSON.stringify({
       ...program,
       port: developPort,


### PR DESCRIPTION
## Description

`gatsby develop` command is broken on windows now

There are backslashes in `developProcessPath`, what should be properly escaped.
