### PR TITLE
fix(gatsby): allow amending autoprefixer options

### DIFF
--- a/packages/gatsby/src/utils/__tests__/webpack-utils.ts
+++ b/packages/gatsby/src/utils/__tests__/webpack-utils.ts
@@ -185,8 +185,6 @@ describe(`webpack utils`, () => {
         postcss = config.loaders.postcss()
       })
       it(`initialises autoprefixer with defaults`, () => {
-        expect(postcss).toHaveProperty(`options`)
-        expect(postcss.options).toHaveProperty(`plugins`)
         postcss.options.plugins(postcss.loader)
         expect(autoprefixer).toBeCalled()
         expect(autoprefixer).toBeCalledWith({
@@ -208,8 +206,6 @@ describe(`webpack utils`, () => {
         })
       })
       it(`initialises autoprefixer with overrides`, () => {
-        expect(postcss).toHaveProperty(`options`)
-        expect(postcss.options).toHaveProperty(`plugins`)
         postcss.options.plugins(postcss.loader)
         expect(autoprefixer).toBeCalled()
         expect(autoprefixer).toBeCalledWith({

--- a/packages/gatsby/src/utils/__tests__/webpack-utils.ts
+++ b/packages/gatsby/src/utils/__tests__/webpack-utils.ts
@@ -1,6 +1,8 @@
 import { createWebpackUtils } from "../webpack-utils"
 import { Stage, IProgram } from "../../commands/types"
 
+import autoprefixer from "autoprefixer"
+
 jest.mock(`../browserslist`, () => {
   return {
     getBrowsersList: (): string[] => [],
@@ -12,6 +14,15 @@ jest.mock(`babel-preset-gatsby/package.json`, () => {
     version: `1.0.0`,
   }
 })
+
+jest.mock(`autoprefixer`, () =>
+  jest.fn(options => {
+    return {
+      options,
+      postcssPlugin: `autoprefixer`,
+    }
+  })
+)
 
 let config
 
@@ -161,6 +172,51 @@ describe(`webpack utils`, () => {
             `/Users/sidharthachatterjee/Code/gatsby-seo-test/gatsby-browser.js`
           )
         ).toEqual(true)
+      })
+    })
+  })
+  describe(`postcss`, () => {
+    it(`adds postcss rule`, () => {
+      expect(config.loaders.postcss).toEqual(expect.any(Function))
+    })
+    describe(`uses defaults when no options are passed`, () => {
+      let postcss
+      beforeAll(() => {
+        postcss = config.loaders.postcss()
+      })
+      it(`initialises autoprefixer with defaults`, () => {
+        expect(postcss).toHaveProperty(`options`)
+        expect(postcss.options).toHaveProperty(`plugins`)
+        postcss.options.plugins(postcss.loader)
+        expect(autoprefixer).toBeCalled()
+        expect(autoprefixer).toBeCalledWith({
+          flexbox: `no-2009`,
+          overrideBrowserslist: [],
+        })
+      })
+    })
+    describe(`uses override options when they are passed`, () => {
+      let postcss
+      beforeAll(() => {
+        jest.clearAllMocks()
+        postcss = config.loaders.postcss({
+          plugins: [
+            autoprefixer({
+              grid: `no-autoplace`,
+            }),
+          ],
+        })
+      })
+      it(`initialises autoprefixer with overrides`, () => {
+        expect(postcss).toHaveProperty(`options`)
+        expect(postcss.options).toHaveProperty(`plugins`)
+        postcss.options.plugins(postcss.loader)
+        expect(autoprefixer).toBeCalled()
+        expect(autoprefixer).toBeCalledWith({
+          flexbox: `no-2009`,
+          grid: `no-autoplace`,
+          overrideBrowserslist: [],
+        })
       })
     })
   })

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -223,24 +223,18 @@ export const createWebpackUtils = (
           ident: `postcss-${++ident}`,
           sourceMap: !PRODUCTION,
           plugins: (loader: Loader): postcss.Plugin<any>[] => {
-            const autoprefixerOptions = {
-              overrideBrowserslist,
-              flexbox: `no-2009`,
-            }
             plugins =
               (typeof plugins === `function` ? plugins(loader) : plugins) || []
 
-            if (plugins && plugins.length) {
-              const autoprefixerOverride: autoprefixer.Autoprefixer = plugins.find(
+            const autoprefixerPlugin = autoprefixer({
+              overrideBrowserslist,
+              flexbox: `no-2009`,
+              ...((plugins.find(
                 plugin => plugin.postcssPlugin === `autoprefixer`
-              )
-              Object.assign(
-                autoprefixerOptions,
-                autoprefixerOverride.options || {}
-              )
-            }
+              ) as autoprefixer.Autoprefixer)?.options ?? {}),
+            })
 
-            return [flexbugs, autoprefixer(autoprefixerOptions), ...plugins]
+            return [flexbugs, autoprefixerPlugin, ...plugins]
           },
           ...postcssOpts,
         },


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
 - Changed types for PostCSS plugins from webpack `Plugin` type to PostCSS
   `Plugin<T>` type.
 - Added a check of each plugin's `postcssPlugin` property; a plugin
   with a `postcssPlugin` property equal to `autoprefixer` will have its
   options assigned to the default.

### Documentation
Hopefully this is just a fix and should not change the public interface. There are however references to it here https://www.gatsbyjs.org/docs/post-css/#postcss-plugins and here https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass#postcss-plugins
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
Addresses #15509, #17428, #11984
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
