### PR TITLE
fix(www): card component imported as ColorSwatch in guidelines/logo page

### DIFF
--- a/www/src/components/guidelines/color/card.js
+++ b/www/src/components/guidelines/color/card.js
@@ -3,13 +3,21 @@ import { jsx } from "theme-ui"
 import React from "react"
 import { MdLaunch } from "react-icons/md"
 
-import { Box, Flex, Link, Text } from "../system"
+import { Box, Flex } from "theme-ui"
+import { Link, Text } from "../system"
 import BoxWithBorder from "../box-with-border"
 import { getTextColor } from "../../../utils/guidelines/color"
 import { SrOnly } from "../typography"
 
 const ColorValue = ({ label, inverted, value, href }) => (
-  <Box mt={4} px={2} css={{ flexShrink: 0, flexBase: `50%` }}>
+  <Box
+    sx={{
+      mt: 4,
+      px: 3,
+      flexShrink: 0,
+      flexBasis: `50%`,
+    }}
+  >
     <Text
       color={inverted ? `whiteFade.70` : `blackFade.70`}
       fontFamily="heading"
@@ -17,7 +25,11 @@ const ColorValue = ({ label, inverted, value, href }) => (
     >
       {label}
     </Text>
-    <Flex alignItems="center">
+    <Flex
+      sx={{
+        alignItems: `center`,
+      }}
+    >
       <Text
         fontSize={1}
         css={{ whiteSpace: `nowrap` }}
@@ -55,9 +67,9 @@ const ColorSwatch = ({ color, ...rest }) => {
       width={{ md: 1 / 3 }}
       py={4}
       px={2}
-      {...rest}
       bg={color.hex}
       withBorder={!inverted}
+      {...rest}
     >
       <Text
         fontFamily="heading"
@@ -68,7 +80,11 @@ const ColorSwatch = ({ color, ...rest }) => {
       >
         {color.name}
       </Text>
-      <Flex flexWrap="wrap">
+      <Flex
+        sx={{
+          flexWrap: `wrap`,
+        }}
+      >
         <ColorValue value={color.hex} label="HEX" inverted={inverted} />
         <ColorValue
           label="RGB"


### PR DESCRIPTION
## Description

The following changes have been done in the card component which is imported as ColorSwatch in guidelines/logo page

1. Import the `<Box/>` and `<Flex/>` component from theme-ui
2. Fix the typo in flexBase css property, changed it to flexBasis

### Screenshot(s)

#### Before
##### Desktop

<img width="400" alt="logo-swatch-card-before-desktop" src="https://user-images.githubusercontent.com/19193724/83940733-f19a2200-a803-11ea-8f2c-1a3c9305d065.png">

##### Mobile

![logo-swatch-card-before-mobile](https://user-images.githubusercontent.com/19193724/83940775-2d34ec00-a804-11ea-9738-2087012e7d26.png)



#### After
##### Desktop

<img width="400" alt="logo-swatch-card-after-desktop" src="https://user-images.githubusercontent.com/19193724/83940730-ee069b00-a803-11ea-8ceb-c6185bf7e416.png">

##### Mobile

![logo-swatch-card-after-mobile](https://user-images.githubusercontent.com/19193724/83940778-332acd00-a804-11ea-989a-74f0fb08162f.png)


### How to test
1. Go to the links mentioned below
Local URL: http://localhost:8000/guidelines/logo/
Production URL: https://www.gatsbyjs.org/guidelines/logo/
2. Scroll down to the colors section


