### PR TITLE
fix(gatsby): add explicit dependency on `socket.io-client` and explicitly set `url-loader` fallback

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -132,6 +132,7 @@
     "signal-exit": "^3.0.3",
     "slugify": "^1.4.0",
     "socket.io": "^2.3.0",
+    "socket.io-client": "2.3.0",
     "stack-trace": "^0.0.10",
     "string-similarity": "^1.2.2",
     "style-loader": "^0.23.1",

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -250,6 +250,7 @@ export const createWebpackUtils = (
         options: {
           limit: 10000,
           name: `${assetRelativeRoot}[name]-[hash].[ext]`,
+          fallback: require.resolve(`file-loader`),
           ...options,
         },
       }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -404,6 +404,9 @@ module.exports = async (
         "@pmmmwh/react-refresh-webpack-plugin": path.dirname(
           require.resolve(`@pmmmwh/react-refresh-webpack-plugin/package.json`)
         ),
+        "socket.io-client": path.dirname(
+          require.resolve(`socket.io-client/package.json`)
+        ),
       },
       plugins: [
         // Those two folders are special and contain gatsby-generated files


### PR DESCRIPTION
## Description

After upgrading to latest, I have begun to have issues with `url-loader` being able to resolve `file-loader`, and `.cache/app.js` being able to resolve `socket.io-client`.  This is likely because I am using pnpm in my particular repository.

`url-loader` uses a [fallback of `file-loader`](https://github.com/webpack-contrib/url-loader/blob/v1.1.2/src/utils/normalizeFallback.js#L4), but it only provides a simple string.  `url-loader` also doesn't provide `file-loader` as a production dependency, nor does it list it as a peer dependency, so it would need to get it from somewhere else.

I'm not sure why this only started breaking now, but this is the error I get:
```sh
 ERROR #98123  WEBPACK

Generating JavaScript bundles failed

Cannot find module 'file-loader'
Require stack:
- <require stack leading to url-loader>

File: /path/to/node_modules/typeface-poppins/files/poppins-latin-600.woff
```

What I've done here is simply resolved that to a fully qualified path, relative to Gatsby.

Additionally, I have added an alias for `socket.io-client`, because `.cache/app.js` now imports it, but Webpack cannot find it because the project I am working on doesn't have it installed in its dependencies.  That's to fix this error:

```sh
 ERROR #98124  WEBPACK

Generating development JavaScript bundle failed

Can't resolve 'socket.io-client' in '/path/to/project/.cache'

If you're trying to use a package make sure that 'socket.io-client' is installed. If you're trying to use a local file make sure that the path is correct.

File: .cache/app.js
```

Both of these fixes work great in my testing.  The only thing I can't be sure of is if the `fallback` for `url-loader` will have unintended side effects.

Additionally, because `socket.io-client` is used directly by Gatsby, it should be installed as a production dependency.  If not, then yarn 2 will break, because it won't be able to retrieve it from `socket.io`.