### PR TITLE
feat(gatsby): Improve cssmodules performance

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/cssmodules.js
+++ b/e2e-tests/production-runtime/cypress/integration/cssmodules.js
@@ -9,7 +9,6 @@ describe(`Cssmodule integration`, () => {
     })
 
     cssModuleEl.invoke("attr", "class").then(className => {
-      console.log(className)
       cy.get("style").contains(className).should("exist")
     })
     cy.get("style").should("have.length", 3)

--- a/e2e-tests/production-runtime/cypress/integration/cssmodules.js
+++ b/e2e-tests/production-runtime/cypress/integration/cssmodules.js
@@ -1,0 +1,28 @@
+describe(`Cssmodule integration`, () => {
+  it(`the header has the right style`, () => {
+    cy.visit(`/cssmodules/`).waitForRouteChange()
+
+    const cssModuleEl = cy.getTestElement(`cssmodule`)
+    cssModuleEl.should("have.css", "font-size", "48px")
+    cssModuleEl.should($el => {
+      expect($el[0].className).to.have.lengthOf(6)
+    })
+
+    cssModuleEl.invoke("attr", "class").then(className => {
+      console.log(className)
+      cy.get("style").contains(className).should("exist")
+    })
+    cy.get("style").should("have.length", 3)
+  })
+
+  it(`homepage should not have cssmodules`, () => {
+    cy.visit(`/`).waitForRouteChange()
+    cy.get("style").should("have.length", 2)
+
+    cy.getTestElement("cssmodules").click()
+    cy.waitForRouteChange().location(`pathname`).should(`equal`, `/cssmodules/`)
+    cy.get('link[rel="stylesheet"]')
+      .should("have.attr", "href")
+      .and("include", "pages-cssmodules")
+  })
+})

--- a/e2e-tests/production-runtime/src/components/mystyle.module.css
+++ b/e2e-tests/production-runtime/src/components/mystyle.module.css
@@ -1,0 +1,3 @@
+.heading {
+  font-size: 48px;
+}

--- a/e2e-tests/production-runtime/src/pages/cssmodules.js
+++ b/e2e-tests/production-runtime/src/pages/cssmodules.js
@@ -1,0 +1,14 @@
+import * as React from "react"
+
+import Layout from "../components/layout"
+import { heading } from "../components/mystyle.module.css"
+
+const CssModule = () => (
+  <Layout>
+    <h1 className={heading} data-testid="cssmodule">
+      Hi, we're using cssmodules
+    </h1>
+  </Layout>
+)
+
+export default CssModule

--- a/e2e-tests/production-runtime/src/pages/index.js
+++ b/e2e-tests/production-runtime/src/pages/index.js
@@ -61,6 +61,11 @@ const IndexPage = ({ pageContext }) => (
           Go to page with unicode path
         </Link>
       </li>
+      <li>
+        <Link to="/cssmodules/" data-testid="cssmodules">
+          Go to page with cssmodules
+        </Link>
+      </li>
     </ul>
   </Layout>
 )

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -345,7 +345,10 @@ module.exports = async (
         configRules = configRules.concat([
           {
             oneOf: [
-              rules.cssModules(),
+              rules.cssModules({
+                // enable smaller css classnames
+                localIdentName: `[hash:base64:5]`,
+              }),
               {
                 ...rules.css(),
                 use: [loaders.null()],
@@ -364,7 +367,13 @@ module.exports = async (
         // classNames to use.
         configRules = configRules.concat([
           {
-            oneOf: [rules.cssModules(), rules.css()],
+            oneOf: [
+              rules.cssModules({
+                // enable smaller css classnames
+                localIdentName: `[hash:base64:5]`,
+              }),
+              rules.css(),
+            ],
           },
         ])
 
@@ -490,7 +499,8 @@ module.exports = async (
 
   if (stage === `build-javascript`) {
     const componentsCount = store.getState().components.size
-    const isCssModule = module => module.type === `css/mini-extract`
+    const isCssModule = module =>
+      module.type === `css/mini-extract` && !module.issuer.usedExports
 
     const splitChunks = {
       chunks: `all`,


### PR DESCRIPTION
## Description

We didn't optimize CSS modules correctly. We added all `.module.css` files to the main file so we had one big stylesheet and our classNames weren't short.

With these changes, I tackle both.

## Information

```
const isCssModule = module =>
      module.type === `css/mini-extract` && !module.issuer.usedExports
```

A CSS modules is an extra layer above a webpack module so we have to get the issuer which is the css file and check if it's exporting anything. It only exports when modules are on. Else it's false.

The other change is changing identName on production. It's widely used by many libs:
- https://github.com/developit/microbundle/blob/436498fac0e517b22e84052c57517dc73f49dc73/src/index.js#L724
- https://github.com/seek-oss/treat/blob/4dc6d9c781ee1de52c609b1c20f0d7a80e7411e3/packages/gatsby-plugin-treat/gatsby-node.js#L21
- https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/getCSSModuleLocalIdent.js#L26-L31

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/21253
