### PR TITLE
fix(gatsby): double encoded urls breaking 404

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/find-path.js
+++ b/packages/gatsby/cache-dir/__tests__/find-path.js
@@ -81,6 +81,13 @@ describe(`find-path`, () => {
       )
     })
 
+    it(`should return the decoded path when encoded once or twice`, () => {
+      expect(findPath(`/notanapp%2Fmy-page`)).toBe(`/notanapp/my-page`)
+
+      // encoded twice
+      expect(findPath(`/notanapp%252Fmy-page`)).toBe(`/notanapp/my-page`)
+    })
+
     it(`should only process a request once`, () => {
       jest.resetModules()
       jest.mock(`@reach/router/lib/utils`)

--- a/packages/gatsby/cache-dir/find-path.js
+++ b/packages/gatsby/cache-dir/find-path.js
@@ -6,7 +6,9 @@ const pathCache = new Map()
 let matchPaths = []
 
 const trimPathname = rawPathname => {
-  const pathname = decodeURIComponent(rawPathname)
+  // Decode twice because encoded URIs might be encoded a second time when
+  // coming from the router.
+  const pathname = decodeURIComponent(decodeURIComponent(rawPathname))
   // Remove the pathPrefix from the pathname.
   const trimmedPathname = stripPrefix(pathname, __BASE_PATH__)
     // Remove any hashfragment


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
Decode urls a second time as, probably, the router encodes them even when they are already encoded. For example, requesting http://localhost:9000/foo/bar%2Fabc leads to http://localhost:9000/foo/bar%252Fabc which can break custom 404 pages in the special case of using encoded URLs as described in #23580. 

Not sure if it's an issue from the router, but this solution could be used as a fail-safe way.

## Related Issues

Fixes #23580
