### PR TITLE
chore(graphiql-explorer): upgrade graphiql-explorer

### DIFF
--- a/packages/gatsby-graphiql-explorer/package.json
+++ b/packages/gatsby-graphiql-explorer/package.json
@@ -44,7 +44,7 @@
     "css-loader": "^1.0.1",
     "graphiql": "^0.17.5",
     "graphiql-code-exporter": "^2.0.8",
-    "graphiql-explorer": "^0.4.6",
+    "graphiql-explorer": "^0.6.2",
     "html-webpack-plugin": "^3.2.0",
     "npm-run-all": "4.1.5",
     "react": "^16.12.0",

--- a/packages/gatsby-graphiql-explorer/src/app/app.css
+++ b/packages/gatsby-graphiql-explorer/src/app/app.css
@@ -17,3 +17,7 @@ code {
   height: 100vh;
   width: 100vw;
 }
+
+div.graphiql-explorer-root > div:last-child {
+  display: none;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12113,10 +12113,10 @@ graphiql-code-exporter@^2.0.8:
   dependencies:
     copy-to-clipboard "^3.0.8"
 
-graphiql-explorer@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/graphiql-explorer/-/graphiql-explorer-0.4.6.tgz#501b0b27d154efbdd224b9b0d528cfb6917ebda8"
-  integrity sha512-xnIArsOzWdGEz/z4I3r4XIiukVmpRWu64co5IxaqQ7pK7Ar0l00dPmOvWdRF/cBTMQDBbkMpKDc2yxwUebIjOg==
+graphiql-explorer@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/graphiql-explorer/-/graphiql-explorer-0.6.2.tgz#ea81a8770e3e68c2a97fe849b294bad94ed509e3"
+  integrity sha512-hYSM+TI/0IAXltMOL7YXrvnA5xrKoDjjN7qiksxca2DY7yu46cyHVHG0IKIrBozMDBQLvFOhQMPrzplErwVZ1g==
 
 graphiql@^0.17.5:
   version "0.17.5"


### PR DESCRIPTION
## Description

GraphiQL Explorer could use a few minor versions update. This might fix a few outstanding issues.

I also removed the actions dropdown for now, using `:nth-selector` which could be fragile. A PR to `graphiql-explorer` is the next step.

I tested this locally with latest master gatsby-cli, and everything seemed to work fine.

## Related Issues

- possibly resolves #15805 (cannot confirm without OSX)
- was hoping it would help with #24250 but it does not. 