### PR TITLE
docs: fix code formatting for MDX getting-started

### DIFF
--- a/docs/docs/mdx/getting-started.md
+++ b/docs/docs/mdx/getting-started.md
@@ -54,7 +54,7 @@ Alternatively, you may be looking to configure an existing blog site to use MDX.
    }
    ```
 
-3. **Restart `gatsby develop`** and add an `.mdx` page to \`src/pages
+3. **Restart `gatsby develop`** and add an `.mdx` page to `src/pages`
 
 > **Note:** If you want to query for frontmatter, exports, or other fields like
 > `tableOfContents` and you haven't previously added a `gatsby-source-filesystem`


### PR DESCRIPTION
Not sure why the opening backtick was escaped.