### PR TITLE
Chore(starters) add gatsby starter azure swa

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -3,6 +3,7 @@ starter:
   - AMP
   - Authentication
   - AWS
+  - Azure
   - Blog
   - Client-side App
   - CMS:Agility CMS

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6355,3 +6355,17 @@
     - Progressive Web App/PWA - Offline Support
     - Fast and Accessible
     - SEO
+- url: https://jolly-tree-003047c03.azurestaticapps.net/
+  repo: https://github.com/floAr/gatsby-starter-azure_swa
+  description: A simple GatsbyJS starter making use of the new 
+  [Azure Static Web App](https://azure.microsoft.com/en-us/services/app-service/static/) service. 
+  Uses automatic CI/CD from github actions
+  # These correspond to the category filters in the library
+  # See docs/categories.yml for valid tags.
+  tags:
+    - Redux
+    - Styling:None
+  # Add your site features
+  # These will be included on your starter's detail page.
+  features:
+    - CI/CD using github actions

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6365,6 +6365,7 @@
   tags:
     - Redux
     - Styling:None
+    - Azure
   # Add your site features
   # These will be included on your starter's detail page.
   features:

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6357,9 +6357,8 @@
     - SEO
 - url: https://jolly-tree-003047c03.azurestaticapps.net/
   repo: https://github.com/floAr/gatsby-starter-azure_swa
-  description: A simple GatsbyJS starter making use of the new 
-  [Azure Static Web App](https://azure.microsoft.com/en-us/services/app-service/static/) service. 
-  Uses automatic CI/CD from github actions
+  description: A simple GatsbyJS starter making use of the new Azure Static Web App service.
+   
   # These correspond to the category filters in the library
   # See docs/categories.yml for valid tags.
   tags:


### PR DESCRIPTION
## Description

Added a starter that connects the default starter to Microsoft's newly announces Azure static Web Apps. This includes automatic CI/CD using GitHub actions, as well as behind the scene staging environments etc.
