### PR TITLE
chore(docs): apache troubleshooting section to gatsby-plugin-manifest

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -478,7 +478,7 @@ If updating these doesn't fix the issue, your project probably uses other plugin
 
 ### APACHE: Error while trying to use the following icon from the Manifest
 
-If you are on an Apache webserver and utilizing the automatic solution, you may receive an error when attempting to access an icon listed in the Manifest as residing in the `/icons` folder. This is because Apache restricts access to all `/icons` folders by default. You can fix this by switching to the hybrid solution and changing the folder name from 'icons' to something like 'favicons'.
+If you are on an Apache webserver and utilizing the automatic solution, you may receive an error when attempting to access an icon listed in the manifest as residing in the `/icons` folder. This is because Apache restricts access to all `/icons` folders by default. You can fix this by switching to the hybrid solution and changing the folder name from `icons` to something like `favicons`.
 
 Example:
 
@@ -498,13 +498,13 @@ Alternatively, if you have access to modify Apache, you can resolve this issue b
 
 #### On Debian based systems
 
-Backup the /etc/apache2/mods-available/alias.conf file:
+Backup the `/etc/apache2/mods-available/alias.conf` file:
 
 ```shell
 cp /etc/apache2/mods-available/alias.conf /etc/apache2/mods-available/alias.conf.back
 ```
 
-Comment out the Alias /icons/ "/usr/share/apache2/icons/" row in /etc/apache2/mods-available/alias.conf file:
+Comment out the Alias `/icons/ "/usr/share/apache2/icons/"` row in `/etc/apache2/mods-available/alias.conf` file:
 
 ```shell
 cat /etc/apache2/mods-available/alias.conf | grep "Alias /icons/"
@@ -524,13 +524,13 @@ Create a backup of `/etc/httpd/conf.d/autoindex.conf`:
 cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back
 ```
 
-Comment out "Alias /icons/" in /etc/httpd/conf.d/autoindex.conf:
+Comment out `"Alias /icons/"` in `/etc/httpd/conf.d/autoindex.conf`:
 
 ```shell
 cat /etc/httpd/conf.d/autoindex.conf | grep "Alias /icons/"
 ```
 
-Reload Apache/or restart server:
+Reload Apache or restart  the server:
 
 ```shell
 service httpd reload

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -530,7 +530,7 @@ Comment out `"Alias /icons/"` in `/etc/httpd/conf.d/autoindex.conf`:
 cat /etc/httpd/conf.d/autoindex.conf | grep "Alias /icons/"
 ```
 
-Reload Apache or restart  the server:
+Reload Apache or restart the server:
 
 ```shell
 service httpd reload

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -477,9 +477,11 @@ npm install gatsby-plugin-sharp gatsby-plugin-manifest gatsby-remark-images-cont
 If updating these doesn't fix the issue, your project probably uses other plugins from the community that depend on a different version of `sharp`. Try running `npm list sharp` or `yarn why sharp` to see all packages in the current project that use `sharp` and try updating them as well.
 
 ### APACHE: Error while trying to use the following icon from the Manifest
-If you are on an Apache webserver and utilizing the automatic solution, you may receive an error when attempting to access an icon listed in the Manifest as residing in the `/icons` folder. This is because Apache restricts access to all `/icons` folders by default. You can fix this by switching to the hybrid solution and changing the folder name from 'icons' to something like 'favicons'. 
+
+If you are on an Apache webserver and utilizing the automatic solution, you may receive an error when attempting to access an icon listed in the Manifest as residing in the `/icons` folder. This is because Apache restricts access to all `/icons` folders by default. You can fix this by switching to the hybrid solution and changing the folder name from 'icons' to something like 'favicons'.
 
 Example:
+
 ```js
 // In the gatsby-plugin-manifest section of your gatsby-config.js
   icon: `src/images/icon.png`, // This path is relative to the root of the site.
@@ -495,33 +497,41 @@ Example:
 Alternatively, if you have access to modify Apache, you can resolve this issue by removing the restriction on `/icons` folders.
 
 #### On Debian based systems
+
 Backup the /etc/apache2/mods-available/alias.conf file:
+
 ```shell
 cp /etc/apache2/mods-available/alias.conf /etc/apache2/mods-available/alias.conf.back
 ```
 
 Comment out the Alias /icons/ "/usr/share/apache2/icons/" row in /etc/apache2/mods-available/alias.conf file:
+
 ```shell
 cat /etc/apache2/mods-available/alias.conf | grep "Alias /icons/"
 ```
 
 Reload Apache service:
+
 ```shell
 service apache2 reload
 ```
 
 #### On Red Hat or CentOS systems
+
 Create a backup of `/etc/httpd/conf.d/autoindex.conf`:
+
 ```shell
 cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back
 ```
 
 Comment out "Alias /icons/" in /etc/httpd/conf.d/autoindex.conf:
+
 ```shell
 cat /etc/httpd/conf.d/autoindex.conf | grep "Alias /icons/"
 ```
 
 Reload Apache/or restart server:
+
 ```shell
 service httpd reload
 ```

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -494,7 +494,7 @@ Example:
 
 Alternatively, if you have access to modify Apache, you can resolve this issue by removing the restriction on `/icons` folders.
 
-Create a backup of /etc/httpd/conf.d/autoindex.conf:
+Create a backup of `/etc/httpd/conf.d/autoindex.conf`:
 ```shell
 cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back
 ```

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -494,6 +494,23 @@ Example:
 
 Alternatively, if you have access to modify Apache, you can resolve this issue by removing the restriction on `/icons` folders.
 
+#### On Debian based systems
+Backup the /etc/apache2/mods-available/alias.conf file:
+```shell
+cp /etc/apache2/mods-available/alias.conf /etc/apache2/mods-available/alias.conf.back
+```
+
+Comment out the Alias /icons/ "/usr/share/apache2/icons/" row in /etc/apache2/mods-available/alias.conf file:
+```shell
+cat /etc/apache2/mods-available/alias.conf | grep "Alias /icons/"
+```
+
+Reload Apache service:
+```shell
+service apache2 reload
+```
+
+#### On Red Hat or CentOS systems
 Create a backup of `/etc/httpd/conf.d/autoindex.conf`:
 ```shell
 cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -477,7 +477,7 @@ npm install gatsby-plugin-sharp gatsby-plugin-manifest gatsby-remark-images-cont
 If updating these doesn't fix the issue, your project probably uses other plugins from the community that depend on a different version of `sharp`. Try running `npm list sharp` or `yarn why sharp` to see all packages in the current project that use `sharp` and try updating them as well.
 
 ### APACHE: Error while trying to use the following icon from the Manifest
-If you are on an Apache webserver and utilising the automatic solution, you may receive an error when attempting to access an icon listed in the Manifest as residing in the /icons folder. This is because Apache restricts access to all /icons folders by default. You can fix this by switching to the hybrid solution and changing the foldername from 'icons' to something like 'favicons'. 
+If you are on an Apache webserver and utilizing the automatic solution, you may receive an error when attempting to access an icon listed in the Manifest as residing in the `/icons` folder. This is because Apache restricts access to all `/icons` folders by default. You can fix this by switching to the hybrid solution and changing the folder name from 'icons' to something like 'favicons'. 
 
 Example:
 ```js

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -495,7 +495,9 @@ Example:
 Alternatively, if you have access to modify Apache, you can resolve this issue by removing the restriction on `/icons` folders.
 
 Create a backup of /etc/httpd/conf.d/autoindex.conf:
-`cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back`
+```shell
+cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back
+```
 
 Comment out "Alias /icons/" in /etc/httpd/conf.d/autoindex.conf:
 `cat /etc/httpd/conf.d/autoindex.conf | grep "Alias /icons/"`

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -492,7 +492,7 @@ Example:
   ]
 ```
 
-Alternatively, if you have access to modify apache, you can resolve this issue by removing the restriction on /icons folders.
+Alternatively, if you have access to modify Apache, you can resolve this issue by removing the restriction on `/icons` folders.
 
 Create a backup of /etc/httpd/conf.d/autoindex.conf:
 `cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back`

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -500,7 +500,9 @@ cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back
 ```
 
 Comment out "Alias /icons/" in /etc/httpd/conf.d/autoindex.conf:
-`cat /etc/httpd/conf.d/autoindex.conf | grep "Alias /icons/"`
+```shell
+cat /etc/httpd/conf.d/autoindex.conf | grep "Alias /icons/"
+```
 
 Reload Apache/or restart server:
 ```shell

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -475,3 +475,30 @@ npm install gatsby-plugin-sharp gatsby-plugin-manifest gatsby-remark-images-cont
 ```
 
 If updating these doesn't fix the issue, your project probably uses other plugins from the community that depend on a different version of `sharp`. Try running `npm list sharp` or `yarn why sharp` to see all packages in the current project that use `sharp` and try updating them as well.
+
+### APACHE: Error while trying to use the following icon from the Manifest
+If you are on an Apache webserver and utilising the automatic solution, you may receive an error when attempting to access an icon listed in the Manifest as residing in the /icons folder. This is because Apache restricts access to all /icons folders by default. You can fix this by switching to the hybrid solution and changing the foldername from 'icons' to something like 'favicons'. 
+
+Example:
+```js
+// In the gatsby-plugin-manifest section of your gatsby-config.js
+  icon: `src/images/icon.png`, // This path is relative to the root of the site.
+  icons: [
+    {
+        "src": "favicons/icon-144x144.png",
+        "sizes": "144x144",
+        "type": "image/png"
+    },  // Add or remove icon sizes as desired
+  ]
+```
+
+Alternatively, if you have access to modify apache, you can resolve this issue by removing the restriction on /icons folders.
+
+Create a backup of /etc/httpd/conf.d/autoindex.conf:
+`cp /etc/httpd/conf.d/autoindex.conf /etc/httpd/conf.d/autoindex.conf.back`
+
+Comment out "Alias /icons/" in /etc/httpd/conf.d/autoindex.conf:
+`cat /etc/httpd/conf.d/autoindex.conf | grep "Alias /icons/"`
+
+Reload Apache/or restart server:
+`service httpd reload`

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -503,4 +503,6 @@ Comment out "Alias /icons/" in /etc/httpd/conf.d/autoindex.conf:
 `cat /etc/httpd/conf.d/autoindex.conf | grep "Alias /icons/"`
 
 Reload Apache/or restart server:
-`service httpd reload`
+```shell
+service httpd reload
+```


### PR DESCRIPTION
## Description
I received an error in my browser during a lighthouse audit, wherein an icon listed in the manifest returned a 404 not found. This issue was due to a conflict between the apache websever and gatsby-plugin-manifest. 

I created an issue and had it checked by @marcysutton, who then requested someone created a pull requests to add this short text to the docs for plugin-manifest.

## Related Issues
https://github.com/gatsbyjs/gatsby/issues/24764
