### PR TITLE
fix(gatsby-recipes): Clean up dist folder before build

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -102,7 +102,9 @@
   "scripts": {
     "build": "babel src --out-dir dist --ignore \"**/__tests__\"  --extensions \".ts,.js,.tsx\"",
     "build:watch": "npm run build -- --watch",
+    "prebuild": "rimraf dist",
     "prepare": "npm run build",
+    "prewatch": "rimraf dist",
     "watch": "npm run build:watch",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
This ensures that there aren't any files being left around when the build runs for publishing.