### PR TITLE
refactor(www): Rearrange node apis in gatsby-node by build step

### DIFF
--- a/www/src/utils/node/creators.js
+++ b/www/src/utils/node/creators.js
@@ -23,6 +23,29 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
   `)
 }
 
+exports.onCreateNode = ({ node, actions }) => {
+  const { createNodeField } = actions
+  let slug
+  if (node.internal.type === `CreatorsYaml`) {
+    // Creator pages
+    const validTypes = {
+      individual: `people`,
+      agency: `agencies`,
+      company: `companies`,
+    }
+
+    if (!validTypes[node.type]) {
+      throw new Error(
+        `Creators must have a type of “individual”, “agency”, or “company”, but invalid type “${node.type}” was provided for ${node.name}.`
+      )
+    }
+    slug = `/creators/${validTypes[node.type]}/${slugify(node.name, {
+      lower: true,
+    })}`
+    createNodeField({ node, name: `slug`, value: slug })
+  }
+}
+
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions
 
@@ -54,27 +77,4 @@ exports.createPages = async ({ graphql, actions }) => {
       },
     })
   })
-}
-
-exports.onCreateNode = ({ node, actions }) => {
-  const { createNodeField } = actions
-  let slug
-  if (node.internal.type === `CreatorsYaml`) {
-    // Creator pages
-    const validTypes = {
-      individual: `people`,
-      agency: `agencies`,
-      company: `companies`,
-    }
-
-    if (!validTypes[node.type]) {
-      throw new Error(
-        `Creators must have a type of “individual”, “agency”, or “company”, but invalid type “${node.type}” was provided for ${node.name}.`
-      )
-    }
-    slug = `/creators/${validTypes[node.type]}/${slugify(node.name, {
-      lower: true,
-    })}`
-    createNodeField({ node, name: `slug`, value: slug })
-  }
 }

--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -99,6 +99,57 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
   `)
 }
 
+exports.onCreateNode = async ({
+  node,
+  actions,
+  getNode,
+  loadNodeContent,
+  createNodeId,
+  createContentDigest,
+}) => {
+  const { createNode, createParentChildLink, createNodeField } = actions
+
+  if (isCodeFile(node)) {
+    const calls = await findApiCalls({ node, loadNodeContent })
+    if (calls.length > 0) {
+      calls.forEach(call => {
+        const apiCallNode = {
+          id: createNodeId(`findApiCalls-${JSON.stringify(call)}`),
+          parent: node.id,
+          children: [],
+          ...call,
+          internal: {
+            type: `GatsbyAPICall`,
+          },
+        }
+        apiCallNode.internal.contentDigest = createContentDigest(apiCallNode)
+
+        createNode(apiCallNode)
+        createParentChildLink({ parent: node, child: apiCallNode })
+      })
+    }
+    return
+  }
+
+  const slug = getMdxContentSlug(node, getNode(node.parent))
+  if (!slug) return
+
+  const locale = `en`
+  const section = slug.split(`/`)[1]
+  // fields for blog pages are handled in `utils/node/blog.js`
+  if (section === `blog`) return
+
+  // Add slugs and other fields for docs pages
+  if (slug) {
+    createNodeField({ node, name: `anchor`, value: slugToAnchor(slug) })
+    createNodeField({ node, name: `slug`, value: slug })
+    createNodeField({ node, name: `section`, value: section })
+  }
+  if (locale) {
+    createNodeField({ node, name: `locale`, value: locale })
+  }
+}
+
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions
 
@@ -162,55 +213,4 @@ exports.createPages = async ({ graphql, actions }) => {
       })
     }
   })
-}
-
-exports.onCreateNode = async ({
-  node,
-  actions,
-  getNode,
-  loadNodeContent,
-  createNodeId,
-  createContentDigest,
-}) => {
-  const { createNode, createParentChildLink, createNodeField } = actions
-
-  if (isCodeFile(node)) {
-    const calls = await findApiCalls({ node, loadNodeContent })
-    if (calls.length > 0) {
-      calls.forEach(call => {
-        const apiCallNode = {
-          id: createNodeId(`findApiCalls-${JSON.stringify(call)}`),
-          parent: node.id,
-          children: [],
-          ...call,
-          internal: {
-            type: `GatsbyAPICall`,
-          },
-        }
-        apiCallNode.internal.contentDigest = createContentDigest(apiCallNode)
-
-        createNode(apiCallNode)
-        createParentChildLink({ parent: node, child: apiCallNode })
-      })
-    }
-    return
-  }
-
-  const slug = getMdxContentSlug(node, getNode(node.parent))
-  if (!slug) return
-
-  const locale = `en`
-  const section = slug.split(`/`)[1]
-  // fields for blog pages are handled in `utils/node/blog.js`
-  if (section === `blog`) return
-
-  // Add slugs and other fields for docs pages
-  if (slug) {
-    createNodeField({ node, name: `anchor`, value: slugToAnchor(slug) })
-    createNodeField({ node, name: `slug`, value: slug })
-    createNodeField({ node, name: `section`, value: section })
-  }
-  if (locale) {
-    createNodeField({ node, name: `locale`, value: locale })
-  }
 }

--- a/www/src/utils/node/packages.js
+++ b/www/src/utils/node/packages.js
@@ -5,6 +5,23 @@ const { plugins: featuredPlugins } = loadYaml(
   `src/data/ecosystem/featured-items.yaml`
 )
 
+exports.onCreateNode = ({ node, actions }) => {
+  const { createNodeField } = actions
+  if (node.internal.type === `NPMPackage`) {
+    createNodeField({
+      node,
+      name: `featured`,
+      value: featuredPlugins.includes(node.name),
+    })
+
+    createNodeField({
+      node,
+      name: `official`,
+      value: isOfficialPackage(node),
+    })
+  }
+}
+
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions
 
@@ -35,21 +52,4 @@ exports.createPages = async ({ graphql, actions }) => {
       },
     })
   })
-}
-
-exports.onCreateNode = ({ node, actions }) => {
-  const { createNodeField } = actions
-  if (node.internal.type === `NPMPackage`) {
-    createNodeField({
-      node,
-      name: `featured`,
-      value: featuredPlugins.includes(node.name),
-    })
-
-    createNodeField({
-      node,
-      name: `official`,
-      value: isOfficialPackage(node),
-    })
-  }
 }

--- a/www/src/utils/node/showcase.js
+++ b/www/src/utils/node/showcase.js
@@ -30,6 +30,24 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
   `)
 }
 
+exports.onCreateNode = ({ node, actions, getNode }) => {
+  const { createNodeField } = actions
+  let slug
+  if (node.internal.type === `SitesYaml` && node.main_url) {
+    const parsed = url.parse(node.main_url)
+    const cleaned = parsed.hostname + parsed.pathname
+    slug = `/showcase/${slugify(cleaned)}`
+    createNodeField({ node, name: `slug`, value: slug })
+
+    // determine if screenshot is available
+    const screenshotNode = node.children
+      .map(childID => getNode(childID))
+      .find(node => node.internal.type === `Screenshot`)
+
+    createNodeField({ node, name: `hasScreenshot`, value: !!screenshotNode })
+  }
+}
+
 exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
 
@@ -67,22 +85,4 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       },
     })
   })
-}
-
-exports.onCreateNode = ({ node, actions, getNode }) => {
-  const { createNodeField } = actions
-  let slug
-  if (node.internal.type === `SitesYaml` && node.main_url) {
-    const parsed = url.parse(node.main_url)
-    const cleaned = parsed.hostname + parsed.pathname
-    slug = `/showcase/${slugify(cleaned)}`
-    createNodeField({ node, name: `slug`, value: slug })
-
-    // determine if screenshot is available
-    const screenshotNode = node.children
-      .map(childID => getNode(childID))
-      .find(node => node.internal.type === `Screenshot`)
-
-    createNodeField({ node, name: `hasScreenshot`, value: !!screenshotNode })
-  }
 }

--- a/www/src/utils/node/starters.js
+++ b/www/src/utils/node/starters.js
@@ -62,56 +62,6 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
   `)
 }
 
-exports.createPages = async ({ graphql, actions, reporter }) => {
-  const { createPage } = actions
-
-  const starterTemplate = getTemplate(`template-starter-page`)
-
-  const { data, errors } = await graphql(/* GraphQL */ `
-    query {
-      allStartersYaml {
-        nodes {
-          id
-          fields {
-            starterShowcase {
-              slug
-            }
-            hasScreenshot
-          }
-          url
-          repo
-        }
-      }
-    }
-  `)
-  if (errors) throw errors
-
-  // Create starter pages.
-  const starters = _.filter(data.allStartersYaml.nodes, node => {
-    const slug = _.get(node, `fields.starterShowcase.slug`)
-    if (!slug) {
-      return null
-    } else if (!_.get(node, `fields.hasScreenshot`)) {
-      reporter.warn(
-        `Starter showcase entry "${node.repo}" seems offline. Skipping.`
-      )
-      return null
-    } else {
-      return node
-    }
-  })
-
-  starters.forEach(node => {
-    createPage({
-      path: `/starters${node.fields.starterShowcase.slug}`,
-      component: starterTemplate,
-      context: {
-        slug: node.fields.starterShowcase.slug,
-      },
-    })
-  })
-}
-
 const fetchGithubData = async ({ owner, repo, reporter }, retry = 0) =>
   githubApiClient
     .request(
@@ -262,4 +212,54 @@ exports.onCreateNode = ({ node, actions, getNode, reporter }) => {
         })
     }
   }
+}
+
+exports.createPages = async ({ graphql, actions, reporter }) => {
+  const { createPage } = actions
+
+  const starterTemplate = getTemplate(`template-starter-page`)
+
+  const { data, errors } = await graphql(/* GraphQL */ `
+    query {
+      allStartersYaml {
+        nodes {
+          id
+          fields {
+            starterShowcase {
+              slug
+            }
+            hasScreenshot
+          }
+          url
+          repo
+        }
+      }
+    }
+  `)
+  if (errors) throw errors
+
+  // Create starter pages.
+  const starters = _.filter(data.allStartersYaml.nodes, node => {
+    const slug = _.get(node, `fields.starterShowcase.slug`)
+    if (!slug) {
+      return null
+    } else if (!_.get(node, `fields.hasScreenshot`)) {
+      reporter.warn(
+        `Starter showcase entry "${node.repo}" seems offline. Skipping.`
+      )
+      return null
+    } else {
+      return node
+    }
+  })
+
+  starters.forEach(node => {
+    createPage({
+      path: `/starters${node.fields.starterShowcase.slug}`,
+      component: starterTemplate,
+      context: {
+        slug: node.fields.starterShowcase.slug,
+      },
+    })
+  })
 }


### PR DESCRIPTION
## Description

Rearrange the various node APIs in www by the their step in the build process, so e.g. `onCreateNode` comes before `createPages`.