### PR TITLE
chore(www): convert the overview component to theme-ui

### DIFF
--- a/www/src/components/guidelines/avatar.js
+++ b/www/src/components/guidelines/avatar.js
@@ -1,16 +1,21 @@
-import styled from "@emotion/styled"
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import { Box } from "theme-ui"
 
-import { Box } from "./system"
-
-const Avatar = styled(Box)()
-
-Avatar.defaultProps = {
-  bg: `grey.10`,
-  borderRadius: 6,
-  flex: `0 0 auto`,
-  height: `avatar`,
-  lineHeight: `solid`,
-  width: `avatar`,
-}
+const Avatar = ({ children, ...rest }) => (
+  <Box
+    sx={{
+      bg: `grey.10`,
+      borderRadius: 6,
+      flex: `0 0 auto`,
+      height: `avatar`,
+      lineHeight: `solid`,
+      width: `avatar`,
+      ...rest,
+    }}
+  >
+    {children}
+  </Box>
+)
 
 export default Avatar

--- a/www/src/components/guidelines/avatar.js
+++ b/www/src/components/guidelines/avatar.js
@@ -1,21 +1,16 @@
-/** @jsx jsx */
-import { jsx } from "theme-ui"
-import { Box } from "theme-ui"
+import styled from "@emotion/styled"
 
-const Avatar = ({ children, ...rest }) => (
-  <Box
-    sx={{
-      bg: `grey.10`,
-      borderRadius: 6,
-      flex: `0 0 auto`,
-      height: `avatar`,
-      lineHeight: `solid`,
-      width: `avatar`,
-      ...rest,
-    }}
-  >
-    {children}
-  </Box>
-)
+import { Box } from "./system"
+
+const Avatar = styled(Box)()
+
+Avatar.defaultProps = {
+  bg: `grey.10`,
+  borderRadius: 6,
+  flex: `0 0 auto`,
+  height: `avatar`,
+  lineHeight: `solid`,
+  width: `avatar`,
+}
 
 export default Avatar

--- a/www/src/components/guidelines/color/overview.js
+++ b/www/src/components/guidelines/color/overview.js
@@ -68,11 +68,10 @@ const Palette = ({ color, handler }) => {
       sx={{
         display: `flex`,
         flexDirection: `column`,
-        mb: 4,
+        mb: [4, null, null, 0],
         [mediaQueries.lg]: {
           flexDirection: `row`,
           alignItems: `center`,
-          mb: 0,
         },
       }}
     >

--- a/www/src/components/guidelines/color/overview.js
+++ b/www/src/components/guidelines/color/overview.js
@@ -10,7 +10,7 @@ import Swatch from "./swatch"
 import { getA11yLabel, getTextColor } from "../../../utils/guidelines/color"
 import { copyColumnGutter, CopyColumn } from "../containers"
 import palette from "../../../utils/guidelines/extend-palette-info"
-import { Box, Flex } from "../system"
+import { Box, Flex } from "theme-ui"
 
 // Color swatches
 const swatchWidth = 40
@@ -87,13 +87,11 @@ const Palette = ({ color, handler }) => {
       >
         <Box
           as="button"
-          bg="none"
-          p={0}
-          onClick={e => {
-            handler(e, node)
-          }}
+          onClick={e => handler(e, node)}
           sx={{
+            p: 0,
             background: `transparent`,
+            bg: `none`,
             border: 0,
             cursor: `pointer`,
             WebkitAppearance: `none`,
@@ -120,11 +118,25 @@ const Palette = ({ color, handler }) => {
           </SectionSubheading>
         </Box>
       </Box>
-      <Flex flexWrap="wrap">
-        <Flex flexDirection="row" alignItems="stretch">
+      <Flex
+        sx={{
+          flexWrap: `wrap`,
+        }}
+      >
+        <Flex
+          sx={{
+            flexDirection: `row`,
+            alignItems: `stretch`,
+          }}
+        >
           {range.range(0, 5).map(i => colores(node)[i])}
         </Flex>
-        <Flex flexDirection="row" alignItems="stretch">
+        <Flex
+          sx={{
+            flexDirection: `row`,
+            alignItems: `stretch`,
+          }}
+        >
           {range.range(5, 10).map(i => colores(node)[i])}
         </Flex>
       </Flex>


### PR DESCRIPTION
## Description

Convert the `<Overview/>` component used in guidelines/color page, to theme-ui.

**There is not change functionality wise, just the implementation is different.**

### How to test

**Local URL:**  http://localhost:8000/guidelines/color/
**Production URL:** https://www.gatsbyjs.org/guidelines/color/