### PR TITLE
feat(gatsby-reporter): Add Gatsby Reporter as its own package

### DIFF
--- a/packages/gatsby-reporter/.babelrc
+++ b/packages/gatsby-reporter/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["babel-preset-gatsby-package"]]
+}

--- a/packages/gatsby-reporter/.gitignore
+++ b/packages/gatsby-reporter/.gitignore
@@ -1,0 +1,2 @@
+/lib
+/node_modules

--- a/packages/gatsby-reporter/CHANGELOG.md
+++ b/packages/gatsby-reporter/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/gatsby-reporter/README.md
+++ b/packages/gatsby-reporter/README.md
@@ -1,0 +1,1 @@
+# gatsby-reporter

--- a/packages/gatsby-reporter/package.json
+++ b/packages/gatsby-reporter/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "gatsby-reporter",
+  "description": "Gatsby Reporter used throughout Gatsby",
+  "version": "1.0.0",
+  "bugs": {
+    "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "dependencies": {
+    "@hapi/joi": "^15.1.1",
+    "chalk": "^2.4.2",
+    "common-tags": "^1.8.0",
+    "convert-hrtime": "^3.0.0",
+    "gatsby-core-utils": "^1.3.5",
+    "gatsby-telemetry": "^1.3.11",
+    "ink": "^2.7.1",
+    "ink-spinner": "^3.0.1",
+    "lodash": "^4.17.15",
+    "opentracing": "^0.14.4",
+    "progress": "^2.0.3",
+    "react": "^16.8.0",
+    "redux": "^4.0.5",
+    "semver": "^6.3.0",
+    "signal-exit": "^3.0.3",
+    "strip-ansi": "^5.2.0",
+    "uuid": "3.4.0",
+    "yurnalist": "^1.1.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.10.1",
+    "@babel/core": "^7.10.2",
+    "babel-preset-gatsby-package": "^0.4.4",
+    "cross-env": "^5.2.1",
+    "rimraf": "^3.0.2",
+    "typescript": "^3.9.3"
+  },
+  "files": [
+    "lib",
+    "lib/index.d.ts"
+  ],
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-reporter#readme",
+  "keywords": [
+    "gatsby"
+  ],
+  "license": "MIT",
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gatsbyjs/gatsby.git",
+    "directory": "packages/gatsby-reporter"
+  },
+  "scripts": {
+    "build": "babel src --out-dir lib --ignore \"**/__tests__\" --extensions \".ts,.js,.tsx\"",
+    "prepare": "cross-env NODE_ENV=production npm run build && npm run typegen",
+    "typegen": "rimraf \"lib/**/*.d.ts\" && tsc --emitDeclarationOnly --declaration --declarationDir lib/",
+    "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\"  --extensions \".ts,.js,.tsx\""
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  }
+}

--- a/packages/gatsby-reporter/package.json
+++ b/packages/gatsby-reporter/package.json
@@ -34,8 +34,7 @@
     "typescript": "^3.9.3"
   },
   "files": [
-    "lib",
-    "lib/index.d.ts"
+    "lib"
   ],
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-reporter#readme",
   "keywords": [

--- a/packages/gatsby-reporter/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/gatsby-reporter/src/__tests__/__snapshots__/index.ts.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`report.error handles "Array of Errors" signature correctly 1`] = `
+Object {
+  "context": Object {
+    "sourceMessage": "Message 3 from new Error",
+  },
+  "docsUrl": "https://gatsby.dev/issue-how-to",
+  "error": [Error: Message 3 from new Error],
+  "level": "ERROR",
+  "stack": Any<Array>,
+  "text": "Message 3 from new Error",
+}
+`;
+
+exports[`report.error handles "Error" signature correctly 1`] = `
+Object {
+  "context": Object {
+    "sourceMessage": "Message from new Error",
+  },
+  "docsUrl": "https://gatsby.dev/issue-how-to",
+  "error": [Error: Message from new Error],
+  "level": "ERROR",
+  "stack": Any<Array>,
+  "text": "Message from new Error",
+}
+`;
+
+exports[`report.error handles "String" signature correctly 1`] = `
+Object {
+  "context": Object {
+    "sourceMessage": "Error created in Jest",
+  },
+  "docsUrl": "https://gatsby.dev/issue-how-to",
+  "level": "ERROR",
+  "stack": Array [],
+  "text": "Error created in Jest",
+}
+`;
+
+exports[`report.error handles "String, Error" signature correctly 1`] = `
+Object {
+  "context": Object {
+    "sourceMessage": "Error string passed to reporter Message from new Error",
+  },
+  "docsUrl": "https://gatsby.dev/issue-how-to",
+  "error": [Error: Message from new Error],
+  "level": "ERROR",
+  "stack": Any<Array>,
+  "text": "Error string passed to reporter Message from new Error",
+}
+`;
+
+exports[`report.error handles "structuredError" signature correctly 1`] = `
+Object {
+  "code": "95312",
+  "context": Object {
+    "ref": "navigator",
+  },
+  "docsUrl": "https://gatsby.dev/debug-html",
+  "level": "ERROR",
+  "stack": Array [],
+  "text": "\\"navigator\\" is not available during server side rendering.",
+}
+`;

--- a/packages/gatsby-reporter/src/__tests__/index.ts
+++ b/packages/gatsby-reporter/src/__tests__/index.ts
@@ -1,0 +1,95 @@
+import { reporter } from "../"
+import * as reporterActions from "../redux/actions"
+
+// TODO: report.error now DOES return something. Get rid of this spying mocking stuff
+
+// report.error doesn't return anything, it creates a `structuredError` object and
+// calls reporterInstance.error(structuredError)
+
+// Spy on reporterInstance.error and mock its implementation so it
+// returns structuredError
+
+// We can then use the returned structuredError for snapshots.
+jest
+  .spyOn(reporterActions, `createLog`)
+  // @ts-ignore
+  .mockImplementation(structuredLog => structuredLog)
+
+// We don't care about this
+reporter.log = jest.fn()
+
+const getErrorMessages = (fn: jest.Mock): any =>
+  fn.mock.calls
+    .map(([firstArg]) => firstArg)
+    .filter(structuredMessage => structuredMessage.level === `ERROR`)
+
+describe(`report.error`, () => {
+  beforeEach(() => {
+    ;(reporterActions.createLog as jest.Mock).mockClear()
+  })
+
+  it(`handles "String, Error" signature correctly`, () => {
+    reporter.error(
+      `Error string passed to reporter`,
+      new Error(`Message from new Error`)
+    )
+    const generatedError = getErrorMessages(
+      reporterActions.createLog as jest.Mock
+    )[0]
+
+    expect(generatedError).toMatchSnapshot({
+      stack: expect.any(Array),
+    })
+  })
+
+  it(`handles "Error" signature correctly`, () => {
+    reporter.error(new Error(`Message from new Error`))
+    const generatedError = getErrorMessages(
+      reporterActions.createLog as jest.Mock
+    )[0]
+    expect(generatedError).toMatchSnapshot({
+      stack: expect.any(Array),
+    })
+  })
+
+  it(`handles "Array of Errors" signature correctly`, () => {
+    reporter.error([
+      new Error(`Message 1 from new Error`),
+      new Error(`Message 2 from new Error`),
+      new Error(`Message 3 from new Error`),
+    ])
+
+    const generatedErrors = getErrorMessages(
+      reporterActions.createLog as jest.Mock
+    )
+
+    expect(generatedErrors.length).toEqual(3)
+
+    // get final generated object
+    const generatedError = generatedErrors[2]
+    expect(generatedError).toMatchSnapshot({
+      stack: expect.any(Array),
+    })
+  })
+
+  it(`handles "structuredError" signature correctly`, () => {
+    reporter.error({
+      id: `95312`,
+      context: {
+        ref: `navigator`,
+      },
+    })
+    const generatedError = getErrorMessages(
+      reporterActions.createLog as jest.Mock
+    )[0]
+    expect(generatedError).toMatchSnapshot()
+  })
+
+  it(`handles "String" signature correctly`, () => {
+    reporter.error(`Error created in Jest`)
+    const generatedError = getErrorMessages(
+      reporterActions.createLog as jest.Mock
+    )[0]
+    expect(generatedError).toMatchSnapshot()
+  })
+})

--- a/packages/gatsby-reporter/src/__tests__/patch-console.ts
+++ b/packages/gatsby-reporter/src/__tests__/patch-console.ts
@@ -1,0 +1,60 @@
+import { patchConsole } from "../patch-console"
+import { reporter as gatsbyReporter } from "../reporter"
+
+describe(`patchConsole`, () => {
+  const reporter = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+  }
+
+  patchConsole((reporter as unknown) as typeof gatsbyReporter)
+  ;[`info`, `log`, `warn`].forEach(method => {
+    describe(method, () => {
+      beforeEach(reporter[method].mockReset)
+
+      it(`handles an empty call`, () => {
+        console[method]()
+
+        expect(reporter[method]).toBeCalledWith(``)
+      })
+
+      it(`handles multiple arguments`, () => {
+        console[method](`foo`, `bar`, `baz`)
+
+        expect(reporter[method]).toBeCalledWith(`foo bar baz`)
+      })
+
+      it(`handles formatting`, () => {
+        console[method](`%s %d`, `bar`, true)
+
+        expect(reporter[method]).toBeCalledWith(`bar 1`)
+      })
+
+      it(`handles normal values`, () => {
+        console[method](1)
+        console[method](0)
+        console[method](true)
+        console[method](false)
+        console[method]([1, true, false, {}])
+        console[method]({ 1: 1, true: true, false: `false`, obj: {} })
+
+        expect(reporter[method].mock.calls[0][0]).toBe(`1`)
+        expect(reporter[method].mock.calls[1][0]).toBe(`0`)
+        expect(reporter[method].mock.calls[2][0]).toBe(`true`)
+        expect(reporter[method].mock.calls[3][0]).toBe(`false`)
+        expect(reporter[method].mock.calls[4][0]).toBe(`[ 1, true, false, {} ]`)
+        expect(reporter[method].mock.calls[5][0]).toBe(
+          `{ '1': 1, true: true, false: 'false', obj: {} }`
+        )
+      })
+
+      it(`handles undefined variables`, () => {
+        let a
+        console[method](a)
+
+        expect(reporter[method]).toBeCalledWith(``)
+      })
+    })
+  })
+})

--- a/packages/gatsby-reporter/src/catch-exit-signals.ts
+++ b/packages/gatsby-reporter/src/catch-exit-signals.ts
@@ -1,0 +1,42 @@
+/*
+ * This module is used to catch if the user kills the gatsby process via cmd+c
+ * When this happens, there is some clean up logic we need to fire offf
+ */
+import signalExit from "signal-exit"
+import { getStore } from "./redux"
+import { createPendingActivity } from "./redux/actions"
+import { ActivityStatuses } from "./constants"
+import { reporter } from "./reporter"
+
+const interruptActivities = (): void => {
+  const { activities } = getStore().getState().logs
+  Object.keys(activities).forEach(activityId => {
+    const activity = activities[activityId]
+    if (
+      activity.status === ActivityStatuses.InProgress ||
+      activity.status === ActivityStatuses.NotStarted
+    ) {
+      reporter.completeActivity(activityId, ActivityStatuses.Interrupted)
+    }
+  })
+}
+
+export const prematureEnd = (): void => {
+  // hack so at least one activity is surely failed, so
+  // we are guaranteed to generate FAILED status
+  // if none of activity did explicitly fail
+  createPendingActivity({
+    id: `panic`,
+    status: ActivityStatuses.Failed,
+  })
+
+  interruptActivities()
+}
+
+export const catchExitSignals = (): void => {
+  signalExit((code, signal) => {
+    if (code !== 0 && signal !== `SIGINT` && signal !== `SIGTERM`)
+      prematureEnd()
+    else interruptActivities()
+  })
+}

--- a/packages/gatsby-reporter/src/constants.ts
+++ b/packages/gatsby-reporter/src/constants.ts
@@ -1,0 +1,44 @@
+export enum Actions {
+  LogAction = `LOG_ACTION`,
+  SetStatus = `SET_STATUS`,
+  Log = `LOG`,
+  SetLogs = `SET_LOGS`,
+
+  StartActivity = `ACTIVITY_START`,
+  EndActivity = `ACTIVITY_END`,
+  UpdateActivity = `ACTIVITY_UPDATE`,
+  PendingActivity = `ACTIVITY_PENDING`,
+  CancelActivity = `ACTIVITY_CANCEL`,
+  ActivityErrored = `ACTIVITY_ERRORED`,
+}
+
+export enum LogLevels {
+  Debug = `DEBUG`,
+  Success = `SUCCESS`,
+  Info = `INFO`,
+  Warning = `WARNING`,
+  Log = `LOG`,
+  Error = `ERROR`,
+}
+
+export enum ActivityLogLevels {
+  Success = `ACTIVITY_SUCCESS`,
+  Failed = `ACTIVITY_FAILED`,
+  Interrupted = `ACTIVITY_INTERRUPTED`,
+}
+
+export enum ActivityStatuses {
+  InProgress = `IN_PROGRESS`,
+  NotStarted = `NOT_STARTED`,
+  Interrupted = `INTERRUPTED`,
+  Failed = `FAILED`,
+  Success = `SUCCESS`,
+  Cancelled = `CANCELLED`,
+}
+
+export enum ActivityTypes {
+  Spinner = `spinner`,
+  Hidden = `hidden`,
+  Progress = `progress`,
+  Pending = `pending`,
+}

--- a/packages/gatsby-reporter/src/get-error-formater.ts
+++ b/packages/gatsby-reporter/src/get-error-formater.ts
@@ -1,7 +1,10 @@
 import PrettyError from "pretty-error"
-import { ErrorWithCodeFrame } from "gatsby-core-utils"
 
-type PrettyRenderError = Error | ErrorWithCodeFrame
+interface IErrorWithCodeFrame extends Error {
+  codeFrame: string
+}
+
+type PrettyRenderError = Error | IErrorWithCodeFrame
 
 export function getErrorFormatter(): PrettyError {
   const prettyError = new PrettyError()

--- a/packages/gatsby-reporter/src/get-error-formater.ts
+++ b/packages/gatsby-reporter/src/get-error-formater.ts
@@ -1,0 +1,53 @@
+import PrettyError from "pretty-error"
+import { ErrorWithCodeFrame } from "gatsby-core-utils"
+
+type PrettyRenderError = Error | ErrorWithCodeFrame
+
+export function getErrorFormatter(): PrettyError {
+  const prettyError = new PrettyError()
+  const baseRender = prettyError.render
+
+  prettyError.skipNodeFiles()
+  prettyError.skipPackage(
+    `regenerator-runtime`,
+    `graphql`,
+    `core-js`
+    // `static-site-generator-webpack-plugin`,
+    // `tapable`, // webpack
+  )
+
+  // @ts-ignore the type defs in prettyError are wrong
+  prettyError.skip((traceLine: any) => {
+    if (traceLine && traceLine.file === `asyncToGenerator.js`) return true
+    return false
+  })
+
+  prettyError.appendStyle({
+    "pretty-error": {
+      marginTop: 1,
+    },
+    "pretty-error > header": {
+      background: `red`,
+    },
+    "pretty-error > header > colon": {
+      color: `white`,
+    },
+  })
+
+  if (process.env.FORCE_COLOR === `0`) {
+    prettyError.withoutColors()
+  }
+
+  prettyError.render = (
+    err: PrettyRenderError | PrettyRenderError[]
+  ): string => {
+    if (Array.isArray(err)) {
+      return err.map(e => prettyError.render(e)).join(`\n`)
+    }
+
+    let rendered = baseRender.call(prettyError, err)
+    if (`codeFrame` in err) rendered = `\n${err.codeFrame}\n${rendered}`
+    return rendered
+  }
+  return prettyError
+}

--- a/packages/gatsby-reporter/src/index.ts
+++ b/packages/gatsby-reporter/src/index.ts
@@ -1,0 +1,20 @@
+import { startLogger } from "./start-logger"
+import { patchConsole } from "./patch-console"
+import { catchExitSignals } from "./catch-exit-signals"
+import { reporter } from "./reporter"
+import { setStore } from "./redux"
+import { reducer } from "./redux/reducer"
+import { IGatsbyCLIState } from "./redux/types"
+import { IActivityArgs, IPhantomReporter, IProgressReporter } from "./types"
+
+catchExitSignals()
+startLogger()
+patchConsole(reporter)
+
+export { reporter }
+export { setStore }
+export const reduxLogReducer = reducer
+
+// Types
+export { IActivityArgs, IPhantomReporter, IProgressReporter, IGatsbyCLIState }
+export type IGatsbyReporter = typeof reporter

--- a/packages/gatsby-reporter/src/loggers/ink/cli.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/cli.tsx
@@ -1,0 +1,135 @@
+import React from "react"
+import { Box, Static } from "ink"
+import { trackBuildError } from "gatsby-telemetry"
+import { Spinner } from "./components/spinner"
+import { ProgressBar } from "./components/progress-bar"
+import { Message, IMessageProps } from "./components/messages"
+import { Error as ErrorComponent } from "./components/error"
+import Develop from "./components/develop"
+import { IGatsbyCLIState, IActivity } from "../../redux/types"
+import { ActivityLogLevels } from "../../constants"
+import { IStructuredError } from "../../structured-errors/types"
+import { isCI } from "gatsby-core-utils"
+
+// Some CI pipelines incorrectly report process.stdout.isTTY status,
+// which causes unwanted lines in the output. An additional check for isCI helps.
+// @see https://github.com/prettier/prettier/blob/36aeb4ce4f620023c8174e826d7208c0c64f1a0b/src/utils/is-tty.js
+const showProgress = process.stdout.isTTY && !isCI()
+
+interface ICLIProps {
+  logs: IGatsbyCLIState
+  showStatusBar: boolean
+}
+
+interface ICLIState {
+  hasError: boolean
+  error?: Error
+}
+
+class CLI extends React.Component<ICLIProps, ICLIState> {
+  readonly state: ICLIState = {
+    hasError: false,
+  }
+  memoizedReactElementsForMessages: React.ReactElement[] = []
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    trackBuildError(`INK`, {
+      error: {
+        stack: info.componentStack,
+        text: error.message,
+        context: {},
+      },
+    })
+  }
+
+  static getDerivedStateFromError(error: Error): ICLIState {
+    return { hasError: true, error }
+  }
+
+  render(): React.ReactElement {
+    const {
+      logs: { messages, activities },
+      showStatusBar,
+    } = this.props
+
+    const { hasError, error } = this.state
+
+    if (hasError && error) {
+      // You can render any custom fallback UI
+      return (
+        <Box flexDirection="row">
+          <Message
+            level={ActivityLogLevels.Failed}
+            text={`We've encountered an error: ${error.message}`}
+          />
+        </Box>
+      )
+    }
+
+    /*
+      Only operation on messages array is to push new message into it. Once
+      message is there it can't change. Because of that we can do single
+      transform from message object to react element and store it.
+      This will avoid calling React.createElement completely for every message
+      that can't change.
+    */
+    if (messages.length > this.memoizedReactElementsForMessages.length) {
+      for (
+        let index = this.memoizedReactElementsForMessages.length;
+        index < messages.length;
+        index++
+      ) {
+        const msg = messages[index]
+        this.memoizedReactElementsForMessages.push(
+          msg.level === `ERROR` ? (
+            <ErrorComponent details={msg as IStructuredError} key={index} />
+          ) : (
+            <Message key={index} {...(msg as IMessageProps)} />
+          )
+        )
+      }
+    }
+
+    const spinners: Array<IActivity> = []
+    const progressBars: Array<IActivity> = []
+    if (showProgress) {
+      Object.keys(activities).forEach(activityName => {
+        const activity = activities[activityName]
+        if (activity.status !== `IN_PROGRESS`) {
+          return
+        }
+        if (activity.type === `spinner`) {
+          spinners.push(activity)
+        }
+        if (activity.type === `progress` && activity.startTime) {
+          progressBars.push(activity)
+        }
+      })
+    }
+
+    return (
+      <Box flexDirection="column">
+        <Box flexDirection="column">
+          <Static>{this.memoizedReactElementsForMessages}</Static>
+
+          {spinners.map(activity => (
+            <Spinner key={activity.id} {...activity} />
+          ))}
+
+          {progressBars.map(activity => (
+            <ProgressBar
+              key={activity.id}
+              message={activity.text}
+              total={activity.total || 0}
+              current={activity.current || 0}
+              startTime={activity.startTime || [0, 0]}
+            />
+          ))}
+        </Box>
+        {showStatusBar && <Develop />}
+      </Box>
+    )
+  }
+}
+
+export default CLI

--- a/packages/gatsby-reporter/src/loggers/ink/components/develop.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/components/develop.tsx
@@ -1,0 +1,79 @@
+import React, { useContext, useState, useEffect } from "react"
+import { Box, Color, StdoutContext } from "ink"
+import StoreStateContext from "../context"
+import { ActivityStatuses } from "../../../constants"
+import { createLabel } from "./utils"
+
+const getLabel = (
+  level: ActivityStatuses | string
+): ReturnType<typeof createLabel> => {
+  switch (level) {
+    case ActivityStatuses.InProgress:
+      return createLabel(`In Progress`, `white`)
+    case ActivityStatuses.Interrupted:
+      return createLabel(`Interrupted`, `gray`)
+    case ActivityStatuses.Failed:
+      return createLabel(`Failed`, `red`)
+    case ActivityStatuses.Success:
+      return createLabel(`Success`, `green`)
+
+    default:
+      return createLabel(level, `white`)
+  }
+}
+
+// Track the width and height of the terminal. Responsive app design baby!
+const useTerminalResize = (): Array<number> => {
+  const { stdout } = useContext(StdoutContext)
+  const [sizes, setSizes] = useState([stdout.columns, stdout.rows])
+  useEffect(() => {
+    const resizeListener = (): void => {
+      setSizes([stdout.columns, stdout.rows])
+    }
+    stdout.on(`resize`, resizeListener)
+    return (): void => {
+      stdout.off(`resize`, resizeListener)
+    }
+  }, [stdout])
+
+  return sizes
+}
+
+interface IDevelopProps {
+  pagesCount: number
+  appName: string
+  status: ActivityStatuses | ""
+}
+
+const Develop: React.FC<IDevelopProps> = ({ pagesCount, appName, status }) => {
+  const [width] = useTerminalResize()
+
+  const StatusLabel = getLabel(status)
+
+  return (
+    <Box flexDirection="column" marginTop={2}>
+      <Box textWrap={`truncate`}>{`—`.repeat(width)}</Box>
+      <Box height={1} flexDirection="row">
+        <StatusLabel />
+        <Box flexGrow={1} />
+        <Color>{appName}</Color>
+        <Box flexGrow={1} />
+        <Color>{pagesCount} pages</Color>
+      </Box>
+    </Box>
+  )
+}
+
+const ConnectedDevelop: React.FC = () => {
+  const state = useContext(StoreStateContext)
+
+  return (
+    <Develop
+      pagesCount={state.pages?.size || 0}
+      appName={state.program?.sitePackageJson.name || ``}
+      status={state.logs?.status || ``}
+    />
+  )
+}
+
+export default ConnectedDevelop

--- a/packages/gatsby-reporter/src/loggers/ink/components/error.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/components/error.tsx
@@ -1,0 +1,93 @@
+import React, { FunctionComponent } from "react"
+import path from "path"
+import { Color, Box } from "ink"
+import { IStructuredError } from "../../../structured-errors/types"
+
+interface IFileProps {
+  filePath: string
+  location: IStructuredError["location"]
+}
+
+const File: FunctionComponent<IFileProps> = ({ filePath, location }) => {
+  const lineNumber = location?.start.line
+
+  let locString = ``
+  if (typeof lineNumber !== `undefined`) {
+    locString += `:${lineNumber}`
+    const columnNumber = location?.start.column
+    if (typeof columnNumber !== `undefined`) {
+      locString += `:${columnNumber}`
+    }
+  }
+
+  return (
+    <Color blue>
+      {path.relative(process.cwd(), filePath)}
+      {locString}
+    </Color>
+  )
+}
+
+interface IDocsLinkProps {
+  docsUrl: string | undefined
+}
+
+const DocsLink: FunctionComponent<IDocsLinkProps> = ({ docsUrl }) => {
+  // TODO: when there's no specific docsUrl, add helpful message describing how
+  // to submit an issue
+  if (docsUrl === `https://gatsby.dev/issue-how-to`) return null
+  return (
+    <Box marginTop={1}>
+      See our docs page for more info on this error: {docsUrl}
+    </Box>
+  )
+}
+
+export interface IErrorProps {
+  details: IStructuredError
+}
+
+export const Error: FunctionComponent<IErrorProps> = React.memo(
+  ({ details }) => (
+    // const stackLength = get(details, `stack.length`, 0
+
+    <Box marginY={1} flexDirection="column">
+      <Box flexDirection="column">
+        <Box flexDirection="column">
+          <Box>
+            <Box marginRight={1}>
+              <Color black bgRed>
+                {` ${details.level} `}
+                {details.code ? `#${details.code} ` : ``}
+              </Color>
+              <Color red>{details.type ? ` ` + details.type : ``}</Color>
+            </Box>
+          </Box>
+          <Box marginTop={1}>{details.text}</Box>
+          {details.filePath && (
+            <Box marginTop={1}>
+              File:{` `}
+              <File filePath={details.filePath} location={details.location} />
+            </Box>
+          )}
+        </Box>
+        <DocsLink docsUrl={details.docsUrl} />
+      </Box>
+      {/* TODO: use this to replace errorFormatter.render in reporter.error func
+      {stackLength > 0 && (
+        <Box>
+          <Color>
+            <Box flexDirection="column">
+              <Box>Error stack:</Box>
+              {details.stack.map((item, id) => (
+                <Box key={id}>
+                  {item.fileName && `${item.fileName} line ${item.lineNumber}`}
+                </Box>
+              ))}
+            </Box>
+          </Color>
+        </Box>
+      )} */}
+    </Box>
+  )
+)

--- a/packages/gatsby-reporter/src/loggers/ink/components/messages.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/components/messages.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import { Box } from "ink"
+import { createLabel } from "./utils"
+
+import { ActivityLogLevels, LogLevels } from "../../../constants"
+
+const getLabel = (
+  level: ActivityLogLevels | LogLevels
+): ReturnType<typeof createLabel> => {
+  switch (level) {
+    case ActivityLogLevels.Success:
+    case LogLevels.Success:
+      return createLabel(`success`, `green`)
+    case LogLevels.Warning:
+      return createLabel(`warn`, `yellow`)
+    case LogLevels.Debug:
+      return createLabel(`verbose`, `gray`)
+    case LogLevels.Info:
+      return createLabel(`info`, `blue`)
+    case ActivityLogLevels.Failed:
+      return createLabel(`failed`, `red`)
+    case ActivityLogLevels.Interrupted:
+      return createLabel(`not finished`, `gray`)
+
+    default:
+      return createLabel(level, `blue`)
+  }
+}
+
+export interface IMessageProps {
+  level: ActivityLogLevels | LogLevels
+  text: string
+  duration?: number
+  statusText?: string
+}
+
+export const Message = React.memo<IMessageProps>(
+  ({ level, text, duration, statusText }) => {
+    let message = text
+    if (duration) {
+      message += ` - ${duration.toFixed(3)}s`
+    }
+    if (statusText) {
+      message += ` - ${statusText}`
+    }
+    if (!level || level === `LOG`) {
+      return <>{message}</>
+    }
+
+    const TextLabel = getLabel(level)
+
+    return (
+      <Box textWrap="wrap" flexDirection="row">
+        <TextLabel />
+        {` `}
+        {message}
+      </Box>
+    )
+  }
+)

--- a/packages/gatsby-reporter/src/loggers/ink/components/progress-bar.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/components/progress-bar.tsx
@@ -1,0 +1,61 @@
+import React from "react"
+import { Box } from "ink"
+import convertHrtime from "convert-hrtime"
+
+function calcElapsedTime(startTime: [number, number]): string {
+  const elapsed = process.hrtime(startTime)
+
+  return convertHrtime(elapsed)[`seconds`].toFixed(3)
+}
+
+const maxWidth = 30
+const minWidth = 10
+
+const getLength = (prop: string | number): number => String(prop).length
+
+export interface IProgressbarProps {
+  message: string
+  current: number
+  total: number
+  startTime: [number, number]
+}
+
+export function ProgressBar({
+  message,
+  current,
+  total,
+  startTime,
+}: IProgressbarProps): JSX.Element {
+  const percentage = total ? Math.round((current / total) * 100) : 0
+  const terminalWidth = process.stdout.columns || 80
+  const availableWidth =
+    terminalWidth -
+    getLength(message) -
+    getLength(current) -
+    getLength(total) -
+    getLength(percentage) -
+    11 // margins + extra characters
+
+  const progressBarWidth = Math.max(
+    minWidth,
+    Math.min(maxWidth, availableWidth)
+  )
+
+  return (
+    <Box flexDirection="row">
+      <Box marginRight={3} width={progressBarWidth}>
+        [
+        <Box width={progressBarWidth - 2}>
+          {`=`.repeat(((progressBarWidth - 2) * percentage) / 100)}
+        </Box>
+        ]
+      </Box>
+      <Box marginRight={1}>{calcElapsedTime(startTime)} s</Box>
+      <Box marginRight={1}>
+        {current}/{total}
+      </Box>
+      <Box marginRight={1}>{`` + percentage}%</Box>
+      <Box textWrap="truncate">{message}</Box>
+    </Box>
+  )
+}

--- a/packages/gatsby-reporter/src/loggers/ink/components/spinner.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/components/spinner.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { Box } from "ink"
+import InkSpinner from "ink-spinner"
+
+interface ISpinnerProps {
+  text: string
+  statusText?: string
+}
+export function Spinner({ text, statusText }: ISpinnerProps): JSX.Element {
+  let label = text
+  if (statusText) {
+    label += ` — ${statusText}`
+  }
+
+  return (
+    <Box>
+      <InkSpinner type="dots" /> {label}
+    </Box>
+  )
+}

--- a/packages/gatsby-reporter/src/loggers/ink/components/utils.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/components/utils.tsx
@@ -1,0 +1,14 @@
+import React, { FunctionComponent } from "react"
+import { Color, ColorProps } from "ink"
+
+export const ColorSwitcher: FunctionComponent<ColorProps> = ({
+  children,
+  ...props
+}) => <Color {...props}>{children}</Color>
+
+export const createLabel = (
+  text: string,
+  color: string
+): FunctionComponent<ColorProps> => (...props): JSX.Element => (
+  <ColorSwitcher {...{ [color]: true, ...props }}>{text}</ColorSwitcher>
+)

--- a/packages/gatsby-reporter/src/loggers/ink/context.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/context.tsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect, createContext } from "react"
+import { getStore, onLogAction } from "../../redux"
+import { IGatsbyState } from "gatsby/src/redux/types"
+
+// These weird castings we are doing in this file is because the way gatsby-cli works is that it starts with it's own store
+// but then quickly swaps it out with the store from the installed gatsby. This would benefit from a refactor later on
+// to not use it's own store temporarily.
+// By the time this is actually running, it will become an `IGatsbyState`
+const StoreStateContext = createContext<IGatsbyState>(
+  (getStore().getState() as any) as IGatsbyState
+)
+
+export const StoreStateProvider: React.FC = ({
+  children,
+}): React.ReactElement => {
+  const [state, setState] = useState(
+    (getStore().getState() as any) as IGatsbyState
+  )
+
+  useEffect(
+    () =>
+      onLogAction(() => {
+        setState((getStore().getState() as any) as IGatsbyState)
+      }),
+    []
+  )
+
+  return (
+    <StoreStateContext.Provider value={state}>
+      {children}
+    </StoreStateContext.Provider>
+  )
+}
+
+export default StoreStateContext

--- a/packages/gatsby-reporter/src/loggers/ink/index.tsx
+++ b/packages/gatsby-reporter/src/loggers/ink/index.tsx
@@ -1,0 +1,21 @@
+import React, { useContext } from "react"
+import { render } from "ink"
+import StoreStateContext, { StoreStateProvider } from "./context"
+import CLI from "./cli"
+
+const ConnectedCLI: React.FC = (): React.ReactElement => {
+  const state = useContext(StoreStateContext)
+  const showStatusBar =
+    state.program?._?.[0] === `develop` &&
+    state.program?.status === `BOOTSTRAP_FINISHED`
+
+  return <CLI showStatusBar={Boolean(showStatusBar)} logs={state.logs} />
+}
+
+export function initializeINKLogger(): void {
+  render(
+    <StoreStateProvider>
+      <ConnectedCLI />
+    </StoreStateProvider>
+  )
+}

--- a/packages/gatsby-reporter/src/loggers/ipc/index.ts
+++ b/packages/gatsby-reporter/src/loggers/ipc/index.ts
@@ -1,0 +1,60 @@
+import { onLogAction } from "../../redux/index"
+import { ISetStatus, ActionsUnion } from "../../redux/types"
+import { Actions, LogLevels } from "../../constants"
+import stripAnsi from "strip-ansi"
+import { cloneDeep } from "lodash"
+
+const isStringPayload = (action: ActionsUnion): action is ISetStatus =>
+  typeof action.payload === `string`
+
+/**
+ * Payload can either be a String or an Object
+ * See more at integration-tests/structured-logging/__tests__/to-do.js
+ */
+const sanitizeAction = (action: ActionsUnion): ActionsUnion => {
+  const copiedAction = cloneDeep(action)
+
+  if (isStringPayload(copiedAction)) {
+    return copiedAction
+  }
+
+  if (`text` in copiedAction.payload && copiedAction.payload.text) {
+    copiedAction.payload.text = stripAnsi(copiedAction.payload.text)
+  }
+  if (`statusText` in copiedAction.payload && copiedAction.payload.statusText) {
+    copiedAction.payload.statusText = stripAnsi(copiedAction.payload.statusText)
+  }
+
+  return copiedAction
+}
+
+export const initializeIPCLogger = (): void => {
+  onLogAction((action: ActionsUnion) => {
+    if (!process.send) return
+
+    const sanitizedAction = sanitizeAction(action)
+
+    // we mutate sanitizedAction but this is already deep copy of action so we should be good
+    if (sanitizedAction.type === Actions.Log) {
+      // Don't emit Debug over IPC
+      if (
+        [LogLevels.Debug].includes(sanitizedAction.payload.level as LogLevels)
+      ) {
+        return
+      }
+      // Override Success and Log types to Info over IPC
+      if (
+        [LogLevels.Success, LogLevels.Log].includes(
+          sanitizedAction.payload.level as LogLevels
+        )
+      ) {
+        sanitizedAction.payload.level = LogLevels.Info
+      }
+    }
+
+    process.send({
+      type: Actions.LogAction,
+      action: sanitizedAction,
+    })
+  })
+}

--- a/packages/gatsby-reporter/src/loggers/json/index.ts
+++ b/packages/gatsby-reporter/src/loggers/json/index.ts
@@ -1,0 +1,32 @@
+import { onLogAction } from "../../redux/index"
+import { ActionsUnion, ISetStatus } from "../../redux/types"
+import stripAnsi from "strip-ansi"
+import { cloneDeep } from "lodash"
+
+const isStringPayload = (action: ActionsUnion): action is ISetStatus =>
+  typeof action.payload === `string`
+
+const sanitizeAction = (action: ActionsUnion): ActionsUnion => {
+  const copiedAction = cloneDeep(action)
+
+  if (isStringPayload(copiedAction)) {
+    return copiedAction
+  }
+
+  if (`text` in copiedAction.payload && copiedAction.payload.text) {
+    copiedAction.payload.text = stripAnsi(copiedAction.payload.text)
+  }
+  if (`statusText` in copiedAction.payload && copiedAction.payload.statusText) {
+    copiedAction.payload.statusText = stripAnsi(copiedAction.payload.statusText)
+  }
+
+  return copiedAction
+}
+
+export function initializeJSONLogger(): void {
+  onLogAction((action: ActionsUnion) => {
+    const sanitizedAction = sanitizeAction(action)
+
+    process.stdout.write(JSON.stringify(sanitizedAction) + `\n`)
+  })
+}

--- a/packages/gatsby-reporter/src/loggers/yurnalist/index.ts
+++ b/packages/gatsby-reporter/src/loggers/yurnalist/index.ts
@@ -1,0 +1,138 @@
+import { onLogAction } from "../../redux"
+import {
+  Actions,
+  LogLevels,
+  ActivityLogLevels,
+  ActivityTypes,
+} from "../../constants"
+
+import { createReporter } from "yurnalist"
+import ProgressBar from "progress"
+import chalk from "chalk"
+import { IUpdateActivity } from "../../redux/types"
+
+interface IYurnalistActivities {
+  [activityId: string]: {
+    text: string | undefined
+    statusText: string | undefined
+    update(payload: IUpdateActivity["payload"]): void
+    end(): void
+  }
+}
+
+export function initializeYurnalistLogger(): void {
+  const activities: IYurnalistActivities = {}
+  const yurnalist = createReporter({ emoji: true, verbose: true })
+
+  const levelToYurnalist = {
+    [LogLevels.Log]: yurnalist.log.bind(yurnalist),
+    [LogLevels.Warning]: yurnalist.warn.bind(yurnalist),
+    [LogLevels.Error]: yurnalist.error.bind(yurnalist),
+    [LogLevels.Info]: yurnalist.info.bind(yurnalist),
+    [LogLevels.Success]: yurnalist.success.bind(yurnalist),
+    [ActivityLogLevels.Success]: yurnalist.success.bind(yurnalist),
+    [ActivityLogLevels.Failed]: (text: string): void => {
+      yurnalist.log(`${chalk.red(`failed`)} ${text}`)
+    },
+    [ActivityLogLevels.Interrupted]: (text: string): void => {
+      yurnalist.log(`${chalk.gray(`not finished`)} ${text}`)
+    },
+  }
+
+  onLogAction(action => {
+    switch (action.type) {
+      case Actions.Log: {
+        const yurnalistMethod = levelToYurnalist[action.payload.level]
+        if (!yurnalistMethod) {
+          process.stdout.write(`NO "${action.payload.level}" method\n`)
+        } else {
+          let message = action.payload.text
+          if (action.payload.duration) {
+            message += ` - ${action.payload.duration.toFixed(3)}s`
+          }
+          if (action.payload.statusText) {
+            message += ` - ${action.payload.statusText}`
+          }
+          yurnalistMethod(message)
+        }
+        break
+      }
+      case Actions.StartActivity: {
+        if (action.payload.type === ActivityTypes.Spinner) {
+          const spinner = yurnalist.activity()
+          spinner.tick(action.payload.text)
+
+          const activity = {
+            text: action.payload.text,
+            statusText: action.payload.statusText,
+            update(payload: any): void {
+              // TODO: I'm not convinced that this is ever called with a text property.
+              // From searching the codebase it appears that we do not ever assign a text
+              // property during the IUpdateActivity action.
+              if (payload.text) {
+                activity.text = payload.text
+              }
+              if (payload.statusText) {
+                activity.statusText = payload.statusText
+              }
+
+              let message = activity.text
+              if (activity.statusText) {
+                message += ` - ${activity.statusText}`
+              }
+
+              message += ` id:"${action.payload.id}"`
+
+              spinner.tick(message)
+            },
+            end(): void {
+              spinner.end()
+            },
+          }
+          activities[action.payload.id] = activity
+        } else if (action.payload.type === ActivityTypes.Progress) {
+          const bar = new ProgressBar(
+            ` [:bar] :current/:total :elapsed s :percent ${action.payload.text}`,
+            {
+              total: action.payload.total,
+              curr: action.payload.current,
+              width: 30,
+              clear: true,
+            }
+          )
+
+          activities[action.payload.id] = {
+            text: undefined,
+            statusText: undefined,
+            update(payload): void {
+              if (payload.total) {
+                bar.total = payload.total
+              }
+              if (payload.current) {
+                bar.curr = payload.current
+              }
+
+              bar.tick(0)
+            },
+            end(): void {},
+          }
+        }
+        break
+      }
+      case Actions.UpdateActivity: {
+        const activity = activities[action.payload.id]
+        if (activity) {
+          activity.update(action.payload)
+        }
+        break
+      }
+      case Actions.EndActivity: {
+        const activity = activities[action.payload.id]
+        if (activity) {
+          activity.end()
+          delete activities[action.payload.id]
+        }
+      }
+    }
+  })
+}

--- a/packages/gatsby-reporter/src/patch-console.ts
+++ b/packages/gatsby-reporter/src/patch-console.ts
@@ -1,0 +1,24 @@
+/*
+ * This module is used to patch console through our reporter so we can track
+ * these logs
+ */
+import util from "util"
+import { reporter as gatsbyReporter } from "./reporter"
+
+export function patchConsole(reporter: typeof gatsbyReporter): void {
+  console.log = (...args: any[]): void => {
+    const [format, ...rest] = args
+    reporter.log(util.format(format === undefined ? `` : format, ...rest))
+  }
+  console.warn = (...args: any[]): void => {
+    const [format, ...rest] = args
+    reporter.warn(util.format(format === undefined ? `` : format, ...rest))
+  }
+  console.info = (...args: any[]): void => {
+    const [format, ...rest] = args
+    reporter.info(util.format(format === undefined ? `` : format, ...rest))
+  }
+  console.error = (format: any, ...args: any[]): void => {
+    reporter.error(util.format(format === undefined ? `` : format, ...args))
+  }
+}

--- a/packages/gatsby-reporter/src/redux/actions.ts
+++ b/packages/gatsby-reporter/src/redux/actions.ts
@@ -1,0 +1,44 @@
+import { bindActionCreators } from "redux"
+import { Dispatch } from "redux"
+import { dispatch } from "./"
+import {
+  createLog as internalCreateLog,
+  createPendingActivity as internalCreatePendingActivity,
+  setStatus as internalSetStatus,
+  startActivity as internalStartActivity,
+  endActivity as internalEndActivity,
+  updateActivity as internalUpdateActivity,
+  setActivityErrored as internalSetActivityErrored,
+  setActivityStatusText as internalSetActivityStatusText,
+  setActivityTotal as internalSetActivityTotal,
+  activityTick as internalActivityTick,
+} from "./internal-actions"
+
+const actions = {
+  createLog: internalCreateLog,
+  createPendingActivity: internalCreatePendingActivity,
+  setStatus: internalSetStatus,
+  startActivity: internalStartActivity,
+  endActivity: internalEndActivity,
+  updateActivity: internalUpdateActivity,
+  setActivityErrored: internalSetActivityErrored,
+  setActivityStatusText: internalSetActivityStatusText,
+  setActivityTotal: internalSetActivityTotal,
+  activityTick: internalActivityTick,
+}
+
+const boundActions = bindActionCreators<typeof actions, any>(
+  actions,
+  (dispatch as any) as Dispatch
+)
+
+export const createLog = boundActions.createLog as typeof internalCreateLog
+export const createPendingActivity = boundActions.createPendingActivity as typeof internalCreatePendingActivity
+export const setStatus = boundActions.setStatus as typeof internalSetStatus
+export const startActivity = boundActions.startActivity as typeof internalStartActivity
+export const endActivity = boundActions.endActivity as typeof internalEndActivity
+export const updateActivity = boundActions.updateActivity as typeof internalUpdateActivity
+export const setActivityErrored = boundActions.setActivityErrored as typeof internalSetActivityErrored
+export const setActivityStatusText = boundActions.setActivityStatusText as typeof internalSetActivityStatusText
+export const setActivityTotal = boundActions.setActivityTotal as typeof internalSetActivityTotal
+export const activityTick = boundActions.activityTick as typeof internalActivityTick

--- a/packages/gatsby-reporter/src/redux/index.ts
+++ b/packages/gatsby-reporter/src/redux/index.ts
@@ -1,0 +1,78 @@
+import { createStore, combineReducers } from "redux"
+import { reducer } from "./reducer"
+import { ActionsUnion, ISetLogs } from "./types"
+import { isInternalAction } from "./utils"
+import { Actions } from "../constants"
+
+let store = createStore(
+  combineReducers({
+    logs: reducer,
+  }),
+  {}
+)
+
+type GatsbyCLIStore = typeof store
+type StoreListener = (store: GatsbyCLIStore) => void
+type ActionLogListener = (action: ActionsUnion) => any
+type Thunk = (...args: any[]) => ActionsUnion
+
+const storeSwapListeners: StoreListener[] = []
+const onLogActionListeners = new Set<ActionLogListener>()
+
+export const getStore = (): typeof store => store
+
+export const dispatch = (action: ActionsUnion | Thunk): void => {
+  if (!action) {
+    return
+  }
+
+  if (Array.isArray(action)) {
+    action.forEach(item => dispatch(item))
+    return
+  } else if (typeof action === `function`) {
+    action(dispatch)
+    return
+  }
+
+  action = {
+    ...action,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore this is a typescript no-no..
+    // And i'm pretty sure this timestamp isn't used anywhere.
+    // but for now, the structured logs integration tests expect it
+    // so it's easier to leave it and then explore as a follow up
+    timestamp: new Date().toJSON(),
+  } as ActionsUnion
+
+  store.dispatch(action)
+
+  if (isInternalAction(action)) {
+    // consumers (ipc, yurnalist, json logger) shouldn't have to
+    // deal with actions needed just for internal tracking of status
+    return
+  }
+  for (const fn of onLogActionListeners) {
+    fn(action)
+  }
+}
+
+export const onStoreSwap = (fn: StoreListener): void => {
+  storeSwapListeners.push(fn)
+}
+
+export const onLogAction = (fn: ActionLogListener): (() => void) => {
+  onLogActionListeners.add(fn)
+
+  return (): void => {
+    onLogActionListeners.delete(fn)
+  }
+}
+
+export const setStore = (s: GatsbyCLIStore): void => {
+  s.dispatch({
+    type: Actions.SetLogs,
+    payload: store.getState().logs,
+  } as ISetLogs)
+  store = s
+  storeSwapListeners.forEach(fn => fn(store))
+}

--- a/packages/gatsby-reporter/src/redux/internal-actions.ts
+++ b/packages/gatsby-reporter/src/redux/internal-actions.ts
@@ -1,0 +1,379 @@
+/* eslint-disable @typescript-eslint/camelcase */
+
+import uuidv4 from "uuid/v4"
+import { trackCli } from "gatsby-telemetry"
+import signalExit from "signal-exit"
+import { Dispatch } from "redux"
+
+import { getStore } from "./"
+import {
+  Actions,
+  ActivityLogLevels,
+  ActivityStatuses,
+  ActivityTypes,
+} from "../constants"
+import {
+  IPendingActivity,
+  ICreateLog,
+  ISetStatus,
+  IStartActivity,
+  ICancelActivity,
+  IEndActivity,
+  IUpdateActivity,
+  IActivityErrored,
+  IGatsbyCLIState,
+  ISetLogs,
+} from "./types"
+import {
+  delayedCall,
+  getActivity,
+  getElapsedTimeMS,
+  getGlobalStatus,
+} from "./utils"
+import { IStructuredError } from "../structured-errors/types"
+
+const ActivityStatusToLogLevel = {
+  [ActivityStatuses.Interrupted]: ActivityLogLevels.Interrupted,
+  [ActivityStatuses.Failed]: ActivityLogLevels.Failed,
+  [ActivityStatuses.Success]: ActivityLogLevels.Success,
+}
+
+let weShouldExit = false
+signalExit(() => {
+  weShouldExit = true
+})
+
+let cancelDelayedSetStatus: (() => void) | null
+// TODO: THIS IS NOT WORKING ATM
+export const setStatus = (
+  status: ActivityStatuses | "",
+  force: boolean = false
+) => (dispatch: Dispatch<ISetStatus>): void => {
+  const currentStatus = getStore().getState().logs.status
+  if (cancelDelayedSetStatus) {
+    cancelDelayedSetStatus()
+    cancelDelayedSetStatus = null
+  }
+  if (status !== currentStatus) {
+    if (status === `IN_PROGRESS` || force || weShouldExit) {
+      dispatch({
+        type: Actions.SetStatus,
+        payload: status,
+      })
+    } else {
+      cancelDelayedSetStatus = delayedCall(() => {
+        setStatus(status, true)(dispatch)
+      }, 1000)
+    }
+  }
+}
+
+export const createLog = ({
+  level,
+  text,
+  statusText,
+  duration,
+  group,
+  code,
+  type,
+  filePath,
+  location,
+  docsUrl,
+  context,
+  activity_current,
+  activity_total,
+  activity_type,
+  activity_uuid,
+  stack,
+}: {
+  level: string
+  text?: string
+  statusText?: string
+  duration?: number
+  group?: string
+  code?: string
+  type?: string
+  filePath?: string
+  location?: IStructuredError["location"]
+  docsUrl?: string
+  context?: string
+  activity_current?: number
+  activity_total?: number
+  activity_type?: string
+  activity_uuid?: string
+  stack?: IStructuredError["stack"]
+}): ICreateLog => {
+  return {
+    type: Actions.Log,
+    payload: {
+      level,
+      text,
+      statusText,
+      duration,
+      group,
+      code,
+      type,
+      filePath,
+      location,
+      docsUrl,
+      context,
+      activity_current,
+      activity_total,
+      activity_type,
+      activity_uuid,
+      timestamp: new Date().toJSON(),
+      stack,
+    },
+  }
+}
+
+type ActionsToEmit = Array<IPendingActivity | ReturnType<typeof setStatus>>
+export const createPendingActivity = ({
+  id,
+  status = ActivityStatuses.NotStarted,
+}: {
+  id: string
+  status?: ActivityStatuses
+}): ActionsToEmit => {
+  const actionsToEmit: ActionsToEmit = []
+
+  const logsState = getStore().getState().logs
+
+  const globalStatus = getGlobalStatus(id, status)
+
+  if (globalStatus !== logsState.status) {
+    actionsToEmit.push(setStatus(globalStatus))
+  }
+
+  actionsToEmit.push({
+    type: Actions.PendingActivity,
+    payload: {
+      id,
+      type: ActivityTypes.Pending,
+      status,
+    },
+  })
+
+  return actionsToEmit
+}
+
+type QueuedStartActivityActions = Array<
+  IStartActivity | ReturnType<typeof setStatus>
+>
+export const startActivity = ({
+  id,
+  text,
+  type,
+  status = ActivityStatuses.InProgress,
+  current,
+  total,
+}: {
+  id: string
+  text: string
+  type: ActivityTypes
+  status?: ActivityStatuses
+  current?: number
+  total?: number
+}): QueuedStartActivityActions => {
+  const actionsToEmit: QueuedStartActivityActions = []
+
+  const logsState = getStore().getState().logs
+
+  const globalStatus = getGlobalStatus(id, status)
+
+  if (globalStatus !== logsState.status) {
+    actionsToEmit.push(setStatus(globalStatus))
+  }
+
+  actionsToEmit.push({
+    type: Actions.StartActivity,
+    payload: {
+      id,
+      uuid: uuidv4(),
+      text,
+      type,
+      status,
+      startTime: process.hrtime(),
+      statusText: ``,
+      current,
+      total,
+    },
+  })
+
+  return actionsToEmit
+}
+
+type QueuedEndActivity = Array<
+  ICancelActivity | IEndActivity | ICreateLog | ReturnType<typeof setStatus>
+>
+
+export const endActivity = ({
+  id,
+  status,
+}: {
+  id: string
+  status: ActivityStatuses
+}): QueuedEndActivity | null => {
+  const activity = getActivity(id)
+  if (!activity) {
+    return null
+  }
+
+  const actionsToEmit: QueuedEndActivity = []
+  const durationMS = getElapsedTimeMS(activity)
+  const durationS = durationMS / 1000
+
+  if (activity.type === ActivityTypes.Pending) {
+    actionsToEmit.push({
+      type: Actions.CancelActivity,
+      payload: {
+        id,
+        status: ActivityStatuses.Cancelled,
+        type: activity.type,
+        duration: durationS,
+      },
+    })
+  } else if (activity.status === ActivityStatuses.InProgress) {
+    trackCli(`ACTIVITY_DURATION`, {
+      name: activity.text,
+      duration: Math.round(durationMS),
+    })
+
+    if (activity.errored) {
+      status = ActivityStatuses.Failed
+    }
+    actionsToEmit.push({
+      type: Actions.EndActivity,
+      payload: {
+        uuid: activity.uuid,
+        id,
+        status,
+        duration: durationS,
+        type: activity.type,
+      },
+    })
+
+    if (activity.type !== ActivityTypes.Hidden) {
+      actionsToEmit.push(
+        createLog({
+          text: activity.text,
+          level: ActivityStatusToLogLevel[status],
+          duration: durationS,
+          statusText:
+            activity.statusText ||
+            (status === ActivityStatuses.Success &&
+            activity.type === ActivityTypes.Progress
+              ? `${activity.current}/${activity.total} ${(
+                  (activity.total || 0) / durationS
+                ).toFixed(2)}/s`
+              : undefined),
+          activity_uuid: activity.uuid,
+          activity_current: activity.current,
+          activity_total: activity.total,
+          activity_type: activity.type,
+        })
+      )
+    }
+  }
+
+  const logsState = getStore().getState().logs
+
+  const globalStatus = getGlobalStatus(id, status)
+
+  if (globalStatus !== logsState.status) {
+    actionsToEmit.push(setStatus(globalStatus))
+  }
+
+  return actionsToEmit
+}
+
+export const updateActivity = ({
+  id = ``,
+  ...rest
+}: {
+  id: string
+  statusText?: string
+  total?: number
+  current?: number
+}): IUpdateActivity | null => {
+  const activity = getActivity(id)
+  if (!activity) {
+    return null
+  }
+
+  return {
+    type: Actions.UpdateActivity,
+    payload: {
+      uuid: activity.uuid,
+      id,
+      ...rest,
+    },
+  }
+}
+
+export const setActivityErrored = ({
+  id,
+}: {
+  id: string
+}): IActivityErrored | null => {
+  const activity = getActivity(id)
+  if (!activity) {
+    return null
+  }
+
+  return {
+    type: Actions.ActivityErrored,
+    payload: {
+      id,
+    },
+  }
+}
+
+export const setActivityStatusText = ({
+  id,
+  statusText,
+}: {
+  id: string
+  statusText: string
+}): IUpdateActivity | null =>
+  updateActivity({
+    id,
+    statusText,
+  })
+
+export const setActivityTotal = ({
+  id,
+  total,
+}: {
+  id: string
+  total: number
+}): IUpdateActivity | null =>
+  updateActivity({
+    id,
+    total,
+  })
+
+export const activityTick = ({
+  id,
+  increment = 1,
+}: {
+  id: string
+  increment: number
+}): IUpdateActivity | null => {
+  const activity = getActivity(id)
+  if (!activity) {
+    return null
+  }
+
+  return updateActivity({
+    id,
+    current: (activity.current || 0) + increment,
+  })
+}
+
+export const setLogs = (logs: IGatsbyCLIState): ISetLogs => {
+  return {
+    type: Actions.SetLogs,
+    payload: logs,
+  }
+}

--- a/packages/gatsby-reporter/src/redux/reducer.ts
+++ b/packages/gatsby-reporter/src/redux/reducer.ts
@@ -1,0 +1,102 @@
+import { ActionsUnion, IGatsbyCLIState, ISetLogs } from "./types"
+import { Actions } from "../constants"
+
+export const reducer = (
+  state: IGatsbyCLIState = {
+    messages: [],
+    activities: {},
+    status: ``,
+  },
+  action: ActionsUnion | ISetLogs
+): IGatsbyCLIState => {
+  switch (action.type) {
+    case Actions.SetStatus: {
+      return {
+        ...state,
+        status: action.payload,
+      }
+    }
+
+    case Actions.Log: {
+      if (!action.payload.text) {
+        // set empty character to fix ink
+        action.payload.text = `\u2800`
+      }
+
+      return {
+        ...state,
+        messages: [...state.messages, action.payload],
+      }
+    }
+
+    case Actions.StartActivity: {
+      const { id } = action.payload
+      return {
+        ...state,
+        activities: {
+          ...state.activities,
+          [id]: action.payload,
+        },
+      }
+    }
+
+    case Actions.UpdateActivity:
+    case Actions.PendingActivity: {
+      const { id, ...rest } = action.payload
+      const activity = state.activities[id]
+
+      return {
+        ...state,
+        activities: {
+          ...state.activities,
+          [id]: {
+            ...activity,
+            ...rest,
+          },
+        },
+      }
+    }
+    case Actions.ActivityErrored: {
+      const { id } = action.payload
+      const activity = state.activities[id]
+
+      return {
+        ...state,
+        activities: {
+          ...state.activities,
+          [id]: {
+            ...activity,
+            errored: true,
+          },
+        },
+      }
+    }
+
+    case Actions.EndActivity:
+    case Actions.CancelActivity: {
+      const { id, status, duration } = action.payload
+      const activity = state.activities[id]
+      if (!activity) {
+        return state
+      }
+
+      const activities = { ...state.activities }
+      activities[id] = {
+        ...activity,
+        status,
+        duration,
+      }
+
+      return {
+        ...state,
+        activities,
+      }
+    }
+
+    case Actions.SetLogs: {
+      return action.payload
+    }
+  }
+
+  return state
+}

--- a/packages/gatsby-reporter/src/redux/types.ts
+++ b/packages/gatsby-reporter/src/redux/types.ts
@@ -1,0 +1,123 @@
+import { Actions, ActivityStatuses, ActivityTypes } from "../constants"
+import { IStructuredError } from "../structured-errors/types"
+
+export interface IGatsbyCLIState {
+  messages: ILog[]
+  activities: {
+    [id: string]: IActivity
+  }
+  status: ActivityStatuses | ""
+}
+
+export type ActionsUnion =
+  | ICreateLog
+  | ISetStatus
+  | IEndActivity
+  | IPendingActivity
+  | IStartActivity
+  | ICancelActivity
+  | IUpdateActivity
+  | IActivityErrored
+  | ISetLogs
+
+export interface IActivity {
+  startTime?: [number, number]
+  id: string
+  uuid: string
+  text: string
+  type: ActivityTypes
+  status: ActivityStatuses
+  statusText: string
+  current?: number
+  total?: number
+  duration?: number
+  errored?: boolean
+}
+
+interface ILog {
+  level: string
+  text: string | undefined
+  statusText: string | undefined
+  duration: number | undefined
+  group: string | undefined
+  code: string | undefined
+  type: string | undefined
+  filePath: string | undefined
+  location: IStructuredError["location"] | undefined
+  docsUrl: string | undefined
+  context: string | undefined
+  activity_current: number | undefined
+  activity_total: number | undefined
+  activity_type: string | undefined
+  activity_uuid: string | undefined
+  timestamp: string
+  stack: IStructuredError["stack"] | undefined
+}
+
+export interface ICreateLog {
+  type: Actions.Log
+  payload: ILog
+}
+
+export interface ISetStatus {
+  type: Actions.SetStatus
+  payload: ActivityStatuses | ""
+}
+
+export interface IPendingActivity {
+  type: Actions.PendingActivity
+  payload: {
+    id: string
+    type: ActivityTypes
+    status: ActivityStatuses
+  }
+}
+
+export interface IStartActivity {
+  type: Actions.StartActivity
+  payload: IActivity
+}
+
+export interface ICancelActivity {
+  type: Actions.CancelActivity
+  payload: {
+    id: string
+    status: ActivityStatuses.Cancelled
+    duration: number
+    type: ActivityTypes
+  }
+}
+
+export interface IEndActivity {
+  type: Actions.EndActivity
+  payload: {
+    uuid: string
+    id: string
+    status: ActivityStatuses
+    duration: number
+    type: ActivityTypes
+  }
+}
+
+export interface IUpdateActivity {
+  type: Actions.UpdateActivity
+  payload: {
+    uuid: string
+    id: string
+    statusText?: string
+    total?: number
+    current?: number
+  }
+}
+
+export interface IActivityErrored {
+  type: Actions.ActivityErrored
+  payload: {
+    id: string
+  }
+}
+
+export interface ISetLogs {
+  type: Actions.SetLogs
+  payload: IGatsbyCLIState
+}

--- a/packages/gatsby-reporter/src/redux/utils.ts
+++ b/packages/gatsby-reporter/src/redux/utils.ts
@@ -1,0 +1,89 @@
+import { getStore } from "./index"
+import convertHrtime from "convert-hrtime"
+import { Actions, ActivityTypes, ActivityStatuses } from "../constants"
+import { ActionsUnion, IActivity } from "./types"
+import signalExit from "signal-exit"
+
+export const getGlobalStatus = (
+  id: string,
+  status: ActivityStatuses
+): ActivityStatuses => {
+  const { logs } = getStore().getState()
+
+  const currentActivities = [id, ...Object.keys(logs.activities)]
+
+  return currentActivities.reduce(
+    (
+      generatedStatus: ActivityStatuses,
+      activityId: string
+    ): ActivityStatuses => {
+      const activityStatus =
+        activityId === id ? status : logs.activities[activityId].status
+
+      if (
+        activityStatus === ActivityStatuses.InProgress ||
+        activityStatus === ActivityStatuses.NotStarted
+      ) {
+        return ActivityStatuses.InProgress
+      } else if (
+        activityStatus === ActivityStatuses.Failed &&
+        generatedStatus !== ActivityStatuses.InProgress
+      ) {
+        return ActivityStatuses.Failed
+      } else if (
+        activityStatus === ActivityStatuses.Interrupted &&
+        generatedStatus !== ActivityStatuses.InProgress
+      ) {
+        return ActivityStatuses.Interrupted
+      }
+      return generatedStatus
+    },
+    ActivityStatuses.Success
+  )
+}
+
+export const getActivity = (id: string): IActivity | null =>
+  getStore().getState().logs.activities[id]
+
+/**
+ * @returns {Number} Milliseconds from activity start
+ */
+export const getElapsedTimeMS = (activity: IActivity): number => {
+  const elapsed = process.hrtime(activity.startTime)
+  return convertHrtime(elapsed).milliseconds
+}
+
+export const isInternalAction = (action: ActionsUnion): boolean => {
+  switch (action.type) {
+    case Actions.PendingActivity:
+    case Actions.CancelActivity:
+    case Actions.ActivityErrored:
+      return true
+    case Actions.StartActivity:
+    case Actions.EndActivity:
+      return action.payload.type === ActivityTypes.Hidden
+    default:
+      return false
+  }
+}
+
+/**
+ * Like setTimeout, but also handle signalExit
+ */
+export const delayedCall = (fn: () => void, timeout: number): (() => void) => {
+  const fnWrap = (): void => {
+    fn()
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    clear()
+  }
+
+  const timeoutID = setTimeout(fnWrap, timeout)
+  const cancelSignalExit = signalExit(fnWrap)
+
+  const clear = (): void => {
+    clearTimeout(timeoutID)
+    cancelSignalExit()
+  }
+
+  return clear
+}

--- a/packages/gatsby-reporter/src/reporter-phantom.ts
+++ b/packages/gatsby-reporter/src/reporter-phantom.ts
@@ -1,0 +1,37 @@
+import * as reporterActions from "./redux/actions"
+import { ActivityStatuses, ActivityTypes } from "./constants"
+import { Span } from "opentracing"
+import { IPhantomReporter } from "./types"
+
+interface ICreatePhantomReporterArguments {
+  text: string
+  id: string
+  span: Span
+}
+
+export const createPhantomReporter = ({
+  text,
+  id,
+  span,
+}: ICreatePhantomReporterArguments): IPhantomReporter => {
+  return {
+    start(): void {
+      reporterActions.startActivity({
+        id,
+        text,
+        type: ActivityTypes.Hidden,
+      })
+    },
+
+    end(): void {
+      span.finish()
+
+      reporterActions.endActivity({
+        id,
+        status: ActivityStatuses.Success,
+      })
+    },
+
+    span,
+  }
+}

--- a/packages/gatsby-reporter/src/reporter-progress.ts
+++ b/packages/gatsby-reporter/src/reporter-progress.ts
@@ -1,0 +1,118 @@
+import * as reporterActions from "./redux/actions"
+import { ActivityStatuses, ActivityTypes } from "./constants"
+import { Span } from "opentracing"
+import { reporter as gatsbyReporter } from "./reporter"
+import { IStructuredError } from "./structured-errors/types"
+import { ErrorMeta, IProgressReporter } from "./types"
+
+interface ICreateProgressReporterArguments {
+  id: string
+  text: string
+  start: number
+  total: number
+  span: Span
+  reporter: typeof gatsbyReporter
+}
+
+export const createProgressReporter = ({
+  id,
+  text,
+  start,
+  total,
+  span,
+  reporter,
+}: ICreateProgressReporterArguments): IProgressReporter => {
+  let lastUpdateTime = 0
+  let unflushedProgress = 0
+  let unflushedTotal = 0
+  const progressUpdateDelay = Math.round(1000 / 10) // 10 fps *shrug*
+
+  const updateProgress = (forced: boolean = false): void => {
+    const t = Date.now()
+    if (!forced && t - lastUpdateTime <= progressUpdateDelay) return
+
+    if (unflushedTotal > 0) {
+      reporterActions.setActivityTotal({ id, total: unflushedTotal })
+      unflushedTotal = 0
+    }
+    if (unflushedProgress > 0) {
+      reporterActions.activityTick({ id, increment: unflushedProgress })
+      unflushedProgress = 0
+    }
+    lastUpdateTime = t
+  }
+
+  return {
+    start(): void {
+      reporterActions.startActivity({
+        id,
+        text,
+        type: ActivityTypes.Progress,
+        current: start,
+        total,
+      })
+    },
+
+    setStatus(statusText: string): void {
+      reporterActions.setActivityStatusText({
+        id,
+        statusText,
+      })
+    },
+
+    tick(increment: number = 1): void {
+      unflushedProgress += increment // Have to manually track this :/
+      updateProgress()
+    },
+
+    panicOnBuild(
+      errorMeta: ErrorMeta,
+      error?: Error | Error[]
+    ): IStructuredError | IStructuredError[] {
+      span.finish()
+
+      reporterActions.setActivityErrored({
+        id,
+      })
+
+      return reporter.panicOnBuild(errorMeta, error)
+    },
+
+    panic(errorMeta: ErrorMeta, error?: Error | Error[]): never {
+      span.finish()
+
+      reporterActions.endActivity({
+        id,
+        status: ActivityStatuses.Failed,
+      })
+
+      return reporter.panic(errorMeta, error)
+    },
+
+    end(): void {
+      updateProgress(true)
+      span.finish()
+      reporterActions.endActivity({
+        id,
+        status: ActivityStatuses.Success,
+      })
+    },
+
+    // @deprecated - use end()
+    done(): void {
+      updateProgress(true)
+      span.finish()
+      reporterActions.endActivity({
+        id,
+        status: ActivityStatuses.Success,
+      })
+    },
+
+    set total(value: number) {
+      unflushedTotal = value
+      updateProgress()
+    },
+
+    span,
+  }
+}

--- a/packages/gatsby-reporter/src/reporter-timer.ts
+++ b/packages/gatsby-reporter/src/reporter-timer.ts
@@ -1,0 +1,76 @@
+/*
+ * This module is used when calling reporter.
+ * these logs
+ */
+import * as reporterActions from "./redux/actions"
+import { ActivityStatuses, ActivityTypes } from "./constants"
+import { Span } from "opentracing"
+import { reporter as gatsbyReporter } from "./reporter"
+import { IStructuredError } from "./structured-errors/types"
+import { ErrorMeta, ITimerReporter } from "./types"
+
+interface ICreateTimerReporterArguments {
+  text: string
+  id: string
+  span: Span
+  reporter: typeof gatsbyReporter
+}
+
+export const createTimerReporter = ({
+  text,
+  id,
+  span,
+  reporter,
+}: ICreateTimerReporterArguments): ITimerReporter => {
+  return {
+    start(): void {
+      reporterActions.startActivity({
+        id,
+        text: text || `__timer__`,
+        type: ActivityTypes.Spinner,
+      })
+    },
+
+    setStatus(statusText: string): void {
+      reporterActions.setActivityStatusText({
+        id,
+        statusText,
+      })
+    },
+
+    panicOnBuild(
+      errorMeta: ErrorMeta,
+      error?: Error | Error[]
+    ): IStructuredError | IStructuredError[] {
+      span.finish()
+
+      reporterActions.setActivityErrored({
+        id,
+      })
+
+      return reporter.panicOnBuild(errorMeta, error)
+    },
+
+    panic(errorMeta: ErrorMeta, error?: Error | Error[]): never {
+      span.finish()
+
+      reporterActions.endActivity({
+        id,
+        status: ActivityStatuses.Failed,
+      })
+
+      return reporter.panic(errorMeta, error)
+    },
+
+    end(): void {
+      span.finish()
+
+      reporterActions.endActivity({
+        id,
+        status: ActivityStatuses.Success,
+      })
+    },
+
+    span,
+  }
+}

--- a/packages/gatsby-reporter/src/reporter.ts
+++ b/packages/gatsby-reporter/src/reporter.ts
@@ -1,0 +1,261 @@
+import { stripIndent } from "common-tags"
+import chalk from "chalk"
+import { trackError } from "gatsby-telemetry"
+import { globalTracer } from "opentracing"
+import { getErrorFormatter } from "./get-error-formater"
+
+import * as reporterActions from "./redux/actions"
+import { LogLevels, ActivityStatuses } from "./constants"
+import constructError from "./structured-errors/construct-error"
+import { prematureEnd } from "./catch-exit-signals"
+import { IStructuredError } from "./structured-errors/types"
+import { createTimerReporter } from "./reporter-timer"
+import { createPhantomReporter } from "./reporter-phantom"
+import { createProgressReporter } from "./reporter-progress"
+import {
+  ErrorMeta,
+  IActivityArgs,
+  IPhantomReporter,
+  IProgressReporter,
+  ITimerReporter,
+} from "./types"
+import { ICreateLog } from "./redux/types"
+
+const errorFormatter = getErrorFormatter()
+const tracer = globalTracer()
+
+let isVerbose = false
+
+/**
+ * Reporter module.
+ * @module reporter
+ */
+class Reporter {
+  /**
+   * Strip initial indentation template function.
+   */
+  stripIndent = stripIndent
+  format = chalk
+
+  /**
+   * Toggle verbosity.
+   */
+  setVerbose = (_isVerbose: boolean = true): void => {
+    isVerbose = _isVerbose
+  }
+
+  /**
+   * Turn off colors in error output.
+   */
+  setNoColor = (isNoColor: boolean = false): void => {
+    if (isNoColor) {
+      errorFormatter.withoutColors()
+    }
+
+    // disables colors in popular terminal output coloring packages
+    //  - chalk: see https://www.npmjs.com/package/chalk#chalksupportscolor
+    //  - ansi-colors: see https://github.com/doowb/ansi-colors/blob/8024126c7115a0efb25a9a0e87bc5e29fd66831f/index.js#L5-L7
+    if (isNoColor) {
+      process.env.FORCE_COLOR = `0`
+      // chalk determines color level at import time. Before we reach this point,
+      // chalk was already imported, so we need to retroactively adjust level
+      chalk.level = 0
+    }
+  }
+
+  /**
+   * Log arguments and exit process with status 1.
+   */
+  panic = (errorMeta: ErrorMeta, error?: Error | Error[]): never => {
+    const reporterError = this.error(errorMeta, error)
+    trackError(`GENERAL_PANIC`, { error: reporterError })
+    prematureEnd()
+    return process.exit(1)
+  }
+
+  panicOnBuild = (
+    errorMeta: ErrorMeta,
+    error?: Error | Error[]
+  ): IStructuredError | IStructuredError[] => {
+    const reporterError = this.error(errorMeta, error)
+    trackError(`BUILD_PANIC`, { error: reporterError })
+    if (process.env.gatsby_executing_command === `build`) {
+      prematureEnd()
+      process.exit(1)
+    }
+    return reporterError
+  }
+
+  error = (
+    errorMeta: ErrorMeta | ErrorMeta[],
+    error?: Error | Error[]
+  ): IStructuredError | IStructuredError[] => {
+    let details: {
+      error?: Error
+      context: {}
+    } = {
+      context: {},
+    }
+
+    // Many paths to retain backcompat :scream:
+    // 1.
+    //   reporter.error(any, Error);
+    //   reporter.error(any, [Error]);
+    if (error) {
+      if (Array.isArray(error)) {
+        return error.map(errorItem =>
+          this.error(errorMeta, errorItem)
+        ) as IStructuredError[]
+      }
+      details.error = error
+      details.context = {
+        sourceMessage: errorMeta + ` ` + error.message,
+      }
+      // 2.
+      //    reporter.error(Error);
+    } else if (errorMeta instanceof Error) {
+      details.error = errorMeta
+      details.context = {
+        sourceMessage: errorMeta.message,
+      }
+      // 3.
+      //    reporter.error([Error]);
+    } else if (Array.isArray(errorMeta)) {
+      // when we get an array of messages, call this function once for each error
+      return errorMeta.map(errorItem =>
+        this.error(errorItem)
+      ) as IStructuredError[]
+      // 4.
+      //    reporter.error(errorMeta);
+    } else if (typeof errorMeta === `object`) {
+      details = { ...errorMeta }
+      // 5.
+      //    reporter.error('foo');
+    } else if (typeof errorMeta === `string`) {
+      details.context = {
+        sourceMessage: errorMeta,
+      }
+    }
+
+    const structuredError = constructError({ details })
+    if (structuredError) {
+      reporterActions.createLog(structuredError)
+    }
+
+    // TODO: remove this once Error component can render this info
+    // log formatted stacktrace
+    if (structuredError.error) {
+      this.log(errorFormatter.render(structuredError.error))
+    }
+    return structuredError
+  }
+
+  /**
+   * Set prefix on uptime.
+   */
+  uptime = (prefix: string): void => {
+    this.verbose(`${prefix}: ${(process.uptime() * 1000).toFixed(3)}ms`)
+  }
+
+  verbose = (text: string): void => {
+    if (isVerbose) {
+      reporterActions.createLog({
+        level: LogLevels.Debug,
+        text,
+      })
+    }
+  }
+
+  success = (text?: string): ICreateLog =>
+    reporterActions.createLog({ level: LogLevels.Success, text })
+  info = (text?: string): ICreateLog =>
+    reporterActions.createLog({ level: LogLevels.Info, text })
+  warn = (text?: string): ICreateLog =>
+    reporterActions.createLog({ level: LogLevels.Warning, text })
+  log = (text?: string): ICreateLog =>
+    reporterActions.createLog({ level: LogLevels.Log, text })
+
+  pendingActivity = reporterActions.createPendingActivity
+
+  completeActivity = (
+    id: string,
+    status: ActivityStatuses = ActivityStatuses.Success
+  ): void => {
+    reporterActions.endActivity({ id, status })
+  }
+
+  /**
+   * Time an activity.
+   */
+  activityTimer = (
+    text: string,
+    activityArgs: IActivityArgs = {}
+  ): ITimerReporter => {
+    let { parentSpan, id, tags } = activityArgs
+    const spanArgs = parentSpan ? { childOf: parentSpan, tags } : { tags }
+    if (!id) {
+      id = text
+    }
+
+    const span = tracer.startSpan(text, spanArgs)
+
+    return createTimerReporter({ text, id, span, reporter: this })
+  }
+
+  /**
+   * Create an Activity that is not visible to the user
+   *
+   * During the lifecycle of the Gatsby process, sometimes we need to do some
+   * async work and wait for it to complete. A typical example of this is a job.
+   * This work should set the status of the process to `in progress` while running and
+   * `complete` (or `failure`) when complete. Activities do just this! However, they
+   * are visible to the user. So this function can be used to create a _hidden_ activity
+   * that while not displayed in the CLI, still triggers a change in process status.
+   */
+  phantomActivity = (
+    text: string,
+    activityArgs: IActivityArgs = {}
+  ): IPhantomReporter => {
+    let { parentSpan, id, tags } = activityArgs
+    const spanArgs = parentSpan ? { childOf: parentSpan, tags } : { tags }
+    if (!id) {
+      id = text
+    }
+
+    const span = tracer.startSpan(text, spanArgs)
+
+    return createPhantomReporter({ id, text, span })
+  }
+
+  /**
+   * Create a progress bar for an activity
+   */
+  createProgress = (
+    text: string,
+    total = 0,
+    start = 0,
+    activityArgs: IActivityArgs = {}
+  ): IProgressReporter => {
+    let { parentSpan, id, tags } = activityArgs
+    const spanArgs = parentSpan ? { childOf: parentSpan, tags } : { tags }
+    if (!id) {
+      id = text
+    }
+    const span = tracer.startSpan(text, spanArgs)
+
+    return createProgressReporter({
+      id,
+      text,
+      total,
+      start,
+      span,
+      reporter: this,
+    })
+  }
+
+  // This method was called in older versions of gatsby, so we need to keep it to avoid
+  // "reporter._setStage is not a function" error when gatsby@<2.16 is used with gatsby-cli@>=2.8
+  _setStage = (): void => {}
+}
+
+export const reporter = new Reporter()

--- a/packages/gatsby-reporter/src/start-logger.ts
+++ b/packages/gatsby-reporter/src/start-logger.ts
@@ -1,0 +1,44 @@
+/*
+ * This module is a side-effect filled module to load in the proper logger.
+ */
+import semver from "semver"
+import { isCI } from "gatsby-core-utils"
+import { initializeIPCLogger } from "./loggers/ipc"
+import { initializeJSONLogger } from "./loggers/json"
+import { initializeYurnalistLogger } from "./loggers/yurnalist"
+import { initializeINKLogger } from "./loggers/ink"
+
+export const startLogger = (): void => {
+  let inkExists = false
+  try {
+    inkExists = !!require.resolve(`ink`)
+    // eslint-disable-next-line no-empty
+  } catch (err) {}
+
+  if (!process.env.GATSBY_LOGGER) {
+    if (
+      inkExists &&
+      semver.satisfies(process.version, `>=8`) &&
+      !isCI() &&
+      typeof jest === `undefined`
+    ) {
+      process.env.GATSBY_LOGGER = `ink`
+    } else {
+      process.env.GATSBY_LOGGER = `yurnalist`
+    }
+  }
+  // if child process - use ipc logger
+  if (process.send) {
+    // process.env.FORCE_COLOR = `0`
+
+    initializeIPCLogger()
+  }
+
+  if (process.env.GATSBY_LOGGER.includes(`json`)) {
+    initializeJSONLogger()
+  } else if (process.env.GATSBY_LOGGER.includes(`yurnalist`)) {
+    initializeYurnalistLogger()
+  } else {
+    initializeINKLogger()
+  }
+}

--- a/packages/gatsby-reporter/src/structured-errors/__tests__/construct-error.ts
+++ b/packages/gatsby-reporter/src/structured-errors/__tests__/construct-error.ts
@@ -1,0 +1,40 @@
+import constructError from "../construct-error"
+
+let log
+let processExit
+beforeEach(() => {
+  log = jest.spyOn(console, `log`).mockImplementation(() => {})
+  processExit = ((jest.spyOn(
+    process,
+    `exit`
+  ) as unknown) as jest.Mock).mockImplementation(() => {})
+
+  log.mockReset()
+  processExit.mockReset()
+})
+
+afterAll(() => {
+  ;(console.log as jest.Mock).mockClear()
+  ;((process.exit as unknown) as jest.Mock).mockClear()
+})
+
+test(`it exits on invalid error schema`, () => {
+  constructError({ details: { context: {}, lol: `invalid` } })
+
+  expect(processExit).toHaveBeenCalledWith(1)
+})
+
+test(`it logs error on invalid schema`, () => {
+  constructError({ details: { context: {}, lol: `invalid` } })
+
+  expect(log).toHaveBeenCalledWith(
+    `Failed to validate error`,
+    expect.any(Object)
+  )
+})
+
+test(`it passes through on valid error schema`, () => {
+  constructError({ details: { context: {} } })
+
+  expect(log).not.toHaveBeenCalled()
+})

--- a/packages/gatsby-reporter/src/structured-errors/__tests__/error-map.ts
+++ b/packages/gatsby-reporter/src/structured-errors/__tests__/error-map.ts
@@ -1,0 +1,23 @@
+import { errorMap, defaultError } from "../error-map"
+
+test(`it defaults to generic error`, () => {
+  expect(defaultError).toEqual(
+    expect.objectContaining({
+      level: `ERROR`,
+    })
+  )
+
+  expect(defaultError.text({})).toEqual(`There was an error`)
+})
+
+test(`it supports structured lookups`, () => {
+  const error = errorMap[`95312`]
+
+  expect(error).toEqual(
+    expect.objectContaining({
+      text: expect.any(Function),
+      docsUrl: `https://gatsby.dev/debug-html`,
+      level: `ERROR`,
+    })
+  )
+})

--- a/packages/gatsby-reporter/src/structured-errors/__tests__/error-schema.ts
+++ b/packages/gatsby-reporter/src/structured-errors/__tests__/error-schema.ts
@@ -1,0 +1,13 @@
+import { errorSchema } from "../error-schema"
+
+test(`throws invalid on an invalid error`, () => {
+  expect(errorSchema.validate({ lol: `true` })).rejects.toBeDefined()
+})
+
+test(`does not throw on a valid schema`, () => {
+  expect(
+    errorSchema.validate({
+      context: {},
+    })
+  ).resolves.toEqual(expect.any(Object))
+})

--- a/packages/gatsby-reporter/src/structured-errors/construct-error.ts
+++ b/packages/gatsby-reporter/src/structured-errors/construct-error.ts
@@ -1,0 +1,39 @@
+import stackTrace from "stack-trace"
+import { errorSchema } from "./error-schema"
+import { errorMap, defaultError, IErrorMapEntry } from "./error-map"
+import { sanitizeStructuredStackTrace } from "./sanitize-structured-stack-trace"
+import { IConstructError, IStructuredError } from "./types"
+// Merge partial error details with information from the errorMap
+// Validate the constructed object against an error schema
+const constructError = ({
+  details: { id, ...otherDetails },
+}: IConstructError): IStructuredError => {
+  const result: IErrorMapEntry = (id && errorMap[id]) || defaultError
+
+  // merge
+  const structuredError: IStructuredError = {
+    context: {},
+    ...otherDetails,
+    ...result,
+    text: result.text(otherDetails.context),
+    stack: otherDetails.error
+      ? sanitizeStructuredStackTrace(stackTrace.parse(otherDetails.error))
+      : [],
+    docsUrl: result.docsUrl || `https://gatsby.dev/issue-how-to`,
+  }
+
+  if (id) {
+    structuredError.code = id
+  }
+
+  // validate
+  const { error } = errorSchema.validate(structuredError)
+  if (error !== null) {
+    console.log(`Failed to validate error`, error)
+    process.exit(1)
+  }
+
+  return structuredError
+}
+
+export default constructError

--- a/packages/gatsby-reporter/src/structured-errors/error-map.ts
+++ b/packages/gatsby-reporter/src/structured-errors/error-map.ts
@@ -1,0 +1,508 @@
+import { stripIndent, stripIndents } from "common-tags"
+import { IOptionalGraphQLInfoContext, ErrorLevel, ErrorType } from "./types"
+
+const optionalGraphQLInfo = (context: IOptionalGraphQLInfoContext): string =>
+  `${context.codeFrame ? `\n\n${context.codeFrame}` : ``}${
+    context.filePath ? `\n\nFile path: ${context.filePath}` : ``
+  }${context.urlPath ? `\nUrl path: ${context.urlPath}` : ``}${
+    context.plugin ? `\nPlugin: ${context.plugin}` : ``
+  }`
+
+const errors = {
+  "": {
+    text: (context): string => {
+      const sourceMessage = context.sourceMessage
+        ? context.sourceMessage
+        : `There was an error`
+      return sourceMessage
+    },
+    level: ErrorLevel.ERROR,
+  },
+  "95312": {
+    text: (context): string =>
+      `"${context.ref}" is not available during server side rendering.`,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://gatsby.dev/debug-html`,
+  },
+  "95313": {
+    text: (context): string =>
+      `Building static HTML failed${
+        context.errorPath ? ` for path "${context.errorPath}"` : ``
+      }`,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://gatsby.dev/debug-html`,
+  },
+  "98123": {
+    text: (context): string =>
+      `${context.stageLabel} failed\n\n${
+        context.sourceMessage ?? context.message
+      }`,
+    type: ErrorType.WEBPACK,
+    level: ErrorLevel.ERROR,
+  },
+  "98124": {
+    text: (context): string =>
+      `${context.stageLabel} failed\n\n${context.sourceMessage}\n\nIf you're trying to use a package make sure that '${context.packageName}' is installed. If you're trying to use a local file make sure that the path is correct.`,
+    type: ErrorType.WEBPACK,
+    level: ErrorLevel.ERROR,
+  },
+  "85901": {
+    text: (context): string =>
+      stripIndent(`
+        There was an error in your GraphQL query:\n\n${
+          context.sourceMessage
+        }${optionalGraphQLInfo(context)}`),
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  // Deprecated
+  "85907": {
+    text: (context): string =>
+      `There was an error in your GraphQL query:\n\n${context.message}`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85908": {
+    text: (context): string => {
+      const closestFragment = context.closestFragment
+        ? `\n\nDid you mean to use ` + `"${context.closestFragment}"?`
+        : ``
+
+      return `There was an error in your GraphQL query:\n\nThe fragment "${context.fragmentName}" does not exist.\n\n${context.codeFrame}${closestFragment}`
+    },
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  // Deprecated
+  "85909": {
+    text: (context): string => context.sourceMessage,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85910": {
+    text: (context): string =>
+      stripIndents(`
+        Multiple "root" queries found: "${context.name}" and "${context.otherName}".
+        Only the first ("${context.otherName}") will be registered.
+
+        Instead of:
+
+        ${context.beforeCodeFrame}
+
+        Do:
+
+        ${context.afterCodeFrame}
+
+        This can happen when you use two page/static queries in one file. Please combine those into one query.
+        If you're defining multiple components (each with a static query) in one file, you'll need to move each component to its own file.
+      `),
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://www.gatsbyjs.org/docs/graphql/`,
+  },
+  "85911": {
+    text: (context): string =>
+      stripIndent(`
+        There was a problem parsing "${context.filePath}"; any GraphQL
+        fragments or queries in this file were not processed.
+
+        This may indicate a syntax error in the code, or it may be a file type
+        that Gatsby does not know how to parse.
+      `),
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85912": {
+    text: (context): string =>
+      `Failed to parse preprocessed file ${context.filePath}`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85913": {
+    text: (context): string =>
+      `There was a problem reading the file: ${context.filePath}`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85914": {
+    text: (context): string =>
+      `There was a problem reading the file: ${context.filePath}`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  // default parsing error
+  "85915": {
+    text: (context): string =>
+      `There was a problem parsing the GraphQL query in file: ${context.filePath}`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85916": {
+    text: (context): string =>
+      `String interpolation is not allowed in graphql tag:\n\n${context.codeFrame}`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85917": {
+    text: (context): string =>
+      `Unexpected empty graphql tag${
+        context.codeFrame ? `\n\n${context.codeFrame}` : ``
+      }`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85918": {
+    text: (context): string =>
+      stripIndent(`
+        GraphQL syntax error in query:\n\n${context.sourceMessage}${
+        context.codeFrame ? `\n\n${context.codeFrame}` : ``
+      }`),
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  // Duplicate fragment
+  "85919": {
+    text: (context): string =>
+      stripIndent(`
+      Found two different GraphQL fragments with identical name "${context.fragmentName}". Fragment names must be unique
+
+      File: ${context.leftFragment.filePath}
+      ${context.leftFragment.codeFrame}
+
+      File: ${context.rightFragment.filePath}
+      ${context.rightFragment.codeFrame}
+    `),
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  // Undefined variables in Queries
+  "85920": {
+    text: (context): string => {
+      const staticQueryMessage = stripIndents(`Suggestion 1:
+
+      If you're not using a page query but a useStaticQuery / StaticQuery you see this error because they currently don't support variables. To learn more about the limitations of useStaticQuery / StaticQuery, please visit these docs:
+
+      https://www.gatsbyjs.org/docs/use-static-query/
+      https://www.gatsbyjs.org/docs/static-query/`)
+
+      const generalMessage = stripIndents(`Suggestion 2:
+
+      You might have a typo in the variable name "${context.variableName}" or you didn't provide the variable via context to this page query. Have a look at the docs to learn how to add data to context:
+
+      https://www.gatsbyjs.org/docs/page-query/#how-to-add-query-variables-to-a-page-query`)
+
+      return stripIndent(`
+        There was an error in your GraphQL query:\n\n${
+          context.sourceMessage
+        }${optionalGraphQLInfo(
+        context
+      )}\n\n${staticQueryMessage}\n\n${generalMessage}`)
+    },
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85921": {
+    text: (context): string =>
+      `There was an error in your GraphQL query:\n\n${context.sourceMessage}\n\nIf you're e.g. filtering for specific nodes make sure that you choose the correct field (that has the same type "${context.inputType}") or adjust the context variable to the type "${context.expectedType}".`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85922": {
+    text: (context): string =>
+      `There was an error in your GraphQL query:\n\n${context.sourceMessage}\n\nThis can happen if you e.g. accidentally added { } to the field "${context.fieldName}". If you didn't expect "${context.fieldName}" to be of type "${context.fieldType}" make sure that your input source and/or plugin is correct.`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85923": {
+    text: (context): string =>
+      `There was an error in your GraphQL query:\n\n${context.sourceMessage}\n\nIf you don't expect "${context.field}" to exist on the type "${context.type}" it is most likely a typo.\nHowever, if you expect "${context.field}" to exist there are a couple of solutions to common problems:\n\n- If you added a new data source and/or changed something inside gatsby-node.js/gatsby-config.js, please try a restart of your development server\n- The field might be accessible in another subfield, please try your query in GraphiQL and use the GraphiQL explorer to see which fields you can query and what shape they have\n- You want to optionally use your field "${context.field}" and right now it is not used anywhere. Therefore Gatsby can't infer the type and add it to the GraphQL schema. A quick fix is to add a least one entry with that field ("dummy content")\n\nIt is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for "${context.type}":\nhttps://www.gatsbyjs.org/docs/schema-customization/#creating-type-definitions`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85924": {
+    text: (context): string =>
+      `There was an error in your GraphQL query:\n\n${
+        context.sourceMessage
+      }\n\nThis can happen when you or a plugin/theme explicitly defined the GraphQL schema for this GraphQL object type via the schema customization API and "${
+        context.value
+      }" doesn't match the (scalar) type of "${
+        context.type
+      }".${optionalGraphQLInfo(context)}`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85925": {
+    text: (context): string =>
+      `There was an error in your GraphQL query:\n\n${
+        context.sourceMessage
+      }\n\nThe field "${
+        context.field
+      }" was explicitly defined as non-nullable via the schema customization API (by yourself or a plugin/theme). This means that this field is not optional and you have to define a value. If this is not your desired behavior and you defined the schema yourself, go to "createTypes" in gatsby-node.js. If you're using a plugin/theme, you can learn more here on how to fix field types:\nhttps://www.gatsbyjs.org/docs/schema-customization/#fixing-field-types${optionalGraphQLInfo(
+        context
+      )}`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85926": {
+    text: (context): string =>
+      `There was an error in your GraphQL query:\n\n${context.sourceMessage}\n\nThis can happen when you used graphql\`{ ...yourQuery }\` instead of graphql(\`{ ...yourQuery }\`) inside gatsby-node.js\n\nYou can't use the template literal function you're used to (from page queries) and rather have to call graphql() as a normal function.`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  "85927": {
+    text: (context): string =>
+      `There was an error in your GraphQL query:\n\n${context.sourceMessage}\n\nSee if ${context.variable} has a typo or ${context.operation} doesn't actually require this variable.`,
+    type: ErrorType.GRAPHQL,
+    level: ErrorLevel.ERROR,
+  },
+  // Config errors
+  "10122": {
+    text: (context): string =>
+      `The site's gatsby-config.js failed validation:\n\n${context.sourceMessage}`,
+    type: ErrorType.CONFIG,
+    level: ErrorLevel.ERROR,
+  },
+  "10123": {
+    text: (context): string =>
+      `We encountered an error while trying to load your site's ${context.configName}. Please fix the error and try again.`,
+    type: ErrorType.CONFIG,
+    level: ErrorLevel.ERROR,
+  },
+  "10124": {
+    text: (context): string =>
+      `It looks like you were trying to add the config file? Please rename "${context.nearMatch}" to "${context.configName}.js"`,
+    type: ErrorType.CONFIG,
+    level: ErrorLevel.ERROR,
+  },
+  "10125": {
+    text: (context): string =>
+      `Your ${context.configName} file is in the wrong place. You've placed it in the src/ directory. It must instead be at the root of your site next to your package.json file.`,
+    type: ErrorType.CONFIG,
+    level: ErrorLevel.ERROR,
+  },
+  "10126": {
+    text: (context): string =>
+      `${context.path}/${context.configName} cannot export a function.` +
+      `\n\nA ${context.configName} exported as a Function can only be used as a theme and not run directly.` +
+      `\nIf you are trying to run a theme directly, use the theme in an example site or starter instead and run that site to test.` +
+      `\nIf you are in the root gatsby-config.js for your site, change the export to be an object and not a function as functions` +
+      `\nare not supported in the root gatsby-config.`,
+    type: ErrorType.CONFIG,
+    level: ErrorLevel.ERROR,
+  },
+  "10226": {
+    text: (context): string =>
+      [
+        `Couldn't find the "${context.themeName}" plugin declared in "${context.configFilePath}".`,
+        context.pathToLocalTheme &&
+          `Tried looking for a local plugin in ${context.pathToLocalTheme}.`,
+        `Tried looking for an installed package in the following paths:\n${context.nodeResolutionPaths
+          .map(potentialLocationPath => ` - ${potentialLocationPath}`)
+          .join(`\n`)}`,
+      ]
+        .filter(Boolean)
+        .join(`\n\n`),
+    type: ErrorType.CONFIG,
+    level: ErrorLevel.ERROR,
+  },
+  // Plugin errors
+  "11321": {
+    text: (context): string =>
+      `"${context.pluginName}" threw an error while running the ${
+        context.api
+      } lifecycle:\n\n${
+        context.sourceMessage ?? context.message
+      }${optionalGraphQLInfo(context)}`,
+    type: ErrorType.PLUGIN,
+    level: ErrorLevel.ERROR,
+  },
+  "11322": {
+    text: (context): string =>
+      `${
+        context.pluginName
+      } created a page and didn't pass the path to the component.\n\nThe page object passed to createPage:\n${JSON.stringify(
+        context.pageObject,
+        null,
+        4
+      )}\n\nSee the documentation for the "createPage" action — https://www.gatsbyjs.org/docs/actions/#createPage`,
+    level: ErrorLevel.ERROR,
+  },
+  "11323": {
+    text: (context): string =>
+      `${
+        context.pluginName
+      } must set the page path when creating a page.\n\nThe page object passed to createPage:\n${JSON.stringify(
+        context.pageObject,
+        null,
+        4
+      )}\n\nSee the documentation for the "createPage" action — https://www.gatsbyjs.org/docs/actions/#createPage`,
+    level: ErrorLevel.ERROR,
+  },
+  "11324": {
+    text: (context): string =>
+      `${context.message}\n\nSee the documentation for the "createPage" action — https://www.gatsbyjs.org/docs/actions/#createPage`,
+    level: ErrorLevel.ERROR,
+  },
+  "11325": {
+    text: (context): string =>
+      `${
+        context.pluginName
+      } created a page with a component that doesn't exist.\n\nThe path to the missing component is "${
+        context.component
+      }"\n\nThe page object passed to createPage:\n${JSON.stringify(
+        context.pageObject,
+        null,
+        4
+      )}\n\nSee the documentation for the "createPage" action — https://www.gatsbyjs.org/docs/actions/#createPage`,
+    level: ErrorLevel.ERROR,
+  },
+  "11326": {
+    text: (context): string =>
+      `${
+        context.pluginName
+      } must set the absolute path to the page component when create creating a page.\n\nThe (relative) path you used for the component is "${
+        context.component
+      }"\n\nYou can convert a relative path to an absolute path by requiring the path module and calling path.resolve() e.g.\n\nconst path = require("path")\npath.resolve("${
+        context.component
+      }")\n\nThe page object passed to createPage:\n${JSON.stringify(
+        context.pageObject,
+        null,
+        4
+      )}\n\nSee the documentation for the "createPage" action — https://www.gatsbyjs.org/docs/actions/#createPage`,
+    level: ErrorLevel.ERROR,
+  },
+  "11327": {
+    text: (context): string =>
+      `You have an empty file in the "src/pages" directory at "${context.relativePath}". Please remove it or make it a valid component`,
+    level: ErrorLevel.ERROR,
+  },
+  "11328": {
+    text: (context): string =>
+      `A page component must export a React component for it to be valid. Please make sure this file exports a React component:\n\n${context.fileName}`,
+    level: ErrorLevel.ERROR,
+  },
+  // invalid or deprecated APIs
+  "11329": {
+    text: (context): string =>
+      [
+        stripIndent(`
+          Your plugins must export known APIs from their gatsby-${context.exportType}.js.
+
+          See https://www.gatsbyjs.org/docs/${context.exportType}-apis/ for the list of Gatsby ${context.exportType} APIs.
+        `),
+      ]
+        .concat([``].concat(context.errors))
+        .concat(
+          context.fixes.length > 0
+            ? [
+                ``,
+                `Some of the following may help fix the error(s):`,
+                ``,
+                ...context.fixes.map(fix => `- ${fix}`),
+              ]
+            : []
+        )
+        .join(`\n`),
+    level: ErrorLevel.ERROR,
+  },
+  // "X" is not defined in Gatsby's node APIs
+  "11330": {
+    text: (context): string =>
+      `"${context.pluginName}" threw an error while running the ${
+        context.api
+      } lifecycle:\n\n${context.sourceMessage ?? context.message}\n\n${
+        context.codeFrame
+      }\n\nMake sure that you don't have a typo somewhere and use valid arguments in ${
+        context.api
+      } lifecycle.\nLearn more about ${
+        context.api
+      } here: https://www.gatsbyjs.org/docs/node-apis/#${context.api}`,
+    type: ErrorType.PLUGIN,
+    level: ErrorLevel.ERROR,
+  },
+  // Directory/file name exceeds OS character limit
+  "11331": {
+    text: (context): string =>
+      [
+        `One or more path segments are too long - they exceed OS filename length limit.\n`,
+        `Page path: "${context.path}"`,
+        `Invalid segments:\n${context.invalidPathSegments
+          .map(segment => ` - "${segment}"`)
+          .join(`\n`)}`,
+        ...(!context.isProduction
+          ? [
+              `\nThis will fail production builds, please adjust your paths.`,
+              `\nIn development mode gatsby truncated to: "${context.truncatedPath}"`,
+            ]
+          : []),
+      ]
+        .filter(Boolean)
+        .join(`\n`),
+    level: ErrorLevel.ERROR,
+  },
+  // node object didn't pass validation
+  "11467": {
+    text: (context): string =>
+      [
+        `The new node didn't pass validation: ${context.validationErrorMessage}`,
+        `Failing node:`,
+        JSON.stringify(context.node, null, 4),
+        `Note: there might be more nodes that failed validation. Output is limited to one node per type of validation failure to limit terminal spam.`,
+        context.codeFrame,
+      ]
+        .filter(Boolean)
+        .join(`\n\n`),
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://www.gatsbyjs.org/docs/actions/#createNode`,
+  },
+  // local SSL certificate errors
+  "11521": {
+    text: (): string =>
+      `for custom ssl --https, --cert-file, and --key-file must be used together`,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://www.gatsbyjs.org/docs/local-https/#custom-key-and-certificate-files`,
+  },
+  "11522": {
+    text: (): string => `Failed to generate dev SSL certificate`,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://www.gatsbyjs.org/docs/local-https/#setup`,
+  },
+  // cli new command errors
+  "11610": {
+    text: (context): string =>
+      `It looks like you gave wrong argument orders . Try running instead "gatsby new ${context.starter} ${context.rootPath}"`,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://www.gatsbyjs.org/docs/gatsby-cli/#new`,
+  },
+  "11611": {
+    text: (context): string =>
+      `It looks like you passed a URL to your project name. Try running instead "gatsby new new-gatsby-project ${context.rootPath}"`,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://www.gatsbyjs.org/docs/gatsby-cli/#new`,
+  },
+  "11612": {
+    text: (context): string =>
+      `Could not create a project in "${context.path}" because it's not a valid path`,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://www.gatsbyjs.org/docs/gatsby-cli/#new`,
+  },
+  "11613": {
+    text: (context): string =>
+      `Directory ${context.rootPath} is already an npm project`,
+    level: ErrorLevel.ERROR,
+    docsUrl: `https://www.gatsbyjs.org/docs/gatsby-cli/#new`,
+  },
+}
+
+export type ErrorId = keyof typeof errors
+
+export const errorMap: Record<ErrorId, IErrorMapEntry> = errors
+
+export const defaultError = errorMap[``]
+
+export interface IErrorMapEntry {
+  text: (context) => string
+  level: ErrorLevel
+  type?: ErrorType
+  docsUrl?: string
+}

--- a/packages/gatsby-reporter/src/structured-errors/error-schema.ts
+++ b/packages/gatsby-reporter/src/structured-errors/error-schema.ts
@@ -1,0 +1,39 @@
+import Joi from "@hapi/joi"
+import { ILocationPosition, IStructuredError } from "./types"
+
+export const Position: Joi.ObjectSchema<ILocationPosition> = Joi.object().keys({
+  line: Joi.number(),
+  column: Joi.number(),
+})
+
+export const errorSchema: Joi.ObjectSchema<IStructuredError> = Joi.object().keys(
+  {
+    code: Joi.string(),
+    text: Joi.string(),
+    stack: Joi.array()
+      .items(
+        Joi.object().keys({
+          fileName: Joi.string(),
+          functionName: Joi.string().allow(null),
+          lineNumber: Joi.number().allow(null),
+          columnNumber: Joi.number().allow(null),
+        })
+      )
+      .allow(null),
+    level: Joi.string().valid([`ERROR`, `WARNING`, `INFO`, `DEBUG`]),
+    type: Joi.string().valid([`GRAPHQL`, `CONFIG`, `WEBPACK`, `PLUGIN`]),
+    filePath: Joi.string(),
+    location: Joi.object({
+      start: Position.required(),
+      end: Position,
+    }),
+    docsUrl: Joi.string().uri({
+      allowRelative: false,
+      relativeOnly: false,
+    }),
+    error: Joi.object({}).unknown(),
+    context: Joi.object({}).unknown(),
+    group: Joi.string(),
+    panicOnBuild: Joi.boolean(),
+  }
+)

--- a/packages/gatsby-reporter/src/structured-errors/sanitize-structured-stack-trace.ts
+++ b/packages/gatsby-reporter/src/structured-errors/sanitize-structured-stack-trace.ts
@@ -1,0 +1,47 @@
+import stackTrace from "stack-trace"
+import { isNodeInternalModulePath } from "gatsby-core-utils"
+import { IStructuredStackFrame } from "./types"
+
+const packagesToSkip = [`core-js`, `bluebird`, `regenerator-runtime`, `graphql`]
+
+const packagesToSkipTest = new RegExp(
+  `node_modules[\\/](${packagesToSkip.join(`|`)})`
+)
+
+// TO-DO: move this this out of this file (and probably delete this file completely)
+// it's here because it re-implements similar thing as `pretty-error` already does
+export const sanitizeStructuredStackTrace = (
+  stack: stackTrace.StackFrame[]
+): IStructuredStackFrame[] => {
+  // first filter out not useful call sites
+  stack = stack.filter(callSite => {
+    if (!callSite.getFileName()) {
+      return false
+    }
+
+    if (packagesToSkipTest.test(callSite.getFileName())) {
+      return false
+    }
+
+    if (callSite.getFileName().includes(`asyncToGenerator.js`)) {
+      return false
+    }
+
+    if (isNodeInternalModulePath(callSite.getFileName())) {
+      return false
+    }
+
+    return true
+  })
+
+  // then sanitize individual call site objects to make sure we don't
+  // emit objects with extra fields that won't be handled by consumers
+  return stack.map(callSite => {
+    return {
+      fileName: callSite.getFileName(),
+      functionName: callSite.getFunctionName(),
+      columnNumber: callSite.getColumnNumber(),
+      lineNumber: callSite.getLineNumber(),
+    }
+  })
+}

--- a/packages/gatsby-reporter/src/structured-errors/types.ts
+++ b/packages/gatsby-reporter/src/structured-errors/types.ts
@@ -1,0 +1,59 @@
+import { IErrorMapEntry, ErrorId } from "./error-map"
+
+export interface IConstructError {
+  details: {
+    id?: ErrorId
+    context?: Record<string, string>
+    error?: Error
+    [key: string]: unknown
+  }
+}
+
+export interface ILocationPosition {
+  line: number
+  column: number
+}
+
+export interface IStructuredStackFrame {
+  fileName: string
+  functionName?: string
+  lineNumber?: number
+  columnNumber?: number
+}
+
+export interface IStructuredError {
+  code?: string
+  text: string
+  stack: IStructuredStackFrame[]
+  filePath?: string
+  location?: {
+    start: ILocationPosition
+    end?: ILocationPosition
+  }
+  error?: Error
+  group?: string
+  level: IErrorMapEntry["level"]
+  type?: IErrorMapEntry["type"]
+  docsUrl?: string
+}
+
+export interface IOptionalGraphQLInfoContext {
+  codeFrame?: string
+  filePath?: string
+  urlPath?: string
+  plugin?: string
+}
+
+export enum ErrorLevel {
+  ERROR = `ERROR`,
+  WARNING = `WARNING`,
+  INFO = `INFO`,
+  DEBUG = `DEBUG`,
+}
+
+export enum ErrorType {
+  GRAPHQL = `GRAPHQL`,
+  CONFIG = `CONFIG`,
+  WEBPACK = `WEBPACK`,
+  PLUGIN = `PLUGIN`,
+}

--- a/packages/gatsby-reporter/src/types.ts
+++ b/packages/gatsby-reporter/src/types.ts
@@ -1,0 +1,52 @@
+import { Span } from "opentracing"
+import { IStructuredError } from "./structured-errors/types"
+
+export type ErrorMeta =
+  | {
+      id: string
+      error?: Error
+      context: Record<string, any>
+      [id: string]: any
+    }
+  | string
+  | Error
+  | ErrorMeta[]
+
+export interface IActivityArgs {
+  id?: string
+  parentSpan?: Span
+  tags?: { [key: string]: any }
+}
+
+export interface IPhantomReporter {
+  start(): void
+  end(): void
+  span: Span
+}
+
+export interface IProgressReporter {
+  start(): void
+  setStatus(statusText: string): void
+  tick(increment?: number): void
+  panicOnBuild(
+    arg: any,
+    ...otherArgs: any[]
+  ): IStructuredError | IStructuredError[]
+  panic(arg: any, ...otherArgs: any[]): never
+  end(): void
+  done(): void
+  total: number
+  span: Span
+}
+
+export interface ITimerReporter {
+  start(): void
+  setStatus(statusText: string): void
+  panicOnBuild(
+    arg: any,
+    ...otherArgs: any[]
+  ): IStructuredError | IStructuredError[]
+  panic(arg: any, ...otherArgs: any[]): never
+  end(): void
+  span: Span
+}

--- a/packages/gatsby-reporter/tsconfig.json
+++ b/packages/gatsby-reporter/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "exclude": ["node_modules", "**/__tests__/**/*", "src/__mocks__", "lib"]
+  "include": ["src"],
+  "exclude": ["**/__tests__/**/*"]
 }

--- a/packages/gatsby-reporter/tsconfig.json
+++ b/packages/gatsby-reporter/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "src/__tests__", "src/__mocks__", "lib"]
+}

--- a/packages/gatsby-reporter/tsconfig.json
+++ b/packages/gatsby-reporter/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "exclude": ["node_modules", "src/__tests__", "src/__mocks__", "lib"]
+  "exclude": ["node_modules", "**/__tests__/**/*", "src/__mocks__", "lib"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2808,14 +2808,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.4":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
-  integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
   integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
@@ -2843,7 +2836,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.8.7", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
   integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
@@ -10900,14 +10893,6 @@ dom-converter@~0.1:
   resolved "http://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
-
-dom-helpers@^5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
-  integrity sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^2.6.7"
 
 dom-serializer@0, dom-serializer@~0.1.0, dom-serializer@~0.1.1:
   version "0.1.1"
@@ -20244,11 +20229,6 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
-page-lifecycle@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/page-lifecycle/-/page-lifecycle-0.1.2.tgz#f17a083c082bd5ababddd77f1025a4b1c8808012"
-  integrity sha512-+3uccYgL0CXG0KSXRxZi4uc2E6mqFWV5HqiJJgcnaJCiS0LqiuJ4vB420N21NFuLvuvLB4Jr5drgQ2NXAXF9Iw==
-
 pako@^0.2.5:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -24307,15 +24287,6 @@ schemes@^1.0.1:
   dependencies:
     extend "^3.0.0"
 
-scroll-behavior@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.11.0.tgz#fff2765b6007341b80a04678fcd314e54d5b03ea"
-  integrity sha512-wQvNs3Q1TRvEkkwrFd/BkIL+dA4PYQl55/FUlmtjgz63/FtbnyR6MkLyRmjK0Rg3LCZCr0jORsFfMLkeNYdFuA==
-  dependencies:
-    dom-helpers "^5.1.4"
-    invariant "^2.2.4"
-    page-lifecycle "^0.1.2"
-
 section-matter@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/section-matter/-/section-matter-1.0.0.tgz#e9041953506780ec01d59f292a19c7b850b84167"
@@ -27739,12 +27710,6 @@ walker@^1.0.7, walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  dependencies:
-    loose-envify "^1.0.0"
 
 warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
## Description

This is a child PR of #25058 where I'm trying to break the PR into manageable _parts_.

This PR only adds the `gatsby-reporter` package, which is largely a `mv` from `gatsby-cli/src/reporter` with a couple TypeScript export improvements.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
