### PR TITLE
fix(graphiql-explorer): variables on edit

### DIFF
--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -88,12 +88,12 @@ function updateURL() {
 const DEFAULT_QUERY =
   parameters.query ||
   (window.localStorage && window.localStorage.getItem(`graphiql:query`)) ||
-  null
+  undefined
 
 const DEFAULT_VARIABLES =
   parameters.variables ||
   (window.localStorage && window.localStorage.getItem(`graphiql:variables`)) ||
-  null
+  undefined
 
 const QUERY_EXAMPLE_SITEMETADATA_TITLE = `#     {
 #       site {


### PR DESCRIPTION
## Description

Resolves #24250 by defaulting to `undefined` instead of `null`, so that the variables prop is not passed when unset
