### PR TITLE
Update benchmark reporting plugin verisons

### DIFF
--- a/benchmarks/source-cosmicjs/package.json
+++ b/benchmarks/source-cosmicjs/package.json
@@ -16,7 +16,7 @@
     "dotenv": "^8.2.0",
     "gatsby": "^2.19.7",
     "gatsby-image": "^2.2.40",
-    "gatsby-plugin-benchmark-reporting": "^0.0.2",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-source-cosmicjs": "^1.1.0",
     "gatsby-source-filesystem": "^2.1.48",

--- a/benchmarks/source-sanity/package.json
+++ b/benchmarks/source-sanity/package.json
@@ -17,7 +17,7 @@
     "dotenv": "^8.2.0",
     "gatsby": "^2.19.7",
     "gatsby-image": "^2.2.40",
-    "gatsby-plugin-benchmark-reporting": "^0.0.2",
+    "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-source-sanity": "^5.0.6",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Update the benchmark reporting plugin versions in the new benchmarks to match the others.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

n/a

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

n/a