### PR TITLE
feat(docs): Add explanation of Site.siteMetadata field

### DIFF
--- a/docs/docs/internal-data-bridge.md
+++ b/docs/docs/internal-data-bridge.md
@@ -2,14 +2,6 @@
 title: Internal Data Bridge
 ---
 
-> This documentation isn't up to date with the latest version of Gatsby.
->
-> Outdated areas are:
->
-> - should mention `siteMetaData` as an internal type
->
-> You can help by making a PR to [update this documentation](https://github.com/gatsbyjs/gatsby/issues/14228).
-
 The Internal Data Bridge is an internal Gatsby plugin located at [internal-plugins/internal-data-bridge](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby/src/internal-plugins/internal-data-bridge). Its purpose is to create nodes representing pages, plugins, and site config so that they can be introspected for arbitrary purposes. As of writing, the only usage of this is by the [gatsby-plugin-sitemap](/packages/gatsby-plugin-sitemap) which uses it to... yes you guessed it, create a site map of your site.
 
 ## Example usage
@@ -35,6 +27,28 @@ The internal data bridge creates 3 types of nodes that can be introspected.
 ### Site
 
 This is a node that contains fields from your site's `gatsby-config.js`, as well as program information such as host and port for the local development server.
+
+A very commonly used field on this node is the `siteMetadata` field. This field provides access to any arbitrary data that's added to your site's `gatsby-config.js` under the `siteMetadata` property.
+
+In `gatsby-config.js`:
+```js
+module.exports = {
+  siteMetadata: {
+    title: `My beautiful Gatsby site title`,
+  },
+ }
+```
+
+In a page or static query:
+```graphql
+query {
+  site {
+    siteMetadata {
+      title # returns "My beautiful Gatsby site title" as entered above in gatsby-config.js.
+    }
+  }
+}
+```
 
 ### SitePlugin
 

--- a/docs/docs/internal-data-bridge.md
+++ b/docs/docs/internal-data-bridge.md
@@ -31,15 +31,17 @@ This is a node that contains fields from your site's `gatsby-config.js`, as well
 A very commonly used field on this node is the `siteMetadata` field. This field provides access to any arbitrary data that's added to your site's `gatsby-config.js` under the `siteMetadata` property.
 
 In `gatsby-config.js`:
+
 ```js
 module.exports = {
   siteMetadata: {
     title: `My beautiful Gatsby site title`,
   },
- }
+}
 ```
 
 In a page or static query:
+
 ```graphql
 query {
   site {


### PR DESCRIPTION
This PR updates the docs at this page https://www.gatsbyjs.org/docs/internal-data-bridge/#site to provide more info about the `Site.siteMetadata` field.

The todo on that page mentions https://github.com/gatsbyjs/gatsby/issues/14228 but I'm not totally sure that that's the right issue since that's about Schema Customization and this is about the internal data bridge.