### PR TITLE
chore(CODEOWNERS): define rule for /benchmarks/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,9 @@
 /docs/                                          @gatsbyjs/learning
 **/README.md                                    @gatsbyjs/learning
 
+# Benchmarks
+/benchmarks/                                    @duffn @pvdz @smthomas
+
 # All blog posts must be reviewed by the content team.
 /docs/blog/                                     @gatsbyjs/content
 


### PR DESCRIPTION
## Description

Right now `/benchmarks/` is partially owned by core (`*`) and learning (`**/README.md`) which makes it frustrating to maintain code there for folks who really own that code. This PR adds actual owners.

I can create `bechmarks` team if we don't want individual accounts mentioned in CODEOWNERS
