### PR TITLE
docs(gatsby): Update path to slug

### DIFF
--- a/docs/docs/adding-a-list-of-markdown-blog-posts.md
+++ b/docs/docs/adding-a-list-of-markdown-blog-posts.md
@@ -73,7 +73,7 @@ export const pageQuery = graphql`
           excerpt(pruneLength: 250)
           frontmatter {
             date(formatString: "MMMM DD, YYYY")
-            path
+            slug
             title
           }
         }


### PR DESCRIPTION
Fix for the misleading aforementioned docs:

Cannot query field "path" on type "MarkdownRemarkFrontmatter"

Since there is no mention of `path` on the docs 'Adding Markdown Pages' on createPages api of gatsby-node.js.
Using path would throw the error. Hence using slug as it is aforementioned in the adding markdown pages helps.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
