### PR TITLE
docs: add forgotten paren to client-only routes

### DIFF
--- a/docs/docs/client-only-routes-and-user-authentication.md
+++ b/docs/docs/client-only-routes-and-user-authentication.md
@@ -49,7 +49,7 @@ const App = () => {
 export default App
 ```
 
-Briefly, when a page loads, Reach Router looks at the `path` prop of each component nested under `<Router />`, and chooses _one_ to render that best matches `window.location` (you can learn more about how routing works from the [@reach/router documentation](https://reach.tech/router/api/Router). In the case of the `/app/profile` path, the `Profile` component will be rendered, as its prefix matches the base path of `/app`, and the remaining part is identical to the child's path.
+Briefly, when a page loads, Reach Router looks at the `path` prop of each component nested under `<Router />`, and chooses _one_ to render that best matches `window.location` (you can learn more about how routing works from the [@reach/router documentation](https://reach.tech/router/api/Router)). In the case of the `/app/profile` path, the `Profile` component will be rendered, as its prefix matches the base path of `/app`, and the remaining part is identical to the child's path.
 
 ### Adjusting routes to account for authenticated users
 


### PR DESCRIPTION
Just a minor fix from my last commit to this page.