### PR TITLE
fix(using-i18n): Add slash to make absolute path, not relative

### DIFF
--- a/examples/using-i18n/src/components/localizedLink.js
+++ b/examples/using-i18n/src/components/localizedLink.js
@@ -15,7 +15,7 @@ const LocalizedLink = ({ to, ...props }) => {
   // Because otherwise this would add a trailing slash
   const path = locales[locale].default
     ? to
-    : `${locales[locale].path}${isIndex ? `` : `${to}`}`
+    : `/${locales[locale].path}${isIndex ? `` : `${to}`}`
 
   return <Link {...props} to={path} />
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/25170
Without the slash the path was relative and thus the current path was added.

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/24054
