### PR TITLE
fix(gatsby-core-utils): create lock per service, rather than per site

### DIFF
--- a/packages/gatsby-core-utils/src/service-lock.ts
+++ b/packages/gatsby-core-utils/src/service-lock.ts
@@ -1,7 +1,7 @@
 /*
  * Service lock: handles service discovery for Gatsby develop processes
  * The problem:  the develop process starts a proxy server, the actual develop process and a websocket server for communication. The two latter ones have random ports that need to be discovered. We also cannot run multiple of the same site at the same time.
- * The solution: lockfiles! We create a lockfolder in `.config/gatsby/sites/${sitePathHash} and then write a file to that lockfolder for every service with its port.
+ * The solution: lockfiles! We create a folder in `.config/gatsby/sites/${sitePathHash}, lock it with a site.lock lockfile and then for each service (e.g. developstatusserver) write a file with its data.
  *
  * NOTE(@mxstbr): This is NOT EXPORTED from the main index.ts due to this relying on Node.js-specific APIs but core-utils also being used in browser environments. See https://github.com/jprichardson/node-fs-extra/issues/743
  */
@@ -15,14 +15,16 @@ import { isCI } from "./ci"
 
 const globalConfigPath = xdgBasedir.config || tmp.fileSync().name
 
-const getLockfileDir = (programPath: string): string => {
+const LOCKFILE_NAME = `site.lock`
+
+const getSiteDir = (programPath: string): string => {
   const hash = createContentDigest(programPath)
 
-  return path.join(globalConfigPath, `gatsby`, `sites`, `${hash}.lock`)
+  return path.join(globalConfigPath, `gatsby`, `sites`, hash)
 }
 
-const getDataFilePath = (lockfileDir: string, serviceName: string): string =>
-  path.join(lockfileDir, `${serviceName}.lock`)
+const getDataFilePath = (siteDir: string, serviceName: string): string =>
+  path.join(siteDir, `${serviceName}.json`)
 
 type UnlockFn = () => Promise<void>
 
@@ -30,7 +32,7 @@ const memoryServices = {}
 export const createServiceLock = async (
   programPath: string,
   name: string,
-  content: string
+  content: Record<string, any>
 ): Promise<UnlockFn | null> => {
   // NOTE(@mxstbr): In CI, we cannot reliably access the global config dir and do not need cross-process coordination anyway
   // so we fall back to storing the services in memory instead!
@@ -43,18 +45,19 @@ export const createServiceLock = async (
     }
   }
 
-  const lockfileDir = getLockfileDir(programPath)
+  const siteDir = getSiteDir(programPath)
 
-  await fs.ensureDir(lockfileDir)
+  await fs.ensureDir(siteDir)
 
   try {
-    const unlock = await lockfile.lock(lockfileDir, {
+    const unlock = await lockfile.lock(siteDir, {
       // Use the minimum stale duration
       stale: 5000,
+      lockfilePath: path.join(siteDir, LOCKFILE_NAME),
     })
 
     // Once the directory for this site is locked, we write a file to the dir with the service metadata
-    await fs.writeFile(getDataFilePath(lockfileDir, name), content)
+    await fs.writeFile(getDataFilePath(siteDir, name), JSON.stringify(content))
 
     return unlock
   } catch (err) {
@@ -62,35 +65,34 @@ export const createServiceLock = async (
   }
 }
 
-export const getService = (
+export const getService = async (
   programPath: string,
   name: string
 ): Promise<string | null> => {
-  if (isCI()) return Promise.resolve(memoryServices[name] || null)
+  if (isCI()) return memoryServices[name] || null
 
-  const lockfileDir = getLockfileDir(programPath)
+  const siteDir = getSiteDir(programPath)
 
   try {
-    return fs.readFile(getDataFilePath(lockfileDir, name), `utf8`)
+    return JSON.parse(await fs.readFile(getDataFilePath(siteDir, name), `utf8`))
   } catch (err) {
-    return Promise.resolve(null)
+    return null
   }
 }
 
 export const getServices = async (programPath: string): Promise<any> => {
   if (isCI()) return memoryServices
-  const lockfileDir = getLockfileDir(programPath)
+  const siteDir = getSiteDir(programPath)
 
-  const files = await fs.readdir(lockfileDir)
+  const serviceNames = (await fs.readdir(siteDir))
+    .filter(file => file.endsWith(`.json`))
+    .map(file => file.replace(`.json`, ``))
+
   const services = {}
-
   await Promise.all(
-    files
-      .filter(file => file.endsWith(`.lock`))
-      .map(async file => {
-        const service = file.replace(`.lock`, ``)
-        services[service] = await getService(programPath, service)
-      })
+    serviceNames.map(async service => {
+      services[service] = await getService(programPath, service)
+    })
   )
 
   return services

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -35,7 +35,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     .then(services => {
       if (services.developstatusserver) {
         const parentSocket = io(
-          `${window.location.protocol}//${window.location.hostname}:${services.developstatusserver}`
+          `${window.location.protocol}//${window.location.hostname}:${services.developstatusserver.port}`
         )
 
         parentSocket.on(`develop:needs-restart`, msg => {

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -128,11 +128,9 @@ module.exports = async (program: IProgram): Promise<void> => {
 
   let unlock
   if (!isCI()) {
-    unlock = await createServiceLock(
-      program.directory,
-      `developstatusserver`,
-      statusServerPort.toString()
-    )
+    unlock = await createServiceLock(program.directory, `developstatusserver`, {
+      port: statusServerPort,
+    })
 
     if (!unlock) {
       console.error(

--- a/packages/gatsby/src/utils/restarting-screen.ts
+++ b/packages/gatsby/src/utils/restarting-screen.ts
@@ -91,7 +91,11 @@ export default html`
             .then(res => res.json())
             .then(services => {
               const socket = io(
-                "http://localhost:" + services.developstatusserver
+                window.location.protocol +
+                  "//" +
+                  window.location.hostname +
+                  ":" +
+                  services.developstatusserver.port
               )
               socket.on("develop:started", () => {
                 window.location.reload()


### PR DESCRIPTION
In #22759 I introduced a service discovery mechanism to allow for coordination between all the various processes.

Unfortunately, while it worked it was implemented completely wrong. It created a lock _per site_, which meant if you wanted to run multiple services per site it would fail on the second `createServiceLock` call, as the site would already be locked. (I noticed as I need this functionality for #23733)

I reworked the service discovery mechanism to create a lock _per service_ instead. While I was at it, I also made it store JSON rather than strings to allow for more complex data to be discovered in the future and give more semantic information about the data automatically.

Here is what the service discovery folder structure would look like when starting a site and two services now:

```sh
~/.config/gatsby/sites/${siteHash}/
├── developstatusserver.json # The data for a specific service, in this case this would contain {"port":55912}
├── developstatusserver.json.lock # The lock directory for the service to ensure we don't start it twice
├── recipesgraphqlserver.json # Another service, this would contain something like {"port":61572}
└── recipesgraphqlserver.json.lock # The lock directory for the service to ensure we don't start it twice
```

A big reason this "mistake" happened was because a) it was irrelevant for #22759 as it worked anyway (we were only using one service) and b) the variable naming within `service-lock.ts` made it seem like everything worked the way it should. To remedy b), I have also took the liberty to rename _all the things_ to make it more clear what is actually happening (which I actually did first, which exposed the other problem as we were calling `lockfile.lock(siteDir)` which makes no sense)