### PR TITLE
fix(gatsby-dev-cli): show spawned processes output unless `--quiet` is used

### DIFF
--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -312,6 +312,7 @@ jest.mock(`../local-npm-registry/install-packages`, () => {
 jest.mock(`../utils/promisified-spawn`, () => {
   return {
     promisifiedSpawn: jest.fn(() => Promise.resolve()),
+    setDefaultSpawnStdio: jest.fn(),
   }
 })
 

--- a/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
@@ -139,8 +139,9 @@ const publishPackage = async ({
     console.log(
       `Published ${packageName}@${newPackageVersion} to local registry`
     )
-  } catch {
-    console.error(`Failed to publish ${packageName}@${newPackageVersion}`)
+  } catch (e) {
+    console.error(`Failed to publish ${packageName}@${newPackageVersion}`, e)
+    process.exit(1)
   }
 
   uncreateTemporaryNPMRC()

--- a/packages/gatsby-dev-cli/src/utils/promisified-spawn.js
+++ b/packages/gatsby-dev-cli/src/utils/promisified-spawn.js
@@ -2,11 +2,28 @@ const execa = require(`execa`)
 
 const defaultSpawnArgs = {
   cwd: process.cwd(),
-  stdio: process.env.DEBUG ? `inherit` : `ignore`,
+  stdio: `inherit`,
 }
 
-exports.promisifiedSpawn = ([cmd, args = [], spawnArgs = {}]) =>
-  execa(cmd, args, {
+exports.setDefaultSpawnStdio = stdio => {
+  defaultSpawnArgs.stdio = stdio
+}
+
+exports.promisifiedSpawn = async ([cmd, args = [], spawnArgs = {}]) => {
+  const spawnOptions = {
     ...defaultSpawnArgs,
     ...spawnArgs,
-  })
+  }
+  try {
+    return await execa(cmd, args, spawnOptions)
+  } catch (e) {
+    if (spawnOptions.stdio === `ignore`) {
+      console.log(
+        `\nCommand "${cmd} ${args.join(
+          ` `
+        )}" failed.\nTo see details of failed command, rerun "gatsby-dev" without "--quiet" or "-q" switch\n`
+      )
+    }
+    throw e
+  }
+}

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -8,7 +8,10 @@ const findWorkspaceRoot = require(`find-yarn-workspace-root`)
 const { publishPackagesLocallyAndInstall } = require(`./local-npm-registry`)
 const { checkDepsChanges } = require(`./utils/check-deps-changes`)
 const { getDependantPackages } = require(`./utils/get-dependant-packages`)
-const { promisifiedSpawn } = require(`./utils/promisified-spawn`)
+const {
+  setDefaultSpawnStdio,
+  promisifiedSpawn,
+} = require(`./utils/promisified-spawn`)
 const { traversePackagesDeps } = require(`./utils/traverse-package-deps`)
 
 let numCopied = 0
@@ -29,6 +32,7 @@ async function watch(
   packages,
   { scanOnce, quiet, forceInstall, monoRepoPackages, localPackages }
 ) {
+  setDefaultSpawnStdio(quiet ? `ignore` : `inherit`)
   // determine if in yarn workspace - if in workspace, force using verdaccio
   // as current logic of copying files will not work correctly.
   const yarnWorkspaceRoot = findWorkspaceRoot()


### PR DESCRIPTION
## Description

`gatsby-dev-cli` is currently hiding output of various `yarn` commands we run under the hood unless `DEBUG` env var is set - this was done to prevent quite large console spam in case we need to go through verdaccio path, but tradeoff of frustration when something fails without clear reason is not worth having clean terminal output.

With this PR output of commands is hidden only when using `--quiet` flag. And if we hit errors with `--quiet` flag there is hopefully helpful message to drop `--quiet` switch to see the output.