### PR TITLE
feat(gatsby-source-shopify): Add handle field to blog + article queries

### DIFF
--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -35,6 +35,7 @@ export const ARTICLES_QUERY = `
           excerpt
           excerptHtml
           id
+          handle
           image {
             altText
             id
@@ -64,6 +65,7 @@ export const BLOGS_QUERY = `
         cursor
         node {
           id
+          handle
           title
           url
         }


### PR DESCRIPTION
## Description

Shopify Storefront API provides a handle field for Article + Blog queryable objects. gatsby-source-shopify package is missing the field for these queries.