### PR TITLE
fix(gatsby-image): add required check for one of fluid or fixed

### DIFF
--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -49,6 +49,8 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
 </div>
 `;
 
+exports[`<Image /> should not not render anything if called without parameters 1`] = `<div />`;
+
 exports[`<Image /> should render fixed size images 1`] = `
 <div>
   <div

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -49,8 +49,6 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
 </div>
 `;
 
-exports[`<Image /> should not not render anything if called without parameters 1`] = `<div />`;
-
 exports[`<Image /> should render fixed size images 1`] = `
 <div>
   <div

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -220,6 +220,12 @@ describe(`<Image />`, () => {
     expect(console.warn).toBeCalled()
   })
 
+  it(`should not not render anything if called without parameters`, () => {
+    const { container } = render(<Image />)
+
+    expect(container).toMatchSnapshot()
+  })
+
   it(`should select the correct mocked image of fluid variants provided.`, () => {
     const tripleFluidImageShapeMock = fluidImagesShapeMock.concat({
       aspectRatio: 5,

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -225,7 +225,9 @@ describe(`<Image />`, () => {
 
     render(<Image fixed={null} />)
 
-    expect(console.warn).toBeCalled()
+    expect(console.warn).toBeCalledWith(
+      expect.stringContaining(`expects a 'fixed'`)
+    )
   })
 
   it(`should select the correct mocked image of fluid variants provided.`, () => {

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -221,12 +221,14 @@ describe(`<Image />`, () => {
   })
 
   it(`should warn if missing both fixed and fluid props`, () => {
-    jest.spyOn(global.console, `warn`)
+    jest.spyOn(global.console, `error`)
 
     render(<Image fixed={null} />)
 
-    expect(console.warn).toBeCalledWith(
-      expect.stringContaining(`expects a 'fixed'`)
+    expect(console.error).toBeCalledWith(
+      expect.stringContaining(
+        `The prop \`fluid\` or \`fixed\` is marked as required`
+      )
     )
   })
 

--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -220,10 +220,12 @@ describe(`<Image />`, () => {
     expect(console.warn).toBeCalled()
   })
 
-  it(`should not not render anything if called without parameters`, () => {
-    const { container } = render(<Image />)
+  it(`should warn if missing both fixed and fluid props`, () => {
+    jest.spyOn(global.console, `warn`)
 
-    expect(container).toMatchSnapshot()
+    render(<Image fixed={null} />)
+
+    expect(console.warn).toBeCalled()
   })
 
   it(`should select the correct mocked image of fluid variants provided.`, () => {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -71,7 +71,7 @@ const matchesMedia = ({ media }) =>
  * Find the source of an image to use as a key in the image cache.
  * Use `the first image in either `fixed` or `fluid`
  * @param {{fluid: {src: string, media?: string}[], fixed: {src: string, media?: string}[]}} args
- * @return {string} or undefined if not cacheable
+ * @return {string?} Returns image src or undefined it not given.
  */
 const getImageCacheKey = ({ fluid, fixed }) => {
   const srcData = getCurrentSrcData(fluid || fixed || [])

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -334,7 +334,7 @@ class Image extends React.Component {
   constructor(props) {
     super(props)
 
-    if (process.env.NODE_ENV === `production`) {
+    if (process.env.NODE_ENV !== `production`) {
       this.validateProps(props)
     }
 

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -71,7 +71,7 @@ const matchesMedia = ({ media }) =>
  * Find the source of an image to use as a key in the image cache.
  * Use `the first image in either `fixed` or `fluid`
  * @param {{fluid: {src: string, media?: string}[], fixed: {src: string, media?: string}[]}} args
- * @return {string} or null if not cacheable
+ * @return {string} or undefined if not cacheable
  */
 const getImageCacheKey = ({ fluid, fixed }) => {
   const srcData = getCurrentSrcData(fluid || fixed || [])

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -330,12 +330,22 @@ Img.propTypes = {
   onLoad: PropTypes.func,
 }
 
+// Intentionally not an instance method because webpack is not able to
+// three-shake it away in production
+function validateImageProps({ fluid, fixed }) {
+  if (!fluid && !fixed) {
+    console.warn(
+      `gatsby-image expects a 'fixed' or a 'fluid' prop; neither was present.`
+    )
+  }
+}
+
 class Image extends React.Component {
   constructor(props) {
     super(props)
 
     if (process.env.NODE_ENV !== `production`) {
-      this.validateProps(props)
+      validateImageProps(props)
     }
 
     // If this image has already been loaded before then we can assume it's
@@ -366,14 +376,6 @@ class Image extends React.Component {
     this.placeholderRef = props.placeholderRef || React.createRef()
     this.handleImageLoaded = this.handleImageLoaded.bind(this)
     this.handleRef = this.handleRef.bind(this)
-  }
-
-  validateProps({ fluid, fixed }) {
-    if (!fluid && !fixed) {
-      console.warn(
-        `gatsby-image expects a 'fixed' or a 'fluid' prop; neither was present.`
-      )
-    }
   }
 
   componentDidMount() {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -74,9 +74,9 @@ const matchesMedia = ({ media }) =>
  * @return {string}
  */
 const getImageSrcKey = ({ fluid, fixed }) => {
-  const data = fluid ? getCurrentSrcData(fluid) : getCurrentSrcData(fixed)
+  const currentData = fluid || fixed
 
-  return data.src
+  return currentData && getCurrentSrcData(currentData).src
 }
 
 /**

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -368,9 +368,7 @@ class Image extends React.Component {
     this.handleRef = this.handleRef.bind(this)
   }
 
-  validateProps(props) {
-    const { fluid, fixed } = props
-
+  validateProps({ fluid, fixed }) {
     if (!fluid && !fixed) {
       console.warn(
         `gatsby-image expects a 'fixed' or a 'fluid' prop; neither was present.`


### PR DESCRIPTION
## Description

Prevents the rendering from crashing if Gatsby image is called without any parameters. The error message that was printed before this change was not helpful to users.

## Related Issues

Fixes #25370