### PR TITLE
chore(categories): Add Ghost to list of categories

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -92,6 +92,7 @@ site:
   - Food
   - Freelance
   - Gallery
+  - Ghost
   - Government
   - Healthcare
   - Human Resources
@@ -123,4 +124,3 @@ site:
   - Video
   - Web Development
   - WordPress
-  - Ghost

--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -124,4 +124,3 @@ site:
   - Web Development
   - WordPress
   - Ghost
-  

--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -123,3 +123,5 @@ site:
   - Video
   - Web Development
   - WordPress
+  - Ghost
+  


### PR DESCRIPTION
Hi Team,

We've been seeing a lot of Ghost blogs using Gatsby front-end now. WordPress is already a category, Ghost should be too.

Thanks in advance.

-Tanmay