### PR TITLE
perf(gatsby): Drop Sift for query filtering

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -128,7 +128,6 @@
     "redux-thunk": "^2.3.0",
     "semver": "^5.7.1",
     "shallow-compare": "^1.2.2",
-    "sift": "^5.1.0",
     "signal-exit": "^3.0.3",
     "slugify": "^1.4.0",
     "socket.io": "^2.3.0",

--- a/packages/gatsby/src/db/common/__tests__/query.js
+++ b/packages/gatsby/src/db/common/__tests__/query.js
@@ -1,4 +1,4 @@
-import { createDbQueriesFromObject, dbQueryToSiftQuery } from "../query"
+import { createDbQueriesFromObject } from "../query"
 
 describe(`DbQuery`, () => {
   it(`converts basic query`, () => {
@@ -14,15 +14,6 @@ describe(`DbQuery`, () => {
             "value": "2",
           },
           "type": "query",
-        },
-      ]
-    `)
-    expect(query.map(q => dbQueryToSiftQuery(q))).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "id": Object {
-            "$eq": "2",
-          },
         },
       ]
     `)
@@ -44,15 +35,6 @@ describe(`DbQuery`, () => {
             "value": "2",
           },
           "type": "query",
-        },
-      ]
-    `)
-    expect(query.map(q => dbQueryToSiftQuery(q))).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "internal.value": Object {
-            "$eq": "2",
-          },
         },
       ]
     `)
@@ -85,20 +67,6 @@ describe(`DbQuery`, () => {
             "value": /baz/,
           },
           "type": "query",
-        },
-      ]
-    `)
-    expect(query.map(q => dbQueryToSiftQuery(q))).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "internal.value": Object {
-            "$eq": "2",
-          },
-        },
-        Object {
-          "internal.otherValue": Object {
-            "$regex": /baz/,
-          },
         },
       ]
     `)
@@ -148,27 +116,6 @@ describe(`DbQuery`, () => {
         },
       ]
     `)
-    expect(query.map(q => dbQueryToSiftQuery(q))).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "id": Object {
-            "$in": Array [
-              "foo",
-            ],
-          },
-        },
-        Object {
-          "internal.value": Object {
-            "$eq": "2",
-          },
-        },
-        Object {
-          "internal.otherValue": Object {
-            "$regex": /baz/,
-          },
-        },
-      ]
-    `)
   })
 
   it(`converts elemMatch`, () => {
@@ -190,17 +137,6 @@ describe(`DbQuery`, () => {
             "nested",
           ],
           "type": "elemMatch",
-        },
-      ]
-    `)
-    expect(query.map(q => dbQueryToSiftQuery(q))).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "nested": Object {
-            "$elemMatch": Object {
-              "$eq": "foo",
-            },
-          },
         },
       ]
     `)
@@ -227,19 +163,6 @@ describe(`DbQuery`, () => {
             "nested",
           ],
           "type": "elemMatch",
-        },
-      ]
-    `)
-    expect(query.map(q => dbQueryToSiftQuery(q))).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "nested": Object {
-            "$elemMatch": Object {
-              "foo": Object {
-                "$eq": "foo",
-              },
-            },
-          },
         },
       ]
     `)

--- a/packages/gatsby/src/db/common/query.ts
+++ b/packages/gatsby/src/db/common/query.ts
@@ -104,24 +104,6 @@ export function prefixResolvedFields(
   return queries
 }
 
-export function dbQueryToSiftQuery(query: DbQuery): object {
-  const result = {}
-  if (query.type === `elemMatch`) {
-    result[query.path.join(`.`)] = {
-      $elemMatch: dbQueryToSiftQuery(query.nestedQuery),
-    }
-  } else if (query.path.length) {
-    result[query.path.join(`.`)] = {
-      [query.query.comparator]: query.query.value,
-    }
-  } else {
-    return {
-      [query.query.comparator]: query.query.value,
-    }
-  }
-  return result
-}
-
 // Converts a nested mongo args object into a dotted notation. acc
 // (accumulator) must be a reference to an empty object. The converted
 // fields will be added to it. E.g

--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -130,254 +130,250 @@ describe(`run-sift tests`, () => {
       actions.createNode(node, { name: `test` })(store.dispatch)
     )
   })
-  ;[
-    { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
-    { desc: `no cache`, cb: () => null }, // Always goes through sift
-  ].forEach(({ desc, cb: createFiltersCache }) => {
-    describe(desc, () => {
-      describe(`filters by just id correctly`, () => {
-        it(`eq operator`, async () => {
-          const queryArgs = {
-            filter: {
-              id: { eq: `id_2` },
-            },
-          }
 
-          const resultSingular = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: true,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
+  const createFiltersCache = () /*:FiltersCache*/ => new Map()
 
-          const resultMany = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: false,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
+  describe(`filters by just id correctly`, () => {
+    it(`eq operator`, async () => {
+      const queryArgs = {
+        filter: {
+          id: { eq: `id_2` },
+        },
+      }
 
-          expect(resultSingular.map(o => o.id)).toEqual([mockNodes()[1].id])
-          expect(resultMany.map(o => o.id)).toEqual([mockNodes()[1].id])
-        })
-
-        it(`eq operator honors type`, async () => {
-          const queryArgs = {
-            filter: {
-              id: { eq: `id_1` },
-            },
-          }
-
-          const resultSingular = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: true,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          const resultMany = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: false,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          // `id-1` node is not of queried type, so results should be empty
-          expect(resultSingular).toEqual([])
-          expect(resultMany).toEqual(null)
-        })
-
-        it(`non-eq operator`, async () => {
-          const queryArgs = {
-            filter: {
-              id: { ne: `id_2` },
-            },
-          }
-
-          const resultSingular = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: true,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          const resultMany = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: false,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          expect(resultSingular.map(o => o.id)).toEqual([mockNodes()[2].id])
-          expect(resultMany.map(o => o.id)).toEqual([
-            mockNodes()[2].id,
-            mockNodes()[3].id,
-          ])
-        })
-        it(`return empty array in case of empty nodes`, async () => {
-          const queryArgs = { filter: {}, sort: {} }
-          const resultSingular = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: true,
-            nodeTypeNames: [`NonExistentNodeType`],
-            filtersCache: createFiltersCache(),
-          })
-          expect(resultSingular).toEqual([])
-        })
+      const resultSingular = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: true,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
       })
-      describe(`filters by arbitrary property correctly`, () => {
-        it(`eq operator flat single`, async () => {
-          const queryArgs = {
-            filter: {
-              slog: { eq: `def` },
-            },
-          }
 
-          const resultSingular = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: true,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          expect(Array.isArray(resultSingular)).toBe(true)
-          expect(resultSingular.length).toEqual(1)
-
-          resultSingular.map(node => {
-            expect(node.slog).toEqual(`def`)
-          })
-        })
-        it(`eq operator flat many`, async () => {
-          const queryArgs = {
-            filter: {
-              slog: { eq: `def` },
-            },
-          }
-
-          const resultMany = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: false,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          expect(Array.isArray(resultMany)).toBe(true)
-          expect(resultMany.length).toEqual(2)
-
-          resultMany.map(node => {
-            expect(node.slog).toEqual(`def`)
-          })
-        })
-        it(`eq operator deep single`, async () => {
-          const queryArgs = {
-            filter: {
-              deep: { flat: { search: { chain: { eq: 300 } } } },
-            },
-          }
-
-          const resultSingular = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: true,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          expect(Array.isArray(resultSingular)).toBe(true)
-          expect(resultSingular.length).toEqual(1)
-
-          resultSingular.map(node => {
-            expect(node.deep.flat.search.chain).toEqual(300)
-          })
-        })
-        it(`eq operator deep many`, async () => {
-          const queryArgs = {
-            filter: {
-              deep: { flat: { search: { chain: { eq: 300 } } } },
-            },
-          }
-
-          const resultMany = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: false,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          expect(Array.isArray(resultMany)).toBe(true)
-          expect(resultMany.length).toEqual(2)
-
-          resultMany.map(node => {
-            expect(node.deep.flat.search.chain).toEqual(300)
-          })
-        })
-        it(`eq operator deep miss single`, async () => {
-          const queryArgs = {
-            filter: {
-              deep: { flat: { search: { chain: { eq: 999 } } } },
-            },
-          }
-
-          const resultSingular = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: true,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          expect(Array.isArray(resultSingular)).toBe(true)
-          expect(resultSingular.length).toEqual(0)
-        })
-        it(`eq operator deep miss many`, async () => {
-          const queryArgs = {
-            filter: {
-              deep: { flat: { search: { chain: { eq: 999 } } } },
-            },
-          }
-
-          const resultMany = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: false,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          expect(resultMany).toBe(null)
-        })
-
-        it(`elemMatch on array of objects`, async () => {
-          const queryArgs = {
-            filter: {
-              elemList: {
-                elemMatch: { foo: { eq: `baz` } },
-              },
-            },
-          }
-
-          const resultMany = await runSift({
-            gqlType,
-            queryArgs,
-            firstOnly: false,
-            nodeTypeNames: [gqlType.name],
-            filtersCache: createFiltersCache(),
-          })
-
-          expect(Array.isArray(resultMany)).toBe(true)
-          expect(resultMany.map(({ id }) => id)).toEqual([`id_2`, `id_3`])
-        })
+      const resultMany = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: false,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
       })
+
+      expect(resultSingular.map(o => o.id)).toEqual([mockNodes()[1].id])
+      expect(resultMany.map(o => o.id)).toEqual([mockNodes()[1].id])
+    })
+
+    it(`eq operator honors type`, async () => {
+      const queryArgs = {
+        filter: {
+          id: { eq: `id_1` },
+        },
+      }
+
+      const resultSingular = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: true,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      const resultMany = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: false,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      // `id-1` node is not of queried type, so results should be empty
+      expect(resultSingular).toEqual([])
+      expect(resultMany).toEqual(null)
+    })
+
+    it(`non-eq operator`, async () => {
+      const queryArgs = {
+        filter: {
+          id: { ne: `id_2` },
+        },
+      }
+
+      const resultSingular = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: true,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      const resultMany = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: false,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      expect(resultSingular.map(o => o.id)).toEqual([mockNodes()[2].id])
+      expect(resultMany.map(o => o.id)).toEqual([
+        mockNodes()[2].id,
+        mockNodes()[3].id,
+      ])
+    })
+    it(`return empty array in case of empty nodes`, async () => {
+      const queryArgs = { filter: {}, sort: {} }
+      const resultSingular = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: true,
+        nodeTypeNames: [`NonExistentNodeType`],
+        filtersCache: createFiltersCache(),
+      })
+      expect(resultSingular).toEqual([])
+    })
+  })
+  describe(`filters by arbitrary property correctly`, () => {
+    it(`eq operator flat single`, async () => {
+      const queryArgs = {
+        filter: {
+          slog: { eq: `def` },
+        },
+      }
+
+      const resultSingular = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: true,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      expect(Array.isArray(resultSingular)).toBe(true)
+      expect(resultSingular.length).toEqual(1)
+
+      resultSingular.map(node => {
+        expect(node.slog).toEqual(`def`)
+      })
+    })
+    it(`eq operator flat many`, async () => {
+      const queryArgs = {
+        filter: {
+          slog: { eq: `def` },
+        },
+      }
+
+      const resultMany = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: false,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      expect(Array.isArray(resultMany)).toBe(true)
+      expect(resultMany.length).toEqual(2)
+
+      resultMany.map(node => {
+        expect(node.slog).toEqual(`def`)
+      })
+    })
+    it(`eq operator deep single`, async () => {
+      const queryArgs = {
+        filter: {
+          deep: { flat: { search: { chain: { eq: 300 } } } },
+        },
+      }
+
+      const resultSingular = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: true,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      expect(Array.isArray(resultSingular)).toBe(true)
+      expect(resultSingular.length).toEqual(1)
+
+      resultSingular.map(node => {
+        expect(node.deep.flat.search.chain).toEqual(300)
+      })
+    })
+    it(`eq operator deep many`, async () => {
+      const queryArgs = {
+        filter: {
+          deep: { flat: { search: { chain: { eq: 300 } } } },
+        },
+      }
+
+      const resultMany = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: false,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      expect(Array.isArray(resultMany)).toBe(true)
+      expect(resultMany.length).toEqual(2)
+
+      resultMany.map(node => {
+        expect(node.deep.flat.search.chain).toEqual(300)
+      })
+    })
+    it(`eq operator deep miss single`, async () => {
+      const queryArgs = {
+        filter: {
+          deep: { flat: { search: { chain: { eq: 999 } } } },
+        },
+      }
+
+      const resultSingular = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: true,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      expect(Array.isArray(resultSingular)).toBe(true)
+      expect(resultSingular.length).toEqual(0)
+    })
+    it(`eq operator deep miss many`, async () => {
+      const queryArgs = {
+        filter: {
+          deep: { flat: { search: { chain: { eq: 999 } } } },
+        },
+      }
+
+      const resultMany = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: false,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      expect(resultMany).toBe(null)
+    })
+
+    it(`elemMatch on array of objects`, async () => {
+      const queryArgs = {
+        filter: {
+          elemList: {
+            elemMatch: { foo: { eq: `baz` } },
+          },
+        },
+      }
+
+      const resultMany = await runSift({
+        gqlType,
+        queryArgs,
+        firstOnly: false,
+        nodeTypeNames: [gqlType.name],
+        filtersCache: createFiltersCache(),
+      })
+
+      expect(Array.isArray(resultMany)).toBe(true)
+      expect(resultMany.map(({ id }) => id)).toEqual([`id_2`, `id_3`])
     })
   })
 })

--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -147,58 +147,6 @@ export const saveResolvedNodes = async (
   }
 }
 
-/**
- * Get node and save path dependency.
- */
-export const getResolvedNode = (
-  typeName: string,
-  id: string
-): IGatsbyNode | null => {
-  const { nodesByType, resolvedNodesCache } = store.getState()
-  const nodes = nodesByType.get(typeName)
-
-  if (!nodes) {
-    return null
-  }
-
-  const node = nodes.get(id)
-
-  if (!node) {
-    return null
-  }
-
-  const resolvedNodes = resolvedNodesCache.get(typeName)
-
-  if (resolvedNodes) {
-    node.__gatsby_resolved = resolvedNodes.get(id)
-  }
-
-  return node
-}
-
-export const addResolvedNodes = (
-  typeName: string,
-  resolvedNodes: IGatsbyNode[] = []
-): IGatsbyNode[] => {
-  const { nodesByType, resolvedNodesCache } = store.getState()
-  const nodes = nodesByType.get(typeName)
-
-  if (!nodes) {
-    return []
-  }
-
-  const resolvedNodesFromCache = resolvedNodesCache.get(typeName)
-
-  nodes.forEach(node => {
-    if (resolvedNodesFromCache) {
-      node.__gatsby_resolved = resolvedNodesFromCache.get(node.id)
-    }
-    resolvedNodes.push(node)
-  })
-
-  return resolvedNodes
-}
-
 export function postIndexingMetaSetup(
   filterCache: IFilterCache,
   op: FilterOp
@@ -419,13 +367,13 @@ function addNodeToFilterCache(
     const resolvedNodes = resolvedNodesCache.get(typeName)
     node.__gatsby_resolved = resolvedNodes?.get(node.id)
   }
-
   // - for plain query, valueOffset === node
   // - for elemMatch, valueOffset is sub-tree of the node to continue matching
   let v = valueOffset as any
   let i = 0
   while (i < chain.length && v) {
     const nextProp = chain[i++]
+    // if (chain.length === i && Array.isArray(v)) break
     v = v[nextProp]
   }
 

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -7,6 +7,10 @@ const typeBuilders = require(`../types/type-builders`)
 
 const nodes = require(`./fixtures/node-model`)
 
+function createFiltersCache() {
+  return new Map()
+}
+
 describe(`NodeModel`, () => {
   let nodeModel
   let schema
@@ -284,205 +288,201 @@ describe(`NodeModel`, () => {
         )
       })
     })
-    ;[
-      { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
-      { desc: `no cache`, cb: () => null }, // Always goes through sift
-    ].forEach(({ desc, cb: createFiltersCache }) => {
-      describe(`runQuery [${desc}]`, () => {
-        it(`returns first result only`, async () => {
-          const type = `Post`
-          const query = {
-            filter: { frontmatter: { published: { eq: false } } },
-          }
-          const firstOnly = true
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          const result = await nodeModel.runQuery({
+
+    describe(`runQuery`, () => {
+      it(`returns first result only`, async () => {
+        const type = `Post`
+        const query = {
+          filter: { frontmatter: { published: { eq: false } } },
+        }
+        const firstOnly = true
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        const result = await nodeModel.runQuery({
+          query,
+          firstOnly,
+          type,
+        })
+        expect(result.id).toBe(`post1`)
+      })
+
+      it(`returns all results`, async () => {
+        const type = `Post`
+        const query = {
+          filter: { frontmatter: { published: { eq: false } } },
+        }
+        const firstOnly = false
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        const result = await nodeModel.runQuery({
+          query,
+          firstOnly,
+          type,
+        })
+        expect(result.length).toBe(2)
+        expect(result[0].id).toBe(`post1`)
+        expect(result[1].id).toBe(`post3`)
+      })
+
+      it(`creates page dependencies`, async () => {
+        const type = `Post`
+        const query = {
+          filter: { frontmatter: { published: { eq: false } } },
+        }
+        const firstOnly = false
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        await nodeModel.runQuery(
+          {
             query,
             firstOnly,
             type,
-          })
-          expect(result.id).toBe(`post1`)
+          },
+          { path: `/` }
+        )
+        expect(createPageDependency).toHaveBeenCalledTimes(2)
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          nodeId: `post1`,
         })
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          nodeId: `post3`,
+        })
+      })
 
-        it(`returns all results`, async () => {
-          const type = `Post`
-          const query = {
-            filter: { frontmatter: { published: { eq: false } } },
-          }
-          const firstOnly = false
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          const result = await nodeModel.runQuery({
+      it(`creates page dependencies when called with context`, async () => {
+        const type = `Post`
+        const query = {
+          filter: { frontmatter: { published: { eq: false } } },
+        }
+        const firstOnly = false
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        await nodeModel.withContext({ path: `/` }).runQuery({
+          query,
+          firstOnly,
+          type,
+        })
+        expect(createPageDependency).toHaveBeenCalledTimes(2)
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          nodeId: `post1`,
+        })
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          nodeId: `post3`,
+        })
+      })
+
+      it(`creates page dependencies with connection type`, async () => {
+        const type = `Post`
+        const query = {
+          filter: { frontmatter: { published: { eq: false } } },
+        }
+        const firstOnly = false
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        await nodeModel.runQuery(
+          {
             query,
             firstOnly,
             type,
-          })
-          expect(result.length).toBe(2)
-          expect(result[0].id).toBe(`post1`)
-          expect(result[1].id).toBe(`post3`)
+          },
+          { path: `/`, connectionType: `Post` }
+        )
+        expect(createPageDependency).toHaveBeenCalledTimes(1)
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          connection: `Post`,
         })
+      })
 
-        it(`creates page dependencies`, async () => {
-          const type = `Post`
-          const query = {
-            filter: { frontmatter: { published: { eq: false } } },
-          }
-          const firstOnly = false
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          await nodeModel.runQuery(
-            {
-              query,
-              firstOnly,
-              type,
+      it(`doesn't allow querying union types`, () => {
+        const type = `AllFiles`
+        const query = {}
+        const firstOnly = true
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        const result = nodeModel.runQuery({
+          query,
+          firstOnly,
+          type,
+        })
+        return expect(result).rejects.toThrowError(
+          `Querying GraphQLUnion types is not supported.`
+        )
+      })
+
+      it(`handles interface types`, async () => {
+        const type = `TeamMember`
+        const query = { name: { ne: null } }
+        const firstOnly = true
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        const result = await nodeModel.runQuery({
+          query,
+          firstOnly,
+          type,
+        })
+        expect(result.name).toBe(`Person1`)
+      })
+
+      it(`allows passing GraphQLType instead of type name`, async () => {
+        const type = schema.getType(`File`)
+        const query = {
+          filter: {
+            children: { elemMatch: { internal: { type: { eq: `Post` } } } },
+          },
+        }
+        const firstOnly = false
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        const result = await nodeModel.runQuery({
+          query,
+          firstOnly,
+          type,
+        })
+        expect(result.length).toBe(2)
+        expect(result[0].id).toBe(`file1`)
+        expect(result[1].id).toBe(`file3`)
+      })
+
+      it(`handles elemMatch`, async () => {
+        const type = `Post`
+        const query = {
+          filter: {
+            nestedObject: { elemMatch: { nestedValue: { eq: `2` } } },
+          },
+        }
+        const firstOnly = true
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        const result = await nodeModel.runQuery({
+          query,
+          firstOnly,
+          type,
+        })
+        expect(result).toBeDefined()
+        expect(result.id).toEqual(`post2`)
+      })
+
+      // FIXME: Filters on date instances are not supported yet
+      //  SIFT requires such filters to be expressed as Date instances but we
+      //  don't know if date is stored as `Date` instance or `string`
+      //  so can't really do that
+      //  See https://github.com/crcn/sift.js#date-comparison
+      it.skip(`queries date instances in nodes`, async () => {
+        const type = `Post`
+        const query = {
+          filter: {
+            frontmatter: {
+              date: { lte: `2018-01-01T00:00:00Z` },
             },
-            { path: `/` }
-          )
-          expect(createPageDependency).toHaveBeenCalledTimes(2)
-          expect(createPageDependency).toHaveBeenCalledWith({
-            path: `/`,
-            nodeId: `post1`,
-          })
-          expect(createPageDependency).toHaveBeenCalledWith({
-            path: `/`,
-            nodeId: `post3`,
-          })
+          },
+        }
+        const firstOnly = false
+        nodeModel.replaceTypeKeyValueCache(createFiltersCache())
+        const result = await nodeModel.runQuery({
+          query,
+          firstOnly,
+          type,
         })
-
-        it(`creates page dependencies when called with context`, async () => {
-          const type = `Post`
-          const query = {
-            filter: { frontmatter: { published: { eq: false } } },
-          }
-          const firstOnly = false
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          await nodeModel.withContext({ path: `/` }).runQuery({
-            query,
-            firstOnly,
-            type,
-          })
-          expect(createPageDependency).toHaveBeenCalledTimes(2)
-          expect(createPageDependency).toHaveBeenCalledWith({
-            path: `/`,
-            nodeId: `post1`,
-          })
-          expect(createPageDependency).toHaveBeenCalledWith({
-            path: `/`,
-            nodeId: `post3`,
-          })
-        })
-
-        it(`creates page dependencies with connection type`, async () => {
-          const type = `Post`
-          const query = {
-            filter: { frontmatter: { published: { eq: false } } },
-          }
-          const firstOnly = false
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          await nodeModel.runQuery(
-            {
-              query,
-              firstOnly,
-              type,
-            },
-            { path: `/`, connectionType: `Post` }
-          )
-          expect(createPageDependency).toHaveBeenCalledTimes(1)
-          expect(createPageDependency).toHaveBeenCalledWith({
-            path: `/`,
-            connection: `Post`,
-          })
-        })
-
-        it(`doesn't allow querying union types`, () => {
-          const type = `AllFiles`
-          const query = {}
-          const firstOnly = true
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          const result = nodeModel.runQuery({
-            query,
-            firstOnly,
-            type,
-          })
-          return expect(result).rejects.toThrowError(
-            `Querying GraphQLUnion types is not supported.`
-          )
-        })
-
-        it(`handles interface types`, async () => {
-          const type = `TeamMember`
-          const query = { name: { ne: null } }
-          const firstOnly = true
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          const result = await nodeModel.runQuery({
-            query,
-            firstOnly,
-            type,
-          })
-          expect(result.name).toBe(`Person1`)
-        })
-
-        it(`allows passing GraphQLType instead of type name`, async () => {
-          const type = schema.getType(`File`)
-          const query = {
-            filter: {
-              children: { elemMatch: { internal: { type: { eq: `Post` } } } },
-            },
-          }
-          const firstOnly = false
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          const result = await nodeModel.runQuery({
-            query,
-            firstOnly,
-            type,
-          })
-          expect(result.length).toBe(2)
-          expect(result[0].id).toBe(`file1`)
-          expect(result[1].id).toBe(`file3`)
-        })
-
-        it(`handles elemMatch`, async () => {
-          const type = `Post`
-          const query = {
-            filter: {
-              nestedObject: { elemMatch: { nestedValue: { eq: `2` } } },
-            },
-          }
-          const firstOnly = true
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          const result = await nodeModel.runQuery({
-            query,
-            firstOnly,
-            type,
-          })
-          expect(result).toBeDefined()
-          expect(result.id).toEqual(`post2`)
-        })
-
-        // FIXME: Filters on date instances are not supported yet
-        //  SIFT requires such filters to be expressed as Date instances but we
-        //  don't know if date is stored as `Date` instance or `string`
-        //  so can't really do that
-        //  See https://github.com/crcn/sift.js#date-comparison
-        it.skip(`queries date instances in nodes`, async () => {
-          const type = `Post`
-          const query = {
-            filter: {
-              frontmatter: {
-                date: { lte: `2018-01-01T00:00:00Z` },
-              },
-            },
-          }
-          const firstOnly = false
-          nodeModel.replaceTypeKeyValueCache(createFiltersCache())
-          const result = await nodeModel.runQuery({
-            query,
-            firstOnly,
-            type,
-          })
-          expect(result).toBeDefined()
-          expect(result.length).toEqual(2)
-          expect(result[0].id).toEqual(`post2`)
-          expect(result[1].id).toEqual(`post3`)
-        })
+        expect(result).toBeDefined()
+        expect(result.length).toEqual(2)
+        expect(result[0].id).toEqual(`post2`)
+        expect(result[1].id).toEqual(`post3`)
       })
     })
 
@@ -576,90 +576,86 @@ describe(`NodeModel`, () => {
         createPageDependency,
       })
     })
-    ;[
-      { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
-      { desc: `no cache`, cb: () => null }, // Always goes through sift
-    ].forEach(({ desc, cb: createFiltersCache }) => {
-      it(`[${desc}] should not resolve prepared nodes more than once`, async () => {
-        nodeModel.replaceFiltersCache(createFiltersCache())
-        await nodeModel.runQuery(
-          {
-            query: { filter: { betterTitle: { eq: `foo` } } },
-            firstOnly: false,
-            type: `Test`,
-          },
-          { path: `/` }
-        )
-        expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
-        expect(resolveOtherTitleMock.mock.calls.length).toBe(0)
-        nodeModel.replaceFiltersCache(createFiltersCache())
-        await nodeModel.runQuery(
-          {
-            query: { filter: { betterTitle: { eq: `foo` } } },
-            firstOnly: false,
-            type: `Test`,
-          },
-          { path: `/` }
-        )
-        expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
-        expect(resolveOtherTitleMock.mock.calls.length).toBe(0)
-        nodeModel.replaceFiltersCache(createFiltersCache())
-        await nodeModel.runQuery(
-          {
-            query: {
-              filter: { betterTitle: { eq: `foo` }, otherTitle: { eq: `Bar` } },
-            },
-            firstOnly: false,
-            type: `Test`,
-          },
-          { path: `/` }
-        )
-        expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
-        expect(resolveOtherTitleMock.mock.calls.length).toBe(2)
-        nodeModel.replaceFiltersCache(createFiltersCache())
-        await nodeModel.runQuery(
-          {
-            query: {
-              filter: { betterTitle: { eq: `foo` }, otherTitle: { eq: `Bar` } },
-            },
-            firstOnly: false,
-            type: `Test`,
-          },
-          { path: `/` }
-        )
-        expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
-        expect(resolveOtherTitleMock.mock.calls.length).toBe(2)
-        nodeModel.replaceFiltersCache(createFiltersCache())
-        await nodeModel.runQuery(
-          {
-            query: {
-              filter: { betterTitle: { eq: `foo` }, otherTitle: { eq: `Bar` } },
-            },
-            firstOnly: true,
-            type: `Test`,
-          },
-          { path: `/` }
-        )
-        expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
-        expect(resolveOtherTitleMock.mock.calls.length).toBe(2)
-      })
 
-      it(`[${desc}] can filter by resolved fields`, async () => {
-        nodeModel.replaceFiltersCache(createFiltersCache())
-        const result = await nodeModel.runQuery(
-          {
-            query: {
-              filter: { hidden: { eq: false } },
-            },
-            firstOnly: false,
-            type: `Test`,
+    it(`should not resolve prepared nodes more than once`, async () => {
+      nodeModel.replaceFiltersCache(createFiltersCache())
+      await nodeModel.runQuery(
+        {
+          query: { filter: { betterTitle: { eq: `foo` } } },
+          firstOnly: false,
+          type: `Test`,
+        },
+        { path: `/` }
+      )
+      expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
+      expect(resolveOtherTitleMock.mock.calls.length).toBe(0)
+      nodeModel.replaceFiltersCache(createFiltersCache())
+      await nodeModel.runQuery(
+        {
+          query: { filter: { betterTitle: { eq: `foo` } } },
+          firstOnly: false,
+          type: `Test`,
+        },
+        { path: `/` }
+      )
+      expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
+      expect(resolveOtherTitleMock.mock.calls.length).toBe(0)
+      nodeModel.replaceFiltersCache(createFiltersCache())
+      await nodeModel.runQuery(
+        {
+          query: {
+            filter: { betterTitle: { eq: `foo` }, otherTitle: { eq: `Bar` } },
           },
-          { path: `/` }
-        )
-        expect(result.length).toBe(2)
-        expect(result[0].id).toBe(`id1`)
-        expect(result[1].id).toBe(`id2`)
-      })
+          firstOnly: false,
+          type: `Test`,
+        },
+        { path: `/` }
+      )
+      expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
+      expect(resolveOtherTitleMock.mock.calls.length).toBe(2)
+      nodeModel.replaceFiltersCache(createFiltersCache())
+      await nodeModel.runQuery(
+        {
+          query: {
+            filter: { betterTitle: { eq: `foo` }, otherTitle: { eq: `Bar` } },
+          },
+          firstOnly: false,
+          type: `Test`,
+        },
+        { path: `/` }
+      )
+      expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
+      expect(resolveOtherTitleMock.mock.calls.length).toBe(2)
+      nodeModel.replaceFiltersCache(createFiltersCache())
+      await nodeModel.runQuery(
+        {
+          query: {
+            filter: { betterTitle: { eq: `foo` }, otherTitle: { eq: `Bar` } },
+          },
+          firstOnly: true,
+          type: `Test`,
+        },
+        { path: `/` }
+      )
+      expect(resolveBetterTitleMock.mock.calls.length).toBe(2)
+      expect(resolveOtherTitleMock.mock.calls.length).toBe(2)
+    })
+
+    it(`can filter by resolved fields`, async () => {
+      nodeModel.replaceFiltersCache(createFiltersCache())
+      const result = await nodeModel.runQuery(
+        {
+          query: {
+            filter: { hidden: { eq: false } },
+          },
+          firstOnly: false,
+          type: `Test`,
+        },
+        { path: `/` }
+      )
+      expect(result.length).toBe(2)
+      expect(result[0].id).toBe(`id1`)
+      expect(result[1].id).toBe(`id2`)
     })
   })
 
@@ -789,49 +785,45 @@ describe(`NodeModel`, () => {
         expect(trackedRootNode).not.toEqual(node)
       })
     })
-    ;[
-      { desc: `with cache`, cb: () => new Map() }, // Avoids sift
-      { desc: `no cache`, cb: () => null }, // Requires sift
-    ].forEach(({ desc, cb: createFiltersCache }) => {
-      describe(`[${desc}] Tracks nodes returned by queries`, () => {
-        it(`Tracks objects when running query without filter`, async () => {
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          const result = await nodeModel.runQuery({
-            query: {},
-            type: schema.getType(`Test`),
-            firstOnly: false,
-          })
 
-          expect(result.length).toEqual(2)
-          expect(
-            nodeModel.findRootNodeAncestor(result[0].inlineObject)
-          ).toEqual(result[0])
-          expect(
-            nodeModel.findRootNodeAncestor(result[1].inlineObject)
-          ).toEqual(result[1])
+    describe(`Tracks nodes returned by queries`, () => {
+      it(`Tracks objects when running query without filter`, async () => {
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        const result = await nodeModel.runQuery({
+          query: {},
+          type: schema.getType(`Test`),
+          firstOnly: false,
         })
 
-        it(`Tracks objects when running query with filter`, async () => {
-          nodeModel.replaceFiltersCache(createFiltersCache())
-          const result = await nodeModel.runQuery({
-            query: {
-              filter: {
-                inlineObject: {
-                  field: {
-                    eq: `fieldOfSecondNode`,
-                  },
+        expect(result.length).toEqual(2)
+        expect(nodeModel.findRootNodeAncestor(result[0].inlineObject)).toEqual(
+          result[0]
+        )
+        expect(nodeModel.findRootNodeAncestor(result[1].inlineObject)).toEqual(
+          result[1]
+        )
+      })
+
+      it(`Tracks objects when running query with filter`, async () => {
+        nodeModel.replaceFiltersCache(createFiltersCache())
+        const result = await nodeModel.runQuery({
+          query: {
+            filter: {
+              inlineObject: {
+                field: {
+                  eq: `fieldOfSecondNode`,
                 },
               },
             },
-            type: schema.getType(`Test`),
-            firstOnly: false,
-          })
-
-          expect(result.length).toEqual(1)
-          expect(
-            nodeModel.findRootNodeAncestor(result[0].inlineObject)
-          ).toEqual(result[0])
+          },
+          type: schema.getType(`Test`),
+          firstOnly: false,
         })
+
+        expect(result.length).toEqual(1)
+        expect(nodeModel.findRootNodeAncestor(result[0].inlineObject)).toEqual(
+          result[0]
+        )
       })
     })
   })

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -116,10 +116,10 @@ describe(`Query schema`, () => {
                     query: {
                       filter: {
                         frontmatter: {
-                          authors: { email: { eq: source.email } },
-                          // authors: {
-                          //   elemMatch: { email: { eq: source.email } },
-                          // },
+                          // authors: { email: { eq: source.email } },
+                          authors: {
+                            elemMatch: { email: { eq: source.email } },
+                          },
                         },
                       },
                     },

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -1,10 +1,6 @@
 const { runQuery: nodesQuery } = require(`../../db/nodes`)
-const { didLastFilterUseSift } = require(`../../redux/run-sift`)
 const { store } = require(`../../redux`)
 const { actions } = require(`../../redux/actions`)
-
-const EXPECT_SIFT = true
-const EXPECT_FAST_FILTER = false
 
 const makeNodesUneven = () => [
   // Note: This is assumed to be an uneven node count
@@ -325,9 +321,8 @@ function resetDb(nodes) {
 
 async function runQuery(
   queryArgs,
-  filtersCache,
   nodes = makeNodesUneven(),
-  alwaysSift = !filtersCache
+  filtersCache = new Map()
 ) {
   resetDb(nodes)
   const { sc, type: gqlType } = makeGqlType(nodes)
@@ -340,39 +335,21 @@ async function runQuery(
     filtersCache,
   }
 
-  let result = await nodesQuery(args)
-
-  // If the filters cache was set, then the test expects fast filters to handle
-  // the query and to skip Sift. If it's not set, then it can't use fast filters
-  // Might revise this when adding tests where we don't expect fast filters to
-  // support it yet..?
-  if (result && result.length) {
-    // Currently, empty results must go through Sift, so ignore those cases here
-    if (alwaysSift) {
-      expect(didLastFilterUseSift()).toBe(true)
-    } else {
-      expect(didLastFilterUseSift()).toBe(!filtersCache)
-    }
-  }
-
-  return result
+  return nodesQuery(args)
 }
 
-async function runQuery2(queryArgs, filtersCache, alwaysSift) {
+async function runFilter(filter) {
   const nodes = makeNodesUneven()
-  return [await runQuery(queryArgs, filtersCache, nodes, alwaysSift), nodes]
-}
-
-async function runFilterOnCache(filter, filtersCache, alwaysSift) {
-  return await runQuery2({ filter }, filtersCache, alwaysSift)
+  return [await runQuery({ filter }, nodes), nodes]
 }
 
 it(`should use the cache argument`, async () => {
   const filtersCache = new Map()
-  const [result] = await runFilterOnCache(
-    { hair: { eq: 2 } },
-    filtersCache,
-    EXPECT_FAST_FILTER
+  const nodes = makeNodesUneven()
+  const result = await runQuery(
+    { filter: { hair: { eq: 2 } } },
+    nodes,
+    filtersCache
   )
 
   // Validate answer
@@ -397,2044 +374,2001 @@ it(`should use the cache argument`, async () => {
   )
 })
 
-// Make sure to test fast filters (with cache) and Sift (without cache)
-;[
-  { desc: `without cache`, cb: () => null }, // Forces no cache, must use Sift
-  { desc: `with cache`, cb: () => new Map() },
-].forEach(({ desc, cb: createFiltersCache }) => {
-  async function runFastFilter(filter) {
-    // Assume (and assert) that the query used fast filters if a cache was given
-    return runFilterOnCache(filter, createFiltersCache(), EXPECT_FAST_FILTER)
-  }
-  async function runSlowFilter(filter) {
-    // Assume (and assert) that the query used Sift even if a cache was given
-    // (These are cases we still need to support, at least, before dropping Sift)
-    return runFilterOnCache(filter, createFiltersCache(), EXPECT_SIFT)
-  }
+describe(`Filter fields`, () => {
+  describe(`none`, () => {
+    it(`handles empty filter`, async () => {
+      const [result, allNodes] = await runFilter({})
 
-  describe(desc, () => {
-    describe(`Filter fields`, () => {
-      describe(`none`, () => {
-        it(`handles empty filter`, async () => {
-          const [result, allNodes] = await runFastFilter({})
+      // Expecting all nodes
+      expect(result?.length).toEqual(allNodes.length)
+    })
+  })
 
-          // Expecting all nodes
-          expect(result?.length).toEqual(allNodes.length)
-        })
+  describe(`$eq`, () => {
+    it(`handles eq operator with number value`, async () => {
+      const needle = 2
+      const [result, allNodes] = await runFilter({
+        hair: { eq: needle },
       })
 
-      describe(`$eq`, () => {
-        it(`handles eq operator with number value`, async () => {
-          const needle = 2
-          const [result, allNodes] = await runFastFilter({
-            hair: { eq: needle },
-          })
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.hair === needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.hair).toEqual(needle))
+    })
 
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.hair === needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.hair).toEqual(needle))
-        })
-
-        it(`handles eq operator with false value`, async () => {
-          const needle = false
-          const [result, allNodes] = await runFastFilter({
-            boolean: { eq: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.boolean === needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.boolean).toEqual(needle))
-        })
-
-        it(`handles eq operator with 0`, async () => {
-          const needle = 0
-          const [result, allNodes] = await runFastFilter({
-            hair: { eq: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.hair === needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.hair).toEqual(needle))
-        })
-
-        it(`handles eq operator with null`, async () => {
-          const needle = null // note: this should find nodes with null OR undefined (apparently)
-          const [result, allNodes] = await runFastFilter({
-            nil: { eq: needle },
-          })
-
-          // Also returns nodes that do not have the property at all (NULL in db)
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.nil == needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil == null).toEqual(true))
-        })
-
-        // grapqhl would never pass on `undefined`
-        // it(`handles eq operator with undefined`, async () => {
-        //   const [result, allNodes] = await runFastFilter{ undef: { eq: undefined } })
-        //
-        //   expect(result.length).toEqual(?)
-        //   expect(result[0].hair).toEqual(?)
-        // })
-
-        it(`handles eq operator with serialized array value`, async () => {
-          const needle = `[5,6,7,8]`
-          const [result, allNodes] = await runFastFilter({
-            strArray: { eq: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.strArray === needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.strArray).toEqual(needle))
-        })
-
-        it(`finds numbers inside arrays`, async () => {
-          const needle = 3
-          const [result, allNodes] = await runFastFilter({
-            anArray: { eq: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.anArray?.includes(needle)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(node.anArray?.includes(needle)).toEqual(true)
-          )
-        })
-
-        it(`finds numbers inside single-element arrays`, async () => {
-          const needle = 8
-          const [result, allNodes] = await runFastFilter({
-            singleArray: { eq: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.singleArray?.includes(needle)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(node.singleArray?.includes(needle)).toEqual(true)
-          )
-        })
-
-        it(`does not coerce numbers against single-element arrays`, async () => {
-          const needle = `8` // note: `('8' == [8]) === true`
-          const [result] = await runFastFilter({
-            singleArray: { eq: needle },
-          })
-
-          // Note: no coercion, so [8]=='8' is true but Sift ignores those
-          expect(result).toEqual(null)
-        })
+    it(`handles eq operator with false value`, async () => {
+      const needle = false
+      const [result, allNodes] = await runFilter({
+        boolean: { eq: needle },
       })
 
-      describe(`$ne`, () => {
-        it(`handles ne operator`, async () => {
-          const needle = 2
-          const [result, allNodes] = await runFastFilter({
-            hair: { ne: needle },
-          })
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.boolean === needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.boolean).toEqual(needle))
+    })
 
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.hair !== needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.hair).not.toEqual(needle))
-        })
-
-        it(`coerces number to string`, async () => {
-          const needle = 2 // Note: `id` is a numstr
-          const [result, allNodes] = await runFastFilter({ id: { ne: needle } })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.id !== needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.id).not.toEqual(needle))
-        })
-
-        // This test causes a stack overflow right now
-        it.skip(`dpes not coerce string to number`, async () => {
-          const needle = `2` // Note: `id` is a numstr
-          const [result] = await runSlowFilter({ id: { hair: needle } })
-
-          // Slow filter because it's an empty result
-          expect(result).toEqual(null)
-        })
-
-        it(`handles ne operator with true`, async () => {
-          const needle = true
-          const [result, allNodes] = await runFastFilter({
-            boolean: { ne: true },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.boolean !== needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.boolean).not.toEqual(needle))
-        })
-
-        describe(`exhaustive checks for null and partial paths`, () => {
-          // This group of tests exhausitvely checks what happens when you $ne on path a.b.c=value a node that
-          // has a partial path, either ending in null or undefined prematurely, for all partials of the path.
-
-          it(`should deal with eq null`, async () => {
-            const needle = null
-            const allNodes = makeNodesNeNull()
-            const result = await runQuery(
-              { filter: { a: { b: { c: { ne: needle } } } } },
-              createFiltersCache(),
-              allNodes
-            )
-
-            // Sift only returns id=6,7, where a.b.c===true/false.
-
-            expect(result?.length).toEqual(
-              allNodes.filter(node => !(node?.a?.b?.c == null)).length
-            )
-            expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-            result.forEach(node => expect(node?.a?.b?.c).not.toEqual(needle))
-          })
-
-          it(`should deal with eq true`, async () => {
-            const needle = true
-            const allNodes = makeNodesNeNull()
-            const result = await runQuery(
-              { filter: { a: { b: { c: { ne: needle } } } } },
-              createFiltersCache(),
-              allNodes
-            )
-
-            // Note: Sift only omits id=6, where a.b.c===true (contrary to searching for null)
-
-            expect(result?.length).toEqual(
-              allNodes.filter(node => node?.a?.b?.c !== needle).length
-            )
-            expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-            result.forEach(node => expect(node?.a?.b?.c).not.toEqual(needle))
-          })
-
-          it(`should deal with eq false`, async () => {
-            const needle = false
-            const allNodes = makeNodesNeNull()
-            const result = await runQuery(
-              { filter: { a: { b: { c: { ne: needle } } } } },
-              createFiltersCache(),
-              allNodes
-            )
-
-            // Note: Sift only omits id=7, where a.b.c===false (contrary to searching for null)
-
-            expect(result?.length).toEqual(
-              allNodes.filter(node => node?.a?.b?.c !== needle).length
-            )
-            expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-            result.forEach(node => expect(node?.a?.b?.c).not.toEqual(needle))
-          })
-        })
-
-        it(`handles nested ne operator with true`, async () => {
-          const needle = true
-          const [result, allNodes] = await runFastFilter({
-            waxOnly: { foo: { ne: true } },
-          })
-
-          // Note: one node has this, one node has waxOnly=null, one node does not have the waxOnly property at all.
-          // Redux seems to return only the node that doesn't have the property at all (node.id=0)
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.waxOnly?.foo !== needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.waxOnly?.foo).not.toEqual(needle))
-        })
-
-        it(`handles ne operator with 0`, async () => {
-          const needle = 0
-          const [result, allNodes] = await runFastFilter({
-            hair: { ne: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.hair !== needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.hair).not.toEqual(needle))
-        })
-
-        it(`handles ne operator with null`, async () => {
-          const needle = 0
-          const [result, allNodes] = await runFastFilter({
-            nil: { ne: needle },
-          })
-
-          // Should only return nodes who do have the property, not set to null
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.nil !== needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil).not.toEqual(needle))
-        })
-
-        // grapqhl would never pass on `undefined`
-        // it(`handles ne operator with undefined`, async () => {
-        //   const [result, allNodes] = await runFastFilter({ undef: { ne: undefined } })
-        //
-        //   expect(result.length).toEqual(?)
-        //   expect(result?.length).toEqual(allNodes.filter(node => node.nil !== needle).length)
-        //   expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-        //   result.forEach(node => expect(node.nil).not.toEqual(needle))
-        // })
-
-        it(`handles deeply nested ne: true operator`, async () => {
-          const needle = true
-          const [result, allNodes] = await runFastFilter({
-            waxOnly: { bar: { baz: { ne: needle } } },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.waxOnly?.bar?.baz !== needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(node.waxOnly?.bar?.baz).not.toEqual(needle)
-          )
-        })
-
-        it(`handles the ne operator for array field values`, async () => {
-          const needle = 1
-          const [result, allNodes] = await runFastFilter({
-            anArray: { ne: needle },
-          })
-
-          // Sift returns only the node that doesn't have the property at all (the other two arrays contain 1)
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => !node.anArray?.includes(needle)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(node.anArray?.includes(needle)).not.toEqual(true)
-          )
-        })
+    it(`handles eq operator with 0`, async () => {
+      const needle = 0
+      const [result, allNodes] = await runFilter({
+        hair: { eq: needle },
       })
 
-      describe(`$lt`, () => {
-        it(`handles lt operator with number`, async () => {
-          const needle = 1
-          const [result, allNodes] = await runFastFilter({
-            hair: { lt: needle },
-          })
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.hair === needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.hair).toEqual(needle))
+    })
 
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.hair < needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.hair < needle).toEqual(true))
-        })
+    it(`handles eq operator with null`, async () => {
+      const needle = null // note: this should find nodes with null OR undefined (apparently)
+      const [result, allNodes] = await runFilter({
+        nil: { eq: needle },
+      })
 
-        async function confirmPosition(allNodes, needle) {
-          const result = await runQuery(
-            { filter: { exh: { lt: needle } } },
-            createFiltersCache(),
-            allNodes
-          )
+      // Also returns nodes that do not have the property at all (NULL in db)
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.nil == needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.nil == null).toEqual(true))
+    })
 
-          // Just check whether the reported count is equal to the actual count
-          // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
-          expect(result?.length ?? 0).toEqual(
-            allNodes.filter(node => node.exh < needle).length
-          )
-          if (result) result.forEach(node => expect(node.exh < needle))
-        }
+    // grapqhl would never pass on `undefined`
+    // it(`handles eq operator with undefined`, async () => {
+    //   const [result, allNodes] = await runFastFilter{ undef: { eq: undefined } })
+    //
+    //   expect(result.length).toEqual(?)
+    //   expect(result[0].hair).toEqual(?)
+    // })
 
-        ;[`uneven`, `even`].forEach(count => {
-          describe(`positional checks for count=` + count, () => {
-            for (let i = 0; i <= 5; i += 0.5) {
-              it(
-                `should be able to lt anywhere in an array i=` + i.toFixed(1),
-                async () => {
-                  // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
-                  // This checks the ordered search, to check before, on every, between, and after each position in the list
-                  await confirmPosition(
-                    count === `even` ? makeNodesEven() : makeNodesUneven(),
-                    i
-                  )
-                }
+    it(`handles eq operator with serialized array value`, async () => {
+      const needle = `[5,6,7,8]`
+      const [result, allNodes] = await runFilter({
+        strArray: { eq: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.strArray === needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.strArray).toEqual(needle))
+    })
+
+    it(`finds numbers inside arrays`, async () => {
+      const needle = 3
+      const [result, allNodes] = await runFilter({
+        anArray: { eq: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.anArray?.includes(needle)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(node.anArray?.includes(needle)).toEqual(true)
+      )
+    })
+
+    it(`finds numbers inside single-element arrays`, async () => {
+      const needle = 8
+      const [result, allNodes] = await runFilter({
+        singleArray: { eq: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.singleArray?.includes(needle)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(node.singleArray?.includes(needle)).toEqual(true)
+      )
+    })
+
+    it(`does not coerce numbers against single-element arrays`, async () => {
+      const needle = `8` // note: `('8' == [8]) === true`
+      const [result] = await runFilter({
+        singleArray: { eq: needle },
+      })
+
+      // Note: no coercion, so [8]=='8' is true but Sift ignores those
+      expect(result).toEqual(null)
+    })
+  })
+
+  describe(`$ne`, () => {
+    it(`handles ne operator`, async () => {
+      const needle = 2
+      const [result, allNodes] = await runFilter({
+        hair: { ne: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.hair !== needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.hair).not.toEqual(needle))
+    })
+
+    it(`coerces number to string`, async () => {
+      const needle = 2 // Note: `id` is a numstr
+      const [result, allNodes] = await runFilter({
+        id: { ne: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.id !== needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.id).not.toEqual(needle))
+    })
+
+    // This test causes a stack overflow right now
+    it.skip(`dpes not coerce string to number`, async () => {
+      const needle = `2` // Note: `id` is a numstr
+      const [result] = await runFilter({ id: { hair: needle } })
+
+      // Slow filter because it's an empty result
+      expect(result).toEqual(null)
+    })
+
+    it(`handles ne operator with true`, async () => {
+      const needle = true
+      const [result, allNodes] = await runFilter({
+        boolean: { ne: true },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.boolean !== needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.boolean).not.toEqual(needle))
+    })
+
+    describe(`exhaustive checks for null and partial paths`, () => {
+      // This group of tests exhausitvely checks what happens when you $ne on path a.b.c=value a node that
+      // has a partial path, either ending in null or undefined prematurely, for all partials of the path.
+
+      it(`should deal with eq null`, async () => {
+        const needle = null
+        const allNodes = makeNodesNeNull()
+        const result = await runQuery(
+          { filter: { a: { b: { c: { ne: needle } } } } },
+          allNodes
+        )
+
+        // Sift only returns id=6,7, where a.b.c===true/false.
+
+        expect(result?.length).toEqual(
+          allNodes.filter(node => !(node?.a?.b?.c == null)).length
+        )
+        expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+        result.forEach(node => expect(node?.a?.b?.c).not.toEqual(needle))
+      })
+
+      it(`should deal with eq true`, async () => {
+        const needle = true
+        const allNodes = makeNodesNeNull()
+        const result = await runQuery(
+          { filter: { a: { b: { c: { ne: needle } } } } },
+          allNodes
+        )
+
+        // Note: Sift only omits id=6, where a.b.c===true (contrary to searching for null)
+
+        expect(result?.length).toEqual(
+          allNodes.filter(node => node?.a?.b?.c !== needle).length
+        )
+        expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+        result.forEach(node => expect(node?.a?.b?.c).not.toEqual(needle))
+      })
+
+      it(`should deal with eq false`, async () => {
+        const needle = false
+        const allNodes = makeNodesNeNull()
+        const result = await runQuery(
+          { filter: { a: { b: { c: { ne: needle } } } } },
+          allNodes
+        )
+
+        // Note: Sift only omits id=7, where a.b.c===false (contrary to searching for null)
+
+        expect(result?.length).toEqual(
+          allNodes.filter(node => node?.a?.b?.c !== needle).length
+        )
+        expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+        result.forEach(node => expect(node?.a?.b?.c).not.toEqual(needle))
+      })
+    })
+
+    it(`handles nested ne operator with true`, async () => {
+      const needle = true
+      const [result, allNodes] = await runFilter({
+        waxOnly: { foo: { ne: true } },
+      })
+
+      // Note: one node has this, one node has waxOnly=null, one node does not have the waxOnly property at all.
+      // Redux seems to return only the node that doesn't have the property at all (node.id=0)
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.waxOnly?.foo !== needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.waxOnly?.foo).not.toEqual(needle))
+    })
+
+    it(`handles ne operator with 0`, async () => {
+      const needle = 0
+      const [result, allNodes] = await runFilter({
+        hair: { ne: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.hair !== needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.hair).not.toEqual(needle))
+    })
+
+    it(`handles ne operator with null`, async () => {
+      const needle = 0
+      const [result, allNodes] = await runFilter({
+        nil: { ne: needle },
+      })
+
+      // Should only return nodes who do have the property, not set to null
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.nil !== needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.nil).not.toEqual(needle))
+    })
+
+    // grapqhl would never pass on `undefined`
+    // it(`handles ne operator with undefined`, async () => {
+    //   const [result, allNodes] = await runFastFilter({ undef: { ne: undefined } })
+    //
+    //   expect(result.length).toEqual(?)
+    //   expect(result?.length).toEqual(allNodes.filter(node => node.nil !== needle).length)
+    //   expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+    //   result.forEach(node => expect(node.nil).not.toEqual(needle))
+    // })
+
+    it(`handles deeply nested ne: true operator`, async () => {
+      const needle = true
+      const [result, allNodes] = await runFilter({
+        waxOnly: { bar: { baz: { ne: needle } } },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.waxOnly?.bar?.baz !== needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.waxOnly?.bar?.baz).not.toEqual(needle))
+    })
+
+    it(`handles the ne operator for array field values`, async () => {
+      const needle = 1
+      const [result, allNodes] = await runFilter({
+        anArray: { ne: needle },
+      })
+
+      // Sift returns only the node that doesn't have the property at all (the other two arrays contain 1)
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => !node.anArray?.includes(needle)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(node.anArray?.includes(needle)).not.toEqual(true)
+      )
+    })
+  })
+
+  describe(`$lt`, () => {
+    it(`handles lt operator with number`, async () => {
+      const needle = 1
+      const [result, allNodes] = await runFilter({
+        hair: { lt: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.hair < needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.hair < needle).toEqual(true))
+    })
+
+    async function confirmPosition(allNodes, needle) {
+      const result = await runQuery(
+        { filter: { exh: { lt: needle } } },
+        allNodes
+      )
+
+      // Just check whether the reported count is equal to the actual count
+      // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
+      expect(result?.length ?? 0).toEqual(
+        allNodes.filter(node => node.exh < needle).length
+      )
+      if (result) result.forEach(node => expect(node.exh < needle))
+    }
+
+    ;[`uneven`, `even`].forEach(count => {
+      describe(`positional checks for count=` + count, () => {
+        for (let i = 0; i <= 5; i += 0.5) {
+          it(
+            `should be able to lt anywhere in an array i=` + i.toFixed(1),
+            async () => {
+              // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
+              // This checks the ordered search, to check before, on every, between, and after each position in the list
+              await confirmPosition(
+                count === `even` ? makeNodesEven() : makeNodesUneven(),
+                i
               )
             }
-
-            // Note: needle property ranges from 1 to 99 or 100. Needles should not exist, otherwise binary search
-            // is skipped entirely. This test is trying to verify the op when the needle misses with ~100 nodes.
-            for (const needle of [
-              0,
-              1.5,
-              33.5,
-              49.5,
-              50.5,
-              66.5,
-              98.5,
-              99.5,
-              100.5,
-            ]) {
-              it(`should pivot upward when needle does not exist, needle=${needle}`, async () => {
-                // This caught a bug in the binary search algo which was incorrectly generating the next pivot index.
-                await confirmPosition(make100Nodes(count === `even`), needle)
-              })
-            }
-          })
-        })
-
-        // Note: this test currently stackoverflows
-        it.skip(`should lt when type coercion fails direct value lookup`, async () => {
-          // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
-          // This test checks whether we don't incorrectly assume that if the
-          // value wasn't mapped, that it can't be found.
-          const needle = `1.5`
-          const [result, allNodes] = await runFastFilter({
-            float: { lt: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.float < needle).length
           )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.float < needle).toEqual(true))
-        })
-
-        it(`handles lt operator with null`, async () => {
-          const needle = null
-          // Note: Slow filter because it returns an empty result
-          const [result, allNodes] = await runFastFilter({
-            nil: { lt: needle },
-          })
-
-          // Nothing is lt null so zero nodes should match
-          // (Note: this is different from `lte`, which does return nulls here!)
-          expect(result).toEqual(null)
-          expect(
-            allNodes.filter(node => node.nil === needle).length
-          ).toBeGreaterThan(0) // They should _exist_...
-        })
-      })
-
-      describe(`$lte`, () => {
-        it(`handles lte operator with number`, async () => {
-          const needle = 1
-          const [result, allNodes] = await runFastFilter({
-            hair: { lte: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.hair <= needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.hair <= needle).toEqual(true))
-        })
-
-        async function confirmPosition(allNodes, needle) {
-          const result = await runQuery(
-            { filter: { exh: { lte: needle } } },
-            createFiltersCache(),
-            allNodes
-          )
-
-          // Just check whether the reported count is equal to the actual count
-          // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
-          expect(result?.length ?? 0).toEqual(
-            allNodes.filter(node => node.exh <= needle).length
-          )
-          if (result) result.forEach(node => expect(node.exh <= needle))
         }
 
-        ;[`uneven`, `even`].forEach(count => {
-          describe(`positional checks for count=` + count, () => {
-            for (let i = 0; i <= 5; i += 0.5) {
-              it(
-                `should be able to lte anywhere in an array i=` + i.toFixed(1),
-                async () => {
-                  // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
-                  // This checks the ordered search, to check before, on every, between, and after each position in the list
-                  await confirmPosition(
-                    count === `even` ? makeNodesEven() : makeNodesUneven(),
-                    i
-                  )
-                }
-              )
-            }
-
-            // Note: needle property ranges from 1 to 99 or 100. Needles should not exist, otherwise binary search
-            // is skipped entirely. This test is trying to verify the op when the needle misses with ~100 nodes.
-            for (const needle of [
-              0,
-              1.5,
-              33.5,
-              49.5,
-              50.5,
-              66.5,
-              98.5,
-              99.5,
-              100.5,
-            ]) {
-              it(`should pivot upward when needle does not exist, needle=${needle}`, async () => {
-                // This caught a bug in the binary search algo which was incorrectly generating the next pivot index.
-                await confirmPosition(make100Nodes(count === `even`), needle)
-              })
-            }
+        // Note: needle property ranges from 1 to 99 or 100. Needles should not exist, otherwise binary search
+        // is skipped entirely. This test is trying to verify the op when the needle misses with ~100 nodes.
+        for (const needle of [
+          0,
+          1.5,
+          33.5,
+          49.5,
+          50.5,
+          66.5,
+          98.5,
+          99.5,
+          100.5,
+        ]) {
+          it(`should pivot upward when needle does not exist, needle=${needle}`, async () => {
+            // This caught a bug in the binary search algo which was incorrectly generating the next pivot index.
+            await confirmPosition(make100Nodes(count === `even`), needle)
           })
-        })
+        }
+      })
+    })
 
-        // Note: this test currently stackoverflows
-        it.skip(`should lte when type coercion fails direct value lookup`, async () => {
-          // Here 1.5 exists but only as number. However, `1.5 <= '1.5' === true`
-          // This test checks whether we don't incorrectly assume that if the
-          // value wasn't mapped, that it can't be found.
-          const needle = `1.5`
-          const [result, allNodes] = await runFastFilter({
-            float: { lte: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.float <= needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.float <= needle).toEqual(true))
-        })
-
-        it(`handles lte operator with null`, async () => {
-          const needle = null
-          const [result, allNodes] = await runFastFilter({
-            nil: { lte: needle },
-          })
-
-          // lte null matches null but no nodes without the property (NULL)
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.nil === needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil === needle).toEqual(true))
-        })
+    // Note: this test currently stackoverflows
+    it.skip(`should lt when type coercion fails direct value lookup`, async () => {
+      // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
+      // This test checks whether we don't incorrectly assume that if the
+      // value wasn't mapped, that it can't be found.
+      const needle = `1.5`
+      const [result, allNodes] = await runFilter({
+        float: { lt: needle },
       })
 
-      describe(`$gt`, () => {
-        it(`handles gt operator with number`, async () => {
-          const needle = 1
-          const [result, allNodes] = await runFastFilter({
-            hair: { gt: needle },
-          })
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.float < needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.float < needle).toEqual(true))
+    })
 
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.hair > needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.hair > needle).toEqual(true))
-        })
+    it(`handles lt operator with null`, async () => {
+      const needle = null
+      // Note: Slow filter because it returns an empty result
+      const [result, allNodes] = await runFilter({
+        nil: { lt: needle },
+      })
 
-        async function confirmPosition(allNodes, needle) {
-          const result = await runQuery(
-            { filter: { exh: { gt: needle } } },
-            createFiltersCache(),
-            allNodes
-          )
+      // Nothing is lt null so zero nodes should match
+      // (Note: this is different from `lte`, which does return nulls here!)
+      expect(result).toEqual(null)
+      expect(
+        allNodes.filter(node => node.nil === needle).length
+      ).toBeGreaterThan(0) // They should _exist_...
+    })
+  })
 
-          // Just check whether the reported count is equal to the actual count
-          // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
-          expect(result?.length ?? 0).toEqual(
-            allNodes.filter(node => node.exh > needle).length
+  describe(`$lte`, () => {
+    it(`handles lte operator with number`, async () => {
+      const needle = 1
+      const [result, allNodes] = await runFilter({
+        hair: { lte: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.hair <= needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.hair <= needle).toEqual(true))
+    })
+
+    async function confirmPosition(allNodes, needle) {
+      const result = await runQuery(
+        { filter: { exh: { lte: needle } } },
+        allNodes
+      )
+
+      // Just check whether the reported count is equal to the actual count
+      // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
+      expect(result?.length ?? 0).toEqual(
+        allNodes.filter(node => node.exh <= needle).length
+      )
+      if (result) result.forEach(node => expect(node.exh <= needle))
+    }
+
+    ;[`uneven`, `even`].forEach(count => {
+      describe(`positional checks for count=` + count, () => {
+        for (let i = 0; i <= 5; i += 0.5) {
+          it(
+            `should be able to lte anywhere in an array i=` + i.toFixed(1),
+            async () => {
+              // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
+              // This checks the ordered search, to check before, on every, between, and after each position in the list
+              await confirmPosition(
+                count === `even` ? makeNodesEven() : makeNodesUneven(),
+                i
+              )
+            }
           )
-          if (result) result.forEach(node => expect(node.exh > needle))
         }
 
-        ;[`uneven`, `even`].forEach(count => {
-          describe(`positional checks for count=` + count, () => {
-            for (let i = 0; i <= 5; i += 0.5) {
-              it(
-                `should be able to gt anywhere in an array i=` + i.toFixed(1),
-                async () => {
-                  // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
-                  // This checks the ordered search, to check before, on every, between, and after each position in the list
-                  await confirmPosition(
-                    count === `even` ? makeNodesEven() : makeNodesUneven(),
-                    i
-                  )
-                }
-              )
-            }
-
-            // Note: needle property ranges from 1 to 99 or 100. Needles should not exist, otherwise binary search
-            // is skipped entirely. This test is trying to verify the op when the needle misses with ~100 nodes.
-            for (const needle of [
-              0,
-              1.5,
-              33.5,
-              49.5,
-              50.5,
-              66.5,
-              98.5,
-              99.5,
-              100.5,
-            ]) {
-              it(`should pivot upward when needle does not exist, needle=${needle}`, async () => {
-                // This caught a bug in the binary search algo which was incorrectly generating the next pivot index.
-                await confirmPosition(make100Nodes(count === `even`), needle)
-              })
-            }
+        // Note: needle property ranges from 1 to 99 or 100. Needles should not exist, otherwise binary search
+        // is skipped entirely. This test is trying to verify the op when the needle misses with ~100 nodes.
+        for (const needle of [
+          0,
+          1.5,
+          33.5,
+          49.5,
+          50.5,
+          66.5,
+          98.5,
+          99.5,
+          100.5,
+        ]) {
+          it(`should pivot upward when needle does not exist, needle=${needle}`, async () => {
+            // This caught a bug in the binary search algo which was incorrectly generating the next pivot index.
+            await confirmPosition(make100Nodes(count === `even`), needle)
           })
-        })
+        }
+      })
+    })
 
-        // Note: this test currently stackoverflows
-        it.skip(`should gt when type coercion fails direct value lookup`, async () => {
-          // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
-          // This test checks whether we don't incorrectly assume that if the
-          // value wasn't mapped, that it can't be found.
-          const needle = `1.5`
-          const [result, allNodes] = await runFastFilter({
-            float: { gt: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.float > needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.float > needle).toEqual(true))
-        })
-
-        it(`handles gt operator with null`, async () => {
-          const needle = null
-          // Note: Slow filter because it returns an empty result
-          const [result, allNodes] = await runFastFilter({
-            nil: { gt: needle },
-          })
-
-          // Nothing is gt null so zero nodes should match
-          // (Note: this is different from `gte`, which does return nulls here!)
-          expect(result).toEqual(null)
-          expect(
-            allNodes.filter(node => node.nil === needle).length
-          ).toBeGreaterThan(0) // They should _exist_...
-        })
+    // Note: this test currently stackoverflows
+    it.skip(`should lte when type coercion fails direct value lookup`, async () => {
+      // Here 1.5 exists but only as number. However, `1.5 <= '1.5' === true`
+      // This test checks whether we don't incorrectly assume that if the
+      // value wasn't mapped, that it can't be found.
+      const needle = `1.5`
+      const [result, allNodes] = await runFilter({
+        float: { lte: needle },
       })
 
-      describe(`$gte`, () => {
-        it(`handles gte operator with number`, async () => {
-          const needle = 1
-          const [result, allNodes] = await runFastFilter({
-            hair: { gte: needle },
-          })
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.float <= needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.float <= needle).toEqual(true))
+    })
 
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.hair >= needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.hair >= needle).toEqual(true))
-        })
+    it(`handles lte operator with null`, async () => {
+      const needle = null
+      const [result, allNodes] = await runFilter({
+        nil: { lte: needle },
+      })
 
-        async function confirmPosition(allNodes, needle) {
-          const result = await runQuery(
-            { filter: { exh: { gte: needle } } },
-            createFiltersCache(),
-            allNodes
-          )
+      // lte null matches null but no nodes without the property (NULL)
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.nil === needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.nil === needle).toEqual(true))
+    })
+  })
 
-          // Just check whether the reported count is equal to the actual count
-          // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
-          expect(result?.length ?? 0).toEqual(
-            allNodes.filter(node => node.exh >= needle).length
+  describe(`$gt`, () => {
+    it(`handles gt operator with number`, async () => {
+      const needle = 1
+      const [result, allNodes] = await runFilter({
+        hair: { gt: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.hair > needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.hair > needle).toEqual(true))
+    })
+
+    async function confirmPosition(allNodes, needle) {
+      const result = await runQuery(
+        { filter: { exh: { gt: needle } } },
+        allNodes
+      )
+
+      // Just check whether the reported count is equal to the actual count
+      // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
+      expect(result?.length ?? 0).toEqual(
+        allNodes.filter(node => node.exh > needle).length
+      )
+      if (result) result.forEach(node => expect(node.exh > needle))
+    }
+
+    ;[`uneven`, `even`].forEach(count => {
+      describe(`positional checks for count=` + count, () => {
+        for (let i = 0; i <= 5; i += 0.5) {
+          it(
+            `should be able to gt anywhere in an array i=` + i.toFixed(1),
+            async () => {
+              // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
+              // This checks the ordered search, to check before, on every, between, and after each position in the list
+              await confirmPosition(
+                count === `even` ? makeNodesEven() : makeNodesUneven(),
+                i
+              )
+            }
           )
-          if (result) result.forEach(node => expect(node.exh >= needle))
         }
 
-        ;[`uneven`, `even`].forEach(count => {
-          describe(`positional checks for count=` + count, () => {
-            for (let i = 0; i <= 5; i += 0.5) {
-              it(
-                `should be able to gte anywhere in an array i=` + i.toFixed(1),
-                async () => {
-                  // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
-                  // This checks the ordered search, to check before, on every, between, and after each position in the list
-                  await confirmPosition(
-                    count === `even` ? makeNodesEven() : makeNodesUneven(),
-                    i
-                  )
-                }
+        // Note: needle property ranges from 1 to 99 or 100. Needles should not exist, otherwise binary search
+        // is skipped entirely. This test is trying to verify the op when the needle misses with ~100 nodes.
+        for (const needle of [
+          0,
+          1.5,
+          33.5,
+          49.5,
+          50.5,
+          66.5,
+          98.5,
+          99.5,
+          100.5,
+        ]) {
+          it(`should pivot upward when needle does not exist, needle=${needle}`, async () => {
+            // This caught a bug in the binary search algo which was incorrectly generating the next pivot index.
+            await confirmPosition(make100Nodes(count === `even`), needle)
+          })
+        }
+      })
+    })
+
+    // Note: this test currently stackoverflows
+    it.skip(`should gt when type coercion fails direct value lookup`, async () => {
+      // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
+      // This test checks whether we don't incorrectly assume that if the
+      // value wasn't mapped, that it can't be found.
+      const needle = `1.5`
+      const [result, allNodes] = await runFilter({
+        float: { gt: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.float > needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.float > needle).toEqual(true))
+    })
+
+    it(`handles gt operator with null`, async () => {
+      const needle = null
+      // Note: Slow filter because it returns an empty result
+      const [result, allNodes] = await runFilter({
+        nil: { gt: needle },
+      })
+
+      // Nothing is gt null so zero nodes should match
+      // (Note: this is different from `gte`, which does return nulls here!)
+      expect(result).toEqual(null)
+      expect(
+        allNodes.filter(node => node.nil === needle).length
+      ).toBeGreaterThan(0) // They should _exist_...
+    })
+  })
+
+  describe(`$gte`, () => {
+    it(`handles gte operator with number`, async () => {
+      const needle = 1
+      const [result, allNodes] = await runFilter({
+        hair: { gte: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.hair >= needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.hair >= needle).toEqual(true))
+    })
+
+    async function confirmPosition(allNodes, needle) {
+      const result = await runQuery(
+        { filter: { exh: { gte: needle } } },
+        allNodes
+      )
+
+      // Just check whether the reported count is equal to the actual count
+      // We prepend the "hint" to make debugging easier; this way you know whether it's even/uneven and needle
+      expect(result?.length ?? 0).toEqual(
+        allNodes.filter(node => node.exh >= needle).length
+      )
+      if (result) result.forEach(node => expect(node.exh >= needle))
+    }
+
+    ;[`uneven`, `even`].forEach(count => {
+      describe(`positional checks for count=` + count, () => {
+        for (let i = 0; i <= 5; i += 0.5) {
+          it(
+            `should be able to gte anywhere in an array i=` + i.toFixed(1),
+            async () => {
+              // Test op on all positions in an even/uneven ordered node list. `exh` will only be 1,2,3,4 or 1,2,3
+              // This checks the ordered search, to check before, on every, between, and after each position in the list
+              await confirmPosition(
+                count === `even` ? makeNodesEven() : makeNodesUneven(),
+                i
               )
             }
-
-            // Note: needle property ranges from 1 to 99 or 100. Needles should not exist, otherwise binary search
-            // is skipped entirely. This test is trying to verify the op when the needle misses with ~100 nodes.
-            for (const needle of [
-              0,
-              1.5,
-              33.5,
-              49.5,
-              50.5,
-              66.5,
-              98.5,
-              99.5,
-              100.5,
-            ]) {
-              it(`should pivot upward when needle does not exist, needle=${needle}`, async () => {
-                // This caught a bug in the binary search algo which was incorrectly generating the next pivot index.
-                await confirmPosition(make100Nodes(count === `even`), needle)
-              })
-            }
-          })
-        })
-
-        // Note: this test currently stackoverflows
-        it.skip(`should gte when type coercion fails direct value lookup`, async () => {
-          // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
-          // This test checks whether we don't incorrectly assume that if the
-          // value wasn't mapped, that it can't be found.
-          const needle = `1.5`
-          const [result, allNodes] = await runFastFilter({
-            float: { gte: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.float >= needle).length
           )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.float >= needle).toEqual(true))
-        })
+        }
 
-        it(`handles gte operator with null`, async () => {
-          const needle = null
-          const [result, allNodes] = await runFastFilter({
-            nil: { gte: needle },
+        // Note: needle property ranges from 1 to 99 or 100. Needles should not exist, otherwise binary search
+        // is skipped entirely. This test is trying to verify the op when the needle misses with ~100 nodes.
+        for (const needle of [
+          0,
+          1.5,
+          33.5,
+          49.5,
+          50.5,
+          66.5,
+          98.5,
+          99.5,
+          100.5,
+        ]) {
+          it(`should pivot upward when needle does not exist, needle=${needle}`, async () => {
+            // This caught a bug in the binary search algo which was incorrectly generating the next pivot index.
+            await confirmPosition(make100Nodes(count === `even`), needle)
           })
+        }
+      })
+    })
 
-          // gte null matches null but no nodes without the property (NULL)
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.nil === needle).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.nil === needle).toEqual(true))
-        })
+    // Note: this test currently stackoverflows
+    it.skip(`should gte when type coercion fails direct value lookup`, async () => {
+      // Here 1.5 exists but only as number. However, `1.5 < '1.5' === true`
+      // This test checks whether we don't incorrectly assume that if the
+      // value wasn't mapped, that it can't be found.
+      const needle = `1.5`
+      const [result, allNodes] = await runFilter({
+        float: { gte: needle },
       })
 
-      describe(`$regex`, () => {
-        it(`handles the regex operator without flags`, async () => {
-          const needleStr = `/^The.*Wax/`
-          const needleRex = /^The.*Wax/
-          const [result, allNodes] = await runFastFilter({
-            name: { regex: needleStr },
-          })
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.float >= needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.float >= needle).toEqual(true))
+    })
 
-          expect(result?.length).toEqual(
-            allNodes.filter(node => needleRex.test(node.name)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(needleRex.test(node.name)).toEqual(true)
-          )
-        })
-
-        it(`handles the regex operator with i-flag`, async () => {
-          // Note: needle is different from checked because `new RegExp('/a/i')` does _not_ work
-          const needleRex = /^the.*wax/i
-          const needleStr = `/^the.*wax/i`
-          const [result, allNodes] = await runFastFilter({
-            name: { regex: needleStr },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => needleRex.test(node.name)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(needleRex.test(node.name)).toEqual(true)
-          )
-        })
-
-        it(`rejects strings without forward slashes`, async () => {
-          await expect(
-            runFastFilter({
-              name: { regex: `^The.*Wax` },
-            })
-          ).rejects.toThrow()
-        })
-
-        it(`rejects strings without trailing slash`, async () => {
-          await expect(
-            runFastFilter({
-              name: { regex: `/^The.*Wax` },
-            })
-          ).rejects.toThrow()
-        })
-
-        it(`accepts strings without leading slash`, async () => {
-          // If this test starts failing, that might be okay and it should be dropped.
-          // At the time of writing it, this was a status quo edge case for Sift
-
-          // Passes because the requirement is mostly about a .split() failing
-          // for the other fail cases. As long as it passes a regex ultimately
-          // we don't really have to care / validate.
-
-          const needleRex = /(?:)/i // This was what it turned into
-          const needleStr = `^the.*wax/i`
-          const [result, allNodes] = await runFastFilter({
-            name: { regex: needleStr },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => needleRex.test(node.name)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(needleRex.test(node.name)).toEqual(true)
-          )
-        })
-
-        it(`rejects actual regex`, async () => {
-          await expect(
-            runFastFilter({
-              name: { regex: /^The.*Wax/ },
-            })
-          ).rejects.toThrow()
-        })
-
-        it(`handles the nested regex operator and ignores partial paths`, async () => {
-          const needleStr = `/.*/`
-          const needleRex = /.*/
-          const [result, allNodes] = await runFastFilter({
-            nestedRegex: { field: { regex: needleStr } },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(
-              node =>
-                node.nestedRegex !== undefined &&
-                node.nestedRegex.field !== undefined &&
-                needleRex.test(node.nestedRegex.field)
-            ).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(
-              node.nestedRegex === undefined ||
-                needleRex.test(node.nestedRegex.field)
-            ).toEqual(true)
-          )
-        })
-
-        it(`does not match double quote for string without it`, async () => {
-          const [result, allNodes] = await runFastFilter({
-            name: { regex: `/"/` },
-          })
-
-          expect(result).toEqual(null)
-          expect(allNodes.filter(node => node.name === `"`).length).toEqual(0)
-        })
+    it(`handles gte operator with null`, async () => {
+      const needle = null
+      const [result, allNodes] = await runFilter({
+        nil: { gte: needle },
       })
 
-      describe(`$in`, () => {
-        it(`handles the in operator for strings`, async () => {
-          const needle = [`b`, `c`]
-          const [result, allNodes] = await runFastFilter({
-            string: { in: needle },
-          })
+      // gte null matches null but no nodes without the property (NULL)
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.nil === needle).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.nil === needle).toEqual(true))
+    })
+  })
 
-          expect(result?.length).toEqual(
-            allNodes.filter(node => needle.includes(node.string)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(needle.includes(node.string)).toEqual(true)
-          )
-        })
-
-        it(`handles the in operator for ints`, async () => {
-          const needle = [0, 2]
-          const [result, allNodes] = await runFastFilter({
-            index: { in: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => needle.includes(node.index)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(needle.includes(node.index)).toEqual(true)
-          )
-        })
-
-        it(`handles the in operator for floats`, async () => {
-          const needle = [1.5, 2.5]
-          const [result, allNodes] = await runFastFilter({
-            float: { in: needle },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => needle.includes(node.float)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(needle.includes(node.float)).toEqual(true)
-          )
-        })
-
-        it(`handles the in operator for just null`, async () => {
-          const [result, allNodes] = await runFastFilter({
-            nil: { in: [null] },
-          })
-
-          // May not have the property, or must be null
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.nil === undefined || node.nil === null)
-              .length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(node.nil === undefined || node.nil === null).toEqual(true)
-          )
-        })
-
-        it(`handles the in operator for double null`, async () => {
-          const [result, allNodes] = await runFastFilter({
-            nil: { in: [null, null] },
-          })
-
-          // May not have the property, or must be null
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.nil === undefined || node.nil === null)
-              .length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(node.nil === undefined || node.nil === null).toEqual(true)
-          )
-        })
-
-        it(`handles the in operator for null in int and null`, async () => {
-          const [result, allNodes] = await runFastFilter({
-            nil: { in: [5, null] },
-          })
-
-          // Include the nodes without a `nil` property
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.nil === undefined || node.nil === null)
-              .length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(node.nil === undefined || node.nil === null).toEqual(true)
-          )
-        })
-
-        it(`handles the in operator for int in int and null`, async () => {
-          const [result, allNodes] = await runFastFilter({
-            index: { in: [2, null] },
-          })
-
-          // Include the nodes without a `index` property (there aren't any)
-          expect(result?.length).toEqual(
-            allNodes.filter(
-              node =>
-                node.index === undefined ||
-                node.index === null ||
-                node.index === 2
-            ).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(
-              node.index === undefined ||
-                node.index === null ||
-                node.index === 2
-            ).toEqual(true)
-          )
-        })
-
-        it(`handles the in operator for booleans`, async () => {
-          const [result, allNodes] = await runFastFilter({
-            boolean: { in: [true] },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.boolean === true).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node => expect(node.boolean === true).toEqual(true))
-        })
-
-        it(`handles the in operator for array with one element`, async () => {
-          // Note: `node.anArray` doesn't exist or it's an array of multiple numbers
-          const [result, allNodes] = await runFastFilter({
-            anArray: { in: [5] },
-          })
-
-          // The first one has a 5, the second one does not have a 5, the third does
-          // not have the property at all (NULL). It should return the first and last.
-          // (If the target value has `null` then the third should be omitted)
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.anArray?.includes(5)).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(node.anArray?.includes(5)).toEqual(true)
-          )
-        })
-
-        it(`handles the in operator for array some elements`, async () => {
-          // Note: `node.anArray` doesn't exist or it's an array of multiple numbers
-          const needle = [20, 5, 300]
-          const [result, allNodes] = await runFastFilter({
-            anArray: { in: needle },
-          })
-
-          // Same as the test for just `[5]`. 20 and 300 do not appear anywhere.
-          expect(result?.length).toEqual(
-            allNodes.filter(node => node.anArray?.some(n => needle.includes(n)))
-              .length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(
-              node.anArray && needle.some(n => node.anArray.includes(n))
-            ).toEqual(true)
-          )
-        })
-
-        it(`handles the nested in operator for array of strings`, async () => {
-          const needle = [`moo`]
-          const [result, allNodes] = await runFastFilter({
-            frontmatter: { tags: { in: needle } },
-          })
-
-          expect(result?.length).toEqual(
-            allNodes.filter(node =>
-              node.frontmatter.tags?.some(n => needle.includes(n))
-            ).length
-          )
-          expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
-          result.forEach(node =>
-            expect(
-              node.frontmatter?.tags &&
-                needle.some(n => node.frontmatter.tags.includes(n))
-            ).toEqual(true)
-          )
-        })
-
-        it(`refuses a non-arg number argument`, async () => {
-          await expect(
-            runFastFilter({
-              hair: { in: 2 },
-            })
-          ).rejects.toThrow()
-        })
-
-        // I'm convinced this only works in Sift because of a fluke
-        it.skip(`refuses a non-arg string argument`, async () => {
-          await expect(
-            runFastFilter({
-              name: { in: `The Mad Max` },
-            })
-          ).rejects.toThrow()
-        })
-
-        it(`refuses a non-arg boolean argument`, async () => {
-          await expect(
-            runFastFilter({
-              boolean: { in: true },
-            })
-          ).rejects.toThrow()
-        })
+  describe(`$regex`, () => {
+    it(`handles the regex operator without flags`, async () => {
+      const needleStr = `/^The.*Wax/`
+      const needleRex = /^The.*Wax/
+      const [result, allNodes] = await runFilter({
+        name: { regex: needleStr },
       })
 
-      describe(`$elemMatch`, () => {
-        it(`handles the elemMatch operator on a proper single tree`, async () => {
-          const [result] = await runFastFilter({
-            singleElem: {
-              things: {
-                elemMatch: {
-                  one: {
-                    two: {
-                      three: { eq: 123 },
-                    },
-                  },
-                },
-              },
-            },
-          })
+      expect(result?.length).toEqual(
+        allNodes.filter(node => needleRex.test(node.name)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(needleRex.test(node.name)).toEqual(true))
+    })
 
-          expect(result.length).toEqual(1)
-          expect(
-            result[0]?.singleElem?.things.some(e => e?.one?.two?.three === 123)
-          ).toEqual(true)
+    it(`handles the regex operator with i-flag`, async () => {
+      // Note: needle is different from checked because `new RegExp('/a/i')` does _not_ work
+      const needleRex = /^the.*wax/i
+      const needleStr = `/^the.*wax/i`
+      const [result, allNodes] = await runFilter({
+        name: { regex: needleStr },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => needleRex.test(node.name)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(needleRex.test(node.name)).toEqual(true))
+    })
+
+    it(`rejects strings without forward slashes`, async () => {
+      await expect(
+        runFilter({
+          name: { regex: `^The.*Wax` },
         })
+      ).rejects.toThrow()
+    })
 
-        it(`handles the elemMatch operator on the second element`, async () => {
-          const [result] = await runFastFilter({
-            singleElem: {
-              things: {
-                elemMatch: {
-                  one: {
-                    five: {
-                      three: { eq: 153 },
-                    },
-                  },
-                },
-              },
-            },
-          })
-
-          expect(result.length).toEqual(1)
-          // Should contain the entire array even only one matched
-          expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
-          expect(result[0].singleElem.things[1].one.five.three).toEqual(153)
+    it(`rejects strings without trailing slash`, async () => {
+      await expect(
+        runFilter({
+          name: { regex: `/^The.*Wax` },
         })
+      ).rejects.toThrow()
+    })
 
-        it(`should return only one node if elemMatch hits multiples`, async () => {
-          const [result] = await runFastFilter({
-            singleElem: {
-              things: {
-                elemMatch: {
-                  one: {
-                    two: {
-                      three: { lt: 1000 }, // one match is 123, the other 404
-                    },
-                  },
-                },
-              },
-            },
-          })
+    it(`accepts strings without leading slash`, async () => {
+      // If this test starts failing, that might be okay and it should be dropped.
+      // At the time of writing it, this was a status quo edge case for Sift
 
-          // The `elemMatch` operator only returns the first nodde that matches so
-          // even though the `lt 1000` would match two elements in the `things` array
-          // it will return one node.
-          expect(result.length).toEqual(1)
-          expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
-          expect(result[0].singleElem.things[2].one.two.three).toEqual(404)
+      // Passes because the requirement is mostly about a .split() failing
+      // for the other fail cases. As long as it passes a regex ultimately
+      // we don't really have to care / validate.
+
+      const needleRex = /(?:)/i // This was what it turned into
+      const needleStr = `^the.*wax/i`
+      const [result, allNodes] = await runFilter({
+        name: { regex: needleStr },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => needleRex.test(node.name)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(needleRex.test(node.name)).toEqual(true))
+    })
+
+    it(`rejects actual regex`, async () => {
+      await expect(
+        runFilter({
+          name: { regex: /^The.*Wax/ },
         })
+      ).rejects.toThrow()
+    })
 
-        it(`ignores the elemMatch operator on a partial sub tree`, async () => {
-          const [result] = await runFastFilter({
-            singleElem: {
-              things: {
-                elemMatch: {
+    it(`handles the nested regex operator and ignores partial paths`, async () => {
+      const needleStr = `/.*/`
+      const needleRex = /.*/
+      const [result, allNodes] = await runFilter({
+        nestedRegex: { field: { regex: needleStr } },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(
+          node =>
+            node.nestedRegex !== undefined &&
+            node.nestedRegex.field !== undefined &&
+            needleRex.test(node.nestedRegex.field)
+        ).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(
+          node.nestedRegex === undefined ||
+            needleRex.test(node.nestedRegex.field)
+        ).toEqual(true)
+      )
+    })
+
+    it(`does not match double quote for string without it`, async () => {
+      const [result, allNodes] = await runFilter({
+        name: { regex: `/"/` },
+      })
+
+      expect(result).toEqual(null)
+      expect(allNodes.filter(node => node.name === `"`).length).toEqual(0)
+    })
+  })
+
+  describe(`$in`, () => {
+    it(`handles the in operator for strings`, async () => {
+      const needle = [`b`, `c`]
+      const [result, allNodes] = await runFilter({
+        string: { in: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => needle.includes(node.string)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(needle.includes(node.string)).toEqual(true))
+    })
+
+    it(`handles the in operator for ints`, async () => {
+      const needle = [0, 2]
+      const [result, allNodes] = await runFilter({
+        index: { in: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => needle.includes(node.index)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(needle.includes(node.index)).toEqual(true))
+    })
+
+    it(`handles the in operator for floats`, async () => {
+      const needle = [1.5, 2.5]
+      const [result, allNodes] = await runFilter({
+        float: { in: needle },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => needle.includes(node.float)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(needle.includes(node.float)).toEqual(true))
+    })
+
+    it(`handles the in operator for just null`, async () => {
+      const [result, allNodes] = await runFilter({
+        nil: { in: [null] },
+      })
+
+      // May not have the property, or must be null
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.nil === undefined || node.nil === null)
+          .length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(node.nil === undefined || node.nil === null).toEqual(true)
+      )
+    })
+
+    it(`handles the in operator for double null`, async () => {
+      const [result, allNodes] = await runFilter({
+        nil: { in: [null, null] },
+      })
+
+      // May not have the property, or must be null
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.nil === undefined || node.nil === null)
+          .length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(node.nil === undefined || node.nil === null).toEqual(true)
+      )
+    })
+
+    it(`handles the in operator for null in int and null`, async () => {
+      const [result, allNodes] = await runFilter({
+        nil: { in: [5, null] },
+      })
+
+      // Include the nodes without a `nil` property
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.nil === undefined || node.nil === null)
+          .length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(node.nil === undefined || node.nil === null).toEqual(true)
+      )
+    })
+
+    it(`handles the in operator for int in int and null`, async () => {
+      const [result, allNodes] = await runFilter({
+        index: { in: [2, null] },
+      })
+
+      // Include the nodes without a `index` property (there aren't any)
+      expect(result?.length).toEqual(
+        allNodes.filter(
+          node =>
+            node.index === undefined || node.index === null || node.index === 2
+        ).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(
+          node.index === undefined || node.index === null || node.index === 2
+        ).toEqual(true)
+      )
+    })
+
+    it(`handles the in operator for booleans`, async () => {
+      const [result, allNodes] = await runFilter({
+        boolean: { in: [true] },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.boolean === true).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.boolean === true).toEqual(true))
+    })
+
+    it(`handles the in operator for array with one element`, async () => {
+      // Note: `node.anArray` doesn't exist or it's an array of multiple numbers
+      const [result, allNodes] = await runFilter({
+        anArray: { in: [5] },
+      })
+
+      // The first one has a 5, the second one does not have a 5, the third does
+      // not have the property at all (NULL). It should return the first and last.
+      // (If the target value has `null` then the third should be omitted)
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.anArray?.includes(5)).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node => expect(node.anArray?.includes(5)).toEqual(true))
+    })
+
+    it(`handles the in operator for array some elements`, async () => {
+      // Note: `node.anArray` doesn't exist or it's an array of multiple numbers
+      const needle = [20, 5, 300]
+      const [result, allNodes] = await runFilter({
+        anArray: { in: needle },
+      })
+
+      // Same as the test for just `[5]`. 20 and 300 do not appear anywhere.
+      expect(result?.length).toEqual(
+        allNodes.filter(node => node.anArray?.some(n => needle.includes(n)))
+          .length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(
+          node.anArray && needle.some(n => node.anArray.includes(n))
+        ).toEqual(true)
+      )
+    })
+
+    it(`handles the nested in operator for array of strings`, async () => {
+      const needle = [`moo`]
+      const [result, allNodes] = await runFilter({
+        frontmatter: { tags: { in: needle } },
+      })
+
+      expect(result?.length).toEqual(
+        allNodes.filter(node =>
+          node.frontmatter.tags?.some(n => needle.includes(n))
+        ).length
+      )
+      expect(result?.length).toBeGreaterThan(0) // Make sure there _are_ results, don't let this be zero
+      result.forEach(node =>
+        expect(
+          node.frontmatter?.tags &&
+            needle.some(n => node.frontmatter.tags.includes(n))
+        ).toEqual(true)
+      )
+    })
+
+    it(`refuses a non-arg number argument`, async () => {
+      await expect(
+        runFilter({
+          hair: { in: 2 },
+        })
+      ).rejects.toThrow()
+    })
+
+    // I'm convinced this only works in Sift because of a fluke
+    it.skip(`refuses a non-arg string argument`, async () => {
+      await expect(
+        runFilter({
+          name: { in: `The Mad Max` },
+        })
+      ).rejects.toThrow()
+    })
+
+    it(`refuses a non-arg boolean argument`, async () => {
+      await expect(
+        runFilter({
+          boolean: { in: true },
+        })
+      ).rejects.toThrow()
+    })
+  })
+
+  describe(`$elemMatch`, () => {
+    it(`handles the elemMatch operator on a proper single tree`, async () => {
+      const [result] = await runFilter({
+        singleElem: {
+          things: {
+            elemMatch: {
+              one: {
+                two: {
                   three: { eq: 123 },
                 },
               },
             },
-          })
+          },
+        },
+      })
 
-          expect(result).toEqual(null)
-        })
+      expect(result.length).toEqual(1)
+      expect(
+        result[0]?.singleElem?.things.some(e => e?.one?.two?.three === 123)
+      ).toEqual(true)
+    })
 
-        it(`handles the elemMatch operator for array of objects (1)`, async () => {
-          const [result] = await runFastFilter({
-            data: {
-              tags: {
-                elemMatch: {
-                  tag: {
-                    document: {
-                      elemMatch: {
-                        data: {
-                          tag: { eq: `Gatsby` },
-                        },
-                      },
+    it(`handles the elemMatch operator on the second element`, async () => {
+      const [result] = await runFilter({
+        singleElem: {
+          things: {
+            elemMatch: {
+              one: {
+                five: {
+                  three: { eq: 153 },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result.length).toEqual(1)
+      // Should contain the entire array even only one matched
+      expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
+      expect(result[0].singleElem.things[1].one.five.three).toEqual(153)
+    })
+
+    it(`should return only one node if elemMatch hits multiples`, async () => {
+      const [result] = await runFilter({
+        singleElem: {
+          things: {
+            elemMatch: {
+              one: {
+                two: {
+                  three: { lt: 1000 }, // one match is 123, the other 404
+                },
+              },
+            },
+          },
+        },
+      })
+
+      // The `elemMatch` operator only returns the first nodde that matches so
+      // even though the `lt 1000` would match two elements in the `things` array
+      // it will return one node.
+      expect(result.length).toEqual(1)
+      expect(result[0].singleElem.things[0].one.two.three).toEqual(123)
+      expect(result[0].singleElem.things[2].one.two.three).toEqual(404)
+    })
+
+    it(`ignores the elemMatch operator on a partial sub tree`, async () => {
+      const [result] = await runFilter({
+        singleElem: {
+          things: {
+            elemMatch: {
+              three: { eq: 123 },
+            },
+          },
+        },
+      })
+
+      expect(result).toEqual(null)
+    })
+
+    it(`handles the elemMatch operator for array of objects (1)`, async () => {
+      const [result] = await runFilter({
+        data: {
+          tags: {
+            elemMatch: {
+              tag: {
+                document: {
+                  elemMatch: {
+                    data: {
+                      tag: { eq: `Gatsby` },
                     },
                   },
                 },
               },
             },
-          })
+          },
+        },
+      })
 
-          expect(result.length).toEqual(1)
-          expect(result[0].index).toEqual(2)
-        })
+      expect(result.length).toEqual(1)
+      expect(result[0].index).toEqual(2)
+    })
 
-        it(`handles the elemMatch operator for array of objects (2)`, async () => {
-          const [result] = await runFastFilter({
-            data: {
-              tags: {
-                elemMatch: {
-                  tag: {
-                    document: {
-                      elemMatch: {
-                        data: {
-                          tag: { eq: `Design System` },
-                        },
-                      },
+    it(`handles the elemMatch operator for array of objects (2)`, async () => {
+      const [result] = await runFilter({
+        data: {
+          tags: {
+            elemMatch: {
+              tag: {
+                document: {
+                  elemMatch: {
+                    data: {
+                      tag: { eq: `Design System` },
                     },
                   },
                 },
               },
             },
-          })
-
-          expect(result.length).toEqual(1)
-          expect(result[0].index).toEqual(2)
-        })
-
-        it(`works for elemMatch on boolean field`, async () => {
-          const [result] = await runFastFilter({
-            boolean: {
-              elemMatch: {
-                eq: true,
-              },
-            },
-          })
-
-          // Does NOT contain nodes that do not have the field
-          expect(result.length).toEqual(1)
-          expect(result[0].boolean).toEqual(true)
-        })
-
-        it(`skips nodes without the field for elemMatch on boolean`, async () => {
-          const [result] = await runFastFilter({
-            boolSecondOnly: {
-              elemMatch: {
-                eq: false,
-              },
-            },
-          })
-
-          // Does NOT contain nodes that do not have the field so returns 2nd node
-          expect(result.length).toEqual(1)
-          expect(result[0].boolSecondOnly).toEqual(false)
-        })
-
-        it(`works for elemMatch on string field`, async () => {
-          const [result] = await runFastFilter({
-            string: {
-              elemMatch: {
-                eq: `a`,
-              },
-            },
-          })
-
-          // Does NOT contain nodes that do not have the field
-          expect(result.length).toEqual(1)
-          expect(result[0].string).toEqual(`a`)
-        })
-
-        it(`should return all nodes for elemMatch on non-arrays too`, async () => {
-          const [result] = await runFastFilter({
-            name: {
-              elemMatch: {
-                eq: `The Mad Wax`,
-              },
-            },
-          })
-
-          // Can return more than one node
-          // Does NOT contain nodes that do not have the field
-          expect(result.length).toEqual(2)
-          expect(result[0].name).toEqual(`The Mad Wax`)
-          expect(result[1].name).toEqual(`The Mad Wax`)
-        })
-
-        it(`skips nodes without the field for elemMatch on string`, async () => {
-          const [result] = await runFastFilter({
-            strSecondOnly: {
-              elemMatch: {
-                eq: `needle`,
-              },
-            },
-          })
-
-          // Does NOT contain nodes that do not have the field so returns 2nd node
-          expect(result.length).toEqual(1)
-          expect(result[0].strSecondOnly).toEqual(`needle`)
-        })
-
-        it(`works for elemMatch on number field`, async () => {
-          const [result] = await runFastFilter({
-            float: {
-              elemMatch: {
-                eq: 1.5,
-              },
-            },
-          })
-
-          // Does NOT contain nodes that do not have the field
-          expect(result.length).toEqual(1)
-          expect(result[0].float).toEqual(1.5)
-        })
+          },
+        },
       })
 
-      describe(`$nin`, () => {
-        it(`handles the nin operator for array [5]`, async () => {
-          const [result] = await runFastFilter({ anArray: { nin: [5] } })
+      expect(result.length).toEqual(1)
+      expect(result[0].index).toEqual(2)
+    })
 
-          // Since the array does not contain `null`, the query should also return the
-          // nodes that do not have the field at all (NULL).
-
-          expect(result.length).toEqual(2)
-          // Either does not exist or does not contain
-          result
-            .filter(node => node.anArray !== undefined)
-            .forEach(node => {
-              // In this test, if the property exists it should be an array
-              expect(Array.isArray(node.anArray)).toBe(true)
-              expect(node.anArray.includes(5)).toBe(false)
-            })
-        })
-
-        it(`handles the nin operator for array [null]`, async () => {
-          const [result] = await runFastFilter({
-            nullArray: { nin: [null] },
-          })
-
-          // Since the array contains `null`, the query should NOT return the
-          // nodes that do not have the field at all (NULL).
-
-          expect(result.length).toEqual(1)
-          expect(result[0].nullArray.includes(null)).toBe(false)
-        })
-
-        it(`handles the nin operator for strings`, async () => {
-          const [result] = await runFastFilter({
-            string: { nin: [`b`, `c`] },
-          })
-
-          expect(result.length).toEqual(1)
-          result.forEach(node => {
-            expect(node.string).not.toEqual(`b`)
-            expect(node.string).not.toEqual(`c`)
-          })
-        })
-
-        it(`handles the nin operator for ints`, async () => {
-          const [result] = await runFastFilter({ index: { nin: [0, 2] } })
-
-          expect(result.length).toEqual(1)
-          result.forEach(node => {
-            expect(node.index).not.toEqual(0)
-            expect(node.index).not.toEqual(2)
-          })
-        })
-
-        it(`handles the nin operator for floats`, async () => {
-          const [result] = await runFastFilter({ float: { nin: [1.5] } })
-
-          expect(result.length).toEqual(2)
-          result.forEach(node => {
-            // Might not have the property (-> undefined), must not be 1.5
-            expect(node.float).not.toEqual(1.5)
-          })
-        })
-
-        it(`handles the nin operator for boolean and null on boolean`, async () => {
-          const [result] = await runFastFilter({
-            boolean: { nin: [true, null] },
-          })
-
-          // Do not return the node that does not have the field because of `null`
-          expect(result.length).toEqual(1)
-          result.forEach(node => {
-            // Must have the property, must not be true nor null
-            expect(node.boolean !== undefined).toBe(true)
-            expect(node.boolean !== true && node.boolean !== null).toBe(true)
-          })
-        })
-
-        it(`handles the nin operator for double null`, async () => {
-          const [result] = await runFastFilter({
-            nil: { nin: [null, null] },
-          })
-
-          // Do not return the node that does not have the field because of `null`
-          expect(result.length).toEqual(1)
-          result.forEach(node => {
-            // Must have the property, must not be null
-            expect(node.nil !== undefined).toBe(true)
-            expect(node.nil !== null).toBe(true)
-          })
-        })
-
-        it(`handles the nin operator for null in int+null`, async () => {
-          const [result] = await runFastFilter({
-            nil: { nin: [5, null] },
-          })
-
-          // Do not return the node that does not have the field because of `null`
-          expect(result.length).toEqual(1)
-          result.forEach(node => {
-            // Must have the property, must not be 5 nor null
-            expect(node.nil !== undefined).toBe(true)
-            expect(node.nil !== 5 && node.nil !== null).toBe(true)
-          })
-        })
-
-        it(`handles the nin operator for int in int+null`, async () => {
-          const [result] = await runFastFilter({
-            index: { nin: [2, null] },
-          })
-
-          // Do not return the node that does not have the field because of `null`
-          expect(result.length).toEqual(2)
-          result.forEach(node => {
-            // Must have the property, must not be 2 nor null
-            expect(node.index !== undefined).toBe(true)
-            expect(node.index !== 2 && node.index !== null).toBe(true)
-          })
-        })
+    it(`works for elemMatch on boolean field`, async () => {
+      const [result] = await runFilter({
+        boolean: {
+          elemMatch: {
+            eq: true,
+          },
+        },
       })
 
-      describe(`$glob`, () => {
-        // Note: glob internally uses $regex
+      // Does NOT contain nodes that do not have the field
+      expect(result.length).toEqual(1)
+      expect(result[0].boolean).toEqual(true)
+    })
 
-        it(`handles the glob operator`, async () => {
-          const [result] = await runFastFilter({ name: { glob: `*Wax` } })
-
-          expect(result.length).toEqual(2)
-          expect(result[0].name).toEqual(`The Mad Wax`)
-        })
+    it(`skips nodes without the field for elemMatch on boolean`, async () => {
+      const [result] = await runFilter({
+        boolSecondOnly: {
+          elemMatch: {
+            eq: false,
+          },
+        },
       })
 
-      describe(`date`, () => {
-        it(`filters date fields`, async () => {
-          const [result] = await runFastFilter({ date: { ne: null } })
+      // Does NOT contain nodes that do not have the field so returns 2nd node
+      expect(result.length).toEqual(1)
+      expect(result[0].boolSecondOnly).toEqual(false)
+    })
 
-          expect(result.length).toEqual(2)
-          expect(result[0].index).toEqual(0)
-          expect(result[1].index).toEqual(2)
+    it(`works for elemMatch on string field`, async () => {
+      const [result] = await runFilter({
+        string: {
+          elemMatch: {
+            eq: `a`,
+          },
+        },
+      })
+
+      // Does NOT contain nodes that do not have the field
+      expect(result.length).toEqual(1)
+      expect(result[0].string).toEqual(`a`)
+    })
+
+    it(`should return all nodes for elemMatch on non-arrays too`, async () => {
+      const [result] = await runFilter({
+        name: {
+          elemMatch: {
+            eq: `The Mad Wax`,
+          },
+        },
+      })
+
+      // Can return more than one node
+      // Does NOT contain nodes that do not have the field
+      expect(result.length).toEqual(2)
+      expect(result[0].name).toEqual(`The Mad Wax`)
+      expect(result[1].name).toEqual(`The Mad Wax`)
+    })
+
+    it(`skips nodes without the field for elemMatch on string`, async () => {
+      const [result] = await runFilter({
+        strSecondOnly: {
+          elemMatch: {
+            eq: `needle`,
+          },
+        },
+      })
+
+      // Does NOT contain nodes that do not have the field so returns 2nd node
+      expect(result.length).toEqual(1)
+      expect(result[0].strSecondOnly).toEqual(`needle`)
+    })
+
+    it(`works for elemMatch on number field`, async () => {
+      const [result] = await runFilter({
+        float: {
+          elemMatch: {
+            eq: 1.5,
+          },
+        },
+      })
+
+      // Does NOT contain nodes that do not have the field
+      expect(result.length).toEqual(1)
+      expect(result[0].float).toEqual(1.5)
+    })
+  })
+
+  describe(`$nin`, () => {
+    it(`handles the nin operator for array [5]`, async () => {
+      const [result] = await runFilter({ anArray: { nin: [5] } })
+
+      // Since the array does not contain `null`, the query should also return the
+      // nodes that do not have the field at all (NULL).
+
+      expect(result.length).toEqual(2)
+      // Either does not exist or does not contain
+      result
+        .filter(node => node.anArray !== undefined)
+        .forEach(node => {
+          // In this test, if the property exists it should be an array
+          expect(Array.isArray(node.anArray)).toBe(true)
+          expect(node.anArray.includes(5)).toBe(false)
         })
+    })
+
+    it(`handles the nin operator for array [null]`, async () => {
+      const [result] = await runFilter({
+        nullArray: { nin: [null] },
+      })
+
+      // Since the array contains `null`, the query should NOT return the
+      // nodes that do not have the field at all (NULL).
+
+      expect(result.length).toEqual(1)
+      expect(result[0].nullArray.includes(null)).toBe(false)
+    })
+
+    it(`handles the nin operator for strings`, async () => {
+      const [result] = await runFilter({
+        string: { nin: [`b`, `c`] },
+      })
+
+      expect(result.length).toEqual(1)
+      result.forEach(node => {
+        expect(node.string).not.toEqual(`b`)
+        expect(node.string).not.toEqual(`c`)
       })
     })
 
-    describe(`collection fields`, () => {
-      it(`orders by given field desc with limit`, async () => {
-        let result = await runQuery({
-          limit: 10,
-          sort: {
-            fields: [`frontmatter.blue`],
-            order: [`desc`],
-          },
-        })
-
-        expect(result.length).toEqual(3)
-        expect(result[0].id).toEqual(`1`)
-        expect(result[1].id).toEqual(`2`)
-        expect(result[2].id).toEqual(`0`)
-      })
-
-      describe(`num, null, and nullable order`, () => {
-        // This suite asserts the order of a field that is a number vs a field that
-        // is explicitly set to the value `null`, vs a field that is not set
-        // (which gets NULL in the database). This should do whatever redux does!
-        // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
-
-        // node 1  2   3
-        //  - num_null_not    1st node has field set, 2nd set to null, 3rd not set
-        //  - num_not_null    etc
-        //  - null_num_not
-        //  - null_not_num
-        //  - not_null_num
-        //  - not_num_null
-
-        it(`sorts num_null_not asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`num_null_not`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts num_null_not desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`num_null_not`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts num_not_null asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`num_not_null`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts num_not_null desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`num_not_null`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts null_num_not asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_num_not`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts null_num_not desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_num_not`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts null_not_num asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_not_num`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts null_not_num desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_not_num`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts not_null_num asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_null_num`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts not_null_num desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_null_num`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts not_num_null asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_num_null`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts not_num_null desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_num_null`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`1`)
-        })
-      })
-
-      describe(`string, null, and nullable order`, () => {
-        // This suite asserts the order of a field that is a string vs a field that
-        // is explicitly set to the value `null`, vs a field that is not set
-        // (which gets NULL in the database). This should do whatever redux does!
-        // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
-
-        // node 1  2   3
-        //  - str_null_not    1st node has field set, 2nd set to null, 3rd not set
-        //  - str_not_null    etc
-        //  - null_str_not
-        //  - null_not_str
-        //  - not_null_str
-        //  - not_str_null
-
-        it(`sorts str_null_not asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`str_null_not`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts str_null_not desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`str_null_not`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts str_not_null asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`str_not_null`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts str_not_null desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`str_not_null`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts null_str_not asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_str_not`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts null_str_not desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_str_not`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts null_not_str asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_not_str`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts null_not_str desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_not_str`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts not_null_str asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_null_str`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts not_null_str desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_null_str`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts not_str_null asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_str_null`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts not_str_null desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_str_null`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`1`)
-        })
-      })
-
-      describe(`obj, null, and nullable order`, () => {
-        // This suite asserts the order of a field that is a object vs a field that
-        // is explicitly set to the value `null`, vs a field that is not set
-        // (which gets NULL in the database). This should do whatever redux does!
-        // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
-
-        // node 1  2   3
-        //  - obj_null_not    1st node has field set, 2nd set to null, 3rd not set
-        //  - obj_not_null    etc
-        //  - null_obj_not
-        //  - null_not_obj
-        //  - not_null_obj
-        //  - not_obj_null
-
-        it(`sorts obj_null_not asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`obj_null_not`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts obj_null_not desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`obj_null_not`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts obj_not_null asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`obj_not_null`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts obj_not_null desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`obj_not_null`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts null_obj_not asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_obj_not`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts null_obj_not desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_obj_not`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts null_not_obj asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_not_obj`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`1`)
-        })
-
-        it(`sorts null_not_obj desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`null_not_obj`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`0`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts not_null_obj asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_null_obj`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`2`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts not_null_obj desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_null_obj`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`1`)
-          expect(result[2].id).toEqual(`2`)
-        })
-
-        it(`sorts not_obj_null asc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_obj_null`],
-              order: [`asc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`1`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`0`)
-        })
-
-        it(`sorts not_obj_null desc`, async () => {
-          let result = await runQuery({
-            sort: {
-              fields: [`not_obj_null`],
-              order: [`desc`],
-            },
-          })
-
-          expect(result.length).toEqual(3)
-          expect(result[0].id).toEqual(`0`)
-          expect(result[1].id).toEqual(`2`)
-          expect(result[2].id).toEqual(`1`)
-        })
-      })
-
-      it(`sorts results with desc has null fields first vs obj second`, async () => {
-        let result = await runQuery({
-          limit: 10,
-          sort: {
-            fields: [`waxOnly`],
-            order: [`desc`],
-          },
-        })
-
-        // 0 doesnt have it, 1 has it as an object, 2 has it as null
-
-        expect(result.length).toEqual(3)
-        expect(result[0].id).toEqual(`0`)
-        expect(result[1].id).toEqual(`2`)
-        expect(result[2].id).toEqual(`1`)
-      })
-
-      it(`sorts results with asc has null fields last vs obj first`, async () => {
-        let result = await runQuery({
-          limit: 10,
-          sort: {
-            fields: [`waxOnly`],
-            order: [`asc`],
-          },
-        })
-
-        // 0 doesnt have it, 1 has it as an object, 2 has it as null
-
-        expect(result.length).toEqual(3)
-        expect(result[0].id).toEqual(`1`)
-        expect(result[1].id).toEqual(`2`)
-        expect(result[2].id).toEqual(`0`)
-      })
-
-      it(`applies specified sort order, and sorts asc by default`, async () => {
-        let result = await runQuery({
-          limit: 10,
-          sort: {
-            fields: [`frontmatter.blue`, `id`],
-            order: [`desc`], // `id` field will be sorted asc
-          },
-        })
-
-        expect(result.length).toEqual(3)
-        expect(result[0].id).toEqual(`1`) // blue = 10010, id = 1
-        expect(result[1].id).toEqual(`2`) // blue = 10010, id = 2
-        expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
-      })
-
-      it(`applies specified sort order per field`, async () => {
-        let result = await runQuery({
-          limit: 10,
-          sort: {
-            fields: [`frontmatter.blue`, `id`],
-            order: [`desc`, `desc`], // `id` field will be sorted desc
-          },
-        })
-
-        expect(result.length).toEqual(3)
-        expect(result[0].id).toEqual(`2`) // blue = 10010, id = 2
-        expect(result[1].id).toEqual(`1`) // blue = 10010, id = 1
-        expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
+    it(`handles the nin operator for ints`, async () => {
+      const [result] = await runFilter({ index: { nin: [0, 2] } })
+
+      expect(result.length).toEqual(1)
+      result.forEach(node => {
+        expect(node.index).not.toEqual(0)
+        expect(node.index).not.toEqual(2)
       })
     })
+
+    it(`handles the nin operator for floats`, async () => {
+      const [result] = await runFilter({ float: { nin: [1.5] } })
+
+      expect(result.length).toEqual(2)
+      result.forEach(node => {
+        // Might not have the property (-> undefined), must not be 1.5
+        expect(node.float).not.toEqual(1.5)
+      })
+    })
+
+    it(`handles the nin operator for boolean and null on boolean`, async () => {
+      const [result] = await runFilter({
+        boolean: { nin: [true, null] },
+      })
+
+      // Do not return the node that does not have the field because of `null`
+      expect(result.length).toEqual(1)
+      result.forEach(node => {
+        // Must have the property, must not be true nor null
+        expect(node.boolean !== undefined).toBe(true)
+        expect(node.boolean !== true && node.boolean !== null).toBe(true)
+      })
+    })
+
+    it(`handles the nin operator for double null`, async () => {
+      const [result] = await runFilter({
+        nil: { nin: [null, null] },
+      })
+
+      // Do not return the node that does not have the field because of `null`
+      expect(result.length).toEqual(1)
+      result.forEach(node => {
+        // Must have the property, must not be null
+        expect(node.nil !== undefined).toBe(true)
+        expect(node.nil !== null).toBe(true)
+      })
+    })
+
+    it(`handles the nin operator for null in int+null`, async () => {
+      const [result] = await runFilter({
+        nil: { nin: [5, null] },
+      })
+
+      // Do not return the node that does not have the field because of `null`
+      expect(result.length).toEqual(1)
+      result.forEach(node => {
+        // Must have the property, must not be 5 nor null
+        expect(node.nil !== undefined).toBe(true)
+        expect(node.nil !== 5 && node.nil !== null).toBe(true)
+      })
+    })
+
+    it(`handles the nin operator for int in int+null`, async () => {
+      const [result] = await runFilter({
+        index: { nin: [2, null] },
+      })
+
+      // Do not return the node that does not have the field because of `null`
+      expect(result.length).toEqual(2)
+      result.forEach(node => {
+        // Must have the property, must not be 2 nor null
+        expect(node.index !== undefined).toBe(true)
+        expect(node.index !== 2 && node.index !== null).toBe(true)
+      })
+    })
+  })
+
+  describe(`$glob`, () => {
+    // Note: glob internally uses $regex
+
+    it(`handles the glob operator`, async () => {
+      const [result] = await runFilter({ name: { glob: `*Wax` } })
+
+      expect(result.length).toEqual(2)
+      expect(result[0].name).toEqual(`The Mad Wax`)
+    })
+  })
+
+  describe(`date`, () => {
+    it(`filters date fields`, async () => {
+      const [result] = await runFilter({ date: { ne: null } })
+
+      expect(result.length).toEqual(2)
+      expect(result[0].index).toEqual(0)
+      expect(result[1].index).toEqual(2)
+    })
+  })
+})
+
+describe(`collection fields`, () => {
+  it(`orders by given field desc with limit`, async () => {
+    let result = await runQuery({
+      limit: 10,
+      sort: {
+        fields: [`frontmatter.blue`],
+        order: [`desc`],
+      },
+    })
+
+    expect(result.length).toEqual(3)
+    expect(result[0].id).toEqual(`1`)
+    expect(result[1].id).toEqual(`2`)
+    expect(result[2].id).toEqual(`0`)
+  })
+
+  describe(`num, null, and nullable order`, () => {
+    // This suite asserts the order of a field that is a number vs a field that
+    // is explicitly set to the value `null`, vs a field that is not set
+    // (which gets NULL in the database). This should do whatever redux does!
+    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
+
+    // node 1  2   3
+    //  - num_null_not    1st node has field set, 2nd set to null, 3rd not set
+    //  - num_not_null    etc
+    //  - null_num_not
+    //  - null_not_num
+    //  - not_null_num
+    //  - not_num_null
+
+    it(`sorts num_null_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`num_null_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts num_null_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`num_null_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts num_not_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`num_not_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts num_not_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`num_not_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts null_num_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_num_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts null_num_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_num_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_num asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_num`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_num desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_num`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_null_num asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_num`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_null_num desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_num`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_num_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_num_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_num_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_num_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+  })
+
+  describe(`string, null, and nullable order`, () => {
+    // This suite asserts the order of a field that is a string vs a field that
+    // is explicitly set to the value `null`, vs a field that is not set
+    // (which gets NULL in the database). This should do whatever redux does!
+    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
+
+    // node 1  2   3
+    //  - str_null_not    1st node has field set, 2nd set to null, 3rd not set
+    //  - str_not_null    etc
+    //  - null_str_not
+    //  - null_not_str
+    //  - not_null_str
+    //  - not_str_null
+
+    it(`sorts str_null_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`str_null_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts str_null_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`str_null_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts str_not_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`str_not_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts str_not_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`str_not_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts null_str_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_str_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts null_str_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_str_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_str asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_str`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_str desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_str`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_null_str asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_str`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_null_str desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_str`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_str_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_str_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_str_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_str_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+  })
+
+  describe(`obj, null, and nullable order`, () => {
+    // This suite asserts the order of a field that is a object vs a field that
+    // is explicitly set to the value `null`, vs a field that is not set
+    // (which gets NULL in the database). This should do whatever redux does!
+    // Exhaustive suite; 2^3 x2 = 12 tests, all cases in asc and desc
+
+    // node 1  2   3
+    //  - obj_null_not    1st node has field set, 2nd set to null, 3rd not set
+    //  - obj_not_null    etc
+    //  - null_obj_not
+    //  - null_not_obj
+    //  - not_null_obj
+    //  - not_obj_null
+
+    it(`sorts obj_null_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`obj_null_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts obj_null_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`obj_null_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts obj_not_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`obj_not_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts obj_not_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`obj_not_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts null_obj_not asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_obj_not`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts null_obj_not desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_obj_not`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_obj asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_obj`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`1`)
+    })
+
+    it(`sorts null_not_obj desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`null_not_obj`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`0`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_null_obj asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_obj`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`2`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_null_obj desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_null_obj`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`1`)
+      expect(result[2].id).toEqual(`2`)
+    })
+
+    it(`sorts not_obj_null asc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_obj_null`],
+          order: [`asc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`1`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`0`)
+    })
+
+    it(`sorts not_obj_null desc`, async () => {
+      let result = await runQuery({
+        sort: {
+          fields: [`not_obj_null`],
+          order: [`desc`],
+        },
+      })
+
+      expect(result.length).toEqual(3)
+      expect(result[0].id).toEqual(`0`)
+      expect(result[1].id).toEqual(`2`)
+      expect(result[2].id).toEqual(`1`)
+    })
+  })
+
+  it(`sorts results with desc has null fields first vs obj second`, async () => {
+    let result = await runQuery({
+      limit: 10,
+      sort: {
+        fields: [`waxOnly`],
+        order: [`desc`],
+      },
+    })
+
+    // 0 doesnt have it, 1 has it as an object, 2 has it as null
+
+    expect(result.length).toEqual(3)
+    expect(result[0].id).toEqual(`0`)
+    expect(result[1].id).toEqual(`2`)
+    expect(result[2].id).toEqual(`1`)
+  })
+
+  it(`sorts results with asc has null fields last vs obj first`, async () => {
+    let result = await runQuery({
+      limit: 10,
+      sort: {
+        fields: [`waxOnly`],
+        order: [`asc`],
+      },
+    })
+
+    // 0 doesnt have it, 1 has it as an object, 2 has it as null
+
+    expect(result.length).toEqual(3)
+    expect(result[0].id).toEqual(`1`)
+    expect(result[1].id).toEqual(`2`)
+    expect(result[2].id).toEqual(`0`)
+  })
+
+  it(`applies specified sort order, and sorts asc by default`, async () => {
+    let result = await runQuery({
+      limit: 10,
+      sort: {
+        fields: [`frontmatter.blue`, `id`],
+        order: [`desc`], // `id` field will be sorted asc
+      },
+    })
+
+    expect(result.length).toEqual(3)
+    expect(result[0].id).toEqual(`1`) // blue = 10010, id = 1
+    expect(result[1].id).toEqual(`2`) // blue = 10010, id = 2
+    expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
+  })
+
+  it(`applies specified sort order per field`, async () => {
+    let result = await runQuery({
+      limit: 10,
+      sort: {
+        fields: [`frontmatter.blue`, `id`],
+        order: [`desc`, `desc`], // `id` field will be sorted desc
+      },
+    })
+
+    expect(result.length).toEqual(3)
+    expect(result[0].id).toEqual(`2`) // blue = 10010, id = 2
+    expect(result[1].id).toEqual(`1`) // blue = 10010, id = 1
+    expect(result[2].id).toEqual(`0`) // blue = 100, id = 0
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -22564,10 +22564,6 @@ side-channel@^1.0.2:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
 
-sift@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-5.1.0.tgz#1bbf2dfb0eb71e56c4cc7fb567fbd1351b65015e"
-
 sift@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/sift/-/sift-7.0.1.tgz#47d62c50b159d316f1372f8b53f9c10cd21a4b08"


### PR DESCRIPTION
This drops Sift, in favor of our own fast filters.

Still some things to clean up.