### PR TITLE
chore(docs): update help wanted label link

### DIFF
--- a/docs/contributing/how-to-label-an-issue.md
+++ b/docs/contributing/how-to-label-an-issue.md
@@ -22,7 +22,7 @@ Gatsby is a very active project with many new issues opened each day. Labelling 
 
 Anyone who's a member of the [Gatsby Maintainers team](https://github.com/orgs/gatsbyjs/teams/maintainers) can label issues.
 
-You can get an invite to the team by having a Pull Request merged into the Gatsby project. Check out the list of [`help wanted`](https://github.com/gatsbyjs/gatsby/labels/%F0%9F%93%8D%20status%3A%20help%20wanted) issues and the [How To Contribute Guide](/contributing/how-to-contribute/) to get started.
+You can get an invite to the team by having a Pull Request merged into the Gatsby project. Check out the list of [`help wanted`](https://github.com/gatsbyjs/gatsby/labels/help%20wanted) issues and the [How To Contribute Guide](/contributing/how-to-contribute/) to get started.
 
 **NOTE:** If you’ve already had a pull request merged and you have _not_ been invited to the maintainers team, please go to [the dashboard](https://store.gatsbyjs.org/) and request a discount code. You should get an invite to the team — _and you get free Gatsby swag!_ If that doesn’t work, please email team@gatsbyjs.com and we'll get you invited.
 


### PR DESCRIPTION
## Description

In the how to label an issue doc (https://www.gatsbyjs.org/contributing/how-to-label-an-issue/) the `Help Wanted` link currently points to https://github.com/gatsbyjs/gatsby/labels/%F0%9F%93%8D%20status%3A%20help%20wanted which returns no results. Updated to point to https://github.com/gatsbyjs/gatsby/labels/help%20wanted


