### PR TITLE
fix(docs): show where `getNodesByType` comes from

### DIFF
--- a/docs/docs/creating-a-source-plugin.md
+++ b/docs/docs/creating-a-source-plugin.md
@@ -432,7 +432,7 @@ If possible, the proactive listener approach creates the best experience if exis
 The code to support this behavior looks like this:
 
 ```javascript:title=source-plugin/gatsby-node.js
-exports.sourceNodes = async ({ actions }, pluginOptions) => {
+exports.sourceNodes = async ({ actions, getNodesByType }, pluginOptions) => {
   const { createNode, touchNode, deleteNode } = actions
 
   // highlight-start

--- a/docs/docs/creating-a-source-plugin.md
+++ b/docs/docs/creating-a-source-plugin.md
@@ -429,7 +429,7 @@ One challenge when developing locally is that a developer might make modificatio
 
 If possible, the proactive listener approach creates the best experience if existing APIs in the data source can support it (or you have access to build support into the data source).
 
-The code to support this behavior looks like this:
+Here's some pseudo code that shows this behavior:
 
 ```javascript:title=source-plugin/gatsby-node.js
 exports.sourceNodes = async ({ actions, getNodesByType }, pluginOptions) => {


### PR DESCRIPTION
## Description

The example code showing how to proactively update nodes used `getNodesByType` but didn't destructure it from the function parameters. This PR fixes that omission.