### PR TITLE
fix(www): Fix getting active item when pathname does not end with /

### DIFF
--- a/www/src/components/sidebar/__tests__/sidebar.js
+++ b/www/src/components/sidebar/__tests__/sidebar.js
@@ -83,6 +83,11 @@ describe(`sidebar`, () => {
       const { queryByText } = renderSidebar(`/characters/jay-gatsby/`)
       expect(queryByText(`Jay Gatsby`)).toBeInTheDocument()
     })
+
+    it(`opens sections with active items when the pathname is missing a trailing slash`, () => {
+      const { queryByText } = renderSidebar(`/characters/jay-gatsby`)
+      expect(queryByText(`Jay Gatsby`)).toBeInTheDocument()
+    })
   })
 
   describe(`toggle section`, () => {
@@ -124,6 +129,11 @@ describe(`sidebar`, () => {
   describe(`scroll into view`, () => {
     it(`scrolls the sidebar into view on load`, () => {
       renderSidebar(`/characters/jay-gatsby/`)
+      expect(scrollIntoViewMock).toHaveBeenCalled()
+    })
+
+    it(`scrolls the sidebar into view on load when the pathname is missing a trailing slash`, () => {
+      renderSidebar(`/characters/jay-gatsby`)
       expect(scrollIntoViewMock).toHaveBeenCalled()
     })
 

--- a/www/src/utils/sidebar/get-active-item.js
+++ b/www/src/utils/sidebar/get-active-item.js
@@ -1,7 +1,12 @@
 import { getLocaleAndBasePath } from "../i18n"
 
+function addTrailingSlashIfMissing(pathname) {
+  return pathname.endsWith(`/`) ? pathname : `${pathname}/`
+}
+
 const isItemActive = (location, item, activeItemHash) => {
-  const { basePath } = getLocaleAndBasePath(location.pathname)
+  const pathnameWithTrailingSlash = addTrailingSlashIfMissing(location.pathname)
+  const { basePath } = getLocaleAndBasePath(pathnameWithTrailingSlash)
   const linkMatchesPathname = item.link === basePath
   const linkWithoutHashMatchesPathname =
     item.link.replace(/#.*/, ``) === basePath


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

Getting the active item for breadcrumbs and the sidebar fails if the pathname does not end in a trailing slash. This is because all the links in docs item list end with a trailing slash.

There are different ways I could approach fixing this. I thought the easiest would just be to add a trailing slash if it was missing, let me know if you think a different approach would be better.

## Related Issues

Fixes: #20767 
