### PR TITLE
fix(gatsby): show error message instead of [Object object]

### DIFF
--- a/packages/gatsby/src/utils/jobs-manager.js
+++ b/packages/gatsby/src/utils/jobs-manager.js
@@ -290,10 +290,6 @@ exports.enqueueJob = async job => {
     }
     deferred.resolve(result)
   } catch (err) {
-    if (err instanceof Error) {
-      deferred.reject(new WorkerError(err.message))
-    }
-
     deferred.reject(new WorkerError(err))
   } finally {
     // when all jobs are done we end the activity
@@ -354,8 +350,17 @@ exports.isJobStale = job => {
 }
 
 export class WorkerError extends Error {
-  constructor(message) {
-    super(message)
+  /**
+   * @param {Error|string} error
+   */
+  constructor(error) {
+    if (typeof error === `string`) {
+      super(error)
+    } else {
+      // use error.message or else stringiyf the object so we don't get [Object object]
+      super(error.message ?? JSON.stringify(error))
+    }
+
     this.name = `WorkerError`
 
     Error.captureStackTrace(this, WorkerError)


### PR DESCRIPTION
## Description

We didn't always show error messages correctly, especially on our cloud platform.
![image](https://user-images.githubusercontent.com/1120926/85255646-f47f4e80-b462-11ea-9a9f-4137504a5977.png)
