### PR TITLE
Change official plugins testing condition

### DIFF
--- a/www/src/utils/is-official-package.js
+++ b/www/src/utils/is-official-package.js
@@ -3,6 +3,6 @@ module.exports = function isOfficialPackage(pkg) {
   return (
     pkg.repository &&
     !pkg.name.startsWith(`@`) &&
-    pkg.repository.url.startsWith(`https://github.com/gatsbyjs/gatsby`)
+    pkg.repository.url.startsWith(`https://github.com/gatsbyjs`)
   )
 }


### PR DESCRIPTION
As we transition to the new themes repo we want themes to be marked as official plugins on the website. This will allow for that.