### PR TITLE
chore(gatsby-plugin-less): less-loader version 6.1.0 with tests and doc…

### DIFF
--- a/packages/gatsby-plugin-less/README.md
+++ b/packages/gatsby-plugin-less/README.md
@@ -16,8 +16,8 @@ Provides drop-in support for Less stylesheets
 plugins: [`gatsby-plugin-less`]
 ```
 
-If you need to pass options to Less use the plugins options; see [less options](http://lesscss.org/usage/#less-options)
-for all available options.
+If you need to pass options to the Less loader use the `loaderOptions` and to Less use `lessOptions` object;
+see [less-loader](https://github.com/webpack-contrib/less-loader) for all available options.
 
 ```javascript
 // in gatsby-config.js
@@ -25,7 +25,13 @@ plugins: [
   {
     resolve: `gatsby-plugin-less`,
     options: {
-      strictMath: true,
+      loaderOptions: {
+        appendData: `@env: ${process.env.NODE_ENV};`,
+      },
+      lessOptions: {
+        strictMath: true,
+        plugins: [new CleanCSSPlugin({ advanced: true })],
+      },
     },
   },
 ]
@@ -42,20 +48,6 @@ plugins: [
       cssLoaderOptions: {
         camelCase: false,
       },
-    },
-  },
-]
-```
-
-If you need to provide [Less plugins](https://github.com/less/less-docs/blob/master/content/usage/plugins.md), normally you would provide a `plugins` in the Less options, but this option attribute is already used by Gatsby. It has been remapped to `lessPlugins`
-
-```javascript
-// in gatsby-config.js
-plugins: [
-  {
-    resolve: `gatsby-plugin-less`,
-    options: {
-      lessPlugins: [MyLessPlugin],
     },
   },
 ]
@@ -88,6 +80,11 @@ plugins: [
 ## Breaking changes history
 
 <!-- Please keep the breaking changes list ordered with the newest change at the top -->
+
+### v4.0.0
+
+- `less-loader` options now possible with the object `loaderOptions`.
+- `less` options moved to the object `lessOptions` because of api change on `less-loader` v6.
 
 ### v2.0.0
 

--- a/packages/gatsby-plugin-less/README.md
+++ b/packages/gatsby-plugin-less/README.md
@@ -4,7 +4,7 @@ Provides drop-in support for Less stylesheets
 
 ## Install
 
-`npm install --save less gatsby-plugin-less`
+`npm install --save gatsby-plugin-less`
 
 ## How to use
 
@@ -16,7 +16,7 @@ Provides drop-in support for Less stylesheets
 plugins: [`gatsby-plugin-less`]
 ```
 
-If you need to pass options to Less use the plugins options; see [less-loader](https://github.com/webpack-contrib/less-loader)
+If you need to pass options to Less use the plugins options; see [less options](http://lesscss.org/usage/#less-options)
 for all available options.
 
 ```javascript

--- a/packages/gatsby-plugin-less/package.json
+++ b/packages/gatsby-plugin-less/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.3",
-    "less-loader": "^5.0.0"
+    "less-loader": "^6.1.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",
@@ -25,8 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0",
-    "less": "^3.0.0"
+    "gatsby": "^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -99,6 +99,52 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #2 1`] = `
 }
 `;
 
+exports[`gatsby-plugin-less Stage: build-html / Loader options #1 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "module": Object {
+          "rules": Array [
+            Object {
+              "oneOf": Array [
+                Object {
+                  "test": /\\\\\\.module\\\\\\.less\\$/,
+                  "use": Array [
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "appendData": "@env: test;",
+                        "lessOptions": Object {},
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.less\\$/,
+                  "use": Array [
+                    "null",
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`gatsby-plugin-less Stage: build-html / No options 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -341,6 +387,63 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                             "text-color": "#fff",
                           },
                         },
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gatsby-plugin-less Stage: build-javascript / Loader options #1 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "module": Object {
+          "rules": Array [
+            Object {
+              "oneOf": Array [
+                Object {
+                  "test": /\\\\\\.module\\\\\\.less\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "appendData": "@env: test;",
+                        "lessOptions": Object {},
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.less\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css({\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "appendData": "@env: test;",
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -655,6 +758,63 @@ exports[`gatsby-plugin-less Stage: develop / Less options #2 1`] = `
 }
 `;
 
+exports[`gatsby-plugin-less Stage: develop / Loader options #1 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "module": Object {
+          "rules": Array [
+            Object {
+              "oneOf": Array [
+                Object {
+                  "test": /\\\\\\.module\\\\\\.less\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "appendData": "@env: test;",
+                        "lessOptions": Object {},
+                        "sourceMap": true,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.less\\$/,
+                  "use": Array [
+                    "miniCssExtract",
+                    "css({\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "appendData": "@env: test;",
+                        "lessOptions": Object {},
+                        "sourceMap": true,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`gatsby-plugin-less Stage: develop / No options 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -892,6 +1052,52 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #2 1`] = `
                             "text-color": "#fff",
                           },
                         },
+                        "sourceMap": false,
+                      },
+                    },
+                  ],
+                },
+                Object {
+                  "test": /\\\\\\.less\\$/,
+                  "use": Array [
+                    "null",
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gatsby-plugin-less Stage: develop-html / Loader options #1 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "module": Object {
+          "rules": Array [
+            Object {
+              "oneOf": Array [
+                Object {
+                  "test": /\\\\\\.module\\\\\\.less\\$/,
+                  "use": Array [
+                    "css({\\"modules\\":true,\\"importLoaders\\":2})",
+                    "postcss({})",
+                    Object {
+                      "loader": "/resolved/path/less-loader",
+                      "options": Object {
+                        "appendData": "@env: test;",
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },

--- a/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -17,12 +17,14 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #1 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
+                          "strictMath": true,
                         },
-                        "plugins": Array [],
                         "sourceMap": false,
-                        "strictMath": true,
                       },
                     },
                   ],
@@ -66,10 +68,12 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #2 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
                         },
-                        "plugins": Array [],
                         "sourceMap": false,
                       },
                     },
@@ -114,7 +118,9 @@ exports[`gatsby-plugin-less Stage: build-html / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -159,7 +165,9 @@ exports[`gatsby-plugin-less Stage: build-html / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -204,7 +212,9 @@ exports[`gatsby-plugin-less Stage: build-html / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -250,12 +260,14 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
+                          "strictMath": true,
                         },
-                        "plugins": Array [],
                         "sourceMap": false,
-                        "strictMath": true,
                       },
                     },
                   ],
@@ -269,12 +281,14 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
+                          "strictMath": true,
                         },
-                        "plugins": Array [],
                         "sourceMap": false,
-                        "strictMath": true,
                       },
                     },
                   ],
@@ -313,10 +327,12 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
                         },
-                        "plugins": Array [],
                         "sourceMap": false,
                       },
                     },
@@ -331,10 +347,12 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
                         },
-                        "plugins": Array [],
                         "sourceMap": false,
                       },
                     },
@@ -374,7 +392,9 @@ exports[`gatsby-plugin-less Stage: build-javascript / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -389,7 +409,9 @@ exports[`gatsby-plugin-less Stage: build-javascript / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -429,7 +451,9 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -444,7 +468,9 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -484,7 +510,9 @@ exports[`gatsby-plugin-less Stage: build-javascript / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -499,7 +527,9 @@ exports[`gatsby-plugin-less Stage: build-javascript / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -539,12 +569,14 @@ exports[`gatsby-plugin-less Stage: develop / Less options #1 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
+                          "strictMath": true,
                         },
-                        "plugins": Array [],
                         "sourceMap": true,
-                        "strictMath": true,
                       },
                     },
                   ],
@@ -558,12 +590,14 @@ exports[`gatsby-plugin-less Stage: develop / Less options #1 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
+                          "strictMath": true,
                         },
-                        "plugins": Array [],
                         "sourceMap": true,
-                        "strictMath": true,
                       },
                     },
                   ],
@@ -602,10 +636,12 @@ exports[`gatsby-plugin-less Stage: develop / Less options #2 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
                         },
-                        "plugins": Array [],
                         "sourceMap": true,
                       },
                     },
@@ -620,10 +656,12 @@ exports[`gatsby-plugin-less Stage: develop / Less options #2 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
                         },
-                        "plugins": Array [],
                         "sourceMap": true,
                       },
                     },
@@ -663,7 +701,9 @@ exports[`gatsby-plugin-less Stage: develop / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": true,
                       },
                     },
@@ -678,7 +718,9 @@ exports[`gatsby-plugin-less Stage: develop / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": true,
                       },
                     },
@@ -718,7 +760,9 @@ exports[`gatsby-plugin-less Stage: develop / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": true,
                       },
                     },
@@ -733,7 +777,9 @@ exports[`gatsby-plugin-less Stage: develop / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": true,
                       },
                     },
@@ -773,7 +819,9 @@ exports[`gatsby-plugin-less Stage: develop / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": true,
                       },
                     },
@@ -788,7 +836,9 @@ exports[`gatsby-plugin-less Stage: develop / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": true,
                       },
                     },
@@ -827,12 +877,14 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #1 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
+                          "strictMath": true,
                         },
-                        "plugins": Array [],
                         "sourceMap": false,
-                        "strictMath": true,
                       },
                     },
                   ],
@@ -876,10 +928,12 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #2 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "modifyVars": Object {
-                          "text-color": "#fff",
+                        "lessOptions": Object {
+                          "modifyVars": Object {
+                            "text-color": "#fff",
+                          },
+                          "plugins": Array [],
                         },
-                        "plugins": Array [],
                         "sourceMap": false,
                       },
                     },
@@ -924,7 +978,9 @@ exports[`gatsby-plugin-less Stage: develop-html / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -969,7 +1025,9 @@ exports[`gatsby-plugin-less Stage: develop-html / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },
@@ -1014,7 +1072,9 @@ exports[`gatsby-plugin-less Stage: develop-html / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "plugins": Array [],
+                        "lessOptions": Object {
+                          "plugins": Array [],
+                        },
                         "sourceMap": false,
                       },
                     },

--- a/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-less/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -21,7 +21,6 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #1 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                           "strictMath": true,
                         },
                         "sourceMap": false,
@@ -72,7 +71,6 @@ exports[`gatsby-plugin-less Stage: build-html / Less options #2 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                         },
                         "sourceMap": false,
                       },
@@ -118,9 +116,7 @@ exports[`gatsby-plugin-less Stage: build-html / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -165,9 +161,7 @@ exports[`gatsby-plugin-less Stage: build-html / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -212,9 +206,7 @@ exports[`gatsby-plugin-less Stage: build-html / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -264,7 +256,6 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                           "strictMath": true,
                         },
                         "sourceMap": false,
@@ -285,7 +276,6 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #1 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                           "strictMath": true,
                         },
                         "sourceMap": false,
@@ -331,7 +321,6 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                         },
                         "sourceMap": false,
                       },
@@ -351,7 +340,6 @@ exports[`gatsby-plugin-less Stage: build-javascript / Less options #2 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                         },
                         "sourceMap": false,
                       },
@@ -392,9 +380,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -409,9 +395,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -451,9 +435,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -468,9 +450,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -510,9 +490,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -527,9 +505,7 @@ exports[`gatsby-plugin-less Stage: build-javascript / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -573,7 +549,6 @@ exports[`gatsby-plugin-less Stage: develop / Less options #1 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                           "strictMath": true,
                         },
                         "sourceMap": true,
@@ -594,7 +569,6 @@ exports[`gatsby-plugin-less Stage: develop / Less options #1 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                           "strictMath": true,
                         },
                         "sourceMap": true,
@@ -640,7 +614,6 @@ exports[`gatsby-plugin-less Stage: develop / Less options #2 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                         },
                         "sourceMap": true,
                       },
@@ -660,7 +633,6 @@ exports[`gatsby-plugin-less Stage: develop / Less options #2 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                         },
                         "sourceMap": true,
                       },
@@ -701,9 +673,7 @@ exports[`gatsby-plugin-less Stage: develop / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": true,
                       },
                     },
@@ -718,9 +688,7 @@ exports[`gatsby-plugin-less Stage: develop / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": true,
                       },
                     },
@@ -760,9 +728,7 @@ exports[`gatsby-plugin-less Stage: develop / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": true,
                       },
                     },
@@ -777,9 +743,7 @@ exports[`gatsby-plugin-less Stage: develop / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": true,
                       },
                     },
@@ -819,9 +783,7 @@ exports[`gatsby-plugin-less Stage: develop / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": true,
                       },
                     },
@@ -836,9 +798,7 @@ exports[`gatsby-plugin-less Stage: develop / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": true,
                       },
                     },
@@ -881,7 +841,6 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #1 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                           "strictMath": true,
                         },
                         "sourceMap": false,
@@ -932,7 +891,6 @@ exports[`gatsby-plugin-less Stage: develop-html / Less options #2 1`] = `
                           "modifyVars": Object {
                             "text-color": "#fff",
                           },
-                          "plugins": Array [],
                         },
                         "sourceMap": false,
                       },
@@ -978,9 +936,7 @@ exports[`gatsby-plugin-less Stage: develop-html / No options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -1025,9 +981,7 @@ exports[`gatsby-plugin-less Stage: develop-html / PostCss plugins 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },
@@ -1072,9 +1026,7 @@ exports[`gatsby-plugin-less Stage: develop-html / css-loader options 1`] = `
                     Object {
                       "loader": "/resolved/path/less-loader",
                       "options": Object {
-                        "lessOptions": Object {
-                          "plugins": Array [],
-                        },
+                        "lessOptions": Object {},
                         "sourceMap": false,
                       },
                     },

--- a/packages/gatsby-plugin-less/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/__tests__/gatsby-node.js
@@ -23,6 +23,11 @@ describe(`gatsby-plugin-less`, () => {
     stages: [`develop`, `build-javascript`, `develop-html`, `build-html`],
     options: {
       "No options": {},
+      "Loader options #1": {
+        loaderOptions: {
+          appendData: `@env: ${process.env.NODE_ENV};`,
+        },
+      },
       "Less options #1": {
         lessOptions: {
           modifyVars: {

--- a/packages/gatsby-plugin-less/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/__tests__/gatsby-node.js
@@ -24,13 +24,17 @@ describe(`gatsby-plugin-less`, () => {
     options: {
       "No options": {},
       "Less options #1": {
-        modifyVars: {
-          "text-color": `#fff`,
+        lessOptions: {
+          modifyVars: {
+            "text-color": `#fff`,
+          },
+          strictMath: true,
         },
-        strictMath: true,
       },
       "Less options #2": {
-        modifyVars: require(`../theme-test.js`),
+        lessOptions: {
+          modifyVars: require(`../theme-test.js`),
+        },
       },
       "PostCss plugins": {
         postCssPlugins: [`test1`],

--- a/packages/gatsby-plugin-less/src/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/gatsby-node.js
@@ -12,8 +12,10 @@ exports.onCreateWebpackConfig = (
     loader: resolve(`less-loader`),
     options: {
       sourceMap: !PRODUCTION,
-      ...lessOptions,
-      plugins: lessOptions.lessPlugins || [], // for #4645
+      lessOptions: {
+        ...lessOptions,
+        plugins: lessOptions.lessPlugins || [], // for #4645
+      },
     },
   }
 

--- a/packages/gatsby-plugin-less/src/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/gatsby-node.js
@@ -2,7 +2,7 @@ import resolve from "./resolve"
 
 exports.onCreateWebpackConfig = (
   { actions, stage, rules, plugins, loaders },
-  { cssLoaderOptions = {}, postCssPlugins, ...lessOptions }
+  { cssLoaderOptions = {}, postCssPlugins, loaderOptions, lessOptions }
 ) => {
   const { setWebpackConfig } = actions
   const PRODUCTION = stage !== `develop`
@@ -14,8 +14,8 @@ exports.onCreateWebpackConfig = (
       sourceMap: !PRODUCTION,
       lessOptions: {
         ...lessOptions,
-        plugins: lessOptions.lessPlugins || [], // for #4645
       },
+      ...loaderOptions,
     },
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,10 +3533,10 @@
   resolved "https://registry.yarnpkg.com/@types/joi/-/joi-14.3.4.tgz#eed1e14cbb07716079c814138831a520a725a1e0"
   integrity sha512-1TQNDJvIKlgYXGNIABfgFp9y0FziDpuGrd799Q5RcnsDu+krD+eeW/0Fs5PHARvWWFelOhIG2OPCo6KbadBM4A==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.3":
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
-  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -4338,7 +4338,7 @@ ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.0, ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.0, ajv@^6.5.5, ajv@^6.9.1:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
@@ -6493,7 +6493,7 @@ clone@^1.0.1, clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
-clone@^2.1.1:
+clone@^2.1.1, clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
 
@@ -8706,7 +8706,7 @@ err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
 
-errno@^0.1.3, errno@~0.1.1, errno@~0.1.7:
+errno@^0.1.1, errno@^0.1.3, errno@~0.1.1, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
@@ -11993,6 +11993,11 @@ image-size@^0.6.1:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.3.tgz#e7e5c65bb534bd7cdcedd6cb5166272a85f75fb2"
 
+image-size@~0.5.0:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
+  integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
+
 imageinfo@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/imageinfo/-/imageinfo-1.0.4.tgz#1dd2456ecb96fc395f0aa1179c467dfb3d5d7a2a"
@@ -14216,14 +14221,32 @@ lerna@^3.22.1:
     import-local "^2.0.0"
     npmlog "^4.1.2"
 
-less-loader@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-5.0.0.tgz#498dde3a6c6c4f887458ee9ed3f086a12ad1b466"
-  integrity sha512-bquCU89mO/yWLaUq0Clk7qCsKhsF/TZpJUzETRvJa9KSVEL9SO3ovCvdEHISBhrC81OwC8QSVX7E0bzElZj9cg==
+less-loader@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-6.1.3.tgz#f1d46e69158da1282e26f738117dd891cb13fc50"
+  integrity sha512-gzG3gQd3da+E06yasOB1zR6klEEyfXp/kYZ+5Su89AVE656klCilD58QFYALqky6yL1d/ZSEKgVjkwH3meIpIQ==
   dependencies:
-    clone "^2.1.1"
-    loader-utils "^1.1.0"
-    pify "^4.0.1"
+    clone "^2.1.2"
+    less "^3.11.3"
+    loader-utils "^2.0.0"
+    schema-utils "^2.7.0"
+
+less@^3.11.3:
+  version "3.11.3"
+  resolved "https://registry.yarnpkg.com/less/-/less-3.11.3.tgz#2d853954fcfe0169a8af869620bcaa16563dcc1c"
+  integrity sha512-VkZiTDdtNEzXA3LgjQiC3D7/ejleBPFVvq+aRI9mIj+Zhmif5TvFPM244bT4rzkvOCvJ9q4zAztok1M7Nygagw==
+  dependencies:
+    clone "^2.1.2"
+    tslib "^1.10.0"
+  optionalDependencies:
+    errno "^0.1.1"
+    graceful-fs "^4.1.2"
+    image-size "~0.5.0"
+    make-dir "^2.1.0"
+    mime "^1.4.1"
+    promise "^7.1.1"
+    request "^2.83.0"
+    source-map "~0.6.0"
 
 level-codec@^9.0.0:
   version "9.0.1"
@@ -14558,6 +14581,15 @@ loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+loader-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -15656,7 +15688,7 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.40.0"
 
-mime@1.6.0, mime@^1.3.4:
+mime@1.6.0, mime@^1.3.4, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
@@ -20919,12 +20951,13 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.6.5:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
-  integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
+schema-utils@^2.6.5, schema-utils@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
+  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
   dependencies:
-    ajv "^6.12.0"
+    "@types/json-schema" "^7.0.4"
+    ajv "^6.12.2"
     ajv-keywords "^3.4.1"
 
 schemes@^1.0.1:


### PR DESCRIPTION
### Description

I update less-loader to a new major version, it has some bugfixes and some feature (resolve imports without tilde).

node and webpack version should be covered:

> minimum supported Node.js version is 10.13
> minimum support webpack version is 4

### Documentation

[less-loader releases 6.0.0 and 6.1.0](https://github.com/webpack-contrib/less-loader/releases)

## Related Issues

Fixes #24867