### PR TITLE
chore(docs): 🔒 Fix missing HTTPS on github.io links

### DIFF
--- a/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
+++ b/docs/blog/2017-11-06-migrate-hugo-gatsby/index.md
@@ -21,7 +21,7 @@ and reusable.
 - Content migration
 - Programmatic page creation in Gatsby
 - Manage styles with
-  [`Typography.js`](http://kyleamathews.github.io/typography.js/)
+  [`Typography.js`](https://kyleamathews.github.io/typography.js/)
 - Automatic pagination
 - Tag pages
 - Add an admin panel with [NetlifyCMS](https://www.netlifycms.org/)
@@ -165,7 +165,7 @@ Now that the system displays the content, it's time to style it. I decided to go
 for the
 [`typography.js` route](/tutorial/part-two/#typographyjs).
 The approach is well documented and you can also see
-[previews of the themes online](http://kyleamathews.github.io/typography.js/).
+[previews of the themes online](https://kyleamathews.github.io/typography.js/).
 
 Steps were:
 

--- a/docs/blog/2018-05-24-launching-new-gatsby-company/index.md
+++ b/docs/blog/2018-05-24-launching-new-gatsby-company/index.md
@@ -55,7 +55,7 @@ I was hooked on being able to ship production code so quickly. Life was good.
 
 Then in 2013, React.js was released.
 
-I first heard about React from [David Nolen’s blog post introducing his ClojureScript wrapper of React Om](http://swannodette.github.io/2013/12/17/the-future-of-javascript-mvcs). I was completely fascinated by his analysis; his identification of DOM manipulation code as a major contributor to application complexity and slowdowns resonated with me. I started reading everything I could find on React and soon became a huge fan.
+I first heard about React from [David Nolen’s blog post introducing his ClojureScript wrapper of React Om](https://swannodette.github.io/2013/12/17/the-future-of-javascript-mvcs). I was completely fascinated by his analysis; his identification of DOM manipulation code as a major contributor to application complexity and slowdowns resonated with me. I started reading everything I could find on React and soon became a huge fan.
 
 Early in 2014, I left Pantheon to explore new opportunities. I dove deeper into React and built a number of sample applications and was astounded at how productive I was. Problems that used to take me weeks to solve in Backbone.js took me hours in React.js. Not only was I productive; my code felt remarkably simple. With Backbone.js, I always felt I was one or two slip-ups from the whole application spiraling out of control. With React, elegant and simple solutions seemed to come naturally from using the library. Again, I could feel things in web land were changing in a very big way.
 

--- a/docs/blog/2018-10-26-export-a-drupal-site-to-gatsby/index.md
+++ b/docs/blog/2018-10-26-export-a-drupal-site-to-gatsby/index.md
@@ -126,7 +126,7 @@ To have comments on your site you can use a service like [Disqus](https://disqus
 ```javascript
 const Database = require("better-sqlite3")
 const fs = require("fs")
-const yourSite = "http://username.github.io/yoursite/"
+const yourSite = "https://username.github.io/yoursite/"
 
 if (process.argv.length < 3) {
   usage()

--- a/docs/docs/ab-testing-with-google-analytics-and-netlify.md
+++ b/docs/docs/ab-testing-with-google-analytics-and-netlify.md
@@ -6,7 +6,7 @@ Learn how to create an A/B test (otherwise known as a split test) with Google An
 
 ## Creating an A/B test with Netlify
 
-An A/B test compares changes on a web page. If you are creating an A/B test with Netlify, you can [use multiple Git branches containing variations of your site](https://docs.netlify.com/site-deploys/split-testing/#run-a-branch-based-test). If you are not familiar with Git branches, visit the [Git Guide](http://rogerdudler.github.io/git-guide/), which explains Git in detail.
+An A/B test compares changes on a web page. If you are creating an A/B test with Netlify, you can [use multiple Git branches containing variations of your site](https://docs.netlify.com/site-deploys/split-testing/#run-a-branch-based-test). If you are not familiar with Git branches, visit the [Git Guide](https://rogerdudler.github.io/git-guide/), which explains Git in detail.
 
 Let’s say you read on Twitter that users spend more time on webpages with blue headers. You have a hunch that this might be correct, but you want some data to verify this claim.
 

--- a/docs/docs/localization-i18n.md
+++ b/docs/docs/localization-i18n.md
@@ -50,4 +50,4 @@ This framework also has experimental support for the React suspense API and it s
 
 - [Gatsby i18n articles](https://www.gatsbyjs.org/blog/tags/i-18-n/)
 
-- [W3C's i18n resources](http://w3c.github.io/i18n-drafts/getting-started/contentdev.en#reference)
+- [W3C's i18n resources](https://w3c.github.io/i18n-drafts/getting-started/contentdev.en#reference)

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1281,7 +1281,7 @@
     - Features a custom, accessible lightbox with gatsby-image
     - Styled with styled-components using CSS Grid
     - React Helmet for SEO
-- url: http://jackbravo.github.io/gatsby-starter-i18n-blog/
+- url: https://jackbravo.github.io/gatsby-starter-i18n-blog/
   repo: https://github.com/jackbravo/gatsby-starter-i18n-blog
   description: Same as official gatsby-starter-blog but with i18n support
   tags:

--- a/examples/styleguide/src/templates/ComponentPage/components/ComponentPreview/prism-theme.css
+++ b/examples/styleguide/src/templates/ComponentPage/components/ComponentPreview/prism-theme.css
@@ -1,9 +1,9 @@
 /*
 
 Name:       Base16 Atelier Sulphurpool Light
-Author:     Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool)
+Author:     Bram de Haan (https://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool)
 
-Prism template by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/prism/)
+Prism template by Bram de Haan (https://atelierbram.github.io/syntax-highlighting/prism/)
 Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
 
 */

--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -239,7 +239,7 @@ If you see a page on your site, rather than the JSON output, check if your perma
 
 ## Fetching Data: WordPress REST API Route Selection
 
-By default `gatsby-source-wordpress` plugin will fetch data from all endpoints provided by introspection `/wp-json` response. To customize the routes fetched, two configuration options are available: `includeRoutes` for whitelisting and `excludeRoutes` for blacklisting. Both options expect an array of glob patterns. Glob matching is done by [minimatch](https://github.com/isaacs/minimatch). To test your glob patterns, [use this tool](http://pthrasher.github.io/minimatch-test/). You can inspect discovered routes by using `verboseOutput: true` configuration option.
+By default `gatsby-source-wordpress` plugin will fetch data from all endpoints provided by introspection `/wp-json` response. To customize the routes fetched, two configuration options are available: `includeRoutes` for whitelisting and `excludeRoutes` for blacklisting. Both options expect an array of glob patterns. Glob matching is done by [minimatch](https://github.com/isaacs/minimatch). To test your glob patterns, [use this tool](https://pthrasher.github.io/minimatch-test/). You can inspect discovered routes by using `verboseOutput: true` configuration option.
 
 If an endpoint is whitelisted and not blacklisted, it will be fetched. Otherwise, it will be ignored.
 

--- a/packages/gatsby-transformer-toml/README.md
+++ b/packages/gatsby-transformer-toml/README.md
@@ -21,7 +21,7 @@ issues.
 
 Live demo of TOML to JSON conversion using
 [toml](https://www.npmjs.com/package/toml) is
-[here](http://binarymuse.github.io/toml-node/).
+[here](https://binarymuse.github.io/toml-node/).
 
 If you have `user.toml` in your project, with contents like this:
 


### PR DESCRIPTION

## Description

By default `github.io` subdomains are served over `HTTPS`

