### PR TITLE
chore(gatsby): convert loadNodeContent to async and cache it

### DIFF
--- a/packages/gatsby/src/db/nodes.js
+++ b/packages/gatsby/src/db/nodes.js
@@ -28,7 +28,7 @@ interface NodeStore {
  */
 async function loadNodeContent(node) {
   if (_.isString(node.internal.content)) {
-    return Promise.resolve(node.internal.content)
+    return node.internal.content
   }
 
   // Load plugin's loader function
@@ -46,7 +46,7 @@ async function loadNodeContent(node) {
 
   const content = loadNodeContent(node)
 
-  node.internal.context = content
+  node.internal.content = content
 
   return content
 }

--- a/packages/gatsby/src/db/nodes.js
+++ b/packages/gatsby/src/db/nodes.js
@@ -23,31 +23,32 @@ interface NodeStore {
 /**
  * Get content for a node from the plugin that created it.
  *
- * @param {Object} node
- * @returns {promise}
+ * @param {IGatsbyNode} node
+ * @returns {Promise<string>}
  */
-function loadNodeContent(node) {
+async function loadNodeContent(node) {
   if (_.isString(node.internal.content)) {
     return Promise.resolve(node.internal.content)
-  } else {
-    return new Promise(resolve => {
-      // Load plugin's loader function
-      const plugin = store
-        .getState()
-        .flattenedPlugins.find(plug => plug.name === node.internal.owner)
-      const { loadNodeContent } = require(plugin.resolve)
-      if (!loadNodeContent) {
-        throw new Error(
-          `Could not find function loadNodeContent for plugin ${plugin.name}`
-        )
-      }
-
-      return loadNodeContent(node).then(content => {
-        // TODO update node's content field here.
-        resolve(content)
-      })
-    })
   }
+
+  // Load plugin's loader function
+  const plugin = store
+    .getState()
+    .flattenedPlugins.find(plug => plug.name === node.internal.owner)
+
+  const { loadNodeContent } = require(plugin.resolve)
+
+  if (!loadNodeContent) {
+    throw new Error(
+      `Could not find function loadNodeContent for plugin ${plugin.name}`
+    )
+  }
+
+  const content = loadNodeContent(node)
+
+  node.internal.context = content
+
+  return content
 }
 
 module.exports = {

--- a/packages/gatsby/src/db/nodes.js
+++ b/packages/gatsby/src/db/nodes.js
@@ -44,7 +44,7 @@ async function loadNodeContent(node) {
     )
   }
 
-  const content = loadNodeContent(node)
+  const content = await loadNodeContent(node)
 
   node.internal.content = content
 


### PR DESCRIPTION
Refactors a use of `Promise` to an `async function`.

Also caches the result of calling `loadNodeContent`, as I believe was intended.

Suggest to ignore whitespace when reviewing.

Next step will be to convert this file to TS, but I didn't want to combine those two steps in one PR.