### PR TITLE
chore(docs): update link to build-javascript

### DIFF
--- a/docs/docs/production-app.md
+++ b/docs/docs/production-app.md
@@ -14,7 +14,7 @@ Gatsby generates your site's HTML pages, but also creates a JavaScript runtime t
 
 ## webpack config
 
-The [build-javascript.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/commands/build-javascript.js) Gatsby file is the entry point to this section. It dynamically creates a webpack configuration by calling [webpack.config.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js). This can produce radically different configs depending on the stage. E.g. `build-javascript`, `build-html`, `develop`, or `develop-html`. This section deals with the `build-javascript` stage.
+The [build-javascript.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/commands/build-javascript.ts) Gatsby file is the entry point to this section. It dynamically creates a webpack configuration by calling [webpack.config.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js). This can produce radically different configs depending on the stage. E.g. `build-javascript`, `build-html`, `develop`, or `develop-html`. This section deals with the `build-javascript` stage.
 
 The config is quite large, but here are some of the important values in the final output.
 

--- a/docs/docs/production-app.md
+++ b/docs/docs/production-app.md
@@ -14,7 +14,7 @@ Gatsby generates your site's HTML pages, but also creates a JavaScript runtime t
 
 ## webpack config
 
-The [build-javascript.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/commands/build-javascript.ts) Gatsby file is the entry point to this section. It dynamically creates a webpack configuration by calling [webpack.config.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js). This can produce radically different configs depending on the stage. E.g. `build-javascript`, `build-html`, `develop`, or `develop-html`. This section deals with the `build-javascript` stage.
+The [build-javascript.ts](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/commands/build-javascript.ts) Gatsby file is the entry point to this section. It dynamically creates a webpack configuration by calling [webpack.config.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/webpack.config.js). This can produce radically different configs depending on the stage. E.g. `build-javascript`, `build-html`, `develop`, or `develop-html`. This section deals with the `build-javascript` stage.
 
 The config is quite large, but here are some of the important values in the final output.
 


### PR DESCRIPTION
## Description

updated link to build-javascript as it was converted to `ts` few days ago so, link turned obsolete 

