### PR TITLE
chore(www): convert swatch component to theme-ui

### DIFF
--- a/www/src/components/guidelines/color/swatch.js
+++ b/www/src/components/guidelines/color/swatch.js
@@ -3,7 +3,7 @@ import { jsx } from "theme-ui"
 import React, { useState } from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
 
-import { Box } from "../system"
+import { Box } from "theme-ui"
 
 export default function Swatch(props) {
   const { a11yLabel, color, swatchStyle, textColor } = props
@@ -24,8 +24,8 @@ export default function Swatch(props) {
 
   return (
     <Box
-      bg={color.hex}
       sx={{
+        bg: color.hex,
         ...swatchStyle,
         ":hover > .btn-copy": {
           display: `block`,
@@ -34,11 +34,11 @@ export default function Swatch(props) {
     >
       {a11yLabel !== `×` && (
         <Box
-          color={textColor}
-          fontSize={0}
-          position="absolute"
-          fontWeight="body"
           sx={{
+            color: textColor,
+            fontSize: 0,
+            position: `absolute`,
+            fontWeight: `body`,
             bottom: `2px`,
             left: `3px`,
             lineHeight: `dense`,
@@ -55,15 +55,15 @@ export default function Swatch(props) {
           sx={{
             background: `none`,
             border: 0,
-            bottom: 0,
             color: `black`,
             cursor: `pointer`,
-            height: `100%`,
-            left: 0,
-            position: `absolute`,
-            right: 0,
-            top: 0,
             width: `100%`,
+            height: `100%`,
+            position: `absolute`,
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
             zIndex: 1,
             ":focus .tooltip, :hover .tooltip": {
               display: `block`,
@@ -73,19 +73,19 @@ export default function Swatch(props) {
           onClick={handleClick}
         >
           <Box
-            bg="white"
-            boxShadow="raised"
-            borderRadius={1}
-            fontSize={1}
             className="tooltip"
             sx={{
-              top: `-40px`,
-              height: `32px`,
-              left: 0,
+              bg: `white`,
+              boxShadow: `raised`,
+              borderRadius: 1,
+              fontSize: 1,
               lineHeight: `32px`,
-              display: `none`,
-              position: `absolute`,
               width: `160px`,
+              height: `32px`,
+              position: `absolute`,
+              top: `-40px`,
+              left: 0,
+              display: `none`,
             }}
           >
             {displayCopied ? (
@@ -101,19 +101,17 @@ export default function Swatch(props) {
 
       {(color.name || color.base) && (
         <Box
-          bg={textColor}
-          borderRadius={7}
-          bottom={4}
-          fontSize={0}
-          lineHeight="solid"
-          height={8}
-          width={8}
-          position="absolute"
-          top="auto"
-          right={4}
-          css={{
-            bottom: 4,
-            right: 4,
+          sx={{
+            bg: textColor,
+            fontSize: 0,
+            lineHeight: `solid`,
+            height: 8,
+            width: 8,
+            position: `absolute`,
+            top: `auto`,
+            right: `4px`,
+            bottom: `4px`,
+            borderRadius: 7,
           }}
         />
       )}

--- a/www/src/components/guidelines/color/swatch.js
+++ b/www/src/components/guidelines/color/swatch.js
@@ -39,10 +39,10 @@ export default function Swatch(props) {
             fontSize: 0,
             position: `absolute`,
             fontWeight: `body`,
-            bottom: `2px`,
-            left: `3px`,
             lineHeight: `dense`,
             top: `auto`,
+            bottom: `2px`,
+            left: `3px`,
           }}
         >
           {a11yLabel}


### PR DESCRIPTION
## Description

1. Converted the `<Swatch/>` component to theme-ui
2. Some CSS rules were repeating, they are fixed

### Screenshot(s)

<img width="400" alt="swatch-dark" src="https://user-images.githubusercontent.com/19193724/83534821-efd41400-a50e-11ea-803d-37852e6efa77.png">
<img width="400" alt="swatch-light" src="https://user-images.githubusercontent.com/19193724/83534827-f19dd780-a50e-11ea-8124-f50cf8ef8a83.png">

### How to test

**Local URL:** http://localhost:8000/guidelines/color/
**Production URL:** https://www.gatsbyjs.org/guidelines/color/
