### PR TITLE
fix(docs): page creation - 404

### DIFF
--- a/docs/docs/page-creation.md
+++ b/docs/docs/page-creation.md
@@ -10,7 +10,7 @@ A page is created by calling the [createPage](/docs/actions/#createPage) action.
 
 ## Update pages Redux namespace
 
-The `pages` Redux namespace is a map of page `path` to page object. The [pages reducer](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/redux/reducers/pages.js) takes care of updating this on a `CREATE_PAGE` action. It also creates a [Foreign Key Reference](/docs/schema-gql-type/#foreign-key-reference-___node) to the plugin that created the page by adding a `pluginCreator___NODE` field.
+The `pages` Redux namespace is a map of page `path` to page object. The [pages reducer](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/redux/reducers/pages.ts) takes care of updating this on a `CREATE_PAGE` action. It also creates a [Foreign Key Reference](/docs/schema-gql-type/#foreign-key-reference-___node) to the plugin that created the page by adding a `pluginCreator___NODE` field.
 
 ## Update components Redux namespace
 


### PR DESCRIPTION
## Description

changes:
- fix 404 link (js -> ts)

## Related Issues

- #19267 `Add link checker for Gatsby Docs`