### PR TITLE
chore(docs): Standardize word website

### DIFF
--- a/docs/blog/2018-10-03-gatsby-perf/index.md
+++ b/docs/blog/2018-10-03-gatsby-perf/index.md
@@ -63,7 +63,7 @@ WebPagetest allows you to collect performance measurements in running on a _real
 
 ![WebPagetest](./images/webpagetest.png)
 
-Running a test in WebPagetest will pull up the specified site on the browser/network specified, and then collect performance measurements that can be reviewed and analyzed. These tests can serve as a baseline that can be compared against after changes are made, e.g. like a change in comparing the Gatsby v1 site to the Gatsby v2 site 🤓 Additionally, it's helpful to run these tests fairly often after meaningful changes and features are added to your web site, to ensure that you're guarding against performance regressions! For your consideration, check out Gatsby v1's metrics in WebPagetest.
+Running a test in WebPagetest will pull up the specified site on the browser/network specified, and then collect performance measurements that can be reviewed and analyzed. These tests can serve as a baseline that can be compared against after changes are made, e.g. like a change in comparing the Gatsby v1 site to the Gatsby v2 site 🤓 Additionally, it's helpful to run these tests fairly often after meaningful changes and features are added to your website, to ensure that you're guarding against performance regressions! For your consideration, check out Gatsby v1's metrics in WebPagetest.
 
 [![WebPagetest v1](./images/webpagetest-v1.png)][webpagetestv1-results]
 

--- a/docs/blog/2019-04-19-your-website-should-be-built-with-gatsby/index.md
+++ b/docs/blog/2019-04-19-your-website-should-be-built-with-gatsby/index.md
@@ -34,7 +34,7 @@ We’ve covered the basics, stick around as we dive into the details.
 
 ### The Landscape
 
-We’ve grown high expectations for web sites since their humble beginnings in the early 90s. Primarily, most websites are attached to diverse set data sources - a Content Management System (CMS) like WordPress or Shopify, a social feed from Instagram or Twitter, or high-resolution images hosted in a repository like Cloudinary.
+We’ve grown high expectations for websites since their humble beginnings in the early 90s. Primarily, most websites are attached to diverse set data sources - a Content Management System (CMS) like WordPress or Shopify, a social feed from Instagram or Twitter, or high-resolution images hosted in a repository like Cloudinary.
 
 This is fantastic, the CMS allows anyone to publish content to the web without having to continually hire a web developer. Pulling content from our social feeds means that we don’t have to duplicate content, and it promotes all the different mediums through which users can engage with our brand.
 

--- a/docs/blog/2019-09-26-announcing-gatsby-15m-series-a-funding-round/index.md
+++ b/docs/blog/2019-09-26-announcing-gatsby-15m-series-a-funding-round/index.md
@@ -18,7 +18,7 @@ With Gatsby, we’re reinventing website technology so people can create sites t
 
 Gatsby strips away much of the complexity that plagues website development. Teams tell us that they can build stunning sites 3-5x faster with Gatsby—and have a lot more fun in the process.
 
-The web is an incredible medium. Anyone, anywhere can produce a site and ship their ideas to the world. [Individuals, teams, and organizations are turning to Gatsby to create web sites and apps that stand out](https://www.gatsbyjs.org/blog/tags/case-studies)[.](https://www.gatsbyjs.org/blog/tags/case-studies)
+The web is an incredible medium. Anyone, anywhere can produce a site and ship their ideas to the world. [Individuals, teams, and organizations are turning to Gatsby to create websites and apps that stand out](https://www.gatsbyjs.org/blog/tags/case-studies)[.](https://www.gatsbyjs.org/blog/tags/case-studies)
 
 ## From the CMS to the content mesh
 

--- a/docs/blog/2019-11-14-announcing-gatsby-cloud/index.md
+++ b/docs/blog/2019-11-14-announcing-gatsby-cloud/index.md
@@ -55,7 +55,7 @@ Let's step back and discuss why we're building Gatsby and how our new Cloud plat
 
 For most of the history of the web, the dominant web architecture has been the LAMP stack e.g., applications like WordPress. But the last decade has seen the rise of two enormous trends—cloud computing and JavaScript-rich web apps (driven by component frameworks like React). Gatsby was founded around the idea that web architectures are converging on these two ideas and will be foundational for decades to come.
 
-Gatsby provides the building blocks for a modern web site:
+Gatsby provides the building blocks for a modern website:
 
 - **JavaScript Component Library**. Gatsby sites are React apps, so you can create high-quality, dynamic web apps, from blogs to e-commerce sites to user dashboards.
 - **Load Data From Anywhere**. Gatsby pulls in data from any data source, whether it's Markdown files, a headless CMS like Contentful or WordPress, or a REST or GraphQL API. Use source plugins to load your data, then develop using Gatsby's uniform GraphQL interface.

--- a/docs/docs/deploying-to-azure.md
+++ b/docs/docs/deploying-to-azure.md
@@ -4,7 +4,7 @@ title: Deploying to Azure
 
 This guide walks through how to deploy and host your next Gatsby site on Azure.
 
-Azure is a great option for deploying Gatsby sites. Azure is a large cloud platform with hundreds of services working together to give you serverless, databases, AI, and static web site hosting. The Azure Static Web Apps service is meant to be used with static web sites. It provides features like hosting, [CDN](/docs/glossary/content-delivery-network/), authentication/authorization, [continuous deployment](/docs/glossary/continuous-deployment/) with Git-triggered builds, HTTPS, the ability to add a serverless API, and much more.
+Azure is a great option for deploying Gatsby sites. Azure is a large cloud platform with hundreds of services working together to give you serverless, databases, AI, and static website hosting. The Azure Static Web Apps service is meant to be used with static websites. It provides features like hosting, [CDN](/docs/glossary/content-delivery-network/), authentication/authorization, [continuous deployment](/docs/glossary/continuous-deployment/) with Git-triggered builds, HTTPS, the ability to add a serverless API, and much more.
 
 ## Prerequisites
 

--- a/docs/docs/glossary/jamstack.md
+++ b/docs/docs/glossary/jamstack.md
@@ -21,7 +21,7 @@ A JAMStack backend is a content API that returns JSON or XML. This API can be a 
 
 ### Advantages of a JAMStack architecture
 
-JAMStack sites, such as those created with Gatsby, offer four key advantages over other web site architectures.
+JAMStack sites, such as those created with Gatsby, offer four key advantages over other website architectures.
 
 - **Speed**: JAMStack sites lack the overhead caused by software and database layers. As a result, they render and load more quickly than sites that use monolithic architectures.
 - **Hosting flexibility**: Because they're static files, JAMStack sites can be hosted anywhere. You can use traditional web server software, such as Apache or Nginx. For the best performance and security, you can use an object storage service and content delivery network such as [Netlify](/docs/deploying-to-netlify), [Render](/docs/deploying-to-render), or Amazon Web Services' [S3 and Cloudfront](/docs/deploying-to-s3-cloudfront).

--- a/docs/docs/glossary/node.md
+++ b/docs/docs/glossary/node.md
@@ -25,10 +25,10 @@ You'll use npm to install Gatsby and its dependencies. Type `npm install -g gats
 
 ## Learn more about Node.js
 
-- [Node.js](https://nodejs.org/en/) official web site
+- [Node.js](https://nodejs.org/en/) official website
 
 - [Introduction to Node.js](https://nodejs.dev)
 
 - [NodeSchool](https://nodeschool.io/) offers online and in-person Node.js workshops
 
-- [V8](https://v8.dev/) developer blog web site
+- [V8](https://v8.dev/) developer blog website

--- a/docs/docs/glossary/progressive-enhancement.md
+++ b/docs/docs/glossary/progressive-enhancement.md
@@ -7,7 +7,7 @@ Learn what _progressive enhancement_ is and how Gatsby builds sites using progre
 
 ## What is progressive enhancement?
 
-_Progressive enhancement_ is a strategy for building web sites in which core functionality is available to all browsers, while non-critical enhancements are available to capable browsers. For example, a progressively-enhanced form submission might trigger a `fetch` network request in browsers that support the Fetch API, and a traditional form submission with a full page reload in browsers that do not.
+_Progressive enhancement_ is a strategy for building websites in which core functionality is available to all browsers, while non-critical enhancements are available to capable browsers. For example, a progressively-enhanced form submission might trigger a `fetch` network request in browsers that support the Fetch API, and a traditional form submission with a full page reload in browsers that do not.
 
 Progressive enhancement can also ensure that your site is usable even if JavaScript fails to load. Poor network conditions, firewalls, and some browser settings can prevent JavaScript from executing. If your site relies entirely on JavaScript and client-side rendering, visitors may see a blank screen while waiting for JavaScript to load.
 
@@ -19,7 +19,7 @@ Gatsby uses [server-side rendering](/docs/glossary/server-side-rendering/) and a
 
 When a site visitor requests their first URL from your site, the initial response will be server-rendered HTML, along with linked JavaScript, CSS, and images. If their browser is capable, React will hydrate the DOM, adding event listeners and state. Subsequent URL requests become DOM updates managed by React. If hydration fails, however, your site still works. Subsequent URL requests will instead trigger a network request and a full-page load.
 
-Gatsby helps you build blazing-fast web sites and applications that work with the latest browsers, without excluding older ones.
+Gatsby helps you build blazing-fast websites and applications that work with the latest browsers, without excluding older ones.
 
 ### Learn more
 

--- a/docs/docs/glossary/react.md
+++ b/docs/docs/glossary/react.md
@@ -11,7 +11,7 @@ React is a code library for building web-based user interfaces. It's written usi
 
 Facebook first released React in 2013. The company still maintains the project, along with a community of contributors. It's free to use and open source under the terms of the [MIT License](https://github.com/facebook/react/blob/master/LICENSE).
 
-Where publishing tools such as WordPress and Jekyll rely on a system of template files to create a UI, React uses [components](/docs/glossary#component). Components are contained chunks of JavaScript, CSS, and HTML or SVG that can be reused, shared, and combined to create a web site or application.
+Where publishing tools such as WordPress and Jekyll rely on a system of template files to create a UI, React uses [components](/docs/glossary#component). Components are contained chunks of JavaScript, CSS, and HTML or SVG that can be reused, shared, and combined to create a website or application.
 
 Components may be purely presentational. For example, you might create a `Logo` component that's just an SVG image. Or a component may encapsulate functionality. An `InputBox` component might include an input control, a label, and some simple validation.
 
@@ -19,8 +19,8 @@ Components are also _composable_, which is a fancy way of saying that you can us
 
 React components respond to changes in _state_. In React, _state_ is a set of properties and values that determine how a component looks or behaves. State can change in response to user activity, such as a click or key press. State can also change as the result of a completed network request. When a value in a component's state changes, the component is the only part of the UI that changes. In other words, React can update part of a page or an entire view without requiring a full page reload.
 
-Gatsby bundles React, [webpack](/docs/glossary#webpack), [GraphQL](/docs/glossary#graphql), and other tools into a single framework for building web sites. With Gatsby, you get a head start on meeting your SEO, accessibility, and performance requirements. Rather than installing and configuring a development environment from scratch, you can install Gatsby and start building.
+Gatsby bundles React, [webpack](/docs/glossary#webpack), [GraphQL](/docs/glossary#graphql), and other tools into a single framework for building websites. With Gatsby, you get a head start on meeting your SEO, accessibility, and performance requirements. Rather than installing and configuring a development environment from scratch, you can install Gatsby and start building.
 
 ### Learn more about React
 
-- [React](https://reactjs.org/) Official web site
+- [React](https://reactjs.org/) Official website

--- a/docs/docs/glossary/server-side-rendering.md
+++ b/docs/docs/glossary/server-side-rendering.md
@@ -3,7 +3,7 @@ title: Server Side Rendering
 disableTableOfContents: true
 ---
 
-Learn what server side rendering is and why it's preferable to client-side (browser) rendering. You'll also learn how Gatsby uses server-side rendering to create static web sites.
+Learn what server side rendering is and why it's preferable to client-side (browser) rendering. You'll also learn how Gatsby uses server-side rendering to create static websites.
 
 ## What is Server-Side rendering?
 

--- a/docs/docs/glossary/static-site-generator.md
+++ b/docs/docs/glossary/static-site-generator.md
@@ -15,7 +15,7 @@ Static site generators, on the other hand, generate HTML pages during a [build](
 
 > Note: It's also possible to use Gatsby [without GraphQL](/docs/using-gatsby-without-graphql/), using the `createPages` API.
 
-You can also use static site generators to create [JAMStack](/docs/glossary/#jamstack) sites. JAMStack is a modern web site architecture that uses JavaScript, content APIs, and markup. Gatsby, for example, can use the [WordPress REST API](/docs/sourcing-from-wordpress/) as a data source.
+You can also use static site generators to create [JAMStack](/docs/glossary/#jamstack) sites. JAMStack is a modern website architecture that uses JavaScript, content APIs, and markup. Gatsby, for example, can use the [WordPress REST API](/docs/sourcing-from-wordpress/) as a data source.
 
 ### Advantages of static site generators
 

--- a/docs/docs/glossary/webpack.md
+++ b/docs/docs/glossary/webpack.md
@@ -3,7 +3,7 @@ title: webpack
 disableTableOfContents: true
 ---
 
-Learn what webpack is, how it works, and how Gatsby uses it to accelerate web site development.
+Learn what webpack is, how it works, and how Gatsby uses it to accelerate website development.
 
 ## What is webpack?
 

--- a/docs/docs/prpl-pattern.md
+++ b/docs/docs/prpl-pattern.md
@@ -4,7 +4,7 @@ title: PRPL Pattern
 
 ## What is PRPL?
 
-PRPL is a web site architecture developed by Google for building websites and
+PRPL is a website architecture developed by Google for building websites and
 apps that work exceptionally well on smartphones and other devices with
 unreliable network connections.
 

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -4413,7 +4413,7 @@
   url: https://arctica.io
   main_url: https://arctica.io
   description: >
-    Arctica specialises in purpose-built web sites and progressive web applications with user optimal experiences, tailored to meet the objectives of your business.
+    Arctica specialises in purpose-built websites and progressive web applications with user optimal experiences, tailored to meet the objectives of your business.
   categories:
     - Portfolio
     - Agency
@@ -4585,7 +4585,7 @@
   url: https://gmartinez.dev/
   source_url: https://github.com/nephlin7/gmartinez.dev
   description: >
-    Personal web site for show my skills and my works.
+    Personal website for show my skills and my works.
   categories:
     - Web Development
     - Portfolio
@@ -10713,7 +10713,7 @@
   main_url: https://xn--28jma5da5l6e.com/en/
   source_url: https://github.com/dondoko-susumu/website-v2
   description: >
-    The Web site of Dondoko Susumu, a Japanese cartoonist. His cartoons have been posted. It is internationalized into 12 languages.
+    The Website of Dondoko Susumu, a Japanese cartoonist. His cartoons have been posted. It is internationalized into 12 languages.
   categories:
     - Blog
     - Entertainment
@@ -10779,7 +10779,7 @@
   featured: false
 - title: Que Jamear
   description: >-
-    A directory with a map of food delivery services 
+    A directory with a map of food delivery services
     to be used during the health emergency caused by covid 19.
   main_url: https://quejamear.com/encebollados
   url: https://quejamear.com/encebollados


### PR DESCRIPTION

## Description

Changed `web site` to `website`.

The term `website` is used a lot more currently in the code.

