### PR TITLE
chore(starters): add gatsby-starter-paper-css-landing-page

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6660,3 +6660,14 @@
     - Fully responsive
     - Includes React Helmet to allow editing site meta tags
     - All landing page content can be customised through YAML files stored in content folder and in gatsby-config.js
+- url: https://www.stefanseegerer.de/gatsby-starter-paper-css-landing-page/
+  repo: https://github.com/manzanillo/gatsby-starter-paper-css-landing-page
+  description: Single page starter with PaperCSS for workshop, educational material, or other minimal landing pages
+  tags:
+    - Onepage
+    - Landing Page
+    - Education
+  features:
+    - Landing Page
+    - Google Analytics
+    - PaperCSS style


### PR DESCRIPTION
A landing page starter with PaperCSS useful for multiple occasions, such as workshops, concepts, or websites for educational material.