### PR TITLE
feat(gatsby): Add data layer state machine config

### DIFF
--- a/packages/gatsby/src/bootstrap/index.ts
+++ b/packages/gatsby/src/bootstrap/index.ts
@@ -19,7 +19,7 @@ import JestWorker from "jest-worker"
 const tracer = globalTracer()
 
 export async function bootstrap(
-  initialContext: IBuildContext
+  initialContext: Partial<IBuildContext>
 ): Promise<{
   gatsbyNodeGraphQLFunction: Runner
   workerPool: JestWorker

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -44,7 +44,7 @@ process.on(`unhandledRejection`, (reason: unknown) => {
 export async function initialize({
   program: args,
   parentSpan,
-}: IBuildContext): Promise<{
+}: Partial<IBuildContext>): Promise<{
   store: Store<IGatsbyState, AnyAction>
   workerPool: JestWorker
 }> {

--- a/packages/gatsby/src/services/types.ts
+++ b/packages/gatsby/src/services/types.ts
@@ -17,6 +17,11 @@ export interface IMutationAction {
 }
 export interface IBuildContext {
   program?: IProgram
+  nodesMutatedDuringQueryRun: boolean
+  firstRun: boolean
+  nodeMutationBatch: IMutationAction[]
+  filesDirty?: boolean
+  runningBatch: IMutationAction[]
   store?: Store<IGatsbyState, AnyAction>
   parentSpan?: Span
   gatsbyNodeGraphQLFunction?: Runner
@@ -26,4 +31,6 @@ export interface IBuildContext {
   refresh?: boolean
   workerPool?: JestWorker
   app?: Express
+  pagesToBuild?: string[]
+  pagesToDelete?: string[]
 }

--- a/packages/gatsby/src/state-machines/__tests__/data-layer.ts
+++ b/packages/gatsby/src/state-machines/__tests__/data-layer.ts
@@ -1,5 +1,15 @@
+/* eslint-disable no-unused-expressions */
 import { dataLayerStates } from "./../data-layer"
-import { Machine, interpret } from "xstate"
+import { Machine, interpret, Interpreter, State, EventObject } from "xstate"
+import { IBuildContext } from "../../services"
+jest.useFakeTimers()
+
+export const INITIAL_CONTEXT: IBuildContext = {
+  nodesMutatedDuringQueryRun: false,
+  firstRun: true,
+  nodeMutationBatch: [],
+  runningBatch: [],
+}
 
 const actions = {
   callApi: jest.fn(),
@@ -11,37 +21,155 @@ const actions = {
   assignChangedPages: jest.fn(),
   assignBootstrap: jest.fn(),
   resetGraphQlRunner: jest.fn(),
-  assignGatsbyNodeGraphQl: jest.fn(),
+  assignGatsbyNodeGraphQL: jest.fn(),
 }
 
+const resolveSoon = <T = undefined>(returnValue?: T) => (): Promise<T> =>
+  new Promise(resolve => setTimeout(() => resolve(returnValue), 1))
+
+const resolveUndefined = resolveSoon()
+
 const services = {
-  customizeSchema: jest.fn(),
-  sourceNodes: jest.fn(),
-  createPages: jest.fn(),
-  buildSchema: jest.fn(),
-  createPagesStatefully: jest.fn(),
-  extractQueries: jest.fn(),
-  writeOutRequires: jest.fn(),
-  calculateDirtyQueries: jest.fn(),
-  runStaticQueries: jest.fn(),
-  runPageQueries: jest.fn(),
-  initialize: jest.fn(),
-  writeHTML: jest.fn(),
-  waitUntilAllJobsComplete: jest.fn(),
-  postBootstrap: jest.fn(),
-  writeOutRedirects: jest.fn(),
-  startWebpackServer: jest.fn(),
+  customizeSchema: jest.fn(resolveUndefined),
+  sourceNodes: jest.fn(resolveUndefined),
+  createPages: jest.fn(resolveUndefined),
+  buildSchema: jest.fn(resolveUndefined),
+  createPagesStatefully: jest.fn(resolveUndefined),
+  extractQueries: jest.fn(resolveUndefined),
+  writeOutRequires: jest.fn(resolveUndefined),
+  calculateDirtyQueries: jest.fn(resolveUndefined),
+  runStaticQueries: jest.fn(resolveUndefined),
+  runPageQueries: jest.fn(resolveUndefined),
+  initialize: jest.fn(resolveUndefined),
+  writeHTML: jest.fn(resolveUndefined),
+  waitUntilAllJobsComplete: jest.fn(resolveUndefined),
+  postBootstrap: jest.fn(resolveUndefined),
+  writeOutRedirects: jest.fn(resolveUndefined),
+  startWebpackServer: jest.fn(resolveUndefined),
 }
 
 // eslint-disable-next-line new-cap
-const machine = Machine(dataLayerStates, {
-  actions,
-  services,
-})
+const machine = Machine(
+  {
+    id: `build`,
+    initial: `running`,
+    states: {
+      running: {
+        initial: `initializingDataLayer`,
+        states: {
+          initializingDataLayer: {
+            id: `initializingDataLayer`,
+            ...dataLayerStates,
+          },
+          extractingAndRunningQueries: {
+            initial: `extractingQueries`,
+            states: {
+              extractingQueries: {
+                id: `extracting-queries`,
+                type: `final`,
+              },
+            },
+          },
+        },
+      },
+      waiting: {},
+    },
+  },
+  {
+    actions,
+    services,
+  }
+)
 
 describe(`the data layer state machine`, () => {
-  let service
-  beforeEach(() => {
-    service = interpret(machine)
+  let service: Interpreter<IBuildContext> | undefined
+  const awaitNextEvent = (): Promise<EventObject> =>
+    new Promise(resolve => {
+      const handler = (event: EventObject): void => {
+        service?.off(handler)
+        resolve(event)
+      }
+      service?.onEvent(handler)
+    })
+
+  it(`runs through the happy path`, async () => {
+    service = interpret(machine.withContext(INITIAL_CONTEXT))
+    service?.start()
+
+    // customizingSchema
+    expect(service?.state.value).toMatchObject({
+      running: { initializingDataLayer: `customizingSchema` },
+    })
+
+    expect(services.customizeSchema).toHaveBeenCalledWith(INITIAL_CONTEXT, {
+      type: `xstate.init`,
+    })
+
+    jest.runAllTimers()
+    await awaitNextEvent()
+
+    //  sourcingNodes
+    expect(service?.state.value).toMatchObject({
+      running: { initializingDataLayer: `sourcingNodes` },
+    })
+    expect(services.sourceNodes).toHaveBeenCalledWith(
+      INITIAL_CONTEXT,
+      expect.objectContaining({
+        type: `done.invoke.customizing-schema`,
+      })
+    )
+    actions.assignChangedPages.mockClear()
+    jest.runAllTimers()
+    services.buildSchema.mockClear()
+    await awaitNextEvent()
+    expect(actions.assignChangedPages).toHaveBeenCalled()
+
+    // buildingSchema
+
+    expect(service?.state.value).toMatchObject({
+      running: { initializingDataLayer: `buildingSchema` },
+    })
+
+    expect(services.buildSchema).toHaveBeenCalled()
+
+    actions.assignGatsbyNodeGraphQL.mockClear()
+    jest.runAllTimers()
+    services.createPages.mockClear()
+    await awaitNextEvent()
+
+    expect(actions.assignGatsbyNodeGraphQL).toHaveBeenCalled()
+
+    // creatingPages
+
+    expect(service?.state.value).toMatchObject({
+      running: { initializingDataLayer: `creatingPages` },
+    })
+
+    expect(services.createPages).toHaveBeenCalled()
+
+    actions.assignChangedPages.mockClear()
+    jest.runAllTimers()
+    services.buildSchema.mockClear()
+    await awaitNextEvent()
+    expect(actions.assignChangedPages).toHaveBeenCalled()
+
+    // creatingPagesStatefully
+
+    expect(service?.state.value).toMatchObject({
+      running: { initializingDataLayer: `creatingPagesStatefully` },
+    })
+
+    expect(services.createPagesStatefully).toHaveBeenCalled()
+
+    actions.assignChangedPages.mockClear()
+    jest.runAllTimers()
+    services.buildSchema.mockClear()
+    await awaitNextEvent()
+
+    //  Done
+
+    expect(service?.state.value).toMatchObject({
+      running: { extractingAndRunningQueries: `extractingQueries` },
+    })
   })
 })

--- a/packages/gatsby/src/state-machines/__tests__/data-layer.ts
+++ b/packages/gatsby/src/state-machines/__tests__/data-layer.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import { dataLayerStates } from "./../data-layer"
-import { Machine, interpret, Interpreter, State, EventObject } from "xstate"
+import { Machine, interpret, Interpreter, EventObject } from "xstate"
 import { IBuildContext } from "../../services"
 jest.useFakeTimers()
 

--- a/packages/gatsby/src/state-machines/__tests__/data-layer.ts
+++ b/packages/gatsby/src/state-machines/__tests__/data-layer.ts
@@ -1,0 +1,47 @@
+import { dataLayerStates } from "./../data-layer"
+import { Machine, interpret } from "xstate"
+
+const actions = {
+  callApi: jest.fn(),
+  addNodeMutation: jest.fn(),
+  markFilesDirty: jest.fn(),
+  markNodesDirty: jest.fn(),
+  writeCompilationHash: jest.fn(),
+  spawnMutationListener: jest.fn(),
+  assignChangedPages: jest.fn(),
+  assignBootstrap: jest.fn(),
+  resetGraphQlRunner: jest.fn(),
+  assignGatsbyNodeGraphQl: jest.fn(),
+}
+
+const services = {
+  customizeSchema: jest.fn(),
+  sourceNodes: jest.fn(),
+  createPages: jest.fn(),
+  buildSchema: jest.fn(),
+  createPagesStatefully: jest.fn(),
+  extractQueries: jest.fn(),
+  writeOutRequires: jest.fn(),
+  calculateDirtyQueries: jest.fn(),
+  runStaticQueries: jest.fn(),
+  runPageQueries: jest.fn(),
+  initialize: jest.fn(),
+  writeHTML: jest.fn(),
+  waitUntilAllJobsComplete: jest.fn(),
+  postBootstrap: jest.fn(),
+  writeOutRedirects: jest.fn(),
+  startWebpackServer: jest.fn(),
+}
+
+// eslint-disable-next-line new-cap
+const machine = Machine(dataLayerStates, {
+  actions,
+  services,
+})
+
+describe(`the data layer state machine`, () => {
+  let service
+  beforeEach(() => {
+    service = interpret(machine)
+  })
+})

--- a/packages/gatsby/src/state-machines/actions.ts
+++ b/packages/gatsby/src/state-machines/actions.ts
@@ -1,0 +1,95 @@
+import {
+  assign,
+  AnyEventObject,
+  ActionFunction,
+  AssignAction,
+  DoneInvokeEvent,
+  ActionFunctionMap,
+} from "xstate"
+import { Store } from "redux"
+import { IBuildContext, IMutationAction } from "../services"
+import { actions } from "../redux/actions"
+import { createGraphQLRunner } from "../bootstrap/create-graphql-runner"
+import reporter from "gatsby-cli/lib/reporter"
+
+const concatUnique = <T>(array1?: T[], array2?: T[]): T[] =>
+  Array.from(new Set((array1 || []).concat(array2 || [])))
+
+export const callRealApi = async (
+  event: IMutationAction,
+  store?: Store
+): Promise<unknown> => {
+  if (!store) {
+    console.error(`No store`)
+    return null
+  }
+  const { type, payload } = event
+  if (type in actions) {
+    store.dispatch(actions[type](...payload))
+  }
+  return null
+}
+
+type BuildMachineAction =
+  | ActionFunction<IBuildContext, any>
+  | AssignAction<IBuildContext, any>
+
+/**
+ * Handler for when we're inside handlers that should be able to mutate nodes
+ */
+export const callApi: BuildMachineAction = async (
+  ctx,
+  event
+): Promise<unknown> => callRealApi(event.payload, ctx.store)
+
+/**
+ * Event handler used in all states where we're not ready to process node
+ * mutations. Instead we add it to a batch to process when we're next idle
+ */
+export const addNodeMutation: BuildMachineAction = assign((ctx, event) => {
+  return {
+    nodeMutationBatch: ctx.nodeMutationBatch.concat([event.payload]),
+  }
+})
+
+export const assignChangedPages: BuildMachineAction = assign<
+  IBuildContext,
+  DoneInvokeEvent<{
+    changedPages: string[]
+    deletedPages: string[]
+  }>
+>((context, event) => {
+  console.log({ event })
+  return {
+    pagesToBuild: concatUnique(context.pagesToBuild, event.data.changedPages),
+    pagesToDelete: concatUnique(context.pagesToDelete, event.data.deletedPages),
+  }
+})
+
+/**
+ * Event handler used in all states where we're not ready to process a file change
+ * Instead we add it to a batch to process when we're next idle
+ */
+export const markFilesDirty: BuildMachineAction = assign<IBuildContext>({
+  filesDirty: true,
+})
+
+export const markNodesDirty: BuildMachineAction = assign<IBuildContext>({
+  nodesMutatedDuringQueryRun: true,
+})
+
+export const assignGatsbyNodeGraphQL: BuildMachineAction = assign<
+  IBuildContext
+>({
+  gatsbyNodeGraphQLFunction: ({ store }: IBuildContext) =>
+    store ? createGraphQLRunner(store, reporter) : undefined,
+})
+
+export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
+  callApi,
+  addNodeMutation,
+  markFilesDirty,
+  markNodesDirty,
+  assignChangedPages,
+  assignGatsbyNodeGraphQL,
+}

--- a/packages/gatsby/src/state-machines/data-layer.ts
+++ b/packages/gatsby/src/state-machines/data-layer.ts
@@ -1,0 +1,81 @@
+import { IBuildContext } from "../services"
+import { MachineConfig } from "xstate"
+import { runMutationAndMarkDirty, onError } from "./shared-transition-configs"
+
+export const dataLayerStates: MachineConfig<IBuildContext, any, any> = {
+  initial: `customizingSchema`,
+  states: {
+    customizingSchema: {
+      invoke: {
+        src: `customizeSchema`,
+        id: `customizing-schema`,
+        onDone: {
+          target: `sourcingNodes`,
+        },
+        onError,
+      },
+    },
+    sourcingNodes: {
+      invoke: {
+        src: `sourceNodes`,
+        id: `sourcing-nodes`,
+        onDone: {
+          target: `buildingSchema`,
+          actions: `assignChangedPages`,
+        },
+        onError,
+      },
+    },
+    buildingSchema: {
+      invoke: {
+        id: `building-schema`,
+        src: `buildSchema`,
+        onDone: {
+          target: `creatingPages`,
+          actions: `assignGatsbyNodeGraphQL`,
+        },
+        onError,
+      },
+    },
+    creatingPages: {
+      on: { ADD_NODE_MUTATION: runMutationAndMarkDirty },
+      invoke: {
+        id: `creating-pages`,
+        src: `createPages`,
+        onDone: [
+          {
+            target: `creatingPagesStatefully`,
+            actions: `assignChangedPages`,
+            cond: (context): boolean => context.firstRun,
+          },
+          {
+            target: `#build.running.extractingAndRunningQueries`,
+            actions: `assignChangedPages`,
+          },
+        ],
+        onError,
+      },
+    },
+    creatingPagesStatefully: {
+      on: {
+        //  Empty string means run on every transition
+        "": [
+          {
+            // If files have changed we need to extract queries again
+            cond: (ctx): boolean => !!ctx.filesDirty,
+            target: `#extracting-queries`,
+          },
+        ],
+        ADD_NODE_MUTATION: runMutationAndMarkDirty,
+      },
+      invoke: {
+        src: `createPagesStatefully`,
+        id: `creating-pages-statefully`,
+        onDone: {
+          target: `#build.running.extractingAndRunningQueries`,
+        },
+        onError,
+      },
+    },
+  },
+}

--- a/packages/gatsby/src/state-machines/shared-transition-configs.ts
+++ b/packages/gatsby/src/state-machines/shared-transition-configs.ts
@@ -1,0 +1,35 @@
+import { TransitionConfig, AnyEventObject, DoneInvokeEvent } from "xstate"
+import { IBuildContext } from "../services"
+
+type BuildTransition = TransitionConfig<IBuildContext, AnyEventObject>
+
+/**
+ * Event handler used in all states where we're not ready to process node
+ * mutations. Instead we add it to a batch to process when we're next idle
+ */
+export const ADD_NODE_MUTATION: BuildTransition = {
+  actions: `addNodeMutation`,
+}
+
+/**
+ * Event handler used in all states where we're not ready to process a file change
+ * Instead we add it to a batch to process when we're next idle
+ */
+export const SOURCE_FILE_CHANGED: BuildTransition = {
+  actions: `markFilesDirty`,
+}
+
+/**
+ * When running queries we might add nodes (e.g from resolvers). If so we'll
+ * want to re-run queries and schema inference
+ */
+export const runMutationAndMarkDirty: BuildTransition = {
+  actions: [`markNodesDirty`, `callApi`],
+}
+
+export const onError: TransitionConfig<IBuildContext, DoneInvokeEvent<any>> = {
+  target: `#build.waiting`,
+  actions: (_context, event): void => {
+    console.error(`Error`, event)
+  },
+}


### PR DESCRIPTION
This PR includes the first part of the actual state machine. This is just one of the sub-machines, specifically the " initializing data layer" machine which handles customizing schema, sourcing nodes, building schema and creating pages. For this it uses the [services](https://xstate.js.org/docs/guides/communication.html) that we now have in core. This PR is currently dead code, but there will be future PRs that add more machines, then eventually the code that executes them.

This machine is defined in `develop` as `#build.running.initializingDataLayer`, meaning it has a parent state `running`. For full context, see the feat/state-machine branch.

As well as the data-layer config, this adds the associated [actions](https://xstate.js.org/docs/guides/actions.html), which mostly change the `context` based on the return value of a service, such as adding to the list of changed pages.

There are a number of helpers in shared-transition-config. We have actions that need to run when a node mutation is enqueued, which need to happen in lots of different states, so it's easier to define that config and reuse it in each config.

On the subject of enqueuing node mutations, this is a feature that will be added in another PR. It adds a `deferNodeMutations` option to `apiRunnerNode`, which if set wraps actions that would mutate nodes with a function which instead emits an `ENQUEUE_NODE_MUTATION` event. This means we can safely run the machine with a guarantee that the node store will not be mutated unless we are in a state where we are expecting it. More in a PR to follow.