### PR TITLE
refactor(websocket): unify page-data emitting

### DIFF
--- a/packages/gatsby/cache-dir/query-result-store.js
+++ b/packages/gatsby/cache-dir/query-result-store.js
@@ -83,7 +83,7 @@ export class PageQueryStore extends React.Component {
       return <div />
     }
 
-    return <PageRenderer {...this.props} {...data} />
+    return <PageRenderer {...this.props} {...data.result} />
   }
 }
 

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -13,7 +13,7 @@ interface IPageData {
   path: IGatsbyPage["path"]
 }
 
-interface IPageDataWithQueryResult extends IPageData {
+export interface IPageDataWithQueryResult extends IPageData {
   result: IExecutionResult
 }
 
@@ -127,19 +127,15 @@ export async function flush(): Promise<void> {
     // them, a page might not exist anymore щ（ﾟДﾟщ）
     // This is why we need this check
     if (page) {
-      const body = await writePageData(
+      const result = await writePageData(
         path.join(program.directory, `public`),
         page
       )
 
       if (program?._?.[0] === `develop`) {
         websocketManager.emitPageData({
-          ...body.result,
           id: pagePath,
-          result: {
-            data: body.result.data,
-            pageContext: body.result.pageContext,
-          },
+          result,
         })
       }
     }

--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -4,7 +4,7 @@ import { store } from "../redux"
 import { Server as HTTPSServer } from "https"
 import { Server as HTTPServer } from "http"
 import fs from "fs"
-import { readPageData } from "../utils/page-data"
+import { readPageData, IPageDataWithQueryResult } from "../utils/page-data"
 import telemetry from "gatsby-telemetry"
 import url from "url"
 import { createHash } from "crypto"
@@ -13,7 +13,7 @@ import socketIO from "socket.io"
 
 export interface IPageQueryResult {
   id: string
-  result: unknown // TODO: Improve this once we understand what the type is
+  result?: IPageDataWithQueryResult
 }
 
 export interface IStaticQueryResult {
@@ -35,10 +35,13 @@ const getCachedPageData = async (
   const publicDir = path.join(program.directory, `public`)
   if (pages.has(denormalizePagePath(pagePath)) || pages.has(pagePath)) {
     try {
-      const pageData = await readPageData(publicDir, pagePath)
+      const pageData: IPageDataWithQueryResult = await readPageData(
+        publicDir,
+        pagePath
+      )
 
       return {
-        result: pageData.result,
+        result: pageData,
         id: pagePath,
       }
     } catch (err) {


### PR DESCRIPTION
## Description

This changes our websocket manager to emit full body of `page-data` and not just query results + streamlines what we pass to `emitPageData`. 

This change on its own it's not doing much, it's just preparation to pass `page-data` emitted by websocket to run through `loader` to make sure we load modules that could have been added as a result of query running

## Related Issues

Tracking PR for data-driven code-splitting - https://github.com/gatsbyjs/gatsby/pull/24903