### PR TITLE
chore(starters): add gatsby-starter-blog-boost

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6660,3 +6660,16 @@
     - Fully responsive
     - Includes React Helmet to allow editing site meta tags
     - All landing page content can be customised through YAML files stored in content folder and in gatsby-config.js
+- url: https://cocky-williams-9d49bd.netlify.app/
+  repo: https://github.com/peterdurham/gatsby-starter-blog-boost
+  description: A Netlify CMS powered blog starter to jumpstart your personal or company's development.
+  tags:
+    - Blog
+    - Markdown 
+    - CMS:Netlify 
+  features:
+    - Articles (Blog Post) CMS Model 
+    - Topics pages
+    - Tag Pages
+    - Mobile ready
+


### PR DESCRIPTION
Hoping to add gatsby-starter-blog-boost, details in starters.yml file
Thanks!!
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
