### PR TITLE
docs: show how to pass plugin options to Babel

### DIFF
--- a/docs/docs/babel.md
+++ b/docs/docs/babel.md
@@ -23,7 +23,9 @@ npm install --save-dev babel-preset-gatsby
 <!-- prettier-ignore-start -->
 ```json:title=.babelrc
 {
-  "plugins": ["@babel/plugin-proposal-optional-chaining"],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "legacy": true }]
+  ],
   "presets": [
     [
       "babel-preset-gatsby",


### PR DESCRIPTION
## Description

This PR changes the example from [How to use a custom .babelrc file](https://www.gatsbyjs.org/docs/babel/#how-to-use-a-custom-babelrc-file) to use a different plugin, for two reason:

1. The current plugin, optional chaining, is now included in [the default TypeScript setup](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-typescript/src/gatsby-node.js)
2. The decorators proposal plugin is commonly used with the `{ legacy: true }` option, which gives the opportunity to include a copy&paste-able example of passing options to a Babel plugin.