### PR TITLE
[gatsby-plugin-feed] Await async serializers

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -100,7 +100,7 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
         ? feed.serialize
         : serialize
 
-    const rssFeed = serializer(locals).reduce((merged, item) => {
+    const rssFeed = (await serializer(locals)).reduce((merged, item) => {
       merged.item(item)
       return merged
     }, new RSS(setup(locals)))


### PR DESCRIPTION
## Description

I hope I'm not oversimplifying this, but I think we can slip in this `await` on the result of `serializer` with no consequences- we're already in an `async` function.
I'd like to use a unified processor in my serializer, but it seems quite difficult to use async plugins in a synchronous function.

### Documentation

I think the only necessary change would be just to mention that `serializer` can be asynchronous in the README. I'll add that to the PR and edit this line (I'm in the web UI currently)

## Related Issues

I didn't create an issue, nor could I find an existing one.
