### PR TITLE
feat(recipes): add gitlab-ci-cd recipe to cli list

### DIFF
--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -159,6 +159,10 @@ const RecipesList = ({ setRecipe }) => {
       label: `Add Preact`,
       value: `preact.mdx`,
     },
+    {
+      label: `Add Gitlab CI/CD`,
+      value: `gitlab-ci-cd.mdx`,
+    },
   ]
 
   return (


### PR DESCRIPTION
## Description
This only adds an existent recipe to the CLI list, so that it is shown to the world!

The recipe is this: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-recipes/recipes/gitlab-ci-cd.mdx

## Related Pull Request
Related to https://github.com/gatsbyjs/gatsby/pull/24275
