### PR TITLE
chore: Add eslint rule exception for `Machine()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
     "react/prop-types": "off",
     "require-jsdoc": "off",
     "valid-jsdoc": "off",
+    "new-cap": ["error", { capIsNewExceptions: ["Machine"] }],
   },
   overrides: [
     {


### PR DESCRIPTION
Adds an [ESLint rule exception](https://eslint.org/docs/rules/new-cap#capisnewexceptions) to allow an initial cap when calling the xstate function `Machine()`, which we will be using a lot. We currently have a rule that bans function names with an initial cap except when instantiating objects.