### PR TITLE
Update surge CNAME instructions

### DIFF
--- a/docs/docs/deploying-to-surge.md
+++ b/docs/docs/deploying-to-surge.md
@@ -44,10 +44,12 @@ You're done! Your terminal will output the address of the domain where your site
 
 ## Step 4: Bonus - Remembering a domain
 
-To ensure future deploys are sent to the same location, you can store the domain name in a [`CNAME`](https://surge.sh/help/remembering-a-domain) file from your project root. Assuming your site was deployed to `https://my-cool-domain.surge.sh`, run the following command:
+To ensure future deploys are sent to the same location, you can store the domain name in a [`CNAME`](https://surge.sh/help/remembering-a-domain) file that is added your project. First, create a [`static` directory](https://www.gatsbyjs.org/docs/static-folder/) at the root of your Gatsby project if it doesn't already exist. Then put a file named `CNAME` (no file extension) in the `static` directory.
+
+Assuming your site was deployed to `https://my-cool-domain.surge.sh`, the following command will add the file for you:
 
 ```shell
-echo my-cool-domain.surge.sh > CNAME
+echo my-cool-domain.surge.sh > static/CNAME
 ```
 
 Consult the [Surge Docs](https://surge.sh/help/) for information about how to customize your deployment further. Remember that each time you redeploy your site, you will need to rerun `gatsby build` first.


### PR DESCRIPTION
The existing instructions there don't work. It appears that the CNAME file has to be in the public directory in order to run the "surge public" command. The Surge.sh docs also appear to not work at the moment. (I posted there too.)

This is my first pull request here. If I should do something differently, please let me know. :) 

## Description

This updates a part of the documentation that is out of date.

Full description in the issue: https://github.com/gatsbyjs/gatsby/issues/24206

## Related Issues

Fixes #24206 