### PR TITLE
chore(doc): replace typefaces with fontsource

### DIFF
--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -399,18 +399,18 @@ Hosting your own [Google Fonts](https://fonts.google.com/) locally within a proj
 
 - A [Gatsby site](/docs/quick-start)
 - The [Gatsby CLI](/docs/gatsby-cli/) installed
-- Choosing a font package from [the typefaces project](https://github.com/KyleAMathews/typefaces)
+- Choosing a font package from [Fontsource](https://github.com/DecliningLotus/fontsource)
 
 ### Directions
 
-1. Run `npm install --save typeface-your-chosen-font`, replacing `your-chosen-font` with the name of the font you want to install from [the typefaces project](https://github.com/KyleAMathews/typefaces).
+1. Run `npm install fontsource-your-chosen-font`, replacing `your-chosen-font` with the name of the font you want to install from the [Fontsource project](https://github.com/DecliningLotus/fontsource).
 
-An example to load the popular 'Source Sans Pro' font would be: `npm install --save typeface-source-sans-pro`.
+An example to load the popular 'Source Sans Pro' font would be: `npm install fontsource-source-sans-pro`.
 
-2. Add `import "typeface-your-chosen-font"` to a layout template, page component, or `gatsby-browser.js`.
+2. Add `import "fontsource-your-chosen-font"` to a layout template, page component, or `gatsby-browser.js`.
 
 ```jsx:title=src/components/layout.js
-import "typeface-your-chosen-font"
+import "fontsource-your-chosen-font"
 ```
 
 3. Once it's imported, you can reference the font name in a CSS stylesheet, CSS Module, or CSS-in-JS.
@@ -426,8 +426,7 @@ _NOTE: So for the above example, the relevant CSS declaration would be `font-fam
 ### Additional resources
 
 - [Typography.js](/docs/typography-js/) - Another option for using Google fonts on a Gatsby site
-- [The Typefaces Project Docs](https://github.com/KyleAMathews/typefaces/blob/master/README.md)
-- [Live example on Kyle Mathews' blog](https://www.bricolage.io/typefaces-easiest-way-to-self-host-fonts/)
+- [Fontsource](https://github.com/DecliningLotus/fontsource) - Self-host fonts in neatly bundled NPM packages
 
 ## Using Font Awesome
 


### PR DESCRIPTION
## Description

Replaced the ageing Typefaces project with a link to Fontsource, a newly actively maintained Open Source NPM font packager. Link : https://github.com/DecliningLotus/fontsource

The Typefaces project has somewhat been neglected over the years and has a long list of issues and pull requests that have left it outdated. Although very understandable, as I can imagine Kyle is very busy with Gatsby.

Fontsource is a major rebuild of this project, with added features such as the ability to choose subsets, weights and styles. It also clears up all the bugs from the previous project, checks for updates on Google Fonts on a weekly basis via Github Actions, has far more in-depth documentation and is also adding a lot more Open Source fonts that haven't been added by the original Typefaces project.

Let me know if there are any concerns and thoughts toward this!

### Documentation
Where is this feature or API documented?
https://www.gatsbyjs.org/docs/recipes/styling-css/#using-google-fonts

@gatsbyjs/learning


