### PR TITLE
fix(bin): point bin to always existing files

### DIFF
--- a/packages/gatsby-cli/cli.js
+++ b/packages/gatsby-cli/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require(`./lib/index.js`)

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -4,7 +4,7 @@
   "version": "2.12.46",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {
-    "gatsby": "lib/index.js"
+    "gatsby": "cli.js"
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
@@ -65,7 +65,8 @@
   },
   "files": [
     "lib",
-    "scripts"
+    "scripts",
+    "cli.js"
   ],
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli#readme",
   "keywords": [

--- a/packages/gatsby/cli.js
+++ b/packages/gatsby/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require(`./dist/bin/gatsby.js`)

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -4,7 +4,7 @@
   "version": "2.23.4",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {
-    "gatsby": "./dist/bin/gatsby.js"
+    "gatsby": "./cli.js"
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
@@ -181,6 +181,7 @@
     "apis.json",
     "ipc.json",
     "cache-dir",
+    "cli.js",
     "dist",
     "gatsby-admin-public",
     "graphql.js",


### PR DESCRIPTION
## Description

Currently we point `bin` to files that have to be built. That means that first time running `yarn` will not create actual `node_modules/.bin` files. This cause problems in CI in some cases - like in https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/43431/workflows/5f2af482-c297-489f-aecf-dbfec72a45b8/jobs/440080/steps where `gatsby-admin` can't be built because `bin` for neither `gatsby` nor `gatsby-cli` is created yet