### PR TITLE
feat(gatsby-link): add onPreload to Link component

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -178,6 +178,30 @@ const AreYouSureLink = () => (
 )
 ```
 
+### Listen for the preloading event with `onPreload`
+
+Adding an `onPreload` handler, you can get notified when the page preload is triggered.
+
+```jsx
+import React from "react"
+// highlight-next-line
+import { Link } from "gatsby"
+
+const Page = () => (
+  <div>
+    <p>
+      Check out my <Link
+        to="/blog"
+        {/* highlight-next-line */}
+        onPreload={() => console.log(`/blog page preload triggered`)}
+      >
+        blog
+      </Link>!
+    </p>
+  </div>
+)
+```
+
 ## How to use the `navigate` helper function
 
 <EggheadEmbed

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -383,3 +383,25 @@ describe(`state`, () => {
     )
   })
 })
+
+describe(`onPreload`, () => {
+  it(`calls onPreload when path enqueued`, () => {
+    global.___loader = {
+      enqueue: jest.fn(() => true),
+    }
+    const linkProps = { onPreload: jest.fn() }
+    setup({ linkProps })
+
+    expect(linkProps.onPreload).toHaveBeenCalledTimes(1)
+  })
+
+  it(`doesn't call onPreload when path not enqueued`, () => {
+    global.___loader = {
+      enqueue: jest.fn(() => false),
+    }
+    const linkProps = { onPreload: jest.fn() }
+    setup({ linkProps })
+
+    expect(linkProps.onPreload).toHaveBeenCalledTimes(0)
+  })
+})

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -88,25 +88,20 @@ class GatsbyLink extends React.Component {
       IOSupported,
     }
     this.handleRef = this.handleRef.bind(this)
+    this.preload = this.preload.bind(this)
   }
 
   componentDidUpdate(prevProps, prevState) {
     // Preserve non IO functionality if no support
     if (this.props.to !== prevProps.to && !this.state.IOSupported) {
-      ___loader.enqueue(
-        parsePath(rewriteLinkPath(this.props.to, window.location.pathname))
-          .pathname
-      )
+      this.preload()
     }
   }
 
   componentDidMount() {
     // Preserve non IO functionality if no support
     if (!this.state.IOSupported) {
-      ___loader.enqueue(
-        parsePath(rewriteLinkPath(this.props.to, window.location.pathname))
-          .pathname
-      )
+      this.preload()
     }
   }
 
@@ -129,12 +124,18 @@ class GatsbyLink extends React.Component {
 
     if (this.state.IOSupported && ref) {
       // If IO supported and element reference found, setup Observer functionality
-      this.io = createIntersectionObserver(ref, () => {
-        ___loader.enqueue(
-          parsePath(rewriteLinkPath(this.props.to, window.location.pathname))
-            .pathname
-        )
-      })
+      this.io = createIntersectionObserver(ref, this.preload)
+    }
+  }
+
+  preload() {
+    const preloaded = ___loader.enqueue(
+      parsePath(rewriteLinkPath(this.props.to, window.location.pathname))
+        .pathname
+    )
+    const { onPreload } = this.props
+    if (onPreload && preloaded) {
+      onPreload()
     }
   }
 
@@ -163,6 +164,7 @@ class GatsbyLink extends React.Component {
       partiallyActive,
       state,
       replace,
+      onPreload,
       /* eslint-enable no-unused-vars */
       ...rest
     } = this.props
@@ -234,6 +236,7 @@ class GatsbyLink extends React.Component {
 GatsbyLink.propTypes = {
   ...NavLinkPropTypes,
   onClick: PropTypes.func,
+  onPreload: PropTypes.func,
   to: PropTypes.string.isRequired,
   replace: PropTypes.bool,
   state: PropTypes.object,


### PR DESCRIPTION
## Description

Add onPreload to the Link component.

### Documentation

Gatsby Link API

@gatsbyjs/learning

## Related Issues

Addresses #17952 