### PR TITLE
fix(code): redux types - sireUrl -> siteUrl

### DIFF
--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -48,7 +48,7 @@ export interface IGatsbyConfig {
     title?: string
     author?: string
     description?: string
-    sireUrl?: string
+    siteUrl?: string
     // siteMetadata is free form
     [key: string]: unknown
   }


### PR DESCRIPTION
## Description

changes:

- `sireUrl` -> `siteUrl`

i guess the bug was not catched because of the default `[key: string]: unknown`

## Related Issues

- #23620 `fix(gatsby): log config validation errors`
