### PR TITLE
fix(gatsby): adjust `create-react-context` alias to match actual package exports

### DIFF
--- a/packages/gatsby/cache-dir/create-react-context.js
+++ b/packages/gatsby/cache-dir/create-react-context.js
@@ -1,3 +1,26 @@
-import React from "react"
+/*
+  Why commonjs and not ES imports/exports?
 
-export default React.createContext
+  This module is used to alias `create-react-context` package, but drop the the actual implementation part
+  because Gatsby requires version of react that has implementatoin baked in.
+  
+  Package source is using ES modules:
+    - https://github.com/jamiebuilds/create-react-context/blob/v0.3.0/src/index.js
+  
+  But to build this package `babel-plugin-add-module-exports` is used ( https://www.npmjs.com/package/babel-plugin-add-module-exports).
+  Which result in both `module.exports` and `exports.default` being set to same thing.
+
+  We don't use that babel plugin so we only have `exports.default`.
+
+  This cause problems in various 3rd party react components that rely on `module.exports` being set.
+  See https://github.com/gatsbyjs/gatsby/issues/23645 for example of it.
+  
+  Instead of adding same babel plugin we mimic output here. Adding babel plugin just for this would:
+   a) unnecesairly slow down compilation for all other files (if we just apply it everywhere)
+   b) or complicate babel-loader configuration with overwrite specifically for this file
+*/
+
+const { createContext } = require(`react`)
+
+module.exports = createContext
+module.exports.default = createContext


### PR DESCRIPTION
## Description

Our `create-react-context` alias which is useful for saving few kbs for bundles when some legacy components are used doesn't match exports structure of actual package we are aliasing. In some cases this cause problems - particularly when package is using `const createReactContext = require('create-react-context')`, because our babel setup creates just `exports.default` and not the `module.exports` one

## Related Issues

Fixes #23645