### PR TITLE
enhancement(docs): dictionary.txt -> with-layout2 -> Remove file name from image alt text and dictionary

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -2117,7 +2117,6 @@ wireframe-level
 Wirth
 Wiseman
 wishlist
-with-layout2
 with-navigation2
 Woah
 WooCommerce

--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -135,7 +135,7 @@ export default function Home() {
 }
 ```
 
-![with-layout2](with-layout2.png)
+![Screenshot of a Gatsby page with a centered column of text](with-layout2.png)
 
 Sweet. You've installed and configured your very first Gatsby plugin!
 
@@ -218,7 +218,7 @@ export default function Home() {
 }
 ```
 
-![with-layout2](with-layout2.png)
+![Screenshot of a Gatsby page with a centered column of text](with-layout2.png)
 
 Sweet, the layout is working! The content of your index page is still centered.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,7 +5922,7 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@*", "@types/webpack@4.41.18", "@types/webpack@^4.41.18":
+"@types/webpack@*", "@types/webpack@^4.41.18":
   version "4.41.18"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.18.tgz#2945202617866ecdffa582087f1b6de04a7eed55"
   integrity sha512-mQm2R8vV2BZE/qIDVYqmBVLfX73a8muwjs74SpjEyJWJxeXBbsI9L65Pcia9XfYLYWzD1c1V8m+L0p30y2N7MA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,7 +5922,7 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@*", "@types/webpack@^4.41.18":
+"@types/webpack@*", "@types/webpack@4.41.18", "@types/webpack@^4.41.18":
   version "4.41.18"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.18.tgz#2945202617866ecdffa582087f1b6de04a7eed55"
   integrity sha512-mQm2R8vV2BZE/qIDVYqmBVLfX73a8muwjs74SpjEyJWJxeXBbsI9L65Pcia9XfYLYWzD1c1V8m+L0p30y2N7MA==


### PR DESCRIPTION
## Description

This removes "with-layout2" from the dictionary and replace "with-layout2" in alt texts with a more descriptive phrase.

### Documentation

No documentation is required for this.

## Related Issues

Addresses #25290.
