### PR TITLE
chore(showcase): Add mobileui.dev

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -9,6 +9,8 @@
     - Programming
     - Landing Page
     - Blog
+    - WordPress
+    - E-commerce
   built_by: NeverNull GmbH
   built_by_url: https://nevernull.io
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -1,3 +1,17 @@
+- title: MobileUI
+  main_url: https://mobileui.dev
+  url: https://mobileui.dev
+  description: >
+    A java-based framework for cross-platform app development with Java and Kotlin.
+  categories:
+    - Mobile Development
+    - Technology
+    - Programming
+    - Landing Page
+    - Blog
+  built_by: NeverNull GmbH
+  built_by_url: https://nevernull.io
+  featured: false
 - title: ReactJS
   main_url: https://reactjs.org/
   url: https://reactjs.org/


### PR DESCRIPTION
Our MobileUI framework product website. The framework is about cross-platform app development.

Built with Gatsby, WPGraphQL and Apollo for the dynamic user area, that is connected to WordPress.

It consists of a landing page, a blog (https://mobileui.dev/blog/), and a private user area with e-commerce content.
