### PR TITLE
refactor(www): convert sticky-responsive-sidebar to function component

### DIFF
--- a/www/src/components/sidebar/sticky-responsive-sidebar.js
+++ b/www/src/components/sidebar/sticky-responsive-sidebar.js
@@ -1,145 +1,121 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { Component, Fragment } from "react"
+import { useState, Fragment } from "react"
 
 import Sidebar from "./sidebar"
 import ScrollSyncSidebar from "./scroll-sync-sidebar"
 import ChevronSvg from "./chevron-svg"
 import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
-class StickyResponsiveSidebar extends Component {
-  constructor(props) {
-    super(props)
+export default function StickyResponsiveSidebar(props) {
+  const [isOpen, setIsOpen] = useState(false)
 
-    this.state = { open: false }
-  }
+  const { enableScrollSync } = props
+  const SidebarComponent = enableScrollSync ? ScrollSyncSidebar : Sidebar
+  const iconOffset = isOpen ? 5 : -5
+  const menuOpacity = isOpen ? 1 : 0
 
-  _openSidebar = () => {
-    this.setState({ open: !this.state.open })
-  }
-
-  _closeSidebar = () => {
-    this.setState({ open: false })
-  }
-
-  render() {
-    const { open } = this.state
-    const { enableScrollSync } = this.props
-    const SidebarComponent = enableScrollSync ? ScrollSyncSidebar : Sidebar
-
-    const iconOffset = open ? 5 : -5
-    const menuOpacity = open ? 1 : 0
-
-    return (
-      <Fragment>
+  return (
+    <Fragment>
+      <div
+        sx={{
+          border: 0,
+          bottom: 0,
+          display: `block`,
+          height: `100vh`,
+          position: `fixed`,
+          top: 0,
+          transition: t =>
+            `opacity ${t.transition.speed.default} ${t.transition.curve.default}`,
+          width: `sidebarWidth.mobile`,
+          zIndex: `sidebar`,
+          [mediaQueries.md]: {
+            height: t =>
+              `calc(100vh - ${t.sizes.headerHeight} - ${t.sizes.bannerHeight})`,
+            maxWidth: `none`,
+            opacity: `1 !important`,
+            pointerEvents: `auto`,
+            top: t => `calc(${t.sizes.headerHeight} + ${t.sizes.bannerHeight})`,
+            width: `sidebarWidth.default`,
+          },
+          [mediaQueries.lg]: {
+            width: `sidebarWidth.large`,
+          },
+          opacity: menuOpacity,
+          pointerEvents: isOpen ? `auto` : `none`,
+        }}
+      >
         <div
           sx={{
-            border: 0,
-            bottom: 0,
-            display: `block`,
-            height: `100vh`,
-            position: `fixed`,
-            top: 0,
+            boxShadow: `dialog`,
+            height: `100%`,
+            transform: isOpen
+              ? `translateX(0)`
+              : t => `translateX(-${t.sizes.sidebarWidth.mobile})`,
             transition: t =>
-              `opacity ${t.transition.speed.default} ${t.transition.curve.default}`,
-            width: `sidebarWidth.mobile`,
-            zIndex: `sidebar`,
+              `transform ${t.transition.speed.default} ${t.transition.curve.default}`,
             [mediaQueries.md]: {
-              height: t =>
-                `calc(100vh - ${t.sizes.headerHeight} - ${t.sizes.bannerHeight})`,
-              maxWidth: `none`,
-              opacity: `1 !important`,
-              pointerEvents: `auto`,
-              top: t =>
-                `calc(${t.sizes.headerHeight} + ${t.sizes.bannerHeight})`,
-              width: `sidebarWidth.default`,
+              boxShadow: `none`,
+              transform: `none !important`,
             },
-            [mediaQueries.lg]: {
-              width: `sidebarWidth.large`,
-            },
-            opacity: menuOpacity,
-            pointerEvents: open ? `auto` : `none`,
           }}
         >
-          <div
-            sx={{
-              boxShadow: `dialog`,
-              height: `100%`,
-              transform: open
-                ? `translateX(0)`
-                : t => `translateX(-${t.sizes.sidebarWidth.mobile})`,
+          <SidebarComponent closeSidebar={() => setIsOpen(false)} {...props} />
+        </div>
+      </div>
+      <div
+        sx={{
+          backgroundColor: `gatsby`,
+          borderRadius: `50%`,
+          bottom: t => t.space[11],
+          boxShadow: `dialog`,
+          cursor: `pointer`,
+          display: `flex`,
+          height: t => t.space[10],
+          justifyContent: `space-around`,
+          position: `fixed`,
+          right: t => t.space[6],
+          visibility: `visible`,
+          width: t => t.space[10],
+          zIndex: `floatingActionButton`,
+          [mediaQueries.md]: { display: `none` },
+        }}
+        onClick={() => setIsOpen(isOpen => !isOpen)}
+        role="button"
+        aria-label="Show Secondary Navigation"
+        aria-controls="SecondaryNavigation"
+        aria-expanded={isOpen ? `true` : `false`}
+        tabIndex={0}
+      >
+        <div
+          sx={{
+            alignSelf: `center`,
+            color: `white`,
+            display: `flex`,
+            flexDirection: `column`,
+            height: t => t.space[5],
+            visibility: `visible`,
+            width: t => t.space[5],
+          }}
+        >
+          <ChevronSvg
+            size={16}
+            cssProps={{
+              transform: `translate(${iconOffset}px, 5px) rotate(90deg)`,
               transition: t =>
                 `transform ${t.transition.speed.default} ${t.transition.curve.default}`,
-              [mediaQueries.md]: {
-                boxShadow: `none`,
-                transform: `none !important`,
-              },
             }}
-          >
-            <SidebarComponent
-              closeSidebar={this._closeSidebar}
-              {...this.props}
-            />
-          </div>
-        </div>
-        <div
-          sx={{
-            backgroundColor: `gatsby`,
-            borderRadius: `50%`,
-            bottom: t => t.space[11],
-            boxShadow: `dialog`,
-            cursor: `pointer`,
-            display: `flex`,
-            height: t => t.space[10],
-            justifyContent: `space-around`,
-            position: `fixed`,
-            right: t => t.space[6],
-            visibility: `visible`,
-            width: t => t.space[10],
-            zIndex: `floatingActionButton`,
-            [mediaQueries.md]: { display: `none` },
-          }}
-          onClick={this._openSidebar}
-          role="button"
-          aria-label="Show Secondary Navigation"
-          aria-controls="SecondaryNavigation"
-          aria-expanded={open ? `true` : `false`}
-          tabIndex={0}
-        >
-          <div
-            sx={{
-              alignSelf: `center`,
-              color: `white`,
-              display: `flex`,
-              flexDirection: `column`,
-              height: t => t.space[5],
-              visibility: `visible`,
-              width: t => t.space[5],
+          />
+          <ChevronSvg
+            size={16}
+            cssProps={{
+              transform: `translate(${5 - iconOffset}px, -5px) rotate(270deg)`,
+              transition: t =>
+                `transform ${t.transition.speed.default} ${t.transition.curve.default}`,
             }}
-          >
-            <ChevronSvg
-              size={16}
-              cssProps={{
-                transform: `translate(${iconOffset}px, 5px) rotate(90deg)`,
-                transition: t =>
-                  `transform ${t.transition.speed.default} ${t.transition.curve.default}`,
-              }}
-            />
-            <ChevronSvg
-              size={16}
-              cssProps={{
-                transform: `translate(${
-                  5 - iconOffset
-                }px, -5px) rotate(270deg)`,
-                transition: t =>
-                  `transform ${t.transition.speed.default} ${t.transition.curve.default}`,
-              }}
-            />
-          </div>
+          />
         </div>
-      </Fragment>
-    )
-  }
+      </div>
+    </Fragment>
+  )
 }
-
-export default StickyResponsiveSidebar


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
1. The class based `<StickyResponsiveSidebar/>` has been converted to function component.
2. It was using state called `open` to toggle the opening and closing behaviour of the sidebar, now this state is being managed by useState hook. Also, name of `open` has been changed to `isOpen` because it contains boolean value.
3. Functional updates have been used to toggle the state `isOpen`.  
```onClick={() => setOpen(open => !open)}```

### Screenshots(s) _iPhone(X)_

#### Sidebar in closed state and floating button appearing on bottom right
![sidebar-closed](https://user-images.githubusercontent.com/19193724/84530389-b5355d00-ad00-11ea-953b-59abd3092826.png)

#### Sidebar in open state
![sidebar-open](https://user-images.githubusercontent.com/19193724/84530391-b6ff2080-ad00-11ea-9930-1dd409b88695.png)

### How to test

The `<StickyResponsiveSidebar/>` component is used in `<PageWithSidebar/>` component

1. Go to https://www.gatsbyjs.org/docs/ page.
2. Open this page in responsive device.
3. Click on the floating button on the bottom right of screen.
4. A sidebar will open up from the left side of the device.
5. Clicking again on the floating button will close the sidebar or selecting any item from the sidebar will also close the sidebar.