### PR TITLE
refactor(www): convert EcosystemBoard to function component + cleanup

### DIFF
--- a/www/src/components/ecosystem/ecosystem-board.js
+++ b/www/src/components/ecosystem/ecosystem-board.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import { Component } from "react"
+import { useEffect } from "react"
 import PropTypes from "prop-types"
 
 import EcosystemSection from "./ecosystem-section"
@@ -10,78 +10,73 @@ import {
   unobserveScrollers,
 } from "../../utils/scrollers-observer"
 
-class EcosystemBoard extends Component {
-  componentDidMount() {
+export default function EcosystemBoard(props) {
+  useEffect(() => {
     setupScrollersObserver()
-  }
+    return () => unobserveScrollers()
+  }, [])
 
-  componentWillUnmount() {
-    unobserveScrollers()
-  }
+  const {
+    icons: { plugins: PluginsIcon, starters: StartersIcon },
+    starters,
+    plugins,
+  } = props
 
-  render() {
-    const {
-      icons: { plugins: PluginsIcon, starters: StartersIcon },
-      starters,
-      plugins,
-    } = this.props
-
-    return (
-      <div
-        sx={{
-          display: `flex`,
-          flexDirection: `column`,
-          [mediaQueries.md]: {
-            flexDirection: `row`,
-            flexWrap: `wrap`,
-            height: t =>
-              `calc(100vh - (${t.sizes.bannerHeight} + ${t.sizes.headerHeight} + 1px))`,
-            pt: 7,
-            px: 4,
-            pb: 4,
+  return (
+    <div
+      sx={{
+        display: `flex`,
+        flexDirection: `column`,
+        [mediaQueries.md]: {
+          flexDirection: `row`,
+          flexWrap: `wrap`,
+          height: t =>
+            `calc(100vh - (${t.sizes.bannerHeight} + ${t.sizes.headerHeight} + 1px))`,
+          pt: 7,
+          px: 4,
+          pb: 4,
+        },
+      }}
+    >
+      <EcosystemSection
+        title="Plugins"
+        description="Plugins are packages that extend Gatsby sites. They can source content, transform data, and more!"
+        subTitle="Featured Plugins"
+        icon={PluginsIcon}
+        links={[
+          { label: `Browse Plugins`, to: `/plugins/` },
+          {
+            label: `Creating Plugins`,
+            to: `/docs/creating-plugins/`,
+            secondary: true,
           },
-        }}
-      >
-        <EcosystemSection
-          title="Plugins"
-          description="Plugins are packages that extend Gatsby sites. They can source content, transform data, and more!"
-          subTitle="Featured Plugins"
-          icon={PluginsIcon}
-          links={[
-            { label: `Browse Plugins`, to: `/plugins/` },
-            {
-              label: `Creating Plugins`,
-              to: `/docs/creating-plugins/`,
-              secondary: true,
-            },
-            { label: `Using Plugins`, to: `/docs/plugins/`, secondary: true },
-          ]}
-          featuredItems={plugins}
-        />
-        <EcosystemSection
-          title="Starters"
-          description="Starters are Gatsby sites that are preconfigured for different use cases to give you a head start for your project."
-          subTitle="Featured Starters"
-          icon={StartersIcon}
-          links={[
-            { label: `Browse Starters`, to: `/starters/` },
-            { label: `Using Starters`, to: `/docs/starters/`, secondary: true },
-          ]}
-          featuredItems={starters}
-        />
-        <EcosystemSection
-          title="External Resources"
-          description="A curated list of interesting Gatsby community projects and learning resources like podcasts and tutorials."
-          links={[
-            {
-              label: `Browse Resources`,
-              to: `/docs/awesome-gatsby-resources/`,
-            },
-          ]}
-        />
-      </div>
-    )
-  }
+          { label: `Using Plugins`, to: `/docs/plugins/`, secondary: true },
+        ]}
+        featuredItems={plugins}
+      />
+      <EcosystemSection
+        title="Starters"
+        description="Starters are Gatsby sites that are preconfigured for different use cases to give you a head start for your project."
+        subTitle="Featured Starters"
+        icon={StartersIcon}
+        links={[
+          { label: `Browse Starters`, to: `/starters/` },
+          { label: `Using Starters`, to: `/docs/starters/`, secondary: true },
+        ]}
+        featuredItems={starters}
+      />
+      <EcosystemSection
+        title="External Resources"
+        description="A curated list of interesting Gatsby community projects and learning resources like podcasts and tutorials."
+        links={[
+          {
+            label: `Browse Resources`,
+            to: `/docs/awesome-gatsby-resources/`,
+          },
+        ]}
+      />
+    </div>
+  )
 }
 
 EcosystemBoard.propTypes = {
@@ -89,5 +84,3 @@ EcosystemBoard.propTypes = {
   starters: PropTypes.array,
   plugins: PropTypes.array,
 }
-
-export default EcosystemBoard


### PR DESCRIPTION
## Description

1. Converts the class based `<EcosystemBoard/>` component to function component.
2. Now, it **setupScrollersObserver** and **unobserveScrollers** inside `useEffect` hook instead of `componentDidMount()` and `componentWillUnmount()`.

### Screenshots(s)

#### EcosystemBoard
<img width="512" alt="ecosystem-board" src="https://user-images.githubusercontent.com/19193724/84583103-6ed02300-ae12-11ea-8d87-835d13af1a6d.png">


### How to test

Go to the following link mentioned below, the component should work same in both the local and production link, just the implementation of component is now different.

**Local URL:** http://localhost:8000/ecosystem/
**Production URL:** https://www.gatsbyjs.org/ecosystem/