### PR TITLE
maintenance(packages/gatsby): public types for NodeModel

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -10,7 +10,7 @@ import {
   ComposeScalarTypeConfig,
   ComposeUnionTypeConfig,
 } from "graphql-compose"
-import { GraphQLOutputType } from "graphql"
+import { GraphQLOutputType, GraphQLFieldConfigMap } from "graphql"
 
 export {
   default as Link,


### PR DESCRIPTION
##  Description

Add Types for [Node Model](https://www.gatsbyjs.org/docs/node-model/) in gatsby's `index.d.ts` file with documentation and update `createResolvers` typing to guarantee that we return it.

### Documentation

[Node Model API](https://www.gatsbyjs.org/docs/node-model/)