### PR TITLE
fix(recipes): CI recipes - change Gitlab to GitLab

### DIFF
--- a/docs/docs/recipes/gitlab-continuous-integration.md
+++ b/docs/docs/recipes/gitlab-continuous-integration.md
@@ -1,15 +1,15 @@
 ---
-title: "Recipes: Continuous Integration on Gitlab"
+title: "Recipes: Continuous Integration on GitLab"
 tableOfContentsDepth: 1
 ---
 
 Continuous Integration works by pushing small code chunks to your application’s code base hosted in a Git repository, and, to every push, run a pipeline of scripts to build, test, and validate the code changes before merging them into the main branch.
-This recipe helps you set up CI/CD on Gitlab and automate your production build!.
+This recipe helps you set up CI/CD on GitLab and automate your production build!.
 
 ## Prerequisites
 
 - Make sure you have the [Gatsby CLI](/docs/gatsby-cli) installed
-- A [Gitlab](https://gitlab.com/) account
+- A [GitLab](https://gitlab.com/) account
 
 ## Directions
 
@@ -54,7 +54,7 @@ install_dependencies:
 
 ## Additional resources
 
-- See how you can develop this simple file into something more real world [Gitlab CI/CD Docs](https://docs.gitlab.com/ee/ci/README.html)
-- Check this especially to learn how to make your newly build available for a next job - [Gitlab Job Artifacts Docs](https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html)
+- See how you can develop this simple file into something more real world [GitLab CI/CD Docs](https://docs.gitlab.com/ee/ci/README.html)
+- Check this especially to learn how to make your newly build available for a next job - [GitLab Job Artifacts Docs](https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html)
 
 - [Getting started with GitLab CI/CD](https://gitlab.com/help/ci/quick_start/README)

--- a/packages/gatsby-recipes/recipes/gitlab-ci-cd.mdx
+++ b/packages/gatsby-recipes/recipes/gitlab-ci-cd.mdx
@@ -1,6 +1,6 @@
-# Add Gitlab CI/CD
+# Add GitLab CI/CD
 
-This recipe helps you setup Gitlab CI/CD in your Gatsby site to create a pipeline on gitlab.com
+This recipe helps you setup GitLab CI/CD in your Gatsby site to create a pipeline on gitlab.com
 
 ---
 
@@ -17,6 +17,6 @@ Now, every time you `git push <you-remote-gitlab-repo>` you will have your gatsb
 
 ---
 
-- See how you can develop this simple file into something more real world [Gitlab CI/CD Docs](https://docs.gitlab.com/ee/ci/README.html)
-- Check this especially to learn how to make your newly build available for a next job - [Gitlab Job Artifacts Docs](https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html)
+- See how you can develop this simple file into something more real world [GitLab CI/CD Docs](https://docs.gitlab.com/ee/ci/README.html)
+- Check this especially to learn how to make your newly build available for a next job - [GitLab Job Artifacts Docs](https://docs.gitlab.com/ee/ci/pipelines/job_artifacts.html)
 - [Getting started with GitLab CI/CD](https://gitlab.com/help/ci/quick_start/README)


### PR DESCRIPTION
## Description

fix brand names:

- Gitlab -> GitLab


## Related Issues

- #23367 `docs: Create gitlab-continuous-integration.md`