### PR TITLE
chore(eslint-config): change eslint to better match strict ruleset

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -24,7 +24,7 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
           },
         ],
         "react/jsx-pascal-case": `off`, // Prevents errors with Theme-UI and Styled component
-        // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
+        // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/master/docs/rules
         "jsx-a11y/accessible-emoji": `warn`,
         "jsx-a11y/alt-text": `warn`,
         "jsx-a11y/anchor-has-content": `warn`,
@@ -34,20 +34,56 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
         "jsx-a11y/aria-proptypes": `warn`,
         "jsx-a11y/aria-role": `warn`,
         "jsx-a11y/aria-unsupported-elements": `warn`,
-        // TODO: It looks like the `autocomplete-valid` rule hasn't been published yet
-        // "jsx-a11y/autocomplete-valid": [
-        //   "warn",
-        //   {
-        //     inputComponents: [],
-        //   },
-        // ],
+        "jsx-a11y/autocomplete-valid": `warn`,
         "jsx-a11y/click-events-have-key-events": `warn`,
-        "jsx-a11y/control-has-associated-label": `warn`,
+        "jsx-a11y/control-has-associated-label": [
+          `warn`,
+          {
+            ignoreElements: [
+              `audio`,
+              `canvas`,
+              `embed`,
+              `input`,
+              `textarea`,
+              `tr`,
+              `video`,
+            ],
+            ignoreRoles: [
+              `grid`,
+              `listbox`,
+              `menu`,
+              `menubar`,
+              `radiogroup`,
+              `row`,
+              `tablist`,
+              `toolbar`,
+              `tree`,
+              `treegrid`,
+            ],
+            includeRoles: [`alert`, `dialog`],
+          },
+        ],
         "jsx-a11y/heading-has-content": `warn`,
         "jsx-a11y/html-has-lang": `warn`,
         "jsx-a11y/iframe-has-title": `warn`,
         "jsx-a11y/img-redundant-alt": `warn`,
-        "jsx-a11y/interactive-supports-focus": `warn`,
+        "jsx-a11y/interactive-supports-focus": [
+          `warn`,
+          {
+            tabbable: [
+              `button`,
+              `checkbox`,
+              `link`,
+              `progressbar`,
+              `searchbox`,
+              `slider`,
+              `spinbutton`,
+              `switch`,
+              `textbox`,
+            ],
+          },
+        ],
+        "jsx-a11y/label-has-for": `warn`,
         "jsx-a11y/label-has-associated-control": `warn`,
         "jsx-a11y/lang": `warn`,
         "jsx-a11y/media-has-caption": `warn`,
@@ -56,7 +92,14 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
         "jsx-a11y/no-autofocus": `warn`,
         "jsx-a11y/no-distracting-elements": `warn`,
         "jsx-a11y/no-interactive-element-to-noninteractive-role": `warn`,
-        "jsx-a11y/no-noninteractive-element-interactions": `warn`,
+        "jsx-a11y/no-noninteractive-element-interactions": [
+          `warn`,
+          {
+            body: [`onError`, `onLoad`],
+            iframe: [`onError`, `onLoad`],
+            img: [`onError`, `onLoad`],
+          },
+        ],
         "jsx-a11y/no-noninteractive-element-to-interactive-role": `warn`,
         "jsx-a11y/no-noninteractive-tabindex": `warn`,
         "jsx-a11y/no-onchange": `warn`,

--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -34,7 +34,13 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
         "jsx-a11y/aria-proptypes": `warn`,
         "jsx-a11y/aria-role": `warn`,
         "jsx-a11y/aria-unsupported-elements": `warn`,
-        "jsx-a11y/autocomplete-valid": `warn`,
+        // TODO: It looks like the `autocomplete-valid` rule hasn't been published yet
+        // "jsx-a11y/autocomplete-valid": [
+        //   "warn",
+        //   {
+        //     inputComponents: [],
+        //   },
+        // ],
         "jsx-a11y/click-events-have-key-events": `warn`,
         "jsx-a11y/control-has-associated-label": [
           `warn`,


### PR DESCRIPTION
Refine a11y linting rules so that some trigger alerts or dialogs instead of warnings.

Fixes #24582 