### PR TITLE
fix(docs): Add missing definition

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1915,6 +1915,7 @@ Theming
 themself
 Thijs
 Thinkmill
+Thinkster
 Tibaldi
 timeframe
 timeframes


### PR DESCRIPTION
## Description

Add missing dictionary definition causing lint to break.