### PR TITLE
chore(gatsby): Update resolve-module-exports to TS

### DIFF
--- a/packages/gatsby/src/bootstrap/__mocks__/resolve-module-exports.ts
+++ b/packages/gatsby/src/bootstrap/__mocks__/resolve-module-exports.ts
@@ -2,7 +2,7 @@
 
 let mockResults = {}
 
-module.exports = input => {
+export const resolveModuleExports = (input: unknown): string[] | undefined => {
   // return a mocked result
   if (typeof input === `string`) {
     return mockResults[input]

--- a/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
+++ b/packages/gatsby/src/bootstrap/__tests__/resolve-module-exports.js
@@ -13,7 +13,7 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
 
 const fs = require(`fs`)
 const reporter = require(`gatsby-cli/lib/reporter`)
-const resolveModuleExports = require(`../resolve-module-exports`)
+const { resolveModuleExports } = require(`../resolve-module-exports`)
 let resolver
 
 describe(`Resolve module exports`, () => {

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/validate.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/validate.js
@@ -41,7 +41,7 @@ describe(`collatePluginAPIs`, () => {
   }
 
   beforeEach(() => {
-    const resolveModuleExports = require(`../../resolve-module-exports`)
+    const { resolveModuleExports } = require(`../../resolve-module-exports`)
     resolveModuleExports(MOCK_RESULTS)
   })
 

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.js
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.js
@@ -3,7 +3,7 @@ const semver = require(`semver`)
 const stringSimilarity = require(`string-similarity`)
 const { version: gatsbyVersion } = require(`gatsby/package.json`)
 const reporter = require(`gatsby-cli/lib/reporter`)
-const resolveModuleExports = require(`../resolve-module-exports`)
+const { resolveModuleExports } = require(`../resolve-module-exports`)
 const { getLatestAPIs } = require(`../../utils/get-latest-apis`)
 
 const getGatsbyUpgradeVersion = entries =>


### PR DESCRIPTION
## Description

This PR migrates `packages/gatsby/src/bootstrap/resolve-module-exports` to TypeScript.

## Related Issues

Unblocks #22504. Part of #21995.