### PR TITLE
chore(gatsby-plugin-mdx): be more explicit in explicit api

### DIFF
--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -46,6 +46,7 @@ module.exports = async function genMDX(
     options,
     getNode,
     getNodes,
+    getNodesByType,
     reporter,
     cache,
     pathPrefix,
@@ -110,9 +111,9 @@ export const _frontmatter = ${JSON.stringify(data)}`
     {
       gatsbyRemarkPlugins: options.gatsbyRemarkPlugins,
       mdxNode: node,
-      //          files,
       getNode,
       getNodes,
+      getNodesByType,
       reporter,
       cache,
       pathPrefix,

--- a/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -12,10 +12,12 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
   gatsbyRemarkPlugins,
   mdxNode,
   getNode,
+  getNodes,
   getNodesByType,
   reporter,
   cache,
   pathPrefix,
+  compiler,
   ...helpers
 }) {
   debug(`getSourcePluginsAsRemarkPlugins`)
@@ -55,11 +57,13 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
           markdownAST,
           markdownNode: mdxNode,
           getNode,
+          getNodes,
           getNodesByType,
           files: fileNodes,
           pathPrefix,
           reporter,
           cache,
+          compiler,
           ...helpers,
         },
         plugin.options || {}


### PR DESCRIPTION
Tiny refactor, no semantic change.

All the args to the toplevel `genMDX` call are passed on to mdx plugins and it's unclear what gets tucked into `...helper` there, but some keys _are_ explicit and we should be consistent in mentioning them.

At a later point we may want to get rid of this `helper` binding altogether. Or TS solves this for us. Whichever comes first.

I'm not happy about passing on these `getNode*` api's because they are raw unprotected API's that are dangerous to build perf for sites at scale. So being explicit here is also important for visibility.