### PR TITLE
fix(gatsby) escape string in develop command

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -109,7 +109,7 @@ module.exports = async (program: IProgram): Promise<void> => {
   const developPort = await getRandomPort()
 
   const developProcess = new ControllableScript(`
-    const cmd = require("${developProcessPath}");
+    const cmd = require(${JSON.stringify(developProcessPath)});
     const args = ${JSON.stringify({
       ...program,
       port: developPort,


### PR DESCRIPTION
## Description

In my previous PR (#24233) I was proposing to fix develop command by escaping string, but it was updated to use custom `slash()` function instead.

I recommend to keep `JSON.stringify()` there too.

This is not the same case like the one @KyleAMathews referred here:
https://github.com/gatsbyjs/gatsby/pull/24233#issuecomment-631138932

Here, the value is used to build another string so it should be properly escaped. It is not very likely there will be other unsafe chars since it is a file path, but it is possible. For example, on linux path can contain quotation mark, backslash, newline...

Try to rename project folder, or any parent and include quote:
```
$ mv my-project my-\"project\"
$ cd my-\"project\"
$ gatsby develop

.cache/tmp-2897-NEAUzfcqHpYg:2
    const cmd = require("/home/prog/my-"project"/node_modules/gatsby/dist/commands/develop-process.js");
                        ^^^^^^^^^^^^^^^^

SyntaxError: missing ) after argument list
```

Actually, its not important whether there could be unsafe chars or not.
We should always escape inputs when building strings so we don't even need to think about it. 

## Related Issues

Related to #24238, #24233
