### PR TITLE
maintenance(www): add environment variables to disable sourcing from docs/plugins

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -52,7 +52,39 @@ The list of possible locales can be found at [i18n.json](/www/i18n.json).
 
 The default locale, English, is always on. There is currently no UI to link to the localizations, so you'll have to type in the name of the file you want to go to using the language code (e.g. /es/tutorial/part-one).
 
-## Running slow build? (Screenshots placeholder)
+## Running slow build?
+
+### Disabling sourcing docs
+
+You can disable sourcing from the `docs/` and `packages/` directory by setting the following variable to `.env.development`:
+
+```shell
+DISABLE_SOURCE_DOCS=true
+```
+
+This will mean that the following URLs won't be generated:
+
+- docs/
+- tutorial/
+- blog/
+- features/
+- starters/
+- showcase/
+- creators/
+
+Use this option when you just want to test that the site builds or when working on a component that is not part of these sections (such as the homepage or the navigation).
+
+### Disabling NPM search (plugins/packages)
+
+If you are not working with plugins/packages, you can add the following variable to `.env.development`:
+
+```shell
+DISABLE_NPM_SEARCH=true
+```
+
+This will tell the plugin `gatsby-transformer-npm-package-search` to not search gatsby-related packages, and instead only search for a placeholder keyword.
+
+### Screenshots placeholder
 
 If you are not working on a starter or site showcase, it might be beneficial to use a placeholder image instead of actual screenshots. It will skip downloading screenshots and generating responsive images for all screenshots and replace them with a placeholder image.
 

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -51,6 +51,26 @@ if (process.env.AIRTABLE_API_KEY) {
   })
 }
 
+if (!process.env.DISABLE_SOURCE_DOCS) {
+  dynamicPlugins.push({
+    resolve: `gatsby-source-filesystem`,
+    options: {
+      name: `docs`,
+      path: `${__dirname}/../docs/`,
+    },
+  })
+  // The `packages` directory is only used for API definitions,
+  // which are part of the docs.
+  dynamicPlugins.push({
+    resolve: `gatsby-source-filesystem`,
+    options: {
+      name: `gatsby-core`,
+      path: `${__dirname}/../packages/gatsby/`,
+      ignore: [`**/dist/**`],
+    },
+  })
+}
+
 module.exports = {
   siteMetadata: {
     title: `GatsbyJS`,
@@ -80,22 +100,12 @@ module.exports = {
     {
       resolve: `gatsby-source-npm-package-search`,
       options: {
-        keywords: [`gatsby-plugin`, `gatsby-component`],
-      },
-    },
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `docs`,
-        path: `${__dirname}/../docs/`,
-      },
-    },
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `gatsby-core`,
-        path: `${__dirname}/../packages/gatsby/`,
-        ignore: [`**/dist/**`],
+        // If DISABLE_NPM_SEARCH is true, search for a placeholder keyword
+        // that returns a lot fewer packages
+        // (In this case, stuff that Lennart has published)
+        keywords: process.env.DISABLE_NPM_SEARCH
+          ? [`lekoarts`]
+          : [`gatsby-plugin`, `gatsby-component`],
       },
     },
     {


### PR DESCRIPTION
## Description

Add two new env variables, `DISABLE_SOURCE_DOCS` and `DISABLE_NPM_SEARCH` to provide a way to run the Gatsby site without expensive sourcing.

## Motivation

The gatsby site usually takes ~30 mins to run. When these env variables are turned on, the build time is ~30 seconds.

This makes it easier to build the site for devs who just want to edit components that aren't in these pages, and for contributors to work on the website without having to download all the docs/blog (using `git clone —sparse`).

## Further Improvement Ideas

More granular ways to enable sections — for example, being able to disable everything except `tutorials/` and `starters/`. I was thinking of using the `ignore:` property on `gatsby-source-filesystem` but I haven't been able to get the globs to play nice with me. 🤷‍♀️ 

## Related Issues

This PR builds off work from #24943 