### PR TITLE
Added information on  @reach/router's <Match> to docs

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -91,6 +91,32 @@ Gatsby's `<Link>` component comes with a `getProps` prop, which can be useful fo
 
 You can read more about it on [`@reach/router`'s documentation](https://reach.tech/router/api/Link).
 
+### Use `<Match>` for advanced link styling or conditional rendering
+
+You can wrap Gatsby's `<Link>` component in Reach Router's `<Match>`. `<Match>`'s props contain a boolean property `match` that tells you whetever the given path was matched or not. You have to provide `<Match>` with a path to match against, so you can wrap Gatsby's `<Link>` component in a custom component: 
+
+```jsx
+import React from "react"
+import { Link } from "gatsby"
+import { Match } from "@reach/router"
+
+const NavButton = ({ destination, text }) {
+  return (
+    <Match path={destination}>
+      {({ match }) => (
+        <Link
+          className={match ? "active-menu-item" : "inactive-menu-item"}
+          to={destination}
+        >
+          {text}
+        </Link>
+      )}
+    </Match>
+  )
+```
+`<Match>`
+You can read more about it on [`@reach/router`'s documentation](https://reach.tech/router/api/Match).
+
 ### Show active styles for partially matched and parent links
 
 By default the `activeStyle` and `activeClassName` props will only be set on a `<Link>` component if the current URL matches its `to` prop _exactly_. Sometimes, you may want to style a `<Link>` as active even if it partially matches the current URL. For example:


### PR DESCRIPTION
Added information on Match for conditionally rendering classes.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This will add documentation about @reach/router's `<Match>` to the docs. It took me a while to figure this out and thought it might be useful to others too. 

I was unsure how to go along with this, but tried to ask @gatsbyjs on Twitter for help, but did not hear back, so I am just opening it now. Feel free to close, expand or give feedback :)

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
