### PR TITLE
fix(gatsby-dev-cli): chmod new bin files

### DIFF
--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -66,7 +66,11 @@ async function watch(
       // This fixes the issue where after running gatsby-dev, running `yarn gatsby develop`
       // fails with a permission issue.
       // @fixes https://github.com/gatsbyjs/gatsby/issues/18809
-      if (/bin\/gatsby.js$/.test(newPath)) {
+      // Binary files we target:
+      // - gatsby/bin/gatsby.js
+      //  -gatsby/cli.js
+      //  -gatsby-cli/cli.js
+      if (/(bin\/gatsby.js|gatsby(-cli)?\/cli.js)$/.test(newPath)) {
         fs.chmodSync(newPath, `0755`)
       }
 


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/25121 changed bin files, but `gatsby-dev-cli` doesn't know about those and it's not applying executable permissions on those files. This PR fixes it

Related PR: https://github.com/gatsbyjs/gatsby/pull/25121