### PR TITLE
chore(redirects): unify all entries to include slash

### DIFF
--- a/www/redirects.yaml
+++ b/www/redirects.yaml
@@ -150,9 +150,9 @@
   toPath: /contributing/blog-contributions/
 - fromPath: /contributing/docs-and-website-components/
   toPath: /contributing/docs-and-blog-components/
-- fromPath: /docs/pixabay-source-plugin-tutorial
-  toPath: /docs/source-plugin-tutorial
-- fromPath: /docs/page-build-optimizations-for-incremental-data-changes
-  toPath: /docs/conditional-page-builds
+- fromPath: /docs/pixabay-source-plugin-tutorial/
+  toPath: /docs/source-plugin-tutorial/
+- fromPath: /docs/page-build-optimizations-for-incremental-data-changes/
+  toPath: /docs/conditional-page-builds/
 - fromPath: /docs/contributing/translation/ui-messages/
   toPath: /docs/contributing/translation/


### PR DESCRIPTION
## Description

changes: 

- unify all entries to include trailing slash

## Related Issues

- #21608 `chore(redirects): unify all entries to include slash`