### PR TITLE
feat(gatsby-image): Add customProps as catchall

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -437,6 +437,7 @@ class Image extends React.Component {
       itemProp,
       loading,
       draggable,
+      ...customProps
     } = convertProps(this.props)
 
     const shouldReveal = this.state.fadeIn === false || this.state.imgLoaded
@@ -486,6 +487,7 @@ class Image extends React.Component {
           }}
           ref={this.handleRef}
           key={`fluid-${JSON.stringify(image.srcSet)}`}
+          {...customProps}
         >
           {/* Preserve the aspect ratio. */}
           <Tag

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -437,13 +437,8 @@ class Image extends React.Component {
       itemProp,
       loading,
       draggable,
-      ...props
+      tagProps = {},
     } = convertProps(this.props)
-    // filter out props not used in render
-    const customProps = [`placeholderRef`, `innerRef`, `fadeIn`].reduce((propObject, prop) => {
-      const { [prop]: _, ...withoutProp } = propObject
-      return withoutProp
-    }, props)
 
     const shouldReveal = this.state.fadeIn === false || this.state.imgLoaded
     const shouldFadeIn = this.state.fadeIn === true && !this.state.imgCached
@@ -492,7 +487,7 @@ class Image extends React.Component {
           }}
           ref={this.handleRef}
           key={`fluid-${JSON.stringify(image.srcSet)}`}
-          {...customProps}
+          {...tagProps}
         >
           {/* Preserve the aspect ratio. */}
           <Tag
@@ -608,7 +603,7 @@ class Image extends React.Component {
           style={divStyle}
           ref={this.handleRef}
           key={`fixed-${JSON.stringify(image.srcSet)}`}
-          {...customProps}
+          {...tagProps}
         >
           {/* Show a solid background color. */}
           {bgColor && (

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -437,8 +437,13 @@ class Image extends React.Component {
       itemProp,
       loading,
       draggable,
-      ...customProps
+      ...props
     } = convertProps(this.props)
+    // filter out props not used in render
+    const customProps = [`placeholderRef`, `innerRef`, `fadeIn`].reduce((propObject, prop) => {
+      const { [prop]: _, ...withoutProp } = propObject
+      return withoutProp
+    }, props)
 
     const shouldReveal = this.state.fadeIn === false || this.state.imgLoaded
     const shouldFadeIn = this.state.fadeIn === true && !this.state.imgCached
@@ -603,6 +608,7 @@ class Image extends React.Component {
           style={divStyle}
           ref={this.handleRef}
           key={`fixed-${JSON.stringify(image.srcSet)}`}
+          {...customProps}
         >
           {/* Show a solid background color. */}
           {bgColor && (


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Allow `gatsby-image` to accept custom props. This is important for accessibility (i.e. `aria-label` and `role` attributes) along with some other use cases mentioned in #24876.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->
I'm not sure where the appropriate documentation changes would need to go. I assume a one-line

> Any other props will be passed on to the root tag of the `gatsby-image` component.

added to wherever is relevant will do.

@gatsbyjs/learning

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #24876.
