### PR TITLE
Remove regex from page validator

### DIFF
--- a/packages/gatsby/src/utils/validate-page-component.ts
+++ b/packages/gatsby/src/utils/validate-page-component.ts
@@ -4,7 +4,7 @@ import { IGatsbyPage } from "../redux/types"
 
 const validationCache = new Set<string>()
 
-const sourceExtensionsArray = [`jsx`, `tsx`, `js`, `ts`]
+const sourceExtensionsArray = [`.jsx`, `.tsx`, `.js`, `.ts`]
 const sourceExtensions = new Set<string>(sourceExtensionsArray)
 
 interface IErrorMeta {

--- a/packages/gatsby/src/utils/validate-page-component.ts
+++ b/packages/gatsby/src/utils/validate-page-component.ts
@@ -4,6 +4,9 @@ import { IGatsbyPage } from "../redux/types"
 
 const validationCache = new Set<string>()
 
+const sourceExtensionsArray = [`jsx`, `tsx`, `js`, `ts`]
+const sourceExtensions = new Set<string>(sourceExtensionsArray)
+
 interface IErrorMeta {
   id: string
   context: Record<string, unknown>
@@ -83,7 +86,7 @@ export function validatePageComponent(
 
     // this check only applies to js and ts, not mdx
     if (
-      /\.(jsx?|tsx?)/.test(path.extname(component)) &&
+      sourceExtensions.has(path.extname(component)) &&
       !includesDefaultExport
     ) {
       return {


### PR DESCRIPTION
A recent bug fix showed that the regex code in this file could be improved/is not necessary. This small refactor should clean things up.