### PR TITLE
docs(gatsby-transformer-remark): Removed superfluous "an" from README

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -178,7 +178,7 @@ By default, Gatsby will return excerpts as plain text. This might be useful for 
 }
 ```
 
-It's also possible to ask Gatsby to return excerpts formatted as HTML. You might use this if you have a blog post whose an excerpt contains markdown content--e.g. header, link, etc.--and you want these links to render as HTML.
+It's also possible to ask Gatsby to return excerpts formatted as HTML. You might use this if you have a blog post whose excerpt contains markdown content--e.g. header, link, etc.--and you want these links to render as HTML.
 
 ```graphql
 {


### PR DESCRIPTION
Line 181 of gatsby-transformer-remark's README.md, read "You might use this if you have a blog post whose **an** excerpt contains markdown content." I removed "an".