### PR TITLE
feat(gatsby-source-drupal): [localFile] Add support to other Files & Media

### DIFF
--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -24,9 +24,7 @@ const nodeFromData = (datum, createNodeId) => {
 exports.nodeFromData = nodeFromData
 
 const isFileNode = node =>
-  node.internal.type === `files` ||
-  /^file__/.test(node.internal.type) ||
-  /^media__/.test(node.internal.type);
+  node.internal.type === `files` || /^file__/.test(node.internal.type)
 
 exports.isFileNode = isFileNode
 

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -24,7 +24,9 @@ const nodeFromData = (datum, createNodeId) => {
 exports.nodeFromData = nodeFromData
 
 const isFileNode = node =>
-  node.internal.type === `files` || node.internal.type === `file__file`
+  node.internal.type === `files` ||
+  /^file__/.test(node.internal.type) ||
+  /^media__/.test(node.internal.type);
 
 exports.isFileNode = isFileNode
 


### PR DESCRIPTION
## Description

Add support to **Media** module.
In Drupal CMS files (images, ..etc) are exposed as `file--file` by default.
Lately a new functionality was added for better images manipulation, Media is a drop-in replacement for the Drupal core upload field with a unified User Interface where editors and administrators can upload, manage, and reuse files and multimedia assets.

When Drupal sites install the **Media** module, new image fields will be exposed as `media--image`, so we need to support this type in `gatsby-source-drupal` plugin.

Another test was added for **Media Entity Browser** which expose images as `file--image`.

### Documentation

With this enabled **GraphQL Interface (GraphiQL)** will now show `localFile` field.

## Related Issues

Fixes #24619