### PR TITLE
chore(docs): Update adding-a-list-of-markdown-blog-posts

### DIFF
--- a/docs/docs/adding-a-list-of-markdown-blog-posts.md
+++ b/docs/docs/adding-a-list-of-markdown-blog-posts.md
@@ -10,7 +10,7 @@ As described [here](/docs/adding-markdown-pages), you will have to create your p
 
 ```markdown
 ---
-path: "/blog/my-first-post"
+slug: "/blog/my-first-post"
 date: "2017-11-07"
 title: "My first blog post"
 ---
@@ -93,7 +93,7 @@ import { Link } from "gatsby"
 
 const PostLink = ({ post }) => (
   <div>
-    <Link to={post.frontmatter.path}>
+    <Link to={post.frontmatter.slug}>
       {post.frontmatter.title} ({post.frontmatter.date})
     </Link>
   </div>


### PR DESCRIPTION
## Description

In the page of the tutorial named [Adding Markdown Pages](https://www.gatsbyjs.org/docs/adding-markdown-pages/), the variable used to define the path in the Markdown frontmatter is called `slug`.

The next page, [Adding a List of Markdown Blog Posts](https://www.gatsbyjs.org/docs/adding-a-list-of-markdown-blog-posts/), uses variable `path` in the remindering frontmatter and in the PostLink component code.

![image](https://user-images.githubusercontent.com/265963/84840516-05cdf280-b040-11ea-8979-bc14e5792dd8.png)

![image](https://user-images.githubusercontent.com/265963/84840546-20a06700-b040-11ea-82a2-aaca6ffe845c.png)

This PR is a quick & simple fix that uses the variable name `slug`.

### Documentation

## Related Issues

Did not find any related issue by looking for "[slug](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+sort%3Aupdated-desc+slug+)" or "[PostLink](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+sort%3Aupdated-desc+PostLink)" in recent GitHub issues.