### PR TITLE
feat(gatsby-plugin-offline): Import idb-keyval as it does for workBox

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -168,9 +168,14 @@ exports.onPostBuild = (
   const idbKeyvalFile = `idb-keyval-iife.min.js`
   const idbKeyvalSource = require.resolve(`idb-keyval/dist/${idbKeyvalFile}`)
   const idbKeyvalPackageJson = require(`idb-keyval/package.json`)
-  const idbKeyValVersioned = `idb-keyval-${idbKeyvalPackageJson.version}-iife.min.js`
+  let idbKeyValVersioned = `idb-keyval-${idbKeyvalPackageJson.version}-iife.min.js`
   const idbKeyvalDest = `public/${idbKeyValVersioned}`
-  fs.createReadStream(idbKeyvalSource).pipe(fs.createWriteStream(idbKeyvalDest))
+  
+  if (combinedOptions.importWorkboxFrom === `cdn`) {
+    idbKeyValVersioned = `https://cdn.jsdelivr.net/npm/idb-keyval@${idbKeyvalPackageJson}/dist/${idbKeyvalFile}`
+  } else {
+    fs.createReadStream(idbKeyvalSource).pipe(fs.createWriteStream(idbKeyvalDest))
+  }
 
   const swDest = `public/sw.js`
   return workboxBuild


### PR DESCRIPTION
Make importing idb-keyval honor importWorkboxFrom config.

Using `appendScript` approach don't solve this because of template string replacing (L#200).


## Description

It makes importation of idb-keyval honor the `options` defined for workBox;

### Documentation

https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-offline/README.md#available-options

## Related Issues

No issue opened.
