### PR TITLE
refactor(www): convert EvaluationTable to function component

### DIFF
--- a/www/src/components/features/evaluation-table.js
+++ b/www/src/components/features/evaluation-table.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { useState } from "react"
-import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 import { renderCell } from "./evaluation-cell"
 import SectionTitle from "./evaluation-table-section-title"
 import SectionHeaderTop from "./evaluation-table-section-header-top"
@@ -68,8 +67,7 @@ const EvaluationTable = props => {
                                 ? `1px solid ${t.colors.ui.border}`
                                 : `none`,
                             minWidth: 40,
-                            paddingRight: 0,
-                            paddingLeft: 0,
+                            px: 0,
                             textAlign: `left`,
                             verticalAlign: `middle`,
                             fontSize: 1,
@@ -100,11 +98,9 @@ const EvaluationTable = props => {
                     >
                       <td
                         sx={{
-                          paddingBottom: t => `calc(${t.space[5]} - 1px)`,
+                          pb: t => `calc(${t.space[5]} - 1px)`,
                           "&&": {
-                            [mediaQueries.xs]: {
-                              px: 3,
-                            },
+                            px: [null, 3],
                           },
                         }}
                         colSpan="5"

--- a/www/src/components/features/evaluation-table.js
+++ b/www/src/components/features/evaluation-table.js
@@ -1,136 +1,132 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { Component } from "react"
+import { useState } from "react"
 import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 import { renderCell } from "./evaluation-cell"
 import SectionTitle from "./evaluation-table-section-title"
 import SectionHeaderTop from "./evaluation-table-section-header-top"
 import SectionHeaderBottom from "./evaluation-table-section-header-bottom"
 
-class EvaluationTable extends Component {
-  constructor() {
-    super()
-    this.state = {}
-  }
-  render() {
-    const showTooltip = (section, row) => this.state[`${section},${row}`]
+const EvaluationTable = props => {
+  const { options, sections, sectionHeaders } = props
+  const [isFeatureCellOpen, setIsFeatureCellOpen] = useState({})
+  const showTooltip = (section, row) => isFeatureCellOpen[`${section},${row}`]
 
-    const { options, sections, sectionHeaders } = this.props
-    const flatten = arrays => [].concat.apply([], arrays)
-    const columnHeaders = [`Category`, `Gatsby`].concat(
-      options.map(o => o.display)
-    )
-    const nodeFieldProperties = [`Feature`, `Gatsby`].concat(
-      options.map(o => o.nodeField)
-    )
+  const flatten = arrays => [].concat.apply([], arrays)
+  const columnHeaders = [`Category`, `Gatsby`].concat(
+    options.map(o => o.display)
+  )
+  const nodeFieldProperties = [`Feature`, `Gatsby`].concat(
+    options.map(o => o.nodeField)
+  )
 
-    return (
-      <div
-        style={{
-          // this should be a table, but that breaks the
-          // anchor links on this page due to a bug in the
-          // scrolling library
-          display: `table`,
-          overflowX: `scroll`,
-          width: `100%`,
-        }}
-      >
-        <tbody>
-          {flatten(
-            sections.map((section, s) =>
-              [
-                <SectionTitle
-                  text={sectionHeaders[s]}
-                  key={`section-title-${s}`}
-                />,
-                <SectionHeaderTop
-                  key={`section-header-${s}`}
-                  columnHeaders={columnHeaders}
-                />,
-              ].concat(
-                flatten(
-                  section.map((row, i) =>
-                    [].concat([
-                      <SectionHeaderBottom
-                        options={options}
-                        display={row.Subcategory}
-                        category={row.Subcategory}
-                        key={`section-header-${s}-bottom-${i}`}
-                      />,
-                      // table row with the name of the feature and corresponding scores
-                      <tr key={`section-${s}-first-row-${i}`}>
-                        {nodeFieldProperties.map((nodeProperty, j) => (
-                          <td
-                            key={j}
-                            sx={{
-                              display: `table-cell`,
-                              "&:hover": {
-                                cursor: j >= 0 ? `pointer` : `inherit`,
-                              },
-                              borderBottom: t =>
-                                !showTooltip(s, i)
-                                  ? `1px solid ${t.colors.ui.border}`
-                                  : `none`,
-                              minWidth: 40,
-                              paddingRight: 0,
-                              paddingLeft: 0,
-                              textAlign: `left`,
-                              verticalAlign: `middle`,
-                              fontSize: 1,
-                              lineHeight: `solid`,
-                            }}
-                            id={
-                              j === 0
-                                ? row.Feature.toLowerCase().split(` `).join(`-`)
-                                : undefined
-                            }
-                            onClick={() => {
-                              this.setState({
-                                [`${s},${i}`]: !showTooltip(s, i),
-                              })
-                            }}
-                          >
-                            {renderCell(row[nodeProperty], j)}
-                          </td>
-                        ))}
-                      </tr>,
-                      // table row containing details of each feature
-                      <tr
-                        style={{
-                          display: showTooltip(s, i) ? `table-row` : `none`,
-                        }}
-                        key={`section-${s}-second-row-${i}`}
-                      >
+  return (
+    <div
+      style={{
+        // this should be a table, but that breaks the
+        // anchor links on this page due to a bug in the
+        // scrolling library
+        display: `table`,
+        overflowX: `scroll`,
+        width: `100%`,
+      }}
+    >
+      <tbody>
+        {flatten(
+          sections.map((section, s) =>
+            [
+              <SectionTitle
+                text={sectionHeaders[s]}
+                key={`section-title-${s}`}
+              />,
+              <SectionHeaderTop
+                key={`section-header-${s}`}
+                columnHeaders={columnHeaders}
+              />,
+            ].concat(
+              flatten(
+                section.map((row, i) =>
+                  [].concat([
+                    <SectionHeaderBottom
+                      options={options}
+                      display={row.Subcategory}
+                      category={row.Subcategory}
+                      key={`section-header-${s}-bottom-${i}`}
+                    />,
+                    // table row with the name of the feature and corresponding scores
+                    <tr key={`section-${s}-first-row-${i}`}>
+                      {nodeFieldProperties.map((nodeProperty, j) => (
                         <td
+                          key={j}
                           sx={{
-                            paddingBottom: t => `calc(${t.space[5]} - 1px)`,
-                            "&&": {
-                              [mediaQueries.xs]: {
-                                px: 3,
-                              },
+                            display: `table-cell`,
+                            "&:hover": {
+                              cursor: j >= 0 ? `pointer` : `inherit`,
                             },
+                            borderBottom: t =>
+                              !showTooltip(s, i)
+                                ? `1px solid ${t.colors.ui.border}`
+                                : `none`,
+                            minWidth: 40,
+                            paddingRight: 0,
+                            paddingLeft: 0,
+                            textAlign: `left`,
+                            verticalAlign: `middle`,
+                            fontSize: 1,
+                            lineHeight: `solid`,
                           }}
-                          colSpan="5"
-                        >
-                          {
-                            <span
-                              dangerouslySetInnerHTML={{
-                                __html: row.Description,
-                              }}
-                            />
+                          id={
+                            j === 0
+                              ? row.Feature.toLowerCase().split(` `).join(`-`)
+                              : undefined
                           }
+                          onClick={() => {
+                            setIsFeatureCellOpen({
+                              ...isFeatureCellOpen,
+                              [`${s},${i}`]: !showTooltip(s, i),
+                            })
+                          }}
+                        >
+                          {renderCell(row[nodeProperty], j)}
                         </td>
-                      </tr>,
-                    ])
-                  )
+                      ))}
+                    </tr>,
+                    // table row containing details of each feature
+                    <tr
+                      style={{
+                        display: showTooltip(s, i) ? `table-row` : `none`,
+                      }}
+                      key={`section-${s}-second-row-${i}`}
+                    >
+                      <td
+                        sx={{
+                          paddingBottom: t => `calc(${t.space[5]} - 1px)`,
+                          "&&": {
+                            [mediaQueries.xs]: {
+                              px: 3,
+                            },
+                          },
+                        }}
+                        colSpan="5"
+                      >
+                        {
+                          <span
+                            dangerouslySetInnerHTML={{
+                              __html: row.Description,
+                            }}
+                          />
+                        }
+                      </td>
+                    </tr>,
+                  ])
                 )
               )
             )
-          )}
-        </tbody>
-      </div>
-    )
-  }
+          )
+        )}
+      </tbody>
+    </div>
+  )
 }
 
 export default EvaluationTable

--- a/www/src/components/features/evaluation-table.js
+++ b/www/src/components/features/evaluation-table.js
@@ -6,7 +6,7 @@ import SectionTitle from "./evaluation-table-section-title"
 import SectionHeaderTop from "./evaluation-table-section-header-top"
 import SectionHeaderBottom from "./evaluation-table-section-header-bottom"
 
-const EvaluationTable = props => {
+export default function EvaluationTable(props) {
   const { options, sections, sectionHeaders } = props
   const [isFeatureCellOpen, setIsFeatureCellOpen] = useState({})
   const showTooltip = (section, row) => isFeatureCellOpen[`${section},${row}`]
@@ -124,5 +124,3 @@ const EvaluationTable = props => {
     </div>
   )
 }
-
-export default EvaluationTable


### PR DESCRIPTION
## Description

1. Convert the `<EvaluationTable/>` to function component from class based component
2. Use theme-ui's array syntax and remove import of mediaQueries
3. CSS cleanup

**There is no change functionality wise, just the implementation is different.**

### Screenshot(s)

#### Before

##### Normal State
<img width="400" alt="evaluation-table-before" src="https://user-images.githubusercontent.com/19193724/83939673-69fce500-a7fc-11ea-84c9-8a3b037d74d9.png">

##### Feature Cell Open State
<img width="400" alt="evaluation-table-opened-before" src="https://user-images.githubusercontent.com/19193724/83939677-6d906c00-a7fc-11ea-9b4c-454169bb8ed4.png">

#### After

##### Normal State
<img width="400" alt="evaluation-table-after" src="https://user-images.githubusercontent.com/19193724/83939672-68332180-a7fc-11ea-9385-b100b9315e10.png">

##### Feature Cell Open State
<img width="400" alt="evaluation-table-opened-after" src="https://user-images.githubusercontent.com/19193724/83939676-6bc6a880-a7fc-11ea-96a7-126f6a3d0a82.png">


### How to test

The table used on features/jamstack and features/cms page is EvaluationTable

**Local URL:** 
http://localhost:8000/features/jamstack/
https://www.gatsbyjs.org/features/cms/
**Production URL:** 
https://www.gatsbyjs.org/features/jamstack/
https://www.gatsbyjs.org/features/cms/