### PR TITLE
fix(gatsby-image): React hydration buster on `image`

### DIFF
--- a/e2e-tests/gatsby-image/cypress/integration/fluid.js
+++ b/e2e-tests/gatsby-image/cypress/integration/fluid.js
@@ -9,7 +9,7 @@ describe(`fluid`, () => {
     cy.getTestElement(fluidTestId)
       .find(`.gatsby-image-wrapper > div`)
       .should(`have.attr`, `style`)
-      .and(`match`, /width:100%;padding-bottom/)
+      .and(`match`, /width: 100%; padding-bottom/)
   })
 
   it(`renders sizes`, () => {

--- a/e2e-tests/gatsby-image/cypress/integration/image.js
+++ b/e2e-tests/gatsby-image/cypress/integration/image.js
@@ -14,11 +14,11 @@ describe(`Production gatsby-image`, () => {
           .should(`eq`, 1)
       })
 
-      it(`contains position relative`, () => {
+      it(`has position relative`, () => {
         cy.getTestElement(fluidTestId)
           .find(`.gatsby-image-wrapper`)
           .should(`have.attr`, `style`)
-          .and(`contains`, `position:relative`)
+          .and(`match`, /position: relative/)
       })
     })
   })

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "jest-cli": "^24.9.0",
     "jest-environment-jsdom-fourteen": "^0.1.0",
     "jest-junit": "^10.0.0",
+    "jest-matchmedia-mock": "^1.0.1",
     "jest-serializer-path": "^0.1.15",
     "jest-silent-reporter": "^0.2.1",
     "joi": "^14.3.1",

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`<Image /> should have a transition-delay of 1sec 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper  _UM6yrA"
+    class="fixedImage  gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
@@ -52,7 +52,7 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
 exports[`<Image /> should render fixed size images 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper  _UM6yrA"
+    class="fixedImage  gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
@@ -101,7 +101,7 @@ exports[`<Image /> should render fixed size images 1`] = `
 exports[`<Image /> should render fluid images 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper _UM6yrA"
+    class="fixedImage  gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline;"
   >
     <div
@@ -155,13 +155,9 @@ exports[`<Image /> should render fluid images 1`] = `
 exports[`<Image /> should render multiple fixed image variants 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper  _3LcOMA"
+    class="fixedImage  gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
-    <style>
-      ._3LcOMA { width: 100px !important; height: 100px !important; }
-@media only screen and (min-width: 768px) { ._3LcOMA { width: 300px !important; height: 300px !important; } }
-    </style>
     <div
       aria-hidden="true"
       style="background-color: lightgray; width: 100px; opacity: 1; height: 100px; transition-delay: 500ms;"
@@ -225,13 +221,9 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
 exports[`<Image /> should render multiple fluid image variants 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper _3LcOMA"
+    class="fixedImage  gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline;"
   >
-    <style>
-      ._3LcOMA { padding-bottom: 50% !important; }
-@media only screen and (min-width: 768px) { ._3LcOMA { padding-bottom: 33.333333333333336% !important; } }
-    </style>
     <div
       aria-hidden="true"
       style="width: 100%; padding-bottom: 50%;"

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`<Image /> should have a transition-delay of 1sec 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper  _UM6yrA"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
@@ -52,7 +52,7 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
 exports[`<Image /> should render fixed size images 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper  _UM6yrA"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
@@ -101,7 +101,7 @@ exports[`<Image /> should render fixed size images 1`] = `
 exports[`<Image /> should render fluid images 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper _UM6yrA"
     style="position: relative; overflow: hidden; display: inline;"
   >
     <div
@@ -155,9 +155,13 @@ exports[`<Image /> should render fluid images 1`] = `
 exports[`<Image /> should render multiple fixed image variants 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper  _3LcOMA"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
+    <style>
+      ._3LcOMA { width: 100px !important; height: 100px !important; }
+@media only screen and (min-width: 768px) { ._3LcOMA { width: 300px !important; height: 300px !important; } }
+    </style>
     <div
       aria-hidden="true"
       style="background-color: lightgray; width: 100px; opacity: 1; height: 100px; transition-delay: 500ms;"
@@ -221,9 +225,13 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
 exports[`<Image /> should render multiple fluid image variants 1`] = `
 <div>
   <div
-    class="fixedImage gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper _3LcOMA"
     style="position: relative; overflow: hidden; display: inline;"
   >
+    <style>
+      ._3LcOMA { padding-bottom: 50% !important; }
+@media only screen and (min-width: 768px) { ._3LcOMA { padding-bottom: 33.333333333333336% !important; } }
+    </style>
     <div
       aria-hidden="true"
       style="width: 100%; padding-bottom: 50%;"

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -3,7 +3,7 @@
 exports[`<Image /> should have a transition-delay of 1sec 1`] = `
 <div>
   <div
-    class="fixedImage  gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
@@ -52,7 +52,7 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
 exports[`<Image /> should render fixed size images 1`] = `
 <div>
   <div
-    class="fixedImage  gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
@@ -101,7 +101,7 @@ exports[`<Image /> should render fixed size images 1`] = `
 exports[`<Image /> should render fluid images 1`] = `
 <div>
   <div
-    class="fixedImage  gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline;"
   >
     <div
@@ -155,7 +155,7 @@ exports[`<Image /> should render fluid images 1`] = `
 exports[`<Image /> should render multiple fixed image variants 1`] = `
 <div>
   <div
-    class="fixedImage  gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline; width: 100px; height: 100px;"
   >
     <div
@@ -221,7 +221,7 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
 exports[`<Image /> should render multiple fluid image variants 1`] = `
 <div>
   <div
-    class="fixedImage  gatsby-image-wrapper"
+    class="fixedImage gatsby-image-wrapper"
     style="position: relative; overflow: hidden; display: inline;"
   >
     <div

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -1,3 +1,4 @@
+import MatchMediaMock from "jest-matchmedia-mock"
 import React from "react"
 import { render, cleanup, fireEvent } from "@testing-library/react"
 import Image from "../"
@@ -117,22 +118,13 @@ const setupImages = (
   return container
 }
 
+let matchMedia
 describe(`<Image />`, () => {
-  const OLD_MATCH_MEDIA = window.matchMedia
-  beforeEach(() => {
-    // None of the media conditions above match.
-    window.matchMedia = jest.fn(media =>
-      media === `only screen and (min-width: 1024px)`
-        ? {
-            matches: true,
-          }
-        : {
-            matches: false,
-          }
-    )
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock()
   })
   afterEach(() => {
-    window.matchMedia = OLD_MATCH_MEDIA
+    matchMedia.clear()
   })
 
   it(`should render fixed size images`, () => {
@@ -221,6 +213,9 @@ describe(`<Image />`, () => {
   })
 
   it(`should select the correct mocked image of fluid variants provided.`, () => {
+    const mediaQuery = `only screen and (min-width: 1024px)`
+    matchMedia.useMediaQuery(mediaQuery)
+
     const tripleFluidImageShapeMock = fluidImagesShapeMock.concat({
       aspectRatio: 5,
       src: `test_image_4.jpg`,
@@ -251,6 +246,9 @@ describe(`<Image />`, () => {
   })
 
   it(`should select the correct mocked image of fixed variants provided.`, () => {
+    const mediaQuery = `only screen and (min-width: 1024px)`
+    matchMedia.useMediaQuery(mediaQuery)
+
     const tripleFixedImageShapeMock = fixedImagesShapeMock.concat({
       width: 1024,
       height: 768,

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -352,6 +352,7 @@ class Image extends React.Component {
       imgLoaded: false,
       imgCached: false,
       fadeIn: !this.seenBefore && props.fadeIn,
+      isHydrated: false,
     }
 
     this.imageRef = React.createRef()
@@ -361,6 +362,10 @@ class Image extends React.Component {
   }
 
   componentDidMount() {
+    this.setState({
+      isHydrated: isBrowser,
+    })
+
     if (this.state.isVisible && typeof this.props.onStartLoad === `function`) {
       this.props.onStartLoad({ wasCached: inImageCache(this.props) })
     }
@@ -474,6 +479,9 @@ class Image extends React.Component {
       const imageVariants = fluid
       const image = getCurrentSrcData(fluid)
 
+      let aspectRatio = image.aspectRatio
+      if (isBrowser && !this.state.isHydrated) { aspectRatio+=0.0001 }
+
       return (
         <Tag
           className={`${className ? className : ``} gatsby-image-wrapper`}
@@ -492,7 +500,7 @@ class Image extends React.Component {
             aria-hidden
             style={{
               width: `100%`,
-              paddingBottom: `${100 / image.aspectRatio}%`,
+              paddingBottom: `${100 / aspectRatio}%`,
             }}
           />
 

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -475,222 +475,221 @@ class Image extends React.Component {
       itemProp,
     }
 
-    // Use a dummy empty object for initial state of `image`.
-    // Fixes React state hydration bug: https://github.com/gatsbyjs/gatsby/pull/24811
-    let image = getCurrentSrcData(fluid || fixed)
-    if (isBrowser && !this.state.isHydrated) {
-      image = {}
-    }
+    const image = getCurrentSrcData(fluid || fixed)
+    
+    // Avoid rendering anything until mounted(hydration complete)
+    // Avoids invalid initial state from hydration phase: https://github.com/gatsbyjs/gatsby/pull/24811
+    if (!isBrowser || this.state.isHydrated) {
+      if (fluid) {
+        const imageVariants = fluid
 
-    if (fluid) {
-      const imageVariants = fluid
-
-      return (
-        <Tag
-          className={`${className ? className : ``} gatsby-image-wrapper`}
-          style={{
-            position: `relative`,
-            overflow: `hidden`,
-            maxWidth: image.maxWidth ? `${image.maxWidth}px` : null,
-            maxHeight: image.maxHeight ? `${image.maxHeight}px` : null,
-            ...style,
-          }}
-          ref={this.handleRef}
-          key={`fluid-${JSON.stringify(image.srcSet)}`}
-        >
-          {/* Preserve the aspect ratio. */}
+        return (
           <Tag
-            aria-hidden
+            className={`${className ? className : ``} gatsby-image-wrapper`}
             style={{
-              width: `100%`,
-              paddingBottom: `${100 / image.aspectRatio}%`,
+              position: `relative`,
+              overflow: `hidden`,
+              maxWidth: image.maxWidth ? `${image.maxWidth}px` : null,
+              maxHeight: image.maxHeight ? `${image.maxHeight}px` : null,
+              ...style,
             }}
-          />
-
-          {/* Show a solid background color. */}
-          {bgColor && (
+            ref={this.handleRef}
+            key={`fluid-${JSON.stringify(image.srcSet)}`}
+          >
+            {/* Preserve the aspect ratio. */}
             <Tag
               aria-hidden
-              title={title}
               style={{
-                backgroundColor: bgColor,
-                position: `absolute`,
-                top: 0,
-                bottom: 0,
-                opacity: !this.state.imgLoaded ? 1 : 0,
-                right: 0,
-                left: 0,
-                ...(shouldFadeIn && delayHideStyle),
+                width: `100%`,
+                paddingBottom: `${100 / image.aspectRatio}%`,
               }}
             />
-          )}
 
-          {/* Show the blurry base64 image. */}
-          {image.base64 && (
-            <Placeholder
-              ariaHidden
-              ref={this.placeholderRef}
-              src={image.base64}
-              spreadProps={placeholderImageProps}
-              imageVariants={imageVariants}
-              generateSources={generateBase64Sources}
-            />
-          )}
-
-          {/* Show the traced SVG image. */}
-          {image.tracedSVG && (
-            <Placeholder
-              ariaHidden
-              ref={this.placeholderRef}
-              src={image.tracedSVG}
-              spreadProps={placeholderImageProps}
-              imageVariants={imageVariants}
-              generateSources={generateTracedSVGSources}
-            />
-          )}
-
-          {/* Once the image is visible (or the browser doesn't support IntersectionObserver), start downloading the image */}
-          {this.state.isVisible && (
-            <picture>
-              {generateImageSources(imageVariants)}
-              <Img
-                alt={alt}
+            {/* Show a solid background color. */}
+            {bgColor && (
+              <Tag
+                aria-hidden
                 title={title}
-                sizes={image.sizes}
-                src={image.src}
-                crossOrigin={this.props.crossOrigin}
-                srcSet={image.srcSet}
-                style={imageStyle}
-                ref={this.imageRef}
-                onLoad={this.handleImageLoaded}
-                onError={this.props.onError}
-                itemProp={itemProp}
-                loading={loading}
-                draggable={draggable}
+                style={{
+                  backgroundColor: bgColor,
+                  position: `absolute`,
+                  top: 0,
+                  bottom: 0,
+                  opacity: !this.state.imgLoaded ? 1 : 0,
+                  right: 0,
+                  left: 0,
+                  ...(shouldFadeIn && delayHideStyle),
+                }}
               />
-            </picture>
-          )}
+            )}
 
-          {/* Show the original image during server-side rendering if JavaScript is disabled */}
-          {this.addNoScript && (
-            <noscript
-              dangerouslySetInnerHTML={{
-                __html: noscriptImg({
-                  alt,
-                  title,
-                  loading,
-                  ...image,
-                  imageVariants,
-                }),
-              }}
-            />
-          )}
-        </Tag>
-      )
-    }
+            {/* Show the blurry base64 image. */}
+            {image.base64 && (
+              <Placeholder
+                ariaHidden
+                ref={this.placeholderRef}
+                src={image.base64}
+                spreadProps={placeholderImageProps}
+                imageVariants={imageVariants}
+                generateSources={generateBase64Sources}
+              />
+            )}
 
-    if (fixed) {
-      const imageVariants = fixed
+            {/* Show the traced SVG image. */}
+            {image.tracedSVG && (
+              <Placeholder
+                ariaHidden
+                ref={this.placeholderRef}
+                src={image.tracedSVG}
+                spreadProps={placeholderImageProps}
+                imageVariants={imageVariants}
+                generateSources={generateTracedSVGSources}
+              />
+            )}
 
-      const divStyle = {
-        position: `relative`,
-        overflow: `hidden`,
-        display: `inline-block`,
-        width: image.width,
-        height: image.height,
-        ...style,
+            {/* Once the image is visible (or the browser doesn't support IntersectionObserver), start downloading the image */}
+            {this.state.isVisible && (
+              <picture>
+                {generateImageSources(imageVariants)}
+                <Img
+                  alt={alt}
+                  title={title}
+                  sizes={image.sizes}
+                  src={image.src}
+                  crossOrigin={this.props.crossOrigin}
+                  srcSet={image.srcSet}
+                  style={imageStyle}
+                  ref={this.imageRef}
+                  onLoad={this.handleImageLoaded}
+                  onError={this.props.onError}
+                  itemProp={itemProp}
+                  loading={loading}
+                  draggable={draggable}
+                />
+              </picture>
+            )}
+
+            {/* Show the original image during server-side rendering if JavaScript is disabled */}
+            {this.addNoScript && (
+              <noscript
+                dangerouslySetInnerHTML={{
+                  __html: noscriptImg({
+                    alt,
+                    title,
+                    loading,
+                    ...image,
+                    imageVariants,
+                  }),
+                }}
+              />
+            )}
+          </Tag>
+        )
       }
 
-      if (style.display === `inherit`) {
-        delete divStyle.display
-      }
+      if (fixed) {
+        const imageVariants = fixed
 
-      return (
-        <Tag
-          className={`${className ? className : ``} gatsby-image-wrapper`}
-          style={divStyle}
-          ref={this.handleRef}
-          key={`fixed-${JSON.stringify(image.srcSet)}`}
-        >
-          {/* Show a solid background color. */}
-          {bgColor && (
-            <Tag
-              aria-hidden
-              title={title}
-              style={{
-                backgroundColor: bgColor,
-                width: image.width,
-                opacity: !this.state.imgLoaded ? 1 : 0,
-                height: image.height,
-                ...(shouldFadeIn && delayHideStyle),
-              }}
-            />
-          )}
+        const divStyle = {
+          position: `relative`,
+          overflow: `hidden`,
+          display: `inline-block`,
+          width: image.width,
+          height: image.height,
+          ...style,
+        }
 
-          {/* Show the blurry base64 image. */}
-          {image.base64 && (
-            <Placeholder
-              ariaHidden
-              ref={this.placeholderRef}
-              src={image.base64}
-              spreadProps={placeholderImageProps}
-              imageVariants={imageVariants}
-              generateSources={generateBase64Sources}
-            />
-          )}
+        if (style.display === `inherit`) {
+          delete divStyle.display
+        }
 
-          {/* Show the traced SVG image. */}
-          {image.tracedSVG && (
-            <Placeholder
-              ariaHidden
-              ref={this.placeholderRef}
-              src={image.tracedSVG}
-              spreadProps={placeholderImageProps}
-              imageVariants={imageVariants}
-              generateSources={generateTracedSVGSources}
-            />
-          )}
-
-          {/* Once the image is visible, start downloading the image */}
-          {this.state.isVisible && (
-            <picture>
-              {generateImageSources(imageVariants)}
-              <Img
-                alt={alt}
+        return (
+          <Tag
+            className={`${className ? className : ``} gatsby-image-wrapper`}
+            style={divStyle}
+            ref={this.handleRef}
+            key={`fixed-${JSON.stringify(image.srcSet)}`}
+          >
+            {/* Show a solid background color. */}
+            {bgColor && (
+              <Tag
+                aria-hidden
                 title={title}
-                width={image.width}
-                height={image.height}
-                sizes={image.sizes}
-                src={image.src}
-                crossOrigin={this.props.crossOrigin}
-                srcSet={image.srcSet}
-                style={imageStyle}
-                ref={this.imageRef}
-                onLoad={this.handleImageLoaded}
-                onError={this.props.onError}
-                itemProp={itemProp}
-                loading={loading}
-                draggable={draggable}
+                style={{
+                  backgroundColor: bgColor,
+                  width: image.width,
+                  opacity: !this.state.imgLoaded ? 1 : 0,
+                  height: image.height,
+                  ...(shouldFadeIn && delayHideStyle),
+                }}
               />
-            </picture>
-          )}
+            )}
 
-          {/* Show the original image during server-side rendering if JavaScript is disabled */}
-          {this.addNoScript && (
-            <noscript
-              dangerouslySetInnerHTML={{
-                __html: noscriptImg({
-                  alt,
-                  title,
-                  loading,
-                  ...image,
-                  imageVariants,
-                }),
-              }}
-            />
-          )}
-        </Tag>
-      )
+            {/* Show the blurry base64 image. */}
+            {image.base64 && (
+              <Placeholder
+                ariaHidden
+                ref={this.placeholderRef}
+                src={image.base64}
+                spreadProps={placeholderImageProps}
+                imageVariants={imageVariants}
+                generateSources={generateBase64Sources}
+              />
+            )}
+
+            {/* Show the traced SVG image. */}
+            {image.tracedSVG && (
+              <Placeholder
+                ariaHidden
+                ref={this.placeholderRef}
+                src={image.tracedSVG}
+                spreadProps={placeholderImageProps}
+                imageVariants={imageVariants}
+                generateSources={generateTracedSVGSources}
+              />
+            )}
+
+            {/* Once the image is visible, start downloading the image */}
+            {this.state.isVisible && (
+              <picture>
+                {generateImageSources(imageVariants)}
+                <Img
+                  alt={alt}
+                  title={title}
+                  width={image.width}
+                  height={image.height}
+                  sizes={image.sizes}
+                  src={image.src}
+                  crossOrigin={this.props.crossOrigin}
+                  srcSet={image.srcSet}
+                  style={imageStyle}
+                  ref={this.imageRef}
+                  onLoad={this.handleImageLoaded}
+                  onError={this.props.onError}
+                  itemProp={itemProp}
+                  loading={loading}
+                  draggable={draggable}
+                />
+              </picture>
+            )}
+
+            {/* Show the original image during server-side rendering if JavaScript is disabled */}
+            {this.addNoScript && (
+              <noscript
+                dangerouslySetInnerHTML={{
+                  __html: noscriptImg({
+                    alt,
+                    title,
+                    loading,
+                    ...image,
+                    imageVariants,
+                  }),
+                }}
+              />
+            )}
+          </Tag>
+        )
+      }
     }
 
     return null

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -210,7 +210,7 @@ function groupByMedia(imageVariants) {
   return [...withMedia, ...without]
 }
 
-// For ArtDirection - SSR + Initial load, removed upon rehydration
+// For Art Direction: SSR + Initial load, removed upon rehydration
 // Ensures correct CSS for image variants is applied
 const ResponsiveQueries = ({ imageVariants, selectorClass }) => {
   const variantRule = ({ width, height, aspectRatio }) => {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -18,9 +18,11 @@ const logDeprecationNotice = (prop, replacement) => {
   }
 }
 
-// DJB2 is a simple and fast hash, reduces input to 32-bit value (hash)
-function djb2_xor(str) {
-  let h = 5381
+// DJB2a (XOR variant) is a simple hashing function, reduces input to 32-bits
+const SEED = 5381
+function djb2a(str) {
+  let h = SEED
+
   for (let i = 0; i < str.length; i++) {
     h = (h * 33) ^ str.charCodeAt(i)
   }
@@ -29,8 +31,9 @@ function djb2_xor(str) {
   return h >>> 0
 }
 
-// Converts number to base 36 string (a-z,0-9)
-const getShortKey = input => `_` + djb2_xor(input).toString(36)
+// Converts string input to a 32-bit base36 string (0-9, a-z)
+// '_' prefix to prevent invalid first chars for CSS class names
+const getShortKey = input => `_` + djb2a(input).toString(36)
 
 // Handle legacy props during their deprecation phase
 const convertProps = props => {
@@ -518,7 +521,7 @@ class Image extends React.Component {
 
     let uniqueKey
     if (!isBrowser && imageVariants.length > 1) {
-      uniqueKey = getShortKey(imageVariants.map(x => x.srcSet).join())
+      uniqueKey = getShortKey(imageVariants.map(v => v.srcSet).join(``))
     }
 
     // Avoid render logic on client until mounted (hydration complete)
@@ -527,8 +530,8 @@ class Image extends React.Component {
       if (fluid) {
         return (
           <Tag
-            className={`${className ? className : ``} ${
-              uniqueKey ? uniqueKey : ``
+            className={`${
+              (className ? className : ``) + (uniqueKey ? uniqueKey : ``)
             } gatsby-image-wrapper`}
             style={{
               position: `relative`,
@@ -653,8 +656,8 @@ class Image extends React.Component {
 
         return (
           <Tag
-            className={`${className ? className : ``} ${
-              uniqueKey ? uniqueKey : ``
+            className={`${
+              (className ? className : ``) + (uniqueKey ? uniqueKey : ``)
             } gatsby-image-wrapper`}
             style={divStyle}
             ref={this.handleRef}

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -480,7 +480,9 @@ class Image extends React.Component {
       const image = getCurrentSrcData(fluid)
 
       let aspectRatio = image.aspectRatio
-      if (isBrowser && !this.state.isHydrated) { aspectRatio+=0.0001 }
+      if (isBrowser && !this.state.isHydrated) {
+        aspectRatio += 0.0001
+      }
 
       return (
         <Tag

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -24,18 +24,19 @@ const nodeBtoa = b => Buffer.from(b, `binary`).toString(`base64`)
 const clientBtoa = b => btoa(String.fromCharCode(...b))
 const base64encode = typeof btoa !== `undefined` ? clientBtoa : nodeBtoa
 
-// fnv1a32 is a simple and fast hash, reduces input to 32-bit value (hash)
+// FNV-1a-32 is a simple and fast hash, reduces input to 32-bit value (hash)
 const fnvOffset = 2166136261
-const fnvPrime = 16777619
 function fnv1a32(str) {
   let h = fnvOffset
-  let i = str.length
-  while (i) {
-    h ^= str.charCodeAt(--i)
-    h *= fnvPrime
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    // JS numbers are inaccurate at calculating 'h *= fnvPrime',
+    // Uses bit shifts to accurately multiply the prime: '16777619'
+    h += (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
   }
 
-  return h
+  // Cast to 32-bit uint
+  return h >>> 0
 }
 
 function getShortKey(input) {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -475,14 +475,15 @@ class Image extends React.Component {
       itemProp,
     }
 
+    // Use a dummy empty object for initial state of `image`.
+    // Fixes React state hydration bug: https://github.com/gatsbyjs/gatsby/pull/24811
+    let image = getCurrentSrcData(fluid || fixed)
+    if (isBrowser && !this.state.isHydrated) {
+      image = {}
+    }
+
     if (fluid) {
       const imageVariants = fluid
-      const image = getCurrentSrcData(fluid)
-
-      let aspectRatio = image.aspectRatio
-      if (isBrowser && !this.state.isHydrated) {
-        aspectRatio += 0.0001
-      }
 
       return (
         <Tag
@@ -502,7 +503,7 @@ class Image extends React.Component {
             aria-hidden
             style={{
               width: `100%`,
-              paddingBottom: `${100 / aspectRatio}%`,
+              paddingBottom: `${100 / image.aspectRatio}%`,
             }}
           />
 
@@ -590,7 +591,6 @@ class Image extends React.Component {
 
     if (fixed) {
       const imageVariants = fixed
-      const image = getCurrentSrcData(fixed)
 
       const divStyle = {
         position: `relative`,

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -18,15 +18,11 @@ const logDeprecationNotice = (prop, replacement) => {
   }
 }
 
-// FNV-1a-32 is a simple and fast hash, reduces input to 32-bit value (hash)
-const fnvOffset = 2166136261
-function fnv1a32(str) {
-  let h = fnvOffset
+// DJB2 is a simple and fast hash, reduces input to 32-bit value (hash)
+function djb2_xor(str) {
+  let h = 5381
   for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i)
-    // JS numbers are inaccurate at calculating 'h *= fnvPrime',
-    // Uses bit shifts to accurately multiply the prime: '16777619'
-    h += (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
+    h = (h * 33) ^ str.charCodeAt(i)
   }
 
   // Cast to 32-bit uint
@@ -34,7 +30,7 @@ function fnv1a32(str) {
 }
 
 // Converts number to base 36 string (a-z,0-9)
-const getShortKey = input => `_` + fnv1a32(input).toString(36)
+const getShortKey = input => `_` + djb2_xor(input).toString(36)
 
 // Handle legacy props during their deprecation phase
 const convertProps = props => {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -18,12 +18,6 @@ const logDeprecationNotice = (prop, replacement) => {
   }
 }
 
-// SSR and Client base64 encode methods, expects Uint8Array input
-// Used for generating short class names from 32-bit values (hash)
-const nodeBtoa = b => Buffer.from(b, `binary`).toString(`base64`)
-const clientBtoa = b => btoa(String.fromCharCode(...b))
-const base64encode = typeof btoa !== `undefined` ? clientBtoa : nodeBtoa
-
 // FNV-1a-32 is a simple and fast hash, reduces input to 32-bit value (hash)
 const fnvOffset = 2166136261
 function fnv1a32(str) {
@@ -39,19 +33,8 @@ function fnv1a32(str) {
   return h >>> 0
 }
 
-function getShortKey(input) {
-  const h = fnv1a32(input)
-  // 32-bit number split into 4 8-bit values for base64 encoding.
-  // Replace '+' and '/' base64 values which aren't ideal for CSS classnames.
-  // 32-bits is always <=6 characters long, '=' padding is truncated off.
-  // '-' should not be a first character, so prefix the string.
-  return (
-    `_` +
-    base64encode(Uint8Array.from([h >> 24, h >> 16, h >> 8, h]))
-      .replace(/[+/]/g, x => (x === `+` ? `_` : `-`))
-      .substr(0, 6)
-  )
-}
+// Converts number to base 36 string (a-z,0-9)
+const getShortKey = input => `_` + fnv1a32(input).toString(36)
 
 // Handle legacy props during their deprecation phase
 const convertProps = props => {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -245,9 +245,10 @@ function generateMediaQueries(imageVariants, selectorClass) {
   return `${base}\n${queries}`
 }
 
-const ResponsiveQueries = ({ imageVariants, selectorClass }) => (
-  <style>{generateMediaQueries(imageVariants, selectorClass)}</style>
-)
+const ResponsiveQueries = ({ imageVariants, selectorClass }) =>
+  imageVariants.length > 1 ? (
+    <style>{generateMediaQueries(imageVariants, selectorClass)}</style>
+  ) : null
 
 function generateTracedSVGSources(imageVariants) {
   return imageVariants.map(({ src, media, tracedSVG }) => (
@@ -558,7 +559,7 @@ class Image extends React.Component {
           >
             <ResponsiveQueries
               imageVariants={imageVariants}
-              uniqueKey={uniqueKey}
+              selectorClass={uniqueKey}
             />
             {/* Preserve the aspect ratio. */}
             <Tag
@@ -676,7 +677,7 @@ class Image extends React.Component {
           >
             <ResponsiveQueries
               imageVariants={imageVariants}
-              uniqueKey={uniqueKey}
+              selectorClass={uniqueKey}
             />
             {/* Show a solid background color. */}
             {bgColor && (

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -509,8 +509,8 @@ class Image extends React.Component {
 
     this.seenBefore = imageCache[match.src]
     this.setState({
-      fadeIn: !this.seenBefore && this.state.fadeIn,
-      imgLoaded: false,
+      imgLoaded: this.seenBefore,
+      imgCached: this.seenBefore,
     })
   }
 

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -245,10 +245,9 @@ function generateMediaQueries(imageVariants, selectorClass) {
   return `${base}\n${queries}`
 }
 
-const ResponsiveQueries = ({ imageVariants, selectorClass }) =>
-  imageVariants.length > 1 ? (
-    <style>{generateMediaQueries(imageVariants, selectorClass)}</style>
-  ) : null
+const ResponsiveQueries = ({ imageVariants, selectorClass }) => (
+  <style>{generateMediaQueries(imageVariants, selectorClass)}</style>
+)
 
 function generateTracedSVGSources(imageVariants) {
   return imageVariants.map(({ src, media, tracedSVG }) => (
@@ -536,7 +535,11 @@ class Image extends React.Component {
     const image = getCurrentSrcData(imageVariants)
 
     const activeVariant = getShortKey(image.srcSet)
-    const uniqueKey = getShortKey(imageVariants.map(x => x.srcSet).join())
+
+    let uniqueKey
+    if (!isBrowser && imageVariants.length > 1) {
+      uniqueKey = getShortKey(imageVariants.map(x => x.srcSet).join())
+    }
 
     // Avoid render logic on client until mounted (hydration complete)
     // Prevents invalid initial state from hydration phase: https://github.com/gatsbyjs/gatsby/pull/24811
@@ -544,9 +547,9 @@ class Image extends React.Component {
       if (fluid) {
         return (
           <Tag
-            className={`${
-              className ? className : ``
-            } gatsby-image-wrapper ${uniqueKey}`}
+            className={`${className ? className : ``} ${
+              uniqueKey ? uniqueKey : ``
+            } gatsby-image-wrapper`}
             style={{
               position: `relative`,
               overflow: `hidden`,
@@ -557,10 +560,12 @@ class Image extends React.Component {
             ref={this.handleRef}
             key={activeVariant}
           >
-            <ResponsiveQueries
-              imageVariants={imageVariants}
-              selectorClass={uniqueKey}
-            />
+            {uniqueKey && (
+              <ResponsiveQueries
+                imageVariants={imageVariants}
+                selectorClass={uniqueKey}
+              />
+            )}
             {/* Preserve the aspect ratio. */}
             <Tag
               aria-hidden
@@ -668,17 +673,19 @@ class Image extends React.Component {
 
         return (
           <Tag
-            className={`${
-              className ? className : ``
-            } gatsby-image-wrapper  ${uniqueKey}`}
+            className={`${className ? className : ``} ${
+              uniqueKey ? uniqueKey : ``
+            } gatsby-image-wrapper`}
             style={divStyle}
             ref={this.handleRef}
             key={activeVariant}
           >
-            <ResponsiveQueries
-              imageVariants={imageVariants}
-              selectorClass={uniqueKey}
-            />
+            {uniqueKey && (
+              <ResponsiveQueries
+                imageVariants={imageVariants}
+                selectorClass={uniqueKey}
+              />
+            )}
             {/* Show a solid background color. */}
             {bgColor && (
               <Tag

--- a/yarn.lock
+++ b/yarn.lock
@@ -13458,6 +13458,11 @@ jest-matcher-utils@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
+jest-matchmedia-mock@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jest-matchmedia-mock/-/jest-matchmedia-mock-1.0.1.tgz#da1c75be82a3b3e46e6c8ae195aa54e4a6032eb4"
+  integrity sha512-IXk2AnldfsCRmhB4pFY0Eb9mk2NxFqOgOwA4DxKOJ22T5bn/j3DzM5s3cdKxuEowmpuXK1gPXAIlVGIC+kb/fA==
+
 jest-message-util@^22.4.0, jest-message-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.4.3.tgz#cf3d38aafe4befddbfc455e57d65d5239e399eb7"


### PR DESCRIPTION
## Description

If you use art-direction with differing aspect ratios(fluid) or dimensions(fixed), SSR bakes in the CSS for the first image, but the first load(hydration) expects the initial state to match the CSS, this is not always the case if your breakpoint differs from SSR, React doesn't realize it needs to update the CSS.

The PR provides addresses this by setting `image` variable to `{}` for initial state(first frame), so that React will update image state correctly with the next rendered frame(triggered when the component mounts).

## Related Issues

Fixes #25938
Fixes #24748
Fixes #16888
Fixes #16763 

---

<details>
<summary>Extra details</summary>

### Original issue
SSR and Client states differ for what image is used which can change the `aspectRatio` affecting the `fluid` image component `bottomPadding` style, causing incorrect rendering.

### `isBrowser && !isHydrated` to bust the hydration state
This introduces a new bool state value as advised for handling this situation by the [official React docs](https://reactjs.org/docs/react-dom.html#hydrate) on hydration. I combine it with `isBrowser` to temporarily ~adjust the `aspectRatio` state a minimal amount~ set an empty initial `image` state before the next render(triggered upon component mount once hydrated).

### Unable to resolve for slow connections prior to React being loaded
That would require embedding JS during SSR to run ASAP on the client, or injecting style tags into the HTML `head` covering each images breakpoints(I know how to do this with `styled-components`, but not without it.
</details>

---

Marked some discussion below as "outdated" to hide it, it's all addressed in visible content, should help minimize time needed to review.

Main considerations for reviewer:

1. Is this an acceptable fix to the hydration issue?
2. Should `<style>` be added to the component with opt-out prop? (handles drawbacks, while the main hydration fix will still work)