### PR TITLE
feat(gatsby): allow serving of dotfiles from public folder

### DIFF
--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -106,7 +106,7 @@ module.exports = async (program: IServeProgram): Promise<void> => {
   app.use(telemetry.expressMiddleware(`SERVE`))
 
   router.use(compression())
-  router.use(express.static(`public`, { dotfiles : 'allow' }))
+  router.use(express.static(`public`, { dotfiles: `allow` }))
   const matchPaths = await readMatchPaths(program)
   router.use(matchPathRouter(matchPaths, { root }))
   router.use((req, res, next) => {

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -106,7 +106,7 @@ module.exports = async (program: IServeProgram): Promise<void> => {
   app.use(telemetry.expressMiddleware(`SERVE`))
 
   router.use(compression())
-  router.use(express.static(`public`))
+  router.use(express.static(`public`, { dotfiles : 'allow' }))
   const matchPaths = await readMatchPaths(program)
   router.use(matchPathRouter(matchPaths, { root }))
   router.use((req, res, next) => {


### PR DESCRIPTION
Currently if we generate a page which name starts with a dot `.` it will not be served correctly by `gatsby serve`. The actual behavior is even stranger because the server returns the `404` page, but then the client side rendering picks it up and actually re-renders the page.

This change fixes this behavior by allowing the serving of `dotfiles` from the static `public` directory.