### PR TITLE
perf(gatsby): Use ranges on arrays rather than slices

### DIFF
--- a/packages/gatsby/src/schema/__tests__/__snapshots__/kitchen-sink.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/kitchen-sink.js.snap
@@ -10,23 +10,23 @@ Object {
         "likes": 33,
       },
       Object {
-        "code": "Bam3G5XFOTK",
-        "id": "1632234281433883850",
-        "likes": 30,
+        "code": "BdIpEzalAJx",
+        "id": "1677771511187112561",
+        "likes": 29,
       },
     ],
     "filter": Object {
       "edges": Array [
         Object {
           "node": Object {
-            "comment": 1,
-            "id": "1270677182602272387",
+            "comment": 2,
+            "id": "1001206739996237060",
           },
         },
         Object {
           "node": Object {
             "comment": 0,
-            "id": "1256134251849702933",
+            "id": "1011212316101041196",
           },
         },
       ],

--- a/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
+++ b/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
@@ -285,12 +285,12 @@ describe(`filtering on linked nodes`, () => {
     }
 
     expect(result.data.eq.edges).toEqual([`bar`, `baz`].map(itemToEdge))
-    expect(result.data.in.edges).toEqual([`bar`, `foo`, `baz`].map(itemToEdge))
+    expect(result.data.in.edges).toEqual([`bar`, `baz`, `foo`].map(itemToEdge))
     expect(result.data.insideInlineArrayEq.edges).toEqual(
       [`lorem`, `ipsum`, `sit`].map(itemToEdge)
     )
     expect(result.data.insideInlineArrayIn.edges).toEqual(
-      [`lorem`, `ipsum`, `dolor`, `sit`].map(itemToEdge)
+      [`lorem`, `ipsum`, `sit`, `dolor`].map(itemToEdge)
     )
   })
 


### PR DESCRIPTION
Followup for https://github.com/gatsbyjs/gatsby/pull/24486

This eliminates another source for filtering at scale; slicing large arrays is expensive. And we just discard those arrays anyways so let's not. Instead we can work on ranges inside an array.