### PR TITLE
fix(docs): theme ui preset: fix brand name Theme UI

### DIFF
--- a/packages/gatsby-theme-ui-preset/README.md
+++ b/packages/gatsby-theme-ui-preset/README.md
@@ -7,13 +7,13 @@
   The Gatsby Theme UI Preset Theme
 </h1>
 
-A Gatsby theme that contains the Theme-UI configuration used in other official Gatsby themes, e.g. `gatsby-theme-blog`.
+A Gatsby theme that contains the Theme UI configuration used in other official Gatsby themes, e.g. `gatsby-theme-blog`.
 
 ## Installation
 
 ### For an existing site
 
-If you already have a site you'd like to add the theme-ui theme to, you can manually configure it.
+If you already have a site you'd like to add the Theme UI theme to, you can manually configure it.
 
 1. Install the theme
 


### PR DESCRIPTION
## Description

changes:

- brand name: `Theme-UI` -> `Theme UI`
- brand name: `theme-ui` -> `Theme UI`


## Related Issues

- #23144 `Create new gatsby-theme-ui-preset theme` 