### PR TITLE
fix(blog): gazette may - remove local domain, brand names, typos

### DIFF
--- a/docs/blog/2020-05-29-gazette/index.md
+++ b/docs/blog/2020-05-29-gazette/index.md
@@ -19,7 +19,7 @@ In May we also announced our [series B round of funding round](/blog/2020-05-27-
 
 Your content editors can now enjoy “instant preview” with Strapi and Gatsby Cloud! If you're new to Strapi, it’s a JavaScript-based, open source CMS. and a great pair for Gatsby projects. The Gatsby starter the Strapi team made for this project is gorgeous 😍 .
 
-![Strapi blog screenshot](/strapi-blog.png)
+![Strapi blog screenshot](./strapi-blog.png)
 
 Give Strapi a try with [this step-by-step tutorial](/blog/2020-05-12-strapi-instant-content-preview-plugin/).
 
@@ -27,7 +27,7 @@ Give Strapi a try with [this step-by-step tutorial](/blog/2020-05-12-strapi-inst
 
 The nice thing about running your project on Gatsby Cloud is that you can go to sleep, wake up, and your site builds have gotten faster without you having to do anything. We're like a CI/CD tooth fairy.
 
-For example, AgilityCMS is [seeing 5 second builds](https://twitter.com/AgilityCMS/status/1257711270532452354) for their own 500-page website! How can this be? Some say it's [unicorn magic](https://twitter.com/3cordguy/status/1257079916434251780).
+For example, Agility CMS is [seeing 5 second builds](https://twitter.com/AgilityCMS/status/1257711270532452354) for their own 500-page website! How can this be? Some say it's [unicorn magic](https://twitter.com/3cordguy/status/1257079916434251780).
 
 Again, you can take a peek at our build time benchmarks at [Will It Build](https://willit.build).
 
@@ -39,7 +39,7 @@ Thanks to a [collaboration with the Chrome team](https://web.dev/granular-chunki
 
 How? By bundling a dependency that is used in at least 2 pages, Gatsby can chunk them together so you don't have to download duplicate libraries over and over again.
 
-This won't benefit first-page load, but it improves page navigation as your site needs less Javascript for the next route. Gatsby projects like Ghost’s website saw a 35% reduction in the overall JavaScript they shipped to browsers.
+This won't benefit first-page load, but it improves page navigation as your site needs less JavaScript for the next route. Gatsby projects like Ghost’s website saw a 35% reduction in the overall JavaScript they shipped to browsers.
 
 ### Faster, and Faster Configuration
 
@@ -47,29 +47,29 @@ When we launched the alpha of Gatsby Recipes in April, it caused a stir in the W
 
 If you missed the initial launch, Paul Scanlon can bring you up-to-speed with ["Gatsby Recipes - What’s All the Fuss About?"](/blog/2020-05-21-gatsby-recipes/). Also, since the launch there’s been an avalanche of official and community made Recipes, including scripts for configuring:
 
-- React libraries like[React Helmet](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/packages/gatsby-recipes/recipes/gatsby-plugin-react-helmet.mdx) and [Preact](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/packages/gatsby-recipes/recipes/preact.mdx)
+- React libraries like [React Helmet](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/packages/gatsby-recipes/recipes/gatsby-plugin-react-helmet.mdx) and [Preact](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/packages/gatsby-recipes/recipes/preact.mdx)
 
 - Themes and Starters, like [gatsby-theme-blog](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/packages/gatsby-recipes/recipes/gatsby-theme-blog.mdx) and [gatsby-theme-notes-starter](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/packages/gatsby-recipes/recipes/gatsby-theme-notes.mdx)
 
 - Advanced configs, like [headless WordPress](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/packages/gatsby-recipes/recipes/wordpress.mdx) and [Progressive WebApps](https://raw.githubusercontent.com/gatsbyjs/gatsby/master/packages/gatsby-recipes/recipes/pwa.mdx)
 
-Learn how to develop your own Gatsby Recipes [here](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-recipes). And if you’re looking for ideas, I could really use a Recipe that spins up placeholder sites for all of the unused domains I purchased last year. And for all of the domains I’m going to purchase - and not use - this year.
+Learn how to develop your own Gatsby Recipes from the [Gatsby Recipes README](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-recipes). And if you’re looking for ideas, I could really use a Recipe that spins up placeholder sites for all of the unused domains I purchased last year. And for all of the domains I’m going to purchase - and not use - this year.
 
 ### TypeScript Support
 
 Gatsby loves the TypeScript community. When you pass one of them, you know exactly what type of person you’re dealing with.
 
-This month we made the Gatsby Typescript plugin part of core Gatsby, so you no longer need to install it to enable TypeScript support in your project. Read our [updated TypeScrip docs](/docs/typescript/) and the Pull Request that enacted this change(https://github.com/gatsbyjs/gatsby/pull/23547). Also [join the Twitter conversation](https://twitter.com/gatsbyjs/status/1258427651066400768).
+This month we made the Gatsby TypeScript plugin part of core Gatsby, so you no longer need to install it to enable TypeScript support in your project. Read our [updated TypeScript docs](/docs/typescript/) and the Pull Request that enacted this change (https://github.com/gatsbyjs/gatsby/pull/23547). Also [join the Twitter conversation](https://twitter.com/gatsbyjs/status/1258427651066400768).
 
 ### GraphQL Tracing
 
-In may we continued to improve our error messaging (see example [here](https://github.com/gatsbyjs/gatsby/pull/24186) and [here](https://github.com/gatsbyjs/gatsby/pull/23741)). But what about slow GraphQL queries? Well, Gatsby now supports performance tracing using the opentracing standard. You can to [enable tracing for GraphQL queries](/docs/performance-tracing/). This is useful because it allows you to debug why querying may be slow in your Gatsby project.
+In may we continued to improve our error messaging (see example [here](https://github.com/gatsbyjs/gatsby/pull/24186) and [here](https://github.com/gatsbyjs/gatsby/pull/23741)). But what about slow GraphQL queries? Well, Gatsby now supports performance tracing using the OpenTracing standard. You can to [enable tracing for GraphQL queries](/docs/performance-tracing/). This is useful because it allows you to debug why querying may be slow in your Gatsby project.
 
 ## 👩‍🚀 New in the Gatsby Community
 
 ### Gatsby Days is June 2 - 3
 
-[Register to attend](https://www.gatsbyjs.com/resources/gatsby-days/) our first ever virtual Gatsby Days!
+[Register to attend](https://www.gatsbyjs.com/resources/gatsby-days/) our first ever Virtual Gatsby Days!
 
 We have a superb [lineup of speakers](/blog/2020-05-13-virtual-gatsby-day-speakers/) from the Gatsby community. And you’ll hear from Gatsby co-founder Kyle Mathews about what’s coming next.
 
@@ -107,13 +107,13 @@ And special thanks to our long time community member, **Horacio Herrera** for ma
 
 ### Gatsby Themes & Plugins
 
-Many exciting Gatsby Themes and Plugins premiered in May. There was [Gatsby Theme Catalyst](https://www.gatsbyjs.org/blog/2020-05-14-introducing-gatsby-theme-catalyst/), Eric Howey exciting exploration in theme architecture. Aravind Balla [launched gatsby-theme-andy](https://twitter.com/aravindballa/status/1260878161920716804), an ambitious theme for power note-taking. And Trevor Harmon [dropped gatsby-theme-shopify-manager](https://thetrevorharmon.com/blog/introducing-gatsby-theme-shopify-manager), a living demonstration of the talk he delivered at Gatsby Days LA, [“Sell Things Fast With Gatsby and Shopify”](https://www.youtube.com/watch?v=tUtuGAFOjYI).
+Many exciting Gatsby Themes and Plugins premiered in May. There was [Gatsby Theme Catalyst](/blog/2020-05-14-introducing-gatsby-theme-catalyst/), Eric Howey exciting exploration in theme architecture. Aravind Balla [launched gatsby-theme-andy](https://twitter.com/aravindballa/status/1260878161920716804), an ambitious theme for power note-taking. And Trevor Harmon [dropped gatsby-theme-shopify-manager](https://thetrevorharmon.com/blog/introducing-gatsby-theme-shopify-manager), a living demonstration of the talk he delivered at Gatsby Days LA, [“Sell Things Fast With Gatsby and Shopify”](https://www.youtube.com/watch?v=tUtuGAFOjYI).
 
 All of the Gatsby Themes above are worth using and studying to accelerate your own work!
 
 ### Azure Static Web Apps
 
-Microsoft debuted [Azure Static Web Apps](https://azure.microsoft.com/en-us/services/app-service/static/) at the Build Conference, and we're excited to see provide first-class support for Gatsby projects. Follow along our new doc so you can [deploy your Gatsby site to Azure](https://www.gatsbyjs.org/docs/deploying-to-azure/).
+Microsoft debuted [Azure Static Web Apps](https://azure.microsoft.com/en-us/services/app-service/static/) at the Build Conference, and we're excited to see provide first-class support for Gatsby projects. Follow along our new doc so you can [deploy your Gatsby site to Azure](/docs/deploying-to-azure/).
 
 ### GraphQL for WordPress is growing!
 


### PR DESCRIPTION
## Description

changes:

- remove domain from local links
- fix brand names: 
  - Javascript -> JavaScript
  - Typescript -> TypeScript
  - TypeScrip -> TypeScript
  - AgilityCMS -> Agility CMS
  - opentracing -> OpenTracing
  - virtual Gatsby Days -> Virtual Gatsby Days
- use relative path for images
- space before link
- replace `here` links with better description for a11y


## Related Issues

- #24581 `(blog) Gatsby Gazette - May 2020` 
- #19267 `Add link checker for Gatsby Docs`