### PR TITLE
chore(starters): add gatsby-typescript-markdown-starter

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -28,9 +28,7 @@
     - Styling:SCSS
     - Styling:CSS-in-JS
     - Markdown
-    - SEO
     - Portfolio
-    - Categories
     - Accessibility
   features:
     - Eslint/Prettier configured

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -29,7 +29,6 @@
     - Styling:CSS-in-JS
     - Markdown
     - Portfolio
-    - Accessibility
   features:
     - Eslint/Prettier configured
     - Easy to customize

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -19,6 +19,34 @@
     - Offline Support
     - RSS Feed
     - Composable and extensible
+- url: https://gatsby-typescript-markdown-starter.vercel.app/
+  repo: https://github.com/caelinsutch/gatsby-typescript-markdown-starter
+  description: A Gatsby starter with TypeScript and Markdown Preconfigured to Make a Portfolio.
+  tags:
+    - Blog
+    - SEO
+    - Styling:SCSS
+    - Styling:CSS-in-JS
+    - Markdown
+    - SEO
+    - Portfolio
+    - Categories
+    - Accessibility
+  features:
+    - Eslint/Prettier configured
+    - Easy to customize
+    - Typescript pre configured
+    - Markdown posts with PrismJS code styling
+    - Categories based off a yaml file
+    - Preconfigured with Gatsby Image
+    - High Lighthouse Scores
+    - Easy to understand product structure
+    - CSS in JS with Emotion
+    - Sass stylesheets
+    - React Helmet for SEO best practices and metatags
+    - SEO optimized
+    - Projects page, categories, home, 404 page
+    - Responsive
 - url: https://gatsby-starter-wordpress-twenty-twenty.netlify.app/
   repo: https://github.com/henrikwirth/gatsby-starter-wordpress-twenty-twenty
   description: A port of the WordPress Twenty Twenty theme to Gatsby.


### PR DESCRIPTION
## Description

Add a portfolio or blog starter with Categories, Typescript, Markdown, and eslint/prettier all preconfigured with SEO best practices. Updated the starters.yml file with the required sections as per [the documentation](https://www.gatsbyjs.org/contributing/submit-to-starter-library/).  Ensured tags are all valid :)

Let me know if I need to change anything