### PR TITLE
update documentation for PageProps type definition

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -48,7 +48,7 @@ export const prefetchPathname: (path: string) => void
  * type LocaleLookUpInfo = { translationStrings: any } & { langKey: string, slug: string }
  * type IndexPageProps = PageProps<IndexQueryProps, LocaleLookUpInfo>
  *
- * export default (props: IndexProps) => {
+ * export default (props: IndexPageProps) => {
  *   ..
  */
 export type PageProps<
@@ -94,7 +94,7 @@ export type PageProps<
    * type IndexQueryProps = { downloadCount: number }
    * type IndexPageProps = PageProps<IndexQueryProps>
    *
-   * export default (props: IndexProps) => {
+   * export default (props: IndexPageProps) => {
    *   ..
    *
    */
@@ -111,7 +111,7 @@ export type PageProps<
    * type LocaleLookUpInfo = { translationStrings: any } & { langKey: string, slug: string }
    * type IndexPageProps = PageProps<IndexQueryProps, LocaleLookUpInfo>
    *
-   * export default (props: IndexProps) => {
+   * export default (props: IndexPageProps) => {
    *   ..
    */
   pageContext: PageContextType

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -46,7 +46,7 @@ export const prefetchPathname: (path: string) => void
  *
  * type IndexQueryProps = { downloadCount: number }
  * type LocaleLookUpInfo = { translationStrings: any } & { langKey: string, slug: string }
- * type IndexPageProps = PageProps<IndexPageProps, LocaleLookUpInfo>
+ * type IndexPageProps = PageProps<IndexQueryProps, LocaleLookUpInfo>
  *
  * export default (props: IndexProps) => {
  *   ..
@@ -92,7 +92,7 @@ export type PageProps<
    * import {PageProps} from "gatsby"
    *
    * type IndexQueryProps = { downloadCount: number }
-   * type IndexPageProps = PageProps<IndexPageProps>
+   * type IndexPageProps = PageProps<IndexQueryProps>
    *
    * export default (props: IndexProps) => {
    *   ..
@@ -109,7 +109,7 @@ export type PageProps<
    *
    * type IndexQueryProps = { downloadCount: number }
    * type LocaleLookUpInfo = { translationStrings: any } & { langKey: string, slug: string }
-   * type IndexPageProps = PageProps<IndexPageProps, LocaleLookUpInfo>
+   * type IndexPageProps = PageProps<IndexQueryProps, LocaleLookUpInfo>
    *
    * export default (props: IndexProps) => {
    *   ..


### PR DESCRIPTION
## Description

Typo in the usage documentation for the PageProps generic type. There is currently a circular reference of IndexPageProps. This PR updates the first generic type argument in the example to be the DataProps, as reflected in the [default starter](https://github.com/gatsbyjs/gatsby-starter-default/blob/f91dd295d9df896d1c5521a2886567f2dae93b40/src/pages/using-typescript.tsx#L14).

