### PR TITLE
fix(docs): add trailing slashes to glossary links

### DIFF
--- a/docs/docs/glossary/decoupled-drupal.md
+++ b/docs/docs/glossary/decoupled-drupal.md
@@ -13,7 +13,7 @@ In a tightly coupled Drupal architecture, themes control your site's appearance.
 
 When a visitor requests a URL, Drupal retrieves the requested content from the database and merges it with the appropriate template to create an HTML response. The downside of such an architecture is that your site's content is only available as HTML. HTML limits where and how your content can be used.
 
-In a decoupled architecture, Drupal's only responsibility is content. Rather than returning HTML documents, Drupal returns JSON from its [REST](https://www.drupal.org/docs/8/api/restful-web-services-api/restful-web-services-api-overview) or [JSON:API](https://www.drupal.org/docs/8/modules/jsonapi/api-overview) interfaces. Or you can use [GraphQL](/docs/glossary/graphql) by installing the [GraphQL module](https://www.drupal.org/docs/8/modules/graphql).
+In a decoupled architecture, Drupal's only responsibility is content. Rather than returning HTML documents, Drupal returns JSON from its [REST](https://www.drupal.org/docs/8/api/restful-web-services-api/restful-web-services-api-overview) or [JSON:API](https://www.drupal.org/docs/8/modules/jsonapi/api-overview) interfaces. Or you can use [GraphQL](/docs/glossary/graphql/) by installing the [GraphQL module](https://www.drupal.org/docs/8/modules/graphql).
 
 A decoupled Drupal architecture offers two key advantages over a tightly coupled one.
 

--- a/docs/docs/glossary/headless-cms.md
+++ b/docs/docs/glossary/headless-cms.md
@@ -11,7 +11,7 @@ A _headless content management system_ or _headless CMS_, is a CMS in which the 
 
 Headless content management systems, on the other hand, return structured data from an [API](/docs/glossary/#api). Rather than merging templates and content to create HTML, a headless CMS returns JSON or unstyled XML. Content creators still use an editing interface to add content to a headless CMS, but the [backend](/docs/glossary#backend) management of the site's content is [_decoupled_](/docs/glossary#decoupled) from the [frontend](/docs/glossary#frontend) that displays it.
 
-When your content is available as structured data, it's available to any client or application that can consume that data whether a [JAMStack](/docs/glossary/jamstack) application, or a mobile device. You can use a headless CMS to provide [JSON content source](/docs/sourcing-content-from-json-or-yaml/) for your Gatsby site and your other content channels.
+When your content is available as structured data, it's available to any client or application that can consume that data whether a [JAMStack](/docs/glossary/jamstack/) application, or a mobile device. You can use a headless CMS to provide [JSON content source](/docs/sourcing-content-from-json-or-yaml/) for your Gatsby site and your other content channels.
 
 With plugins, Gatsby supports several [headless CMS](/docs/headless-cms/) services, including [Contentful](https://www.contentful.com/), [Ghost](https://ghost.org/pricing/) and [Prismic](https://prismic.io/). If you use WordPress, there's no need to switch. You can use WordPress' [REST API](/docs/sourcing-from-wordpress/) as a headless CMS, so that your content team can continue to use the editing tools with which they're familiar.
 

--- a/docs/docs/glossary/npm.md
+++ b/docs/docs/glossary/npm.md
@@ -8,7 +8,7 @@ Learn what _npm_ is, how to use it, and how it fits in to the Gatsby ecosystem.
 ## What is npm?
 
 <abbr>npm</abbr>, or Node package manager, is the default package manager for
-the [Node.js](/docs/glossary/node) JavaScript runtime. It lets you install and
+the [Node.js](/docs/glossary/node/) JavaScript runtime. It lets you install and
 update libraries and frameworks (dependencies) for Node-based projects, and
 interact with the npm Registry. You'll use npm to install and upgrade Gatsby and
 its plugins.


### PR DESCRIPTION
## Description
**Changes: added trailing slash to helps the user identify the hierarchy of page.**

`Fix: Breadcrumb issue resolved in /docs/docs/glossary.md`

## Related Issues
- #20767 `[docs] Breadcrumb shouldn't be dependent on trailing slash`
- #22628 `chore(docs): Add Snipcart reference guide`
- #22933 `fix(docs): add trainling slashes to doc-links.yaml`
- #24068 `fix(docs): added trailing slash to glossary.md` 
- #19267 `Add link checker for Gatsby Docs`
