### PR TITLE
perf(www) Only source gatsby core instead of the whole packages directory

### DIFF
--- a/docs/docs/actions.md
+++ b/docs/docs/actions.md
@@ -2,8 +2,8 @@
 title: Actions
 description: Documentation on actions and how they help you manipulate state within Gatsby
 jsdoc:
-  - "gatsby/src/redux/actions/public.js"
-  - "gatsby/src/redux/actions/restricted.ts"
+  - "src/redux/actions/public.js"
+  - "src/redux/actions/restricted.ts"
 contentsHeading: Functions
 ---
 

--- a/docs/docs/browser-apis.md
+++ b/docs/docs/browser-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Gatsby Browser APIs
 description: Documentation about leveraging standard browser APIs within Gatsby
-jsdoc: ["gatsby/src/utils/api-browser-docs.ts"]
+jsdoc: ["src/utils/api-browser-docs.ts"]
 apiCalls: BrowserAPI
 showTopLevelSignatures: true
 ---

--- a/docs/docs/node-api-helpers.md
+++ b/docs/docs/node-api-helpers.md
@@ -1,7 +1,7 @@
 ---
 title: Node API Helpers
 description: Documentation on API helpers for creating nodes within Gatsby's GraphQL data layer
-jsdoc: ["gatsby/src/utils/api-node-helpers-docs.js"]
+jsdoc: ["src/utils/api-node-helpers-docs.js"]
 apiCalls: NodeAPIHelpers
 contentsHeading: Shared helpers
 showTopLevelSignatures: true

--- a/docs/docs/node-apis.md
+++ b/docs/docs/node-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Gatsby Node APIs
 description: Documentation on Node APIs used in Gatsby build process for common uses like creating pages
-jsdoc: ["gatsby/src/utils/api-node-docs.ts"]
+jsdoc: ["src/utils/api-node-docs.ts"]
 apiCalls: NodeAPI
 ---
 

--- a/docs/docs/node-model.md
+++ b/docs/docs/node-model.md
@@ -1,7 +1,7 @@
 ---
 title: Node Model
 description: Documentation explaining the model of nodes in Gatsby's GraphQL data layer
-jsdoc: ["gatsby/src/schema/node-model.js"]
+jsdoc: ["src/schema/node-model.js"]
 apiCalls: NodeModel
 contentsHeading: Methods
 ---

--- a/docs/docs/ssr-apis.md
+++ b/docs/docs/ssr-apis.md
@@ -1,7 +1,7 @@
 ---
 title: Gatsby Server Rendering APIs
 description: Documentation on APIs related to server side rendering during Gatsby's build process
-jsdoc: ["gatsby/cache-dir/api-ssr-docs.js"]
+jsdoc: ["cache-dir/api-ssr-docs.js"]
 apiCalls: SSRAPI
 showTopLevelSignatures: true
 ---

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -1,4 +1,3 @@
-const path = require(`path`)
 require(`dotenv`).config({
   path: `.env.${process.env.NODE_ENV}`,
 })

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -161,7 +161,7 @@ module.exports = {
           return (
             [`NPMPackage`, `NPMPackageReadme`].includes(node.internal.type) ||
             (node.internal.type === `File` &&
-              path.parse(node.dir).dir.endsWith(`packages`))
+              node.sourceInstanceName === `gatsby-core`)
           )
         },
         gatsbyRemarkPlugins: [

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -121,8 +121,8 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        name: `packages`,
-        path: `${__dirname}/../packages/`,
+        name: `gatsby-core`,
+        path: `${__dirname}/../packages/gatsby/`,
         ignore: [`**/dist/**`],
       },
     },

--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -21,9 +21,8 @@ const ignorePatterns = [
 function isCodeFile(node) {
   return (
     node.internal.type === `File` &&
-    node.sourceInstanceName === `packages` &&
+    node.sourceInstanceName === `gatsby-core` &&
     [`js`].includes(node.extension) &&
-    minimatch(node.relativePath, `gatsby/**`) &&
     !ignorePatterns.some(ignorePattern =>
       minimatch(node.relativePath, ignorePattern)
     )


### PR DESCRIPTION
## Description

Instead of sourcing the entire `/packages` directory, source only from `/packages/gatsby` for docs.

## Motivation

Previously we were sourcing the entire packages directory in order to get package READMEs for local plugins. Since we now get those from npm, there's no more reason to get the entire thing. The only thing we need is the source for gatsby-core in order to generate API documentation.