### PR TITLE
Documentation: fs solution is found in multiple GitHub issues and should be in the docs

### DIFF
--- a/docs/docs/troubleshooting-common-errors.md
+++ b/docs/docs/troubleshooting-common-errors.md
@@ -63,6 +63,22 @@ npm install --save @emotion/core
 
 Or replace `@emotion/core` with the name of the library that is missing. Installing the plugin and any necessary libraries as well as adding the plugin to your `gatsby-config` should resolve this error.
 
+### Issues with `fs` resolution
+
+This error may be a top level `Cannot resolve module 'fs'` or part of a Webpack error like `Can't resolve 'fs'`.
+
+`fs` stands for filesystem and it's a Node.js library that's used to access files on your computer. However, when your packaged Gatsby code runs, your computer is but a distant memory.
+
+Some packages, like Babel, bring `fs` along for the ride anyway. In order to prevent it from causing errors, you can add the following to your `gatsby-node.js` file.
+
+```javascript:title=gatsby-node.js
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    node: {
+      fs: 'empty'
+    }
+```
+
 ## Errors in styling
 
 The following errors are related to styles in your site, using CSS, preprocessors, or CSS-in-JSS solutions.

--- a/docs/docs/troubleshooting-common-errors.md
+++ b/docs/docs/troubleshooting-common-errors.md
@@ -65,6 +65,8 @@ Or replace `@emotion/core` with the name of the library that is missing. Install
 
 ### Issues with `fs` resolution
 
+You may see this error because you're attempting to use `fs` inside a React component. Additionally, it often shows up when working with `@mdx-js/runtime`.
+
 This error may be a top level `Cannot resolve module 'fs'` or part of a Webpack error like `Can't resolve 'fs'`.
 
 `fs` stands for filesystem and it's a Node.js library that's used to access files on your computer. However, when your packaged Gatsby code runs, your computer is but a distant memory.


### PR DESCRIPTION
This recently came up in #24815  but is littered throughout GitHub issues with many emoji responses. This PR puts the solution/fix directly in the common troubleshooting docs.

I felt that's where it was most appropriate, but open to other ideas as well.