### PR TITLE
test(gatsby-recipes): don't store actual version in snapshots

### DIFF
--- a/packages/gatsby-recipes/src/renderer/index.test.js
+++ b/packages/gatsby-recipes/src/renderer/index.test.js
@@ -12,47 +12,59 @@ describe(`renderer`, () => {
   test(`handles MDX as input`, async () => {
     const result = await render(mdxFixture)
 
-    expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "currentState": "",
-          "describe": "Write foo.js",
-          "diff": "- Original  - 0
+    // Gatsby latest version is ever changing so we use regex matcher for currentState property.
+    // Unfortunately jest property matchers work weirdly on arrays so instead
+    // of snapshotting entitre result array it's split into few pieces.
+
+    expect(result.length).toEqual(3)
+    expect(result[0]).toMatchInlineSnapshot(`
+      Object {
+        "currentState": "",
+        "describe": "Write foo.js",
+        "diff": "- Original  - 0
       + Modified  + 1
 
       + /** foo */",
-          "newState": "/** foo */",
-          "resourceDefinitions": Object {
-            "content": "/** foo */",
-            "path": "foo.js",
-          },
-          "resourceName": "File",
+        "newState": "/** foo */",
+        "resourceDefinitions": Object {
+          "content": "/** foo */",
+          "path": "foo.js",
         },
-        Object {
-          "currentState": "",
-          "describe": "Write foo2.js",
-          "diff": "- Original  - 0
+        "resourceName": "File",
+      }
+    `)
+    expect(result[1]).toMatchInlineSnapshot(`
+      Object {
+        "currentState": "",
+        "describe": "Write foo2.js",
+        "diff": "- Original  - 0
       + Modified  + 1
 
       + /** foo2 */",
-          "newState": "/** foo2 */",
-          "resourceDefinitions": Object {
-            "content": "/** foo2 */",
-            "path": "foo2.js",
-          },
-          "resourceName": "File",
+        "newState": "/** foo2 */",
+        "resourceDefinitions": Object {
+          "content": "/** foo2 */",
+          "path": "foo2.js",
         },
-        Object {
-          "currentState": "gatsby@2.22.5",
-          "describe": "Install gatsby@latest",
-          "newState": "gatsby@latest",
-          "resourceDefinitions": Object {
-            "name": "gatsby",
-          },
-          "resourceName": "NPMPackage",
-        },
-      ]
+        "resourceName": "File",
+      }
     `)
+    expect(result[2]).toMatchInlineSnapshot(
+      {
+        currentState: expect.stringMatching(/gatsby@[0-9.]+/),
+      },
+      `
+      Object {
+        "currentState": StringMatching /gatsby@\\[0-9\\.\\]\\+/,
+        "describe": "Install gatsby@latest",
+        "newState": "gatsby@latest",
+        "resourceDefinitions": Object {
+          "name": "gatsby",
+        },
+        "resourceName": "NPMPackage",
+      }
+    `
+    )
   })
 
   test(`handles JSX with a single component`, async () => {

--- a/packages/gatsby-recipes/src/renderer/render.test.js
+++ b/packages/gatsby-recipes/src/renderer/render.test.js
@@ -13,31 +13,41 @@ const fixture = (
 test(`renders to a plan`, async () => {
   const result = await render(fixture, {})
 
-  expect(result).toMatchInlineSnapshot(`
-    Array [
-      Object {
-        "currentState": "",
-        "describe": "Write red.js",
-        "diff": "- Original  - 0
+  // Gatsby latest version is ever changing so we use regex matcher for currentState property.
+  // Unfortunately jest property matchers work weirdly on arrays so instead
+  // of snapshotting entitre result array it's split into few pieces.
+
+  expect(result.length).toEqual(2)
+  expect(result[0]).toMatchInlineSnapshot(`
+    Object {
+      "currentState": "",
+      "describe": "Write red.js",
+      "diff": "- Original  - 0
     + Modified  + 1
 
     + red!",
-        "newState": "red!",
-        "resourceDefinitions": Object {
-          "content": "red!",
-          "path": "red.js",
-        },
-        "resourceName": "File",
+      "newState": "red!",
+      "resourceDefinitions": Object {
+        "content": "red!",
+        "path": "red.js",
       },
-      Object {
-        "currentState": "gatsby@2.22.5",
-        "describe": "Install gatsby@latest",
-        "newState": "gatsby@latest",
-        "resourceDefinitions": Object {
-          "name": "gatsby",
-        },
-        "resourceName": "NPMPackage",
-      },
-    ]
+      "resourceName": "File",
+    }
   `)
+  expect(result[1]).toMatchInlineSnapshot(
+    {
+      currentState: expect.stringMatching(/gatsby@[0-9.]+/),
+    },
+    `
+    Object {
+      "currentState": StringMatching /gatsby@\\[0-9\\.\\]\\+/,
+      "describe": "Install gatsby@latest",
+      "newState": "gatsby@latest",
+      "resourceDefinitions": Object {
+        "name": "gatsby",
+      },
+      "resourceName": "NPMPackage",
+    }
+  `
+  )
 })


### PR DESCRIPTION
Storing actual version of latest gatsby is problematic because we would need to update snapshot each time we publish :)