### PR TITLE
Adding an "Example with Drupal" link

### DIFF
--- a/docs/docs/third-party-graphql.md
+++ b/docs/docs/third-party-graphql.md
@@ -101,3 +101,4 @@ exports.createPages = async ({ actions, graphql }) => {
 - [Example with Hasura](https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/gatsby-postgres-graphql)
 - [Example with AWS AppSync](https://github.com/aws-samples/aws-appsync-gatsby-sample)
 - [Example with Dgraph](https://github.com/dgraph-io/gatsby-dgraph-graphql)
+- [Example with Drupal](https://github.com/smthomas/gatsby-drupal-graphql)


### PR DESCRIPTION
After busting my head and got help from the Slack channel I'm adding an example repo for creating dynamic pages with Drupal+GraphQl.