### PR TITLE
feat(gatsby): Add state machine services

### DIFF
--- a/packages/gatsby/src/services/build-schema.ts
+++ b/packages/gatsby/src/services/build-schema.ts
@@ -1,0 +1,25 @@
+import { IBuildContext } from "../state-machines/develop"
+
+import { build } from "../schema"
+import report from "gatsby-cli/lib/reporter"
+import { createGraphQLRunner, Runner } from "../bootstrap/create-graphql-runner"
+
+export async function buildSchema({
+  store,
+  parentSpan,
+}: IBuildContext): Promise<{ graphqlRunner: Runner } | void> {
+  if (!store) {
+    report.panic(`Cannot build schema before store initialization`)
+    return undefined
+  }
+  const activity = report.activityTimer(`building schema`, {
+    parentSpan,
+  })
+  activity.start()
+  await build({ parentSpan: activity.span })
+  activity.end()
+  const graphqlRunner = createGraphQLRunner(store, report)
+  return {
+    graphqlRunner,
+  }
+}

--- a/packages/gatsby/src/services/calculate-dirty-queries.ts
+++ b/packages/gatsby/src/services/calculate-dirty-queries.ts
@@ -1,0 +1,22 @@
+import { calcInitialDirtyQueryIds, groupQueryIds } from "../query"
+import { IBuildContext } from "../state-machines/develop"
+
+export interface IGroupedQueryIds {
+  pageQueryIds: string[]
+  staticQueryIds: string[]
+}
+
+export async function calculateDirtyQueries({
+  store,
+  filesDirty,
+}: IBuildContext): Promise<{
+  queryIds: IGroupedQueryIds
+}> {
+  const state = store?.getState()
+  if (filesDirty) {
+    // Do stuff
+  }
+
+  const queryIds = calcInitialDirtyQueryIds(state)
+  return { queryIds: groupQueryIds(queryIds) }
+}

--- a/packages/gatsby/src/services/create-pages-statefully.ts
+++ b/packages/gatsby/src/services/create-pages-statefully.ts
@@ -1,0 +1,32 @@
+import { IBuildContext } from "../state-machines/develop"
+
+import reporter from "gatsby-cli/lib/reporter"
+import apiRunnerNode from "../utils/api-runner-node"
+
+export async function createPagesStatefully({
+  parentSpan,
+  graphqlRunner,
+}: IBuildContext): Promise<void> {
+  // A variant on createPages for plugins that want to
+  // have full control over adding/removing pages. The normal
+  // "createPages" API is called every time (during development)
+  // that data changes.
+  const activity = reporter.activityTimer(`createPagesStatefully`, {
+    parentSpan,
+  })
+  activity.start()
+  await apiRunnerNode(
+    `createPagesStatefully`,
+    {
+      graphql: graphqlRunner,
+      traceId: `initial-createPagesStatefully`,
+      waitForCascadingActions: true,
+      parentSpan: activity.span,
+      deferNodeMutation: true,
+    },
+    {
+      activity,
+    }
+  )
+  activity.end()
+}

--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -1,0 +1,70 @@
+import { IBuildContext } from "../state-machines/develop"
+
+import reporter from "gatsby-cli/lib/reporter"
+import apiRunnerNode from "../utils/api-runner-node"
+
+import {
+  deleteUntouchedPages,
+  findChangedPages,
+} from "../utils/check-for-changed-pages"
+
+export async function createPages({
+  parentSpan,
+  graphqlRunner,
+  store,
+}: IBuildContext): Promise<{ changedPages: string[]; deletedPages: string[] }> {
+  if (!store) {
+    reporter.panic(`store not initialized`)
+    return {
+      changedPages: [],
+      deletedPages: [],
+    }
+  }
+  const activity = reporter.activityTimer(`createPages`, {
+    parentSpan,
+  })
+  activity.start()
+  const timestamp = Date.now()
+  const currentPages = new Map(store.getState().pages)
+
+  await apiRunnerNode(
+    `createPages`,
+    {
+      graphql: graphqlRunner,
+      traceId: `initial-createPages`,
+      waitForCascadingActions: true,
+      parentSpan: activity.span,
+    },
+    { activity }
+  )
+
+  activity.end()
+
+  reporter.info(`Checking for deleted pages`)
+
+  const deletedPages = deleteUntouchedPages(store.getState().pages, timestamp)
+
+  reporter.info(
+    `Deleted ${deletedPages.length} page${deletedPages.length === 1 ? `` : `s`}`
+  )
+
+  const tim = reporter.activityTimer(`Checking for changed pages`)
+  tim.start()
+
+  const { changedPages } = findChangedPages(
+    currentPages,
+    store.getState().pages
+  )
+
+  reporter.info(
+    `Found ${changedPages.length} changed page${
+      changedPages.length === 1 ? `` : `s`
+    }`
+  )
+  tim.end()
+
+  return {
+    changedPages,
+    deletedPages,
+  }
+}

--- a/packages/gatsby/src/services/customize-schema.ts
+++ b/packages/gatsby/src/services/customize-schema.ts
@@ -1,0 +1,20 @@
+import reporter from "gatsby-cli/lib/reporter"
+import { createSchemaCustomization } from "../utils/create-schema-customization"
+import { IBuildContext } from "../state-machines/develop"
+
+export async function customizeSchema({
+  parentSpan,
+  refresh,
+  webhookBody,
+}: IBuildContext): Promise<void> {
+  const activity = reporter.activityTimer(`createSchemaCustomization`, {
+    parentSpan,
+  })
+  activity.start()
+  await createSchemaCustomization({
+    parentSpan,
+    refresh,
+    webhookBody,
+  })
+  activity.end()
+}

--- a/packages/gatsby/src/services/extract-queries.ts
+++ b/packages/gatsby/src/services/extract-queries.ts
@@ -1,0 +1,20 @@
+import { IBuildContext } from "../state-machines/develop"
+
+import reporter from "gatsby-cli/lib/reporter"
+import { extractQueries as extractQueriesAndWatch } from "../query/query-watcher"
+import apiRunnerNode from "../utils/api-runner-node"
+
+export async function extractQueries({
+  parentSpan,
+}: IBuildContext): Promise<void> {
+  const activity = reporter.activityTimer(`onPreExtractQueries`, {
+    parentSpan,
+  })
+  activity.start()
+  await apiRunnerNode(`onPreExtractQueries`, {
+    parentSpan: activity.span,
+  })
+  activity.end()
+
+  await extractQueriesAndWatch({ parentSpan })
+}

--- a/packages/gatsby/src/services/index.ts
+++ b/packages/gatsby/src/services/index.ts
@@ -1,0 +1,31 @@
+import { customizeSchema } from "./customize-schema"
+import { sourceNodes } from "./source-nodes"
+import { createPages } from "./create-pages"
+import { buildSchema } from "./build-schema"
+import { createPagesStatefully } from "./create-pages-statefully"
+import { extractQueries } from "./extract-queries"
+import { writeOutRequires } from "./write-out-requires"
+import { calculateDirtyQueries } from "./calculate-dirty-queries"
+import { runStaticQueries } from "./run-static-queries"
+import { runPageQueries } from "./run-page-queries"
+import { initialize } from "./initialize"
+import { writeHTML } from "./write-html"
+import { waitUntilAllJobsComplete } from "../utils/wait-until-jobs-complete"
+import { ServiceConfig } from "xstate"
+import { IBuildContext } from "../state-machines/develop"
+
+export const buildServices: Record<string, ServiceConfig<IBuildContext>> = {
+  customizeSchema,
+  sourceNodes,
+  createPages,
+  buildSchema,
+  createPagesStatefully,
+  extractQueries,
+  writeOutRequires,
+  calculateDirtyQueries,
+  runStaticQueries,
+  runPageQueries,
+  initialize,
+  writeHTML,
+  waitUntilAllJobsComplete,
+}

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -1,0 +1,452 @@
+import _ from "lodash"
+import { slash } from "gatsby-core-utils"
+import fs from "fs-extra"
+import md5File from "md5-file/promise"
+import crypto from "crypto"
+import del from "del"
+import path from "path"
+import telemetry from "gatsby-telemetry"
+
+import apiRunnerNode from "../utils/api-runner-node"
+import { getBrowsersList } from "../utils/browserslist"
+import { Store } from "../.."
+import { Span } from "opentracing"
+import { preferDefault } from "../bootstrap/prefer-default"
+import * as WorkerPool from "../utils/worker/pool"
+import JestWorker from "jest-worker"
+import { startPluginRunner } from "../redux/plugin-runner"
+import { loadPlugins } from "../bootstrap/load-plugins"
+import { store, emitter } from "../redux"
+import loadThemes from "../bootstrap/load-themes"
+import reporter from "gatsby-cli/lib/reporter"
+import { getConfigFile } from "../bootstrap/get-config-file"
+import { removeStaleJobs } from "../bootstrap/remove-stale-jobs"
+import { ErrorMeta } from "gatsby-cli/lib/reporter/types"
+import { globalTracer } from "opentracing"
+import { IPluginInfoOptions } from "../bootstrap/load-plugins/types"
+
+const tracer = globalTracer()
+
+// Show stack trace on unhandled promises.
+process.on(`unhandledRejection`, reason => {
+  reporter.panic({ id: ``, context: reason } as ErrorMeta)
+})
+
+// Override console.log to add the source file + line number.
+// Useful for debugging if you lose a console.log somewhere.
+// Otherwise leave commented out.
+// require(`../bootstrap/log-line-function`)
+
+export async function initialize(
+  context
+): Promise<{ store: Store; bootstrapSpan: Span; workerPool: JestWorker }> {
+  const args = context.program
+  const spanArgs = args.parentSpan ? { childOf: args.parentSpan } : {}
+  const bootstrapSpan = tracer.startSpan(`bootstrap`, spanArgs)
+
+  /* Time for a little story...
+   * When running `gatsby develop`, the globally installed gatsby-cli starts
+   * and sets up a Redux store (which is where logs are now stored). When gatsby
+   * finds your project's locally installed gatsby-cli package in node_modules,
+   * it switches over. This instance will have a separate redux store. We need to
+   * ensure that the correct store is used which is why we call setStore
+   * (/packages/gatsby-cli/src/reporter/redux/index.js)
+   *
+   * This function
+   * - copies over the logs from the global gatsby-cli to the local one
+   * - sets the store to the local one (so that further actions dispatched by
+   * the global gatsby-cli are handled by the local one)
+   */
+  if (args.setStore) {
+    args.setStore(store)
+  }
+
+  // Start plugin runner which listens to the store
+  // and invokes Gatsby API based on actions.
+  startPluginRunner()
+
+  const directory = slash(args.directory)
+
+  const program = {
+    ...args,
+    browserslist: getBrowsersList(directory),
+    // Fix program directory path for windows env.
+    directory,
+  }
+
+  store.dispatch({
+    type: `SET_PROGRAM`,
+    payload: program,
+  })
+
+  let activityForJobs
+
+  emitter.on(`CREATE_JOB`, () => {
+    if (!activityForJobs) {
+      activityForJobs = reporter.phantomActivity(`Running jobs`)
+      activityForJobs.start()
+    }
+  })
+
+  const onEndJob = (): void => {
+    if (activityForJobs && store.getState().jobs.active.length === 0) {
+      activityForJobs.end()
+      activityForJobs = null
+    }
+  }
+
+  emitter.on(`END_JOB`, onEndJob)
+
+  // Try opening the site's gatsby-config.js file.
+  let activity = reporter.activityTimer(`open and validate gatsby-configs`, {
+    parentSpan: bootstrapSpan,
+  })
+  activity.start()
+  const { configModule, configFilePath } = await getConfigFile(
+    program.directory,
+    `gatsby-config`
+  )
+  let config = preferDefault(configModule)
+
+  // The root config cannot be exported as a function, only theme configs
+  if (typeof config === `function`) {
+    reporter.panic({
+      id: `10126`,
+      context: {
+        configName: `gatsby-config`,
+        path: program.directory,
+      },
+    })
+  }
+
+  // theme gatsby configs can be functions or objects
+  if (config && config.__experimentalThemes) {
+    reporter.warn(
+      `The gatsby-config key "__experimentalThemes" has been deprecated. Please use the "plugins" key instead.`
+    )
+    const themes = await loadThemes(config, {
+      useLegacyThemes: true,
+      configFilePath,
+      rootDir: program.directory,
+    })
+    config = themes.config
+
+    store.dispatch({
+      type: `SET_RESOLVED_THEMES`,
+      payload: themes.themes,
+    })
+  } else if (config) {
+    const plugins = await loadThemes(config, {
+      useLegacyThemes: false,
+      configFilePath,
+      rootDir: program.directory,
+    })
+    config = plugins.config
+  }
+
+  if (config && config.polyfill) {
+    reporter.warn(
+      `Support for custom Promise polyfills has been removed in Gatsby v2. We only support Babel 7's new automatic polyfilling behavior.`
+    )
+  }
+
+  store.dispatch({
+    type: `SET_SITE_CONFIG`,
+    payload: config,
+  })
+
+  activity.end()
+
+  // run stale jobs
+  store.dispatch(removeStaleJobs(store.getState()))
+
+  activity = reporter.activityTimer(`load plugins`, {
+    parentSpan: bootstrapSpan,
+  })
+  activity.start()
+  const flattenedPlugins = await loadPlugins(config, program.directory)
+  activity.end()
+
+  // Multiple occurrences of the same name-version-pair can occur,
+  // so we report an array of unique pairs
+  const pluginsStr = _.uniq(flattenedPlugins.map(p => `${p.name}@${p.version}`))
+  telemetry.decorateEvent(`BUILD_END`, {
+    plugins: pluginsStr,
+  })
+
+  telemetry.decorateEvent(`DEVELOP_STOP`, {
+    plugins: pluginsStr,
+  })
+
+  // onPreInit
+  activity = reporter.activityTimer(`onPreInit`, {
+    parentSpan: bootstrapSpan,
+  })
+  activity.start()
+  await apiRunnerNode(`onPreInit`, { parentSpan: activity.span })
+  activity.end()
+
+  // During builds, delete html and css files from the public directory as we don't want
+  // deleted pages and styles from previous builds to stick around.
+  if (
+    !process.env.GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES &&
+    process.env.NODE_ENV === `production`
+  ) {
+    activity = reporter.activityTimer(
+      `delete html and css files from previous builds`,
+      {
+        parentSpan: bootstrapSpan,
+      }
+    )
+    activity.start()
+    await del([
+      `public/**/*.{html,css}`,
+      `!public/page-data/**/*`,
+      `!public/static`,
+      `!public/static/**/*.{html,css}`,
+    ])
+    activity.end()
+  }
+
+  activity = reporter.activityTimer(`initialize cache`, {
+    parentSpan: bootstrapSpan,
+  })
+  activity.start()
+  // Check if any plugins have been updated since our last run. If so
+  // we delete the cache is there's likely been changes
+  // since the previous run.
+  //
+  // We do this by creating a hash of all the version numbers of installed
+  // plugins, the site's package.json, gatsby-config.js, and gatsby-node.js.
+  // The last, gatsby-node.js, is important as many gatsby sites put important
+  // logic in there e.g. generating slugs for custom pages.
+  const pluginVersions = flattenedPlugins.map(p => p.version)
+  const hashes = await Promise.all([
+    !!process.env.GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES,
+    md5File(`package.json`),
+    Promise.resolve(
+      md5File(`${program.directory}/gatsby-config.js`).catch(() => {})
+    ), // ignore as this file isn't required),
+    Promise.resolve(
+      md5File(`${program.directory}/gatsby-node.js`).catch(() => {})
+    ), // ignore as this file isn't required),
+  ])
+  const pluginsHash = crypto
+    .createHash(`md5`)
+    .update(JSON.stringify(pluginVersions.concat(hashes)))
+    .digest(`hex`)
+  const state = store.getState()
+  const oldPluginsHash = state && state.status ? state.status.PLUGINS_HASH : ``
+
+  // Check if anything has changed. If it has, delete the site's .cache
+  // directory and tell reducers to empty themselves.
+  //
+  // Also if the hash isn't there, then delete things just in case something
+  // is weird.
+  if (oldPluginsHash && pluginsHash !== oldPluginsHash) {
+    reporter.info(reporter.stripIndent`
+      One or more of your plugins have changed since the last time you ran Gatsby. As
+      a precaution, we're deleting your site's cache to ensure there's no stale data.
+    `)
+  }
+  const cacheDirectory = `${program.directory}/.cache`
+  if (!oldPluginsHash || pluginsHash !== oldPluginsHash) {
+    try {
+      // Attempt to empty dir if remove fails,
+      // like when directory is mount point
+      await fs.remove(cacheDirectory).catch(() => fs.emptyDir(cacheDirectory))
+    } catch (e) {
+      reporter.error(`Failed to remove .cache files.`, e)
+    }
+    // Tell reducers to delete their data (the store will already have
+    // been loaded from the file system cache).
+    store.dispatch({
+      type: `DELETE_CACHE`,
+    })
+  }
+
+  // Update the store with the new plugins hash.
+  store.dispatch({
+    type: `UPDATE_PLUGINS_HASH`,
+    payload: pluginsHash,
+  })
+
+  // Now that we know the .cache directory is safe, initialize the cache
+  // directory.
+  await fs.ensureDir(cacheDirectory)
+
+  // Ensure the public/static directory
+  await fs.ensureDir(`${program.directory}/public/static`)
+
+  activity.end()
+
+  if (process.env.GATSBY_DB_NODES === `loki`) {
+    const loki = require(`../db/loki`)
+    // Start the nodes database (in memory loki js with interval disk
+    // saves). If data was saved from a previous build, it will be
+    // loaded here
+    activity = reporter.activityTimer(`start nodes db`, {
+      parentSpan: bootstrapSpan,
+    })
+    activity.start()
+    const dbSaveFile = `${cacheDirectory}/loki/loki.db`
+    try {
+      await loki.start({
+        saveFile: dbSaveFile,
+      })
+    } catch (e) {
+      reporter.error(
+        `Error starting DB. Perhaps try deleting ${path.dirname(dbSaveFile)}`
+      )
+    }
+    activity.end()
+  }
+
+  activity = reporter.activityTimer(`copy gatsby files`, {
+    parentSpan: bootstrapSpan,
+  })
+  activity.start()
+  const srcDir = `${__dirname}/../../cache-dir`
+  const siteDir = cacheDirectory
+  const tryRequire = `${__dirname}/../utils/test-require-error.js`
+  try {
+    await fs.copy(srcDir, siteDir)
+    await fs.copy(tryRequire, `${siteDir}/test-require-error.js`)
+    await fs.ensureDirSync(`${cacheDirectory}/json`)
+
+    // Ensure .cache/fragments exists and is empty. We want fragments to be
+    // added on every run in response to data as fragments can only be added if
+    // the data used to create the schema they're dependent on is available.
+    await fs.emptyDir(`${cacheDirectory}/fragments`)
+  } catch (err) {
+    reporter.panic(`Unable to copy site files to .cache`, err)
+  }
+
+  // Find plugins which implement gatsby-browser and gatsby-ssr and write
+  // out api-runners for them.
+  const hasAPIFile = (env, plugin): string | undefined => {
+    // The plugin loader has disabled SSR APIs for this plugin. Usually due to
+    // multiple implementations of an API that can only be implemented once
+    if (env === `ssr` && plugin.skipSSR === true) return undefined
+
+    const envAPIs = plugin[`${env}APIs`]
+
+    // Always include gatsby-browser.js files if they exist as they're
+    // a handy place to include global styles and other global imports.
+    try {
+      if (env === `browser`) {
+        return slash(
+          require.resolve(path.join(plugin.resolve, `gatsby-${env}`))
+        )
+      }
+    } catch (e) {
+      // ignore
+    }
+
+    if (envAPIs && Array.isArray(envAPIs) && envAPIs.length > 0) {
+      return slash(path.join(plugin.resolve, `gatsby-${env}`))
+    }
+    return undefined
+  }
+
+  interface IPluginResolution {
+    resolve: string
+    options: IPluginInfoOptions
+  }
+
+  const isResolved = (plugin): plugin is IPluginResolution => !!plugin.resolve
+
+  const ssrPlugins: IPluginResolution[] = flattenedPlugins
+    .map(plugin => {
+      return {
+        resolve: hasAPIFile(`ssr`, plugin),
+        options: plugin.pluginOptions,
+      }
+    })
+    .filter(isResolved)
+
+  const browserPlugins: IPluginResolution[] = flattenedPlugins
+    .map(plugin => {
+      return {
+        resolve: hasAPIFile(`browser`, plugin),
+        options: plugin.pluginOptions,
+      }
+    })
+    .filter(isResolved)
+
+  const browserPluginsRequires = browserPlugins
+    .map(plugin => {
+      // we need a relative import path to keep contenthash the same if directory changes
+      const relativePluginPath = path.relative(siteDir, plugin.resolve)
+      return `{
+      plugin: require('${slash(relativePluginPath)}'),
+      options: ${JSON.stringify(plugin.options)},
+    }`
+    })
+    .join(`,`)
+
+  const browserAPIRunner = `module.exports = [${browserPluginsRequires}]\n`
+
+  let sSRAPIRunner = ``
+
+  try {
+    sSRAPIRunner = fs.readFileSync(`${siteDir}/api-runner-ssr.js`, `utf-8`)
+  } catch (err) {
+    reporter.panic(`Failed to read ${siteDir}/api-runner-ssr.js`, err)
+  }
+
+  const ssrPluginsRequires = ssrPlugins
+    .map(
+      plugin =>
+        `{
+      plugin: require('${plugin.resolve}'),
+      options: ${JSON.stringify(plugin.options)},
+    }`
+    )
+    .join(`,`)
+  sSRAPIRunner = `var plugins = [${ssrPluginsRequires}]\n${sSRAPIRunner}`
+
+  fs.writeFileSync(
+    `${siteDir}/api-runner-browser-plugins.js`,
+    browserAPIRunner,
+    `utf-8`
+  )
+  fs.writeFileSync(`${siteDir}/api-runner-ssr.js`, sSRAPIRunner, `utf-8`)
+
+  activity.end()
+  /**
+   * Start the main bootstrap processes.
+   */
+
+  // onPreBootstrap
+  activity = reporter.activityTimer(`onPreBootstrap`, {
+    parentSpan: bootstrapSpan,
+  })
+  activity.start()
+  await apiRunnerNode(`onPreBootstrap`, {
+    parentSpan: activity.span,
+  })
+  activity.end()
+
+  // Collect resolvable extensions and attach to program.
+  const extensions = [`.mjs`, `.js`, `.jsx`, `.wasm`, `.json`]
+  // Change to this being an action and plugins implement `onPreBootstrap`
+  // for adding extensions.
+  const apiResults = await apiRunnerNode(`resolvableExtensions`, {
+    traceId: `initial-resolvableExtensions`,
+    parentSpan: bootstrapSpan,
+  })
+
+  store.dispatch({
+    type: `SET_PROGRAM_EXTENSIONS`,
+    payload: _.flattenDeep([extensions, apiResults]),
+  })
+
+  const workerPool = WorkerPool.create()
+
+  return {
+    store,
+    bootstrapSpan,
+    workerPool,
+  }
+}

--- a/packages/gatsby/src/services/listen-for-mutations.ts
+++ b/packages/gatsby/src/services/listen-for-mutations.ts
@@ -1,0 +1,24 @@
+import { emitter } from "../redux"
+import { InvokeCallback, Sender } from "xstate"
+
+export const listenForMutations: InvokeCallback = (callback: Sender<any>) => {
+  const emitMutation = (event: unknown): void => {
+    callback({ type: `ADD_NODE_MUTATION`, payload: event })
+  }
+
+  const emitFileChange = (event: unknown): void => {
+    console.log({ event })
+    callback({ type: `SOURCE_FILE_CHANGED`, payload: event })
+  }
+
+  emitter.on(`ENQUEUE_NODE_MUTATION`, emitMutation)
+
+  emitter.on(`SOURCE_FILE_CHANGED`, emitFileChange)
+
+  return (): void => {
+    console.log(`unlistening`)
+    emitter.off(`ENQUEUE_NODE_MUTATION`, emitMutation)
+
+    emitter.off(`SOURCE_FILE_CHANGED`, emitFileChange)
+  }
+}

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -1,0 +1,36 @@
+import { processPageQueries } from "../query"
+import { IBuildContext } from "../state-machines/develop"
+import reporter from "gatsby-cli/lib/reporter"
+
+export async function runPageQueries({
+  parentSpan,
+  queryIds,
+  store,
+}: IBuildContext): Promise<object> {
+  let results = new Map()
+  if (!queryIds || !store) {
+    return { results: [] }
+  }
+  const { pageQueryIds } = queryIds
+  const state = store.getState()
+  const pageQueryIdsCount = pageQueryIds.filter(id => state.pages.has(id))
+    .length
+
+  const activity = reporter.createProgress(
+    `run page queries`,
+    pageQueryIdsCount,
+    0,
+    {
+      id: `page-query-running`,
+      parentSpan,
+    }
+  )
+
+  if (pageQueryIdsCount) {
+    activity.start()
+    results = await processPageQueries(pageQueryIds, { state, activity })
+  }
+
+  activity.done()
+  return { results }
+}

--- a/packages/gatsby/src/services/run-static-queries.ts
+++ b/packages/gatsby/src/services/run-static-queries.ts
@@ -1,0 +1,36 @@
+import { processStaticQueries } from "../query"
+import { IBuildContext } from "../state-machines/develop"
+import reporter from "gatsby-cli/lib/reporter"
+
+export async function runStaticQueries({
+  parentSpan,
+  queryIds,
+  store,
+}: IBuildContext): Promise<object> {
+  let results = new Map()
+  if (!queryIds || !store) {
+    return { results: [] }
+  }
+  const { staticQueryIds } = queryIds
+  const state = store.getState()
+  const activity = reporter.createProgress(
+    `run static queries`,
+    staticQueryIds.length,
+    0,
+    {
+      id: `static-query-running`,
+      parentSpan,
+    }
+  )
+
+  if (staticQueryIds.length) {
+    activity.start()
+    results = await processStaticQueries(staticQueryIds, {
+      state,
+      activity,
+    })
+  }
+
+  activity.done()
+  return { results }
+}

--- a/packages/gatsby/src/services/source-nodes.ts
+++ b/packages/gatsby/src/services/source-nodes.ts
@@ -1,0 +1,55 @@
+import { IBuildContext } from "../state-machines/develop"
+import sourceNodesAndGc from "../utils/source-nodes"
+import reporter from "gatsby-cli/lib/reporter"
+import { findChangedPages } from "../utils/check-for-changed-pages"
+
+export async function sourceNodes({
+  parentSpan,
+  webhookBody,
+  store,
+}: IBuildContext): Promise<{
+  changedPages: string[]
+  deletedPages: string[]
+} | void> {
+  if (!store) {
+    reporter.panic(`No redux store`)
+    return void 0
+  }
+  const activity = reporter.activityTimer(`source and transform nodes`, {
+    parentSpan,
+  })
+  console.log({ webhookBody })
+  activity.start()
+  const currentPages = new Map(store.getState().pages)
+  await sourceNodesAndGc({
+    parentSpan: activity.span,
+    deferNodeMutation: !!(webhookBody && Object.keys(webhookBody).length),
+    webhookBody,
+  })
+  reporter.info(`Checking for deleted pages`)
+
+  const tim = reporter.activityTimer(`Checking for changed pages`)
+  tim.start()
+
+  const { changedPages, deletedPages } = findChangedPages(
+    currentPages,
+    store.getState().pages
+  )
+
+  reporter.info(
+    `Deleted ${deletedPages.length} page${deletedPages.length === 1 ? `` : `s`}`
+  )
+
+  reporter.info(
+    `Found ${changedPages.length} changed page${
+      changedPages.length === 1 ? `` : `s`
+    }`
+  )
+  tim.end()
+
+  activity.end()
+  return {
+    deletedPages,
+    changedPages,
+  }
+}

--- a/packages/gatsby/src/services/start-webpack-server.ts
+++ b/packages/gatsby/src/services/start-webpack-server.ts
@@ -1,0 +1,107 @@
+import openurl from "better-opn"
+import report from "gatsby-cli/lib/reporter"
+import formatWebpackMessages from "react-dev-utils/formatWebpackMessages"
+import chalk from "chalk"
+import { Compiler } from "webpack"
+
+import {
+  reportWebpackWarnings,
+  structureWebpackErrors,
+} from "../utils/webpack-error-utils"
+
+import { printDeprecationWarnings } from "../utils/print-deprecation-warnings"
+import { printInstructions } from "../utils/print-instructions"
+import { prepareUrls } from "../utils/prepare-urls"
+import { startServer } from "../utils/start-server"
+import { WebsocketManager } from "../utils/websocket-manager"
+import { IBuildContext } from "../state-machines/develop"
+
+export async function startWebpackServer({
+  program,
+  app,
+  workerPool,
+}: IBuildContext): Promise<{
+  compiler: Compiler
+  websocketManager: WebsocketManager
+}> {
+  if (!program || !app) {
+    throw new Error(`Missing required params`)
+  }
+  let { compiler, webpackActivity, websocketManager } = await startServer(
+    program,
+    app,
+    workerPool
+  )
+
+  compiler.hooks.watchRun.tapAsync(`log compiling`, function (_, done) {
+    if (webpackActivity) {
+      webpackActivity.end()
+    }
+    webpackActivity = report.activityTimer(`Re-building development bundle`, {
+      id: `webpack-develop`,
+    })
+    webpackActivity.start()
+
+    done()
+  })
+
+  let isFirstCompile = true
+
+  return new Promise(resolve => {
+    compiler.hooks.done.tapAsync(`print gatsby instructions`, async function (
+      stats,
+      done
+    ) {
+      // We have switched off the default Webpack output in WebpackDevServer
+      // options so we are going to "massage" the warnings and errors and present
+      // them in a readable focused way.
+      const messages = formatWebpackMessages(stats.toJson({}, true))
+      const urls = prepareUrls(
+        program.ssl ? `https` : `http`,
+        program.host,
+        program.port
+      )
+      const isSuccessful = !messages.errors.length
+
+      if (isSuccessful && isFirstCompile) {
+        printInstructions(
+          program.sitePackageJson.name || `(Unnamed package)`,
+          urls
+        )
+        printDeprecationWarnings()
+        if (program.open) {
+          try {
+            await openurl(urls.localUrlForBrowser)
+          } catch {
+            console.log(
+              `${chalk.yellow(
+                `warn`
+              )} Browser not opened because no browser was found`
+            )
+          }
+        }
+      }
+
+      isFirstCompile = false
+
+      if (webpackActivity) {
+        reportWebpackWarnings(stats)
+
+        if (!isSuccessful) {
+          const errors = structureWebpackErrors(
+            `develop`,
+            stats.compilation.errors
+          )
+          webpackActivity.panicOnBuild(errors)
+        }
+        webpackActivity.end()
+        webpackActivity = null
+      }
+
+      done()
+      resolve({ compiler, websocketManager })
+    })
+  })
+  // "done" event fires when Webpack has finished recompiling the bundle.
+  // Whether or not you have warnings or errors, you will get this event.
+}

--- a/packages/gatsby/src/services/write-html.ts
+++ b/packages/gatsby/src/services/write-html.ts
@@ -1,0 +1,48 @@
+import { IBuildContext } from "../state-machines/develop"
+import reporter from "gatsby-cli/lib/reporter"
+import { buildHTML } from "../commands/build-html"
+import { Stage } from "../commands/types"
+
+export async function writeHTML({
+  program,
+  parentSpan,
+  workerPool,
+  pagesToBuild = [],
+}: IBuildContext): Promise<void> {
+  console.log(`writing html`)
+  if (!program) {
+    return
+  }
+  const activity = reporter.createProgress(
+    `Building static HTML`,
+    pagesToBuild.length,
+    0,
+    {
+      parentSpan,
+    }
+  )
+  activity.start()
+  try {
+    await buildHTML({
+      program: program,
+      stage: Stage.BuildHTML,
+      pagePaths: pagesToBuild,
+      activity,
+      workerPool: workerPool,
+    })
+  } catch (err) {
+    let id = `95313`
+    if (err.message === `ReferenceError: window is not defined`) {
+      id = `95312`
+    }
+
+    reporter.panic({
+      id,
+      error: err,
+      context: {
+        errorPath: err.context && err.context.path,
+      },
+    })
+  }
+  activity.done()
+}

--- a/packages/gatsby/src/services/write-out-requires.ts
+++ b/packages/gatsby/src/services/write-out-requires.ts
@@ -1,0 +1,23 @@
+import { IBuildContext } from "../state-machines/develop"
+import reporter from "gatsby-cli/lib/reporter"
+import { writeAll } from "../bootstrap/requires-writer"
+
+export async function writeOutRequires({
+  store,
+  parentSpan,
+}: IBuildContext): Promise<void> {
+  if (!store) {
+    throw new Error(`Missing store`)
+  }
+  // Write out files.
+  const activity = reporter.activityTimer(`write out requires`, {
+    parentSpan,
+  })
+  activity.start()
+  try {
+    await writeAll(store.getState())
+  } catch (err) {
+    reporter.panic(`Failed to write out requires`, err)
+  }
+  activity.end()
+}

--- a/packages/gatsby/src/state-machines/actions.ts
+++ b/packages/gatsby/src/state-machines/actions.ts
@@ -1,0 +1,146 @@
+import {
+  assign,
+  AnyEventObject,
+  ActionFunction,
+  AssignAction,
+  spawn,
+  DoneInvokeEvent,
+  ActionFunctionMap,
+} from "xstate"
+import { Store } from "redux"
+import { IBuildContext, IMutationAction } from "./develop"
+import { actions } from "../redux/actions"
+import path from "path"
+import { write as writeAppData } from "../utils/app-data"
+import { listenForMutations } from "../services/listen-for-mutations"
+import { Span } from "opentracing"
+import JestWorker from "jest-worker"
+
+const concatUnique = <T>(array1?: T[], array2?: T[]): T[] =>
+  Array.from(new Set((array1 || []).concat(array2 || [])))
+
+export const callRealApi = async (
+  event: IMutationAction,
+  store?: Store
+): Promise<unknown> => {
+  if (!store) {
+    console.error(`No store`)
+    return null
+  }
+  const { type, payload } = event
+  if (type in actions) {
+    return actions[type](...payload)(store.dispatch.bind(store))
+  }
+  return null
+}
+
+type BuildMachineAction =
+  | ActionFunction<IBuildContext, AnyEventObject>
+  | AssignAction<IBuildContext, AnyEventObject>
+
+/**
+ * Handler for when we're inside handlers that should be able to mutate nodes
+ */
+export const callApi: BuildMachineAction = async (
+  ctx,
+  event
+): Promise<unknown> => callRealApi(event.payload, ctx.store)
+
+/**
+ * Event handler used in all states where we're not ready to process node
+ * mutations. Instead we add it to a batch to process when we're next idle
+ */
+export const addNodeMutation: BuildMachineAction = assign((ctx, event) => {
+  return {
+    nodeMutationBatch: ctx.nodeMutationBatch.concat([event.payload]),
+  }
+})
+
+export const assignChangedPages: BuildMachineAction = assign<
+  IBuildContext,
+  DoneInvokeEvent<{
+    changedPages: string[]
+    deletedPages: string[]
+  }>
+>((context, event) => {
+  console.log({ event })
+  return {
+    pagesToBuild: concatUnique(context.pagesToBuild, event.data.changedPages),
+    pagesToDelete: concatUnique(context.pagesToDelete, event.data.deletedPages),
+  }
+})
+
+export const spawnMutationListener: BuildMachineAction = assign<IBuildContext>({
+  mutationListener: () => spawn(listenForMutations, `listen-for-mutations`),
+})
+
+export const trackNewAndChangedPages: BuildMachineAction = assign(
+  (_ctx, event) => {
+    if (event.type === `CREATE_NODE` || event.type === `DELETE_NODE`) {
+      console.log(`mutate`, event)
+    }
+    return {}
+  }
+)
+
+/**
+ * Event handler used in all states where we're not ready to process a file change
+ * Instead we add it to a batch to process when we're next idle
+ */
+export const markFilesDirty: BuildMachineAction = assign<IBuildContext>({
+  filesDirty: true,
+})
+
+export const markNodesDirty: BuildMachineAction = assign<IBuildContext>({
+  nodesMutatedDuringQueryRun: true,
+})
+
+export const writeCompilationHash: BuildMachineAction = async (
+  { store, program },
+  { stats }
+) => {
+  if (!store || !stats || !program) {
+    return
+  }
+  const prevCompilationHash = store.getState().webpackCompilationHash
+
+  if (stats.hash !== prevCompilationHash) {
+    store.dispatch({
+      type: `SET_WEBPACK_COMPILATION_HASH`,
+      payload: stats.hash,
+    })
+
+    const publicDir = path.join(program.directory, `public`)
+    await writeAppData(publicDir, stats.hash)
+  }
+}
+
+export const assignBootstrap: BuildMachineAction = assign<
+  IBuildContext,
+  DoneInvokeEvent<{ store: Store; bootstrapSpan: Span; workerPool: JestWorker }>
+>((_context, event) => {
+  const { store, bootstrapSpan, workerPool } = event.data
+  return {
+    store,
+    parentSpan: bootstrapSpan,
+    workerPool,
+  }
+})
+
+export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
+  callApi,
+  addNodeMutation,
+  markFilesDirty,
+  markNodesDirty,
+  writeCompilationHash,
+  spawnMutationListener,
+  assignChangedPages,
+  assignBootstrap,
+}
+
+// export const dummyActions = {
+//     callApi,
+//     addNodeMutation,
+//     markFilesDirty,
+//     markNodesDirty,
+//   }

--- a/packages/gatsby/src/state-machines/data-layer.ts
+++ b/packages/gatsby/src/state-machines/data-layer.ts
@@ -1,0 +1,86 @@
+import { IBuildContext } from "./develop"
+import { DoneInvokeEvent, assign, MachineConfig } from "xstate"
+import { runMutationAndMarkDirty, onError } from "./shared-transition-configs"
+
+export const dataLayerStates: MachineConfig<IBuildContext, any, any> = {
+  initial: `customizingSchema`,
+  states: {
+    customizingSchema: {
+      invoke: {
+        src: `customizeSchema`,
+        id: `customizing-schema`,
+        onDone: {
+          target: `sourcingNodes`,
+        },
+        onError,
+      },
+    },
+    sourcingNodes: {
+      invoke: {
+        src: `sourceNodes`,
+        id: `sourcing-nodes`,
+        onDone: {
+          target: `buildingSchema`,
+          actions: `assignChangedPages`,
+        },
+        onError,
+      },
+    },
+    buildingSchema: {
+      invoke: {
+        id: `building-schema`,
+        src: `buildSchema`,
+        onDone: {
+          target: `creatingPages`,
+          actions: assign<IBuildContext, DoneInvokeEvent<any>>(
+            (_context, event) => {
+              const { graphqlRunner } = event.data
+              return {
+                graphqlRunner,
+              }
+            }
+          ),
+        },
+        onError,
+      },
+    },
+    creatingPages: {
+      on: { ADD_NODE_MUTATION: runMutationAndMarkDirty },
+      invoke: {
+        id: `creating-pages`,
+        src: `createPages`,
+        onDone: [
+          {
+            target: `creatingPagesStatefully`,
+            actions: `assignChangedPages`,
+            cond: (context): boolean => context.firstRun,
+          },
+          {
+            target: `#build.running.extractingAndRunningQueries`,
+            actions: `assignChangedPages`,
+          },
+        ],
+        onError,
+      },
+    },
+    creatingPagesStatefully: {
+      on: {
+        "": [
+          {
+            cond: (ctx): boolean => !!ctx.filesDirty,
+            target: `#extracting-queries`,
+          },
+        ],
+        ADD_NODE_MUTATION: runMutationAndMarkDirty,
+      },
+      invoke: {
+        src: `createPagesStatefully`,
+        id: `creating-pages-statefully`,
+        onDone: {
+          target: `#build.running.extractingAndRunningQueries`,
+        },
+        onError,
+      },
+    },
+  },
+}

--- a/packages/gatsby/src/state-machines/develop.ts
+++ b/packages/gatsby/src/state-machines/develop.ts
@@ -1,0 +1,152 @@
+import {
+  Machine,
+  assign,
+  DoneInvokeEvent,
+  Actor,
+  AnyEventObject,
+  MachineConfig,
+} from "xstate"
+import { Express } from "express"
+import { startWebpackServer } from "../services/start-webpack-server"
+import { WebsocketManager } from "../utils/websocket-manager"
+import { Store } from "redux"
+import { Compiler } from "webpack"
+import { Span } from "opentracing"
+import { GraphQLRunner } from "../query/graphql-runner"
+import { idleStates } from "./waiting"
+import {
+  ADD_NODE_MUTATION,
+  SOURCE_FILE_CHANGED,
+} from "./shared-transition-configs"
+import { IProgram } from "../commands/types"
+import { IGroupedQueryIds } from "../services/calculate-dirty-queries"
+import { buildActions } from "./actions"
+import { IGatsbyState } from "../redux/types"
+import { runningStates } from "./running"
+import JestWorker from "jest-worker"
+import { buildServices } from "../services"
+
+export interface IMutationAction {
+  type: string
+  // These are the arguments passed to apiRunnerNode
+  payload: unknown[]
+}
+
+export interface IBuildContext {
+  program?: IProgram
+  app?: Express
+  recursionCount: number
+  nodesMutatedDuringQueryRun: boolean
+  firstRun: boolean
+  nodeMutationBatch: IMutationAction[]
+  filesDirty?: boolean
+  runningBatch: IMutationAction[]
+  compiler?: Compiler
+  websocketManager?: WebsocketManager
+  store?: Store<IGatsbyState>
+  parentSpan?: Span
+  graphqlRunner?: GraphQLRunner
+  refresh?: boolean
+  webhookBody?: Record<string, unknown>
+  queryIds?: IGroupedQueryIds
+  workerPool?: JestWorker
+  pagesToBuild?: string[]
+  pagesToDelete?: string[]
+  mutationListener?: Actor<any, AnyEventObject>
+}
+
+export const INITIAL_CONTEXT: IBuildContext = {
+  recursionCount: 0,
+  nodesMutatedDuringQueryRun: false,
+  firstRun: true,
+  nodeMutationBatch: [],
+  runningBatch: [],
+}
+
+const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
+  id: `build`,
+  initial: `setup`,
+  context: INITIAL_CONTEXT,
+  states: {
+    setup: {
+      on: {
+        "": {
+          actions: `spawnMutationListener`,
+          cond: (context): boolean => !context.mutationListener,
+        },
+        ADD_NODE_MUTATION: {
+          actions: `callApi`,
+        },
+      },
+      invoke: {
+        src: `initialize`,
+        onDone: {
+          target: `running`,
+          actions: `assignBootstrap`,
+        },
+      },
+    },
+    running: {
+      ...runningStates,
+      onDone: [
+        {
+          target: `runningWebpack`,
+          cond: (ctx): boolean => ctx.firstRun,
+        },
+        {
+          target: `waiting`,
+          actions: (ctx): void => console.log(ctx.queryIds),
+        },
+      ],
+    },
+    runningWebpack: {
+      on: {
+        ADD_NODE_MUTATION,
+        SOURCE_FILE_CHANGED,
+      },
+      invoke: {
+        src: startWebpackServer,
+        id: `running-webpack`,
+        onDone: {
+          target: `waiting`,
+          actions: assign<
+            IBuildContext,
+            DoneInvokeEvent<{
+              compiler: Compiler
+              websocketManager: WebsocketManager
+              workerPool: JestWorker
+            }>
+          >((_context, { data }) => {
+            return {
+              ...data,
+              firstRun: false,
+            }
+          }),
+        },
+        onError: {
+          target: `failed`,
+        },
+      },
+    },
+
+    waiting: {
+      on: { ADD_NODE_MUTATION },
+      ...idleStates,
+    },
+
+    failed: {
+      type: `final`,
+      invoke: {
+        src: async (_context, event): Promise<void> => {
+          console.error(`I won't build what you tell me`, event)
+        },
+      },
+    },
+  },
+}
+
+// eslint-disable-next-line new-cap
+export const developMachine = Machine<IBuildContext>(developConfig, {
+  actions: buildActions,
+  services: buildServices,
+})

--- a/packages/gatsby/src/state-machines/index.ts
+++ b/packages/gatsby/src/state-machines/index.ts
@@ -1,0 +1,5 @@
+export { buildServices } from "../services"
+export { INITIAL_CONTEXT } from "./develop"
+export { idleStates } from "./waiting"
+export { runningStates } from "./running"
+export { buildActions } from "./actions"

--- a/packages/gatsby/src/state-machines/queries.ts
+++ b/packages/gatsby/src/state-machines/queries.ts
@@ -1,0 +1,185 @@
+import { MachineConfig, DoneInvokeEvent, assign } from "xstate"
+import { IBuildContext } from "./develop"
+import { runMutationAndMarkDirty, onError } from "./shared-transition-configs"
+import { log } from "xstate/lib/actions"
+
+const MAX_RECURSION = 2
+
+const extractQueriesIfDirty = {
+  cond: (ctx): boolean => !!ctx.filesDirty,
+  target: `extractingQueries`,
+}
+
+const emitStaticQueryDataToWebsocket = (
+  { websocketManager }: IBuildContext,
+  { data: { results } }: DoneInvokeEvent<any>
+): void => {
+  if (websocketManager && results) {
+    results.forEach((result, id) => {
+      websocketManager.emitStaticQueryData({
+        result,
+        id,
+      })
+    })
+  }
+}
+
+const emitPageDataToWebsocket = (
+  { websocketManager }: IBuildContext,
+  { data: { results } }: DoneInvokeEvent<any>
+): void => {
+  console.log({ websocketManager, results })
+  if (websocketManager && results) {
+    results.forEach((result, id) => {
+      websocketManager.emitPageData({
+        result,
+        id,
+      })
+    })
+  }
+}
+
+export const queryStates: MachineConfig<IBuildContext, any, any> = {
+  initial: `extractingQueries`,
+  states: {
+    extractingQueries: {
+      id: `extracting-queries`,
+      invoke: {
+        id: `extracting-queries`,
+        src: `extractQueries`,
+        onDone: [
+          {
+            target: `writingRequires`,
+          },
+        ],
+        onError,
+      },
+    },
+    writingRequires: {
+      invoke: {
+        src: `writeOutRequires`,
+        id: `writing-requires`,
+        onDone: {
+          target: `calculatingDirtyQueries`,
+        },
+        onError: {
+          target: `#build.failed`,
+        },
+      },
+    },
+    calculatingDirtyQueries: {
+      on: {
+        "": extractQueriesIfDirty,
+      },
+      invoke: {
+        id: `calculating-dirty-queries`,
+        src: `calculateDirtyQueries`,
+        onDone: [
+          {
+            target: `runningStaticQueries`,
+            actions: assign<IBuildContext, DoneInvokeEvent<any>>(
+              (_context, { data }) => {
+                const { queryIds } = data
+                return {
+                  filesDirty: false,
+                  queryIds,
+                }
+              }
+            ),
+          },
+        ],
+        onError,
+      },
+    },
+    runningStaticQueries: {
+      on: {
+        "": extractQueriesIfDirty,
+        ADD_NODE_MUTATION: runMutationAndMarkDirty,
+      },
+      invoke: {
+        src: `runStaticQueries`,
+        id: `running-static-queries`,
+        onDone: [
+          {
+            target: `runningPageQueries`,
+            actions: emitStaticQueryDataToWebsocket,
+            cond: (context): boolean => !!context.websocketManager,
+          },
+          {
+            target: `runningPageQueries`,
+          },
+        ],
+        onError,
+      },
+    },
+    runningPageQueries: {
+      on: {
+        "": extractQueriesIfDirty,
+        ADD_NODE_MUTATION: runMutationAndMarkDirty,
+      },
+      invoke: {
+        src: `runPageQueries`,
+        id: `running-page-queries`,
+        onDone: [
+          {
+            target: `checkingForMutatedNodes`,
+            actions: emitPageDataToWebsocket,
+            cond: (context): boolean => !!context.websocketManager,
+          },
+          {
+            target: `checkingForMutatedNodes`,
+          },
+        ],
+        // onError,
+      },
+    },
+    checkingForMutatedNodes: {
+      on: {
+        "": [
+          // Nothing was mutated. Moving to next state
+          {
+            target: `waitingForJobs`,
+            cond: (context): boolean => !context.nodesMutatedDuringQueryRun,
+          },
+          // Nodes were mutated. Starting again.
+          {
+            actions: [
+              assign(context => {
+                return {
+                  recursionCount: context.recursionCount + 1,
+                  nodesMutatedDuringQueryRun: false, // Resetting
+                }
+              }),
+              log(context => `mutated. count ${context.recursionCount}`),
+            ],
+            target: `#initializingDataLayer`,
+            cond: (ctx): boolean => ctx.recursionCount < MAX_RECURSION,
+          },
+          // We seem to be stuck in a loop. Bailing.
+          {
+            actions: [
+              assign<IBuildContext>({
+                recursionCount: 0,
+                nodesMutatedDuringQueryRun: false, // Resetting
+              }),
+              log(`Errro`),
+            ],
+            target: `#build.waiting`,
+          },
+        ],
+      },
+    },
+    waitingForJobs: {
+      invoke: {
+        src: `waitUntilAllJobsComplete`,
+        id: `waiting-for-jobs`,
+        onDone: {
+          target: `done`,
+        },
+      },
+    },
+    done: {
+      type: `final`,
+    },
+  },
+}

--- a/packages/gatsby/src/state-machines/running.ts
+++ b/packages/gatsby/src/state-machines/running.ts
@@ -1,0 +1,38 @@
+import { IBuildContext } from "./develop"
+import { MachineConfig } from "xstate"
+
+import { dataLayerStates } from "./data-layer"
+import { queryStates } from "./queries"
+import {
+  ADD_NODE_MUTATION,
+  SOURCE_FILE_CHANGED,
+} from "./shared-transition-configs"
+
+export const runningStates: MachineConfig<IBuildContext, any, any> = {
+  initial: `initializingDataLayer`,
+  states: {
+    initializingDataLayer: {
+      id: `initializingDataLayer`,
+      on: {
+        ADD_NODE_MUTATION: {
+          actions: `callApi`,
+        },
+      },
+      ...dataLayerStates,
+    },
+    extractingAndRunningQueries: {
+      id: `extractingAndRunningQueries`,
+      on: {
+        ADD_NODE_MUTATION,
+        SOURCE_FILE_CHANGED,
+      },
+      ...queryStates,
+      onDone: {
+        target: `complete`,
+      },
+    },
+    complete: {
+      type: `final`,
+    },
+  },
+}

--- a/packages/gatsby/src/state-machines/shared-transition-configs.ts
+++ b/packages/gatsby/src/state-machines/shared-transition-configs.ts
@@ -1,0 +1,35 @@
+import { TransitionConfig, AnyEventObject, DoneInvokeEvent } from "xstate"
+import { IBuildContext } from "./develop"
+
+type BuildTransition = TransitionConfig<IBuildContext, AnyEventObject>
+
+/**
+ * Event handler used in all states where we're not ready to process node
+ * mutations. Instead we add it to a batch to process when we're next idle
+ */
+export const ADD_NODE_MUTATION: BuildTransition = {
+  actions: `addNodeMutation`,
+}
+
+/**
+ * Event handler used in all states where we're not ready to process a file change
+ * Instead we add it to a batch to process when we're next idle
+ */
+export const SOURCE_FILE_CHANGED: BuildTransition = {
+  actions: `markFilesDirty`,
+}
+
+/**
+ * When running queries we might add nodes (e.g from resolvers). If so we'll
+ * want to re-run queries and schema inference
+ */
+export const runMutationAndMarkDirty: BuildTransition = {
+  actions: [`markNodesDirty`, `callApi`],
+}
+
+export const onError: TransitionConfig<IBuildContext, DoneInvokeEvent<any>> = {
+  target: `#build.waiting`,
+  actions: (_context, event): void => {
+    console.error(`Error`, event)
+  },
+}

--- a/packages/gatsby/src/state-machines/waiting.ts
+++ b/packages/gatsby/src/state-machines/waiting.ts
@@ -1,0 +1,130 @@
+import { MachineConfig, assign } from "xstate"
+import { IBuildContext } from "./develop"
+import { callRealApi } from "./actions"
+
+const NODE_MUTATION_BATCH_SIZE = 100
+const NODE_MUTATION_BATCH_TIMEOUT = 1000
+
+const extractQueriesIfDirty = {
+  cond: (ctx): boolean => !!ctx.filesDirty,
+  target: `#extractingAndRunningQueries`,
+}
+
+export const idleStates: MachineConfig<IBuildContext, any, any> = {
+  initial: `idle`,
+  states: {
+    // There is an empty bus and doors are closed
+    idle: {
+      entry: [
+        assign<IBuildContext>({
+          webhookBody: undefined,
+          refresh: false,
+          recursionCount: 0,
+          nodesMutatedDuringQueryRun: false,
+        }),
+      ],
+      on: {
+        "": [
+          // Node mutations are prioritised because we don't want
+          // to run queries on data that is stale
+          {
+            cond: (ctx): boolean => !!ctx.nodeMutationBatch?.length,
+            target: `batchingNodeMutations`,
+          },
+          extractQueriesIfDirty,
+        ],
+        WEBHOOK_RECEIVED: {
+          target: `refreshing`,
+          actions: assign((_ctx, event) => {
+            return { webhookBody: event.body }
+          }),
+        },
+        ADD_NODE_MUTATION: {
+          actions: `addNodeMutation`,
+          target: `batchingNodeMutations`,
+        },
+        SOURCE_FILE_CHANGED: {
+          target: `#extractingAndRunningQueries`,
+        },
+      },
+    },
+
+    refreshing: {
+      invoke: {
+        src: async (): Promise<void> => {},
+        id: `refreshing`,
+        onDone: {
+          target: `#initializingDataLayer`,
+          actions: assign<IBuildContext>({
+            refresh: true,
+          }),
+        },
+        onError: {
+          target: `#build.failed`,
+        },
+      },
+    },
+
+    // Doors are open for people to enter
+    batchingNodeMutations: {
+      on: {
+        // Check if the batch is already full on entry
+        "": {
+          cond: (ctx): boolean =>
+            ctx.nodeMutationBatch?.length >= NODE_MUTATION_BATCH_SIZE,
+          target: `committingBatch`,
+        },
+        // More people enter same bus
+        ADD_NODE_MUTATION: [
+          // If this fills the batch then commit it
+          {
+            actions: [`addNodeMutation`],
+            cond: (ctx): boolean =>
+              ctx.nodeMutationBatch?.length >= NODE_MUTATION_BATCH_SIZE,
+            target: `committingBatch`,
+          },
+          // otherwise just add it to the batch
+          {
+            actions: `addNodeMutation`,
+          },
+        ],
+      },
+
+      // Check if bus is either full or if enough time has passed since
+      // first passenger entered the bus
+
+      // Fallback
+      after: {
+        [NODE_MUTATION_BATCH_TIMEOUT]: `committingBatch`,
+      },
+    },
+    committingBatch: {
+      entry: [
+        assign(context => {
+          // console.log(
+          //   `context at entry for committing batch`,
+          //   context.runningBatch,
+          //   context.nodeMutationBatch
+          // )
+          // Move the contents of the batch into a batch for running
+          return {
+            target: `#initializingDataLayer.buildingSchema`,
+            nodeMutationBatch: [],
+            runningBatch: context.nodeMutationBatch,
+          }
+        }),
+      ],
+      invoke: {
+        src: async ({ runningBatch, store }: IBuildContext): Promise<any> =>
+          // Consume the entire batch and run actions
+          Promise.all(runningBatch.map(payload => callRealApi(payload, store))),
+        onDone: {
+          target: `#initializingDataLayer.buildingSchema`,
+          actions: assign<IBuildContext>({
+            runningBatch: [],
+          }),
+        },
+      },
+    },
+  },
+}

--- a/packages/gatsby/src/utils/check-for-changed-pages.ts
+++ b/packages/gatsby/src/utils/check-for-changed-pages.ts
@@ -1,0 +1,54 @@
+import { boundActionCreators } from "../redux/actions"
+const { deletePage, deleteComponentsDependencies } = boundActionCreators
+
+import { isEqualWith, IsEqualCustomizer } from "lodash"
+import { IGatsbyPage } from "../redux/types"
+
+export function deleteUntouchedPages(
+  currentPages: Map<string, IGatsbyPage>,
+  timestamp: number
+): string[] {
+  const deletedPages: string[] = []
+
+  // Delete pages that weren't updated when running createPages.
+  currentPages.forEach(page => {
+    if (
+      !page.isCreatedByStatefulCreatePages &&
+      page.updatedAt < timestamp &&
+      page.path !== `/404.html`
+    ) {
+      deleteComponentsDependencies([page.path])
+      deletePage(page)
+      deletedPages.push(page.path, `/page-data${page.path}`)
+    }
+  })
+  return deletedPages
+}
+
+export function findChangedPages(
+  oldPages: Map<string, IGatsbyPage>,
+  currentPages: Map<string, IGatsbyPage>
+): {
+  changedPages: string[]
+  deletedPages: string[]
+} {
+  const changedPages: string[] = []
+
+  const compareWithoutUpdated: IsEqualCustomizer = (_left, _right, key) =>
+    key === `updatedAt` || undefined
+
+  currentPages.forEach((newPage, key) => {
+    const oldPage = oldPages.get(key)
+    if (!oldPage || !isEqualWith(newPage, oldPage, compareWithoutUpdated)) {
+      changedPages.push(key)
+    }
+  })
+  const deletedPages: string[] = []
+  oldPages.forEach((_page, key) => {
+    if (!currentPages.has(key)) {
+      deletedPages.push(key)
+    }
+  })
+
+  return { changedPages, deletedPages }
+}

--- a/packages/gatsby/src/utils/state-machine-server.ts
+++ b/packages/gatsby/src/utils/state-machine-server.ts
@@ -1,0 +1,53 @@
+import WebSocket from "ws"
+import { Interpreter } from "xstate"
+// TODO: run this through express on the same port as Gatsby
+export const startStateMachineServer = (
+  service: Interpreter<any>,
+  port: number
+): WebSocket.Server => {
+  const wss = new WebSocket.Server({ port })
+
+  const { machine } = service
+
+  wss.on(`connection`, ws => {
+    console.log(`WS`)
+
+    ws.on(`open`, () => {
+      console.log(`open`)
+    })
+
+    ws.on(`message`, (msg: WebSocket.Data) => {
+      if (typeof msg !== `string`) {
+        return
+      }
+      const message = JSON.parse(msg)
+      if (message?.type === `GET_MACHINE`) {
+        ws.send(
+          JSON.stringify({
+            event: `SET_MACHINE`,
+            config: machine.config,
+            options: machine.options,
+            state: service.state.value,
+          })
+        )
+      }
+    })
+    let last = service.state
+    service.onTransition(async context => {
+      if (context.changed && !last.matches(context)) {
+        if (ws.readyState === WebSocket.OPEN) {
+          last = context
+          console.log(`sending message`, context.value)
+          ws.send(
+            JSON.stringify({
+              event: `SET_STATE`,
+              state: context.value,
+              timestamp: Date.now(),
+            })
+          )
+        }
+      }
+    })
+  })
+  return wss
+}


### PR DESCRIPTION
This PR adds the services used by the upcoming develop state machine. They are mostly thin wrappers around existing commands, such as calls to apiRunnerNode. This PR doesn't change any existing code paths: it just adds helpers which are used by the state machine which will be in another PR. 

It would be great if reviewers could check if each command looks correct, as it should mostly be familar behaviour, just different structure.

This image shows the structure for the `develop` machine, so you can see where these services are used.

![image (2)](https://user-images.githubusercontent.com/213306/83420413-82e15100-a41e-11ea-88d7-24ed5c3713d5.png)
