### PR TITLE
fix(gatsby): Add null context check

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -192,7 +192,7 @@ actions.createPage = (
 
   // Validate that the context object doesn't overlap with any core page fields
   // as this will cause trouble when running graphql queries.
-  if (typeof page.context === `object`) {
+  if (page.context && typeof page.context === `object`) {
     const invalidFields = reservedFields.filter(field => field in page.context)
 
     if (invalidFields.length > 0) {


### PR DESCRIPTION
Because `typeof null === "object"` this would throw if page context was null. This adds a truthiness check. This is enough, because context can only be JSON-safe types.

Fixes #24884 