### PR TITLE
fix(gatsby-transformer-documentationjs): Add childOf, mimeTypes and fill in other schema typings

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -45,7 +45,7 @@ function prepareDescriptionNode(node, markdownStr, name, helpers) {
 exports.sourceNodes = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = /* GraphQL */ `
-    type DocumentationJs implements Node {
+    type DocumentationJs implements Node @childOf(types: ["File", "DocumentationJs"]) {
       name: String
       kind: String
       memberof: String
@@ -84,11 +84,13 @@ exports.sourceNodes = ({ actions }) => {
       docsLocation: DocumenationJSLocationRange
     }
 
+    type DocumentationJSComponentDescription implements Node @mimeTypes(types: ["text/markdown"]) {}
+
     type DocumentationJSLocation {
       line: Int
       column: Int
     }
-
+    
     type DocumenationJSLocationRange {
       start: DocumentationJSLocation
       end: DocumentationJSLocation

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -45,7 +45,8 @@ function prepareDescriptionNode(node, markdownStr, name, helpers) {
 exports.sourceNodes = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = /* GraphQL */ `
-    type DocumentationJs implements Node @childOf(types: ["File", "DocumentationJs"]) {
+    type DocumentationJs implements Node
+      @childOf(types: ["File", "DocumentationJs"]) {
       name: String
       kind: String
       memberof: String
@@ -84,13 +85,16 @@ exports.sourceNodes = ({ actions }) => {
       docsLocation: DocumenationJSLocationRange
     }
 
-    type DocumentationJSComponentDescription implements Node @mimeTypes(types: ["text/markdown"]) {}
+    type DocumentationJSComponentDescription implements Node
+      @mimeTypes(types: ["text/markdown"]) {
+      id: ID! # empty type
+    }
 
     type DocumentationJSLocation {
       line: Int
       column: Int
     }
-    
+
     type DocumenationJSLocationRange {
       start: DocumentationJSLocation
       end: DocumentationJSLocation


### PR DESCRIPTION
## Description

* Add `@childOf` directive to `DocumentationJs` type to verify it's a descendant of File nodes.
* Add `type DocumentationJSComponentDescription` and add a `@mimeTypes` to specify it's a Markdown node.

## Related

#25112 