### PR TITLE
fix(www): fix APILink to source pointing to wrong location

### DIFF
--- a/www/src/components/api-reference/doc-block.js
+++ b/www/src/components/api-reference/doc-block.js
@@ -54,7 +54,7 @@ const APILink = ({ definition, relativeFilePath }) => {
           variant: `links.muted`,
           display: `inline-flex !important`,
         }}
-        href={`https://github.com/gatsbyjs/gatsby/blob/${process.env.COMMIT_SHA}/packages/${relativeFilePath}#L${definition.codeLocation.start.line}-L${definition.codeLocation.end.line}`}
+        href={`https://github.com/gatsbyjs/gatsby/blob/${process.env.COMMIT_SHA}/packages/gatsby/${relativeFilePath}#L${definition.codeLocation.start.line}-L${definition.codeLocation.end.line}`}
         aria-label="View source on GitHub"
       >
         <GithubIcon focusable="false" sx={{ mr: 2 }} />
@@ -74,7 +74,7 @@ const APILink = ({ definition, relativeFilePath }) => {
           variant: `links.muted`,
           display: `inline-flex !important`,
         }}
-        href={`https://github.com/gatsbyjs/gatsby/blob/${process.env.COMMIT_SHA}/packages/${definition.codeLocation.file}#L${definition.codeLocation.start.line}-L${definition.codeLocation.end.line}`}
+        href={`https://github.com/gatsbyjs/gatsby/blob/${process.env.COMMIT_SHA}/packages/gatsby/${definition.codeLocation.file}#L${definition.codeLocation.start.line}-L${definition.codeLocation.end.line}`}
         aria-label="View source on GitHub"
       >
         <GithubIcon focusable="false" sx={{ mr: 2 }} />
@@ -105,7 +105,7 @@ const APILink = ({ definition, relativeFilePath }) => {
           {definition.codeLocation.map((loc, index) => (
             <LinkBox
               key={`${loc.file}${loc.start.line}-${loc.end.line}`}
-              href={`https://github.com/gatsbyjs/gatsby/blob/${process.env.COMMIT_SHA}/packages/${loc.file}#L${loc.start.line}-L${loc.end.line}`}
+              href={`https://github.com/gatsbyjs/gatsby/blob/${process.env.COMMIT_SHA}/packages/gatsby/${loc.file}#L${loc.start.line}-L${loc.end.line}`}
               aria-label={`View source #${index + 1} on GitHub`}
             >
               {index + 1}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fixes #24914 

Links to source for api docs is broken. (See https://www.gatsbyjs.org/docs/browser-apis/, https://www.gatsbyjs.org/docs/ssr-apis/, etc.)


https://github.com/gatsbyjs/gatsby/pull/24330 made it so only the `/packages/gatsby` dir is sourced, which I think is what broke the source link for api docs. Linking to `/packages/gatsby/` instead of just `/packages` fixes the 404 for the link to source.


### Documentation

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
