### PR TITLE
refactor(www): convert avatar of guidelines to theme-ui

### DIFF
--- a/www/src/components/guidelines/avatar.js
+++ b/www/src/components/guidelines/avatar.js
@@ -10,8 +10,8 @@ const Avatar = ({ ...rest }) => (
       height: `avatar`,
       lineHeight: `solid`,
       width: `avatar`,
-      ...rest,
     }}
+    {…rest}
   ></div>
 )
 

--- a/www/src/components/guidelines/avatar.js
+++ b/www/src/components/guidelines/avatar.js
@@ -1,18 +1,18 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 
-const Avatar = ({ ...rest }) => (
-  <div
-    sx={{
-      bg: `grey.10`,
-      borderRadius: 6,
-      flex: `0 0 auto`,
-      height: `avatar`,
-      lineHeight: `solid`,
-      width: `avatar`,
-    }}
-    {...rest}
-  />
-)
-
-export default Avatar
+export default function Avatar({ ...rest }) {
+  return (
+    <div
+      sx={{
+        bg: `grey.10`,
+        borderRadius: 6,
+        flex: `0 0 auto`,
+        height: `avatar`,
+        lineHeight: `solid`,
+        width: `avatar`,
+      }}
+      {...rest}
+    />
+  )
+}

--- a/www/src/components/guidelines/avatar.js
+++ b/www/src/components/guidelines/avatar.js
@@ -12,7 +12,7 @@ const Avatar = ({ ...rest }) => (
       width: `avatar`,
     }}
     {…rest}
-  ></div>
+  />
 )
 
 export default Avatar

--- a/www/src/components/guidelines/avatar.js
+++ b/www/src/components/guidelines/avatar.js
@@ -1,16 +1,18 @@
-import styled from "@emotion/styled"
+/** @jsx jsx */
+import { jsx } from "theme-ui"
 
-import { Box } from "./system"
-
-const Avatar = styled(Box)()
-
-Avatar.defaultProps = {
-  bg: `grey.10`,
-  borderRadius: 6,
-  flex: `0 0 auto`,
-  height: `avatar`,
-  lineHeight: `solid`,
-  width: `avatar`,
-}
+const Avatar = ({ ...rest }) => (
+  <div
+    sx={{
+      bg: `grey.10`,
+      borderRadius: 6,
+      flex: `0 0 auto`,
+      height: `avatar`,
+      lineHeight: `solid`,
+      width: `avatar`,
+      ...rest,
+    }}
+  ></div>
+)
 
 export default Avatar

--- a/www/src/components/guidelines/avatar.js
+++ b/www/src/components/guidelines/avatar.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 
-export default function Avatar({ ...rest }) {
+export default function Avatar() {
   return (
     <div
       sx={{
@@ -11,8 +11,8 @@ export default function Avatar({ ...rest }) {
         height: `avatar`,
         lineHeight: `solid`,
         width: `avatar`,
+        mr: 2,
       }}
-      {...rest}
     />
   )
 }

--- a/www/src/components/guidelines/avatar.js
+++ b/www/src/components/guidelines/avatar.js
@@ -11,7 +11,7 @@ const Avatar = ({ ...rest }) => (
       lineHeight: `solid`,
       width: `avatar`,
     }}
-    {…rest}
+    {...rest}
   />
 )
 

--- a/www/src/components/guidelines/cards/blog.js
+++ b/www/src/components/guidelines/cards/blog.js
@@ -38,7 +38,7 @@ const BlogCard = () => (
           my: 3,
         }}
       >
-        <Avatar mr={2} />
+        <Avatar />
         <Text color="grey.50" fontSize={1}>
           <Link href="#" css={{ textDecoration: `none` }}>
             Shannon Soper


### PR DESCRIPTION
## Description

Convert the `<Avatar/>` component used in `<BlogCard/>` of guidelines/typography/ page, to theme-ui.

**There is not change functionality wise, just the implementation is different.**

### Screenshots(s)
<img width="400" alt="avatar" src="https://user-images.githubusercontent.com/19193724/83953712-19b76e80-a860-11ea-8c54-203adc40bea9.png">
<img width="400" alt="avatar-zoomed" src="https://user-images.githubusercontent.com/19193724/83953714-1c19c880-a860-11ea-882f-26928b0d0a5c.png">



### How to test

**Local URL:**  http://localhost:8000/guidelines/typography/
**Production URL:** https://www.gatsbyjs.org/guidelines/typography/