### PR TITLE
fix(docs): change Builder to Builder.io

### DIFF
--- a/docs/docs/sourcing-from-builder-io.md
+++ b/docs/docs/sourcing-from-builder-io.md
@@ -2,7 +2,7 @@
 title: Sourcing from Builder.io
 ---
 
-[Builder.io](https://builder.io) has all the benefits of a modern headless CMS platform, plus the power of an easy to learn drag and drop editor that enables everyone to edit more than just content. Builder + Gatsby empowers your entire team to create performant and fully customizable pages quickly.
+[Builder.io](https://builder.io) has all the benefits of a modern headless CMS platform, plus the power of an easy to learn drag and drop editor that enables everyone to edit more than just content. Builder.io + Gatsby empowers your entire team to create performant and fully customizable pages quickly.
 
 <img src="https://imgur.com/HjBWIbv.gif" alt="Editor example" />
 


### PR DESCRIPTION
## Description

fix brand name, because on all other places at this doc it is named Builder.io:

- Builder -> Builder.io

## Note 1

- on the homepage [Builder.io](Builder.io) the Brand name is always only `Builder`

## Note 2

i don't know, but would the link `BuilderIO Gatsby starter` not better also `Builder.io Gatsby starter`?

## Related Issues

- #22650 `[Docs] add sourcing from builder.io doc` from @teleaziz