### PR TITLE
fix(gatsby-plugin-catch-links): fix href attribute

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -123,7 +123,13 @@ export const routeThroughBrowserOrApp = (
   // IE clears the host value if the anchor href changed after creation, e.g.
   // in React. Creating a new anchor element to ensure host value is present
   const destination = document.createElement(`a`)
-  destination.href = clickedAnchor.href
+
+  // https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url-set
+  // If clickedAnchor has no href attribute like `<a>example</a>`, the href getter returns empty string.
+  if (clickedAnchor.href !== ``) {
+    destination.href = clickedAnchor.href
+  }
+
   if (clickedAnchor.href instanceof SVGAnimatedString) {
     destination.href = clickedAnchor.href.animVal
   }


### PR DESCRIPTION
## Description

### Current behavior

If the clickedAnchor with no href attribute has clicked then jump to the page top. Expect to do nothing. 

### Solution

Avoid setting href to an empty string.

### Reason

* If clickedAnchor has no href attribute like `<a>example</a>`, the href getter returns the empty string.
* The empty string is a relative path.

refs: https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url-set

### Documentation

## Related Issues

