### PR TITLE
fix: adds curly braces around Helmet import in seo.js component.

### DIFF
--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -7,7 +7,7 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 const SEO = ({ description, lang, meta, title }) => {


### PR DESCRIPTION
I was attempting to deploy my site on Netlify for two days and had zero luck because I kept getting an error about `Helmet`. I paired with a friend that can better read the docs and he told me to just put curly braces around the import in the `seo.js` component.

**Current:**
`import Helmet from "react-helmet"`

**My Branch:**
`import { Helmet } from "react-helmet"`

Helmet was updated to version 6 and has breaking changes. I am assuming this is a big breaking change and will cause some headaches if anyone is trying to deploy with Netlify and getting failures.

After making this change in my own personal project code, I re-deployed to Netlify and everything worked perfect!

https://github.com/nfl/react-helmet/releases/tag/6.0.0