### PR TITLE
chore(gatsby): validate-page-component - simplify regex

### DIFF
--- a/packages/gatsby/src/utils/validate-page-component.ts
+++ b/packages/gatsby/src/utils/validate-page-component.ts
@@ -75,7 +75,7 @@ export function validatePageComponent(
     }
 
     // this check only applies to js and ts, not mdx
-    if (/\.(jsx?|tsx?)/.test(path.extname(component))) {
+    if ([`.js`, `.jsx`, `.ts`, `.tsx`].includes(path.extname(component))) {
       const includesDefaultExport =
         fileContent.includes(`export default`) ||
         fileContent.includes(`module.exports`) ||


### PR DESCRIPTION
## Description

changes:

- simplify regex (suggestion from @pvdz https://github.com/gatsbyjs/gatsby/pull/24837#discussion_r436270883)
- avoid wrong positive tests ( true: `.jsm`, `.tsxt` etc)


## Related Issues

- #24837 `perf(gatsby): Improved includesDefaultExport Check` 
- #24813 `fix(gatsby): Mdx integration broken since Gatsby 2.22.21` 