### PR TITLE
fix(gatsby-transformer-screenshot): Add explicit source typing for gatsby-transformer-screenshot

### DIFF
--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -76,6 +76,14 @@ exports.onPreBootstrap = (
   })
 }
 
+exports.sourceNodes = ({ actions: { createTypes } }) => {
+  createTypes(/* GraphQL */ `
+    type Screenshot implements Node @dontInfer {
+      screenshotFile: File!
+    }
+  `)
+}
+
 exports.onCreateNode = async (
   { node, actions, store, cache, createNodeId, createContentDigest, getCache },
   pluginOptions

--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -76,12 +76,31 @@ exports.onPreBootstrap = (
   })
 }
 
-exports.sourceNodes = ({ actions: { createTypes } }) => {
-  createTypes(/* GraphQL */ `
-    type Screenshot implements Node @dontInfer {
-      screenshotFile: File!
-    }
-  `)
+exports.schemaCustomization = (
+  { actions: { createTypes }, schema },
+  pluginOptions
+) => {
+  const validNodeTypes = [`SitesYaml`].concat(pluginOptions.nodeTypes || [])
+
+  createTypes(
+    schema.buildObjectType({
+      name: `Screenshot`,
+      fields: {
+        screenshotFile: {
+          type: `File`,
+          extensions: {
+            link: {},
+          },
+        },
+      },
+      interfaces: [`Node`],
+      extensions: {
+        childOf: {
+          types: validNodeTypes,
+        },
+      },
+    })
+  )
 }
 
 exports.onCreateNode = async (

--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -76,7 +76,7 @@ exports.onPreBootstrap = (
   })
 }
 
-exports.schemaCustomization = (
+exports.createSchemaCustomization = (
   { actions: { createTypes }, schema },
   pluginOptions
 ) => {


### PR DESCRIPTION
## Description

Add explicit GraphQL typing to `gatsby-transformer-screenshot` so that queries still work when no screenshots are defined.

## Related

#24913 