### PR TITLE
perf(gatsby): be more conservative in when to sort

### DIFF
--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -166,12 +166,8 @@ const filterWithoutSift = (filters, nodeTypeNames, filtersCache) => {
       b.length - a.length
   )
 
-  if (nodesPerValueArrs.length === 1) {
-    // If there's only one bucket then we have to run it against itself to
-    // make sure it doesn't contain dupes. Otherwise the deduping would
-    // already happen while merging.
-    nodesPerValueArrs.push(nodesPerValueArrs[nodesPerValueArrs.length - 1])
-  }
+  // All elements of nodesPerValueArrs should be sorted by counter and deduped
+  // So if there's only one bucket in this list the next loop is skipped
 
   while (nodesPerValueArrs.length > 1) {
     nodesPerValueArrs.push(
@@ -271,7 +267,8 @@ const getBucketsForQueryFilter = (
   const nodesPerValue /*: Array<IGatsbyNode> | undefined */ = getNodesFromCacheByValue(
     filterCacheKey,
     filterValue,
-    filtersCache
+    filtersCache,
+    false
   )
 
   // If we couldn't find the needle then maybe sift can, for example if the
@@ -331,7 +328,8 @@ const collectBucketForElemMatch = (
   const nodesByValue /*: Array<IGatsbyNode> | undefined*/ = getNodesFromCacheByValue(
     filterCacheKey,
     targetValue,
-    filtersCache
+    filtersCache,
+    true
   )
 
   // If we couldn't find the needle then maybe sift can, for example if the


### PR DESCRIPTION
The sorting was being overly generic which was hurting some fast paths where sorting was not necessary. Instead I've made sure that all buckets are sorted (and assert that they must be deduped by definition, for regular and elemMatch queries). This attempts to push most of the sort time in the one-time cache moment, rather than having to do it for every filter regardless.

This means that anything that pulls only one bucket from the cache shouldn't need to do any sorting/deduping. Anything that does merge or get the buckets differently, still needs to, like `$eq null` or range ops. But regular `$eq`, by far the most common case, etc should now not be burdened by this requirement.