### PR TITLE
chore: skip link markup cleanup

### DIFF
--- a/www/src/components/skip-nav-link.js
+++ b/www/src/components/skip-nav-link.js
@@ -27,7 +27,7 @@ const Link = () => (
       },
     }}
   >
-    rans>Skip to main content
+    Skip to main content
   </SkipNavLink>
 )
 


### PR DESCRIPTION
## Description

I was testing something on the Gatsby site and noticed the skip link has some extra cruft in it from a find and replace or something, so this PR cleans it up.

### The broken skip link

![skip link on Gatsby site with an unclosed html tag in the text](https://user-images.githubusercontent.com/1045233/85188471-9f252080-b25b-11ea-991a-89aed32fe153.png)

### Fixed link with this PR

![skip link fixed](https://user-images.githubusercontent.com/1045233/85188778-0a6ff200-b25e-11ea-931f-5f9d7e11bc6e.png)

### Documentation

N/A

## Related Issues

The code was introduced in this commit: https://github.com/gatsbyjs/gatsby/commit/a6008314655eabafcd00388a94f21758b4d64733#diff-c8638feb462d5fe251bbae9403d62616