### PR TITLE
refactor(www): convert <Banner/> component to theme-ui + cleanup

### DIFF
--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -30,8 +30,7 @@ const Content = ({ children }) => (
     sx={{
       color: t => t.colors.whiteFade[80],
       fontFamily: t => t.fonts.heading,
-      pl: t => t.space[6],
-      pr: t => t.space[6],
+      px: t => t.space[6],
       whiteSpace: `nowrap`,
       a: {
         color: t => t.colors.white,

--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -1,56 +1,74 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import styled from "@emotion/styled"
 import { OutboundLink } from "gatsby-plugin-google-analytics"
 
-const InnerContainer = styled(`div`)`
-  align-items: center;
-  display: flex;
-  height: ${p => p.theme.sizes.bannerHeight};
-  overflow-x: auto;
-  mask-image: ${props =>
-    `linear-gradient(to right, transparent, ${props.theme.colors.purple[90]} ${props.theme.space[6]}, ${props.theme.colors.purple[90]} 96%, transparent)`};
-`
+import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
-const Content = styled(`div`)`
-  color: ${p => p.theme.colors.whiteFade[80]};
-  font-family: ${p => p.theme.fonts.heading};
-  padding-left: ${p => p.theme.space[6]};
-  padding-right: ${p => p.theme.space[6]};
-  white-space: nowrap;
-
-  a {
-    color: ${p => p.theme.colors.white};
-    border-bottom: 1px solid ${p => p.theme.colors.white};
-  }
-
-  a:hover {
-    color: ${p => p.theme.colors.white};
-    border-bottom-color: ${p => p.theme.colors.white}a0;
-  }
-`
-
-const Banner = () => (
-  <aside
-    className="banner"
+const InnerContainer = ({ children }) => (
+  <div
     sx={{
-      backgroundColor: `banner`,
-      height: `bannerHeight`,
-      position: `fixed`,
-      width: `100%`,
-      zIndex: `banner`,
-      px: `env(safe-area-inset-left)`,
+      display: `flex`,
+      alignItems: `center`,
+      justifyContent: `center`,
+      height: `100%`,
+      overflowX: `auto`,
+      maskImage: t =>
+        `linear-gradient(to right, transparent, ${t.colors.purple[`90`]} ${
+          t.space[`6`]
+        }, ${t.colors.purple[`90`]} 96%, transparent)`,
+      [mediaQueries.md]: {
+        justifyContent: `flex-start`,
+      },
     }}
   >
-    <InnerContainer>
-      <Content>
-        {`New! Try Incremental Builds with `}
-        <OutboundLink href="https://www.gatsbyjs.com">
-          Gatsby Cloud!
-        </OutboundLink>
-      </Content>
-    </InnerContainer>
-  </aside>
+    {children}
+  </div>
 )
 
-export default Banner
+const Content = ({ children }) => (
+  <div
+    sx={{
+      color: t => t.colors.whiteFade[80],
+      fontFamily: t => t.fonts.heading,
+      pl: t => t.space[6],
+      pr: t => t.space[6],
+      whiteSpace: `nowrap`,
+      a: {
+        color: t => t.colors.white,
+        borderBottom: t => `1px solid ${t.colors.white}`,
+
+        "&:hover": {
+          color: t => t.colors.white,
+          borderBottom: t => `1px solid ${t.colors.white}`,
+        },
+      },
+    }}
+  >
+    {children}
+  </div>
+)
+
+export default function Banner() {
+  return (
+    <aside
+      className="banner"
+      sx={{
+        position: `fixed`,
+        zIndex: `banner`,
+        backgroundColor: `banner`,
+        height: `bannerHeight`,
+        width: `100%`,
+        px: `env(safe-area-inset-left)`,
+      }}
+    >
+      <InnerContainer>
+        <Content>
+          {`New! Try Incremental Builds with `}
+          <OutboundLink href="https://www.gatsbyjs.com">
+            Gatsby Cloud!
+          </OutboundLink>
+        </Content>
+      </InnerContainer>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Description

1. Convert the `<Banner/>` component to theme-ui
2. Center the banner text on mobile devices, right now it is not perfectly centered.

### Screenshot(s)

#### Desktop

##### Old
<img width="512" alt="banner-old" src="https://user-images.githubusercontent.com/19193724/84589673-d6f02a80-ae4d-11ea-9b2a-500231e3427c.png">

##### New
<img width="512" alt="banner-updated" src="https://user-images.githubusercontent.com/19193724/84589674-d8b9ee00-ae4d-11ea-8828-59380ae70db8.png">

#### iPhone(X)

##### Old
![banner-old-mobile](https://user-images.githubusercontent.com/19193724/84589911-bde87900-ae4f-11ea-977b-b8bb89582cce.png)

##### New
![banner-updated-mobile](https://user-images.githubusercontent.com/19193724/84589913-bfb23c80-ae4f-11ea-9858-4dbc624a80ea.png)


### How to test

1. Go to the homepage
2. The banner is at the top having text "New! Try Incremental Builds with Gatsby Cloud!"
3. This banner should work same on desktop but the banner text should be centered on the mobile devices(less than md width).

**Local URL:** http://localhost:8000/
**Production URL:** https://www.gatsbyjs.org/
