### PR TITLE
chore(docs): add missing prop-types import

### DIFF
--- a/docs/docs/creating-dynamic-navigation.md
+++ b/docs/docs/creating-dynamic-navigation.md
@@ -192,6 +192,7 @@ Locate the `header.js` file inside `src/components` and remove everything so onl
 ```jsx:title=src/components/header.js
 import React from "react"
 import { Link } from "gatsby"
+import PropTypes from "prop-types"
 const Header = ({ siteTitle, menuLinks }) => (
   <header
     style={{

--- a/docs/docs/creating-dynamic-navigation.md
+++ b/docs/docs/creating-dynamic-navigation.md
@@ -193,6 +193,7 @@ Locate the `header.js` file inside `src/components` and remove everything so onl
 import React from "react"
 import { Link } from "gatsby"
 import PropTypes from "prop-types"
+
 const Header = ({ siteTitle, menuLinks }) => (
   <header
     style={{


### PR DESCRIPTION
## Description
The following import seems to be missing:
`import PropTypes from "prop-types"`

### Documentation
https://www.gatsbyjs.org/docs/creating-dynamic-navigation/#using-the-header-component-to-display-the-navigation
