### PR TITLE
fix(gatsby): show correct `serve` info when running on another port

### DIFF
--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -151,7 +151,7 @@ module.exports = async (program: IServeProgram): Promise<void> => {
       const urls = prepareUrls(
         program.ssl ? `https` : `http`,
         program.host,
-        program.port
+        port
       )
       printInstructions(
         program.sitePackageJson.name || `(Unnamed package)`,


### PR DESCRIPTION
## Description

use mutated port variable to generate the urls that inform the user about where is the server running.

## Related Issues

Fixes #24518 
