### PR TITLE
Fix warning section in the "deploying to GitHub pages" documentation

### DIFF
--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -62,7 +62,7 @@ When you run `npm run deploy` all contents of the `public` folder will be moved 
 
 For a repository named like `username.github.io`, you don't need to specify `pathPrefix` and your website needs to be pushed to the `master` branch.
 
-> :warning: Keep in mind that GitHub Pages forces deployment of user/organization pages to the `master` branch. So if you use `master` for development you need to do one of these:
+> ⚠️ Keep in mind that GitHub Pages forces deployment of user/organization pages to the `master` branch. So if you use `master` for development you need to do one of these:
 >
 > - Change the default branch from `master` to something else, and use `master` as a site deployment directory only:
 >   1. To create a new branch called `source` run this command:


### PR DESCRIPTION
Closes https://github.com/gatsbyjs/gatsby/issues/24979

Just changed `:warning:` to a real emoji character. If the emoji is not allowed (I don't know the documentation rules) we can maybe remove it?