### PR TITLE
Add Ghost as CMS in starter tags.

### DIFF
--- a/docs/categories.yml
+++ b/docs/categories.yml
@@ -8,6 +8,7 @@ starter:
   - Client-side App
   - CMS:Agility CMS
   - CMS:Cosmic
+  - CMS:Ghost
   - CMS:Headless
   - CMS:Contentful
   - CMS:DatoCMS


### PR DESCRIPTION
Hi Team,

With rise of Ghost as Headless CMS, it would be helpful for Gatsby community to add and filter starters with CMS:Ghost.

-Regards,
Keyur