### PR TITLE
fix(recipe): Preact - brand name

### DIFF
--- a/packages/gatsby-recipes/recipes/preact.mdx
+++ b/packages/gatsby-recipes/recipes/preact.mdx
@@ -14,7 +14,7 @@ Install the necessary NPM packages:
 
 ---
 
-Add the preact plugin to your Gatsby config. It will setup the correct configuration, which will let gatsby use Preact instead of React.
+Add the Preact plugin to your Gatsby config. It will setup the correct configuration, which will let gatsby use Preact instead of React.
 
 <GatsbyPlugin
   name="gatsby-plugin-preact"


### PR DESCRIPTION
## Description

changes:

- fix brand name: preact -> Preact

## Alternative

```diff
- Add the preact plugin to your Gatsby config.
+ Add the `gatsby-plugin-preact` plugin to your Gatsby config.
````


## Related Issues

- #24156 `feat(gatsby-recipes): add preact recipe`