### PR TITLE
fix(gatsby): bind develop-proxy server to host specified by user

### DIFF
--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -360,7 +360,9 @@ async function startServer(program: IProgram): Promise<IServer> {
 
   const socket = websocketManager.init({ server, directory: program.directory })
 
-  const listener = server.listen(program.port, program.host)
+  // hardcoded `localhost`, because host should match `target` we set
+  // in http proxy in `develop-proxy`
+  const listener = server.listen(program.port, `localhost`)
 
   // Register watcher that rebuilds index.html every time html.js changes.
   const watchGlobs = [`src/html.js`, `plugins/**/gatsby-ssr.js`].map(path =>

--- a/packages/gatsby/src/utils/develop-proxy.ts
+++ b/packages/gatsby/src/utils/develop-proxy.ts
@@ -89,7 +89,7 @@ export const startDevelopProxy = (input: {
     proxy.ws(req, socket, head)
   })
 
-  server.listen(input.proxyPort)
+  server.listen(input.proxyPort, input.program.host)
 
   return {
     server,


### PR DESCRIPTION
## Description

Bind top level server to host provided by user (we fallback to `localhost` if not specified). 

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/24272#issuecomment-638330741
