### PR TITLE
chore(doc): Fix grammatical error in documentation

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1210,8 +1210,8 @@ actions.setBabelPreset = (config: Object, plugin?: ?Plugin = null) => {
 }
 
 /**
- * Create a "job". This is a long-running process that are generally
- * started as side-effects to GraphQL queries.
+ * Create a "job". This is a long-running process that is generally
+ * started as a side-effect to a GraphQL query.
  * [`gatsby-plugin-sharp`](/packages/gatsby-plugin-sharp/) uses this for
  * example.
  *
@@ -1230,8 +1230,8 @@ actions.createJob = (job: Job, plugin?: ?Plugin = null) => {
 }
 
 /**
- * Create a "job". This is a long-running process that are generally
- * started as side-effects to GraphQL queries.
+ * Create a "job". This is a long-running process that is generally
+ * started as a side-effect to a GraphQL query.
  * [`gatsby-plugin-sharp`](/packages/gatsby-plugin-sharp/) uses this for
  * example.
  *


### PR DESCRIPTION
## Description

There was a mix of singular and plural in this short description which didn't make sense.
