### PR TITLE
chore(gatsby-cli): delete *.d.ts files before creating new ones

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -60,6 +60,7 @@
     "@types/yargs": "^15.0.4",
     "babel-preset-gatsby-package": "^0.4.4",
     "cross-env": "^5.2.1",
+    "rimraf": "^3.0.2",
     "typescript": "^3.9.3"
   },
   "files": [
@@ -80,7 +81,7 @@
   "scripts": {
     "build": "babel src --out-dir lib --ignore \"**/__tests__\" --extensions \".ts,.js,.tsx\"",
     "prepare": "cross-env NODE_ENV=production npm run build && npm run typegen",
-    "typegen": "tsc --emitDeclarationOnly --declaration --declarationDir lib/",
+    "typegen": "rimraf \"lib/**/*.d.ts\" && tsc --emitDeclarationOnly --declaration --declarationDir lib/",
     "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\"  --extensions \".ts,.js,.tsx\"",
     "postinstall": "node scripts/postinstall.js"
   },


### PR DESCRIPTION
### Description

https://github.com/gatsbyjs/gatsby/pull/24381 introduced chain where `gatsby-cli` source files try to use build `gatsby-cli` files:

- https://github.com/gatsbyjs/gatsby/blob/96dbf2b42239efd892a9a1d2384daf1fff36b7be/packages/gatsby-cli/src/reporter/loggers/ink/context.tsx#L3
- https://github.com/gatsbyjs/gatsby/blob/96dbf2b42239efd892a9a1d2384daf1fff36b7be/packages/gatsby/src/redux/types.ts#L7
- https://github.com/gatsbyjs/gatsby/blob/96dbf2b42239efd892a9a1d2384daf1fff36b7be/packages/gatsby/src/schema/infer/inference-metadata.ts#L64
- https://github.com/gatsbyjs/gatsby/blob/96dbf2b42239efd892a9a1d2384daf1fff36b7be/packages/gatsby/src/schema/infer/type-conflict-reporter.ts#L2

This weirdly doesn't cause issues other than `tsc` errors when trying to build already built package and it manifest with errors like these:

```
$ cross-env NODE_ENV=production npm run build && npm run typegen
npm WARN lifecycle The node binary used for scripts is /var/folders/7b/7_tqb8f50bx7jhyj0bn9r8v80000gn/T/yarn--1592386922492-0.026473074778530892/node but npm is using /Users/misiek/.nvm/versions/node/v10.16.3/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
> gatsby-cli@2.12.46 build /Users/misiek/dev/gatsby/packages/gatsby-cli
> babel src --out-dir lib --ignore "**/__tests__" --extensions ".ts,.js,.tsx"
Successfully compiled 43 files with Babel (2010ms).
npm WARN lifecycle The node binary used for scripts is /var/folders/7b/7_tqb8f50bx7jhyj0bn9r8v80000gn/T/yarn--1592386922492-0.026473074778530892/node but npm is using /Users/misiek/.nvm/versions/node/v10.16.3/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
> gatsby-cli@2.12.46 typegen /Users/misiek/dev/gatsby/packages/gatsby-cli
> tsc --emitDeclarationOnly --declaration --declarationDir lib/
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/reporter/constants.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/reporter/index.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/reporter/redux/types.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/reporter/reporter-phantom.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/reporter/reporter-progress.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/reporter/reporter-timer.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/reporter/reporter.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/reporter/types.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/structured-errors/error-map.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/Users/misiek/dev/gatsby/packages/gatsby-cli/lib/structured-errors/types.d.ts' because it would overwrite input file.
Found 10 errors.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! gatsby-cli@2.12.46 typegen: `tsc --emitDeclarationOnly --declaration --declarationDir lib/`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the gatsby-cli@2.12.46 typegen script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/misiek/.npm/_logs/2020-06-17T09_42_11_646Z-debug.log
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Making sure we don't have declaration files before running typegen seems to fix (or rather work around this), so this is what this PR does

To reproduce the problem:
```
cd packages/gatsby-cli
yarn prepare
yarn prepare
```

2nd prepare will show those errors (1st one might too if you have those .d.ts files around already)