### PR TITLE
perf(gatsby): stop using Sift as fallback

### DIFF
--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -132,7 +132,7 @@ describe(`run-sift tests`, () => {
   })
   ;[
     { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
-    { desc: `no cache`, cb: () => null }, // Always goes through sift
+    // { desc: `no cache`, cb: () => null }, // Always goes through sift
   ].forEach(({ desc, cb: createFiltersCache }) => {
     describe(desc, () => {
       describe(`filters by just id correctly`, () => {

--- a/packages/gatsby/src/redux/run-sift.js
+++ b/packages/gatsby/src/redux/run-sift.js
@@ -467,20 +467,28 @@ const applyFilters = (
   }
   lastFilterUsedSift = true
 
-  const siftResult /*: Array<IGatsbyNode> | null */ = filterWithSift(
-    filters,
-    firstOnly,
-    nodeTypeNames,
-    resolvedFields
-  )
+  // const siftResult /*: Array<IGatsbyNode> | null */ = filterWithSift(
+  //   filters,
+  //   firstOnly,
+  //   nodeTypeNames,
+  //   resolvedFields
+  // )
+
+  // if (stats) {
+  //   if (!siftResult || siftResult.length === 0) {
+  //     stats.totalSiftHits++
+  //   }
+  // }
 
   if (stats) {
-    if (!siftResult || siftResult.length === 0) {
-      stats.totalSiftHits++
-    }
+    // to mean, "empty results"
+    stats.totalSiftHits++
   }
 
-  return siftResult
+  if (firstOnly) {
+    return []
+  }
+  return null
 }
 
 const filterToStats = (
@@ -512,6 +520,8 @@ const filterToStats = (
  * @returns {Array<IGatsbyNode> | null} Collection of results.
  *   Collection will be limited to 1 if `firstOnly` is true
  */
+// TODO: we will drop this entirely when removing all Sift code
+// eslint-disable-next-line no-unused-vars
 const filterWithSift = (filters, firstOnly, nodeTypeNames, resolvedFields) => {
   let nodes /*: IGatsbyNode[]*/ = []
   nodeTypeNames.forEach(typeName => addResolvedNodes(typeName, nodes))

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -286,7 +286,7 @@ describe(`NodeModel`, () => {
     })
     ;[
       { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
-      { desc: `no cache`, cb: () => null }, // Always goes through sift
+      // { desc: `no cache`, cb: () => null }, // Always goes through sift
     ].forEach(({ desc, cb: createFiltersCache }) => {
       describe(`runQuery [${desc}]`, () => {
         it(`returns first result only`, async () => {
@@ -578,7 +578,7 @@ describe(`NodeModel`, () => {
     })
     ;[
       { desc: `with cache`, cb: () /*:FiltersCache*/ => new Map() }, // Avoids sift for flat filters
-      { desc: `no cache`, cb: () => null }, // Always goes through sift
+      // { desc: `no cache`, cb: () => null }, // Always goes through sift
     ].forEach(({ desc, cb: createFiltersCache }) => {
       it(`[${desc}] should not resolve prepared nodes more than once`, async () => {
         nodeModel.replaceFiltersCache(createFiltersCache())
@@ -791,7 +791,7 @@ describe(`NodeModel`, () => {
     })
     ;[
       { desc: `with cache`, cb: () => new Map() }, // Avoids sift
-      { desc: `no cache`, cb: () => null }, // Requires sift
+      // { desc: `no cache`, cb: () => null }, // Requires sift
     ].forEach(({ desc, cb: createFiltersCache }) => {
       describe(`[${desc}] Tracks nodes returned by queries`, () => {
         it(`Tracks objects when running query without filter`, async () => {

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -116,10 +116,10 @@ describe(`Query schema`, () => {
                     query: {
                       filter: {
                         frontmatter: {
-                          authors: { email: { eq: source.email } },
-                          // authors: {
-                          //   elemMatch: { email: { eq: source.email } },
-                          // },
+                          // authors: { email: { eq: source.email } },
+                          authors: {
+                            elemMatch: { email: { eq: source.email } },
+                          },
                         },
                       },
                     },

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -1,5 +1,5 @@
 const { runQuery: nodesQuery } = require(`../../db/nodes`)
-const { didLastFilterUseSift } = require(`../../redux/run-sift`)
+// const { didLastFilterUseSift } = require(`../../redux/run-sift`)
 const { store } = require(`../../redux`)
 const { actions } = require(`../../redux/actions`)
 
@@ -325,9 +325,9 @@ function resetDb(nodes) {
 
 async function runQuery(
   queryArgs,
-  filtersCache,
-  nodes = makeNodesUneven(),
-  alwaysSift = !filtersCache
+  filtersCache = new Map(),
+  nodes = makeNodesUneven()
+  // alwaysSift = !filtersCache
 ) {
   resetDb(nodes)
   const { sc, type: gqlType } = makeGqlType(nodes)
@@ -342,18 +342,18 @@ async function runQuery(
 
   let result = await nodesQuery(args)
 
-  // If the filters cache was set, then the test expects fast filters to handle
-  // the query and to skip Sift. If it's not set, then it can't use fast filters
-  // Might revise this when adding tests where we don't expect fast filters to
-  // support it yet..?
-  if (result && result.length) {
-    // Currently, empty results must go through Sift, so ignore those cases here
-    if (alwaysSift) {
-      expect(didLastFilterUseSift()).toBe(true)
-    } else {
-      expect(didLastFilterUseSift()).toBe(!filtersCache)
-    }
-  }
+  // // If the filters cache was set, then the test expects fast filters to handle
+  // // the query and to skip Sift. If it's not set, then it can't use fast filters
+  // // Might revise this when adding tests where we don't expect fast filters to
+  // // support it yet..?
+  // if (result && result.length) {
+  //   // Currently, empty results must go through Sift, so ignore those cases here
+  //   if (alwaysSift) {
+  //     expect(didLastFilterUseSift()).toBe(true)
+  //   } else {
+  //     expect(didLastFilterUseSift()).toBe(!filtersCache)
+  //   }
+  // }
 
   return result
 }
@@ -399,7 +399,7 @@ it(`should use the cache argument`, async () => {
 
 // Make sure to test fast filters (with cache) and Sift (without cache)
 ;[
-  { desc: `without cache`, cb: () => null }, // Forces no cache, must use Sift
+  // { desc: `no cache`, cb: () => null }, // Forces no cache, must use Sift
   { desc: `with cache`, cb: () => new Map() },
 ].forEach(({ desc, cb: createFiltersCache }) => {
   async function runFastFilter(filter) {


### PR DESCRIPTION
This is a minimal version of https://github.com/gatsbyjs/gatsby/pull/24345 where we only uncomment the Sift call (and anything in tests that relied on it).

This is _potentially_ a breaking change, although the status quo should already be that everything is handled by fast filters. Before this PR the empty results were still routed through Sift as a safety backup, but we now have a high enough confidence that this is no longer necessary.

__We will do a minor bump for this change__, to err on the safe side of this assumption. We will try to fix-forward anything that might still be broken. But worst case we can still back this out to unblock.

Please tag me message asap if you think this commit causes any kind of problem.

The plan is to actually remove the Sift specific code in about two weeks from now, provided no big problems come up.