### PR TITLE
fix(gatsby-link): Fail gracefully on empty `to` prop

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -7,7 +7,7 @@ import { parsePath } from "./parse-path"
 
 export { parsePath }
 
-const isAbsolutePath = path => path.startsWith(`/`)
+const isAbsolutePath = path => path?.startsWith(`/`)
 
 export function withPrefix(path, prefix = __BASE_PATH__) {
   if (!isLocalLink(path)) {
@@ -25,6 +25,7 @@ export function withPrefix(path, prefix = __BASE_PATH__) {
 }
 
 const isLocalLink = path =>
+  path &&
   !path.startsWith(`http://`) &&
   !path.startsWith(`https://`) &&
   !path.startsWith(`//`)


### PR DESCRIPTION
Adds null check so that an empty `to` prop isn't fatal, but instead warns