### PR TITLE
chore(www): refactor evaluation table components

### DIFF
--- a/www/src/components/features/evaluation-cell.js
+++ b/www/src/components/features/evaluation-cell.js
@@ -79,7 +79,7 @@ const basicStyling = {
   height: t => t.space[5],
   width: t => t.space[5],
   borderRadius: `50%`,
-  margin: `0 auto`,
+  m: `0 auto`,
 }
 
 const EvaluationCell = ({ num, style }) => (

--- a/www/src/components/features/evaluation-table-section-header-bottom.js
+++ b/www/src/components/features/evaluation-table-section-header-bottom.js
@@ -1,50 +1,47 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import styled from "@emotion/styled"
 
 import logo from "../../assets/monogram.svg"
 import logoDictionary from "./logo-dictionary"
 
-const Td = styled.td`
-  background: ${t => t.theme.colors.background};
-  border-color: ${t => t.theme.colors.ui.light};
-  display: table-cell;
-  font-family: ${t => t.theme.fonts.heading};
-  font-weight: 600;
-  line-height: ${t => t.theme.lineHeights.dense};
-  padding: ${t => t.theme.space[3]};
-  text-align: left;
-  vertical-align: middle;
-`
+const tdStyles = {
+  display: `table-cell`,
+  fontFamily: `heading`,
+  lineHeight: `dense`,
+  fontWeight: 600,
+  textAlign: `left`,
+  verticalAlign: `middle`,
+  p: 3,
+}
 
 const subHeaderTitleStyles = {
   display: `block`,
   height: t => [t.space[6], t.space[7]],
-  margin: `auto`,
-  marginBottom: 0,
+  m: `auto`,
+  mb: 0,
 }
 
-const renderSubHeader = props => (
-  <tr
-    key="subhead"
-    style={{
-      display: !props.display ? `none` : `table-row`,
-    }}
-  >
-    <Td>{props.category}</Td>
-    <Td>
-      <img src={logo} sx={subHeaderTitleStyles} alt="Gatsby logo" />
-    </Td>
-    {props.options.map((option, i) => (
-      <Td key={i}>
-        <img
-          src={logoDictionary[option.key]}
-          sx={subHeaderTitleStyles}
-          alt={`${option.display} Logo`}
-        />
-      </Td>
-    ))}
-  </tr>
-)
-
-export default renderSubHeader
+export default function headerBottom({ display, category, options }) {
+  return (
+    <tr
+      key="subhead"
+      sx={{
+        display: !display ? `none` : `table-row`,
+      }}
+    >
+      <td sx={tdStyles}>{category}</td>
+      <td sx={tdStyles}>
+        <img src={logo} sx={subHeaderTitleStyles} alt="Gatsby logo" />
+      </td>
+      {options.map((option, i) => (
+        <td sx={tdStyles} key={i}>
+          <img
+            src={logoDictionary[option.key]}
+            sx={subHeaderTitleStyles}
+            alt={`${option.display} Logo`}
+          />
+        </td>
+      ))}
+    </tr>
+  )
+}

--- a/www/src/components/features/evaluation-table-section-header-bottom.js
+++ b/www/src/components/features/evaluation-table-section-header-bottom.js
@@ -5,6 +5,8 @@ import logo from "../../assets/monogram.svg"
 import logoDictionary from "./logo-dictionary"
 
 const tdStyles = {
+  background: t => t.colors.background,
+  borderColor: t => t.colors.ui.light,
   display: `table-cell`,
   fontFamily: `heading`,
   lineHeight: `dense`,
@@ -21,26 +23,25 @@ const subHeaderTitleStyles = {
   mb: 0,
 }
 
-export default function headerBottom({ display, category, options }) {
+const Td = ({ children }) => <td sx={tdStyles}>{children}</td>
+
+export default function HeaderBottom({ display, category, options }) {
   return (
     <tr
-      key="subhead"
       sx={{
         display: !display ? `none` : `table-row`,
       }}
     >
-      <td sx={tdStyles}>{category}</td>
-      <td sx={tdStyles}>
-        <img src={logo} sx={subHeaderTitleStyles} alt="Gatsby logo" />
-      </td>
+      <Td>{category}</Td>
+      <Td>{<img src={logo} sx={subHeaderTitleStyles} alt="Gatsby logo" />}</Td>
       {options.map((option, i) => (
-        <td sx={tdStyles} key={i}>
+        <Td key={i}>
           <img
             src={logoDictionary[option.key]}
             sx={subHeaderTitleStyles}
             alt={`${option.display} Logo`}
           />
-        </td>
+        </Td>
       ))}
     </tr>
   )

--- a/www/src/components/features/evaluation-table-section-header-top.js
+++ b/www/src/components/features/evaluation-table-section-header-top.js
@@ -1,58 +1,47 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 
-import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
+const tdStyles = {
+  "&&": { p: 3 },
+  display: [`none`, `table-cell`],
+  fontSize: 0,
+  fontWeight: `body`,
+  lineHeight: `solid`,
+  textTransform: `uppercase`,
+  textAlign: `center`,
+  verticalAlign: `bottom`,
+  border: 0,
+  color: `textMuted`,
+  bg: `ui.background`,
+  "&:last-child": {
+    borderTopRightRadius: 2,
+  },
+  span: {
+    WebkitHyphens: `auto`,
+    MsHyphens: `auto`,
+    hyphens: `auto`,
+    display: `inline-block`,
+    "&:first-of-type": {
+      borderTopLeftRadius: 2,
+      textAlign: `left`,
+    },
+  },
+}
 
-const superHeader = ({ columnHeaders }) => (
-  <tr>
-    {columnHeaders.map((header, i) => (
-      <td
-        key={i}
-        sx={{
-          "&&": { p: 3 },
-          display: `none`,
-          textTransform: `uppercase`,
-          fontSize: 0,
-          lineHeight: `solid`,
-          fontWeight: `body`,
-          textAlign: `center`,
-          verticalAlign: `bottom`,
-          width: i === 0 ? 120 : `inherit`,
-          border: 0,
-          color: `textMuted`,
-          bg: `ui.background`,
-          "span:first-of-type": {
-            borderTopLeftRadius: 2,
-            textAlign: `left`,
-          },
-          "&:last-child": {
-            borderTopRightRadius: 2,
-          },
-          [mediaQueries.xs]: {
-            display: `table-cell`,
-            width: 125,
-          },
-          [mediaQueries.md]: {
-            width: 150,
-          },
-          [mediaQueries.lg]: {
-            width: 175,
-          },
-        }}
-      >
-        <span
+export default function headerTop({ columnHeaders }) {
+  return (
+    <tr>
+      {columnHeaders.map((header, i) => (
+        <td
+          key={i}
           sx={{
-            WebkitHyphens: `auto`,
-            MsHyphens: `auto`,
-            hyphens: `auto`,
-            display: `inline-block`,
+            width: [i === 0 ? 120 : `inherit`, 125, 150, 175],
+            ...tdStyles,
           }}
         >
-          {header}
-        </span>
-      </td>
-    ))}
-  </tr>
-)
-
-export default superHeader
+          <span>{header}</span>
+        </td>
+      ))}
+    </tr>
+  )
+}

--- a/www/src/components/features/evaluation-table-section-header-top.js
+++ b/www/src/components/features/evaluation-table-section-header-top.js
@@ -16,6 +16,10 @@ const tdStyles = {
   "&:last-child": {
     borderTopRightRadius: 2,
   },
+  width: [`inherit`, 125, 150, 175],
+  "&:first-of-type": {
+    width: [120, 125, 150, 175],
+  },
   span: {
     WebkitHyphens: `auto`,
     MsHyphens: `auto`,
@@ -28,14 +32,13 @@ const tdStyles = {
   },
 }
 
-export default function headerTop({ columnHeaders }) {
+export default function HeaderTop({ columnHeaders }) {
   return (
     <tr>
       {columnHeaders.map((header, i) => (
         <td
           key={i}
           sx={{
-            width: [i === 0 ? 120 : `inherit`, 125, 150, 175],
             ...tdStyles,
           }}
         >

--- a/www/src/components/features/evaluation-table-section-title.js
+++ b/www/src/components/features/evaluation-table-section-title.js
@@ -2,16 +2,16 @@
 import { jsx } from "theme-ui"
 import PropTypes from "prop-types"
 
-const SectionTitle = props => (
-  <tr css={{ borderBottom: 0 }}>
-    <td css={{ borderBottom: 0 }} colSpan={4}>
-      <h3 sx={{ mt: 6 }}>{props.text}</h3>
-    </td>
-  </tr>
-)
+export default function SectionTitle({ text }) {
+  return (
+    <tr sx={{ borderBottom: 0 }}>
+      <td sx={{ borderBottom: 0 }} colSpan={4}>
+        <h3 sx={{ mt: 6 }}>{text}</h3>
+      </td>
+    </tr>
+  )
+}
 
 SectionTitle.propTypes = {
   text: PropTypes.string,
 }
-
-export default SectionTitle

--- a/www/src/components/features/evaluation-table.js
+++ b/www/src/components/features/evaluation-table.js
@@ -21,7 +21,7 @@ export default function EvaluationTable(props) {
 
   return (
     <div
-      style={{
+      sx={{
         // this should be a table, but that breaks the
         // anchor links on this page due to a bug in the
         // scrolling library
@@ -62,10 +62,8 @@ export default function EvaluationTable(props) {
                             "&:hover": {
                               cursor: j >= 0 ? `pointer` : `inherit`,
                             },
-                            borderBottom: t =>
-                              !showTooltip(s, i)
-                                ? `1px solid ${t.colors.ui.border}`
-                                : `none`,
+                            borderBottom: !showTooltip(s, i) ? 1 : `none`,
+                            borderColor: `ui.border`,
                             minWidth: 40,
                             px: 0,
                             textAlign: `left`,

--- a/www/src/components/features/features-footer.js
+++ b/www/src/components/features/features-footer.js
@@ -1,19 +1,19 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 
-const FeaturesFooter = () => (
-  <p sx={{ fontSize: 1, mt: 8 }}>
-    Want to help keep this information complete, accurate, and up-to-date?
-    Please comment
-    {` `}
-    <a
-      href="https://github.com/gatsbyjs/gatsby/issues/16233"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      here.
-    </a>
-  </p>
-)
-
-export default FeaturesFooter
+export default function featuresFooter() {
+  return (
+    <p sx={{ fontSize: 1, mt: 8 }}>
+      Want to help keep this information complete, accurate, and up-to-date?
+      Please comment
+      {` `}
+      <a
+        href="https://github.com/gatsbyjs/gatsby/issues/16233"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        here.
+      </a>
+    </p>
+  )
+}

--- a/www/src/components/features/features-footer.js
+++ b/www/src/components/features/features-footer.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 
-export default function featuresFooter() {
+export default function FeaturesFooter() {
   return (
     <p sx={{ fontSize: 1, mt: 8 }}>
       Want to help keep this information complete, accurate, and up-to-date?

--- a/www/src/components/features/legend-table.js
+++ b/www/src/components/features/legend-table.js
@@ -3,95 +3,99 @@ import { jsx } from "theme-ui"
 
 import EvaluationCell from "./evaluation-cell"
 
-const LegendTable = () => {
-  const legendBallStyle = {
-    float: `none`,
-    marginLeft: 0,
-    marginRight: 0,
-    display: `inline-block`,
+const legendBallStyle = {
+  float: `none`,
+  ml: 0,
+  mr: 0,
+  display: `inline-block`,
+}
+
+const baseCellStyle = {
+  display: `table-cell`,
+  verticalAlign: `middle`,
+  textAlign: `center`,
+  p: 3,
+}
+
+const legendTableContainerStyle = {
+  border: t => `1px solid ${t.colors.ui.border}`,
+  borderLeft: 0,
+  fontFamily: `heading`,
+}
+
+const legendBallCellStyle = t => {
+  return {
+    ...baseCellStyle,
+    borderLeft: `1px solid ${t.colors.ui.border}`,
+    borderBottom: `1px solid ${t.colors.ui.border}`,
   }
+}
 
-  const legendBallCellStyle = t => {
-    return {
-      display: `table-cell`,
-      verticalAlign: `middle`,
-      textAlign: `center`,
-      padding: 3,
-      borderLeft: `1px solid ${t.colors.ui.border}`,
-      borderBottom: `1px solid ${t.colors.ui.border}`,
-    }
+const legendExplanationCellStyle = t => {
+  return {
+    ...baseCellStyle,
+    borderLeft: `1px solid ${t.colors.ui.border}`,
+    borderBottom: [`1px solid ${t.colors.ui.border}`, null, 0],
   }
+}
 
-  const legendExplanationCellStyle = t => {
-    return {
-      display: `table-cell`,
-      verticalAlign: `middle`,
-      textAlign: `center`,
-      padding: 3,
-      borderLeft: `1px solid ${t.colors.ui.border}`,
-      borderBottom: [`1px solid ${t.colors.ui.border}`, null, 0],
-    }
-  }
+const balls = [
+  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-1`}>
+    <h4 sx={{ m: 0 }}>Icon</h4>
+  </div>,
+  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-2`}>
+    <EvaluationCell num="3" style={legendBallStyle} />
+  </div>,
+  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-3`}>
+    <EvaluationCell num="2" style={legendBallStyle} />
+  </div>,
+  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-4`}>
+    <EvaluationCell num="1" style={legendBallStyle} />
+  </div>,
+  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-5`}>
+    <EvaluationCell num="0" style={legendBallStyle} />
+  </div>,
+]
 
-  const balls = [
-    <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-1`}>
-      <h4 style={{ margin: 0 }}>Icon</h4>
-    </div>,
-    <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-2`}>
-      <EvaluationCell num="3" style={legendBallStyle} />
-    </div>,
-    <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-3`}>
-      <EvaluationCell num="2" style={legendBallStyle} />
-    </div>,
-    <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-4`}>
-      <EvaluationCell num="1" style={legendBallStyle} />
-    </div>,
-    <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-5`}>
-      <EvaluationCell num="0" style={legendBallStyle} />
-    </div>,
-  ]
+const legendText = [
+  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-1`}>
+    <h5 sx={{ m: 0 }}>Feature Availability</h5>
+  </div>,
+  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-2`}>
+    Excellent (fully available)
+  </div>,
+  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-3`}>
+    Good (partially available, e.g. plugins)
+  </div>,
+  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-4`}>
+    Fair (needs customization or limited)
+  </div>,
+  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-5`}>
+    Poor (not possible)
+  </div>,
+]
 
-  const legendText = [
-    <div sx={legendExplanationCellStyle} key={`legendExplanationCell-1`}>
-      <h5 sx={{ m: 0 }}>Feature Availability</h5>
-    </div>,
-    <div sx={legendExplanationCellStyle} key={`legendExplanationCell-2`}>
-      Excellent (fully available)
-    </div>,
-    <div sx={legendExplanationCellStyle} key={`legendExplanationCell-3`}>
-      Good (partially available, e.g. plugins)
-    </div>,
-    <div sx={legendExplanationCellStyle} key={`legendExplanationCell-4`}>
-      Fair (needs customization or limited)
-    </div>,
-    <div sx={legendExplanationCellStyle} key={`legendExplanationCell-5`}>
-      Poor (not possible)
-    </div>,
-  ]
-
+export default function LegendTable() {
   return (
     <div>
       <div
         sx={{
-          border: t => `1px solid ${t.colors.ui.border}`,
-          borderLeft: 0,
-          fontFamily: `heading`,
+          ...legendTableContainerStyle,
           display: [`none`, null, `table`],
+          width: `100%`,
         }}
       >
-        <div css={{ display: `table-row` }}>{balls}</div>
-        <div css={{ display: `table-row` }}>{legendText}</div>
+        <div sx={{ display: `table-row` }}>{balls}</div>
+        <div sx={{ display: `table-row` }}>{legendText}</div>
       </div>
       <div
         sx={{
+          ...legendTableContainerStyle,
           display: [`table`, null, `none`],
-          border: t => `1px solid ${t.colors.ui.border}`,
-          borderLeft: 0,
-          fontFamily: `heading`,
         }}
       >
         {[0, 1, 2, 3, 4].map(i => (
-          <div css={{ display: `table-row` }} key={i}>
+          <div sx={{ display: `table-row` }} key={i}>
             {balls[i]}
             {legendText[i]}
           </div>
@@ -100,5 +104,3 @@ const LegendTable = () => {
     </div>
   )
 }
-
-export default LegendTable

--- a/www/src/components/features/legend-table.js
+++ b/www/src/components/features/legend-table.js
@@ -5,9 +5,8 @@ import EvaluationCell from "./evaluation-cell"
 
 const legendBallStyle = {
   float: `none`,
-  ml: 0,
-  mr: 0,
   display: `inline-block`,
+  mx: 0,
 }
 
 const baseCellStyle = {
@@ -18,25 +17,24 @@ const baseCellStyle = {
 }
 
 const legendTableContainerStyle = {
-  border: t => `1px solid ${t.colors.ui.border}`,
+  border: 1,
   borderLeft: 0,
+  borderColor: `ui.border`,
   fontFamily: `heading`,
 }
 
-const legendBallCellStyle = t => {
-  return {
-    ...baseCellStyle,
-    borderLeft: `1px solid ${t.colors.ui.border}`,
-    borderBottom: `1px solid ${t.colors.ui.border}`,
-  }
+const legendBallCellStyle = {
+  ...baseCellStyle,
+  borderLeft: 1,
+  borderBottom: 1,
+  borderColor: `ui.border`,
 }
 
-const legendExplanationCellStyle = t => {
-  return {
-    ...baseCellStyle,
-    borderLeft: `1px solid ${t.colors.ui.border}`,
-    borderBottom: [`1px solid ${t.colors.ui.border}`, null, 0],
-  }
+const legendExplanationCellStyle = {
+  ...baseCellStyle,
+  borderLeft: 1,
+  borderBottom: [1, null, 0],
+  borderColor: `ui.border`,
 }
 
 const balls = [
@@ -80,8 +78,8 @@ export default function LegendTable() {
     <div>
       <div
         sx={{
-          ...legendTableContainerStyle,
           display: [`none`, null, `table`],
+          ...legendTableContainerStyle,
           width: `100%`,
         }}
       >
@@ -90,8 +88,8 @@ export default function LegendTable() {
       </div>
       <div
         sx={{
-          ...legendTableContainerStyle,
           display: [`table`, null, `none`],
+          ...legendTableContainerStyle,
         }}
       >
         {[0, 1, 2, 3, 4].map(i => (

--- a/www/src/components/features/simple-evaluation-table.js
+++ b/www/src/components/features/simple-evaluation-table.js
@@ -55,7 +55,7 @@ export default function SimpleEvaluationTable(props) {
               </tr>,
               // table row containing details of each feature
               <tr
-                style={{
+                sx={{
                   display: showTooltip(idx) ? `table-row` : `none`,
                 }}
                 key={`feature-second-row-${idx}`}

--- a/www/src/components/features/simple-evaluation-table.js
+++ b/www/src/components/features/simple-evaluation-table.js
@@ -5,6 +5,19 @@ import SectionTitle from "./evaluation-table-section-title"
 import SectionHeaderTop from "./evaluation-table-section-header-top"
 import { renderCell } from "./evaluation-cell"
 
+const tdStyles = {
+  display: `table-cell`,
+  "&:hover": {
+    cursor: `pointer`,
+  },
+  minWidth: 40,
+  px: 0,
+  textAlign: `left`,
+  verticalAlign: `middle`,
+  fontSize: 1,
+  lineHeight: `solid`,
+}
+
 export default function SimpleEvaluationTable(props) {
   const { title, headers, data } = props
   const [featureCell, setFeatureCell] = useState({})
@@ -23,20 +36,11 @@ export default function SimpleEvaluationTable(props) {
                   <td
                     key={`feature-cell-${idx}-${i}`}
                     sx={{
-                      display: `table-cell`,
-                      "&:hover": {
-                        cursor: `pointer`,
-                      },
+                      ...tdStyles,
                       borderBottom: t =>
                         !showTooltip(idx)
                           ? `1px solid ${t.colors.ui.border}`
                           : `none`,
-                      minWidth: 40,
-                      px: 0,
-                      textAlign: `left`,
-                      verticalAlign: `middle`,
-                      fontSize: 1,
-                      lineHeight: `solid`,
                     }}
                     onClick={() => {
                       setFeatureCell({


### PR DESCRIPTION
## Description

Refactors the following components

1. legend-table
2. evaluation-table-section-title
3. evaluation-table-section-header-top
4. evaluation-table-section-header-bottom
5. simple-evaluation-table
6. features-footer

### Screenshots(s)

<img width="512" alt="table-components-1" src="https://user-images.githubusercontent.com/19193724/85925516-7bdf1e80-b8b6-11ea-8488-a2f7c8e7d17a.png">
<img width="512" alt="table-components-2" src="https://user-images.githubusercontent.com/19193724/85925517-7f72a580-b8b6-11ea-834c-e69f922eace3.png">


### How to test

Go to the following link mentioned below, the component should work same in both the local and production link, just the implementation of component is now different.

**Local URL:** http://localhost:8000/features/
**Production URL:** https://www.gatsbyjs.org/features/