### PR TITLE
fix(gatsby-image): Fix typings for fixed and fluid props

### DIFF
--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -62,7 +62,7 @@ interface GatsbyImageFixedProps extends GatsbyImageOptionalProps {
   fixed: FixedObject | FixedObject[]
 }
 
-type GatsbyImageProps = GatsbyImageFluidProps | GatsbyImageFixedProps
+export type GatsbyImageProps = GatsbyImageFluidProps | GatsbyImageFixedProps
 
 export default class GatsbyImage extends React.Component<
   GatsbyImageProps,

--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -24,11 +24,9 @@ export interface FluidObject {
   media?: string
 }
 
-interface GatsbyImageProps {
+interface GatsbyImageOptionalProps {
   resolutions?: FixedObject
   sizes?: FluidObject
-  fixed?: FixedObject | FixedObject[]
-  fluid?: FluidObject | FluidObject[]
   fadeIn?: boolean
   durationFadeIn?: number
   title?: string
@@ -49,6 +47,16 @@ interface GatsbyImageProps {
   loading?: `auto` | `lazy` | `eager`
   draggable?: boolean
 }
+  
+interface GatsbyImageFluidProps extends GatsbyImage {
+  fluid: FluidObject | FluidObject[]
+}
+
+interface GatsbyImageFixedProps extends GatsbyImage {
+  fixed: FixedObject | FixedObject[]
+}
+
+interface GatsbyImageProps = GatsbyImageFluidProps | GatsbyImageFixedProps
 
 export default class GatsbyImage extends React.Component<
   GatsbyImageProps,

--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -56,7 +56,7 @@ interface GatsbyImageFixedProps extends GatsbyImageOptionalProps {
   fixed: FixedObject | FixedObject[]
 }
 
-interface GatsbyImageProps = GatsbyImageFluidProps | GatsbyImageFixedProps
+type GatsbyImageProps = GatsbyImageFluidProps | GatsbyImageFixedProps
 
 export default class GatsbyImage extends React.Component<
   GatsbyImageProps,

--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -25,7 +25,13 @@ export interface FluidObject {
 }
 
 interface GatsbyImageOptionalProps {
+  /**
+   * @deprecated Use `fixed`
+   */
   resolutions?: FixedObject
+  /**
+   * @deprecated Use `fluid`
+   */
   sizes?: FluidObject
   fadeIn?: boolean
   durationFadeIn?: number

--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -48,11 +48,11 @@ interface GatsbyImageOptionalProps {
   draggable?: boolean
 }
   
-interface GatsbyImageFluidProps extends GatsbyImage {
+interface GatsbyImageFluidProps extends GatsbyImageOptionalProps {
   fluid: FluidObject | FluidObject[]
 }
 
-interface GatsbyImageFixedProps extends GatsbyImage {
+interface GatsbyImageFixedProps extends GatsbyImageOptionalProps {
   fixed: FixedObject | FixedObject[]
 }
 

--- a/packages/gatsby-image/withIEPolyfill/index.d.ts
+++ b/packages/gatsby-image/withIEPolyfill/index.d.ts
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import GatsbyImage, { GatsbyImageProps } from "../index"
 
-interface GatsbyImageWithIEPolyfillProps extends GatsbyImageProps {
+type GatsbyImageWithIEPolyfillProps = GatsbyImageProps & {
   objectFit?: `fill` | `contain` | `cover` | `none` | `scale-down`
   objectPosition?: string
 }


### PR DESCRIPTION
## Description

GatsbyImage should require one of "fluid" or "fixed". Currently they are both optional.

### Documentation

Self documenting types. Not changing file exports.

## Related Issues

