### PR TITLE
fix(gatsby-plugin-mdx): Ensure getNodesByType helper is passed to gatsbyRemarkPlugins

### DIFF
--- a/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -61,6 +61,7 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
               markdownAST,
               markdownNode: mdxNode,
               getNode,
+              getNodesByType,
               files: fileNodes,
               pathPrefix,
               reporter,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Ensures `getNodesByType` is passed on to Gatsby Remark plugins

### Documentation

Docs already exist that suggest this should be passed on (see issue).

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #24400
