### PR TITLE
chore(docs): Fix brand name for GitHub

### DIFF
--- a/docs/blog/2020-03-11-netlify-functions-and-gatsby-cloud/index.md
+++ b/docs/blog/2020-03-11-netlify-functions-and-gatsby-cloud/index.md
@@ -60,7 +60,7 @@ exports.handler = async (event, context, callback) => {
 }
 ```
 
-When using Netlify for CI _and_ deployments, you can pop this code in a `/functions` directory and the functions will get built and shipped whenever you push to Github. No manual steps needed 💯.
+When using Netlify for CI _and_ deployments, you can pop this code in a `/functions` directory and the functions will get built and shipped whenever you push to GitHub. No manual steps needed 💯.
 
 Learn more about Netlify Functions in [their documentation](https://docs.netlify.com/functions/overview/).
 
@@ -156,7 +156,7 @@ Why might the directory already exist? Gatsby Cloud maintains a cache, to speed 
 
 ## In conclusion
 
-With a little bit of Node.js configuration, we're able to do some post-processing after the build, packaging up our functions and moving them to the spot Netlify expects to find them. When we push code to Github, Gatsby Cloud will run a new build, and then upload the resulting files to Netlify.
+With a little bit of Node.js configuration, we're able to do some post-processing after the build, packaging up our functions and moving them to the spot Netlify expects to find them. When we push code to GitHub, Gatsby Cloud will run a new build, and then upload the resulting files to Netlify.
 
 If you already have a Gatsby Cloud site, and you're considering using serverless functions, I can say unequivocally that Netlify makes the experience seamless and painless, and their generous pricing model means that you can experiment with them for free.
 

--- a/docs/docs/deploying-to-gatsby-cloud.md
+++ b/docs/docs/deploying-to-gatsby-cloud.md
@@ -18,7 +18,7 @@ Best of all, Gatsby Cloud includes a [free tier](https://www.gatsbyjs.com/pricin
 
 ## Integrations
 
-Gatsby Cloud integrates with the tools you already use to build sites. By connecting your Gatsby project's Github repo, Gatsby Cloud automatically builds and deploys your site when you make changes.
+Gatsby Cloud integrates with the tools you already use to build sites. By connecting your Gatsby project's GitHub repo, Gatsby Cloud automatically builds and deploys your site when you make changes.
 
 ### CMS Integrations
 

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6520,7 +6520,7 @@
     - Twitter Cards meta
     - Beautiful XML Sitemaps
     - Netlify Contact Form, Works right out of the box after deployment.
-    - Invite collaborators into Netlify CMS, without giving access to your Github account via Git Gateway
+    - Invite collaborators into Netlify CMS, without giving access to your GitHub account via Git Gateway
     - Gatsby Incremental Builds with Netlify.
     - For more info, Take a look at readme.md on the Github repo.
 - url: https://gatsby-starter-payments.netlify.app

--- a/rfcs/text/0005-docs-decision-tree.md
+++ b/rfcs/text/0005-docs-decision-tree.md
@@ -39,7 +39,7 @@ I can't see another way to accomplish the goal of becoming a unified, unbiased (
 
 Test it during Hacktoberfest. For the time being, that's good enough because @amberley and I are already getting tagged as @docsteam, so we can test the decision tree anytime we get tagged.
 
-If/when there are more @gatsbyjs/docs team members, we can drive adoption through onboarding and then prizes or something when someone refers to the decision tree in their Github PR or issue comments as a reason for a docs decision. Finally, regularly meeting to revise the decision tree will help everyone have a voice in revising it and own the decision-making process.
+If/when there are more @gatsbyjs/docs team members, we can drive adoption through onboarding and then prizes or something when someone refers to the decision tree in their GitHub PR or issue comments as a reason for a docs decision. Finally, regularly meeting to revise the decision tree will help everyone have a voice in revising it and own the decision-making process.
 
 ## What questions still need to be answered about this idea?
 

--- a/rfcs/text/0011-move-rfcs-to-monorepo.md
+++ b/rfcs/text/0011-move-rfcs-to-monorepo.md
@@ -130,7 +130,7 @@ The size of the monorepo has been considered a barrier to entry for some, for ex
 
 Adding more content, and moving content to the monorepo means that the RFC contribution workflow now has this initial sunk cost as its first step.
 
-I contend that this is worth work doing regardless. The likelihood of opening an RFC and not then needing to (eventually) open a PR implementing the RFC is slim. In any scenario -- Github's existing tools for this, e.g. in-app editing, mitigate this cost and ensure that there are still mechanisms to add an RFC without cloning the repo.
+I contend that this is worth work doing regardless. The likelihood of opening an RFC and not then needing to (eventually) open a PR implementing the RFC is slim. In any scenario -- GitHub's existing tools for this, e.g. in-app editing, mitigate this cost and ensure that there are still mechanisms to add an RFC without cloning the repo.
 
 ## Separation of concerns
 


### PR DESCRIPTION

## Description

Changed `Github` to `GitHub`
