### PR TITLE
chore(gatsby): Export and improve types

### DIFF
--- a/packages/gatsby/src/bootstrap/create-graphql-runner.ts
+++ b/packages/gatsby/src/bootstrap/create-graphql-runner.ts
@@ -9,8 +9,9 @@ import { emitter } from "../redux"
 import { Reporter } from "../.."
 import { ExecutionResult, Source } from "../../graphql"
 import { IGatsbyState } from "../redux/types"
+import { IMatch } from "../types"
 
-type Runner = (
+export type Runner = (
   query: string | Source,
   context: Record<string, any>
 ) => Promise<ExecutionResult<ExecutionResultDataDefault>>
@@ -81,7 +82,7 @@ export const createGraphQLRunner = (
 
               return null
             })
-            .filter(Boolean)
+            .filter((Boolean as unknown) as (match) => match is IMatch)
 
           if (structuredErrors.length) {
             // panic on build exits the process

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -31,6 +31,7 @@ const {
 import { getGatsbyDependents } from "../utils/gatsby-dependents"
 const { store } = require(`../redux`)
 import * as actions from "../redux/actions/internal"
+import { websocketManager } from "../utils/websocket-manager"
 const { default: FileParser } = require(`./file-parser`)
 const {
   graphqlError,
@@ -43,7 +44,6 @@ const {
   default: errorParser,
   locInGraphQlToLocInFile,
 } = require(`./error-parser`)
-const { websocketManager } = require(`../utils/websocket-manager`)
 
 const overlayErrorID = `graphql-compiler`
 

--- a/packages/gatsby/src/utils/wait-until-jobs-complete.ts
+++ b/packages/gatsby/src/utils/wait-until-jobs-complete.ts
@@ -2,7 +2,7 @@ import { emitter, store } from "../redux"
 
 import { waitUntilAllJobsComplete as waitUntilAllJobsV2Complete } from "./jobs-manager"
 
-export const waitUntilAllJobsComplete = (): Promise<void> => {
+export const waitUntilAllJobsComplete = (): Promise<any> => {
   const jobsV1Promise = new Promise(resolve => {
     const onEndJob = (): void => {
       if (store.getState().jobs.active.length === 0) {
@@ -15,8 +15,5 @@ export const waitUntilAllJobsComplete = (): Promise<void> => {
     onEndJob()
   })
 
-  return Promise.all([
-    jobsV1Promise,
-    waitUntilAllJobsV2Complete(),
-  ]).then(() => {})
+  return Promise.all([jobsV1Promise, waitUntilAllJobsV2Complete()])
 }

--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-invalid-this */
 import path from "path"
 import { store } from "../redux"
 import { Server as HTTPSServer } from "https"
@@ -10,14 +11,14 @@ import { createHash } from "crypto"
 import { normalizePagePath, denormalizePagePath } from "./normalize-page-path"
 import socketIO from "socket.io"
 
-interface IPageQueryResult {
+export interface IPageQueryResult {
   id: string
-  result: any // TODO: Improve this once we understand what the type is
+  result: unknown // TODO: Improve this once we understand what the type is
 }
 
-interface IStaticQueryResult {
+export interface IStaticQueryResult {
   id: string
-  result: any // TODO: Improve this once we understand what the type is
+  result: unknown // TODO: Improve this once we understand what the type is
 }
 
 type PageResultsMap = Map<string, IPageQueryResult>
@@ -103,7 +104,7 @@ const getCachedStaticQueryResults = (
 
 const getRoomNameFromPath = (path: string): string => `path-${path}`
 
-class WebsocketManager {
+export class WebsocketManager {
   activePaths: Set<string> = new Set()
   connectedClients = 0
   errors: Map<string, string> = new Map()


### PR DESCRIPTION
This PR tightens up a few types, and exports several interfaces. Functionally, it also returns the result of waitUntilAllJobsComplete rather than void.

This is part of the develop state machine refactor.