### PR TITLE
refactor(www): cleanup of MarkdownPageFooter + convert to function component

### DIFF
--- a/www/src/components/markdown-page-footer.js
+++ b/www/src/components/markdown-page-footer.js
@@ -4,45 +4,38 @@ import React from "react"
 import { graphql } from "gatsby"
 import { MdCreate as EditIcon } from "react-icons/md"
 
-export default class MarkdownPageFooter extends React.Component {
-  constructor() {
-    super()
-    this.state = { feedbackSubmitted: false }
-  }
-  render() {
-    return (
-      <>
-        <hr sx={{ display: `none` }} />
-        {this.props.page && (
-          <div
-            sx={{
-              display: `flex`,
-              alignItems: `center`,
-              justifyContent: `space-between`,
-              mt: 9,
-            }}
+export default function MarkdownPageFooter(props) {
+  return (
+    <>
+      {props.page && (
+        <div
+          sx={{
+            display: `flex`,
+            alignItems: `center`,
+            justifyContent: `space-between`,
+            mt: 9,
+          }}
+        >
+          <a
+            sx={{ variant: `links.muted` }}
+            href={`https://github.com/gatsbyjs/gatsby/blob/master/${
+              props.packagePage ? `packages` : `docs`
+            }/${props.page ? props.page.parent.relativePath : ``}`}
           >
-            <a
-              sx={{ variant: `links.muted` }}
-              href={`https://github.com/gatsbyjs/gatsby/blob/master/${
-                this.props.packagePage ? `packages` : `docs`
-              }/${this.props.page ? this.props.page.parent.relativePath : ``}`}
-            >
-              <EditIcon sx={{ marginRight: 2 }} /> Edit this page on GitHub
-            </a>
-            {this.props.page?.parent?.fields?.gitLogLatestDate && (
-              <span sx={{ color: `textMuted`, fontSize: 1 }}>
-                Last updated:{` `}
-                <time dateTime={this.props.page.parent.fields.gitLogLatestDate}>
-                  {this.props.page.parent.fields.gitLogLatestDate}
-                </time>
-              </span>
-            )}
-          </div>
-        )}
-      </>
-    )
-  }
+            <EditIcon sx={{ marginRight: 2 }} /> Edit this page on GitHub
+          </a>
+          {props.page?.parent?.fields?.gitLogLatestDate && (
+            <span sx={{ color: `textMuted`, fontSize: 1 }}>
+              Last updated:{` `}
+              <time dateTime={props.page.parent.fields.gitLogLatestDate}>
+                {props.page.parent.fields.gitLogLatestDate}
+              </time>
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  )
 }
 
 export const fragment = graphql`

--- a/www/src/components/markdown-page-footer.js
+++ b/www/src/components/markdown-page-footer.js
@@ -1,12 +1,12 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import React from "react"
+import { Fragment } from "react"
 import { graphql } from "gatsby"
 import { MdCreate as EditIcon } from "react-icons/md"
 
 export default function MarkdownPageFooter(props) {
   return (
-    <>
+    <Fragment>
       {props.page && (
         <div
           sx={{
@@ -22,7 +22,7 @@ export default function MarkdownPageFooter(props) {
               props.packagePage ? `packages` : `docs`
             }/${props.page ? props.page.parent.relativePath : ``}`}
           >
-            <EditIcon sx={{ marginRight: 2 }} /> Edit this page on GitHub
+            <EditIcon sx={{ mr: 2 }} /> Edit this page on GitHub
           </a>
           {props.page?.parent?.fields?.gitLogLatestDate && (
             <span sx={{ color: `textMuted`, fontSize: 1 }}>
@@ -34,7 +34,7 @@ export default function MarkdownPageFooter(props) {
           )}
         </div>
       )}
-    </>
+    </Fragment>
   )
 }
 


### PR DESCRIPTION
## Description

1. The class based `<MarkdownPageFooter/>` component has been converted to function component.
2. It was using state defined in constructor called `feedbackSubmitted` which was not getting used anywhere it has been removed.
3. It was having a horizontal rule with display property set to none, it is redundant. 
```<hr sx={{ display: `none` }} />```

### Screenshots(s)

#### MarkdownPageFooter component
<img width="400" alt="MarkdownPageFooter" src="https://user-images.githubusercontent.com/19193724/84567676-d6955800-ad97-11ea-8beb-1931f57802c7.png">


### How to test

Go to the following link mentioned below, the component should work same in both the local and production link, just the implementation of component is now different.

Scroll down to the end of tutorial, you will see MarkdownPageFooter component, this component is being used in multiple pages, I have provided a link of one page below.

**Local URL:** http://localhost:8000/tutorial
**Production URL:** https://www.gatsbyjs.org/tutorial/