### PR TITLE
fix(gatsby-remark-images-contentful): Url search params in inline markdown image urls cause builds to break

### DIFF
--- a/packages/gatsby-remark-images-contentful/src/index.js
+++ b/packages/gatsby-remark-images-contentful/src/index.js
@@ -91,11 +91,14 @@ module.exports = async (
 
     response.data.destroy()
 
-    const responsiveSizesResult = await buildResponsiveSizes({
-      metadata,
-      imageUrl: originalImg,
-      options,
-    })
+    const responsiveSizesResult = await buildResponsiveSizes(
+      {
+        metadata,
+        imageUrl: originalImg,
+        options,
+      },
+      reporter
+    )
 
     // Calculate the paddingBottom %
     const ratio = `${(1 / responsiveSizesResult.aspectRatio) * 100}%`

--- a/packages/gatsby-remark-images-contentful/src/utils/index.js
+++ b/packages/gatsby-remark-images-contentful/src/utils/index.js
@@ -1,20 +1,31 @@
 const axios = require(`axios`)
 
-const getBase64Img = async url => {
-  const response = await axios({
-    method: `GET`,
-    responseType: `arraybuffer`,
-    url: `${url}`,
-  })
+const getBase64Img = async (url, reporter) => {
+  let base64Img
+  try {
+    const response = await axios({
+      method: `GET`,
+      responseType: `arraybuffer`,
+      url: `${url}`,
+    })
 
-  const base64Img = `data:${
-    response.headers[`content-type`]
-  };base64,${new Buffer(response.data).toString(`base64`)}`
+    base64Img = `data:${response.headers[`content-type`]};base64,${new Buffer(
+      response.data
+    ).toString(`base64`)}`
+  } catch (err) {
+    reporter.panic(
+      `Failed downloading the base64 image for ${originalImg}`,
+      err
+    )
+  }
 
   return base64Img
 }
 
-const buildResponsiveSizes = async ({ metadata, imageUrl, options = {} }) => {
+const buildResponsiveSizes = async (
+  { metadata, imageUrl, options = {} },
+  reporter
+) => {
   const { width, height, density } = metadata
   const { sizeByPixelDensity, maxWidth, sizes } = options
   const aspectRatio = width / height
@@ -41,7 +52,7 @@ const buildResponsiveSizes = async ({ metadata, imageUrl, options = {} }) => {
 
   filteredSizes.push(width)
 
-  const base64Img = await getBase64Img(`${imageUrl}?w=40`)
+  const base64Img = await getBase64Img(`${imageUrl}?w=40`, reporter)
 
   const srcSet = filteredSizes
     .map(size => `${imageUrl}?w=${Math.round(size)} ${Math.round(size)}w`)

--- a/packages/gatsby-remark-images-contentful/src/utils/index.js
+++ b/packages/gatsby-remark-images-contentful/src/utils/index.js
@@ -13,10 +13,7 @@ const getBase64Img = async (url, reporter) => {
       response.data
     ).toString(`base64`)}`
   } catch (err) {
-    reporter.panic(
-      `Failed downloading the base64 image for ${originalImg}`,
-      err
-    )
+    reporter.panic(`Failed downloading the base64 image for ${url}`, err)
   }
 
   return base64Img
@@ -26,6 +23,12 @@ const buildResponsiveSizes = async (
   { metadata, imageUrl, options = {} },
   reporter
 ) => {
+  // Remove search params from the image url
+  let formattedImgUrl = imageUrl
+  if (imageUrl.includes(`?`)) {
+    formattedImgUrl = imageUrl.split(`?`)[0]
+  }
+
   const { width, height, density } = metadata
   const { sizeByPixelDensity, maxWidth, sizes } = options
   const aspectRatio = width / height
@@ -52,15 +55,18 @@ const buildResponsiveSizes = async (
 
   filteredSizes.push(width)
 
-  const base64Img = await getBase64Img(`${imageUrl}?w=40`, reporter)
+  const base64Img = await getBase64Img(`${formattedImgUrl}?w=40`, reporter)
 
   const srcSet = filteredSizes
-    .map(size => `${imageUrl}?w=${Math.round(size)} ${Math.round(size)}w`)
+    .map(
+      size => `${formattedImgUrl}?w=${Math.round(size)} ${Math.round(size)}w`
+    )
     .join(`,\n`)
 
   const webpSrcSet = filteredSizes
     .map(
-      size => `${imageUrl}?fm=webp&w=${Math.round(size)} ${Math.round(size)}w`
+      size =>
+        `${formattedImgUrl}?fm=webp&w=${Math.round(size)} ${Math.round(size)}w`
     )
     .join(`,\n`)
 
@@ -70,7 +76,7 @@ const buildResponsiveSizes = async (
     aspectRatio,
     srcSet,
     webpSrcSet,
-    src: imageUrl,
+    src: formattedImgUrl,
     sizes: sizesQuery,
     density,
     presentationWidth,


### PR DESCRIPTION
### Description

The `gatsby-remark-images-contentful` plugin causes builds to break if an image url with a search param is used. The axios call inside of the`getBase64Img` function fails when the image url contains a search param, since the `buildResponsiveSizes` that calls it appends a `?w=40` search param at the end of the provided url. The url then becomes something like `example.com?foo=bar?w=40` which is an invalid url.

This PR adds a try/catch block around the axios call inside of the`getBase64Img` function.
It also strips out search params from the image url, since the `metadata` object passed into `buildResponsiveSizes` already has all of the sizing information that it needs. More information around the issue can be found here #24896

## Related Issues
Fixes #24896

