### PR TITLE
chore(docs): Update documentation for createNodeField

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -963,7 +963,7 @@ type CreateNodeInput = {
  * @param {string} $0.fieldName [deprecated] the name for the field
  * @param {string} $0.fieldValue [deprecated] the value for the field
  * @param {string} $0.name the name for the field
- * @param {string} $0.value the value for the field
+ * @param {any} $0.value the value for the field
  * @example
  * createNodeField({
  *   node,


### PR DESCRIPTION
Value can be anything, not just string.

Closes #23852 
