### PR TITLE
fix(gatsby): Also traverse `FunctionDeclaration`

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
@@ -124,6 +124,7 @@ describe(`Resolve module exports`, () => {
     "/export/named/multiple": `const foo = ''; const bar = ''; const baz = ''; export { foo, bar, baz };`,
     "/export/default": `export default () => {}`,
     "/export/default/name": `const foo = () => {}; export default foo`,
+    "/export/function": `export function foo() {}`,
   }
 
   beforeEach(() => {
@@ -219,6 +220,11 @@ describe(`Resolve module exports`, () => {
   it(`Resolves default export with name`, () => {
     const result = resolveModuleExports(`/export/default/name`, { resolver })
     expect(result).toEqual([`export default foo`])
+  })
+
+  it(`Resolves function declaration`, () => {
+    const result = resolveModuleExports(`/export/function`, { resolver })
+    expect(result).toEqual([`foo`])
   })
 
   it(`Resolves exports when using require mode - simple case`, () => {

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -54,14 +54,26 @@ const staticallyAnalyzeExports = (modulePath, resolver = require.resolve) => {
       isES6 = true
     },
 
-    // get foo from `export const foo = bar`
     ExportNamedDeclaration: function ExportNamedDeclaration(astPath) {
-      const exportName = get(
-        astPath,
-        `node.declaration.declarations[0].id.name`
-      )
-      isES6 = true
-      if (exportName) exportNames.push(exportName)
+      const node = astPath.node.declaration
+
+      // get foo from `export const foo = bar`
+      if (
+        get(astPath, `node.declaration.type`) === `VariableDeclaration` &&
+        get(astPath, `node.declaration.declarations[0].id.name`)
+      ) {
+        isES6 = true
+        exportNames.push(node.declarations[0].id.name)
+      }
+
+      // get foo from `export function foo()`
+      if (
+        get(astPath, `node.declaration.type`) === `FunctionDeclaration` &&
+        get(astPath, `node.declaration.id.name`)
+      ) {
+        isES6 = true
+        exportNames.push(node.id.name)
+      }
     },
 
     // get foo from `export { foo } from 'bar'`

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.js
@@ -55,7 +55,7 @@ const staticallyAnalyzeExports = (modulePath, resolver = require.resolve) => {
     },
 
     ExportNamedDeclaration: function ExportNamedDeclaration(astPath) {
-      const node = astPath.node.declaration
+      const declaration = astPath.node.declaration
 
       // get foo from `export const foo = bar`
       if (
@@ -63,7 +63,7 @@ const staticallyAnalyzeExports = (modulePath, resolver = require.resolve) => {
         get(astPath, `node.declaration.declarations[0].id.name`)
       ) {
         isES6 = true
-        exportNames.push(node.declarations[0].id.name)
+        exportNames.push(declaration.declarations[0].id.name)
       }
 
       // get foo from `export function foo()`
@@ -72,7 +72,7 @@ const staticallyAnalyzeExports = (modulePath, resolver = require.resolve) => {
         get(astPath, `node.declaration.id.name`)
       ) {
         isES6 = true
-        exportNames.push(node.id.name)
+        exportNames.push(declaration.id.name)
       }
     },
 


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/24458

Relevant ASTExplorer: https://astexplorer.net/#/gist/a67d7a00ab34ed73711045da5ab348df/b2bc30b3e138e37851000e7c12770df01a71d29d

Previously it only checked for `astPath.node.declaration.declarations[0].id.name`, now it also checks for `astPath.node.declaration.id.name`.
