### PR TITLE
fix(gatsby-recipes): add missing dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ jobs:
           command: yarn build
           working_directory: ~/project/e2e-tests/gatsby-pnp
       - run:
-          command: 'DEBUG=start-server-and-test yarn start-server-and-test "yarn develop 2>&1 | tee log.txt" :8000 "! cat log.txt | grep -E ''ERROR #|Error:''"'
+          command: 'DEBUG=start-server-and-test yarn start-server-and-test "yarn develop 2>&1 | tee log.txt" :8000 "! cat log.txt | grep -E ''ERROR #|Require stack:''"'
           working_directory: ~/project/e2e-tests/gatsby-pnp
 
   e2e_tests_gatsby-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ jobs:
           command: yarn build
           working_directory: ~/project/e2e-tests/gatsby-pnp
       - run:
-          command: 'DEBUG=start-server-and-test yarn start-server-and-test "yarn develop 2>&1 | tee log.txt" :8000 "! cat log.txt | grep ''ERROR #''"'
+          command: 'DEBUG=start-server-and-test yarn start-server-and-test "yarn develop 2>&1 | tee log.txt" :8000 "! cat log.txt | grep -E ''ERROR #|Error:''"'
           working_directory: ~/project/e2e-tests/gatsby-pnp
 
   e2e_tests_gatsby-image:

--- a/packages/gatsby-recipes/foo
+++ b/packages/gatsby-recipes/foo
@@ -1,0 +1,7 @@
+set -euxo pipefail
+IFS=$'\n\t'
+
+false | cat
+false
+
+echo ok

--- a/packages/gatsby-recipes/foo
+++ b/packages/gatsby-recipes/foo
@@ -1,7 +1,0 @@
-set -euxo pipefail
-IFS=$'\n\t'
-
-false | cat
-false
-
-echo ok

--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -15,6 +15,7 @@
     "@babel/standalone": "^7.9.6",
     "@babel/template": "^7.8.6",
     "@babel/types": "^7.9.6",
+    "@hapi/hoek": "8.x.x",
     "@hapi/joi": "^15.1.1",
     "@mdx-js/mdx": "^1.6.1",
     "@mdx-js/react": "^1.6.1",

--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -54,6 +54,7 @@
     "prettier": "^2.0.5",
     "react-reconciler": "^0.25.1",
     "remark-mdx": "^1.6.1",
+    "remark-parse": "^6.0.3",
     "remark-stringify": "^8.0.0",
     "semver": "^7.3.2",
     "single-trailing-newline": "^1.0.0",

--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -53,6 +53,7 @@
     "pkg-dir": "^4.2.0",
     "prettier": "^2.0.5",
     "react-reconciler": "^0.25.1",
+    "remark-mdx": "^1.6.1",
     "remark-stringify": "^8.0.0",
     "semver": "^7.3.2",
     "single-trailing-newline": "^1.0.0",

--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@babel/core": "^7.9.6",
     "@babel/generator": "^7.9.6",
+    "@babel/helper-plugin-utils": "^7.8.3",
     "@babel/plugin-transform-react-jsx": "^7.9.4",
     "@babel/standalone": "^7.9.6",
     "@babel/template": "^7.8.6",

--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -59,6 +59,7 @@
     "style-to-object": "^0.3.0",
     "subscriptions-transport-ws": "^0.9.16",
     "svg-tag-names": "^2.0.1",
+    "unified": "^8.4.2",
     "unist-util-visit": "^2.0.2",
     "urql": "^1.9.7",
     "ws": "^7.3.0",


### PR DESCRIPTION
## Description

The current test pattern only reports webpack errors (`ERROR #`), not raw errors (`Error: ...`). This is typically not a problem because raw errors cause the process to abort, but it appears this isn't necessarily the case with `gatsby-recipes`:

https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/41626/workflows/00a80c3c-735a-4bc0-8deb-c9a82d380fa4/jobs/418447/parallel-runs/0/steps/0-112

I'll also add in this diff the missing dependencies that didn't get reported until now.
