### PR TITLE
fix(recipe): GitHub Pages - brand names

### DIFF
--- a/packages/gatsby-recipes/recipes/travis-deploy-github-pages.mdx
+++ b/packages/gatsby-recipes/recipes/travis-deploy-github-pages.mdx
@@ -1,10 +1,10 @@
-# Deploy to Github Pages with travis-ci
+# Deploy to GitHub Pages with Travis CI
 
-Github Pages is a solution to host static websites directly in your Github repository by pushing site files to `gh-pages` branch.
+GitHub Pages is a solution to host static websites directly in your GitHub repository by pushing site files to `gh-pages` branch.
 
 ---
 
-Define the basic travis-ci configuration to build and push your site's built files to the `gh-pages` branch on each new commit on master.
+Define the basic Travis CI configuration to build and push your site's built files to the `gh-pages` branch on each new commit on master.
 
 <File
   path=".travis.yml"
@@ -13,11 +13,11 @@ Define the basic travis-ci configuration to build and push your site's built fil
 
 ---
 
-Generate a Github token on [this page](https://github.com/settings/tokens/new).
+Generate a GitHub token on [this page](https://github.com/settings/tokens/new).
 
 ---
 
-Toggle on your repository in [your travis-ci configuration page](https://travis-ci.org/account/repositories).
+Toggle on your repository in [your Travis CI configuration page](https://travis-ci.org/account/repositories).
 
 ---
 

--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -140,7 +140,7 @@ const RecipesList = ({ setRecipe }) => {
       value: `gatsby-plugin-react-helmet.mdx`,
     },
     {
-      label: `Add Github Pages deployment with Travis`,
+      label: `Add GitHub Pages deployment with Travis CI`,
       value: `travis-deploy-github-pages.mdx`,
     },
     {


### PR DESCRIPTION
## Description

changes:
- brand names
  - Github -> GitHub
  - travis-ci -> Travis CI
  - Travis -> Travis CI


## Related Issues

- #23669 `feat(recipes): add github pages deployment with travis`