### PR TITLE
fix(gatsby-cli): build properly in CI

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -57,7 +57,8 @@
     "@types/hosted-git-info": "^3.0.0",
     "@types/yargs": "^15.0.4",
     "babel-preset-gatsby-package": "^0.4.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^5.2.1",
+    "typescript": "^3.9.2"
   },
   "optionalDependencies": {
     "ink": "^2.7.1",


### PR DESCRIPTION
## Description

Follow up #24285 

With typegen now being part of build, we do need typescript to get tsc in node_modules/.bin. Otherwise if system doesn't have global typescript installed it will fail to build the package
