### PR TITLE
fix: add alt text to blog avatar image

### DIFF
--- a/www/src/templates/template-blog-post.js
+++ b/www/src/templates/template-blog-post.js
@@ -69,6 +69,7 @@ class BlogPostTemplate extends React.Component {
                       image={
                         post.frontmatter.author.avatar.childImageSharp.fixed
                       }
+                      alt={post.frontmatter.author.id}
                       overrideCSS={{ mr: 5 }}
                     />
                   </Link>


### PR DESCRIPTION
## Description

I ran the axe extension against my most recent blog post about accessibility, and found a quick win with the blog avatar image which was missing alt text. Now the link wrapping it will have alternative text and be more usable in assistive tech!

### Documentation

N/A

## Related Issues

N/A