### PR TITLE
feat(gatsby): Track static queries by template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,12 @@ jobs:
       - e2e-test:
           test_path: integration-tests/structured-logging
 
+  integration_tests_artifacts:
+    executor: node
+    steps:
+      - e2e-test:
+          test_path: integration-tests/artifacts
+
   e2e_tests_path-prefix:
     <<: *e2e-executor
     environment:
@@ -569,6 +575,8 @@ workflows:
       - integration_tests_gatsby_pipeline:
           <<: *e2e-test-workflow
       - integration_tests_structured_logging:
+          <<: *e2e-test-workflow
+      - integration_tests_artifacts:
           <<: *e2e-test-workflow
       - integration_tests_gatsby_cli:
           requires:

--- a/integration-tests/artifacts/LICENSE
+++ b/integration-tests/artifacts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 gatsbyjs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integration-tests/artifacts/README.md
+++ b/integration-tests/artifacts/README.md
@@ -1,0 +1,3 @@
+## Artifacts test suite
+
+This integration test suite helps us assert some of the artifacts written out for a Gatsby build. The test suite runs a real Gatsby build and then checks the generated `public` directory for `page-data.json` files. Since we added static query hashes to `page-data.json` files, the tests in this suite assert whether the correct static query hashes are included in every respective page.

--- a/integration-tests/artifacts/__tests__/static-queries.js
+++ b/integration-tests/artifacts/__tests__/static-queries.js
@@ -1,0 +1,173 @@
+const { spawn } = require(`child_process`)
+const path = require(`path`)
+const { murmurhash } = require(`babel-plugin-remove-graphql-queries`)
+const { readPageData } = require(`gatsby/dist/utils/page-data`)
+const { stripIgnoredCharacters } = require(`gatsby/graphql`)
+
+jest.setTimeout(100000)
+
+const publicDir = path.join(process.cwd(), `public`)
+
+const gatsbyBin = path.join(`node_modules`, `.bin`, `gatsby`)
+
+const titleQuery = `
+  {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+`
+
+const authorQuery = `
+  {
+    site {
+      siteMetadata {
+        author
+      }
+    }
+  }
+`
+
+const githubQuery = `
+  {
+    site {
+      siteMetadata {
+        github
+      }
+    }
+  }
+`
+
+function hashQuery(query) {
+  const text = stripIgnoredCharacters(query)
+  const hash = murmurhash(text, `abc`)
+  return String(hash)
+}
+
+const globalQueries = [githubQuery]
+
+describe(`Static Queries`, () => {
+  beforeAll(async done => {
+    const gatsbyProcess = spawn(gatsbyBin, [`build`], {
+      stdio: [`inherit`, `inherit`, `inherit`, `inherit`],
+      env: {
+        ...process.env,
+        NODE_ENV: `production`,
+      },
+    })
+
+    gatsbyProcess.on(`exit`, exitCode => {
+      done()
+    })
+  })
+
+  test(`are written correctly when inline`, async () => {
+    const queries = [titleQuery, ...globalQueries]
+    const pagePath = `/inline/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly when imported`, async () => {
+    const queries = [titleQuery, ...globalQueries]
+    const pagePath = `/import/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly when dynamically imported`, async () => {
+    const queries = [titleQuery, ...globalQueries]
+    const pagePath = `/dynamic/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly in jsx`, async () => {
+    const queries = [titleQuery, ...globalQueries]
+    const pagePath = `/jsx/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly in tsx`, async () => {
+    const queries = [titleQuery, ...globalQueries]
+    const pagePath = `/tsx/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly in typescript`, async () => {
+    const queries = [titleQuery, ...globalQueries]
+    const pagePath = `/typescript/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly when nesting imports`, async () => {
+    const queries = [titleQuery, authorQuery, ...globalQueries]
+    const pagePath = `/import-import/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly when nesting dynamic imports`, async () => {
+    const queries = [titleQuery, ...globalQueries]
+    const pagePath = `/dynamic-dynamic/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly when nesting a dynamic import in a regular import`, async () => {
+    const queries = [titleQuery, authorQuery, ...globalQueries]
+    const pagePath = `/import-dynamic/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  test(`are written correctly when nesting a regular import in a dynamic import`, async () => {
+    const queries = [titleQuery, ...globalQueries]
+    const pagePath = `/dynamic-import/`
+
+    const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+    expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  })
+
+  // test(`are written correctly when using wrapRootElement`, async () => {
+  //   const queries = [titleQuery]
+  //   const pagePath = `/dynamic-import/`
+
+  //   const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+  //   expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  // })
+
+  // test(`are written correctly when using wrapPageElement`, async () => {
+  //   const queries = [titleQuery]
+  //   const pagePath = `/dynamic-import/`
+
+  //   const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+  //   expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+  // })
+})

--- a/integration-tests/artifacts/gatsby-browser.js
+++ b/integration-tests/artifacts/gatsby-browser.js
@@ -1,0 +1,9 @@
+const React = require(`react`)
+const Github = require(`./src/components/github`).default
+
+exports.wrapPageElement = ({ element }) => (
+  <>
+    <Github />
+    {element}
+  </>
+)

--- a/integration-tests/artifacts/gatsby-config.js
+++ b/integration-tests/artifacts/gatsby-config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  siteMetadata: {
+    title: `Hello world`,
+    author: `Sid Chatterjee`,
+    twitter: `chatsidhartha`,
+    github: `sidharthachatterjee`,
+  },
+  plugins: [],
+}

--- a/integration-tests/artifacts/jest.config.js
+++ b/integration-tests/artifacts/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testPathIgnorePatterns: [`/node_modules/`, `__tests__/fixtures`, `.cache`],
+}

--- a/integration-tests/artifacts/package.json
+++ b/integration-tests/artifacts/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "artifacts",
+  "private": true,
+  "author": "Sid Chatterjee",
+  "description": "A simplified bare-bones starter for Gatsby",
+  "version": "0.1.0",
+  "license": "MIT",
+  "scripts": {
+    "build": "gatsby build",
+    "develop": "gatsby develop",
+    "serve": "gatsby serve",
+    "clean": "gatsby clean",
+    "test": "jest --config=jest.config.js --runInBand"
+  },
+  "dependencies": {
+    "gatsby": "^2.22.0",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
+  },
+  "devDependencies": {
+    "fs-extra": "^9.0.0",
+    "jest": "^24.0.0",
+    "jest-cli": "^24.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby-starter-hello-world"
+  },
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  }
+}

--- a/integration-tests/artifacts/src/components/author.js
+++ b/integration-tests/artifacts/src/components/author.js
@@ -1,0 +1,15 @@
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+export default function Author() {
+  const { site } = useStaticQuery(graphql`
+    {
+      site {
+        siteMetadata {
+          author
+        }
+      }
+    }
+  `)
+  return <div>{site.siteMetadata.author}</div>
+}

--- a/integration-tests/artifacts/src/components/github.js
+++ b/integration-tests/artifacts/src/components/github.js
@@ -1,0 +1,15 @@
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+export default function Github() {
+  const { site } = useStaticQuery(graphql`
+    {
+      site {
+        siteMetadata {
+          github
+        }
+      }
+    }
+  `)
+  return <div>{site.siteMetadata.github}</div>
+}

--- a/integration-tests/artifacts/src/components/title.js
+++ b/integration-tests/artifacts/src/components/title.js
@@ -1,0 +1,7 @@
+import React from "react"
+import { useTitle } from "../hooks/use-title"
+
+export default function Title() {
+  const title = useTitle()
+  return <div>{title}</div>
+}

--- a/integration-tests/artifacts/src/components/twitter.js
+++ b/integration-tests/artifacts/src/components/twitter.js
@@ -1,0 +1,15 @@
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+export default function Twitter() {
+  const { site } = useStaticQuery(graphql`
+    {
+      site {
+        siteMetadata {
+          twitter
+        }
+      }
+    }
+  `)
+  return <div>{site.siteMetadata.twitter}</div>
+}

--- a/integration-tests/artifacts/src/hooks/use-title.js
+++ b/integration-tests/artifacts/src/hooks/use-title.js
@@ -1,0 +1,14 @@
+import { useStaticQuery, graphql } from "gatsby"
+
+export const useTitle = () => {
+  const { site } = useStaticQuery(graphql`
+    {
+      site {
+        siteMetadata {
+          title
+        }
+      }
+    }
+  `)
+  return site.siteMetadata.title
+}

--- a/integration-tests/artifacts/src/pages/dynamic-dynamic.js
+++ b/integration-tests/artifacts/src/pages/dynamic-dynamic.js
@@ -1,0 +1,17 @@
+import React, { Component } from "react"
+
+export default class Dynamic extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { module: null }
+  }
+  componentDidMount() {
+    import(`../pages/dynamic`).then(module =>
+      this.setState({ module: module.default })
+    )
+  }
+  render() {
+    const { module: Component } = this.state
+    return <div>{Component && <Component />}</div>
+  }
+}

--- a/integration-tests/artifacts/src/pages/dynamic-import.js
+++ b/integration-tests/artifacts/src/pages/dynamic-import.js
@@ -1,0 +1,17 @@
+import React, { Component } from "react"
+
+export default class Dynamic extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { module: null }
+  }
+  componentDidMount() {
+    import(`../pages/import`).then(module =>
+      this.setState({ module: module.default })
+    )
+  }
+  render() {
+    const { module: Component } = this.state
+    return <div>{Component && <Component />}</div>
+  }
+}

--- a/integration-tests/artifacts/src/pages/dynamic.js
+++ b/integration-tests/artifacts/src/pages/dynamic.js
@@ -1,0 +1,17 @@
+import React, { Component } from "react"
+
+export default class Dynamic extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { module: null }
+  }
+  componentDidMount() {
+    import(`../components/title`).then(module =>
+      this.setState({ module: module.default })
+    )
+  }
+  render() {
+    const { module: Component } = this.state
+    return <div>{Component && <Component />}</div>
+  }
+}

--- a/integration-tests/artifacts/src/pages/import-dynamic.js
+++ b/integration-tests/artifacts/src/pages/import-dynamic.js
@@ -1,0 +1,12 @@
+import React from "react"
+import Author from "../components/author"
+import Dynamic from "../pages/dynamic"
+
+export default function ImportImport() {
+  return (
+    <>
+      <Author />
+      <Dynamic />
+    </>
+  )
+}

--- a/integration-tests/artifacts/src/pages/import-import.js
+++ b/integration-tests/artifacts/src/pages/import-import.js
@@ -1,0 +1,12 @@
+import React from "react"
+import Import from "./import"
+import Author from "../components/author"
+
+export default function ImportImport() {
+  return (
+    <>
+      <Author />
+      <Import />
+    </>
+  )
+}

--- a/integration-tests/artifacts/src/pages/import.js
+++ b/integration-tests/artifacts/src/pages/import.js
@@ -1,0 +1,7 @@
+import React from "react"
+import { useTitle } from "../hooks/use-title"
+
+export default function Import() {
+  const title = useTitle()
+  return <div>{title}</div>
+}

--- a/integration-tests/artifacts/src/pages/inline.js
+++ b/integration-tests/artifacts/src/pages/inline.js
@@ -1,0 +1,15 @@
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+export default function Inline() {
+  const { site } = useStaticQuery(graphql`
+    {
+      site {
+        siteMetadata {
+          title
+        }
+      }
+    }
+  `)
+  return <div>{site.siteMetadata.title}</div>
+}

--- a/integration-tests/artifacts/src/pages/jsx.jsx
+++ b/integration-tests/artifacts/src/pages/jsx.jsx
@@ -1,0 +1,7 @@
+import React from "react"
+import { useTitle } from "../hooks/use-title"
+
+export default function Jsx() {
+  const title = useTitle()
+  return <div>{title}</div>
+}

--- a/integration-tests/artifacts/src/pages/tsx.tsx
+++ b/integration-tests/artifacts/src/pages/tsx.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+import { useTitle } from "../hooks/use-title"
+
+export default function Tsx(): any {
+  const title = useTitle()
+  return <div>{title}</div>
+}

--- a/integration-tests/artifacts/src/pages/typescript.ts
+++ b/integration-tests/artifacts/src/pages/typescript.ts
@@ -1,0 +1,7 @@
+import React from "react"
+import { useTitle } from "../hooks/use-title"
+
+export default function Ts(): any {
+  const title = useTitle()
+  return title
+}

--- a/packages/babel-plugin-remove-graphql-queries/src/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.js
@@ -432,4 +432,5 @@ export {
   StringInterpolationNotAllowedError,
   EmptyGraphQLTagError,
   GraphQLSyntaxError,
+  murmurhash,
 }

--- a/packages/gatsby/src/commands/build-javascript.ts
+++ b/packages/gatsby/src/commands/build-javascript.ts
@@ -1,8 +1,11 @@
 import { Span } from "opentracing"
 import webpack from "webpack"
+import { isEqual } from "lodash"
 import flatMap from "lodash/flatMap"
 
 import webpackConfig from "../utils/webpack.config"
+import { store } from "../redux"
+import { mapTemplatesToStaticQueryHashes } from "../utils/map-pages-to-static-query-hashes"
 
 import { IProgram } from "./types"
 
@@ -23,7 +26,44 @@ export const buildProductionBundle = async (
   )
 
   return new Promise((resolve, reject) => {
-    webpack(compilerConfig).run((err, stats) => {
+    const compiler = webpack(compilerConfig)
+
+    compiler.hooks.compilation.tap(`webpack-dep-tree-plugin`, compilation => {
+      compilation.hooks.seal.tap(`webpack-dep-tree-plugin`, () => {
+        const state = store.getState()
+        const mapOfTemplatesToStaticQueryHashes = mapTemplatesToStaticQueryHashes(
+          state,
+          compilation
+        )
+
+        mapOfTemplatesToStaticQueryHashes.forEach(
+          (staticQueryHashes, componentPath) => {
+            if (
+              !isEqual(
+                state.staticQueriesByTemplate.get(componentPath),
+                staticQueryHashes.map(String)
+              )
+            ) {
+              store.dispatch({
+                type: `ADD_PENDING_TEMPLATE_DATA_WRITE`,
+                payload: {
+                  componentPath,
+                },
+              })
+              store.dispatch({
+                type: `SET_STATIC_QUERIES_BY_TEMPLATE`,
+                payload: {
+                  componentPath,
+                  staticQueryHashes,
+                },
+              })
+            }
+          }
+        )
+      })
+    })
+
+    compiler.run((err, stats) => {
       if (err) {
         return reject(err)
       }

--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -204,7 +204,7 @@ module.exports = async (program: IProgram): Promise<void> => {
             })
             queryWatcher.startWatchDeletePage()
 
-            await startWebpackServer({ program, app, workerPool })
+            await startWebpackServer({ program, app, workerPool, store })
           },
         },
       },

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -58,6 +58,7 @@ Object {
     "pagePaths": Set {},
     "templatePaths": Set {},
   },
+  "staticQueriesByTemplate": Map {},
   "staticQueryComponents": Map {},
   "status": Object {
     "PLUGINS_HASH": "",

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -86,6 +86,7 @@ export const saveState = (): void => {
     pageDataStats: state.pageDataStats,
     pageData: state.pageData,
     pendingPageDataWrites: state.pendingPageDataWrites,
+    staticQueriesByTemplate: state.staticQueriesByTemplate,
   })
 }
 

--- a/packages/gatsby/src/redux/reducers/index.ts
+++ b/packages/gatsby/src/redux/reducers/index.ts
@@ -25,6 +25,7 @@ import { flattenedPluginsReducer } from "./flattened-plugins"
 import { pendingPageDataWritesReducer } from "./pending-page-data-writes"
 import { schemaCustomizationReducer } from "./schema-customization"
 import { inferenceMetadataReducer } from "./inference-metadata"
+import { staticQueriesByTemplateReducer } from "./static-queries-by-template"
 
 /**
  * @property exports.nodesTouched Set<string>
@@ -57,4 +58,5 @@ export {
   pageDataStatsReducer as pageDataStats,
   pageDataReducer as pageData,
   pendingPageDataWritesReducer as pendingPageDataWrites,
+  staticQueriesByTemplateReducer as staticQueriesByTemplate,
 }

--- a/packages/gatsby/src/redux/reducers/static-queries-by-template.ts
+++ b/packages/gatsby/src/redux/reducers/static-queries-by-template.ts
@@ -1,0 +1,22 @@
+import { ActionsUnion, IGatsbyState } from "../types"
+
+export const staticQueriesByTemplateReducer = (
+  state: IGatsbyState["staticQueriesByTemplate"] = new Map(),
+  action: ActionsUnion
+): IGatsbyState["staticQueriesByTemplate"] => {
+  switch (action.type) {
+    case `REMOVE_TEMPLATE_COMPONENT`:
+      state.delete(action.payload.componentPath)
+      return state
+
+    case `SET_STATIC_QUERIES_BY_TEMPLATE`: {
+      return state.set(
+        action.payload.componentPath,
+        action.payload.staticQueryHashes
+      )
+    }
+
+    default:
+      return state
+  }
+}

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -199,6 +199,7 @@ export interface IGatsbyState {
     IGatsbyStaticQueryComponents["id"],
     IGatsbyStaticQueryComponents
   >
+  staticQueriesByTemplate: Map<SystemPath, Identifier[]>
   pendingPageDataWrites: {
     pagePaths: Set<string>
     templatePaths: Set<SystemPath>
@@ -255,6 +256,7 @@ export interface ICachedReduxState {
   webpackCompilationHash: IGatsbyState["webpackCompilationHash"]
   pageDataStats: IGatsbyState["pageDataStats"]
   pageData: IGatsbyState["pageData"]
+  staticQueriesByTemplate: IGatsbyState["staticQueriesByTemplate"]
   pendingPageDataWrites: IGatsbyState["pendingPageDataWrites"]
 }
 
@@ -304,6 +306,7 @@ export type ActionsUnion =
   | ICreateJobAction
   | ISetJobAction
   | IEndJobAction
+  | ISetStaticQueriesByTemplateAction
   | IAddPendingPageDataWriteAction
   | IAddPendingTemplateDataWriteAction
   | IClearPendingPageDataWritesAction
@@ -576,6 +579,14 @@ export interface IRemoveTemplateComponentAction {
   type: `REMOVE_TEMPLATE_COMPONENT`
   payload: {
     componentPath: string
+  }
+}
+
+export interface ISetStaticQueriesByTemplateAction {
+  type: `SET_STATIC_QUERIES_BY_TEMPLATE`
+  payload: {
+    componentPath: string
+    staticQueryHashes: Identifier[]
   }
 }
 

--- a/packages/gatsby/src/services/start-webpack-server.ts
+++ b/packages/gatsby/src/services/start-webpack-server.ts
@@ -3,6 +3,7 @@ import report from "gatsby-cli/lib/reporter"
 import formatWebpackMessages from "react-dev-utils/formatWebpackMessages"
 import chalk from "chalk"
 import { Compiler } from "webpack"
+import { isEqual } from "lodash"
 
 import {
   reportWebpackWarnings,
@@ -20,17 +21,19 @@ import {
   markWebpackStatusAsDone,
 } from "../utils/webpack-status"
 import { enqueueFlush } from "../utils/page-data"
+import { mapTemplatesToStaticQueryHashes } from "../utils/map-pages-to-static-query-hashes"
 
 export async function startWebpackServer({
   program,
   app,
   workerPool,
+  store,
 }: Partial<IBuildContext>): Promise<{
   compiler: Compiler
   websocketManager: WebsocketManager
 }> {
-  if (!program || !app) {
-    throw new Error(`Missing required params`)
+  if (!program || !app || !store) {
+    report.panic(`Missing required params`)
   }
   let { compiler, webpackActivity, websocketManager } = await startServer(
     program,
@@ -109,9 +112,45 @@ export async function startWebpackServer({
         webpackActivity.end()
         webpackActivity = null
       }
-      enqueueFlush()
+
+      if (isSuccessful) {
+        const state = store.getState()
+        const mapOfTemplatesToStaticQueryHashes = mapTemplatesToStaticQueryHashes(
+          state,
+          stats.compilation
+        )
+
+        mapOfTemplatesToStaticQueryHashes.forEach(
+          (staticQueryHashes, componentPath) => {
+            if (
+              !isEqual(
+                state.staticQueriesByTemplate.get(componentPath),
+                staticQueryHashes.map(String)
+              )
+            ) {
+              store.dispatch({
+                type: `ADD_PENDING_TEMPLATE_DATA_WRITE`,
+                payload: {
+                  componentPath,
+                },
+              })
+              store.dispatch({
+                type: `SET_STATIC_QUERIES_BY_TEMPLATE`,
+                payload: {
+                  componentPath,
+                  staticQueryHashes,
+                },
+              })
+            }
+          }
+        )
+
+        enqueueFlush()
+      }
+
       markWebpackStatusAsDone()
       done()
+
       resolve({ compiler, websocketManager })
     })
   })

--- a/packages/gatsby/src/utils/map-pages-to-static-query-hashes.ts
+++ b/packages/gatsby/src/utils/map-pages-to-static-query-hashes.ts
@@ -1,0 +1,199 @@
+import { uniqBy, List } from "lodash"
+import { IGatsbyState } from "../redux/types"
+import { Stats } from "webpack"
+
+interface ICompilation {
+  modules: IModule[]
+}
+
+interface IReason extends Omit<Stats.Reason, "module"> {
+  module: IModule
+}
+
+interface IModule extends Omit<Stats.FnModules, "identifier" | "reasons"> {
+  hasReasons: () => boolean
+  resource?: string
+  identifier: () => string
+  reasons: IReason[]
+}
+
+const mapComponentsToStaticQueryHashes = (
+  staticQueryComponents: IGatsbyState["staticQueryComponents"]
+): Map<string, string> => {
+  const map = new Map()
+
+  staticQueryComponents.forEach(({ componentPath, hash }) => {
+    map.set(componentPath, hash)
+  })
+
+  return map
+}
+
+/* This function takes the current Redux state and a compilation
+ * object from webpack and returns a map of unique templates
+ * to static queries included in each (as hashes).
+ *
+ * This isn't super straightforward because templates may include
+ * deep component trees with static queries present at any depth.
+ * This is why it is necessary to map templates to all their (user land and node_modules)
+ * dependencies first and then map those dependencies to known static queries.
+ *
+ * Also, Gatsby makes it possible to wrap an entire site or page with a layout
+ * or other component(s) via the wrapRootElement and wrapPageElement APIs. These must
+ * also be handled when computing static queries for a page.
+ *
+ * Let's go through the implementation step by step.
+ */
+export function mapTemplatesToStaticQueryHashes(
+  reduxState: IGatsbyState,
+  compilation: ICompilation
+): Map<string, Array<number>> {
+  /* The `staticQueryComponents` slice of state is useful because
+   * it is a pre extracted collection of all static queries found in a Gatsby site.
+   * This lets us traverse upwards from those to templates that
+   * may contain components that contain them.
+   * Note that this upward traversal is much shallower (and hence more performant)
+   * than an equivalent downward one from an entry point.
+   */
+  const { components, staticQueryComponents } = reduxState
+  const { modules } = compilation
+
+  /* When we traverse upwards, we need to know where to stop. We'll call these terminal nodes.
+   * `async-requires.js` is the entry point for every page, while `api-runner-browser-plugins.js`
+   * is the one for `gatsby-browser` (where one would use wrapRootElement or wrapPageElement APIs)
+   */
+  const terminalNodes = [
+    `.cache/api-runner-browser-plugins.js`,
+    `.cache/async-requires.js`,
+  ]
+
+  /* We call the queries included above a page (via wrapRootElement or wrapPageElement APIs)
+   * global queries. For now, we include these in every single page for simplicity. Overhead
+   * here is not much since we are storing hashes (that reference separate result files)
+   * as opposed to inlining results. We may move these to app-data perhaps in the future.
+   */
+  const globalStaticQueries = new Set<string>()
+
+  /* This function takes a webpack module corresponding
+   * to the file containing a static query and returns
+   * a Set of strings, each an absolute path of a dependent
+   * of this module
+   */
+  const getDeps = (mod: IModule): Set<string> => {
+    const staticQueryModuleComponentPath = mod.resource
+    const result = new Set<string>()
+
+    // This is the body of the recursively called function
+    const getDepsFn = (m: IModule): Set<string> => {
+      // Reasons in webpack are literally reasons of why this module was included in the tree
+      const hasReasons = m.hasReasons()
+
+      // Is this node one of our known terminal nodes? See explanation above
+      const isTerminalNode = terminalNodes.some(terminalNode =>
+        m?.resource?.includes(terminalNode)
+      )
+
+      // Exit if we don't have any reasons or we have reached a possible terminal node
+      if (!hasReasons || isTerminalNode) {
+        return result
+      }
+
+      // These are non terminal dependents and hence modules that need
+      // further upward traversal
+      const nonTerminalDependents: List<IModule> = m.reasons
+        .filter(r => {
+          const dependentModule = r.module
+          const isTerminal = terminalNodes.some(terminalNode =>
+            dependentModule?.resource?.includes(terminalNode)
+          )
+          return !isTerminal
+        })
+        .map(r => r.module)
+        .filter(Boolean)
+
+      const uniqDependents = uniqBy(nonTerminalDependents, d => d?.identifier())
+
+      for (const uniqDependent of uniqDependents) {
+        if (uniqDependent.resource) {
+          result.add(uniqDependent.resource)
+        }
+
+        if (
+          uniqDependent?.resource?.includes(`gatsby-browser.js`) &&
+          staticQueryModuleComponentPath
+        ) {
+          globalStaticQueries.add(staticQueryModuleComponentPath)
+        }
+        getDepsFn(uniqDependent)
+      }
+
+      return result
+    }
+
+    return getDepsFn(mod)
+  }
+
+  const mapOfStaticQueryComponentsToDependants = new Map()
+
+  // For every known static query, we get its dependents.
+  staticQueryComponents.forEach(({ componentPath }) => {
+    const staticQueryComponentModule = modules.find(
+      m => m.resource === componentPath
+    )
+
+    const dependants = staticQueryComponentModule
+      ? getDeps(staticQueryComponentModule)
+      : new Set()
+
+    mapOfStaticQueryComponentsToDependants.set(componentPath, dependants)
+  })
+
+  const mapOfComponentsToStaticQueryHashes = mapComponentsToStaticQueryHashes(
+    staticQueryComponents
+  )
+
+  const globalStaticQueryHashes: string[] = []
+
+  globalStaticQueries.forEach(q => {
+    const hash = mapOfComponentsToStaticQueryHashes.get(q)
+    if (hash) {
+      globalStaticQueryHashes.push(hash)
+    }
+  })
+
+  // For every known page, we get queries
+  const mapOfTemplatesToStaticQueryHashes = new Map()
+
+  components.forEach(page => {
+    const staticQueryHashes = [...globalStaticQueryHashes]
+
+    // Does this page contain an inline static query?
+    if (mapOfComponentsToStaticQueryHashes.has(page.componentPath)) {
+      const hash = mapOfComponentsToStaticQueryHashes.get(page.componentPath)
+      if (hash) {
+        staticQueryHashes.push(hash)
+      }
+    }
+
+    // Check dependencies
+    mapOfStaticQueryComponentsToDependants.forEach(
+      (setOfDependants, staticQueryComponentPath) => {
+        if (setOfDependants.has(page.componentPath)) {
+          const hash = mapOfComponentsToStaticQueryHashes.get(
+            staticQueryComponentPath
+          )
+          if (hash) {
+            staticQueryHashes.push(hash)
+          }
+        }
+      }
+    )
+
+    mapOfTemplatesToStaticQueryHashes.set(
+      page.componentPath,
+      staticQueryHashes.sort()
+    )
+  })
+
+  return mapOfTemplatesToStaticQueryHashes
+}

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -11,6 +11,7 @@ interface IPageData {
   componentChunkName: IGatsbyPage["componentChunkName"]
   matchPath?: IGatsbyPage["matchPath"]
   path: IGatsbyPage["path"]
+  staticQueryHashes: string[]
 }
 
 export interface IPageDataWithQueryResult extends IPageData {
@@ -55,7 +56,12 @@ export async function removePageData(
 
 export async function writePageData(
   publicDir: string,
-  { componentChunkName, matchPath, path: pagePath }: IPageData
+  {
+    componentChunkName,
+    matchPath,
+    path: pagePath,
+    staticQueryHashes,
+  }: IPageData
 ): Promise<IPageDataWithQueryResult> {
   const inputFilePath = path.join(
     publicDir,
@@ -71,6 +77,7 @@ export async function writePageData(
     path: pagePath,
     matchPath,
     result,
+    staticQueryHashes,
   }
   const bodyStr = JSON.stringify(body)
   // transform asset size to kB (from bytes) to fit 64 bit to numbers
@@ -102,7 +109,13 @@ export async function flush(): Promise<void> {
   }
   isFlushPending = false
   isFlushing = true
-  const { pendingPageDataWrites, components, pages, program } = store.getState()
+  const {
+    pendingPageDataWrites,
+    components,
+    pages,
+    program,
+    staticQueriesByTemplate,
+  } = store.getState()
 
   const { pagePaths, templatePaths } = pendingPageDataWrites
 
@@ -127,9 +140,15 @@ export async function flush(): Promise<void> {
     // them, a page might not exist anymore щ（ﾟДﾟщ）
     // This is why we need this check
     if (page) {
+      const staticQueryHashes =
+        staticQueriesByTemplate.get(page.componentPath)?.map(String) || []
+
       const result = await writePageData(
         path.join(program.directory, `public`),
-        page
+        {
+          ...page,
+          staticQueryHashes,
+        }
       )
 
       if (program?._?.[0] === `develop`) {


### PR DESCRIPTION
To make https://github.com/gatsbyjs/gatsby/pull/23837 possible, we need to track what static queries are present in what templates. 

This PR adds
- a slice of Redux state of exactly that
- adds an array of static query hashes to each page's page data

This also includes a new integration test suite that asserts that page-data for a particular page includes the right static query hashes. 

Do note that this PR does _not_ change any runtime behaviour. That will come in a separate PR (in interest of making reviews easier) but feel free to look at https://github.com/gatsbyjs/gatsby/pull/23837 for the bigger picture. 