### PR TITLE
feat(gatsby-link): allow number type argument of navigate & withPrefix

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -39,23 +39,23 @@ export const navigate: NavigateFn
  * After doing so, Gatsby's `<Link>` component will automatically handle constructing the correct URL in
  * development and production
  */
-export const withPrefix: (path: string) => string
+export const withPrefix: <T = string | number>(path: T) => T
 export const withAssetPrefix: (path: string) => string
 
 /**
  * @deprecated
  * TODO: Remove for Gatsby v3
  */
-export const push: (to: string) => void
+export const push: (to: string | number) => void
 
 /**
  * @deprecated
  * TODO: Remove for Gatsby v3
  */
-export const replace: (to: string) => void
+export const replace: (to: string | number) => void
 
 /**
  * @deprecated
  * TODO: Remove for Gatsby v3
  */
-export const navigateTo: (to: string) => void
+export const navigateTo: (to: string | number) => void

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -208,6 +208,12 @@ describe(`<Link />`, () => {
 })
 
 describe(`withPrefix`, () => {
+  it(`argument will be returned without any changes if its type is number`, () => {
+    const to = -1
+    const root = getWithPrefix(`/whether-prefix-exist`)(to)
+    expect(root).toEqual(to)
+  })
+
   describe(`works with default prefix`, () => {
     it(`default prefix does not return "//"`, () => {
       const to = `/`

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -7,6 +7,10 @@ import { parsePath } from "./parse-path"
 export { parsePath }
 
 export function withPrefix(path) {
+  if (typeof path === `number`) {
+    return path
+  }
+
   return normalizePath(
     [
       typeof __BASE_PATH__ !== `undefined` ? __BASE_PATH__ : __PATH_PREFIX__,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
It should be good if `navigate` allows number as its argument.
With this, developer doesn't need to use `window.history.go(-1);`. can use just `navigate(-1);`.

Implementation of `navigate` in [@reach/router](https://github.com/reach/router/blob/master/src/lib/history.js#L70) looks like below.
```js
    navigate(to, { state, replace = false } = {}) {
      if (typeof to === "number") {
        source.history.go(to);
      } else {
        ...
      }
    }

```


### Documentation
n/a
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
n/a
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
