### PR TITLE
fix(blog): Gatsby Partner program - add links back to Pullquote

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1577,6 +1577,7 @@ Prskavec
 pseudo-gamifying
 Publica
 publicURL
+Pullquote
 pullquotes
 PurgeCSS
 PurifyCSS

--- a/docs/blog/2020-06-22-Announcing-Gatsby-Partner-Program/index.md
+++ b/docs/blog/2020-06-22-Announcing-Gatsby-Partner-Program/index.md
@@ -26,7 +26,14 @@ Agencies are challenged to meet the needs of diverse clients while trying to opt
 - **Training:** Have confidence that you’re getting the most out of Gatsby by accessing training materials and a connection with the Gatsby team.
 - **Certification:** Leverage Gatsby’s brand to elevate your business and give clients confidence they’re working with a Gatsby certified agency.
 
-<Pullquote citation="Dennis Brotzky, Founding Partner, Narative">
+<Pullquote
+  citation={
+    <span>
+      Dennis Brotzky, Founding Partner,{" "}
+      <a href="https://www.narative.co/">Narative</a>
+    </span>
+  }
+>
   “Partnering with Gatsby has been a strong driver for growth. Our clients love
   the performance benefits and our developers are happy to use tools they
   already love.”
@@ -44,7 +51,14 @@ In this API-driven world, developers want to use the best tool for the job and t
 - **Grow with Gatsby:** Tap into the extensive and evolving Gatsby ecosystem by connecting with one of the most exciting and popular website frameworks around.
 - **Increase usage and sales:** Build a first-class experience for developers to increase usage and sales.
 
-<Pullquote citation="Kevin Zellmer, VP of Partnerships, Contentful">
+<Pullquote
+  citation={
+    <span>
+      Kevin Zellmer, VP of Partnerships,{" "}
+      <a href="https://www.contentful.com/">Contentful</a>
+    </span>
+  }
+>
   "Partnering with Gatsby as a first-class integration partner has been a huge
   benefit to Contentful’s customers. This partnership helps our customers
   seamlessly improve site speed and SEO performance, leading to a better

--- a/docs/blog/2020-06-22-Announcing-Gatsby-Partner-Program/index.md
+++ b/docs/blog/2020-06-22-Announcing-Gatsby-Partner-Program/index.md
@@ -26,14 +26,7 @@ Agencies are challenged to meet the needs of diverse clients while trying to opt
 - **Training:** Have confidence that you’re getting the most out of Gatsby by accessing training materials and a connection with the Gatsby team.
 - **Certification:** Leverage Gatsby’s brand to elevate your business and give clients confidence they’re working with a Gatsby certified agency.
 
-<Pullquote
-  citation={
-    <span>
-      Dennis Brotzky, Founding Partner,{" "}
-      <a href="https://www.narative.co/">Narative</a>
-    </span>
-  }
->
+<Pullquote citation={<span>Dennis Brotzky, Founding Partner, <a href="https://www.narative.co/">Narative</a></span>}>
   “Partnering with Gatsby has been a strong driver for growth. Our clients love
   the performance benefits and our developers are happy to use tools they
   already love.”
@@ -51,14 +44,7 @@ In this API-driven world, developers want to use the best tool for the job and t
 - **Grow with Gatsby:** Tap into the extensive and evolving Gatsby ecosystem by connecting with one of the most exciting and popular website frameworks around.
 - **Increase usage and sales:** Build a first-class experience for developers to increase usage and sales.
 
-<Pullquote
-  citation={
-    <span>
-      Kevin Zellmer, VP of Partnerships,{" "}
-      <a href="https://www.contentful.com/">Contentful</a>
-    </span>
-  }
->
+<Pullquote citation={<span>Kevin Zellmer, VP of Partnerships, <a  href="https://www.contentful.com/">Contentful</a></span>}>
   "Partnering with Gatsby as a first-class integration partner has been a huge
   benefit to Contentful’s customers. This partnership helps our customers
   seamlessly improve site speed and SEO performance, leading to a better

--- a/docs/blog/2020-06-22-Announcing-Gatsby-Partner-Program/index.md
+++ b/docs/blog/2020-06-22-Announcing-Gatsby-Partner-Program/index.md
@@ -26,6 +26,7 @@ Agencies are challenged to meet the needs of diverse clients while trying to opt
 - **Training:** Have confidence that you’re getting the most out of Gatsby by accessing training materials and a connection with the Gatsby team.
 - **Certification:** Leverage Gatsby’s brand to elevate your business and give clients confidence they’re working with a Gatsby certified agency.
 
+<!-- prettier-ignore -->
 <Pullquote citation={<span>Dennis Brotzky, Founding Partner, <a href="https://www.narative.co/">Narative</a></span>}>
   “Partnering with Gatsby has been a strong driver for growth. Our clients love
   the performance benefits and our developers are happy to use tools they
@@ -44,6 +45,7 @@ In this API-driven world, developers want to use the best tool for the job and t
 - **Grow with Gatsby:** Tap into the extensive and evolving Gatsby ecosystem by connecting with one of the most exciting and popular website frameworks around.
 - **Increase usage and sales:** Build a first-class experience for developers to increase usage and sales.
 
+<!-- prettier-ignore -->
 <Pullquote citation={<span>Kevin Zellmer, VP of Partnerships, <a  href="https://www.contentful.com/">Contentful</a></span>}>
   "Partnering with Gatsby as a first-class integration partner has been a huge
   benefit to Contentful’s customers. This partnership helps our customers


### PR DESCRIPTION
## Description

changes:
- bring back the links to Pullquote

## Note

- for the linter the JSX components in the MDX items should be on one line - otherwise the closing `>` would be count as quote start marker and get lint errors
- should be fixed with `remark-mdx` implemented (#25290), because now the remark plugin don't know about the JSX components

## Related Issues

- #25173 `Blog: Announcing partner program` 
- #25239 ``fix(blog): Broken link in "Partner Program" article, use `Pullquote` ``
- #25240 ``[www/blog] Allow Markdown in `<Pullquote citation>` ``
- #25251 ``chore(blog): Bring back links in `Pullquote citation` ```
- #25256 ``Revert "chore(blog): Bring back links in `Pullquote citation`" ``
- #25290 `enhancement (docs): Improvements to retext-spell`  *(part: implement `remark-mdx`)*