### PR TITLE
fix(gatsby): add connection data dependency on concrete types when abstract type is queried

### DIFF
--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -502,6 +502,50 @@ describe(`NodeModel`, () => {
         expect(result.id).toBe(`file1`)
       })
     })
+
+    describe(`createPageDependency`, () => {
+      it(`it calls upstream createPageDependency for single nodes`, () => {
+        nodeModel.createPageDependency({
+          path: `/`,
+          nodeId: `person2`,
+        })
+        expect(createPageDependency).toHaveBeenCalledTimes(1)
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          nodeId: `person2`,
+        })
+      })
+
+      it(`it calls upstream createPageDependency for connections of concrete types`, () => {
+        nodeModel.createPageDependency({
+          path: `/`,
+          connection: `Author`,
+        })
+        expect(createPageDependency).toHaveBeenCalledTimes(1)
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          connection: `Author`,
+        })
+      })
+
+      it(`it calls upstream createPageDependency with concrete types for node interface connections`, () => {
+        nodeModel.createPageDependency({
+          path: `/`,
+          connection: `TeamMember`,
+        })
+
+        // TeamMember is interface with Author and Contributor types implementing it
+        expect(createPageDependency).toHaveBeenCalledTimes(2)
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          connection: `Author`,
+        })
+        expect(createPageDependency).toHaveBeenCalledWith({
+          path: `/`,
+          connection: `Contributor`,
+        })
+      })
+    })
   })
 
   describe(`prepare nodes caching`, () => {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -64,25 +64,7 @@ class LocalNodeModel {
     this.schema = schema
     this.schemaComposer = schemaComposer
     this.nodeStore = nodeStore
-    this.createPageDependency = createPageDependencyArgs => {
-      if (createPageDependencyArgs.connection) {
-        const nodeTypeNames = toNodeTypeNames(
-          this.schema,
-          createPageDependencyArgs.connection
-        )
-        if (nodeTypeNames) {
-          nodeTypeNames.forEach(typeName => {
-            createPageDependency({
-              ...createPageDependencyArgs,
-              connection: typeName,
-            })
-          })
-          return
-        }
-      }
-
-      createPageDependency(createPageDependencyArgs)
-    }
+    this.createPageDependencyActionCreator = createPageDependency
 
     this._rootNodeMap = new WeakMap()
     this._trackedRootNodes = new Set()
@@ -90,6 +72,26 @@ class LocalNodeModel {
     this._prepareNodesPromises = {}
     this._preparedNodesCache = new Map()
     this.replaceFiltersCache()
+  }
+
+  createPageDependency(createPageDependencyArgs) {
+    if (createPageDependencyArgs.connection) {
+      const nodeTypeNames = toNodeTypeNames(
+        this.schema,
+        createPageDependencyArgs.connection
+      )
+      if (nodeTypeNames) {
+        nodeTypeNames.forEach(typeName => {
+          this.createPageDependencyActionCreator({
+            ...createPageDependencyArgs,
+            connection: typeName,
+          })
+        })
+        return
+      }
+    }
+
+    this.createPageDependencyActionCreator(createPageDependencyArgs)
   }
 
   /**

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -64,7 +64,25 @@ class LocalNodeModel {
     this.schema = schema
     this.schemaComposer = schemaComposer
     this.nodeStore = nodeStore
-    this.createPageDependency = createPageDependency
+    this.createPageDependency = createPageDependencyArgs => {
+      if (createPageDependencyArgs.connection) {
+        const nodeTypeNames = toNodeTypeNames(
+          this.schema,
+          createPageDependencyArgs.connection
+        )
+        if (nodeTypeNames) {
+          nodeTypeNames.forEach(typeName => {
+            createPageDependency({
+              ...createPageDependencyArgs,
+              connection: typeName,
+            })
+          })
+          return
+        }
+      }
+
+      createPageDependency(createPageDependencyArgs)
+    }
 
     this._rootNodeMap = new WeakMap()
     this._trackedRootNodes = new Set()


### PR DESCRIPTION
## Description

We currently are adding abstract connection as data dependency when querying for `allX` if `X` is interface with `@nodeInterface`. Doing so doesn't allow us to mark query as dirty when nodes of type that implement `X` change, because those concrete node type names don't match interface type name. You can check https://github.com/gatsbyjs/gatsby/issues/24705#issuecomment-638041594 for bit more details.

To solve this problem I overwrite `createPageDependency` in `node-model` and in case of connections I use already existing `toNodeTypeNames` function to get list of concrete type names and add each of those as dependency (instead of adding abstract one as we do today)

This is not a problem for individual nodes with data tracking because we use node ids there and there is no mention of types there.

## Related Issues

Fixes #24705

## TO-DO

- [x] figure out where to add some tests for this to ensure we don't regress again