### PR TITLE
fix(gatsby-plugin-mdx): set childOf extension for Mdx type definition

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -270,7 +270,9 @@ ${e}`
     },
     interfaces: [`Node`],
     extensions: {
-      mimeTypes: options.mediaTypes,
+      childOf: {
+        mimeTypes: options.mediaTypes,
+      },
     },
   })
   createTypes(MdxType)

--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -269,6 +269,9 @@ ${e}`
       },
     },
     interfaces: [`Node`],
+    extensions: {
+      mimeTypes: options.mediaTypes,
+    },
   })
   createTypes(MdxType)
 }


### PR DESCRIPTION
## Description

Add the `childOf` extension to the `Mdx` node type to aid in populating types.

This is equivalent to:

```
type Mdx implements Node @childOf(mimeTypes: ["text/markdown", "text/x-markdown"]) {
  # (or whatever is defined in `options.mediaTypes`
}
```

## Motivation

This makes the typing more robust so that anything with `@mimeTypes(types: ["text/markdown", "text/x-markdown"])` immediately get `childMdx` even if no nodes are created.