### PR TITLE
refactor(www): convert SimpleEvaluationTable to function component

### DIFF
--- a/www/src/components/features/simple-evaluation-table.js
+++ b/www/src/components/features/simple-evaluation-table.js
@@ -1,92 +1,89 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { Component } from "react"
+import { useState } from "react"
 import SectionTitle from "./evaluation-table-section-title"
 import SectionHeaderTop from "./evaluation-table-section-header-top"
 import { renderCell } from "./evaluation-cell"
 import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
-class SimpleEvaluationTable extends Component {
-  constructor() {
-    super()
-    this.state = {}
-  }
-  render() {
-    const showTooltip = row => this.state[`feature-cell-${row}`]
-    const { title, headers, data } = this.props
-    return (
-      <div>
-        {title && <SectionTitle text={title} />}
-        <table>
-          <tbody>
-            <SectionHeaderTop columnHeaders={headers.map(h => h.display)} />
-            {data.map((node, idx) =>
-              [].concat([
-                <tr key={`feature-first-row-${idx}`}>
-                  {headers.map((header, i) => (
-                    <td
-                      key={`feature-cell-${idx}-${i}`}
-                      sx={{
-                        display: `table-cell`,
-                        "&:hover": {
-                          cursor: `pointer`,
-                        },
-                        borderBottom: t =>
-                          !showTooltip(idx)
-                            ? `1px solid ${t.colors.ui.border}`
-                            : `none`,
-                        minWidth: 40,
-                        paddingRight: 0,
-                        paddingLeft: 0,
-                        textAlign: `left`,
-                        verticalAlign: `middle`,
-                        fontSize: 1,
-                        lineHeight: `solid`,
-                      }}
-                      onClick={() => {
-                        this.setState({
-                          [`feature-cell-${idx}`]: !showTooltip(idx),
-                        })
-                      }}
-                    >
-                      {renderCell(node[header.nodeFieldProperty], i)}
-                    </td>
-                  ))}
-                </tr>,
-                // table row containing details of each feature
-                <tr
-                  style={{
-                    display: showTooltip(idx) ? `table-row` : `none`,
-                  }}
-                  key={`feature-second-row-${idx}`}
-                >
+const SimpleEvaluationTable = props => {
+  const { title, headers, data } = props
+  const [featureCell, setFeatureCell] = useState({})
+  const showTooltip = row => featureCell[`feature-cell-${row}`]
+
+  return (
+    <div>
+      {title && <SectionTitle text={title} />}
+      <table>
+        <tbody>
+          <SectionHeaderTop columnHeaders={headers.map(h => h.display)} />
+          {data.map((node, idx) =>
+            [].concat([
+              <tr key={`feature-first-row-${idx}`}>
+                {headers.map((header, i) => (
                   <td
+                    key={`feature-cell-${idx}-${i}`}
                     sx={{
-                      paddingBottom: t => `calc(${t.space[5]} - 1px)`,
-                      "&&": {
-                        [mediaQueries.xs]: {
-                          px: 3,
-                        },
+                      display: `table-cell`,
+                      "&:hover": {
+                        cursor: `pointer`,
                       },
+                      borderBottom: t =>
+                        !showTooltip(idx)
+                          ? `1px solid ${t.colors.ui.border}`
+                          : `none`,
+                      minWidth: 40,
+                      paddingRight: 0,
+                      paddingLeft: 0,
+                      textAlign: `left`,
+                      verticalAlign: `middle`,
+                      fontSize: 1,
+                      lineHeight: `solid`,
                     }}
-                    colSpan="5"
+                    onClick={() => {
+                      setFeatureCell({
+                        ...featureCell,
+                        [`feature-cell-${idx}`]: !showTooltip(idx),
+                      })
+                    }}
                   >
-                    {
-                      <span
-                        dangerouslySetInnerHTML={{
-                          __html: node.Description,
-                        }}
-                      />
-                    }
+                    {renderCell(node[header.nodeFieldProperty], i)}
                   </td>
-                </tr>,
-              ])
-            )}
-          </tbody>
-        </table>
-      </div>
-    )
-  }
+                ))}
+              </tr>,
+              // table row containing details of each feature
+              <tr
+                style={{
+                  display: showTooltip(idx) ? `table-row` : `none`,
+                }}
+                key={`feature-second-row-${idx}`}
+              >
+                <td
+                  sx={{
+                    paddingBottom: t => `calc(${t.space[5]} - 1px)`,
+                    "&&": {
+                      [mediaQueries.xs]: {
+                        px: 3,
+                      },
+                    },
+                  }}
+                  colSpan="5"
+                >
+                  {
+                    <span
+                      dangerouslySetInnerHTML={{
+                        __html: node.Description,
+                      }}
+                    />
+                  }
+                </td>
+              </tr>,
+            ])
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
 }
 
 export default SimpleEvaluationTable

--- a/www/src/components/features/simple-evaluation-table.js
+++ b/www/src/components/features/simple-evaluation-table.js
@@ -58,7 +58,7 @@ const SimpleEvaluationTable = props => {
               >
                 <td
                   sx={{
-                    paddingBottom: t => `calc(${t.space[5]} - 1px)`,
+                    pb: t => `calc(${t.space[5]} - 1px)`,
                     "&&": {
                       px: [null, 3],
                     },

--- a/www/src/components/features/simple-evaluation-table.js
+++ b/www/src/components/features/simple-evaluation-table.js
@@ -5,7 +5,7 @@ import SectionTitle from "./evaluation-table-section-title"
 import SectionHeaderTop from "./evaluation-table-section-header-top"
 import { renderCell } from "./evaluation-cell"
 
-const SimpleEvaluationTable = props => {
+export default function SimpleEvaluationTable(props) {
   const { title, headers, data } = props
   const [featureCell, setFeatureCell] = useState({})
   const showTooltip = row => featureCell[`feature-cell-${row}`]
@@ -81,5 +81,3 @@ const SimpleEvaluationTable = props => {
     </div>
   )
 }
-
-export default SimpleEvaluationTable

--- a/www/src/components/features/simple-evaluation-table.js
+++ b/www/src/components/features/simple-evaluation-table.js
@@ -4,7 +4,6 @@ import { useState } from "react"
 import SectionTitle from "./evaluation-table-section-title"
 import SectionHeaderTop from "./evaluation-table-section-header-top"
 import { renderCell } from "./evaluation-cell"
-import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
 const SimpleEvaluationTable = props => {
   const { title, headers, data } = props
@@ -33,8 +32,7 @@ const SimpleEvaluationTable = props => {
                           ? `1px solid ${t.colors.ui.border}`
                           : `none`,
                       minWidth: 40,
-                      paddingRight: 0,
-                      paddingLeft: 0,
+                      px: 0,
                       textAlign: `left`,
                       verticalAlign: `middle`,
                       fontSize: 1,
@@ -62,9 +60,7 @@ const SimpleEvaluationTable = props => {
                   sx={{
                     paddingBottom: t => `calc(${t.space[5]} - 1px)`,
                     "&&": {
-                      [mediaQueries.xs]: {
-                        px: 3,
-                      },
+                      px: [null, 3],
                     },
                   }}
                   colSpan="5"


### PR DESCRIPTION
## Description

1. Convert the `<SimpleEvaluationTable/>` to function component from class based component
2. Use theme-ui's array syntax and remove import of mediaQueries
3. CSS cleanup

**There is no change functionality wise, just the implementation is different.**

### Screenshot(s)

#### Before

##### Normal State
<img width="400" alt="simple-evaluation-table-before" src="https://user-images.githubusercontent.com/19193724/83939372-0a9dd580-a7fa-11ea-83b6-bceda514cc7f.png">

##### Feature Cell Open State
<img width="400" alt="simple-evaluation-table-opened-before" src="https://user-images.githubusercontent.com/19193724/83939374-0d002f80-a7fa-11ea-8b60-c1d20be21449.png">

#### After

##### Normal State
<img width="400" alt="simple-evaluation-table-after" src="https://user-images.githubusercontent.com/19193724/83939371-07a2e500-a7fa-11ea-9b47-69ef434ab988.png">

##### Feature Cell Open State
<img width="400" alt="simple-evaluation-table-opened-after" src="https://user-images.githubusercontent.com/19193724/83939373-0bcf0280-a7fa-11ea-9672-a16a0b9a5013.png">


### How to test

The table used on features page for comparing features is the SimpleEvaluationTable

**Local URL:** http://localhost:8000/features/
**Production URL:** https://www.gatsbyjs.org/features/
