### PR TITLE
feat(gatsby-source-drupal): Add skipFileDownloads config option

### DIFF
--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -142,6 +142,28 @@ module.exports = {
 }
 ```
 
+### File Downloads
+
+You can use the `skipFileDownloads` option if you do not want Gatsby to download
+files from your Drupal website. This is useful if you are using another option
+for processing/serving images.
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-drupal`,
+      options: {
+        baseUrl: `https://live-contentacms.pantheonsite.io/`,
+        apiBase: `api`, // optional, defaults to `jsonapi`
+        skipFileDownloads: true,
+      },
+    },
+  ],
+}
+```
+
 ## Concurrent File Requests
 
 You can use the `concurrentFileRequests` option to change how many simultaneous file requests are made to the server/service. This benefits build speed, however too many concurrent file request could cause memory exhaustion depending on the server's memory size so change with caution.

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/webhook-file-update.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/webhook-file-update.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "type": "file--file",
+    "id": "file-1",
+    "attributes": {
+      "id": 1,
+      "uuid": "file-1",
+      "filename": "main-image-update.png",
+      "url": "/sites/default/files/main-image-update.png"
+    }
+  },
+  "links": {}
+}

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -213,6 +213,13 @@ describe(`gatsby-source-drupal`, () => {
     )
   })
 
+  it(`Skips File Downloads`, async () => {
+    const skipFileDownloads = true
+    expect(createRemoteFileNode).toBeCalledTimes(8)
+    await sourceNodes(args, { baseUrl, skipFileDownloads })
+    expect(createRemoteFileNode).toBeCalledTimes(8)
+  })
+
   describe(`Update webhook`, () => {
     describe(`Update content`, () => {
       describe(`Before update`, () => {

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -213,10 +213,29 @@ describe(`gatsby-source-drupal`, () => {
     )
   })
 
-  it(`Skips File Downloads`, async () => {
+  it(`Skips File Downloads on initial build`, async () => {
     const skipFileDownloads = true
     expect(createRemoteFileNode).toBeCalledTimes(8)
     await sourceNodes(args, { baseUrl, skipFileDownloads })
+    expect(createRemoteFileNode).toBeCalledTimes(8)
+  })
+
+  it(`Skips File Downloads on webhook update`, async () => {
+    const skipFileDownloads = true
+    expect(createRemoteFileNode).toBeCalledTimes(8)
+    const nodeToUpdate = require(`./fixtures/webhook-file-update.json`).data
+
+    await handleWebhookUpdate(
+      {
+        nodeToUpdate,
+        ...args,
+      },
+      {
+        baseUrl,
+        skipFileDownloads,
+      }
+    )
+
     expect(createRemoteFileNode).toBeCalledTimes(8)
   })
 

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -155,7 +155,7 @@ const handleWebhookUpdate = async (
 
   // download file
   const { skipFileDownloads } = pluginOptions
-  if (isFileNode(newNode) && skipFileDownloads !== false) {
+  if (isFileNode(newNode) && !skipFileDownloads) {
     await downloadFile(
       {
         node: newNode,

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -93,7 +93,7 @@ const handleWebhookUpdate = async (
     reporter,
     store,
   },
-  pluginOptions
+  pluginOptions = {}
 ) => {
   const { createNode } = actions
 
@@ -154,8 +154,8 @@ const handleWebhookUpdate = async (
   }
 
   // download file
-  const skipFileDownloads = pluginOptions.skipFileDownloads || false
-  if (isFileNode(newNode) && !skipFileDownloads) {
+  const { skipFileDownloads } = pluginOptions
+  if (isFileNode(newNode) && skipFileDownloads !== false) {
     await downloadFile(
       {
         node: newNode,

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -154,7 +154,8 @@ const handleWebhookUpdate = async (
   }
 
   // download file
-  if (isFileNode(newNode)) {
+  const skipFileDownloads = pluginOptions.skipFileDownloads || false
+  if (isFileNode(newNode) && !skipFileDownloads) {
     await downloadFile(
       {
         node: newNode,


### PR DESCRIPTION
## Description

This PR adds a skipFileDownloads config option to gatsby-source-drupal. This is useful when using a Drupal site and some third party image processing solution. By enabling this config option Gatsby will not download the remote files which will significantly speed up builds that don't use Gatsby's image processing.

### Documentation

This is documented in the gatsby-source-drupal plugin README file.

### Related Issues

This change would help with issues like this #24257 