### PR TITLE
fix(www): Starter star sorting

### DIFF
--- a/www/src/views/starter-library/starter-list.js
+++ b/www/src/views/starter-library/starter-list.js
@@ -217,7 +217,7 @@ const StartersList = ({ urlState, starters, count }) => {
 export default StartersList
 
 function sortingFunction() {
-  return function ({ node: nodeA }, { node: nodeB }) {
+  return function (nodeA, nodeB) {
     const metricA = get(nodeA, `fields.starterShowcase.stars`, 0)
     const metricB = get(nodeB, `fields.starterShowcase.stars`, 0)
     return metricB - metricA


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/21792 didn't also change the starter sort. So it was actually broken for a couple of months now 😮 

Fixes https://github.com/gatsbyjs/gatsby/issues/24616
