### PR TITLE
fix(docs): themes - convert starter to theme - re-add link

### DIFF
--- a/docs/docs/themes/converting-a-starter.md
+++ b/docs/docs/themes/converting-a-starter.md
@@ -68,7 +68,7 @@ There may be other locations where you will need to update the path resolution l
 
 ## Sourcing pages
 
-Gatsby by default sources pages relative from `src/pages`, like a regular Gatsby site does. However, if you would like to source pages from a different directory you'll have to setup `gatsby-plugin-page-creator`.
+Gatsby by default sources pages relative from `src/pages`, like a regular Gatsby site does. However, if you would like to source pages from a different directory you'll have to setup [`gatsby-plugin-page-creator`](/packages/gatsby-plugin-page-creator/).
 
 ```shell
 npm install --save gatsby-plugin-page-creator


### PR DESCRIPTION
## Description

changes: 
- re-add a link which get lost in #23572


## Related Issues

- #23572 `Fix outdated section in Themes docs` 