### PR TITLE
fix(gatsby-starter-blog): Move typescript usage to other file

### DIFF
--- a/starters/blog/src/pages/index.js
+++ b/starters/blog/src/pages/index.js
@@ -1,36 +1,12 @@
-// Gatsby supports TypeScript natively!
 import React from "react"
-import { PageProps, Link, graphql } from "gatsby"
+import { Link, graphql } from "gatsby"
 
 import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { rhythm } from "../utils/typography"
 
-type Data = {
-  site: {
-    siteMetadata: {
-      title: string
-    }
-  }
-  allMarkdownRemark: {
-    edges: {
-      node: {
-        excerpt: string
-        frontmatter: {
-          title: string
-          date: string
-          description: string
-        }
-        fields: {
-          slug: string
-        }
-      }
-    }[]
-  }
-}
-
-const BlogIndex = ({ data, location }: PageProps<Data>) => {
+const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata.title
   const posts = data.allMarkdownRemark.edges
 

--- a/starters/blog/src/pages/using-typescript.tsx
+++ b/starters/blog/src/pages/using-typescript.tsx
@@ -1,0 +1,34 @@
+// If you don't want to use TypeScript you can delete this file!
+import React from "react"
+import { PageProps, Link, graphql } from "gatsby"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+type DataProps = {
+  site: {
+    buildTime: string
+  }
+}
+
+const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path, location }) => (
+  <Layout title="Using TypeScript" location={location}>
+    <SEO title="Using TypeScript" />
+    <h1>Gatsby supports TypeScript by default!</h1>
+    <p>This means that you can create and write <em>.ts/.tsx</em> files for your pages, components etc. Please note that the <em>gatsby-*.js</em> files (like gatsby-node.js) currently don't support TypeScript yet.</p>
+    <p>For type checking you'll want to install <em>typescript</em> via npm and run <em>tsc --init</em> to create a <em>.tsconfig</em> file.</p>
+    <p>You're currently on the page "{path}" which was built on {data.site.buildTime}.</p>
+    <p>To learn more, head over to our <a href="https://www.gatsbyjs.org/docs/typescript/">documentation about TypeScript</a>.</p>
+    <Link to="/">Go back to the homepage</Link>
+  </Layout>
+)
+
+export default UsingTypescript
+
+export const query = graphql`
+  {
+    site {
+      buildTime(formatString: "YYYY-MM-DD hh:mm a z")
+    }
+  }
+`


### PR DESCRIPTION
## Description

Follow-up of https://github.com/gatsbyjs/gatsby/pull/24565
Didn't realize that we also need to change it in the `blog` starter
