### PR TITLE
chore(rfcs): Update documentation on RFC for its location in gatsbyjs/gatsby

### DIFF
--- a/docs/contributing/rfc-process.md
+++ b/docs/contributing/rfc-process.md
@@ -13,7 +13,7 @@ a bit of a design process and produce a consensus among the Gatsby core team.
 The "RFC" (request for comments) process is intended to provide a consistent
 and controlled path for new features to enter the project.
 
-[Active RFC List](https://github.com/gatsbyjs/rfcs/pulls)
+[Active RFC List](https://github.com/gatsbyjs/gatsby/pulls?q=is%3Aopen+is%3Apr+label%3A%22type%3A+rfc%22)
 
 Gatsby is still **actively developing** this process, and it will still change
 as more features are implemented and the community settles on specific
@@ -57,7 +57,7 @@ RFC merged into the RFC repo as a markdown file. At that point the RFC is
 'active' and may be implemented with the goal of eventual inclusion into
 Gatsby.
 
-- Fork the RFC repo https://github.com/gatsbyjs/rfcs Copy `0000-template.md` to
+- Fork the Gatsby repo https://github.com/gatsbyjs/gatsby. Inside the RFC folder, copy `0000-template.md` to
 - `text/0000-my-feature.md` (where
   'my-feature' is descriptive. Don't assign an RFC number yet).
 - Fill in the RFC. Put care into the details: **RFCs that do not


### PR DESCRIPTION

## Description

The docs are out of date since we deprecated the rfcs repo. This is just an update to the location of the RFCs 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
