### PR TITLE
enhancement(docs): dictionary.txt -> Infer* -> putting all code prefixed with infer into code blocks

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1020,7 +1020,6 @@ IndexedDB
 inferFromFieldName
 inferFromMapping
 inferGraphQLType
-inferInputObjectStrctureFromNodes
 inferInputObjectStructureFromFields
 inferObjectStructureFromNodes
 InfluxData

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1020,7 +1020,6 @@ IndexedDB
 inferFromFieldName
 inferFromMapping
 inferGraphQLType
-inferObjectStructureFromNodes
 InfluxData
 infrastructure-centric
 ing

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1017,7 +1017,6 @@ incineratingly
 Indexability
 indexable
 IndexedDB
-inferFromMapping
 inferGraphQLType
 InfluxData
 infrastructure-centric

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1017,7 +1017,6 @@ incineratingly
 Indexability
 indexable
 IndexedDB
-inferGraphQLType
 InfluxData
 infrastructure-centric
 ing

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1017,7 +1017,6 @@ incineratingly
 Indexability
 indexable
 IndexedDB
-inferFromFieldName
 inferFromMapping
 inferGraphQLType
 InfluxData

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1020,7 +1020,6 @@ IndexedDB
 inferFromFieldName
 inferFromMapping
 inferGraphQLType
-inferInputObjectStructureFromFields
 inferObjectStructureFromNodes
 InfluxData
 infrastructure-centric

--- a/docs/docs/schema-gql-type.md
+++ b/docs/docs/schema-gql-type.md
@@ -82,7 +82,7 @@ With the exampleValue in hand, we can use each of its key/values to infer the Ty
 
 Fields on the node that were created directly by the source and transform plugins. E.g. for `File` type, these would be `relativePath`, `size`, `accessTime` etc.
 
-The creation of these fields is handled by the [inferObjectStructureFromNodes](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L317) function in [infer-graphql-type.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js). Given an object, a field could be in one of 3 sub-categories:
+The creation of these fields is handled by the [`inferObjectStructureFromNodes`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L317) function in [infer-graphql-type.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js). Given an object, a field could be in one of 3 sub-categories:
 
 1. It involves a mapping in [gatsby-config.js](/docs/gatsby-config/#mapping-node-types)
 2. It's value is a foreign key reference to some other node (ends in `___NODE`)
@@ -120,7 +120,7 @@ If the field was not handled as a mapping or foreign key reference, then it must
 
 The core of this step creates a GraphQL Field object, where the type is inferred directly via the result of `typeof`. E.g. `typeof(value) === 'boolean'` would result in type `GraphQLBoolean`. Since these are simple values, resolvers are not defined (graphql-js takes care of that for us).
 
-If however, the value is an object or array, we recurse, using [inferObjectStructureFromNodes](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L317) to create the GraphQL fields.
+If however, the value is an object or array, we recurse, using [`inferObjectStructureFromNodes`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L317) to create the GraphQL fields.
 
 In addition, Gatsby creates custom GraphQL types for `File` ([types/type-file.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/types/type-file.js)) and `Date` ([types/type-date.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/types/type-file.js)). If the value of our field is a string that looks like a filename or a date (handled by [should-infer](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L52) functions), then we return the appropriate custom type.
 

--- a/docs/docs/schema-gql-type.md
+++ b/docs/docs/schema-gql-type.md
@@ -100,7 +100,7 @@ mapping: {
 },
 ```
 
-The field generation in this case is handled by [inferFromMapping](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L129). The first step is to find the type that is mapped to. In this case, `AuthorYaml`. This is known as the `linkedType`. That type will have a field to link by. In this case `name`. If one is not supplied, it defaults to `id`. This field is known as `linkedField`
+The field generation in this case is handled by [`inferFromMapping`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L129). The first step is to find the type that is mapped to. In this case, `AuthorYaml`. This is known as the `linkedType`. That type will have a field to link by. In this case `name`. If one is not supplied, it defaults to `id`. This field is known as `linkedField`
 
 Now we can create a GraphQL Field declaration whose type is `AuthorYaml` (which we look up in list of other `gqlTypes`). The field resolver will get the value for the node (in this case, the author string), and then search through the react nodes until it finds one whose type is `AuthorYaml` and whose `name` field matches the author string.
 

--- a/docs/docs/schema-gql-type.md
+++ b/docs/docs/schema-gql-type.md
@@ -116,7 +116,7 @@ If the foreign key value is an array of IDs, then instead of returning a Field d
 
 #### Plain object or value field
 
-If the field was not handled as a mapping or foreign key reference, then it must be a normal every day field. E.g. a scalar, string, or plain object. These cases are handled by [inferGraphQLType](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L38).
+If the field was not handled as a mapping or foreign key reference, then it must be a normal every day field. E.g. a scalar, string, or plain object. These cases are handled by [`inferGraphQLType`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L38).
 
 The core of this step creates a GraphQL Field object, where the type is inferred directly via the result of `typeof`. E.g. `typeof(value) === 'boolean'` would result in type `GraphQLBoolean`. Since these are simple values, resolvers are not defined (graphql-js takes care of that for us).
 

--- a/docs/docs/schema-gql-type.md
+++ b/docs/docs/schema-gql-type.md
@@ -106,7 +106,7 @@ Now we can create a GraphQL Field declaration whose type is `AuthorYaml` (which 
 
 #### Foreign Key reference (`___NODE`)
 
-If not a mapping field, it might instead end in `___NODE`, signifying that its value is an ID that is a foreign key reference to another node in redux. Check out the [Source Plugin Tutorial](/tutorial/source-plugin-tutorial/) for how this works from a user point of view. Behind the scenes, the field inference is handled by [inferFromFieldName](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L204).
+If not a mapping field, it might instead end in `___NODE`, signifying that its value is an ID that is a foreign key reference to another node in redux. Check out the [Source Plugin Tutorial](/tutorial/source-plugin-tutorial/) for how this works from a user point of view. Behind the scenes, the field inference is handled by [`inferFromFieldName`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-type.js#L204).
 
 This is actually quite similar to the mapping case above. We remove the `___NODE` part of the field name. E.g. `author___NODE` would become `author`. Then, we find our `linkedNode`. I.e given the example value for `author` (which would be an ID), we find its actual node in redux. Then, we find its type in processed types by its `internal.type`. Note, that also like in mapping fields, we can define the `linkedField` too. This can be specified via `nodeFieldname___NODE___linkedFieldName`. E.g. for `author___NODE___name`, the linkedField would be `name` instead of `id`.
 

--- a/docs/docs/schema-input-gql.md
+++ b/docs/docs/schema-input-gql.md
@@ -37,7 +37,7 @@ The first step is to generate an input field for each type of field on the redux
 }
 ```
 
-This step is handled by [inferInputObjectStrctureFromNodes](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-input-fields.js#L235). First, we generate an example Value (see [gqlTypes](/docs/schema-gql-type#gqltype-creation)). For each field on the example value (e.g. `author`), we create a [GraphQLInputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) with an appropriate name. The fields for Input Objects are predicates that depend on the value's `typeof` result. E.g. for a String, we need to be able to query by `eq`, `regex` etc. If the value is an object itself, then we recurse, building its fields as above.
+This step is handled by [`inferInputObjectStructureFromNodes`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-input-fields.js#L235). First, we generate an example Value (see [gqlTypes](/docs/schema-gql-type#gqltype-creation)). For each field on the example value (e.g. `author`), we create a [GraphQLInputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) with an appropriate name. The fields for Input Objects are predicates that depend on the value's `typeof` result. E.g. for a String, we need to be able to query by `eq`, `regex` etc. If the value is an object itself, then we recurse, building its fields as above.
 
 If the key is a foreign key reference (ends in `___NODE`), then we find the field's linked Type first, and progress as above (for more on how foreign keys are implemented, see [gqlType](/docs/schema-gql-type#foreign-key-reference-___node)). After this step, we will end up with an Input Object type such as .
 

--- a/docs/docs/schema-input-gql.md
+++ b/docs/docs/schema-input-gql.md
@@ -73,7 +73,7 @@ Plugins themselves have the opportunity to create custom fields that apply to AL
 }
 ```
 
-Plugins add custom fields by implementing the [setFieldsOnGraphQLNodeType](/docs/node-apis/#setFieldsOnGraphQLNodeType) API. They must return a full GraphQLObjectType, complete with `resolve` function. Once this API has been run, the fields are passed to [inferInputObjectStructureFromFields](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js#L195), which will generate input filters for the new fields. The result would look something like:
+Plugins add custom fields by implementing the [setFieldsOnGraphQLNodeType](/docs/node-apis/#setFieldsOnGraphQLNodeType) API. They must return a full GraphQLObjectType, complete with `resolve` function. Once this API has been run, the fields are passed to [`inferInputObjectStructureFromFields`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/infer-graphql-input-fields-from-fields.js#L195), which will generate input filters for the new fields. The result would look something like:
 
 ```javascript
 { //GraphQLInputObjectType


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In this PR we reference issue #25290 where they have asked to: put code like inferInputObjectStrctureFromNodes in code blocks. I have identified there are a few more cases of these code which I have also taken care of.

We do this by finding all instances of all strings prefixed with infer[X] that are not in code blocks yet and then add a code block around them. I then remove all of those strings from the dictionary.


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

No documentation is required for this

## Related Issues

Partially addresses #25290


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
