### PR TITLE
chore(www): convert BoxWithBorder to theme-ui

### DIFF
--- a/www/src/components/guidelines/box-with-border.js
+++ b/www/src/components/guidelines/box-with-border.js
@@ -1,27 +1,26 @@
-import styled from "@emotion/styled"
-import themeGet from "@styled-system/theme-get"
+/** @jsx jsx */
+import { jsx, Box } from "theme-ui"
 
-import { Box } from "./system"
-
-const BoxWithBorder = styled(Box)(
-  props =>
-    props.withBorder && {
-      ":after": {
-        border: `1px solid ${themeGet(`colors.blackFade.10`)(props)}`,
-        borderRadius: `${themeGet(`radii.1`)(props)}`,
-        bottom: 0,
-        content: `" "`,
-        left: 0,
-        position: `absolute`,
-        right: 0,
-        top: 0,
-      },
-    }
-)
-
-BoxWithBorder.defaultProps = {
-  borderRadius: 1,
-  position: `relative`,
+export default function BoxWithBorder({ withBorder, children, ...rest }) {
+  return (
+    <Box
+      sx={{
+        borderRadius: 1,
+        position: `relative`,
+        ":after": withBorder && {
+          content: `" "`,
+          border: `1px solid ${t.colors.blackFade[10]}`,
+          borderRadius: t => t.radii[1],
+          position: `absolute`,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+        },
+      }}
+      {...rest}
+    >
+      {children}
+    </Box>
+  )
 }
-
-export default BoxWithBorder

--- a/www/src/components/guidelines/box-with-border.js
+++ b/www/src/components/guidelines/box-with-border.js
@@ -9,8 +9,10 @@ export default function BoxWithBorder({ withBorder, children, ...rest }) {
         position: `relative`,
         ":after": withBorder && {
           content: `" "`,
-          border: `1px solid ${t.colors.blackFade[10]}`,
-          borderRadius: t => t.radii[1],
+          borderWidth: `1px`,
+          borderStyle: `solid`,
+          borderColor: `blackFade.10`,
+          borderRadius: 1,
           position: `absolute`,
           top: 0,
           right: 0,

--- a/www/src/components/guidelines/color/card.js
+++ b/www/src/components/guidelines/color/card.js
@@ -64,7 +64,6 @@ const ColorSwatch = ({ color, ...rest }) => {
 
   return (
     <BoxWithBorder
-      width={{ md: 1 / 3 }}
       py={4}
       px={2}
       bg={color.hex}

--- a/www/src/pages/guidelines/logo.js
+++ b/www/src/pages/guidelines/logo.js
@@ -94,7 +94,7 @@ const Guidance = ({ children, image }) => (
     }}
   >
     {image && (
-      <BoxWithBorder withBorder width="100%">
+      <BoxWithBorder withBorder>
         <Img fluid={image.childImageSharp.fluid} />
       </BoxWithBorder>
     )}
@@ -162,15 +162,7 @@ const GatsbyLogoContainered = ({
 )
 
 const LogoContainer = ({ bg, color, inverted, withBorder, ...rest }) => (
-  <BoxWithBorder
-    bg={bg}
-    height={0}
-    p={3}
-    pb="56.25%"
-    width="100%"
-    withBorder={withBorder}
-    {...rest}
-  >
+  <BoxWithBorder bg={bg} p={3} pb="56.25%" withBorder={withBorder} {...rest}>
     <Flex
       sx={{
         alignItems: `center`,


### PR DESCRIPTION
## Description

1. Convert the `<BoxWithBorder/>` component to theme-ui
2. Cleanup of CSS

### Screenshot(s)

#### The logo container is wrapper in BoxWithBorder component
<img width="640" alt="box-with-border-1" src="https://user-images.githubusercontent.com/19193724/85190502-b6edba80-b2d6-11ea-99fd-5c6c4718e925.png">

#### The items inside Guidance are all wrapped inside BoxWithBorder component
<img width="640" alt="box-with-border-2" src="https://user-images.githubusercontent.com/19193724/85190505-b8b77e00-b2d6-11ea-81ad-73bc1676965d.png">


### How to test

1. Go to the https://www.gatsbyjs.org/guidelines/logo/ page.
2. The BoxWithBorder component is used in multiple sections of this page.
3. The production and local should look similar, just the implementation of component is different.

**Local URL:** http://localhost:8000/guidelines/logo/
**Production URL:** https://www.gatsbyjs.org/guidelines/logo/
