### PR TITLE
fix(gatsby-recipes): Don't use 4000 as default recipes port as commonly used by people in apps

### DIFF
--- a/packages/gatsby-recipes/src/graphql-server/index.js
+++ b/packages/gatsby-recipes/src/graphql-server/index.js
@@ -14,7 +14,9 @@ exports.startGraphQLServer = async (programPath, forceStart) => {
   let { port } = (await getService(programPath, `recipesgraphqlserver`)) || {}
 
   if (!port || forceStart) {
-    port = await detectPort(4000)
+    // Use 50400 as our port as it's a highly composite number! Meaning it has
+    // more divisors than any smaller positive integer.
+    port = await detectPort(50400)
     await createServiceLock(programPath, `recipesgraphqlserver`, { port })
 
     const subprocess = execa(`node`, [require.resolve(`./server.js`), port], {

--- a/packages/gatsby-recipes/src/graphql-server/server.js
+++ b/packages/gatsby-recipes/src/graphql-server/server.js
@@ -20,7 +20,7 @@ const createTypes = require(`../create-types`)
 const SITE_ROOT = pkgDir.sync(process.cwd())
 
 const pubsub = new PubSub()
-const PORT = process.argv[2] || 4000
+const PORT = process.argv[2] || 50400
 
 const emitOperation = state => {
   console.log(state)


### PR DESCRIPTION
fixes https://github.com/gatsbyjs/gatsby/issues/24656


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->