### PR TITLE
chore(gatsby): Fix Python print statement to use Python 3 syntax

### DIFF
--- a/examples/using-remark/src/pages/2017-04-04---code-and-syntax-highlighting/index.md
+++ b/examples/using-remark/src/pages/2017-04-04---code-and-syntax-highlighting/index.md
@@ -41,7 +41,7 @@ names, see the [PrismJS homepage][3].
 
     ```python
     s = "Python syntax highlighting"
-    print s
+    print(s)
     ```
 
     ```
@@ -56,7 +56,7 @@ alert(s)
 
 ```python
 s = "Python syntax highlighting"
-print s
+print(s)
 ```
 
 ```


### PR DESCRIPTION

## Description

Changed `print s` to `print(s)`

https://docs.python.org/3/whatsnew/3.0.html




