### PR TITLE
fix(glossary): IaC - fix name for consistency

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -188,9 +188,9 @@ Once a site has been [built](#build) by Gatsby and loaded in a web browser, [cli
 
 As part of its data layer and [build](#build) process, Gatsby will automatically **infer** a [schema](#schema), or type-based structure, based on available data sources (e.g. Markdown file nodes, WordPress posts, etc.). More control can be gained over this structure by using Gatsby's [Schema Customization API](/docs/schema-customization/).
 
-### [Infrastructure As Code](/docs/glossary/infrastructure-as-code/)
+### [Infrastructure as Code](/docs/glossary/infrastructure-as-code/)
 
-Infrastructure As Code is the practice of using configuration files and scripts to automate the process of setting up your development, testing, and production environments.
+Infrastructure as Code is the practice of using configuration files and scripts to automate the process of setting up your development, testing, and production environments.
 
 ## J
 


### PR DESCRIPTION
## Description

changes for consistency with Glossary Page ( https://www.gatsbyjs.org/docs/glossary/infrastructure-as-code/ )

- `Infrastructure As Code` -> `Infrastructure as Code`

## Motivation

> ```diff
> -### [Infrastructure As Code](/docs/glossary/infrastructure-as-code/)
> +### [Infrastructure as Code](/docs/glossary/infrastructure-as-code/)
> ```
> 
> I think we can refer to this as Infrastructure as Code or IaC throughout. As long as "as" isn't capitalized and we're consistent all the way through, I'm good.
> 
> _Originally posted by @AishaBlake in https://github.com/gatsbyjs/gatsby/pull/23431/files_


<!-- Write a brief description of the changes introduced by this PR -->


## Related Issues

- #23431 `Glossary, encyclopedia: Add Infrastructure As Code article.` 