### PR TITLE
fix(gatsby-core-utils): fix hash for buffers

### DIFF
--- a/packages/gatsby-core-utils/src/__tests__/create-content-digest.ts
+++ b/packages/gatsby-core-utils/src/__tests__/create-content-digest.ts
@@ -33,7 +33,7 @@ describe(`Create content digest`, () => {
 
     expect(typeof contentDigest).toEqual(`string`)
     expect(contentDigest).toMatchInlineSnapshot(
-      `"99d81e0b08af04b87f7e4ab0e6d13f12"`
+      `"81dc9bdb52d04dc20036dbd8313ed055"`
     )
     expect(contentDigest2).toMatchInlineSnapshot(
       `"674f3c2c1a8a6f90461e8a66fb5550ba"`

--- a/packages/gatsby-core-utils/src/__tests__/create-content-digest.ts
+++ b/packages/gatsby-core-utils/src/__tests__/create-content-digest.ts
@@ -23,6 +23,32 @@ describe(`Create content digest`, () => {
     )
   })
 
+  // @fixes https://github.com/gatsbyjs/gatsby/issues/21840
+  it(`returns the content digest when input is a Buffer`, () => {
+    const input = Buffer.from(`1234`)
+    const input2 = Buffer.from(`5678`)
+
+    const contentDigest = createContentDigest(input)
+    const contentDigest2 = createContentDigest(input2)
+
+    expect(typeof contentDigest).toEqual(`string`)
+    expect(contentDigest).toMatchInlineSnapshot(
+      `"99d81e0b08af04b87f7e4ab0e6d13f12"`
+    )
+    expect(contentDigest2).toMatchInlineSnapshot(
+      `"674f3c2c1a8a6f90461e8a66fb5550ba"`
+    )
+    expect(contentDigest).not.toEqual(contentDigest2)
+  })
+
+  // @fixes https://github.com/gatsbyjs/gatsby/issues/21840
+  it(`returns a deterministic hash from a Buffer`, () => {
+    const input = Buffer.from(`1234`)
+    const input2 = Buffer.from(`1234`)
+
+    expect(createContentDigest(input)).toEqual(createContentDigest(input2))
+  })
+
   it(`returns a deterministic hash from an object`, () => {
     const input = {
       id: `12345`,

--- a/packages/gatsby-core-utils/src/create-content-digest.ts
+++ b/packages/gatsby-core-utils/src/create-content-digest.ts
@@ -26,7 +26,7 @@ const hashPrimitive = (input: BinaryLike | string): string =>
 export const createContentDigest = (
   input: BinaryLike | string | any
 ): string => {
-  if (typeof input === `object`) {
+  if (typeof input === `object` && !Buffer.isBuffer(input)) {
     return hasher.hash(input)
   }
 


### PR DESCRIPTION
#  Description

When buffer we should just use crypto as node-object-hash isn't working correctly with coerce false.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/21840
