### PR TITLE
fix(gatsby) adjust ControllableScript to correctly escape backslashes

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -109,7 +109,7 @@ module.exports = async (program: IProgram): Promise<void> => {
   const developPort = await getRandomPort()
 
   const developProcess = new ControllableScript(`
-    const cmd = require("${developProcessPath}");
+    const cmd = require("${developProcessPath.replace(/\\/g, `\\\\`)}");
     const args = ${JSON.stringify({
       ...program,
       port: developPort,


### PR DESCRIPTION
## Description

This PR adjusts `develop.ts` to properly escape backslashes in the path written into the `ControllableScript` temporary file.

## Related Issues

Fixes #24238 
