### PR TITLE
fix(docs): next.js github links (zeit to vercel)

### DIFF
--- a/docs/blog/2017-10-03-smartive-goes-gatsby/index.md
+++ b/docs/blog/2017-10-03-smartive-goes-gatsby/index.md
@@ -45,7 +45,7 @@ deep knowledge of React we started looking for an alternative based on that hot
 new thing.
 
 The first thing that caught our attention was
-[Next.js](https://github.com/zeit/next.js/), as seemingly everyone going for a
+[Next.js](https://github.com/vercel/next.js/), as seemingly everyone going for a
 server-side rendered React app was using it. After some days hacking on our app
 we encountered some issues, especially when it came to frontend rendering. We
 chose [prismic.io](https://prismic.io/) for our backend system which served all

--- a/docs/blog/2017-10-29-my-search-for-the-perfect-universal-javaScript-framework/index.md
+++ b/docs/blog/2017-10-29-my-search-for-the-perfect-universal-javaScript-framework/index.md
@@ -55,7 +55,7 @@ used to tweak my configuration all the time to achieve better performance, but
 Gatsby allows me to outsource the configuration and optimization and get a super
 fast website with zero work.
 
-I’ll also mention [next.js](https://github.com/zeit/next.js) which is quite
+I’ll also mention [next.js](https://github.com/vercel/next.js/) which is quite
 similar and supports both SSR for dynamic content and exporting to static pages.
 And don't forget [Netlify](https://www.netlify.com) who is doing an amazing job
 at building and hosting static websites.


### PR DESCRIPTION
## Description
**changes:**

Fix - links for [Next.js](https://github.com/vercel/next.js/) from `https://github.com/zeit/next.js/` to `https://github.com/vercel/next.js/`

## Related Issues
#24019 [Umbrella] Rename Zeit to Vercel