### PR TITLE
chore(gatsby-plugin-benchmark-reporting): dont emit flush error without url

### DIFF
--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -293,7 +293,7 @@ function init(lifecycle) {
 }
 
 process.on(`exit`, () => {
-  if (benchMeta && !benchMeta.flushed) {
+  if (benchMeta && !benchMeta.flushed && !BENCHMARK_REPORTING_URL) {
     // This is probably already a non-zero exit as otherwise node should wait for the last promise to complete
     reportError(
       `gatsby-plugin-benchmark-reporting error`,

--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -293,7 +293,7 @@ function init(lifecycle) {
 }
 
 process.on(`exit`, () => {
-  if (benchMeta && !benchMeta.flushed && !BENCHMARK_REPORTING_URL) {
+  if (benchMeta && !benchMeta.flushed && BENCHMARK_REPORTING_URL) {
     // This is probably already a non-zero exit as otherwise node should wait for the last promise to complete
     reportError(
       `gatsby-plugin-benchmark-reporting error`,


### PR DESCRIPTION
This will prevent the benchmark plugin from emitting "not yet finished flushing" stack traces when an error happened during building and no reporter url was given in the first place.