### PR TITLE
enhancement(docs): dictionary.txt -> .htaccess -> File names in code blocks

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1,6 +1,5 @@
 .babelrc
 .env
-.htaccess
 .html
 .jpg
 .js

--- a/docs/blog/2019-02-14-behind-the-scenes-q-and-a/index.md
+++ b/docs/blog/2019-02-14-behind-the-scenes-q-and-a/index.md
@@ -259,10 +259,10 @@ To watch the full recorded webinar, [register here](https://www.gatsbyjs.com/beh
 **Question:** Following up on upgrade path question—how would you upgrade between version of 2.~?
 **Answer:** You can bump the version # in your package.json and then you're done.
 
-**Question:** If my .htaccess file is configured to read .html files without the extension in the url, can Gatsby compile the links to pages without the .html ending?
+**Question:** If my `.htaccess` file is configured to read .html files without the extension in the url, can Gatsby compile the links to pages without the .html ending?
 **Answer:** We haven't added support for this yet.
 
-**Question:** Follow up to the .htaccess question, how do you manage to hide .html from your url on gatsbyjs.com?
+**Question:** Follow up to the `.htaccess` question, how do you manage to hide .html from your url on gatsbyjs.com?
 **Answer:** Many servers can do this. Generally the feature is called "clean urls".
 
 **Question:** No concern of the additional request for the SVG??


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In this PR we reference issue #25290 where they have asked to: put filenames like .htaccess in code blocks.

We do this by finding all instances of `.htaccess` that are not in code blocks yet and then add a code block around them. I then remove .htaccess from the dictionary.


### Documentation

No documentation is required for this

## Related Issues

Partially addresses #25290

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
