### PR TITLE
chore(gatsby): update http-proxy to fix vulnerability

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -86,7 +86,7 @@
     "graphql-compose": "^6.3.8",
     "graphql-playground-middleware-express": "^1.7.14",
     "hasha": "^5.2.0",
-    "http-proxy": "^1.18.0",
+    "http-proxy": "^1.18.1",
     "invariant": "^2.2.4",
     "is-relative": "^1.0.0",
     "is-relative-url": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12966,10 +12966,10 @@ http-proxy@^1.17.0:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
-http-proxy@^1.18.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
-  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+http-proxy@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   dependencies:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"


### PR DESCRIPTION
> Versions of http-proxy prior to 1.18.1 are vulnerable to Denial of Service

https://www.npmjs.com/advisories/1486