### PR TITLE
fix(gatsby): add control-has-associated-label rule into eslint-config

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -9,7 +9,7 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
       globals: {
         graphql: true,
         __PATH_PREFIX__: true,
-        __BASE_PATH__: true, // this will rarely, if ever, be used by consumers
+        __BASE_PATH__: true // this will rarely, if ever, be used by consumers
       },
       extends: [require.resolve(`eslint-config-react-app`)],
       plugins: [`graphql`],
@@ -20,8 +20,8 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
           {
             env: `relay`,
             schemaString: printSchema(schema, { commentDescriptions: true }),
-            tagName: `graphql`,
-          },
+            tagName: `graphql`
+          }
         ],
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
         "jsx-a11y/accessible-emoji": `warn`,
@@ -41,6 +41,7 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
         //   },
         // ],
         "jsx-a11y/click-events-have-key-events": `warn`,
+        "jsx-a11y/control-has-associated-value": `warn`,
         "jsx-a11y/heading-has-content": `warn`,
         "jsx-a11y/html-has-lang": `warn`,
         "jsx-a11y/iframe-has-title": `warn`,
@@ -63,8 +64,8 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
         "jsx-a11y/role-has-required-aria-props": `warn`,
         "jsx-a11y/role-supports-aria-props": `warn`,
         "jsx-a11y/scope": `warn`,
-        "jsx-a11y/tabindex-no-positive": `warn`,
-      },
-    },
+        "jsx-a11y/tabindex-no-positive": `warn`
+      }
+    }
   }
 }

--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -41,7 +41,7 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
         //   },
         // ],
         "jsx-a11y/click-events-have-key-events": `warn`,
-        "jsx-a11y/control-has-associated-value": `warn`,
+        "jsx-a11y/control-has-associated-label": `warn`,
         "jsx-a11y/heading-has-content": `warn`,
         "jsx-a11y/html-has-lang": `warn`,
         "jsx-a11y/iframe-has-title": `warn`,


### PR DESCRIPTION
## Description

adds `control-has-associated-label` rule back into eslint-config, looks like it wasn't added with the other rules and should definitely be included
