### PR TITLE
fix(gatsby-source-filesystem): Removes erroneously added retries option

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -58,7 +58,6 @@ let totalJobs = 0
 const STALL_RETRY_LIMIT = 3
 const STALL_TIMEOUT = 30000
 
-const CONNECTION_RETRY_LIMIT = 5
 const CONNECTION_TIMEOUT = 30000
 
 /********************
@@ -152,8 +151,9 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
     }
     const responseStream = got.stream(url, {
       headers,
-      timeout: CONNECTION_TIMEOUT,
-      retries: CONNECTION_RETRY_LIMIT,
+      timeout: {
+        send: CONNECTION_TIMEOUT, // https://github.com/sindresorhus/got#timeout
+      },
       ...httpOpts,
     })
     const fsWriteStream = fs.createWriteStream(tmpFilename)


### PR DESCRIPTION
Specifies remote timeout to start after the connection has been made

## Description

gatsby-source-filesystem's remote file node will occasionally throw a [got.TimeoutError](https://github.com/sindresorhus/got#gottimeouterror) if the TCP socket was queued. The solution was to target the specific `send` timeout which starts when the socket is connected and ends with the request has been written to the socket. This keeps with what I assume is the intended purpose of the timeout while hopefully throwing the error simply because the TCP connection was queued.

This also removes the retries option from the got request since the [docs](https://github.com/sindresorhus/got#retry) note streams ignore this option due to the errors that would cause a retry would need to be handled correctly to avoid duplicates (which they are). Note: The got.TimeoutError is a separate timeout and wouldn't be triggered here. 

### Documentation

https://github.com/sindresorhus/got#gottimeouterro
https://github.com/sindresorhus/got#retry

## Related Issues
Fixes #22010 
Fixes the got part of #23123 