### PR TITLE
chore(starters): add gatsby-starter-simple

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6631,6 +6631,6 @@
   features:
     - TypeScript is used for a better developer experience.
     - ESLint and the AirBnB TypeScript style guide help you avoid, and fix, simple issues in your code.
-    - The default Gatsby formating tool Prettier, has been removed in order to avoid conflicts with the ESLint + AirBnB TypeScript tools described above.
+    - The default Gatsby formatting tool Prettier, has been removed in order to avoid conflicts with the ESLint + AirBnB TypeScript tools described above.
     - Firebase Hosting is supported and configured for Gatsby from the start.
     - Dynamic pages for blog posts in markdown is implemented.

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6618,7 +6618,7 @@
     - SEO optimized to include social media images and Twitter handles.
     - React Scroll for one page, anchor based navigation is available.
     - Code highlighting via Prism.
-- url: https://gatsby-starter-simple.web.app
+- url: https://simple.rickkln.com
   repo: https://github.com/rickkln/gatsby-starter-simple
   description: Simple Gatsby starter for a small static site. Replaces Prettier with ESLint (AirBnB style), and adds TypeScript and Firebase hosting.
   tags:

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6618,3 +6618,19 @@
     - SEO optimized to include social media images and Twitter handles.
     - React Scroll for one page, anchor based navigation is available.
     - Code highlighting via Prism.
+- url: https://gatsby-starter-simple.web.app
+  repo: https://github.com/rickkln/gatsby-starter-simple
+  description: Simple Gatsby starter for a small static site. Replaces Prettier with ESLint (AirBnB style), and adds TypeScript and Firebase hosting.
+  tags:
+    - Linting
+    - Language:TypeScript
+    - Firebase
+    - SEO
+    - Markdown
+    - Portfolio
+  features:
+    - TypeScript is used for a better developer experience.
+    - ESLint and the AirBnB TypeScript style guide help you avoid, and fix, simple issues in your code.
+    - The default Gatsby formating tool Prettier, has been removed in order to avoid conflicts with the ESLint + AirBnB TypeScript tools described above.
+    - Firebase Hosting is supported and configured for Gatsby from the start.
+    - Dynamic pages for blog posts in markdown is implemented.


### PR DESCRIPTION
## Description

Adds a new starter, namely [gatsby-starter-simple](https://www.gatsbyjs.org/contributing/submit-to-starter-library/) via the process described [here](https://www.gatsbyjs.org/contributing/submit-to-starter-library/).

**gatsby-starter-simple** is a simple Gatsby starter for a small static site. It replaces Prettier with ESLint (AirBnB style), and adds TypeScript and Firebase hosting.

### Documentation and Demo

The only code changed in this PR is: `docs/starters.yml`
The documentation for the new starter is available at it's repo [here](https://github.com/rickkln/gatsby-starter-simple), and there is a demo available at [simple.rickkln.com](https://simple.rickkln.com/).
