### PR TITLE
docs(gatsby-plugin-typescript): how to add Babel TS plugins

### DIFF
--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -36,7 +36,7 @@ module.exports = {
 ```
 
 For more detailed documentation on the available options, visit https://babeljs.io/docs/en/babel-preset-typescript#options.
-To add TypeScript Babel plugins (e.g. `@babel/plugin-proposal-decorators`), use a [custom .babelrc file](/docs/babel/#how-to-use-a-custom-babelrc-file).
+To add TypeScript Babel plugins (e.g. `@babel/plugin-proposal-decorators`), you can try using a [custom .babelrc file](https://www.gatsbyjs.com/docs/babel/#how-to-use-a-custom-babelrc-file).
 
 ## Caveats
 
@@ -58,7 +58,7 @@ compiler is not involved, the following applies:
 > and import x, {y} from "z".
 >
 > Does not support baseUrl.
-> Workaround: use [gatsby-plugin-root-import](https://www.gatsbyjs.org/packages/gatsby-plugin-root-import/)
+> Workaround: use [gatsby-plugin-root-import](https://www.gatsbyjs.com/packages/gatsby-plugin-root-import/)
 > and configure it to point the baseUrl value (also set baseUrl option in tsconfig.json file).
 
 https://babeljs.io/docs/en/babel-plugin-transform-typescript.html

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -36,6 +36,7 @@ module.exports = {
 ```
 
 For more detailed documentation on the available options, visit https://babeljs.io/docs/en/babel-preset-typescript#options.
+To add TypeScript Babel plugins (e.g. `@babel/plugin-proposal-decorators`), use a [custom .babelrc file](/docs/babel/#how-to-use-a-custom-babelrc-file).
 
 ## Caveats
 


### PR DESCRIPTION
This PR explains how to add TypeScript-related Babel plugins by pointing to the Gatsby Babel docs page.

It should alleviate the need for [decorator support](https://github.com/gatsbyjs/gatsby/pull/23936) (though I haven't yet been able to actually use `@babel/plugin-proposal-decorators`, but that's a separate issue).