### PR TITLE
fix(docs): surge - remove local domain

### DIFF
--- a/docs/docs/deploying-to-surge.md
+++ b/docs/docs/deploying-to-surge.md
@@ -44,7 +44,7 @@ You're done! Your terminal will output the address of the domain where your site
 
 ## Step 4: Bonus - Remembering a domain
 
-To ensure future deploys are sent to the same location, you can store the domain name in a [`CNAME`](https://surge.sh/help/remembering-a-domain) file that is added your project. First, create a [`static` directory](https://www.gatsbyjs.org/docs/static-folder/) at the root of your Gatsby project if it doesn't already exist. Then put a file named `CNAME` (no file extension) in the `static` directory.
+To ensure future deploys are sent to the same location, you can store the domain name in a [`CNAME`](https://surge.sh/help/remembering-a-domain) file that is added your project. First, create a [`static` directory](/docs/static-folder/) at the root of your Gatsby project if it doesn't already exist. Then put a file named `CNAME` (no file extension) in the `static` directory.
 
 Assuming your site was deployed to `https://my-cool-domain.surge.sh`, the following command will add the file for you:
 


### PR DESCRIPTION
## Description

changes:

- remove domain on local links


## Related Issues

- #24278 `Update surge CNAME instructions` 
- #19267 `Add link checker for Gatsby Docs`