### PR TITLE
Add description to Gatsby Plugin resource

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -58,6 +58,7 @@
     "remark-mdx": "^1.6.1",
     "remark-parse": "^6.0.3",
     "remark-stringify": "^8.0.0",
+    "resolve-pkg": "^2.0.0",
     "semver": "^7.3.2",
     "single-trailing-newline": "^1.0.0",
     "style-to-object": "^0.3.0",

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.js
@@ -6,6 +6,7 @@ const declare = require(`@babel/helper-plugin-utils`).declare
 const Joi = require(`@hapi/joi`)
 const glob = require(`glob`)
 const prettier = require(`prettier`)
+const resolvePkg = require(`resolve-pkg`)
 
 const getDiff = require(`../utils/get-diff`)
 const resourceSchema = require(`../resource-schema`)
@@ -16,10 +17,12 @@ const getObjectFromNode = require(`./utils/get-object-from-node`)
 const { getValueFromNode } = require(`./utils/get-object-from-node`)
 const { REQUIRES_KEYS } = require(`./utils/constants`)
 
+const { read: readPackageJSON } = require(`../npm/package`)
+
 const fileExists = filePath => fs.existsSync(filePath)
 
 const listShadowableFilesForTheme = (directory, theme) => {
-  const fullThemePath = path.join(directory, `node_modules`, theme, `src`)
+  const fullThemePath = path.join(resolvePkg(theme), `src`)
   const shadowableThemeFiles = glob.sync(fullThemePath + `/**/*.*`, {
     follow: true,
   })

--- a/packages/gatsby-recipes/src/providers/npm/package.js
+++ b/packages/gatsby-recipes/src/providers/npm/package.js
@@ -3,6 +3,7 @@ const _ = require(`lodash`)
 const Joi = require(`@hapi/joi`)
 const path = require(`path`)
 const fs = require(`fs-extra`)
+const resolvePkg = require(`resolve-pkg`)
 const { getConfigStore } = require(`gatsby-core-utils`)
 
 const packageMangerConfigKey = `cli.packageManager`
@@ -120,7 +121,7 @@ const read = async ({ root }, id) => {
   let packageJSON
   try {
     packageJSON = JSON.parse(
-      await fs.readFile(require.resolve(path.join(id, `package.json`)))
+      await fs.readFile(path.join(resolvePkg(id), `package.json`))
     )
   } catch (e) {
     return undefined

--- a/packages/gatsby-recipes/src/providers/npm/package.js
+++ b/packages/gatsby-recipes/src/providers/npm/package.js
@@ -119,10 +119,8 @@ const create = async ({ root }, resource) => {
 const read = async ({ root }, id) => {
   let packageJSON
   try {
-    // TODO is there a better way to grab this? Can the position of `node_modules`
-    // change?
     packageJSON = JSON.parse(
-      await fs.readFile(path.join(root, `node_modules`, id, `package.json`))
+      await fs.readFile(require.resolve(path.join(id, `package.json`)))
     )
   } catch (e) {
     return undefined

--- a/packages/gatsby-recipes/src/providers/npm/package.js
+++ b/packages/gatsby-recipes/src/providers/npm/package.js
@@ -131,6 +131,7 @@ const read = async ({ root }, id) => {
   return {
     id: packageJSON.name,
     name: packageJSON.name,
+    description: packageJSON.description,
     version: packageJSON.version,
     _message: `Installed NPM package ${packageJSON.name}@${packageJSON.version}`,
   }
@@ -143,6 +144,7 @@ const schema = {
     `dependency`,
     `defaults to regular dependency`
   ),
+  description: Joi.string(),
   ...resourceSchema,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22130,6 +22130,13 @@ resolve-options@^1.1.0:
   dependencies:
     value-or-function "^3.0.0"
 
+resolve-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg/-/resolve-pkg-2.0.0.tgz#ac06991418a7623edc119084edc98b0e6bf05a41"
+  integrity sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==
+  dependencies:
+    resolve-from "^5.0.0"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"


### PR DESCRIPTION
For Gatsby Admin, the design calls for us to render a description for each plugin/theme in the UI. This adds a `gatsbyPlugin.description` field, which returns the `"description"` field from the plugin's `package.json` (using the package.json resource read function!).

----

While I was at it, I also cleaned up the code a bit:

1. Instead of manually resolving the node_modules locations of packages, I wanted to use `require.resolve` (which does exactly this, but works wherever the package is stored). However, `require.resolve` works _from the `__dirname`_, which is not what we want (particularly in our monorepo). Thankfully, I found the `resolve-pkg` module by Sindre, which does the exact some thing `require.resolve` does but from the current working directory :100:
2. Instead of duplicating the "read plugin"-logic in the "all plugins" and the "single plugin" function (which already lead to mismatches where shadowable/ed files weren't defined when fetching a single plugin), I now use the common `read` function in the `all` method. More consistent results and no duplicate code, yay!