### PR TITLE
WIP: State machine base

### DIFF
--- a/packages/gatsby/src/bootstrap/index.ts
+++ b/packages/gatsby/src/bootstrap/index.ts
@@ -19,7 +19,7 @@ import JestWorker from "jest-worker"
 const tracer = globalTracer()
 
 export async function bootstrap(
-  initialContext: IBuildContext
+  initialContext: Partial<IBuildContext>
 ): Promise<{
   gatsbyNodeGraphQLFunction: Runner
   workerPool: JestWorker

--- a/packages/gatsby/src/commands/develop-state-machine.ts
+++ b/packages/gatsby/src/commands/develop-state-machine.ts
@@ -1,0 +1,154 @@
+import { syncStaticDir } from "../utils/get-static-dir"
+import report from "gatsby-cli/lib/reporter"
+import chalk from "chalk"
+import telemetry from "gatsby-telemetry"
+import express from "express"
+import getSslCert from "../utils/get-ssl-cert"
+import { initTracer } from "../utils/tracer"
+import { detectPortInUseAndPrompt } from "../utils/detect-port-in-use-and-prompt"
+// import { startListeningToDevelopQueue } from "../query"
+import onExit from "signal-exit"
+import {
+  userPassesFeedbackRequestHeuristic,
+  showFeedbackRequest,
+} from "../utils/feedback"
+
+import { IProgram } from "./types"
+
+import { developMachine, INITIAL_CONTEXT } from "../state-machines/develop"
+import { interpret } from "xstate"
+import { saveState, startAutosave } from "../db"
+
+// checks if a string is a valid ip
+const REGEX_IP = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$/
+
+// const isInteractive = process.stdout.isTTY
+
+module.exports = async (program: IProgram): Promise<void> => {
+  report.log(`Using experimental develop state machine`)
+
+  // Watch the static directory and copy files to public as they're added or
+  // changed. Wait 10 seconds so copying doesn't interfere with the regular
+  // bootstrap.
+  setTimeout(() => {
+    syncStaticDir()
+  }, 10000)
+
+  // Time for another story...
+  // When the parent process is killed by SIGKILL, Node doesm't kill spawned child processes
+  // Hence, we peiodically send a heart beat to the parent to check if it is still alive
+  // This will crash with Error [ERR_IPC_CHANNEL_CLOSED]: Channel closed
+  // and kill the orphaned child process as a result
+  if (process.send) {
+    setInterval(() => {
+      // eslint-disable-next-line no-unused-expressions
+      process.send?.({
+        type: `HEARTBEAT`,
+      })
+    }, 1000)
+  }
+
+  process.on(`message`, msg => {
+    if (msg.type === `COMMAND` && msg.action.type === `EXIT`) {
+      process.exit(msg.action.payload)
+    }
+  })
+
+  onExit(() => {
+    telemetry.trackCli(`DEVELOP_STOP`)
+  })
+
+  // We want to prompt the feedback request when users quit develop
+  // assuming they pass the heuristic check to know they are a user
+  // we want to request feedback from, and we're not annoying them.
+  process.on(
+    `SIGINT`,
+    async (): Promise<void> => {
+      if (await userPassesFeedbackRequestHeuristic()) {
+        showFeedbackRequest()
+      }
+      process.exit(0)
+    }
+  )
+
+  if (process.env.GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES) {
+    report.panic(
+      `The flag ${chalk.yellow(
+        `GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES`
+      )} is not available with ${chalk.cyan(
+        `gatsby develop`
+      )}, please retry using ${chalk.cyan(`gatsby build`)}`
+    )
+  }
+  initTracer(program.openTracingConfigFile)
+  report.pendingActivity({ id: `webpack-develop` })
+  telemetry.trackCli(`DEVELOP_START`)
+  telemetry.startBackgroundUpdate()
+
+  const port =
+    typeof program.port === `string` ? parseInt(program.port, 10) : program.port
+
+  // In order to enable custom ssl, --cert-file --key-file and -https flags must all be
+  // used together
+  if ((program[`cert-file`] || program[`key-file`]) && !program.https) {
+    report.panic(
+      `for custom ssl --https, --cert-file, and --key-file must be used together`
+    )
+  }
+
+  try {
+    program.port = await detectPortInUseAndPrompt(port)
+  } catch (e) {
+    if (e.message === `USER_REJECTED`) {
+      process.exit(0)
+    }
+
+    throw e
+  }
+
+  // Check if https is enabled, then create or get SSL cert.
+  // Certs are named 'devcert' and issued to the host.
+  if (program.https) {
+    const sslHost =
+      program.host === `0.0.0.0` || program.host === `::`
+        ? `localhost`
+        : program.host
+
+    if (REGEX_IP.test(sslHost)) {
+      report.panic(
+        `You're trying to generate a ssl certificate for an IP (${sslHost}). Please use a hostname instead.`
+      )
+    }
+
+    program.ssl = await getSslCert({
+      name: sslHost,
+      certFile: program[`cert-file`],
+      keyFile: program[`key-file`],
+      directory: program.directory,
+    })
+  }
+
+  const app = express()
+  const developService = interpret(
+    developMachine.withContext({
+      ...INITIAL_CONTEXT,
+      app,
+      program,
+    })
+  ).start()
+
+  let last = developService.state
+
+  developService.onTransition(async state => {
+    if (state.changed && !last.matches(state)) {
+      console.log(`Transitioning to`, state.value)
+      last = state
+    }
+  })
+
+  await saveState()
+
+  startAutosave()
+
+  // queryWatcher.startWatchDeletePage()
+}

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -107,7 +107,12 @@ let isRestarting
 const REGEX_IP = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$/
 
 module.exports = async (program: IProgram): Promise<void> => {
-  const developProcessPath = slash(require.resolve(`./develop-process`))
+  const useStateMachine = !!process.env.GATSBY_EXPERIMENTAL_STATE_MACHINE
+  const developProcessPath = slash(
+    useStateMachine
+      ? require.resolve(`./develop-state-machine`)
+      : require.resolve(`./develop-process`)
+  )
   // Run the actual develop server on a random port, and the proxy on the program port
   // which users will access
   const proxyPort = program.port

--- a/packages/gatsby/src/services/index.ts
+++ b/packages/gatsby/src/services/index.ts
@@ -1,16 +1,60 @@
-export { startWebpackServer } from "./start-webpack-server"
-export { rebuildSchemaWithSitePage } from "./rebuild-schema-with-site-pages"
-export { extractQueries } from "./extract-queries"
-export { writeOutRedirects } from "./write-out-redirects"
-export { postBootstrap } from "./post-bootstrap"
-export { buildSchema } from "./build-schema"
-export { createPages } from "./create-pages"
-export { createPagesStatefully } from "./create-pages-statefully"
-export { customizeSchema } from "./customize-schema"
-export { initialize } from "./initialize"
-export { sourceNodes } from "./source-nodes"
-export { writeOutRequires } from "./write-out-requires"
-export { calculateDirtyQueries } from "./calculate-dirty-queries"
-export { runStaticQueries } from "./run-static-queries"
-export { runPageQueries } from "./run-page-queries"
+import { ServiceConfig } from "xstate"
+import { IBuildContext } from "./"
+
+import { startWebpackServer } from "./start-webpack-server"
+import { rebuildSchemaWithSitePage } from "./rebuild-schema-with-site-pages"
+import { extractQueries } from "./extract-queries"
+import { writeOutRedirects } from "./write-out-redirects"
+import { postBootstrap } from "./post-bootstrap"
+import { buildSchema } from "./build-schema"
+import { createPages } from "./create-pages"
+import { createPagesStatefully } from "./create-pages-statefully"
+import { customizeSchema } from "./customize-schema"
+import { initialize } from "./initialize"
+import { sourceNodes } from "./source-nodes"
+import { writeOutRequires } from "./write-out-requires"
+import { calculateDirtyQueries } from "./calculate-dirty-queries"
+import { runStaticQueries } from "./run-static-queries"
+import { runPageQueries } from "./run-page-queries"
+
+import { waitUntilAllJobsComplete } from "../utils/wait-until-jobs-complete"
+
 export * from "./types"
+
+export {
+  customizeSchema,
+  sourceNodes,
+  createPages,
+  buildSchema,
+  createPagesStatefully,
+  extractQueries,
+  writeOutRequires,
+  calculateDirtyQueries,
+  runStaticQueries,
+  runPageQueries,
+  initialize,
+  waitUntilAllJobsComplete,
+  postBootstrap,
+  writeOutRedirects,
+  startWebpackServer,
+  rebuildSchemaWithSitePage,
+}
+
+export const buildServices: Record<string, ServiceConfig<IBuildContext>> = {
+  customizeSchema,
+  sourceNodes,
+  createPages,
+  buildSchema,
+  createPagesStatefully,
+  extractQueries,
+  writeOutRequires,
+  calculateDirtyQueries,
+  runStaticQueries,
+  runPageQueries,
+  initialize,
+  waitUntilAllJobsComplete,
+  postBootstrap,
+  writeOutRedirects,
+  startWebpackServer,
+  rebuildSchemaWithSitePage,
+}

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -44,7 +44,7 @@ process.on(`unhandledRejection`, (reason: unknown) => {
 export async function initialize({
   program: args,
   parentSpan,
-}: IBuildContext): Promise<{
+}: Partial<IBuildContext>): Promise<{
   store: Store<IGatsbyState, AnyAction>
   workerPool: JestWorker
 }> {

--- a/packages/gatsby/src/services/types.ts
+++ b/packages/gatsby/src/services/types.ts
@@ -1,11 +1,15 @@
+import { WebsocketManager } from "../utils/websocket-manager"
+import { AnyEventObject, Actor } from "xstate"
+import { Compiler } from "webpack"
 import { Span } from "opentracing"
+import { Express } from "express"
+import JestWorker from "jest-worker"
 import { IProgram } from "../commands/types"
 import { Runner } from "../bootstrap/create-graphql-runner"
 import { GraphQLRunner } from "../query/graphql-runner"
 import { Store, AnyAction } from "redux"
 import { IGatsbyState } from "../redux/types"
-import { Express } from "express"
-import JestWorker from "jest-worker"
+
 export interface IGroupedQueryIds {
   pageQueryIds: string[]
   staticQueryIds: string[]
@@ -17,13 +21,24 @@ export interface IMutationAction {
 }
 export interface IBuildContext {
   program?: IProgram
+  recursionCount: number
+  nodesMutatedDuringQueryRun: boolean
+  firstRun: boolean
+  nodeMutationBatch: IMutationAction[]
+  filesDirty?: boolean
+  runningBatch: IMutationAction[]
+  compiler?: Compiler
+  websocketManager?: WebsocketManager
   store?: Store<IGatsbyState, AnyAction>
   parentSpan?: Span
   gatsbyNodeGraphQLFunction?: Runner
   graphqlRunner?: GraphQLRunner
-  queryIds?: IGroupedQueryIds
-  webhookBody?: Record<string, unknown>
   refresh?: boolean
+  webhookBody?: Record<string, unknown>
+  queryIds?: IGroupedQueryIds
   workerPool?: JestWorker
+  mutationListener?: Actor<any, AnyEventObject>
   app?: Express
+  pagesToBuild?: string[]
+  pagesToDelete?: string[]
 }

--- a/packages/gatsby/src/state-machines/actions.ts
+++ b/packages/gatsby/src/state-machines/actions.ts
@@ -1,0 +1,6 @@
+import { ActionFunctionMap, AnyEventObject } from "xstate"
+import { IBuildContext } from "../services"
+
+export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
+  //
+}

--- a/packages/gatsby/src/state-machines/develop.ts
+++ b/packages/gatsby/src/state-machines/develop.ts
@@ -1,0 +1,34 @@
+import { Machine, AnyEventObject, MachineConfig } from "xstate"
+import { IBuildContext } from "../services"
+import { buildServices } from "../services"
+import { buildActions } from "./actions"
+
+export const INITIAL_CONTEXT: IBuildContext = {
+  recursionCount: 0,
+  nodesMutatedDuringQueryRun: false,
+  firstRun: true,
+  nodeMutationBatch: [],
+  runningBatch: [],
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
+  id: `build`,
+  initial: `setup`,
+  context: INITIAL_CONTEXT,
+  states: {
+    setup: {
+      on: {
+        "": {
+          actions: (): void => console.log(`init`),
+        },
+      },
+    },
+  },
+}
+
+// eslint-disable-next-line new-cap
+export const developMachine = Machine<IBuildContext>(developConfig, {
+  actions: buildActions,
+  services: buildServices,
+})

--- a/packages/gatsby/src/state-machines/shared-transition-configs.ts
+++ b/packages/gatsby/src/state-machines/shared-transition-configs.ts
@@ -1,0 +1,35 @@
+import { TransitionConfig, AnyEventObject, DoneInvokeEvent } from "xstate"
+import { IBuildContext } from "../services"
+
+type BuildTransition = TransitionConfig<IBuildContext, AnyEventObject>
+
+/**
+ * Event handler used in all states where we're not ready to process node
+ * mutations. Instead we add it to a batch to process when we're next idle
+ */
+export const ADD_NODE_MUTATION: BuildTransition = {
+  actions: `addNodeMutation`,
+}
+
+/**
+ * Event handler used in all states where we're not ready to process a file change
+ * Instead we add it to a batch to process when we're next idle
+ */
+export const SOURCE_FILE_CHANGED: BuildTransition = {
+  actions: `markFilesDirty`,
+}
+
+/**
+ * When running queries we might add nodes (e.g from resolvers). If so we'll
+ * want to re-run queries and schema inference
+ */
+export const runMutationAndMarkDirty: BuildTransition = {
+  actions: [`markNodesDirty`, `callApi`],
+}
+
+export const onError: TransitionConfig<IBuildContext, DoneInvokeEvent<any>> = {
+  target: `#build.waiting`,
+  actions: (_context, event): void => {
+    console.error(`Error`, event)
+  },
+}


### PR DESCRIPTION
This branch includes the base code to run the develop state machine, and serves as the base for state machine PRs

Initial files, added in e4cc5ba : 

`commands/develop-state-machine.ts`. This is run instead of `develop-process`, and includes a lot of the same boilerplate code. It also contains to the code to initialise and run the state machine.

`commands/develop.ts`. Adds am env var to use the state machine rather than the standard develop command/

`services/index.ts`. Refactor to export the services as a service map object as well as the individual exports used by the existing bootstrap and build commands.

`services/types.ts`. Adds all of the types for the state machine context object.

`state-machines/actions.ts`. Adds an empty actions map.

`state-machines/develop.ts`. Includes an empty state machine, waiting for future PRs.

`state-machines/shared-transition-configs.ts`. Helper utilities shared by all state machines.
