### PR TITLE
Improved includesDefaultExport Check

### DIFF
--- a/packages/gatsby/src/utils/validate-page-component.ts
+++ b/packages/gatsby/src/utils/validate-page-component.ts
@@ -79,11 +79,13 @@ export function validatePageComponent(
       fileContent.includes(`module.exports`) ||
       fileContent.includes(`exports.default`) ||
       fileContent.includes(`exports["default"]`) ||
-      fileContent.match(/export \{.* as default.*\}/s) ||
-      // this check only applies to js and ts, not mdx
-      /\.(jsx?|tsx?)/.test(path.extname(component))
+      fileContent.match(/export \{.* as default.*\}/s)
 
-    if (!includesDefaultExport) {
+    // this check only applies to js and ts, not mdx
+    if (
+      /\.(jsx?|tsx?)/.test(path.extname(component)) &&
+      !includesDefaultExport
+    ) {
       return {
         error: {
           id: `11328`,

--- a/packages/gatsby/src/utils/validate-page-component.ts
+++ b/packages/gatsby/src/utils/validate-page-component.ts
@@ -74,26 +74,25 @@ export function validatePageComponent(
       }
     }
 
-    const includesDefaultExport =
-      fileContent.includes(`export default`) ||
-      fileContent.includes(`module.exports`) ||
-      fileContent.includes(`exports.default`) ||
-      fileContent.includes(`exports["default"]`) ||
-      fileContent.match(/export \{.* as default.*\}/s)
-
     // this check only applies to js and ts, not mdx
-    if (
-      /\.(jsx?|tsx?)/.test(path.extname(component)) &&
-      !includesDefaultExport
-    ) {
-      return {
-        error: {
-          id: `11328`,
-          context: {
-            component,
+    if (/\.(jsx?|tsx?)/.test(path.extname(component))) {
+      const includesDefaultExport =
+        fileContent.includes(`export default`) ||
+        fileContent.includes(`module.exports`) ||
+        fileContent.includes(`exports.default`) ||
+        fileContent.includes(`exports["default"]`) ||
+        fileContent.match(/export \{.* as default.*\}/s)
+
+      if (!includesDefaultExport) {
+        return {
+          error: {
+            id: `11328`,
+            context: {
+              component,
+            },
           },
-        },
-        panicOnBuild: true,
+          panicOnBuild: true,
+        }
       }
     }
   }


### PR DESCRIPTION
Since the check is only valid for ts|js(x) files, calculating the includesDefaultExport check before extension check is unnecessary.

Ref : #24813