### PR TITLE
feat(gatsby-source-npm-package-search): add Node type NpmPackage

### DIFF
--- a/packages/gatsby-source-npm-package-search/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-source-npm-package-search/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -32,7 +32,7 @@ Array [
     "modified": Date { NaN },
     "objectID": "foo",
     "parent": null,
-    "readme___NODE": "readme foo",
+    "readme": "readme foo",
     "slug": "/packages/foo/",
     "title": "foo",
   },

--- a/packages/gatsby-source-npm-package-search/src/gatsby-node.js
+++ b/packages/gatsby-source-npm-package-search/src/gatsby-node.js
@@ -2,6 +2,76 @@ const got = require(`got`)
 const url = require(`url`)
 const { browse } = require(`./search`)
 
+exports.createSchemaCustomization = ({ actions }) => {
+  actions.createTypes(`
+    type NPMPackage implements Node {
+      name: String!
+      slug: String!
+      title: String!
+      created: Date! @dateformat
+      modified: Date! @dateformat
+      deprecated: String
+      downloadsLast30Days: Int!
+      downloadsRatio: Float!
+      humanDownloadsLast30Days: String!
+      popular: Boolean!
+      version: String!
+      description: String
+      gitHead: String
+      homepage: String
+      license: String
+      keywords: [String]
+      computedKeywords: [String]
+      moduleTypes: [String]
+      lastCrawl: Date @dateformat
+      dependents: Int!
+      humanDependents: String
+      changelogFilename: String
+      jsDelivrHits: Int!
+      objectID: String
+      readme: NPMPackageReadme @link
+      repository: NPMPackageRepository
+      githubRepo: NPMPackageGithubRepo
+      owner: NPMPackageOwner
+      owners: [NPMPackageOwner]
+      lastPublisher: NPMPackageOwner
+      _searchInternal: NPMPackage_searchInternal
+    }
+    type NPMPackageReadme implements Node @dontInfer {
+      slug: String!
+    }
+    type NPMPackageRepository {
+      url: String
+      project: String
+      user: String
+      host: String
+      path: String
+      head: String
+      branch: String
+      type: String
+      directory: String
+    }
+    type NPMPackageGithubRepo {
+      user: String
+      project: String
+      path: String
+      head: String
+    }
+    type NPMPackageOwner {
+      name: String
+      avatar: String
+      link: String
+      email: String
+    }
+    type NPMPackage_searchInternal {
+      alternativeNames: [String]
+      downloadsMagnitude: Int
+      jsDelivrPopularity: Int
+      concatenatedName: String
+    }
+  `)
+}
+
 exports.sourceNodes = async (
   { boundActionCreators, createNodeId, createContentDigest },
   { keywords }
@@ -56,7 +126,7 @@ exports.sourceNodes = async (
         parent: null,
         children: [],
         slug: `/packages/${hit.objectID}/`,
-        readme___NODE: readmeNode.id,
+        readme: readmeNode.id,
         title: `${hit.objectID}`,
         internal: {
           type: `NPMPackage`,


### PR DESCRIPTION
## Description

This PR adds to GraphQL Schema Node types NpmPackage and NPMPackageReadme.

### Considerations:

**I didn't add types for fields that seemed too random:**

- *tags:* NPMPackageTags
- *dependencies:* NPMPackageDependencies
- *devDependencies:* NPMPackageDevDependencies
- *bin:* NPMPackageBin

I left them to be inferred by Gatsby.

**Before the following fields have different types:**

- *owner:* NPMPackageOwner
- *owners:* [NPMPackageOwners]
- *lastPublisher:* NPMPackageLastPublisher

Now they all use the same type: NPMPackageOwner

## Related Issues

Fixes #25011