### PR TITLE
fix(recipes): icon format

### DIFF
--- a/packages/gatsby-recipes/recipes/pwa.mdx
+++ b/packages/gatsby-recipes/recipes/pwa.mdx
@@ -31,7 +31,7 @@ We also add a default icon @ src/images/icon.svg (which you can replace afterwar
   options={{
     name: `GatsbyJS`,
     short_name: `GatsbyJS`,
-    icon: `src/images/icon.svg`,
+    icon: `src/images/icon.png`,
     start_url: `/`,
     background_color: `#f7f0eb`,
     theme_color: `#a2466c`,


### PR DESCRIPTION
## Description

should this not be an png icon, since we add a `icon.png` file? or is there some autoconvert (which i don't find in the docs of the manifest)?

changes:

- icon format

## Related Issues

- #23563 `feat(gatsby-recipes): Add PWA recipe + improving diffing for binary files`