### PR TITLE
feature(www): convert the class based swatch component to function component

### DIFF
--- a/www/src/components/guidelines/color/swatch.js
+++ b/www/src/components/guidelines/color/swatch.js
@@ -1,132 +1,122 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import React from "react"
+import React, { useState } from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
 
 import { Box } from "../system"
 
-export default class Swatch extends React.Component {
-  state = {
-    value: this.props.color.hex,
-    displayCopied: false,
-  }
+export default function Swatch(props) {
+  const { a11yLabel, color, swatchStyle, textColor } = props
+  const [displayCopied, setDisplayCopied] = useState(false)
 
-  toggleCopied = () => {
-    this.setState({
-      displayCopied: true,
-    })
+  const toggleCopied = () => {
+    setDisplayCopied(true)
 
     setTimeout(() => {
-      this.setState({
-        displayCopied: false,
-      })
+      setDisplayCopied(false)
     }, 2500)
   }
 
-  handleClick = event => {
+  const handleClick = event => {
     event.preventDefault()
     event.stopPropagation()
   }
 
-  render() {
-    const { a11yLabel, color, swatchStyle, textColor } = this.props
+  return (
+    <Box
+      bg={color.hex}
+      sx={{
+        ...swatchStyle,
+        ":hover > .btn-copy": {
+          display: `block`,
+        },
+      }}
+    >
+      {a11yLabel !== `×` && (
+        <Box
+          color={textColor}
+          fontSize={0}
+          position="absolute"
+          fontWeight="body"
+          sx={{
+            bottom: `2px`,
+            left: `3px`,
+            lineHeight: `dense`,
+            top: `auto`,
+          }}
+        >
+          {a11yLabel}
+        </Box>
+      )}
 
-    return (
-      <Box
-        bg={color.hex}
-        sx={{
-          ...swatchStyle,
-          ":hover > .btn-copy": {
-            display: `block`,
-          },
-        }}
-      >
-        {a11yLabel !== `×` && (
+      <CopyToClipboard text={color.hex} onCopy={toggleCopied}>
+        <button
+          className="btn-copy"
+          sx={{
+            background: `none`,
+            border: 0,
+            bottom: 0,
+            color: `black`,
+            cursor: `pointer`,
+            height: `100%`,
+            left: 0,
+            position: `absolute`,
+            right: 0,
+            top: 0,
+            width: `100%`,
+            zIndex: 1,
+            ":focus .tooltip, :hover .tooltip": {
+              display: `block`,
+            },
+          }}
+          aria-label={color.hex}
+          onClick={handleClick}
+        >
           <Box
-            color={textColor}
-            fontSize={0}
-            position="absolute"
-            fontWeight="body"
+            bg="white"
+            boxShadow="raised"
+            borderRadius={1}
+            fontSize={1}
+            className="tooltip"
             sx={{
-              bottom: `2px`,
-              left: `3px`,
-              lineHeight: `dense`,
-              top: `auto`,
-            }}
-          >
-            {a11yLabel}
-          </Box>
-        )}
-
-        <CopyToClipboard text={this.state.value} onCopy={this.toggleCopied}>
-          <button
-            className="btn-copy"
-            sx={{
-              background: `none`,
-              border: 0,
-              bottom: 0,
-              color: `black`,
-              cursor: `pointer`,
-              height: `100%`,
+              top: `-40px`,
+              height: `32px`,
               left: 0,
+              lineHeight: `32px`,
+              display: `none`,
               position: `absolute`,
-              right: 0,
-              top: 0,
-              width: `100%`,
-              zIndex: 1,
-              ":focus .tooltip, :hover .tooltip": {
-                display: `block`,
-              },
+              width: `160px`,
             }}
-            aria-label={color.hex}
-            onClick={this.handleClick}
           >
-            <Box
-              bg="white"
-              boxShadow="raised"
-              borderRadius={1}
-              fontSize={1}
-              className="tooltip"
-              sx={{
-                top: `-40px`,
-                height: `32px`,
-                left: 0,
-                lineHeight: `32px`,
-                display: `none`,
-                position: `absolute`,
-                width: `160px`,
-              }}
-            >
-              {this.state.displayCopied ? (
-                <>Copied to clipboard!</>
-              ) : (
-                <React.Fragment>
-                  Copy HEX <code sx={{ bg: `yellow.10` }}>{color.hex}</code>
-                </React.Fragment>
-              )}
-            </Box>
-          </button>
-        </CopyToClipboard>
+            {displayCopied ? (
+              <>Copied to clipboard!</>
+            ) : (
+              <React.Fragment>
+                Copy HEX <code sx={{ bg: `yellow.10` }}>{color.hex}</code>
+              </React.Fragment>
+            )}
+          </Box>
+        </button>
+      </CopyToClipboard>
 
-        {(color.name || color.base) && (
-          <Box
-            bg={textColor}
-            borderRadius={7}
-            bottom={4}
-            fontSize={0}
-            lineHeight="solid"
-            height={8}
-            width={8}
-            position="absolute"
-            top="auto"
-            right={4}
-            css={{
-              bottom: 4,
-              right: 4,
-            }}
-          />
-        )}
-      </Box>
-    )
-  }
+      {(color.name || color.base) && (
+        <Box
+          bg={textColor}
+          borderRadius={7}
+          bottom={4}
+          fontSize={0}
+          lineHeight="solid"
+          height={8}
+          width={8}
+          position="absolute"
+          top="auto"
+          right={4}
+          css={{
+            bottom: 4,
+            right: 4,
+          }}
+        />
+      )}
+    </Box>
+  )
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
1. The class based `<Swatch/>` component in color page of guidelines has been converted to function component.
2. It was using state called `displayCopied` to show the **Copied to clipboard!** text after the color code has been copied to clipboard, now this state is being managed by useState hook.
3. It was having another state set in constructor called `value: this.props.color.hex`, it was redundant because value of hex can be retrieved directly from color which we were getting by props destructuring.

### Screenshots(s)

#### Clicking on any color swatch will copy the hex color code to Clipboard
<img width="400" alt="before-copying" src="https://user-images.githubusercontent.com/19193724/83321516-f09a4b00-a26d-11ea-9e6c-3acdfc411df5.png">


#### The hex color code has been copied to the clipboard
<img width="399" alt="after-copying" src="https://user-images.githubusercontent.com/19193724/83321517-f5f79580-a26d-11ea-83bd-99d8890c1c9b.png">


### How to test

Go to the following link mentioned below, the component should work same in both the local and production link, just the implementation of component is now different.

**Local URL:** http://localhost:8000/guidelines/color/
**Production URL:** https://www.gatsbyjs.org/guidelines/color/