### PR TITLE
fix(gatsby-remark-embed-snippet): readme - add example sources

### DIFF
--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -190,7 +190,8 @@ You can specify specific lines for Prism to highlight using
 
 **JavaScript example**:
 
-```no-highlight
+````no-highlight
+```jsx
 import React from "react"
 import ReactDOM from "react-dom"
 
@@ -204,6 +205,7 @@ ReactDOM.render(
   document.getElementById("root")
 )
 ```
+````
 
 ```jsx
 import React from "react"
@@ -222,7 +224,8 @@ ReactDOM.render(
 
 **CSS example**:
 
-```no-highlight
+````no-highlight
+```css
 html {
   /* highlight-range{1-2} */
   height: 100%;
@@ -233,6 +236,7 @@ html {
   box-sizing: border-box; /* highlight-line */
 }
 ```
+````
 
 ```css
 html {
@@ -249,7 +253,8 @@ html {
 **HTML example**:
 
 <!-- prettier-ignore-start -->
-```no-highlight
+````no-highlight
+```html
 <html>
   <body>
     <h1>highlight me</h1> <!-- highlight-line -->
@@ -260,9 +265,8 @@ html {
   </body>
 </html>
 ```
-<!-- prettier-ignore-end -->
+````
 
-<!-- prettier-ignore-start -->
 ```html
 <html>
   <body>
@@ -278,13 +282,15 @@ html {
 
 **YAML example**:
 
-```no-highlight
+````no-highlight
+```yaml
 foo: "highlighted" # highlight-line
 bar: "not highlighted"
 # highlight-range{1-2}
 baz: "highlighted"
 quz: "highlighted"
 ```
+````
 
 ```yaml
 foo: "highlighted" # highlight-line

--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -190,6 +190,21 @@ You can specify specific lines for Prism to highlight using
 
 **JavaScript example**:
 
+```no-highlight
+import React from "react"
+import ReactDOM from "react-dom"
+
+const name = "Brian" // highlight-line
+
+ReactDOM.render(
+  <div>
+    {/* highlight-range{1-3} */}
+    <h1>Hello, ${name}!</h1>
+  </div>,
+  document.getElementById("root")
+)
+```
+
 ```jsx
 import React from "react"
 import ReactDOM from "react-dom"
@@ -207,6 +222,18 @@ ReactDOM.render(
 
 **CSS example**:
 
+```no-highlight
+html {
+  /* highlight-range{1-2} */
+  height: 100%;
+  width: 100%;
+}
+
+* {
+  box-sizing: border-box; /* highlight-line */
+}
+```
+
 ```css
 html {
   /* highlight-range{1-2} */
@@ -220,6 +247,20 @@ html {
 ```
 
 **HTML example**:
+
+<!-- prettier-ignore-start -->
+```no-highlight
+<html>
+  <body>
+    <h1>highlight me</h1> <!-- highlight-line -->
+    <p>
+      <!-- highlight-next-line -->
+      And me
+    </p>
+  </body>
+</html>
+```
+<!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
 ```html
@@ -236,6 +277,14 @@ html {
 <!-- prettier-ignore-end -->
 
 **YAML example**:
+
+```no-highlight
+foo: "highlighted" # highlight-line
+bar: "not highlighted"
+# highlight-range{1-2}
+baz: "highlighted"
+quz: "highlighted"
+```
 
 ```yaml
 foo: "highlighted" # highlight-line


### PR DESCRIPTION
## Description

changes:

- add source code snippets with `no-highlight` to be rendered nice on https://www.gatsbyjs.org/packages/gatsby-remark-embed-snippet/#highlighting-lines


## Questions

- shoud we add a `source` and `result` line before each?

- on github https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-embed-snippet/README.md they would rendered twice (because highlight lines commands are not processed)
- while on Gatsby docs page https://www.gatsbyjs.org/packages/gatsby-remark-embed-snippet/#highlighting-lines they rendered as source/result

## Related Issues

- #24821 `fix(gatsby-remark-embed-snippet): readme - change code language` 