### PR TITLE
maintenance(www): Remove schema overrides for documentationJS

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -64,7 +64,7 @@
     "gatsby-source-git": "^1.1.0",
     "gatsby-source-npm-package-search": "^2.3.8",
     "gatsby-transformer-csv": "^2.3.6",
-    "gatsby-transformer-documentationjs": "^4.3.7",
+    "gatsby-transformer-documentationjs": "^4.3.8",
     "gatsby-transformer-gitinfo": "^1.1.0",
     "gatsby-transformer-remark": "^2.8.20",
     "gatsby-transformer-screenshot": "^2.3.12",

--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -63,7 +63,6 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
     }
 
     type File implements Node {
-      childrenDocumentationJs: DocumentationJs
       fields: FileFields
     }
 
@@ -73,10 +72,6 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
       gitLogLatestDate: Date @dateformat
       gitLogLatestAuthorName: String
       gitLogLatestAuthorEmail: String
-    }
-
-    type DocumentationJSComponentDescription implements Node {
-      childMdx: Mdx
     }
 
     type GatsbyAPICall implements Node @derivedTypes @dontInfer {


### PR DESCRIPTION
## Description

Remove the handwritten schema overrides for DocumentationJS nodes in www. This allows us to turn www into a plugin while still being flexible with whether sources exist or not.

## Related Issues

Follow-up of #25113 #25394 #25112.