### PR TITLE
fix(gatsby-source-contentful): Don't ignore errors thrown when fetching assets

### DIFF
--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -76,25 +76,21 @@ const downloadContentfulAssets = async gatsbyFunctions => {
 
       // If we don't have cached data, download the file
       if (!fileNodeID) {
-        try {
-          const fileNode = await createRemoteFileNode({
-            url,
-            store,
-            cache,
-            createNode,
-            createNodeId,
-            getCache,
-            reporter,
-          })
+        const fileNode = await createRemoteFileNode({
+          url,
+          store,
+          cache,
+          createNode,
+          createNodeId,
+          getCache,
+          reporter,
+        })
 
-          if (fileNode) {
-            bar.tick()
-            fileNodeID = fileNode.id
+        if (fileNode) {
+          bar.tick()
+          fileNodeID = fileNode.id
 
-            await cache.set(remoteDataCacheKey, { fileNodeID })
-          }
-        } catch (err) {
-          // Ignore
+          await cache.set(remoteDataCacheKey, { fileNodeID })
         }
       }
 


### PR DESCRIPTION
##  Description

Prevents `gatsby-source-contentful` from ignoring failed asset downloads. Currently if `createRemoteFileNode` fails for any reason (most likely a network failure), the error is ignored and no `localFile` link is created. This usually causes errors later in the build when pages are being created and unexpected null references are hit.

This doesn't fix all the problems mentioned in #23123 but it does make it obvious when an asset has failed to download.

## Related Issues
Addresses #23123

