### PR TITLE
docs(gatsby): remove unnecessary abbr tags

### DIFF
--- a/docs/docs/glossary/build.md
+++ b/docs/docs/glossary/build.md
@@ -15,7 +15,7 @@ For larger teams or larger projects, you may want to use a continuous deployment
 
 Gatsby Cloud, for example, integrates with [GitHub](https://github.com/), and a number of hosted [content management systems](/docs/glossary#cms). Gatsby Cloud creates a new build after every commit or content change, although you can also trigger a build manually.
 
-### Using Gatsby <abbr>CLI</abbr>
+### Using Gatsby CLI
 
 For smaller teams and projects, use `gatsby build`. The `gatsby build` command is part of the Gatsby command line interface (or CLI). You'll need to install the CLI interface to create a site with Gatsby. Install it globally using [npm](/docs/glossary/#npm).
 

--- a/docs/docs/glossary/infrastructure-as-code/index.md
+++ b/docs/docs/glossary/infrastructure-as-code/index.md
@@ -7,11 +7,11 @@ Learn what <q>Infrastructure as Code</q> means, and how you can use code to stan
 
 ## What is <q>Infrastructure as Code?</q>
 
-_Infrastructure as Code_, or <abbr>IaC</abbr>, is the practice of managing your development, testing, and production environments using configuration files or scripts. Provisioning and configuring environments individually can introduce errors or inconsistencies. You may, for example, find yourself running different versions of Node.js on your laptop and your production servers. Infrastructure as Code minimizes this kind of drift and lets you automate the process of provisioning environments.
+_Infrastructure as Code_, or IaC, is the practice of managing your development, testing, and production environments using configuration files or scripts. Provisioning and configuring environments individually can introduce errors or inconsistencies. You may, for example, find yourself running different versions of Node.js on your laptop and your production servers. Infrastructure as Code minimizes this kind of drift and lets you automate the process of provisioning environments.
 
 Your configuration file describes what resources your project requires. If you're building an API, for example, you might create a configuration file that says, "Please install Node.js 12.16.2, npm 6.14.4, Express 4.17.1, and PostgreSQL 12.2 for Ubuntu Linux." For a Gatsby project, your configuration file may add plugins and themes.
 
-Configuration files, like other code files, are text. That means you can use version control software to store them and track changes to the environment. In short, <abbr>IaC</abbr>:
+Configuration files, like other code files, are text. That means you can use version control software to store them and track changes to the environment. In short, IaC:
 
 - Creates consistent environments.
 - Saves time that would otherwise be spent setting up environments.

--- a/docs/docs/glossary/jamstack.md
+++ b/docs/docs/glossary/jamstack.md
@@ -7,7 +7,7 @@ Learn how to use Gatsby to build websites powered by the JAMStack, a modern arch
 
 ## What is the JAMStack?
 
-JAMStack is a modern architecture for building websites and applications. The _<abbr>JAM</abbr>_ in JAMStack stands for [JavaScript](/docs/glossary#javascript), [APIs](/docs/glossary#api), and HTML markup. Unlike websites built using WordPress or Drupal, JAMStack sites do not require a database. You can even skip the webserver, and opt to host your site using an object storage service and a content delivery network (or CDN).
+JAMStack is a modern architecture for building websites and applications. The _JAM_ in JAMStack stands for [JavaScript](/docs/glossary#javascript), [APIs](/docs/glossary#api), and HTML markup. Unlike websites built using WordPress or Drupal, JAMStack sites do not require a database. You can even skip the webserver, and opt to host your site using an object storage service and a content delivery network (or CDN).
 
 With more traditional websites, such as those built using WordPress or Drupal, content is stored in a database. There's also a presentation layer of template files that mix HTML markup with template tags. Template tags are placeholders for pieces of content, e.g. `{{ title }}` for the title of the page.
 

--- a/docs/docs/glossary/npm.md
+++ b/docs/docs/glossary/npm.md
@@ -7,7 +7,7 @@ Learn what _npm_ is, how to use it, and how it fits in to the Gatsby ecosystem.
 
 ## What is npm?
 
-<abbr>npm</abbr>, or Node package manager, is the default package manager for
+npm, or Node package manager, is the default package manager for
 the [Node.js](/docs/glossary/node/) JavaScript runtime. It lets you install and
 update libraries and frameworks (dependencies) for Node-based projects, and
 interact with the npm Registry. You'll use npm to install and upgrade Gatsby and


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This PR removes a few `<abbr>` elements that aren't needed, as the text is defined in surrounding body copy.

### Documentation

N/A

## Related Issues

Closes https://github.com/gatsbyjs/gatsby/issues/24505