### PR TITLE
fix(gatsby-source-shopify): resource handle

### DIFF
--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -34,6 +34,7 @@ export const ARTICLES_QUERY = `
           contentHtml
           excerpt
           excerptHtml
+          handle
           id
           image {
             altText
@@ -63,6 +64,7 @@ export const BLOGS_QUERY = `
       edges {
         cursor
         node {
+          handle
           id
           title
           url
@@ -232,18 +234,21 @@ export const SHOP_POLICIES_QUERY = `
     shop {
       privacyPolicy {
         body
+        handle
         id
         title
         url
       }
       refundPolicy {
         body
+        handle
         id
         title
         url
       }
       termsOfService {
         body
+        handle
         id
         title
         url


### PR DESCRIPTION
## Description

Add missing resource handle to GraphQL queries

### Documentation

* Article: https://shopify.dev/docs/storefront-api/reference/object/article?api[version]=2019-07#fields-2019-07
* Blog: https://shopify.dev/docs/storefront-api/reference/object/blog?api[version]=2019-07#fields-2019-07
* ShopPolicy: https://shopify.dev/docs/storefront-api/reference/object/shoppolicy?api[version]=2019-07#fields-2019-07

#### Interactive GraphQL Explorer

https://shopify.dev/graphiql/storefront-graphiql

```graphql
{
  articles(first: 12) {
    edges {
      node {
        handle
      }
    }
  }
  blogs(first: 12) {
    edges {
      node {
        handle
      }
    }
  }
  shop {
    privacyPolicy {
      handle
    }
    refundPolicy {
      handle
    }
    termsOfService {
      handle
    }
  }
}
```

```json
{
  "data": {
    "articles": {
      "edges": [
        {
          "node": {
            "handle": "127283971-first-post"
          }
        }
      ]
    },
    "blogs": {
      "edges": [
        {
          "node": {
            "handle": "news"
          }
        }
      ]
    },
    "shop": {
      "privacyPolicy": null,
      "refundPolicy": null,
      "termsOfService": null
    }
  }
}
```