### PR TITLE
fix(gatsby): support Date objects in fast filters

### DIFF
--- a/packages/gatsby/src/redux/nodes.ts
+++ b/packages/gatsby/src/redux/nodes.ts
@@ -424,6 +424,7 @@ function addNodeToFilterCache(
     v = v[nextProp]
   }
 
+  let filterValue: FilterValueNullable = ``
   if (
     (typeof v !== `string` &&
       typeof v !== `number` &&
@@ -441,14 +442,23 @@ function addNodeToFilterCache(
       return
     }
 
-    // This means that either
-    // - The filter resolved to `undefined`, or
-    // - The filter resolved to something other than a primitive
-    // Set the value to `undefined` to mark "path does not (fully) exist"
-    v = undefined
+    if (v instanceof Date) {
+      // While GraphQL serializes Dates as strings, userland _can_ manually create
+      // nodes with actual Date objects. Schema allows this, so we should support
+      // that case, too.
+      filterValue = v.toISOString()
+    } else {
+      // This means that either
+      // - The filter resolved to `undefined`, or
+      // - The filter resolved to something other than a primitive
+      // Set the value to `undefined` to mark "path does not (fully) exist"
+      filterValue = undefined
+    }
+  } else {
+    filterValue = v
   }
 
-  markNodeForValue(filterCache, node, v)
+  markNodeForValue(filterCache, node, filterValue)
 }
 
 function markNodeForValue(

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -454,12 +454,12 @@ describe(`NodeModel`, () => {
         expect(result.id).toEqual(`post2`)
       })
 
-      // FIXME: Filters on date instances are not supported yet
-      //  SIFT requires such filters to be expressed as Date instances but we
-      //  don't know if date is stored as `Date` instance or `string`
-      //  so can't really do that
-      //  See https://github.com/crcn/sift.js#date-comparison
-      it.skip(`queries date instances in nodes`, async () => {
+      // Since it _is_ possible for raw Dates to end up in a IGatsbyNode (when
+      // the user manually creates a node), the filters should support it.
+      // While GraphQL generated nodes wouldn't end up with Date objects (it
+      // will stringify the Date), the schema validator does allow it so we
+      // end up having to support it.
+      it(`queries date instances in nodes`, async () => {
         const type = `Post`
         const query = {
           filter: {
@@ -469,7 +469,7 @@ describe(`NodeModel`, () => {
           },
         }
         const firstOnly = false
-        nodeModel.replaceTypeKeyValueCache()
+        nodeModel.replaceFiltersCache()
         const result = await nodeModel.runQuery({
           query,
           firstOnly,


### PR DESCRIPTION
While GraphQL converts `Date` objects to strings, it is possible for `IGatsbyNode` instances to have `Date` objects anyways when a user manually creates the node. This is because the schema does allow `Date` objects.

So we should allow to query by (stringified) ISO dates in the fast filters.