### PR TITLE
feat(recipes): add recipe for Gitlab CI/CD

### DIFF
--- a/packages/gatsby-recipes/recipes/gitlab-ci-cd.mdx
+++ b/packages/gatsby-recipes/recipes/gitlab-ci-cd.mdx
@@ -1,0 +1,22 @@
+# Add Gitlab CI/CD
+
+This recipe helps you setup Gitlab CI/CD in your Gatsby site to create a pipeling on gitlab.com
+
+---
+
+Adding the `.gitlab-ci.yml`
+
+<File
+  path=".gitlab-ci.yml"
+  content="https://gist.githubusercontent.com/puzzledbytheweb/40028c837e1c20859b7f65bfe92879f1/raw/3ee7d97a4ab2b1e106a3c8a2f031d9a22b6222af/.gitlab-ci.yml"
+/>
+
+---
+
+Now, every time you `git push <you-remote-gitlab-repo>` you will have your gatsby project building!
+
+---
+
+- See how you can develop this simple file into something more real world [Gitlab CI/CD Docs](https://docs.gitlab.com/ee/ci/README.html)
+- Check this especially to learn how to make your newly build available for a next job - [Gitlab Job Artifacts Docs](https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html)
+- [Getting started with GitLab CI/CD](https://gitlab.com/help/ci/quick_start/README)

--- a/packages/gatsby-recipes/recipes/gitlab-ci-cd.mdx
+++ b/packages/gatsby-recipes/recipes/gitlab-ci-cd.mdx
@@ -1,6 +1,6 @@
 # Add Gitlab CI/CD
 
-This recipe helps you setup Gitlab CI/CD in your Gatsby site to create a pipeling on gitlab.com
+This recipe helps you setup Gitlab CI/CD in your Gatsby site to create a pipeline on gitlab.com
 
 ---
 


### PR DESCRIPTION
## Description

This PR adds a new recipe that automates basic CI/CD configuration by creating a minimal .gitlab-ci.yml file, on the root of the project

### Documentation
This is related to this: https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/recipes/gitlab-continuous-integration.md