### PR TITLE
fix(gatsby-plugin-feed): onPostBuild to onPreBuild

### DIFF
--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -24,7 +24,7 @@ const serialize = ({ query: { site, allMarkdownRemark } }) =>
       description: edge.node.excerpt,
       url: site.siteMetadata.siteUrl + edge.node.fields.slug,
       guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
-      custom_elements: [{ "content:encoded": edge.node.html }]
+      custom_elements: [{ "content:encoded": edge.node.html }],
     }
   })
 
@@ -78,7 +78,7 @@ exports.onPreBuild = async ({ graphql }, pluginOptions) => {
    */
   const options = {
     ...defaultOptions,
-    ...pluginOptions
+    ...pluginOptions,
   }
 
   const baseQuery = await runQuery(graphql, options.query)
@@ -92,7 +92,7 @@ exports.onPreBuild = async ({ graphql }, pluginOptions) => {
 
     const { setup, ...locals } = {
       ...options,
-      ...feed
+      ...feed,
     }
 
     const serializer =

--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -24,7 +24,7 @@ const serialize = ({ query: { site, allMarkdownRemark } }) =>
       description: edge.node.excerpt,
       url: site.siteMetadata.siteUrl + edge.node.fields.slug,
       guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
-      custom_elements: [{ "content:encoded": edge.node.html }],
+      custom_elements: [{ "content:encoded": edge.node.html }]
     }
   })
 
@@ -71,14 +71,14 @@ exports.onPreBootstrap = async function onPreBootstrap(
   }
 }
 
-exports.onPostBuild = async ({ graphql }, pluginOptions) => {
+exports.onPreBuild = async ({ graphql }, pluginOptions) => {
   /*
    * Run the site settings query to gather context, then
    * then run the corresponding feed for each query.
    */
   const options = {
     ...defaultOptions,
-    ...pluginOptions,
+    ...pluginOptions
   }
 
   const baseQuery = await runQuery(graphql, options.query)
@@ -92,7 +92,7 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
 
     const { setup, ...locals } = {
       ...options,
-      ...feed,
+      ...feed
     }
 
     const serializer =


### PR DESCRIPTION
## Description

Changes the Node API lifecycle method from `onPostBuild` to `onPreBuild`.  I am aware that this is likely not possible but I was running into some odd behaviour when querying images in the feed, particularly when using nested theme structures and this fixed it for me. In simple terms I think it allowed the image transformations to happen appropriately in the build timeline versus causing some issues when it was happening at the very end of the build process. 

## Related Issues

See #25407 for details and a longer write up.

