### PR TITLE
chore(starters): Add theme ui as dependency to solve npm bug

### DIFF
--- a/starters/gatsby-starter-blog-theme/package-lock.json
+++ b/starters/gatsby-starter-blog-theme/package-lock.json
@@ -6509,6 +6509,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -19091,6 +19096,16 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "theme-ui": {
+      "version": "0.2.52",
+      "resolved": "https://registry.npmjs.org/theme-ui/-/theme-ui-0.2.52.tgz",
+      "integrity": "sha512-JFujorP5aFxIm1UyVCtefN5baXjwh5TXHKFYNWgAP+3rqVvggIr46uSMrRNvDjyhFOQiMK8YI8ctPQrrhcETpw==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.1",
+        "@styled-system/css": "^5.0.16",
+        "deepmerge": "^4.0.0"
+      }
     },
     "through": {
       "version": "2.3.8",

--- a/starters/gatsby-starter-blog-theme/package.json
+++ b/starters/gatsby-starter-blog-theme/package.json
@@ -12,6 +12,7 @@
     "gatsby": "^2.23.4",
     "gatsby-theme-blog": "^1.6.42",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "theme-ui": "^0.2.52"
   }
 }


### PR DESCRIPTION
For some reason theme-ui is not being hoisted in the blog theme when using npm. This bug does not exist when using yarn.

As a workaround, adding theme-ui to the starter dependencies.

Closes #25093 