### PR TITLE
chore: add typescript formatting to prettier

### DIFF
--- a/starters/blog/package.json
+++ b/starters/blog/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",

--- a/starters/default/package.json
+++ b/starters/default/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",

--- a/starters/hello-world/package.json
+++ b/starters/hello-world/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",


### PR DESCRIPTION
## Description
This and derived starter templates have .ts or .tsx files that are not being processed by Prettier when running.

This PR addresses that.

If I search for `prettier --write` in the monorepo there are other occurrences where this might need to be fixed. 
Should I send another PR fixing all of those?

Example: 
![image](https://user-images.githubusercontent.com/1134310/85233178-61133280-b3fc-11ea-9cd3-dae4669bf88b.png)
