### PR TITLE
fix(www): give name to anonymous exported function

### DIFF
--- a/www/src/components/docsearch-content.js
+++ b/www/src/components/docsearch-content.js
@@ -1,15 +1,18 @@
-import React from "react"
+/** @jsx jsx */
+import { jsx } from "theme-ui"
 import FeedbackWidget from "./feedback-widget/feedback-widget"
 
-export default ({ children }) => (
-  <main
-    id={`reach-skip-nav`}
-    className={`docSearch-content`}
-    // need this for the main sidebar's anchor links to work properly
-    // in the context of `template-docs-markdown`
-    css={{ position: `relative` }}
-  >
-    {children}
-    <FeedbackWidget />
-  </main>
-)
+export default function DocSearchContent({ children }) {
+  return (
+    <main
+      id={`reach-skip-nav`}
+      className={`docSearch-content`}
+      // need this for the main sidebar's anchor links to work properly
+      // in the context of `template-docs-markdown`
+      sx={{ position: `relative` }}
+    >
+      {children}
+      <FeedbackWidget />
+    </main>
+  )
+}

--- a/www/src/components/page-with-sidebar.js
+++ b/www/src/components/page-with-sidebar.js
@@ -5,7 +5,11 @@ import { Fragment } from "react"
 import { getItemList } from "../utils/sidebar/item-list"
 import StickyResponsiveSidebar from "./sidebar/sticky-responsive-sidebar"
 
-export default ({ children, enableScrollSync, location }) => {
+export default function PageWithSidebar({
+  children,
+  enableScrollSync,
+  location,
+}) {
   const itemList = getItemList(location.pathname)
   if (!itemList) {
     return children

--- a/www/src/components/slider.js
+++ b/www/src/components/slider.js
@@ -2,22 +2,24 @@
 import { jsx } from "theme-ui"
 import { keyframes } from "@emotion/core"
 
-export default ({ items, color }) => (
-  <span
-    css={{
-      "& span": {
-        animation: `${topToBottom} 5s linear infinite 0s`,
-        opacity: 0,
-      },
-    }}
-  >
-    {items.map(item => (
-      <span key={item} sx={{ color: color }}>
-        {item}
-      </span>
-    ))}
-  </span>
-)
+export default function Slider({ items, color }) {
+  return (
+    <span
+      sx={{
+        "& span": {
+          animation: `${topToBottom} 5s linear infinite 0s`,
+          opacity: 0,
+        },
+      }}
+    >
+      {items.map(item => (
+        <span key={item} sx={{ color: color }}>
+          {item}
+        </span>
+      ))}
+    </span>
+  )
+}
 
 const topToBottom = keyframes({
   "0%": {


### PR DESCRIPTION
## Description

Give name to the anonymous function exported by `<PageWithSidebar/>`, `<DocSearchContent/>` and `<Slider/>` component, also convert them to function declaration.

There is some CSS cleanup also.

**Why should we consider giving them name?**

Anonymous functions have no useful names to display in stack traces, which can make debugging more difficult. Also a descriptive name helps self-document the code.
