### PR TITLE
refactor(www): convert the class based collapsible to function component

### DIFF
--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -5,7 +5,7 @@ import { FaAngleDown, FaAngleUp } from "react-icons/fa"
 
 import { Flex } from "theme-ui"
 
-const Collapsible = props => {
+export default function Collapsible(props) {
   const { heading, fixed, children } = props
   const [collapsed, setCollapsed] = useState(false)
 
@@ -69,5 +69,3 @@ const Collapsible = props => {
     </div>
   )
 }
-
-export default Collapsible

--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -1,83 +1,72 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { Component } from "react"
+import { useState } from "react"
 import { FaAngleDown, FaAngleUp } from "react-icons/fa"
 
-class Collapsible extends Component {
-  state = {
-    collapsed: false,
-  }
+const Collapsible = props => {
+  const { heading, fixed, children } = props
+  const [collapsed, setCollapsed] = useState(false)
 
-  handleClick = () => {
-    this.setState({ collapsed: !this.state.collapsed })
-  }
-
-  render() {
-    const { heading, fixed, children } = this.props
-    const { collapsed } = this.state
-
-    return (
+  return (
+    <div
+      sx={{
+        borderBottom: t => (collapsed ? 0 : `1px solid ${t.colors.ui.border}`),
+        display: collapsed ? false : `flex`,
+        flex: collapsed ? `0 0 auto` : `1 1 auto`,
+        minHeight: fixed ? `${fixed}px` : `initial`,
+        maxHeight: fixed ? `${fixed}px` : `initial`,
+        flexBasis: 0,
+        overflowY: collapsed ? false : `auto`,
+      }}
+    >
       <div
-        sx={{
-          borderBottom: t =>
-            collapsed ? 0 : `1px solid ${t.colors.ui.border}`,
-          display: collapsed ? false : `flex`,
-          flex: collapsed ? `0 0 auto` : `1 1 auto`,
-          minHeight: fixed ? `${fixed}px` : `initial`,
-          maxHeight: fixed ? `${fixed}px` : `initial`,
-          flexBasis: 0,
-          overflowY: collapsed ? false : `auto`,
+        css={{
+          display: `flex`,
+          flexDirection: `column`,
+          minHeight: `100%`,
+          width: `100%`,
         }}
       >
+        <button
+          sx={{
+            alignItems: `center`,
+            color: `textMuted`,
+            cursor: `pointer`,
+            display: `flex`,
+            flexShrink: 0,
+            fontWeight: `body`,
+            fontSize: 1,
+            my: 6,
+            mr: 4,
+            p: 0,
+            letterSpacing: `tracked`,
+            textTransform: `uppercase`,
+            background: `none`,
+            border: `none`,
+            "&:hover": {
+              color: `gatsby`,
+            },
+          }}
+          aria-expanded={!collapsed}
+          onClick={() => setCollapsed(!collapsed)}
+        >
+          {heading}
+          {` `}
+          <span sx={{ ml: `auto` }} css={{ display: `flex` }}>
+            {collapsed ? <FaAngleDown /> : <FaAngleUp />}
+          </span>
+        </button>
         <div
           css={{
-            display: `flex`,
-            flexDirection: `column`,
-            minHeight: `100%`,
-            width: `100%`,
+            display: collapsed ? `none` : `block`,
+            overflowY: `auto`,
           }}
         >
-          <button
-            sx={{
-              alignItems: `center`,
-              color: `textMuted`,
-              cursor: `pointer`,
-              display: `flex`,
-              flexShrink: 0,
-              fontWeight: `body`,
-              fontSize: 1,
-              my: 6,
-              mr: 4,
-              p: 0,
-              letterSpacing: `tracked`,
-              textTransform: `uppercase`,
-              background: `none`,
-              border: `none`,
-              "&:hover": {
-                color: `gatsby`,
-              },
-            }}
-            aria-expanded={!collapsed}
-            onClick={this.handleClick}
-          >
-            {heading}
-            {` `}
-            <span sx={{ ml: `auto` }} css={{ display: `flex` }}>
-              {collapsed ? <FaAngleDown /> : <FaAngleUp />}
-            </span>
-          </button>
-          <div
-            css={{
-              display: collapsed ? `none` : `block`,
-              overflowY: `auto`,
-            }}
-          >
-            {children}
-          </div>
+          {children}
         </div>
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 export default Collapsible

--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -5,13 +5,8 @@ import { FaAngleDown, FaAngleUp } from "react-icons/fa"
 
 import { Flex } from "theme-ui"
 
-export default function Collapsible(props) {
-  const { heading, fixed, children } = props
+export default function Collapsible({ heading, fixed, children }) {
   const [collapsed, setCollapsed] = useState(false)
-
-  function toggleCollapsible() {
-    setCollapsed(!collapsed)
-  }
 
   return (
     <div
@@ -53,7 +48,7 @@ export default function Collapsible(props) {
             },
           }}
           aria-expanded={!collapsed}
-          onClick={toggleCollapsible}
+          onClick={() => setCollapsed(collapsed => !collapsed)}
         >
           {heading}
           {` `}

--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -3,6 +3,8 @@ import { jsx } from "theme-ui"
 import { useState } from "react"
 import { FaAngleDown, FaAngleUp } from "react-icons/fa"
 
+import { Flex } from "theme-ui"
+
 const Collapsible = props => {
   const { heading, fixed, children } = props
   const [collapsed, setCollapsed] = useState(false)
@@ -19,9 +21,8 @@ const Collapsible = props => {
         overflowY: collapsed ? false : `auto`,
       }}
     >
-      <div
-        css={{
-          display: `flex`,
+      <Flex
+        sx={{
           flexDirection: `column`,
           minHeight: `100%`,
           width: `100%`,
@@ -52,19 +53,19 @@ const Collapsible = props => {
         >
           {heading}
           {` `}
-          <span sx={{ ml: `auto` }} css={{ display: `flex` }}>
+          <span sx={{ display: `flex`, ml: `auto` }}>
             {collapsed ? <FaAngleDown /> : <FaAngleUp />}
           </span>
         </button>
         <div
-          css={{
+          sx={{
             display: collapsed ? `none` : `block`,
             overflowY: `auto`,
           }}
         >
           {children}
         </div>
-      </div>
+      </Flex>
     </div>
   )
 }

--- a/www/src/views/shared/collapsible.js
+++ b/www/src/views/shared/collapsible.js
@@ -9,6 +9,10 @@ export default function Collapsible(props) {
   const { heading, fixed, children } = props
   const [collapsed, setCollapsed] = useState(false)
 
+  function toggleCollapsible() {
+    setCollapsed(!collapsed)
+  }
+
   return (
     <div
       sx={{
@@ -49,7 +53,7 @@ export default function Collapsible(props) {
             },
           }}
           aria-expanded={!collapsed}
-          onClick={() => setCollapsed(!collapsed)}
+          onClick={toggleCollapsible}
         >
           {heading}
           {` `}


### PR DESCRIPTION
## Description

1. Converts the class based `<Collapsible/>` component to function component.
2. It was using state called `collapsed` to toggle between the collapsing behaviour, now this state is being managed by useState hook.
3. At some places css rules were applied using `css` prop and at other using `sx` props, now all of the css rules are applied using `sx` props of theme-ui.

**There is not change functionality wise, just the implementation is different.**

### Screenshots(s)

#### Closed state of `<Collapsible/>`
<img width="512" alt="closed-state" src="https://user-images.githubusercontent.com/19193724/83949924-6b520000-a844-11ea-8fec-361e99176ff2.png">

#### Open state of `<Collapsible/>`
<img width="512" alt="open-state" src="https://user-images.githubusercontent.com/19193724/83949929-6db45a00-a844-11ea-8c7a-9b7750882543.png">



### How to test

The `<Collapsible/>` component is used in the following two pages

**Local URL:** http://localhost:8000/showcase/
**Production URL:** https://www.gatsbyjs.org/showcase/

**Local URL:** http://localhost:8000/starters?
**Production URL:** https://www.gatsbyjs.org/starters/?v=2