### PR TITLE
fix(gatsby-design-tokens): yarn run watch broken

### DIFF
--- a/packages/gatsby-design-tokens/package.json
+++ b/packages/gatsby-design-tokens/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "npm run build:tokens && npm run build:theme && npm run build:theme-gatsbyjs-org",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "microbundle watch {src/index.js,src/theme.js,src/theme-gatsbyjs-org.js} --sourcemap=false -f es,cjs",
+    "watch": "microbundle watch src/index.js src/theme.js src/theme-gatsbyjs-org.js --sourcemap=false -f es,cjs",
     "build:tokens": "(microbundle build --sourcemap=false -f es,cjs && agadoo dist/index.esm.js) || node -e \"console.log('\\nMicrobundle failed, make sure you\\'re using node version 10.16 or higher\\n');process.exit(1)\"",
     "build:theme": "(microbundle build src/theme.js -o dist/theme.js --sourcemap=false -f es,cjs) || node -e \"console.log('\\nMicrobundle failed, make sure you\\'re using node version 10.16 or higher\\n');process.exit(1)\"",
     "build:theme-gatsbyjs-org": "(microbundle build src/theme-gatsbyjs-org.js -o dist/theme-gatsbyjs-org.js --sourcemap=false -f es,cjs) || node -e \"console.log('\\nMicrobundle failed, make sure you\\'re using node version 10.16 or higher\\n');process.exit(1)\""


### PR DESCRIPTION
## Description

Running `yarn run watch` on Gatsby is currently broken. This is because `microbundle` 0.12.2 does not seem to support being passed regexps on the command line anymore; replacing files specified as regexps by a list of time.

## Related Issues

Fixes #25368 