### PR TITLE
fix(gatsby-recipes): move strip-ansi to dependencies

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -61,6 +61,7 @@
     "resolve-cwd": "^3.0.0",
     "semver": "^7.3.2",
     "single-trailing-newline": "^1.0.0",
+    "strip-ansi": "^6.0.0",
     "style-to-object": "^0.3.0",
     "subscriptions-transport-ws": "^0.9.16",
     "svg-tag-names": "^2.0.1",
@@ -74,7 +75,6 @@
     "@babel/cli": "^7.8.4",
     "react": "^16.12.0",
     "rimraf": "^3.0.2",
-    "strip-ansi": "^6.0.0",
     "tmp-promise": "^2.1.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-recipes#readme",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
strip-ansi is used by gatsby-recipes/src/providers/utils/get-diff.js, which makes it a dependency rather than devDependency. Make it so.

## Related Issues

Addresses #20949

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
