### PR TITLE
fix(gatsby-dev-cli): support workspaces in yarn@1.22

### DIFF
--- a/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
@@ -61,12 +61,19 @@ const installPackages = async ({
       if (sanitizedStdOut?.length >= 2) {
         // pick content of first (and only) capturing group
         const jsonString = sanitizedStdOut[1]
-        workspacesLayout = JSON.parse(jsonString)
+        try {
+          workspacesLayout = JSON.parse(jsonString)
+        } catch (e) {
+          console.error(
+            `Failed to parse "sanitized" output of "yarn workspaces info" command.\n\nSanitized string: "${jsonString}`
+          )
+          // not exitting here, because we have general check for `workspacesLayout` being set below
+        }
       }
     }
 
     if (!workspacesLayout) {
-      console.log(
+      console.error(
         `Couldn't parse output of "yarn workspaces info" command`,
         stdout
       )

--- a/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
@@ -29,7 +29,49 @@ const installPackages = async ({
       { stdio: `pipe` },
     ])
 
-    const workspacesLayout = JSON.parse(JSON.parse(stdout).data)
+    let workspacesLayout
+    try {
+      workspacesLayout = JSON.parse(JSON.parse(stdout).data)
+    } catch (e) {
+      /*
+      Yarn 1.22 doesn't output pure json - it has leading and trailing text:
+      ```
+      $ yarn workspaces info --json
+      yarn workspaces v1.22.0
+      {
+        "z": {
+          "location": "z",
+          "workspaceDependencies": [],
+          "mismatchedWorkspaceDependencies": []
+        },
+        "y": {
+          "location": "y",
+          "workspaceDependencies": [],
+          "mismatchedWorkspaceDependencies": []
+        }
+      }
+      Done in 0.48s.
+      ```
+      So we need to do some sanitization. We find JSON by matching substring
+      that starts with `{` and ends with `}`
+    */
+
+      const regex = /^[^{]*({.*})[^}]*$/gs
+      const sanitizedStdOut = regex.exec(stdout)
+      if (sanitizedStdOut?.length >= 2) {
+        // pick content of first (and only) capturing group
+        const jsonString = sanitizedStdOut[1]
+        workspacesLayout = JSON.parse(jsonString)
+      }
+    }
+
+    if (!workspacesLayout) {
+      console.log(
+        `Couldn't parse output of "yarn workspaces info" command`,
+        stdout
+      )
+      process.exit(1)
+    }
 
     const handleDeps = deps => {
       if (!deps) {


### PR DESCRIPTION
## Description

When using `yarn@1.22` it has different shape of `yarn workspaces info --json` command than previous versions of yarn - because gatsby-dev-cli relies on this output when running it in workspaces - we need some error catching / sanitization