### PR TITLE
fix(docs): glossary yarn: change yarn to Yarn

### DIFF
--- a/docs/docs/glossary/yarn.md
+++ b/docs/docs/glossary/yarn.md
@@ -6,7 +6,7 @@ description: Learn what the Yarn package manager is, how to use it, and how it f
 
 Learn what the _Yarn_ package manager is, how to use it, and how it fits in to the Gatsby ecosystem.
 
-## What is yarn?
+## What is Yarn?
 
 Yarn is a package manager for the [Node.js](/docs/glossary/node) JavaScript runtime. It's an alternative to Node's standard package manager, [npm](/docs/glossary/npm). [Contributing](/contributing/setting-up-your-local-dev-environment/) to Gatsby core requires Yarn. Gatsby core uses Yarn's [workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) feature to manage dependencies. Gatsby [theme development](/tutorial/building-a-theme/) also uses Yarn workspaces. For Gatsby site development, you can use Yarn or npm.
 
@@ -55,9 +55,9 @@ Gatsby will use Yarn as the package manager for new projects. You can also insta
 
 Using Yarn to install packages generates a `yarn.lock` file. The `yarn.lock` tracks the exact version that you installed with `yarn add`, similar to `package-lock.json`. Commit `yarn.lock` to your project's repository. Doing so keeps your dependencies consistent across team members and computers.
 
-### Learn more about yarn
+### Learn more about Yarn
 
-- [yarn](https://yarnpkg.com/) official website
+- [Yarn](https://yarnpkg.com/) official website
 - [The package.json guide](https://nodejs.dev/the-package-json-guide) from Nodejs.dev
 - [Building a Theme](/tutorial/building-a-theme/)
 - [Gatsby Theme Authoring](https://egghead.io/courses/gatsby-theme-authoring) from egghead.io


### PR DESCRIPTION
## Description

fix brand name:
- yarn to Yarn

## Related Issues

- #23049 `docs/glossary: Add Yarn glossary entry.`