### PR TITLE
fix(babel-plugin-remove-graphql-queries): Strip ignored characters from query text for better caching and deduping

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -1,37 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Allow alternative import of useStaticQuery 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 import * as Gatsby from 'gatsby';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = \\"426988268\\";
   const siteTitle = staticQueryData.data;
   return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"
 `;
 
 exports[`Doesn't add data import for non static queries 1`] = `
-"import staticQueryData from \\"public/static/d/4279313589.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from \\"gatsby\\";
 
 const Test = () => /*#__PURE__*/React.createElement(StaticQuery, {
-  query: \\"4279313589\\",
+  query: \\"426988268\\",
   render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),
   data: staticQueryData
 });
 
 export default Test;
-export const fragment = \\"2962815581\\";"
+export const fragment = \\"4176178832\\";"
 `;
 
 exports[`Handles closing StaticQuery tag 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
 export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
-  query: \\"2626356014\\",
+  query: \\"426988268\\",
   data: staticQueryData
 }, data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title)));"
 `;
@@ -50,7 +50,7 @@ export const query = graphql\`
 exports[`Only runs transforms if useStaticQuery is imported from gatsby 1`] = `
 "import * as React from 'react';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = \\"426988268\\";
   const siteTitle = useStaticQuery(query);
   return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"
@@ -58,12 +58,12 @@ export default (() => {
 
 exports[`Removes all gatsby queries 1`] = `
 "export default (() => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title));
-export const siteMetaQuery = \\"2673797374\\";
-export const query = \\"2589775908\\";"
+export const siteMetaQuery = \\"504726680\\";
+export const query = \\"3211238532\\";"
 `;
 
 exports[`Transformation does not break custom hooks 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import React from \\"react\\";
 
 const useSiteMetadata = () => {
@@ -78,17 +78,17 @@ export default (() => {
 `;
 
 exports[`Transforms exported queries in useStaticQuery 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 export default (() => {
   const data = staticQueryData.data;
   return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, data.site.siteMetadata.title), /*#__PURE__*/React.createElement(\\"p\\", null, data.site.siteMetadata.description));
 });
-export const query = \\"2626356014\\";"
+export const query = \\"426988268\\";"
 `;
 
 exports[`Transforms only the call expression in useStaticQuery 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import React from \\"react\\";
 
 const useSiteMetadata = () => {
@@ -102,10 +102,10 @@ export default (() => {
 `;
 
 exports[`Transforms queries and preserves destructuring in useStaticQuery 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = \\"426988268\\";
   const {
     site
   } = staticQueryData.data;
@@ -114,10 +114,10 @@ export default (() => {
 `;
 
 exports[`Transforms queries and preserves variable type in useStaticQuery 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = \\"426988268\\";
   let {
     site
   } = staticQueryData.data;
@@ -126,10 +126,10 @@ export default (() => {
 `;
 
 exports[`Transforms queries defined in own variable in <StaticQuery> 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
-const query = \\"2626356014\\";
+const query = \\"426988268\\";
 export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
   query: query,
   render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),
@@ -138,30 +138,30 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
 `;
 
 exports[`Transforms queries defined in own variable in useStaticQuery 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 export default (() => {
-  const query = \\"2626356014\\";
+  const query = \\"426988268\\";
   const siteTitle = staticQueryData.data;
   return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"
 `;
 
 exports[`Transforms queries in <StaticQuery> 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
 export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
-  query: \\"2626356014\\",
+  query: \\"426988268\\",
   render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),
   data: staticQueryData
 }));"
 `;
 
-exports[`Transforms queries in page components 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`Transforms queries in page components 1`] = `"export const query = \\"426988268\\";"`;
 
 exports[`Transforms queries in useStaticQuery 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 export default (() => {
   const siteTitle = staticQueryData.data;
@@ -169,7 +169,7 @@ export default (() => {
 });"
 `;
 
-exports[`allows the global tag 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`allows the global tag 1`] = `"export const query = \\"426988268\\";"`;
 
 exports[`distinguishes between the right tags 1`] = `
 "const foo = styled('div')\`
@@ -195,22 +195,22 @@ const pulse = keyframes\`
       animation-timing-function: ease-out;
     }
   \`;
-export const query = \\"3687030656\\";"
+export const query = \\"426988268\\";"
 `;
 
-exports[`handles import aliasing 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`handles import aliasing 1`] = `"export const query = \\"426988268\\";"`;
 
-exports[`handles require 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`handles require 1`] = `"export const query = \\"426988268\\";"`;
 
-exports[`handles require alias 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`handles require alias 1`] = `"export const query = \\"426988268\\";"`;
 
-exports[`handles require namespace 1`] = `"export const query = \\"3687030656\\";"`;
+exports[`handles require namespace 1`] = `"export const query = \\"426988268\\";"`;
 
 exports[`transforms exported variable queries in <StaticQuery> 1`] = `
-"import staticQueryData from \\"public/static/d/2626356014.json\\";
+"import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
-export const query = \\"2626356014\\";
+export const query = \\"426988268\\";
 export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
   query: query,
   render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),

--- a/packages/babel-plugin-remove-graphql-queries/src/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.js
@@ -155,7 +155,9 @@ function getGraphQLTag(path) {
   }
 
   const text = quasis[0].value.raw
-  const hash = murmurhash(text, `abc`)
+  const normalizedText = graphql.stripIgnoredCharacters(text)
+
+  const hash = murmurhash(normalizedText, `abc`)
 
   try {
     const ast = graphql.parse(text)
@@ -163,7 +165,7 @@ function getGraphQLTag(path) {
     if (ast.definitions.length === 0) {
       throw new EmptyGraphQLTagError(quasis[0].loc)
     }
-    return { ast, text, hash, isGlobal }
+    return { ast, text: normalizedText, hash, isGlobal }
   } catch (err) {
     throw new GraphQLSyntaxError(text, err, quasis[0].loc)
   }

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -59,7 +59,7 @@ Array [
       },
     },
     "filePath": "page-query.js",
-    "hash": 3118863590,
+    "hash": 3530286846,
     "isHook": false,
     "isStaticQuery": false,
     "templateLoc": SourceLocation {
@@ -72,11 +72,7 @@ Array [
         "line": 2,
       },
     },
-    "text": "
-query PageQueryName {
-  foo
-}
-",
+    "text": "query PageQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -135,7 +131,7 @@ query PageQueryName {
       },
     },
     "filePath": "page-query-indirect.js",
-    "hash": 1041797972,
+    "hash": 1314068098,
     "isHook": false,
     "isStaticQuery": false,
     "templateLoc": SourceLocation {
@@ -148,11 +144,7 @@ query PageQueryName {
         "line": 2,
       },
     },
-    "text": "
-query PageQueryIndirect {
-  foo
-}
-",
+    "text": "query PageQueryIndirect{foo}",
   },
   Object {
     "doc": Object {
@@ -211,7 +203,7 @@ query PageQueryIndirect {
       },
     },
     "filePath": "page-query-indirect-2.js",
-    "hash": 934529778,
+    "hash": 1258001265,
     "isHook": false,
     "isStaticQuery": false,
     "templateLoc": SourceLocation {
@@ -224,11 +216,7 @@ query PageQueryIndirect {
         "line": 2,
       },
     },
-    "text": "
-query PageQueryIndirect2 {
-  foo
-}
-",
+    "text": "query PageQueryIndirect2{foo}",
   },
   Object {
     "doc": Object {
@@ -242,7 +230,7 @@ query PageQueryIndirect2 {
           },
           "name": Object {
             "kind": "Name",
-            "value": "pageQueryNoNameJs2538359280",
+            "value": "pageQueryNoNameJs1125018085",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -283,7 +271,7 @@ query PageQueryIndirect2 {
       },
     },
     "filePath": "page-query-no-name.js",
-    "hash": 2538359280,
+    "hash": 1125018085,
     "isHook": false,
     "isStaticQuery": false,
     "templateLoc": SourceLocation {
@@ -296,11 +284,7 @@ query PageQueryIndirect2 {
         "line": 2,
       },
     },
-    "text": "
-query {
-  foo
-}
-",
+    "text": "query{foo}",
   },
   Object {
     "doc": Object {
@@ -359,7 +343,7 @@ query {
       },
     },
     "filePath": "static-query.js",
-    "hash": 407706182,
+    "hash": 2687344169,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -372,7 +356,7 @@ query {
         "line": 4,
       },
     },
-    "text": "query StaticQueryName { foo }",
+    "text": "query StaticQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -386,7 +370,7 @@ query {
           },
           "name": Object {
             "kind": "Name",
-            "value": "staticQueryNoNameJs2605331189",
+            "value": "staticQueryNoNameJs3221935794",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -427,7 +411,7 @@ query {
       },
     },
     "filePath": "static-query-no-name.js",
-    "hash": 2605331189,
+    "hash": 3221935794,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -440,7 +424,7 @@ query {
         "line": 4,
       },
     },
-    "text": "{ foo }",
+    "text": "{foo}",
   },
   Object {
     "doc": Object {
@@ -499,7 +483,7 @@ query {
       },
     },
     "filePath": "static-query-named-export.js",
-    "hash": 407706182,
+    "hash": 2687344169,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -512,7 +496,7 @@ query {
         "line": 4,
       },
     },
-    "text": "query StaticQueryName { foo }",
+    "text": "query StaticQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -526,7 +510,7 @@ query {
           },
           "name": Object {
             "kind": "Name",
-            "value": "staticQueryClosingTagJs2605331189",
+            "value": "staticQueryClosingTagJs3221935794",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -567,7 +551,7 @@ query {
       },
     },
     "filePath": "static-query-closing-tag.js",
-    "hash": 2605331189,
+    "hash": 3221935794,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -580,7 +564,7 @@ query {
         "line": 4,
       },
     },
-    "text": "{ foo }",
+    "text": "{foo}",
   },
   Object {
     "doc": Object {
@@ -639,7 +623,7 @@ query {
       },
     },
     "filePath": "page-query-and-static-query-named-export.js",
-    "hash": 407706182,
+    "hash": 2687344169,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -652,7 +636,7 @@ query {
         "line": 4,
       },
     },
-    "text": "query StaticQueryName { foo }",
+    "text": "query StaticQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -711,7 +695,7 @@ query {
       },
     },
     "filePath": "page-query-and-static-query-named-export.js",
-    "hash": 155828431,
+    "hash": 3530286846,
     "isHook": false,
     "isStaticQuery": false,
     "templateLoc": SourceLocation {
@@ -724,7 +708,7 @@ query {
         "line": 8,
       },
     },
-    "text": "query PageQueryName { foo }",
+    "text": "query PageQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -855,7 +839,7 @@ query {
       },
     },
     "filePath": "multiple-fragment-exports.js",
-    "hash": 405302220,
+    "hash": 1171727280,
     "isHook": false,
     "isStaticQuery": false,
     "templateLoc": SourceLocation {
@@ -868,14 +852,7 @@ query {
         "line": 2,
       },
     },
-    "text": "
-  fragment Fragment1 on RootQueryField {
-    foo
-  }
-  fragment Fragment2 on RootQueryField {
-    bar
-  }
-",
+    "text": "fragment Fragment1 on RootQueryField{foo}fragment Fragment2 on RootQueryField{bar}",
   },
   Object {
     "doc": Object {
@@ -947,7 +924,7 @@ query {
       },
     },
     "filePath": "multiple-fragment-exports.js",
-    "hash": 1478112168,
+    "hash": 3923246124,
     "isHook": false,
     "isStaticQuery": false,
     "templateLoc": SourceLocation {
@@ -960,11 +937,7 @@ query {
         "line": 10,
       },
     },
-    "text": "
-  fragment Fragment3 on RootQueryField {
-    baz
-  }
-",
+    "text": "fragment Fragment3 on RootQueryField{baz}",
   },
   Object {
     "doc": Object {
@@ -978,7 +951,7 @@ query {
           },
           "name": Object {
             "kind": "Name",
-            "value": "fragmentShorthandJs1097489062",
+            "value": "fragmentShorthandJs3159585216",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -1073,7 +1046,7 @@ query {
       },
     },
     "filePath": "fragment-shorthand.js",
-    "hash": 1097489062,
+    "hash": 3159585216,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1086,15 +1059,7 @@ query {
         "line": 4,
       },
     },
-    "text": "
-  query {
-    site {
-      siteMetadata {
-        title
-      }
-    }
-  }
-",
+    "text": "query{site{siteMetadata{title}}}",
   },
   Object {
     "doc": Object {
@@ -1108,7 +1073,7 @@ query {
           },
           "name": Object {
             "kind": "Name",
-            "value": "queryInSeparateVariableJs3748317405",
+            "value": "queryInSeparateVariableJs1528532020",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -1230,7 +1195,7 @@ query {
       },
     },
     "filePath": "query-in-separate-variable.js",
-    "hash": 3748317405,
+    "hash": 1528532020,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1243,7 +1208,7 @@ query {
         "line": 4,
       },
     },
-    "text": "{ allMarkdownRemark { blah { node { cheese }}}}",
+    "text": "{allMarkdownRemark{blah{node{cheese}}}}",
   },
   Object {
     "doc": Object {
@@ -1257,7 +1222,7 @@ query {
           },
           "name": Object {
             "kind": "Name",
-            "value": "queryInSeparateVariable2Js1352988887",
+            "value": "queryInSeparateVariable2Js278713111",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -1379,7 +1344,7 @@ query {
       },
     },
     "filePath": "query-in-separate-variable-2.js",
-    "hash": 1352988887,
+    "hash": 278713111,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1392,7 +1357,7 @@ query {
         "line": 5,
       },
     },
-    "text": "{ allStrangeQueryName { blah { node { cheese }}}}",
+    "text": "{allStrangeQueryName{blah{node{cheese}}}}",
   },
   Object {
     "doc": Object {
@@ -1451,7 +1416,7 @@ query {
       },
     },
     "filePath": "static-query-hooks.js",
-    "hash": 407706182,
+    "hash": 2687344169,
     "isHook": true,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1464,7 +1429,7 @@ query {
         "line": 3,
       },
     },
-    "text": "query StaticQueryName { foo }",
+    "text": "query StaticQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -1523,7 +1488,7 @@ query {
       },
     },
     "filePath": "static-query-hooks-with-other-export.js",
-    "hash": 407706182,
+    "hash": 2687344169,
     "isHook": true,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1536,7 +1501,7 @@ query {
         "line": 4,
       },
     },
-    "text": "query StaticQueryName { foo }",
+    "text": "query StaticQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -1595,7 +1560,7 @@ query {
       },
     },
     "filePath": "static-query-hooks-alternative-import.js",
-    "hash": 407706182,
+    "hash": 2687344169,
     "isHook": true,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1608,7 +1573,7 @@ query {
         "line": 3,
       },
     },
-    "text": "query StaticQueryName { foo }",
+    "text": "query StaticQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -1667,7 +1632,7 @@ query {
       },
     },
     "filePath": "static-query-hooks-with-type-parameter.ts",
-    "hash": 407706182,
+    "hash": 2687344169,
     "isHook": true,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1680,7 +1645,7 @@ query {
         "line": 3,
       },
     },
-    "text": "query StaticQueryName { foo }",
+    "text": "query StaticQueryName{foo}",
   },
   Object {
     "doc": Object {
@@ -1694,7 +1659,7 @@ query {
           },
           "name": Object {
             "kind": "Name",
-            "value": "staticQueryHooksInSeparateVariableJs3748317405",
+            "value": "staticQueryHooksInSeparateVariableJs1528532020",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -1816,7 +1781,7 @@ query {
       },
     },
     "filePath": "static-query-hooks-in-separate-variable.js",
-    "hash": 3748317405,
+    "hash": 1528532020,
     "isHook": true,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1829,7 +1794,7 @@ query {
         "line": 4,
       },
     },
-    "text": "{ allMarkdownRemark { blah { node { cheese }}}}",
+    "text": "{allMarkdownRemark{blah{node{cheese}}}}",
   },
   Object {
     "doc": Object {
@@ -1843,7 +1808,7 @@ query {
           },
           "name": Object {
             "kind": "Name",
-            "value": "zhADollarpercentandJs1646962495",
+            "value": "zhADollarpercentandJs1125018085",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -1884,7 +1849,7 @@ query {
       },
     },
     "filePath": "ж-ä-!@#$%^&*()_-=+:;'\\"?,~\`.js",
-    "hash": 1646962495,
+    "hash": 1125018085,
     "isHook": true,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1897,7 +1862,7 @@ query {
         "line": 3,
       },
     },
-    "text": "query { foo }",
+    "text": "query{foo}",
   },
   Object {
     "doc": Object {
@@ -1911,7 +1876,7 @@ query {
           },
           "name": Object {
             "kind": "Name",
-            "value": "staticZhADollarpercentandJs1646962495",
+            "value": "staticZhADollarpercentandJs1125018085",
           },
           "operation": "query",
           "selectionSet": Object {
@@ -1952,7 +1917,7 @@ query {
       },
     },
     "filePath": "static-ж-ä-!@#$%^&*()_-=+:;'\\"?,~\`.js",
-    "hash": 1646962495,
+    "hash": 1125018085,
     "isHook": false,
     "isStaticQuery": true,
     "templateLoc": SourceLocation {
@@ -1965,7 +1930,7 @@ query {
         "line": 4,
       },
     },
-    "text": "query { foo }",
+    "text": "query{foo}",
   },
 ]
 `;

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -252,14 +252,14 @@ export default () => {
     const nameNode = ast[0].doc.definitions[0].name
     expect(nameNode).toEqual({
       kind: `Name`,
-      value: `zhADollarpercentandJs1646962495`,
+      value: `zhADollarpercentandJs1125018085`,
     })
 
     const ast2 = await parser.parseFile(`static-${specialChars}.js`, jest.fn())
     const nameNode2 = ast2[0].doc.definitions[0].name
     expect(nameNode2).toEqual({
       kind: `Name`,
-      value: `staticZhADollarpercentandJs1646962495`,
+      value: `staticZhADollarpercentandJs1125018085`,
     })
   })
 })


### PR DESCRIPTION
This strips spaces and comments from query text before hashing them so that 

```
{
  site {
    siteMetadata {
      github
    }
  }
}
```

is the same as 

```
            {
              site {
                siteMetadata {
                  github
                }
              }
            }

```

This will lead to better caching and query reuse 🙂 