### PR TITLE
chore(gatsby) Rewrite requires-writer.js to TypeScript

### DIFF
--- a/packages/gatsby/src/bootstrap/index.js
+++ b/packages/gatsby/src/bootstrap/index.js
@@ -31,7 +31,7 @@ process.on(`unhandledRejection`, (reason, p) => {
 
 import { createGraphQLRunner } from "./create-graphql-runner"
 const { extractQueries } = require(`../query/query-watcher`)
-const requiresWriter = require(`./requires-writer`)
+import * as requiresWriter from "./requires-writer"
 import { writeRedirects, startRedirectListener } from "./redirects-writer"
 
 // Override console.log to add the source file + line number.

--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -53,7 +53,7 @@ import { detectPortInUseAndPrompt } from "../utils/detect-port-in-use-and-prompt
 import onExit from "signal-exit"
 import queryUtil from "../query"
 import queryWatcher from "../query/query-watcher"
-import requiresWriter from "../bootstrap/requires-writer"
+import * as requiresWriter from "../bootstrap/requires-writer"
 import {
   reportWebpackWarnings,
   structureWebpackErrors,


### PR DESCRIPTION
## Description

This adds type annotations to `requires-writer.js` from the `gatsby` package

I had to introduce one assertion for `matchPath !== undefined` as `IGatsbyPage` it's of type `string | undefined`, but everything in `requires-writer.js` assumes that it's a `string`. It would throw an error anyway, I just made a bit more pretty with `reporter.panic()`

NOTE:
`requires-writer.js` uses the reporter from `gatsby-cli`, and not the TS source, but the compiled version. Not sure if it's ok. Maybe we should extract reporter into a separate package if it is used in both `gatsby` and `gasby-cli`

### Documentation

No changes required

## Related Issues

Related to #21995 