### PR TITLE
fix(gatsby-transformer-documentationjs) Add  many: true to @childOf declaration in DocumentationJS

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -46,7 +46,7 @@ exports.sourceNodes = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = /* GraphQL */ `
     type DocumentationJs implements Node
-      @childOf(types: ["File", "DocumentationJs"]) {
+      @childOf(types: ["File", "DocumentationJs"], many: true) {
       name: String
       kind: String
       memberof: String

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -86,7 +86,7 @@ exports.sourceNodes = ({ actions }) => {
     }
 
     type DocumentationJSComponentDescription implements Node
-      @mimeTypes(types: ["text/markdown", "text/x-markdown"]) {
+      @mimeTypes(types: ["text/markdown"]) {
       id: ID! # empty type
     }
 

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -86,7 +86,7 @@ exports.sourceNodes = ({ actions }) => {
     }
 
     type DocumentationJSComponentDescription implements Node
-      @mimeTypes(types: ["text/markdown"]) {
+      @mimeTypes(types: ["text/markdown", "text/x-markdown"]) {
       id: ID! # empty type
     }
 


### PR DESCRIPTION
## Description

Followup of #25113. Fix the `@childOf` declaration in the `DocumentationJs` type so that the parent types properly get `childrenDocumentationJs` instead of `childDocumentationJs`.