### PR TITLE
fix(gatsby-starter-default): Clear up TS usage example

### DIFF
--- a/starters/default/src/pages/index.js
+++ b/starters/default/src/pages/index.js
@@ -14,7 +14,8 @@ const IndexPage = () => (
     <div style={{ maxWidth: `300px`, marginBottom: `1.45rem` }}>
       <Image />
     </div>
-    <Link to="/page-2/">Go to page 2</Link>
+    <Link to="/page-2/">Go to page 2</Link> <br />
+    <Link to="/using-typescript/">Go to "Using TypeScript"</Link>
   </Layout>
 )
 

--- a/starters/default/src/pages/page-2.js
+++ b/starters/default/src/pages/page-2.js
@@ -1,15 +1,14 @@
-// Gatsby supports TypeScript natively!
 import React from "react"
-import { PageProps, Link } from "gatsby"
+import { Link } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
-const SecondPage = (props: PageProps) => (
+const SecondPage = () => (
   <Layout>
     <SEO title="Page two" />
     <h1>Hi from the second page</h1>
-    <p>Welcome to page 2 ({props.path})</p>
+    <p>Welcome to page 2</p>
     <Link to="/">Go back to the homepage</Link>
   </Layout>
 )

--- a/starters/default/src/pages/using-typescript.tsx
+++ b/starters/default/src/pages/using-typescript.tsx
@@ -1,0 +1,34 @@
+// If you don't want to use TypeScript you can delete this file!
+import React from "react"
+import { PageProps, Link, graphql } from "gatsby"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+type DataProps = {
+  site: {
+    buildTime: string
+  }
+}
+
+const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path }) => (
+  <Layout>
+    <SEO title="Using TypeScript" />
+    <h1>Gatsby supports TypeScript by default!</h1>
+    <p>This means that you can create and write <em>.ts/.tsx</em> files for your pages, components etc. Please note that the <em>gatsby-*.js</em> files (like gatsby-node.js) currently don't support TypeScript yet.</p>
+    <p>For type checking you'll want to install <em>typescript</em> via npm and run <em>tsc --init</em> to create a <em>.tsconfig</em> file.</p>
+    <p>You're currently on the page "{path}" which was built on {data.site.buildTime}.</p>
+    <p>To learn more, head over to our <a href="https://www.gatsbyjs.org/docs/typescript/">documentation about TypeScript</a>.</p>
+    <Link to="/">Go back to the homepage</Link>
+  </Layout>
+)
+
+export default UsingTypescript
+
+export const query = graphql`
+  {
+    site {
+      buildTime(formatString: "YYYY-MM-DD hh:mm a z")
+    }
+  }
+`


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/24388
We also talked about this internally on Slack.

I reverted the `page-2.js` page and added a new `using-typescript.tsx` file. I added some more complexity but it'll be a common use case to have your GraphQL query and data.

### Documentation

I think adding more information to https://www.gatsbyjs.org/docs/typescript/ would be out-of-scope for this PR but once we have more integrations we definitely need to update that page.

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/18983
