### PR TITLE
chore: ignore README.md as package change

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,10 +10,14 @@
       "message": "chore(release): Publish"
     },
     "bootstrap": {
-      "ignore": ["**/gatsby-admin"]
+      "ignore": [
+        "**/gatsby-admin"
+      ]
     }
   },
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/*"
+  ],
   "loglevel": "success",
   "version": "independent",
   "npmClient": "yarn",
@@ -21,6 +25,7 @@
   "useWorkspaces": true,
   "ignoreChanges": [
     "CHANGELOG.md",
+    "README.md",
     "**/__tests__/**",
     "**/__mocks__/**",
     "**/__testfixtures__/**"

--- a/lerna.json
+++ b/lerna.json
@@ -25,7 +25,8 @@
   "useWorkspaces": true,
   "ignoreChanges": [
     "CHANGELOG.md",
-    "README.md",
+    "packages/babel-preset-gatsby/README.md",
+    "packages/babel-preset-gatsby-package/README.md",
     "**/__tests__/**",
     "**/__mocks__/**",
     "**/__testfixtures__/**"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

If only README changes we shouldn't publish a new package. I can narrow it down to some base packages like babel-preset-env if we want.