### PR TITLE
chore(docs): Documented that location does not include href

### DIFF
--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -30,7 +30,7 @@ The `location` object's properties generally do not include the domain of your s
 
 Running [client side](/docs/glossary#client-side) is the exception to this rule. In this case, all the information your browser exposes as `window.location` is available. This includes `href` for the absolute URL of the page, including the domain.
 
-Sometimes you need the absolute URL of the current page (including the host name) while using [server-side rendering](/docs/glossary/server-side-rendering/). For example, you may want to add a canonical URL to the page header.
+Sometimes you need the absolute URL of the current page (including the host name) while using [server-side rendering](/docs/glossary#server-side-rendering/). For example, you may want to add a canonical URL to the page header.
 
 In this case, you would first need to add configuration that describes where your site is deployed. You can add this as a `siteURL` property on `siteMetadata` in [`gatsby-config.js`](/docs/gatsby-config/).
 

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -36,7 +36,18 @@ In this case, you would first need to add configuration that describes where you
 
 Once you have added `siteURL`, you can form the absolute URL of the current page by retrieving `siteURL` and concatenating it with the current path from `location`. Note that the path starts with a slash; `siteURL` must therefore not end in one.
 
-```jsx
+```jsx:title=src/pages/some-page.js
+import React from "react"
+import { graphql } from "gatsby"
+
+const Page = ({ location, data }) => {
+  const canonicalUrl = data.site.siteMetadata.siteURL + location.pathname
+
+  return <div>The URL of this page is {canonicalUrl}</div>
+}
+
+export default Page
+
 export const query = graphql`
   query PageQuery {
     site {
@@ -46,11 +57,6 @@ export const query = graphql`
     }
   }
 `
-const Page = ({ location, data }) => {
-  const canonicalUrl = data.site.siteMetadata.siteURL + location.pathname)
-
-  return <div>The URL of this page is {canonicalUrl}</div>
-}
 ```
 
 ## Use cases

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -24,6 +24,26 @@ Note that you have to parse the `search` field (the [query string](https://devel
 
 Using `hash` in JavaScript is one way to update the browser URL and the DOM without having the browser do a full HTML page reload. HashHistory in `@reach/router` is used to track browser history with JavaScript when using [hashrouter](https://reacttraining.com/react-router/web/api/HashRouter) instead of [browserrouter](https://reacttraining.com/react-router/web/api/BrowserRouter) which uses the newer HTML5 `history` API.
 
+### Getting the absolute URL of a page
+
+The location properties generally do not include the domain of your site, since Gatsby does know where you will deploy it.
+
+This is different when the code is running [client side](/docs/glossary#client-side). In this case, all the information your browser exposes as `window.location` is available. This includes `href` for the absolute URL of the page including domain.
+
+Sometimes you need the absolute URL of the current page (including the host name) while using [server-side rendering](/docs/glossary/server-side-rendering/). This is for example the case if you want to add a canonical URL to the page header.
+
+In this case, you would first need to add configuration that describes where you site is deployed. You can for example add this as a `siteURL` entry in `siteMetadata` in the [Gatsby Config](/docs/gatsby-config/).
+
+Once you have added `siteURL`, you can form the absolute URL of the current page by retrieving `siteURL` and concatenting it with the current path from `location`. Note that the path starts with a slash; `siteURL` must therefore not end in one.
+
+```js
+const Page = ({ location, data }) => {
+  const canonicalUrl = data.site.siteMetadata.siteURL + location.pathname)
+
+  return <div>The URL of this page is {canonicalUrl}</div>
+}
+```
+
 ## Use cases
 
 Through client-side routing in Gatsby you can provide a location object instead of strings, which are helpful in a number of situations:

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -36,7 +36,7 @@ In this case, you would first need to add configuration that describes where you
 
 Once you have added `siteURL`, you can form the absolute URL of the current page by retrieving `siteURL` and concatenating it with the current path from `location`. Note that the path starts with a slash; `siteURL` must therefore not end in one.
 
-```js
+```jsx
 export const query = graphql`
   query PageQuery {
     site {

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -37,6 +37,15 @@ In this case, you would first need to add configuration that describes where you
 Once you have added `siteURL`, you can form the absolute URL of the current page by retrieving `siteURL` and concatenting it with the current path from `location`. Note that the path starts with a slash; `siteURL` must therefore not end in one.
 
 ```js
+export const query = graphql`
+  query PageQuery {
+    site {
+      siteMetadata {
+        siteURL
+      }
+    }
+  }
+`
 const Page = ({ location, data }) => {
   const canonicalUrl = data.site.siteMetadata.siteURL + location.pathname)
 

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -32,7 +32,7 @@ This is different when the code is running [client side](/docs/glossary#client-s
 
 Sometimes you need the absolute URL of the current page (including the host name) while using [server-side rendering](/docs/glossary/server-side-rendering/). For example, you may want to add a canonical URL to the page header.
 
-In this case, you would first need to add configuration that describes where you site is deployed. You can for example add this as a `siteURL` entry in `siteMetadata` in the [Gatsby Config](/docs/gatsby-config/).
+In this case, you would first need to add configuration that describes where your site is deployed. You can add this as a `siteURL` property on `siteMetadata` in [`gatsby-config`](/docs/gatsby-config/).
 
 Once you have added `siteURL`, you can form the absolute URL of the current page by retrieving `siteURL` and concatenating it with the current path from `location`. Note that the path starts with a slash; `siteURL` must therefore not end in one.
 

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -26,7 +26,7 @@ Using `hash` in JavaScript is one way to update the browser URL and the DOM with
 
 ### Getting the absolute URL of a page
 
-The location properties generally do not include the domain of your site, since Gatsby does know where you will deploy it.
+The `location` object's properties generally do not include the domain of your site, since Gatsby doesn't know where you will deploy it.
 
 This is different when the code is running [client side](/docs/glossary#client-side). In this case, all the information your browser exposes as `window.location` is available. This includes `href` for the absolute URL of the page including domain.
 

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -34,7 +34,7 @@ Sometimes you need the absolute URL of the current page (including the host name
 
 In this case, you would first need to add configuration that describes where you site is deployed. You can for example add this as a `siteURL` entry in `siteMetadata` in the [Gatsby Config](/docs/gatsby-config/).
 
-Once you have added `siteURL`, you can form the absolute URL of the current page by retrieving `siteURL` and concatenting it with the current path from `location`. Note that the path starts with a slash; `siteURL` must therefore not end in one.
+Once you have added `siteURL`, you can form the absolute URL of the current page by retrieving `siteURL` and concatenating it with the current path from `location`. Note that the path starts with a slash; `siteURL` must therefore not end in one.
 
 ```js
 export const query = graphql`

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -32,7 +32,7 @@ Running [client side](/docs/glossary#client-side) is the exception to this rule.
 
 Sometimes you need the absolute URL of the current page (including the host name) while using [server-side rendering](/docs/glossary/server-side-rendering/). For example, you may want to add a canonical URL to the page header.
 
-In this case, you would first need to add configuration that describes where your site is deployed. You can add this as a `siteURL` property on `siteMetadata` in [`gatsby-config`](/docs/gatsby-config/).
+In this case, you would first need to add configuration that describes where your site is deployed. You can add this as a `siteURL` property on `siteMetadata` in [`gatsby-config.js`](/docs/gatsby-config/).
 
 Once you have added `siteURL`, you can form the absolute URL of the current page by retrieving `siteURL` and concatenating it with the current path from `location`. Note that the path starts with a slash; `siteURL` must therefore not end in one.
 

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -30,7 +30,7 @@ The `location` object's properties generally do not include the domain of your s
 
 This is different when the code is running [client side](/docs/glossary#client-side). In this case, all the information your browser exposes as `window.location` is available. This includes `href` for the absolute URL of the page including domain.
 
-Sometimes you need the absolute URL of the current page (including the host name) while using [server-side rendering](/docs/glossary/server-side-rendering/). This is for example the case if you want to add a canonical URL to the page header.
+Sometimes you need the absolute URL of the current page (including the host name) while using [server-side rendering](/docs/glossary/server-side-rendering/). For example, you may want to add a canonical URL to the page header.
 
 In this case, you would first need to add configuration that describes where you site is deployed. You can for example add this as a `siteURL` entry in `siteMetadata` in the [Gatsby Config](/docs/gatsby-config/).
 

--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -28,7 +28,7 @@ Using `hash` in JavaScript is one way to update the browser URL and the DOM with
 
 The `location` object's properties generally do not include the domain of your site, since Gatsby doesn't know where you will deploy it.
 
-This is different when the code is running [client side](/docs/glossary#client-side). In this case, all the information your browser exposes as `window.location` is available. This includes `href` for the absolute URL of the page including domain.
+Running [client side](/docs/glossary#client-side) is the exception to this rule. In this case, all the information your browser exposes as `window.location` is available. This includes `href` for the absolute URL of the page, including the domain.
 
 Sometimes you need the absolute URL of the current page (including the host name) while using [server-side rendering](/docs/glossary/server-side-rendering/). For example, you may want to add a canonical URL to the page header.
 


### PR DESCRIPTION
## Description

Describes the differences in the `location` object between the client side and server side.

This is my first commit so thankful for feedback on style!

## Related Issues

Fixes #21946
