### PR TITLE
fix(gatsby): remove page-date from jest-worker

### DIFF
--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -21,7 +21,7 @@ export function fixedPagePath(pagePath: string): string {
   return pagePath === `/` ? `index` : pagePath
 }
 
-export function getFilePath(publicDir: string, pagePath: string): string {
+function getFilePath(publicDir: string, pagePath: string): string {
   return path.join(
     publicDir,
     `page-data`,

--- a/packages/gatsby/src/utils/worker/child.ts
+++ b/packages/gatsby/src/utils/worker/child.ts
@@ -1,3 +1,2 @@
 // Note: this doesn't check for conflicts between module exports
-export { getFilePath } from "../page-data"
 export { renderHTML } from "./render-html"


### PR DESCRIPTION

## Description

Remove every trace of page-data from jest-worker. https://github.com/gatsbyjs/gatsby/pull/23991/ included our reporter inside a jest-worker and messed up ipc communication for a worker.

This doesn't fix the underlying issue but at least unblocks us for now.
