### PR TITLE
refactor: run page queries together with static queries and run requires writer after queries

### DIFF
--- a/packages/gatsby/src/bootstrap/index.ts
+++ b/packages/gatsby/src/bootstrap/index.ts
@@ -5,7 +5,6 @@ import {
   customizeSchema,
   sourceNodes,
   buildSchema,
-  writeOutRequires,
   createPages,
   createPagesStatefully,
   extractQueries,
@@ -49,8 +48,6 @@ export async function bootstrap(
   await rebuildSchemaWithSitePage(context)
 
   await extractQueries(context)
-
-  await writeOutRequires(context)
 
   await writeOutRedirects(context)
 

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -96,6 +96,13 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     graphqlRunner,
   })
 
+  await runPageQueries({
+    queryIds,
+    graphqlRunner,
+    parentSpan: buildSpan,
+    store,
+  })
+
   await apiRunnerNode(`onPreBuild`, {
     graphql: gatsbyNodeGraphQLFunction,
     parentSpan: buildSpan,
@@ -143,13 +150,6 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
 
     rewriteActivityTimer.end()
   }
-
-  await runPageQueries({
-    queryIds,
-    graphqlRunner,
-    parentSpan: buildSpan,
-    store,
-  })
 
   await flushPendingPageDataWrites()
   markWebpackStatusAsDone()

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -30,6 +30,7 @@ import {
   calculateDirtyQueries,
   runStaticQueries,
   runPageQueries,
+  writeOutRequires,
 } from "../services"
 import {
   markWebpackStatusAsPending,
@@ -101,6 +102,11 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     graphqlRunner,
     parentSpan: buildSpan,
     store,
+  })
+
+  await writeOutRequires({
+    store,
+    parentSpan: buildSpan,
   })
 
   await apiRunnerNode(`onPreBuild`, {

--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -73,6 +73,7 @@ import {
   calculateDirtyQueries,
   runStaticQueries,
   runPageQueries,
+  writeOutRequires,
 } from "../services"
 
 // const isInteractive = process.stdout.isTTY
@@ -434,6 +435,8 @@ module.exports = async (program: IProgram): Promise<void> => {
 
   await runStaticQueries({ queryIds, store, program })
   await runPageQueries({ queryIds, store, program })
+
+  await writeOutRequires({ store })
 
   require(`../redux/actions`).boundActionCreators.setProgramStatus(
     `BOOTSTRAP_QUERY_RUNNING_FINISHED`


### PR DESCRIPTION
## Description

This just shuffle services around in preparation for more concrete features from https://github.com/gatsbyjs/gatsby/pull/24903 (which will need queries to run before webpack, as well as requires-writer to run after queries (and before webpack) )

## Related Issues

Tracking PR for data-driven code-splitting - https://github.com/gatsbyjs/gatsby/pull/24903
