### PR TITLE
fix(gatsby-react-router-scroll): replace querySelector with getElementById

### DIFF
--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -81,7 +81,7 @@ export class ScrollHandler extends React.Component<
     hash: string,
     prevProps: LocationContext | undefined
   ): void => {
-    const node = document.getElementById(hash)
+    const node = document.getElementById(hash.substring(1))
 
     if (node && this.shouldUpdateScroll(prevProps, this.props)) {
       node.scrollIntoView()

--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -81,7 +81,7 @@ export class ScrollHandler extends React.Component<
     hash: string,
     prevProps: LocationContext | undefined
   ): void => {
-    const node = document.querySelector(hash)
+    const node = document.getElementById(hash)
 
     if (node && this.shouldUpdateScroll(prevProps, this.props)) {
       node.scrollIntoView()


### PR DESCRIPTION
## Description

@blainekasten introduced a number of improvements to scroll handling in https://github.com/gatsbyjs/gatsby/pull/24306.

In the `scrollToHash` function, we should use `document.getElementById` to find the correct node instead of `document.querySelector`.

The HTML standard allows almost any string to be used as an `id` attribute:

> There are no other restrictions on what form an ID can take; in particular, IDs can consist of just digits, start with a digit, start with an underscore, consist of just punctuation, etc.

From: https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute

`document.querySelector` expects a valid CSS selector string, and will throw an exception if you do not supply one:
https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector

`document.getElementById` is designed to be used with the HTML `id` attribute: https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById

And does not seem to throw any exceptions, even if you give it invalid input.

`document.getElementById` also works with non-ascii text, like the `áccentuated` mentioned in https://github.com/gatsbyjs/gatsby/pull/24306.

And for bonus points, it looks like `document.getElementById` is about twice as fast as `document.querySelector`:
https://www.measurethat.net/Benchmarks/Show/2488/0/getelementbyid-vs-queryselector

### Documentation

None.

## Related Issues

None.