### PR TITLE
docs: update Stripe ecommerce tutorial

### DIFF
--- a/docs/tutorial/ecommerce-tutorial/index.md
+++ b/docs/tutorial/ecommerce-tutorial/index.md
@@ -121,7 +121,8 @@ const redirectToCheckout = async event => {
   event.preventDefault()
   const stripe = await stripePromise
   const { error } = await stripe.redirectToCheckout({
-    items: [{ sku: "sku_DjQJN2HJ1kkvI3", quantity: 1 }],
+    lineItems: [{ price: "price_1GriHeAKu92npuros981EDUL", quantity: 1 }],
+    mode: "payment",
     successUrl: `http://localhost:8000/page-2/`,
     cancelUrl: `http://localhost:8000/`,
   })
@@ -140,6 +141,18 @@ const Checkout = () => {
 }
 
 export default Checkout
+```
+
+#### If you are using the deprecated Stripe Orders API
+
+Replace the invokation of `redirectToCheckout` with the following snippet and it will allow you to accept SKU type products.
+
+```jsx:title=src/components/checkout.js
+const { error } = await stripe.redirectToCheckout({
+  items: [{ sku: "sku_DjQJN2HJ1kkvI3", quantity: 1 }],
+  successUrl: `http://localhost:8000/page-2/`,
+  cancelUrl: `http://localhost:8000/`,
+})
 ```
 
 #### What did you just do?

--- a/docs/tutorial/ecommerce-tutorial/index.md
+++ b/docs/tutorial/ecommerce-tutorial/index.md
@@ -106,8 +106,7 @@ import { loadStripe } from "@stripe/stripe-js"
 const buttonStyles = {
   fontSize: "13px",
   textAlign: "center",
-  color: "#fff",
-  outline: "none",
+  color: "#000",
   padding: "12px 60px",
   boxShadow: "2px 5px 10px rgba(0,0,0,.1)",
   backgroundColor: "rgb(255, 178, 56)",

--- a/docs/tutorial/ecommerce-tutorial/index.md
+++ b/docs/tutorial/ecommerce-tutorial/index.md
@@ -93,11 +93,11 @@ If you're selling a single product, like an eBook for example, you can create a 
 
 To sell your products, you need to create them in your Stripe account using the [Stripe Dashboard](https://dashboard.stripe.com/products) or the [Stripe API](https://stripe.com/docs/api/products/create). This is required for Stripe to validate that the request coming from the frontend is legitimate and to charge the correct amount for the selected product/SKU. Stripe requires every SKU used with Stripe Checkout to have a name: be sure to add one to all of your SKUs.
 
-You will need to create both test and live product SKUs separately in the Stripe Dashboard. Make sure you toggle to "Viewing test data", then create your products for local development.
+You will need to create both test and live product SKUs separately in the Stripe Dashboard. **Make sure you toggle to "Viewing test data", then create your products for local development.**
 
 #### Create a checkout component that loads Stripe.js and redirects to the checkout
 
-Create a new file at `src/components/checkout.js`. Your `checkout.js` file should look like this:
+Create a new file at `src/components/checkout.js`. Your `checkout.js` file should look like this, with `loadStripe` updated with your API key and `lineItems` with one of your product IDs from the Stripe dashboard:
 
 ```jsx:title=src/components/checkout.js
 import React from "react"


### PR DESCRIPTION
## Description
All new Stripe users now use the Products API instead of Orders API, so new stripe accounts will not be able to complete the e-commerce tutorial without figuring out that the code snippet is wrong.

- Adds updated code snippet for Stripe redirectToCheckout to use Products API instead of the deprecated Orders API.
- Adds a deprecation snippet for existing Stripe users who are still using Orders API

Closes: #24883 

### Documentation
Reference URLs:
- Gatsby Ecommerce Stripe Tutorial: https://www.gatsbyjs.org/tutorial/ecommerce-tutorial/#create-a-checkout-component-that-loads-stripejs-and-redirects-to-the-checkout
- Stripe Checkout Documentation: https://stripe.com/docs/payments/checkout/client#generate-checkout-button
- Stripe Deprecated Orders API: https://stripe.com/docs/orders

### Screenshot of changed tutorial
![image](https://user-images.githubusercontent.com/498136/84123240-27414400-aa6c-11ea-8325-1b4a373a4eb4.png)
