### PR TITLE
fix(blog): Partner Program - remove markdown links from email

### DIFF
--- a/docs/blog/2020-06-22-Announcing-Gatsby-Partner-Program/index.md
+++ b/docs/blog/2020-06-22-Announcing-Gatsby-Partner-Program/index.md
@@ -100,4 +100,4 @@ Details on Agency Partner tiers can be found on the [Agency Partner Program page
 
 **Will the partner program include a revenue share?**
 
-Yes. Agency partners will be able to earn a % of revenue from unique referrals they submit that are successfully won. Referred leads will be managed in the partner portal. Technology partners interested in joint sales should reach out to [partners@gatsbyjs.com](mailto:partners@gatsbyjs.com).
+Yes. Agency partners will be able to earn a % of revenue from unique referrals they submit that are successfully won. Referred leads will be managed in the partner portal. Technology partners interested in joint sales should reach out to partners@gatsbyjs.com.


### PR DESCRIPTION
## Description

changes:
- unify email to be same like in line 75
- no need for markdown syntax around emails


## Related Issues

- #25173 `Blog: Announcing partner program` 
- 38eed44 `Fix linting`
- #25198 `fix(blog): Mail link in partner program` 