### PR TITLE
perf(gatsby): support empty filters without sift

### DIFF
--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -354,6 +354,52 @@ export const ensureIndexByQuery = (
   postIndexingMetaSetup(filterCache, op)
 }
 
+export function ensureEmptyFilterCache(
+  filterCacheKey,
+  nodeTypeNames: string[],
+  filtersCache: FiltersCache
+): void {
+  // This is called for queries without any filters
+  // We want to cache the result since it's basically a set of nodes by type(s)
+  // There are sites that have multiple queries which are empty
+
+  const state = store.getState()
+  const resolvedNodesCache = state.resolvedNodesCache
+  const nodesUnordered: Array<IGatsbyNode> = []
+
+  filtersCache.set(filterCacheKey, {
+    op: `$eq`, // Ignore.
+    byValue: new Map<FilterValueNullable, Set<IGatsbyNode>>(),
+    meta: {
+      nodesUnordered, // This is what we want
+    },
+  })
+
+  if (nodeTypeNames.length === 1) {
+    getNodesByType(nodeTypeNames[0]).forEach(node => {
+      if (!node.__gatsby_resolved) {
+        const typeName = node.internal.type
+        const resolvedNodes = resolvedNodesCache.get(typeName)
+        node.__gatsby_resolved = resolvedNodes?.get(node.id)
+      }
+      nodesUnordered.push(node)
+    })
+  } else {
+    // Here we must first filter for the node type
+    // This loop is expensive at scale (!)
+    state.nodes.forEach(node => {
+      if (nodeTypeNames.includes(node.internal.type)) {
+        if (!node.__gatsby_resolved) {
+          const typeName = node.internal.type
+          const resolvedNodes = resolvedNodesCache.get(typeName)
+          node.__gatsby_resolved = resolvedNodes?.get(node.id)
+        }
+        nodesUnordered.push(node)
+      }
+    })
+  }
+}
+
 function addNodeToFilterCache(
   node: IGatsbyNode,
   chain: Array<string>,

--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -380,7 +380,10 @@ export function ensureEmptyFilterCache(
       if (!node.__gatsby_resolved) {
         const typeName = node.internal.type
         const resolvedNodes = resolvedNodesCache.get(typeName)
-        node.__gatsby_resolved = resolvedNodes?.get(node.id)
+        const resolved = resolvedNodes?.get(node.id)
+        if (resolved !== undefined) {
+          node.__gatsby_resolved = resolved
+        }
       }
       nodesUnordered.push(node)
     })
@@ -392,7 +395,10 @@ export function ensureEmptyFilterCache(
         if (!node.__gatsby_resolved) {
           const typeName = node.internal.type
           const resolvedNodes = resolvedNodesCache.get(typeName)
-          node.__gatsby_resolved = resolvedNodes?.get(node.id)
+          const resolved = resolvedNodes?.get(node.id)
+          if (resolved !== undefined) {
+            node.__gatsby_resolved = resolved
+          }
         }
         nodesUnordered.push(node)
       }

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -453,6 +453,8 @@ const applyFilters = (
 
     const cache = filtersCache.get(filterCacheKey).meta.nodesUnordered
 
+    lastFilterUsedSift = false
+
     if (firstOnly || cache.length) {
       return cache.slice(0)
     }

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -414,6 +414,15 @@ it(`should use the cache argument`, async () => {
 
   describe(desc, () => {
     describe(`Filter fields`, () => {
+      describe(`none`, () => {
+        it(`handles empty filter`, async () => {
+          const [result, allNodes] = await runFastFilter({})
+
+          // Expecting all nodes
+          expect(result?.length).toEqual(allNodes.length)
+        })
+      })
+
       describe(`$eq`, () => {
         it(`handles eq operator with number value`, async () => {
           const needle = 2


### PR DESCRIPTION
This supports a fast path for queries without filters.

This happens frequently for sites that unconditionally want all nodes of a particular set of types, perhaps sorted or with some other transformation.

I created a separate early path for this, which also caches the set of nodes.

There's also some cleanup for the return type of various functions in this path and dropping some legacy op support checking code (no longer needed now that fast filters supports everything). Suggest to review commit by commit.