### PR TITLE
chore(gatsby): remove mentions of sift and refactor

### DIFF
--- a/packages/gatsby/src/db/nodes.js
+++ b/packages/gatsby/src/db/nodes.js
@@ -2,7 +2,7 @@
 const _ = require(`lodash`)
 const { store } = require(`../redux`)
 const nodesDb: NodeStore = require(`../redux/nodes`)
-const runQuery = require(`../redux/run-sift`).runSift
+const { runFastFiltersAndSort } = require(`../redux/run-sift`)
 
 interface NodeStore {
   getNodes: () => Array<any>;
@@ -20,15 +20,13 @@ interface NodeStore {
   }) => any | undefined;
 }
 
-module.exports = { ...nodesDb, runQuery }
-
 /**
  * Get content for a node from the plugin that created it.
  *
  * @param {Object} node
  * @returns {promise}
  */
-module.exports.loadNodeContent = node => {
+function loadNodeContent(node) {
   if (_.isString(node.internal.content)) {
     return Promise.resolve(node.internal.content)
   } else {
@@ -50,4 +48,10 @@ module.exports.loadNodeContent = node => {
       })
     })
   }
+}
+
+module.exports = {
+  ...nodesDb,
+  runQuery: runFastFiltersAndSort,
+  loadNodeContent,
 }

--- a/packages/gatsby/src/redux/__tests__/run-sift.js
+++ b/packages/gatsby/src/redux/__tests__/run-sift.js
@@ -1,4 +1,4 @@
-const { runSift, filterWithoutSift } = require(`../run-sift`)
+const { runFastFiltersAndSort, applyFastFilters } = require(`../run-sift`)
 const { store } = require(`../index`)
 const { createDbQueriesFromObject } = require(`../../db/common/query`)
 const { actions } = require(`../actions`)
@@ -123,7 +123,7 @@ const gqlType = new GraphQLObjectType({
   },
 })
 
-describe(`run-sift tests`, () => {
+describe(`fast filter tests`, () => {
   beforeEach(() => {
     store.dispatch({ type: `DELETE_CACHE` })
     mockNodes().forEach(node =>
@@ -139,7 +139,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultSingular = await runSift({
+      const resultSingular = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: true,
@@ -147,7 +147,7 @@ describe(`run-sift tests`, () => {
         filtersCache: new Map(),
       })
 
-      const resultMany = await runSift({
+      const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: false,
@@ -166,7 +166,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultSingular = await runSift({
+      const resultSingular = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: true,
@@ -174,7 +174,7 @@ describe(`run-sift tests`, () => {
         filtersCache: new Map(),
       })
 
-      const resultMany = await runSift({
+      const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: false,
@@ -194,7 +194,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultSingular = await runSift({
+      const resultSingular = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: true,
@@ -202,7 +202,7 @@ describe(`run-sift tests`, () => {
         filtersCache: new Map(),
       })
 
-      const resultMany = await runSift({
+      const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: false,
@@ -218,7 +218,7 @@ describe(`run-sift tests`, () => {
     })
     it(`return empty array in case of empty nodes`, async () => {
       const queryArgs = { filter: {}, sort: {} }
-      const resultSingular = await runSift({
+      const resultSingular = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: true,
@@ -236,7 +236,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultSingular = await runSift({
+      const resultSingular = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: true,
@@ -258,7 +258,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultMany = await runSift({
+      const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: false,
@@ -280,7 +280,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultSingular = await runSift({
+      const resultSingular = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: true,
@@ -302,7 +302,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultMany = await runSift({
+      const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: false,
@@ -324,7 +324,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultSingular = await runSift({
+      const resultSingular = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: true,
@@ -342,7 +342,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultMany = await runSift({
+      const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: false,
@@ -362,7 +362,7 @@ describe(`run-sift tests`, () => {
         },
       }
 
-      const resultMany = await runSift({
+      const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         firstOnly: false,
@@ -376,7 +376,7 @@ describe(`run-sift tests`, () => {
   })
 })
 
-describe(`filterWithoutSift`, () => {
+describe(`applyFastFilters`, () => {
   beforeAll(() => {
     store.dispatch({ type: `DELETE_CACHE` })
     mockNodes().forEach(node =>
@@ -389,7 +389,7 @@ describe(`filterWithoutSift`, () => {
       slog: { $eq: `def` },
     }
 
-    const result = filterWithoutSift(
+    const result = applyFastFilters(
       createDbQueriesFromObject(filter),
       [typeName],
       new Map()
@@ -407,7 +407,7 @@ describe(`filterWithoutSift`, () => {
       deep: { flat: { search: { chain: { $eq: 300 } } } },
     }
 
-    const result = filterWithoutSift(
+    const result = applyFastFilters(
       createDbQueriesFromObject(filter),
       [typeName],
       new Map()
@@ -426,7 +426,7 @@ describe(`filterWithoutSift`, () => {
       deep: { flat: { search: { chain: { $eq: 300 } } } },
     }
 
-    const results = filterWithoutSift(
+    const results = applyFastFilters(
       createDbQueriesFromObject(filter),
       [typeName],
       new Map()
@@ -446,7 +446,7 @@ describe(`filterWithoutSift`, () => {
       },
     }
 
-    const result = filterWithoutSift(
+    const result = applyFastFilters(
       createDbQueriesFromObject(filter),
       [typeName],
       new Map()

--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -203,8 +203,8 @@ export function postIndexingMetaSetup(
 
 function postIndexingMetaSetupNeNin(filterCache: IFilterCache): void {
   // Note: edge cases regarding `null` and `undefined`. Here `undefined` signals
-  // that the property did not exist as sift does not support actual `undefined`
-  // values.
+  // that the property did not exist as the filters do not support actual
+  // `undefined` values.
   // For $ne, `null` only returns nodes that actually have the property
   // and in that case the property cannot be `null` either. For any other value,
   // $ne will return all nodes where the value is not actually the needle,
@@ -538,7 +538,7 @@ function addNodeToBucketWithElemMatch(
   }
 
   if (path.length !== i) {
-    // Found undefined before the end of the path, so let Sift take over
+    // Found undefined before the end of the path
     return
   }
 
@@ -606,7 +606,7 @@ const binarySearchAsc = (
     pivot = min + Math.floor((max - min) / 2)
   }
 
-  // Shouldn't be reachable, but just in case, fall back to Sift if so.
+  // Shouldn't be reachable
   return undefined
 }
 const binarySearchDesc = (
@@ -641,7 +641,7 @@ const binarySearchDesc = (
     pivot = min + Math.floor((max - min) / 2)
   }
 
-  // Shouldn't be reachable, but just in case, fall back to Sift if so.
+  // Shouldn't be reachable
   return undefined
 }
 
@@ -691,8 +691,6 @@ export const getNodesFromCacheByValue = (
 
   if (op === `$in`) {
     if (!Array.isArray(filterValue)) {
-      // Sift assumes the value has an `indexOf` property. By this fluke,
-      // string args would work, but I don't think that's intentional/expected.
       throw new Error("The argument to the `in` comparator should be an array")
     }
     const filterValueArr: Array<FilterValueNullable> = filterValue
@@ -775,7 +773,7 @@ export const getNodesFromCacheByValue = (
     const arr: Array<IGatsbyNode> = []
     filterCache.byValue.forEach((nodes, value) => {
       // TODO: does the value have to be a string for $regex? Can we auto-ignore any non-strings? Or does it coerce.
-      // Note: partial paths should also be included for regex (matching Sift behavior)
+      // Note: for legacy reasons partial paths should also be included for regex
       if (value !== undefined && regex.test(String(value))) {
         nodes.forEach(node => arr.push(node))
       }

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -464,7 +464,7 @@ describe(`Filter fields`, () => {
         singleArray: { eq: needle },
       })
 
-      // Note: no coercion, so [8]=='8' is true but Sift ignores those
+      // Note: no coercion, so [8]=='8' is true but the comparison is strict
       expect(result).toEqual(null)
     })
   })
@@ -528,7 +528,7 @@ describe(`Filter fields`, () => {
           allNodes
         )
 
-        // Sift only returns id=6,7, where a.b.c===true/false.
+        // For legacy reasons, apply strict check; only return id=6,7, where a.b.c===true/false.
 
         expect(result?.length).toEqual(
           allNodes.filter(node => !(node?.a?.b?.c == null)).length
@@ -545,7 +545,7 @@ describe(`Filter fields`, () => {
           allNodes
         )
 
-        // Note: Sift only omits id=6, where a.b.c===true (contrary to searching for null)
+        // For legacy reasons, apply strict check; only omit id=6, where a.b.c===true (contrary to searching for null)
 
         expect(result?.length).toEqual(
           allNodes.filter(node => node?.a?.b?.c !== needle).length
@@ -562,7 +562,7 @@ describe(`Filter fields`, () => {
           allNodes
         )
 
-        // Note: Sift only omits id=7, where a.b.c===false (contrary to searching for null)
+        // For legacy reasons, apply strict check; only omit id=7, where a.b.c===false (contrary to searching for null)
 
         expect(result?.length).toEqual(
           allNodes.filter(node => node?.a?.b?.c !== needle).length
@@ -643,7 +643,7 @@ describe(`Filter fields`, () => {
         anArray: { ne: needle },
       })
 
-      // Sift returns only the node that doesn't have the property at all (the other two arrays contain 1)
+      // For legacy reasons; return only the node that doesn't have the property at all (the other two arrays contain 1)
 
       expect(result?.length).toEqual(
         allNodes.filter(node => !node.anArray?.includes(needle)).length
@@ -1338,7 +1338,7 @@ describe(`Filter fields`, () => {
       ).rejects.toThrow()
     })
 
-    // I'm convinced this only works in Sift because of a fluke
+    // I'm convinced this only worked in Sift because of a fluke
     it.skip(`refuses a non-arg string argument`, async () => {
       await expect(
         runFilter({

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/prepare-regex.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/prepare-regex.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Prepare regex for Sift.js handles flags regex 1`] = `/blue/i`;
+exports[`Prepare regex for filtering handles flags regex 1`] = `/blue/i`;
 
-exports[`Prepare regex for Sift.js handles simple regex 1`] = `/blue/`;
+exports[`Prepare regex for filtering handles simple regex 1`] = `/blue/`;
 
-exports[`Prepare regex for Sift.js handles slashes 1`] = `/bl\\\\/ue/i`;
+exports[`Prepare regex for filtering handles slashes 1`] = `/bl\\\\/ue/i`;

--- a/packages/gatsby/src/utils/__tests__/prepare-regex.js
+++ b/packages/gatsby/src/utils/__tests__/prepare-regex.js
@@ -1,6 +1,6 @@
 const { prepareRegex } = require(`../prepare-regex`)
 
-describe(`Prepare regex for Sift.js`, () => {
+describe(`Prepare regex for filtering`, () => {
   it(`handles simple regex`, () => {
     expect(prepareRegex(`/blue/`)).toMatchSnapshot()
   })


### PR DESCRIPTION
This removes a couple of mentions of Sift, also as part of variable and function names. 

Also some refactoring in run-sift.js which should not change the semantics.