### PR TITLE
fix(docs): creating and modifying pages - pageContext

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -159,7 +159,7 @@ Your template file would look like this:
 
 ```javascript:title=src/templates/product.js
 function Product({ pageContext }) {
-  const { product } = this.props.pageContext
+  const { product } = pageContext
   return (
     <div>
       Name: {product.name}

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -159,11 +159,12 @@ Your template file would look like this:
 
 ```javascript:title=src/templates/product.js
 function Product({ pageContext }) {
+  const { product } = this.props.pageContext
   return (
     <div>
-      Name: {pageContext.name}
-      Price: {pageContext.price}
-      Description: {pageContext.description}
+      Name: {product.name}
+      Price: {product.price}
+      Description: {product.description}
     </div>
   )
 }


### PR DESCRIPTION
## Description

should the `product` need to destructed from `pageContext`?

## Related Issues

- #23136 `chore(docs): Add section to document best practice usage of pageContext`