### PR TITLE
fix(gatsby): TypeScript typings import error

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -11,7 +11,6 @@ import {
   ComposeUnionTypeConfig,
 } from "graphql-compose"
 import { GraphQLOutputType } from "graphql"
-import { PluginRef } from "./src/bootstrap/load-plugins/types"
 
 export {
   default as Link,
@@ -1538,4 +1537,18 @@ export interface Page<TContext = Record<string, unknown>> {
   matchPath?: string
   component: string
   context: TContext
+}
+
+export interface IPluginRefObject {
+  resolve: string
+  options?: IPluginRefOptions
+  parentDir?: string
+}
+
+export type PluginRef = string | IPluginRefObject
+
+export interface IPluginRefOptions {
+  plugins?: PluginRef[]
+  path?: string
+  [option: string]: unknown
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/24645

Since we don't generate types yet it's probably best to just copy/paste this.
