### PR TITLE
WIP: Enhancement (gatsby, www) Generate Gatsby API docs from typedefs in index.d.ts

### DIFF
--- a/docs/docs/actions.md
+++ b/docs/docs/actions.md
@@ -1,9 +1,7 @@
 ---
 title: Actions
 description: Documentation on actions and how they help you manipulate state within Gatsby
-jsdoc:
-  - "gatsby/src/redux/actions/public.js"
-  - "gatsby/src/redux/actions/restricted.ts"
+jsdoc: Actions
 contentsHeading: Functions
 ---
 

--- a/docs/docs/browser-apis.md
+++ b/docs/docs/browser-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Gatsby Browser APIs
 description: Documentation about leveraging standard browser APIs within Gatsby
-jsdoc: ["gatsby/src/utils/api-browser-docs.ts"]
+jsdoc: GatsbyBrowser
 apiCalls: BrowserAPI
 showTopLevelSignatures: true
 ---

--- a/docs/docs/node-api-helpers.md
+++ b/docs/docs/node-api-helpers.md
@@ -1,7 +1,7 @@
 ---
 title: Node API Helpers
 description: Documentation on API helpers for creating nodes within Gatsby's GraphQL data layer
-jsdoc: ["gatsby/src/utils/api-node-helpers-docs.js"]
+jsdoc: NodePluginArgs
 apiCalls: NodeAPIHelpers
 contentsHeading: Shared helpers
 showTopLevelSignatures: true

--- a/docs/docs/node-apis.md
+++ b/docs/docs/node-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Gatsby Node APIs
 description: Documentation on Node APIs used in Gatsby build process for common uses like creating pages
-jsdoc: ["gatsby/src/utils/api-node-docs.ts"]
+jsdoc: GatsbyNode
 apiCalls: NodeAPI
 ---
 

--- a/docs/docs/node-model.md
+++ b/docs/docs/node-model.md
@@ -1,7 +1,7 @@
 ---
 title: Node Model
 description: Documentation explaining the model of nodes in Gatsby's GraphQL data layer
-jsdoc: ["gatsby/src/schema/node-model.js"]
+jsdoc: NodeModel
 apiCalls: NodeModel
 contentsHeading: Methods
 ---

--- a/docs/docs/ssr-apis.md
+++ b/docs/docs/ssr-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Gatsby Server Rendering APIs
 description: Documentation on APIs related to server side rendering during Gatsby's build process
-jsdoc: ["gatsby/cache-dir/api-ssr-docs.js"]
+jsdoc: GatsbySSR
 apiCalls: SSRAPI
 showTopLevelSignatures: true
 ---

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -924,23 +924,41 @@ export interface ParentSpanPluginArgs extends NodePluginArgs {
  * Helpers exposed by Gatsby
  */
 export interface NodePluginArgs {
+  /** See docs */
   pathPrefix: string
+  /** See docs */
   boundActionCreators: Actions
+  /** See docs */
   actions: Actions
+  /** See docs */
   loadNodeContent: Function
+  /** See docs */
   store: Store
+  /** See docs */
   emitter: EventEmitter
+  /** See docs */
   getNodes: Function
+  /** See docs */
   getNode: Function
+  /** See docs */
   getNodesByType: Function
+  /** See docs */
   hasNodeChanged: Function
+  /** See docs */
   reporter: Reporter
+  /** See docs */
   getNodeAndSavePathDependency: Function
+  /** See docs */
   cache: Cache["cache"]
+  /** See docs */
   createNodeId: Function
+  /** See docs */
   createContentDigest: typeof createContentDigest
+  /** See docs */
   tracing: Tracing
+  /** See docs */
   schema: NodePluginSchema
+  /** See docs */
   [key: string]: unknown
 }
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -52,7 +52,11 @@ export const prefetchPathname: (path: string) => void
  * export default (props: IndexProps) => {
  *   ..
  */
-export type PageProps<DataType = object, PageContextType = object, LocationState = WindowLocation["state"]> = {
+export type PageProps<
+  DataType = object,
+  PageContextType = object,
+  LocationState = WindowLocation["state"]
+> = {
   /** The path for this current page */
   path: string
   /** The URI for the current page */
@@ -916,6 +920,9 @@ export interface ParentSpanPluginArgs extends NodePluginArgs {
   parentSpan: object
 }
 
+/**
+ * Helpers exposed by Gatsby
+ */
 export interface NodePluginArgs {
   pathPrefix: string
   boundActionCreators: Actions
@@ -975,6 +982,9 @@ export interface BuildArgs extends ParentSpanPluginArgs {
   }>
 }
 
+/**
+ * Gatsby Actions
+ */
 export interface Actions {
   /** @see https://www.gatsbyjs.org/docs/actions/#deletePage */
   deletePage(args: { path: string; component: string }): void
@@ -1380,4 +1390,53 @@ export interface Page<TContext = Record<string, unknown>> {
   matchPath?: string
   component: string
   context: TContext
+}
+
+type TypeOrTypeName = string | GraphQLOutputType
+
+/**
+ * Optional page dependency information.
+ *
+ * @typedef {Object} PageDependencies
+ * @property {string} path The path of the page that depends on the retrieved nodes' data
+ * @property {string} [connectionType] Mark this dependency as a connection
+ */
+interface PageDependencies {
+  path: string
+  connectionType?: string
+}
+
+interface QueryArguments {
+  type: TypeOrTypeName
+  query: { filter: Object; sort?: Object }
+  firstOnly?: boolean
+}
+
+/**
+ * Node model exposed by Gatsby
+ */
+export interface NodeModel {
+  getNodeById(
+    args: { id: string; type?: TypeOrTypeName },
+    pageDependencies?: PageDependencies
+  ): any | null
+  getNodesByIds(
+    args: { ids: Array<string>; type?: TypeOrTypeName },
+    pageDependencies?: PageDependencies
+  ): Array<any>
+  getAllNodes(
+    args: { type?: TypeOrTypeName },
+    pageDependencies?: PageDependencies
+  ): Array<any>
+  runQuery(
+    args: QueryArguments,
+    pageDependencies?: PageDependencies
+  ): Promise<any>
+  getTypes(): Array<string>
+  trackPageDependencies<NodeOrNodes extends Node | Node[]>(
+    result: NodeOrNodes,
+    pageDependencies?: PageDependencies
+  ): NodeOrNodes
+  findRootNodeAncestor(obj: any, predicate: () => boolean): Node | null
+  trackInlineObjectsInRootNode(node: Node, sanitize: boolean): Node
 }

--- a/www/src/templates/template-api-markdown.js
+++ b/www/src/templates/template-api-markdown.js
@@ -26,7 +26,7 @@ const normalizeGatsbyApiCall = array =>
     return { name: entry.name, codeLocation }
   })
 
-const mergeFunctions = (data, context) => {
+const mergeFunctions = data => {
   const normalized = normalizeGatsbyApiCall(data.nodeAPIs.group)
 
   // const docs = data.jsdoc.nodes.reduce((acc, node) => {


### PR DESCRIPTION
## Description

Generate APIs from type definitions instead of miscellaneous files.

## Motivation

* Makes sure our public type API and our online documentation are aligned: the docs you find when you use the types are the same docs on the website.
* Potential to clean up gatsby-core from using weird hybrid "api-*-docs" files.
* Make APIs easier to translate since types are separated from implementation.

## Related Issues

Resolves: 24283