### PR TITLE
fix(blog): recipes -  code block languages, brand names, local links

### DIFF
--- a/docs/blog/2020-05-21-gatsby-recipes/index.md
+++ b/docs/blog/2020-05-21-gatsby-recipes/index.md
@@ -15,7 +15,7 @@ Recipes can be used to automate npm installs, run npm scripts, add config option
 
 Gatsby ships with a number of default Recipes, but it’s also really easy to create your own! In this post we are going to look at writing a Recipe to install `gatsby-plugin-google-analytics` and add it to your project’s plugins. But first let’s take a look at why Recipes are so very useful and how I got started with doing some for tasks I found particularly taxing.
 
-(You can read more about Recipes [here](https://www.gatsbyjs.org/blog/2020-04-15-announcing-gatsby-recipes/), the experimental README is [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-recipes/README.md) and, to track the conversation, [here’s](https://github.com/gatsbyjs/gatsby/issues/22991) the Umbrella Issue on GitHub).
+(You can read more about [Recipes](/blog/2020-04-15-announcing-gatsby-recipes/), the experimental [README](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-recipes/README.md) and, to track the conversation, [the Umbrella Issue on GitHub](https://github.com/gatsbyjs/gatsby/issues/22991)).
 
 ## Recipes: What’s all the fuss about?
 
@@ -25,10 +25,10 @@ I’m a React UI Developer and I work on a lot of Greenfield Component Library b
 
 To get the two playing nicely together it requires a little under the hood knowledge about Gatsby and Storybook, and this knowledge supplies the foundation for writing a Recipe to handle it:
 
-- Gatsby is written in ES6 and isn’t transpiled to CommonJs until either the `gatsby develop` or `gatsby build` processes are run.
-- Storybook requires all module code to be transpiled to CommonJs
+- Gatsby is written in ES6 and isn’t transpiled to CommonJS until either the `gatsby develop` or `gatsby build` processes are run.
+- Storybook requires all module code to be transpiled to CommonJS.
 
-The problem here is when you run Storybook it has no knowledge of the Gatsby build processes and will only transpile “your” ES6 code to CommonJs. This is mostly fine apart from when you attempt to create a story for a Gatsby component, or a story that embeds or composes a Gatsby component. One such component is `<Link />`
+The problem here is when you run Storybook it has no knowledge of the Gatsby build processes and will only transpile “your” ES6 code to CommonJS. This is mostly fine apart from when you attempt to create a story for a Gatsby component, or a story that embeds or composes a Gatsby component. One such component is `<Link />`
 
 For example:
 
@@ -38,7 +38,7 @@ import { Link } from ‘gatsby’
 
 The reason this will cause Storybook to error is because the `<Link />` component comes from Gatsby / `node_modules` which, as mentioned above, is (as yet) un-transpiled ES6 code.
 
-Storybook has anticipated this issue, fortunately, and so there is a method whereby you can write your own Webpack config and pass it on to combine it with the default Storybook Webpack config. This then aids in the transpiling of any ES6 code located in `node_modules` to CommonJs.
+Storybook has anticipated this issue, fortunately, and so there is a method whereby you can write your own webpack config and pass it on to combine it with the default Storybook webpack config. This then aids in the transpiling of any ES6 code located in `node_modules` to CommonJS.
 
 If (like me) Webpack scares you a little bit, you’ll likely want to avoid writing any Webpack config and just get on with developing your UI. You could try not creating any `.stories` that include a `<Link />` component but this will only get you so far.
 
@@ -52,17 +52,17 @@ And if (like me) Babel also scares you a little bit, you might be having a think
 
 ## Recipes to the rescue
 
-It’s for precisely this reason I created two of my own Recipes to automate the setup of Storybook and its Webpack config for both JavaScript and TypeScript Gatsby projects.
+It’s for precisely this reason I created two of my own Recipes to automate the setup of Storybook and its webpack config for both JavaScript and TypeScript Gatsby projects.
 
 If you haven’t installed the latest Gatsby CLI run this 👇
 
-```sh
+```shell
 npm install -g gatsby-cli@latest
 ```
 
 Now you can now run 👇
 
-```sh
+```shell
 gatsby recipes
 ```
 
@@ -82,15 +82,15 @@ If you’re interested, here is where you can read more about my Recipes👇
 
 ## Fancy writing your own Recipe?
 
-The Recipe we’re going to write will install `gatsby-plugin-google-analytics` and add it to the plugins array in `gatsby-config.js`
+The Recipe we’re going to write will install `gatsby-plugin-google-analytics` and add it to the plugins array in `gatsby-config.js`.
 
 This recipe will utilize two of the Recipe components/providers. The first is `<NPMPackage />` the second is `<GatsbyPlugin />`
 
-You can read more about the components/providers [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-recipes/README.md#developing-recipes)
+You can read more about the components/providers [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-recipes/README.md#developing-recipes).
 
 To get things started you can clone this bare bones repo which has just the bits we need to create and test your very first Recipe:
 
-```sh
+```shell
 git clone https://github.com/PaulieScanlon/gatsby-recipe-google-analytics.git
 ```
 
@@ -98,12 +98,10 @@ Or clone from the repo here: [https://github.com/PaulieScanlon/gatsby-recipe-goo
 
 Once you have the repo cloned locally, create a new file at the root of the project and call it `gatsby-recipe-ga.mdx` and add the following MDX
 
-```javascript
-// gatsby-recipe-ga.mdx
-
+```mdx:title=gatsby-recipe-ga.mdx
 # Add `gatsby-plugin-google-analytics` to Gatsby Project
 
-More info about the plugin can be found here: 👉 [gatsby-plugin-google-analytics](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/)
+More info about the plugin can be found here: 👉 [gatsby-plugin-google-analytics](/packages/gatsby-plugin-google-analytics/)
 
 ---
 
@@ -140,15 +138,14 @@ All done: 🍻
 
 Head over to `gatsby-config.js` to complete the setup by amending or removing the plugin options. You will need a Google Analytics `trackingId`
 
-You can read more about how to use the plugin here: 👉 [How to use](https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#how-to-use)
-
+You can read more about how to use the plugin here: 👉 [How to use](/packages/gatsby-plugin-google-analytics/#how-to-use)
 ```
 
 ## Running your first Recipe
 
 Now that you’ve written your first Recipe, it’s time to run it! 👇
 
-```sh
+```shell
 gatsby recipes ./gatsby-recipe-ga.mdx
 ```
 
@@ -164,7 +161,7 @@ Imagine if Recipes could be used over and over again to automate really monotono
 
 One such task might be creating new components. On any typical project this would be my component setup preference.
 
-```javascript
+```text
 ├─ ComponentName
     └─ index.ts
     └─ ComponentName.tsx
@@ -174,11 +171,11 @@ One such task might be creating new components. On any typical project this woul
 
 Of course within each of those files are a number of imports, exports, interfaces, function declarations and tests. Doing this each and every time you create a new component is tedious and can sometimes be prone to human error.
 
-Also, and especially on larger teams, these preferences for how files should be named -- and/or how the imports, exports and declarations should be written is rarely documented in a “style guide” because that alone is also a rather tiresome task! but in my experience it's something that's rather crucial to have "locked down" at the start of a project.
+Also, and especially on larger teams, these preferences for how files should be named -- and/or how the imports, exports and declarations should be written is rarely documented in a “style guide” because that alone is also a rather tiresome task! But in my experience it's something that's rather crucial to have "locked down" at the start of a project.
 
 In early 2018 I attempted to solve this problem by creating a node module aimed at automating the React “component” creation process, [node-tiny-template](https://www.npmjs.com/package/node-tiny-template):
 
-![landing page for the Node Tiny Template](node-tiny-template.jpg "Node Tiny Template")
+![landing page for the Node Tiny Template](./node-tiny-template.jpg "Node Tiny Template")
 
 The CLI args allow you to pass in the “component name” which can then be used for the function declaration, the imports, the exports and test names, etc.
 

--- a/docs/blog/2020-05-21-gatsby-recipes/index.md
+++ b/docs/blog/2020-05-21-gatsby-recipes/index.md
@@ -86,7 +86,7 @@ The Recipe we’re going to write will install `gatsby-plugin-google-analytics` 
 
 This recipe will utilize two of the Recipe components/providers. The first is `<NPMPackage />` the second is `<GatsbyPlugin />`
 
-You can read more about the components/providers [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-recipes/README.md#developing-recipes).
+You can read more about the components/providers in the [Gatsby Recipes README](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-recipes/README.md#developing-recipes).
 
 To get things started you can clone this bare bones repo which has just the bits we need to create and test your very first Recipe:
 


### PR DESCRIPTION
## Description

changes:

- brand name `CommonJs` -> `CommonJS`
- brand name `Webpack` -> `webpack`
- remove domain from local links
- create talking links, avoid `here` as link text for a11y
- fix code language `sh` -> `shell`
- fix code language `javascript` -> `mdx`
- place file name in `title=...`
- fix code language `text` for directories
- relative link for images



## Related Issues

- #24287 `Blog - Gatsby Recipes`
- #19267 `Add link checker for Gatsby Docs`
