### PR TITLE
fix(gatsby-theme-starter-workspace): Change anonymous function to named function

### DIFF
--- a/starters/gatsby-starter-theme-workspace/example/src/pages/index.js
+++ b/starters/gatsby-starter-theme-workspace/example/src/pages/index.js
@@ -1,3 +1,5 @@
 import React from "react"
 
-export default () => <div>Homepage in a user's site</div>
+export default function Home() {
+  return <div>Homepage in a user's site</div>
+}


### PR DESCRIPTION
Replace anonymous function with named function in gatsby-starter-theme-workspace
Follows conventions used in docs e.g. named regular functioned (not arrow function)

As per this issue - #23575