### PR TITLE
maintenance(docs, www): Remove unnecessary overview from frontmatter

### DIFF
--- a/docs/docs/ab-testing.md
+++ b/docs/docs/ab-testing.md
@@ -1,6 +1,5 @@
 ---
 title: A/B Testing
-overview: true
 ---
 
 A/B or split testing is when you make test changes to a website. Suppose you have two buttons: a green “Buy Now!” button and a red “Buy Now!” button. You want to figure out which button will receive the most clicks. An A/B test would be an ideal way to measure engagement.

--- a/docs/docs/adding-app-and-website-functionality.md
+++ b/docs/docs/adding-app-and-website-functionality.md
@@ -1,6 +1,5 @@
 ---
 title: Adding App and Website Functionality
-overview: true
 ---
 
 Gatsby empowers developers and creators to make many different types of websites. One may wish to add additional functionality to their site such as search, authentication, forms, comments, and plenty of others.

--- a/docs/docs/adding-page-transitions.md
+++ b/docs/docs/adding-page-transitions.md
@@ -1,6 +1,5 @@
 ---
 title: Adding Page Transitions
-overview: true
 ---
 
 Page transitions give users a better experience when navigating between pages. There are a number of ways to add them to your Gatsby site.

--- a/docs/docs/adding-search.md
+++ b/docs/docs/adding-search.md
@@ -1,6 +1,5 @@
 ---
 title: Adding Search
-overview: true
 ---
 
 See below for a list of guides in this section, or keep reading for an overview on adding search functionality to your site.

--- a/docs/docs/api-reference.md
+++ b/docs/docs/api-reference.md
@@ -1,6 +1,5 @@
 ---
 title: Gatsby API Reference
-overview: true
 ---
 
 Learn more about Gatsby API methods and options, common files, and customizations.

--- a/docs/docs/conceptual-guide.md
+++ b/docs/docs/conceptual-guide.md
@@ -1,6 +1,5 @@
 ---
 title: Conceptual Guide
-overview: true
 ---
 
 Read high-level overviews of important Gatsby concepts and philosophies.

--- a/docs/docs/css-in-js.md
+++ b/docs/docs/css-in-js.md
@@ -1,6 +1,5 @@
 ---
 title: Enhancing Styles with CSS-in-JS
-overview: true
 ---
 
 CSS-in-JS refers to an approach where styles are written in JavaScript instead of in external CSS files to easily scope styles in components, eliminate dead code, encourage faster performance and dynamic styling, and more.

--- a/docs/docs/css-libraries-and-frameworks.md
+++ b/docs/docs/css-libraries-and-frameworks.md
@@ -1,6 +1,5 @@
 ---
 title: CSS Libraries and Frameworks
-overview: true
 ---
 
 There are many other CSS style libraries and frameworks that you can use in your Gatsby project.

--- a/docs/docs/customization.md
+++ b/docs/docs/customization.md
@@ -1,6 +1,5 @@
 ---
 title: Custom Configuration
-overview: true
 ---
 
 Sometimes you may find yourself in a situation where Gatsby's default configuration just isn't quite what you need for your site. If you should find yourself in this situation, have no fear my friend, you can customize Gatsby's config for `babel` and `webpack`. You can also customize `html.js`, the React component used to generate the initial HTML file of your build. You'll also find guides on how to get custom environment variables into your website, as well how to proxy API requests in development so your API calls aren't interpreted by your server as static assets.

--- a/docs/docs/debugging.md
+++ b/docs/docs/debugging.md
@@ -1,6 +1,5 @@
 ---
 title: Debugging
-overview: true
 ---
 
 While building your site, you’ll sometimes encounter bugs. These guides help you set up debugging in Gatsby so you can spot and squash bugs more easily.

--- a/docs/docs/deploying-and-hosting.md
+++ b/docs/docs/deploying-and-hosting.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying and Hosting
-overview: true
 ---
 
 Getting your shiny new Gatsby site deployed and accessible is probably the first thing you will want to do now that it's built! Also, give yourself a pat on the back real quick for creating something so great!

--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -1,6 +1,5 @@
 ---
 title: GraphQL & Gatsby
-overview: true
 ---
 
 When building with Gatsby, you access your data through a query language named [GraphQL](https://graphql.org/). GraphQL allows you to declaratively express your data needs. This is done with `queries`, queries are the representation of the data you need. A query looks like this:

--- a/docs/docs/guides.md
+++ b/docs/docs/guides.md
@@ -1,6 +1,5 @@
 ---
 title: Reference Guides
-overview: true
 ---
 
 Dive deeper into different topics around building with Gatsby, like sourcing data, building and styling pages, deployment, and more. While the [tutorials](/tutorial/) are step-by-step instructions, reference guides are resources about the various Gatsby development techniques.

--- a/docs/docs/headless-cms.md
+++ b/docs/docs/headless-cms.md
@@ -1,6 +1,5 @@
 ---
 title: What is a Headless CMS and How to Source Content from One
-overview: true
 ---
 
 A _headless CMS_ is content management software that enables writers to produce and organize content, while providing developers with structured data that can be displayed using a separate system on the frontend of a website or app.

--- a/docs/docs/partnering-with-gatsby.md
+++ b/docs/docs/partnering-with-gatsby.md
@@ -1,6 +1,5 @@
 ---
 title: Partnering with Gatsby
-overview: true
 ---
 
 If you're an organization in the website space -- whether a vendor or an agency -- we'd love to work together with you.

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -1,6 +1,5 @@
 ---
 title: Performance
-overview: true
 ---
 
 While performance is already at the heart of Gatsby, it's important to ensure you are doing all you can to make your content available to your users as fast as possible. Not all users are enjoying high speed connections, or browsing from a desktop. It's important to make no assumptions and serve the smallest and fastest site possible, to provide an optimal experience for wherever your users might be coming from. Since Gatsby is already doing a lot of the heavy lifting for you there isn't a lot required out of the box to make your site blazing fast, but by following these guides you can ensure the best possible performance and delivery of your content to your users.

--- a/docs/docs/plugins-themes-and-starters.md
+++ b/docs/docs/plugins-themes-and-starters.md
@@ -1,6 +1,5 @@
 ---
 title: Plugins, Themes, & Starters
-overview: true
 ---
 
 In the Gatsby ecosystem, there's more than one way to build a site. To help you understand the differences between plugins, themes, and starters, this guide will talk through some of the details.

--- a/docs/docs/preparing-for-site-launch.md
+++ b/docs/docs/preparing-for-site-launch.md
@@ -1,6 +1,5 @@
 ---
 title: Preparing Your Site for Launch
-overview: true
 ---
 
 So your Gatsby site is done, and you're ready to share it with the world, **congratulations**! 🎉

--- a/docs/docs/preparing-your-environment.md
+++ b/docs/docs/preparing-your-environment.md
@@ -1,6 +1,5 @@
 ---
 title: Preparing Your Environment
-overview: true
 ---
 
 To get started with Gatsby, you'll need to make sure you have the following software tools installed:

--- a/docs/docs/releases-and-migration.md
+++ b/docs/docs/releases-and-migration.md
@@ -1,6 +1,5 @@
 ---
 title: Releases & Migration
-overview: true
 ---
 
 Find release notes and guides on how to upgrade Gatsby along with third-party packages.

--- a/docs/docs/styling.md
+++ b/docs/docs/styling.md
@@ -1,6 +1,5 @@
 ---
 title: Styling
-overview: true
 ---
 
 There are many ways to style your website. They can roughly be grouped into three styling approaches:

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,6 +1,5 @@
 ---
 title: Adding Testing
-overview: true
 disableTableOfContents: true
 ---
 

--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -1,6 +1,5 @@
 ---
 title: Themes
-overview: true
 disableTableOfContents: true
 ---
 

--- a/docs/docs/using-gatsby-professionally.md
+++ b/docs/docs/using-gatsby-professionally.md
@@ -1,6 +1,5 @@
 ---
 title: Using Gatsby Professionally
-overview: true
 ---
 
 As a Gatsby developer and enthusiast, you may be interested in how you can spend more of your time professionally building with Gatsby.

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -41,7 +41,6 @@ export const pageQuery = graphql`
       frontmatter {
         title
         description
-        overview
         issue
         disableTableOfContents
         tableOfContentsDepth

--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -49,7 +49,6 @@ exports.sourceNodes = ({ actions: { createTypes } }) => {
       showTopLevelSignatures: Boolean
       disableTableOfContents: Boolean
       tableOfContentsDepth: Int
-      overview: Boolean
       issue: String
       jsdoc: [String!]
       apiCalls: String


### PR DESCRIPTION
## Description

Remove an unused `overview` label from frontmatter.