### PR TITLE
fix(gatsby-remark-embed-snippet): readme - change code language

### DIFF
--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -292,7 +292,7 @@ This is the JSX of my app:
 
 You can also add `// hide-range` comments to your files.
 
-```jsx
+```text
 // hide-range{1-2}
 import React from "react"
 import ReactDOM from "react-dom"

--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -292,7 +292,7 @@ This is the JSX of my app:
 
 You can also add `// hide-range` comments to your files.
 
-```text
+```no-highlight
 // hide-range{1-2}
 import React from "react"
 import ReactDOM from "react-dom"


### PR DESCRIPTION
## Description

the README is displayed in https://www.gatsbyjs.org/packages/gatsby-remark-embed-snippet/#hide-lines
go to `JavaScript Examples`

examples not show commands

changes:

- change code block language `no-highlight` to show commands
