### PR TITLE
Fix clashing theme-ui version

### DIFF
--- a/packages/gatsby-admin/package.json
+++ b/packages/gatsby-admin/package.json
@@ -29,7 +29,7 @@
     "react-icons": "^3.10.0",
     "strict-ui": "^0.1.3",
     "subscriptions-transport-ws": "^0.9.16",
-    "theme-ui": "^0.4.0-alpha.3",
+    "theme-ui": "^0.2.52",
     "typescript": "^3.9.3",
     "urql": "^1.9.7",
     "yup": "^0.29.1"


### PR DESCRIPTION
Right now this version of theme-ui causes problems for sites using themes and npm. It resolves to the alpha release instead of the one expected by the theme and the larger Gatsby project. 

Closes #25093 