### PR TITLE
fix(gatsby): Fix issue where inline static query in page gets added to page data

### DIFF
--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -109,12 +109,15 @@ const updateStateAndRunQueries = (isFirstRun, { parentSpan } = {}) => {
 
     // Run action for each component
     const { components } = snapshot
-    components.forEach(c =>
-      boundActionCreators.queryExtracted({
-        componentPath: c.componentPath,
-        query: queries.get(c.componentPath)?.text || ``,
-      })
-    )
+    components.forEach(c => {
+      const query = queries.get(c.componentPath)
+      if (!query?.isStaticQuery) {
+        boundActionCreators.queryExtracted({
+          componentPath: c.componentPath,
+          query: query?.text || ``,
+        })
+      }
+    })
 
     let queriesWillNotRun = false
     queries.forEach((query, component) => {

--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -110,9 +110,7 @@ const updateStateAndRunQueries = (isFirstRun, { parentSpan } = {}) => {
     // Run action for each component
     const { components } = snapshot
     components.forEach(c => {
-      const query = queries.get(c.componentPath)
-
-      const { isStaticQuery = false, text = `` } = query
+      const { isStaticQuery = false, text = `` } = queries.get(c.componentPath)
 
       boundActionCreators.queryExtracted({
         componentPath: c.componentPath,

--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -111,12 +111,13 @@ const updateStateAndRunQueries = (isFirstRun, { parentSpan } = {}) => {
     const { components } = snapshot
     components.forEach(c => {
       const query = queries.get(c.componentPath)
-      if (!query?.isStaticQuery) {
-        boundActionCreators.queryExtracted({
-          componentPath: c.componentPath,
-          query: query?.text || ``,
-        })
-      }
+
+      const { isStaticQuery = false, text = `` } = query
+
+      boundActionCreators.queryExtracted({
+        componentPath: c.componentPath,
+        query: isStaticQuery ? `` : text,
+      })
     })
 
     let queriesWillNotRun = false

--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -110,7 +110,8 @@ const updateStateAndRunQueries = (isFirstRun, { parentSpan } = {}) => {
     // Run action for each component
     const { components } = snapshot
     components.forEach(c => {
-      const { isStaticQuery = false, text = `` } = queries.get(c.componentPath)
+      const { isStaticQuery = false, text = `` } =
+        queries.get(c.componentPath) || {}
 
       boundActionCreators.queryExtracted({
         componentPath: c.componentPath,


### PR DESCRIPTION
Currently, if a page contains an inline static query (and not a page query), the result of the static query incorrectly gets included in the page's `page-data.json` file. 

This fixes that. 