### PR TITLE
fix(gatsby): Turn off react/jsx-pascal-case in ESLint to fix Theme-UI warnings

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -9,7 +9,7 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
       globals: {
         graphql: true,
         __PATH_PREFIX__: true,
-        __BASE_PATH__: true, // this will rarely, if ever, be used by consumers
+        __BASE_PATH__: true // this will rarely, if ever, be used by consumers
       },
       extends: [require.resolve(`eslint-config-react-app`)],
       plugins: [`graphql`],
@@ -20,9 +20,10 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
           {
             env: `relay`,
             schemaString: printSchema(schema, { commentDescriptions: true }),
-            tagName: `graphql`,
-          },
+            tagName: `graphql`
+          }
         ],
+        "react/jsx-pascal-case": `off`, // Prevents errors with Theme-UI and Styled component
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
         "jsx-a11y/accessible-emoji": `warn`,
         "jsx-a11y/alt-text": `warn`,
@@ -64,8 +65,8 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
         "jsx-a11y/role-has-required-aria-props": `warn`,
         "jsx-a11y/role-supports-aria-props": `warn`,
         "jsx-a11y/scope": `warn`,
-        "jsx-a11y/tabindex-no-positive": `warn`,
-      },
-    },
+        "jsx-a11y/tabindex-no-positive": `warn`
+      }
+    }
   }
 }

--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -9,7 +9,7 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
       globals: {
         graphql: true,
         __PATH_PREFIX__: true,
-        __BASE_PATH__: true // this will rarely, if ever, be used by consumers
+        __BASE_PATH__: true, // this will rarely, if ever, be used by consumers
       },
       extends: [require.resolve(`eslint-config-react-app`)],
       plugins: [`graphql`],
@@ -20,8 +20,8 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
           {
             env: `relay`,
             schemaString: printSchema(schema, { commentDescriptions: true }),
-            tagName: `graphql`
-          }
+            tagName: `graphql`,
+          },
         ],
         "react/jsx-pascal-case": `off`, // Prevents errors with Theme-UI and Styled component
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
@@ -65,8 +65,8 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
         "jsx-a11y/role-has-required-aria-props": `warn`,
         "jsx-a11y/role-supports-aria-props": `warn`,
         "jsx-a11y/scope": `warn`,
-        "jsx-a11y/tabindex-no-positive": `warn`
-      }
-    }
+        "jsx-a11y/tabindex-no-positive": `warn`,
+      },
+    },
   }
 }


### PR DESCRIPTION
## Description

Turns off `react/jsx-pascal-case` in ESLint due to warnings in the console with Theme-UI and the `<Styled>` component. At the end of the day this isn't a big deal, but it does really clutter up the console when building sites with Theme-UI.

Looks like this:

```shell
warn ESLintError: 
/Users/erichowey/Coding/gatsby-theme-catalyst/themes/gatsby-theme-catalyst-helium/src/components/post-list.js
   26:11  warning  Imported JSX component h1 must be in PascalCase or SCREAMING_SNAKE_CASE  react/jsx-pascal-case
  130:19  warning  Imported JSX component h2 must be in PascalCase or SCREAMING_SNAKE_CASE  react/jsx-pascal-case
  138:21  warning  Imported JSX component a must be in PascalCase or SCREAMING_SNAKE_CASE   react/jsx-pascal-case
  142:19  warning  Imported JSX component p must be in PascalCase or SCREAMING_SNAKE_CASE   react/jsx-pascal-case
  159:19  warning  Imported JSX component p must be in PascalCase or SCREAMING_SNAKE_CASE   react/jsx-pascal-case
  169:21  warning  Imported JSX component p must be in PascalCase or SCREAMING_SNAKE_CASE   react/jsx-pascal-case
  173:19  warning  Imported JSX component a must be in PascalCase or SCREAMING_SNAKE_CASE   react/jsx-pascal-case
```

The JSX looks something like this, in case you are not familiar with it:

```jsx
<Styled.p>Some text.</Styled.p>
```

This may be undesired due to the effect this would have on all users, I believe this was originally off because I didn't used to see these errors and then they suddenly started appearing about a week ago after upgrading Gatsby versions.

I just thought I would make a quick PR in case it helps resolve this issue.

Related to #24327

EDIT: Sorry it looks like my prettier config removed some commas in there, feel free to edit as needed.