### PR TITLE
docs: gatsby-plugin-offline mentions Workbox

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -1,8 +1,8 @@
 # gatsby-plugin-offline
 
 Adds drop-in support for making a Gatsby site work offline and more resistant to
-bad network connections. It creates a service worker for the site and loads the
-service worker into the client.
+bad network connections. It uses [Workbox Build](https://developers.google.com/web/tools/workbox/modules/workbox-build)
+to create a service worker for the site and loads the service worker into the client.
 
 If you're using this plugin with `gatsby-plugin-manifest` (recommended) this
 plugin should be listed _after_ that plugin so the manifest file can be included


### PR DESCRIPTION
Clarify in `gatsby-plugin-offline` README how the service worker is generated, and that it uses the Workbox library.