### PR TITLE
Adds the gatsby-starter-hello-world-shopify starter

### DIFF
--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -194,3 +194,4 @@ exports.createPages = async ({ graphql, actions }) => {
 ## Additional Resources
 
 - [Gatsby Shopify Starter](/starters/AlexanderProd/gatsby-shopify-starter/)
+- [Gatsby Shopify Hello World](/starters/ohduran/gatsby-starter-hello-world-shopify/)

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -2038,6 +2038,16 @@
     - Shopify Store Credentials included
     - Optimized images with gatsby-image.
     - SEO
+- url: https://gatsby-starter-hello-world-shopify.netlify.app/
+  repo: https://github.com/ohduran/gatsby-starter-hello-world-shopify
+  description: Boilerplate with the barebones to set up your Shopify Store using Gatsby
+  tags:
+    - E-commerce
+  features:
+    - Shopping Cart
+    - Shopify Integration
+    - Product Grid
+    - Shopify Store Credentials included
 - url: https://gatejs.netlify.com
   repo: https://github.com/sarasate/gate
   description: API Doc generator inspired by Stripe's API docs


### PR DESCRIPTION
## Description

Adds the new gatsby-starter-hello-world-shopify starter, which includes the necessary boilerplate to set up a Shopify store using Gatsby being the least opinionated about the structure of the site.

It also includes being mentioned in the post Building an E-commerce site with Shopify, under additional resources.