### PR TITLE
feature(gatsby-source-contentful): expose additional APIs from the package

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -394,6 +394,69 @@ documentToReactComponents(node.bodyRichText.json, options)
 
 Check out the examples at [@contentful/rich-text-react-renderer](https://github.com/contentful/rich-text/tree/master/packages/rich-text-react-renderer).
 
+### Using Gatsby Image With Contentful's Rich Text
+
+When you query for a rich text field that has an embedded asset or entry that contains an image, the json output does not contain the fluid or fixed props needed for GatsbyImage. What it returns is the assset with a data shape like this:
+
+```
+"fields": {
+    "title": "Playsam Streamliner",
+    "file": {
+      "fileName": "quwowooybuqbl6ntboz3.jpg",
+      "contentType": "image/jpg",
+      "details": {
+        "image": {
+          "width": 600,
+          "height": 446
+        },
+        "size": 27187
+      },
+      "url": "//images.ctfassets.net/yadj1kx9rmg0/wtrHxeu3zEoEce2MokCSi/cf6f68efdcf625fdc060607df0f3baef/quwowooybuqbl6ntboz3.jpg"
+    }
+  }
+```
+
+To turn this into fluid or fixed props, we can use the utility functions from `gatsby-source-contentful`
+
+```jsx
+import { resolveFluid, resolveFixed } from 'gatsby-source-contentful'
+import Img from 'gatsby-image'
+
+const options = {
+  renderNode: {
+    [BLOCKS.EMBEDDED_ASSET]: (node) => {
+      const { file, title } = node.data.target.fields
+      
+      // Note file, and title data are localized so we need to access it further.
+      const image = {
+        file: file['en-US']
+      }
+      
+      const fluidProps = resolveFluid(image, { maxWidth: 800 })
+      
+      return <Img fluid={fluidProps} alt={title['en-US']} />
+    }
+  },
+}
+```
+
+#### Utility functions
+resolveFluid(image, options) ->  {
+  aspectRatio,
+  baseUrl,
+  srcSet,
+  sizes
+} 
+
+resolveFixed(image, options) -> {
+  aspectRatio,
+  baseUrl,
+  width,
+  height,
+  src,
+  srcSet,
+}
+
 ## Sourcing From Multiple Contentful Spaces
 
 To source from multiple Contentful environments/spaces, add another configuration for `gatsby-source-contentful` in `gatsby-config.js`:

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -396,7 +396,7 @@ Check out the examples at [@contentful/rich-text-react-renderer](https://github.
 
 ### Using Gatsby Image With Contentful's Rich Text
 
-When you query for a rich text field that has an embedded asset or entry that contains an image, the json output does not contain the fluid or fixed props needed for GatsbyImage. What it returns is the assset with a data shape like this:
+When you query for a rich text field that has an embedded asset or entry that contains an image, the json output does not contain the fluid or fixed props needed for GatsbyImage. What it returns is the asset with a data shape like this:
 
 ```
 "fields": {

--- a/packages/gatsby-source-contentful/index.js
+++ b/packages/gatsby-source-contentful/index.js
@@ -1,1 +1,9 @@
-module.exports.schemes = require(`./schemes.js`)
+const schemes = require(`./schemes.js`)
+const { resolveFluid, resolveFixed, resolveResize } = require('./extend-node-type.js')
+
+module.exports = {
+  schemes,
+  resolveFluid,
+  resolveFixed,
+  resolveResize
+}


### PR DESCRIPTION
Add resolveFluid, resolveFixed and resolveResize to the named exports.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
This PR allows us to generate `fluid` or `fixed` props from a Conntentful asset without using Graphql.

Relevant [issue](https://github.com/gatsbyjs/gatsby/issues/24633)

<!-- Write a brief description of the changes introduced by this PR -->

TODO:
- [ ] Add documentation on how to use these new APIs

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
