### PR TITLE
test(gatsby-recipes): increase timeout values

### DIFF
--- a/packages/gatsby-recipes/src/parser/index.test.js
+++ b/packages/gatsby-recipes/src/parser/index.test.js
@@ -6,6 +6,10 @@ const parser = require(`.`)
 const fixturePath = path.join(__dirname, `fixtures/prettier-git-hook.mdx`)
 const fixtureSrc = fs.readFileSync(fixturePath, `utf8`)
 
+// There are network calls being made and thoses tests often doesn't finish
+// within default 5s timeout on CI
+jest.setTimeout(100000)
+
 test(`fetches a recipe from unpkg when official short form`, async () => {
   const result = await parser(`theme-ui`)
 


### PR DESCRIPTION
## Description

We see alot of test flakiness in CircleCI with tests not finishing within 5s (default timeout for async tests). This one increase timeout in one of the test files that was very often failing based on just not resolving fast enough in CI
