### PR TITLE
chore(gatsby): Re-export reporter types from gatsby-cli

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -2,6 +2,7 @@ import * as React from "react"
 import { Renderer } from "react-dom"
 import { EventEmitter } from "events"
 import { WindowLocation, NavigateFn } from "@reach/router"
+import reporter from "gatsby-cli/lib/reporter"
 import {
   ComposeEnumTypeConfig,
   ComposeInputObjectTypeConfig,
@@ -1260,16 +1261,15 @@ export interface Store {
   replaceReducer: Function
 }
 
-type LogMessageType = (format: string) => void
-type LogErrorType = (errorMeta: string | Object, error?: Object) => void
+export type Reporter = typeof reporter
 
 export type ActivityTracker = {
   start(): () => void
   end(): () => void
   span: Object
   setStatus(status: string): void
-  panic: LogErrorType
-  panicOnBuild: LogErrorType
+  panic: (errorMeta: string | Object, error?: Object) => never
+  panicOnBuild: (errorMeta: string | Object, error?: Object) => void
 }
 
 export type ProgressActivityTracker = Omit<ActivityTracker, "end"> & {
@@ -1281,29 +1281,6 @@ export type ProgressActivityTracker = Omit<ActivityTracker, "end"> & {
 export type ActivityArgs = {
   parentSpan?: Object
   id?: string
-}
-
-export interface Reporter {
-  stripIndent: (input: string) => string
-  format: object
-  setVerbose(isVerbose?: boolean): void
-  setNoColor(isNoColor?: boolean): void
-  panic: LogErrorType
-  panicOnBuild: LogErrorType
-  error: LogErrorType
-  uptime(prefix: string): void
-  success: LogMessageType
-  verbose: LogMessageType
-  info: LogMessageType
-  warn: LogMessageType
-  log: LogMessageType
-  activityTimer(name: string, activityArgs?: ActivityArgs): ActivityTracker
-  createProgress(
-    text: string,
-    total?: number,
-    start?: number,
-    activityArgs?: ActivityArgs
-  ): ProgressActivityTracker
 }
 
 /**


### PR DESCRIPTION
Rather than re-implementing the `Reporter` types, this re-exports the types from gatsby-cli, which is now properly typed.