### PR TITLE
chore(gatsby): Remove eslint graphql linting

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -15,14 +15,6 @@ export const eslintConfig = (schema: GraphQLSchema): CLIEngine.Options => {
       plugins: [`graphql`],
       rules: {
         "import/no-webpack-loader-syntax": [0],
-        "graphql/template-strings": [
-          `error`,
-          {
-            env: `relay`,
-            schemaString: printSchema(schema, { commentDescriptions: true }),
-            tagName: `graphql`,
-          },
-        ],
         "react/jsx-pascal-case": `off`, // Prevents errors with Theme-UI and Styled component
         // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/master/docs/rules
         "jsx-a11y/accessible-emoji": `warn`,


### PR DESCRIPTION
Currently in gatsby, we validate a user's GraphQL queries twice and in two different ways:

- in packages/gatsby/src/query/file-parser.js whenever a file changes on disk, we extract and validate all GraphQL queries against the schema
- in packages/gatsby/src/utils/eslint-config.ts where we use `graphql/template-strings` and pass in our schema

The latter is redundant and results in duplicated error messages in the console which is annoying

And sometimes... it causes a far more annoying issue:

A change in a GraphQL schema is not registered in time before the webpack run (which includes the eslint loader) finishes and therefore a user is left with a error that is **_impossible_** to clear unless another change on the fs is made that causes a webpack run. 

This also happens to be why so many of our end to end tests are often flaky. An error is not cleared and therefore no number of Cypress retries will _find_ the appropriate element in the DOM. (See example in https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/43800/workflows/eecfb091-9c52-4c32-a1b5-d93d31c2f200/jobs/443944/steps)