### PR TITLE
feat(gatsby): MatchPath could be defined as array of matchPath patterns

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/__tests__/requires-writer.js
@@ -68,6 +68,40 @@ describe(`requires-writer`, () => {
         JSON.stringify([{ path: `/path1`, matchPath: `matchPath1` }], null, 4)
       )
     })
+    it(`matchPath could be an array of different matchPath patterns`, async () => {
+      const pages = generatePagesState([
+        {
+          component: `component1`,
+          componentChunkName: `chunkName1`,
+          matchPath: [`matchPath1`, `matchPath2`, `matchPath3`],
+          path: `/path1`,
+        },
+        {
+          component: `component2`,
+          componentChunkName: `chunkName2`,
+          path: `/path2`,
+        },
+      ])
+
+      const spy = jest.spyOn(mockFsExtra, `writeFile`)
+      await requiresWriter.writeAll({
+        pages,
+        program,
+      })
+
+      expect(spy).toBeCalledWith(
+        joinPath(`/dir`, `.cache`, `match-paths.json.${now}`),
+        JSON.stringify(
+          [
+            { path: `/path1`, matchPath: `matchPath1` },
+            { path: `/path1`, matchPath: `matchPath2` },
+            { path: `/path1`, matchPath: `matchPath3` },
+          ],
+          null,
+          4
+        )
+      )
+    })
   })
 
   describe(`matchPath`, () => {

--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -77,9 +77,12 @@ const getMatchPaths = (pages: IGatsbyPage[]): IGatsbyPageMatchPath[] => {
     score: number
     matchPath: string
   }
+  interface IGatsbyPageWithoutMatchPathArray extends IGatsbyPage {
+    matchPath: Exclude<IGatsbyPage["matchPath"], string[]>
+  }
 
   const createMatchPathEntry = (
-    page: IGatsbyPage,
+    page: IGatsbyPageWithoutMatchPathArray,
     index: number
   ): IMatchPathEntry => {
     const { matchPath } = page
@@ -99,10 +102,24 @@ const getMatchPaths = (pages: IGatsbyPage[]): IGatsbyPageMatchPath[] => {
   }
 
   const matchPathPages: IMatchPathEntry[] = []
+  let index = 0
 
-  pages.forEach((page: IGatsbyPage, index: number): void => {
+  pages.forEach((page: IGatsbyPage): void => {
     if (page.matchPath) {
-      matchPathPages.push(createMatchPathEntry(page, index))
+      if (_.isArray(page.matchPath)) {
+        page.matchPath.forEach(matchPath => {
+          matchPathPages.push(
+            createMatchPathEntry({ ...page, matchPath }, index++)
+          )
+        })
+      } else {
+        matchPathPages.push(
+          createMatchPathEntry(
+            page as IGatsbyPageWithoutMatchPathArray,
+            index++
+          )
+        )
+      }
     }
   })
 

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -26,7 +26,7 @@ export enum ProgramStatus {
 export interface IGatsbyPage {
   internalComponentName: string
   path: string
-  matchPath: undefined | string
+  matchPath: undefined | string | string[]
   component: SystemPath
   componentChunkName: string
   isCreatedByStatefulCreatePages: boolean


### PR DESCRIPTION
relates #22758

## Description

As mentioned in [issue#22758](https://github.com/gatsbyjs/gatsby/issues/22758), Gatsby currently does not handle scenario, where single page application (SPA) lives on multiple routes without common path prefix. I.e. we can route all paths starting with `/app` with matchPath pattern `/app/*` to single static file, but we cannot route to single static file with two completely different paths, e.g. `/home` and `/settings`.

If we allow do define `matchPath` as array of `matchPath` patterns, then we are able to point several different routes to single static file (which contains SPA).

I experimented with many ways to solve this issue and in the end, I change the `.cache/match-paths.json` file during `onPostBootstrap`. I use this solution IN PRODUCTION and it works well, but I would like to standardise this approach and bring it as feature to all users.

PS: this PR lacks change of documentation and thus is incomplete, WIP or more like RFC.