### PR TITLE
fix(gatsby-plugin-mdx): mdxrender should not accept components

### DIFF
--- a/packages/gatsby-plugin-mdx/index.d.ts
+++ b/packages/gatsby-plugin-mdx/index.d.ts
@@ -2,9 +2,6 @@ import * as React from "react"
 
 export interface MDXRendererProps {
   scope?: any
-  components?: {
-    [key: string]: React.ComponentType<any>
-  }
   children: string
   [propName: string]: any
 }

--- a/packages/gatsby-plugin-mdx/mdx-renderer.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.js
@@ -31,5 +31,5 @@ module.exports = function MDXRenderer({
     return fn({}, ...values)
   }, [children, scope])
 
-  return React.createElement(End, { components: mdxComponents, ...props })
+  return React.createElement(End, {...props })
 }

--- a/packages/gatsby-plugin-mdx/mdx-renderer.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.js
@@ -4,7 +4,6 @@ const { useMDXScope } = require(`./context`)
 
 module.exports = function MDXRenderer({
   scope,
-  components,
   children,
   ...props
 }) {

--- a/packages/gatsby-plugin-mdx/mdx-renderer.js
+++ b/packages/gatsby-plugin-mdx/mdx-renderer.js
@@ -1,5 +1,5 @@
 const React = require(`react`)
-const { useMDXComponents, mdx } = require(`@mdx-js/react`)
+const { mdx } = require(`@mdx-js/react`)
 const { useMDXScope } = require(`./context`)
 
 module.exports = function MDXRenderer({
@@ -7,7 +7,6 @@ module.exports = function MDXRenderer({
   children,
   ...props
 }) {
-  const mdxComponents = useMDXComponents(components)
   const mdxScope = useMDXScope(scope)
 
   // Memoize the compiled component


### PR DESCRIPTION

## Description

Removing the components from MDXRenderer based on discussion in https://github.com/gatsbyjs/gatsby/issues/21682

### Documentation
As far as i can see documentation is fine, as https://www.gatsbyjs.org/packages/gatsby-plugin-mdx/#mdxprovider already has no mention of 'components'

## Related Issues
Fixes #21682
