### PR TITLE
fix(gatsby-cli) add missing @types/common-tags

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -13,6 +13,7 @@
     "@babel/code-frame": "^7.10.1",
     "@babel/runtime": "^7.10.2",
     "@hapi/joi": "^15.1.1",
+    "@types/common-tags": "^1.8.0",
     "better-opn": "^1.0.0",
     "bluebird": "^3.7.2",
     "chalk": "^2.4.2",


### PR DESCRIPTION
## Description

Add missing `common-tags` types, which otherwise generates the following error when compling with `noImplicitAny`:

```
node_modules/gatsby-cli/lib/reporter/reporter.d.ts:23:25 - error TS7016: Could not find a declaration file for module 'common-tags'. '/Users/gosha/Documents/git/repro-no-common-tags-types/node_modules/common-tags/lib/index.js' implicitly has an 'any' type.
  Try `npm install @types/common-tags` if it exists or add a new declaration (.d.ts) file containing `declare module 'common-tags';`

23     stripIndent: import("common-tags").TemplateTag; 
```

### Documentation

## Related Issues

Fixes #25129