### PR TITLE
docs: mention pageContext serialization affect on Dates

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -259,7 +259,7 @@ const Page = ({ pageContext }) => {
 export default Page
 ```
 
-Page context is serialized before being passed to pages: This means it can't be used to pass functions into components.
+Page context is serialized before being passed to pages: This means it can't be used to pass functions into components, and `Date` objects will be serialized into strings.
 
 ## Creating Client-only routes
 

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -259,7 +259,7 @@ const Page = ({ pageContext }) => {
 export default Page
 ```
 
-Page context is serialized before being passed to pages: This means it can't be used to pass functions into components, and `Date` objects will be serialized into strings.
+Page context is serialized before being passed to pages. This means it can't be used to pass functions into components and `Date` objects will be serialized into strings.
 
 ## Creating Client-only routes
 


### PR DESCRIPTION
This PR adds a brief note at https://www.gatsbyjs.org/docs/creating-and-modifying-pages/#pass-context-to-pages that Date objects are also subject to serialization.