### PR TITLE
feat(gatsby-recipes): Add Snipcart

### DIFF
--- a/packages/gatsby-recipes/recipes/snipcart.mdx
+++ b/packages/gatsby-recipes/recipes/snipcart.mdx
@@ -2,7 +2,7 @@
 
 Snipcart is a shopping cart platform for developers.
 
-This recipe will guide you through enabling ecommerce on your Gatsby site.
+This recipe will guide you through enabling e-commerce on your Gatsby site.
 
 ## Create a Snipcart account
 
@@ -31,7 +31,8 @@ You can use this account for FREE to test things out as long as you like!
 
 <File
   path="./bin/snipcart-setup.js"
-  content="https://gist.githubusercontent.com/thatfrankdev/4544e73bce47d90d0b1db1c8305198a6/raw/8ad06e2fbb1032df0faf214bf09029627c1e8321/snipcart-setup.js" />
+  content="https://gist.githubusercontent.com/thatfrankdev/4544e73bce47d90d0b1db1c8305198a6/raw/8ad06e2fbb1032df0faf214bf09029627c1e8321/snipcart-setup.js"
+/>
 
 <NPMScript
   name="snipcart-setup"

--- a/packages/gatsby-recipes/recipes/snipcart.mdx
+++ b/packages/gatsby-recipes/recipes/snipcart.mdx
@@ -1,0 +1,58 @@
+# Add e-commerce powered by Snipcart
+
+Snipcart is a shopping cart platform for developers.
+
+This recipe will guide you through enabling ecommerce on your Gatsby site.
+
+## Create a Snipcart account
+
+If you do not already have a Snipcart account, please register [here](https://app.snipcart.com/register).
+
+You can use this account for FREE to test things out as long as you like!
+
+---
+
+## Install Gatsby plugin for Snipcart
+
+<NPMPackage name="gatsby-plugin-snipcart-advanced" />
+
+<GatsbyPlugin
+  name="gatsby-plugin-snipcart-advanced"
+  options={{
+    publicApiKey:"[YOUR_PUBLIC_API_KEY]"
+  }}
+/>
+
+---
+
+## Pull Snipcart setup script
+
+<Directory path="bin" />
+
+<File
+  path="./bin/snipcart-setup.js"
+  content="https://gist.githubusercontent.com/thatfrankdev/4544e73bce47d90d0b1db1c8305198a6/raw/8ad06e2fbb1032df0faf214bf09029627c1e8321/snipcart-setup.js" />
+
+<NPMScript
+  name="snipcart-setup"
+  command="node ./bin/snipcart-setup.js"
+/>
+
+<NPMPackage
+  name="abstract-syntax-tree"
+  dependencyType="development"
+/>
+
+---
+
+Snipcart has been installed to your gatsby site!
+
+The documentation of the plugin can be found [here](https://github.com/ipatate/gatsby-plugin-snipcart-advanced/blob/master/readme.md).
+
+Please set your account's public API key in the plugin config to get started.
+
+OPTIONAL: To automate the plugin configuration, you can run this command in your terminal: `npm run snipcart-setup`.
+
+Here's how to add your first Snipcart buy button: https://docs.snipcart.com/v3/setup/products.
+
+Happy selling!

--- a/packages/gatsby-recipes/src/cli.js
+++ b/packages/gatsby-recipes/src/cli.js
@@ -148,6 +148,10 @@ const RecipesList = ({ setRecipe }) => {
       value: `wordpress.mdx`,
     },
     {
+      label: `Add e-commerce powered by Snipcart`,
+      value: `snipcart.mdx`,
+    },
+    {
       label: `Add Storybook - JavaScript`,
       value: `storybook-js.mdx`,
     },


### PR DESCRIPTION
Adds a Gatsby recipe that enables ecommerce with a Snipcart plugin

_💭 I'm not a fan of the external setup script + additional dev dependency on abstract-syntax-tree. I'd be happy revisit once support for user input is added 🙏. I'm also open to remove it if it violates some "anti-bloat" rule_