### PR TITLE
added another path for `yarn lint:docs` and error message is no longer there

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -13,7 +13,7 @@ module.exports = {
         .use(require("retext-sentence-spacing")),
     ],
     "remark-preset-lint-recommended",
-    "remark-preset-lint-markdown-style-guide",
+    
 
     // additional remark-lint rules
     ["remark-lint-list-item-indent", "space"],

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "lerna-prepare": "lerna run prepare",
     "lint": "npm-run-all --continue-on-error -p lint:code lint:docs lint:other",
     "lint:code": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
-    "lint:docs": "remark --quiet --frail \"./docs/\"",
+    "lint:docs": "remark --quiet --frail \"./docs/docs/\"",
     "lint:scripts": "sh scripts/lint-shell-scripts.sh",
     "lint:other": "npm run prettier -- --check",
     "markdown": "md-magic --path \"starters/**/*.md\"",


### PR DESCRIPTION

## Description

Changed the package.json script to direct to the docs folder inside docs.

### Documentation

<!--
  Where is this feature or API documented?



## Related Issues

<!--

  Link to an issue that is partially addressed by this PR (if there are any)
  https://github.com/gatsbyjs/gatsby/issues/23660

  Link to related issues (if there are any)
  #23660
-->
