### PR TITLE
add calcPrefixDefault() function

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -9,7 +9,11 @@ export { parsePath }
 
 const isAbsolutePath = path => path?.startsWith(`/`)
 
-export function withPrefix(path, prefix = __BASE_PATH__) {
+function calcPrefixDefault() {
+  return typeof __BASE_PATH__ !== `undefined` ? __BASE_PATH__ : __PATH_PREFIX__
+}
+
+export function withPrefix(path, prefix = calcPrefixDefault()) {
   if (!isLocalLink(path)) {
     return path
   }


### PR DESCRIPTION
## Description

Instantiating a Link component in a Jest/ReactTestingLibrary unit test was generating a reference error:
```
    ReferenceError: __BASE_PATH__ is not defined
```

This PR uses the code existed in a previous version of this function to ensure that this error doesn't happen.

## Related Issues

Fixes Issue #24789
