### PR TITLE
perf(gatsby-plugin-mdx): prevent babel parse step at sourcing time

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
@@ -6,7 +6,7 @@ const { createContentDigest } = require(`gatsby-core-utils`)
 const defaultOptions = require(`../utils/default-options`)
 const createMDXNode = require(`../utils/create-mdx-node`)
 const { MDX_SCOPES_LOCATION } = require(`../constants`)
-const genMDX = require(`../utils/gen-mdx`)
+const { findImports } = require(`../utils/gen-mdx`)
 
 const contentDigest = val => createContentDigest(val)
 
@@ -56,22 +56,19 @@ module.exports = async (
   createParentChildLink({ parent: node, child: mdxNode })
 
   // write scope files into .cache for later consumption
-  const { scopeImports, scopeIdentifiers } = await genMDX(
-    {
-      node: mdxNode,
-      getNode,
-      getNodes,
-      reporter,
-      cache,
-      pathPrefix,
-      options,
-      loadNodeContent,
-      actions,
-      createNodeId,
-      ...helpers,
-    },
-    { forceDisableCache: true }
-  )
+  const { scopeImports, scopeIdentifiers } = await findImports({
+    node: mdxNode,
+    getNode,
+    getNodes,
+    reporter,
+    cache,
+    pathPrefix,
+    options,
+    loadNodeContent,
+    actions,
+    createNodeId,
+    ...helpers,
+  })
   await cacheScope({
     cache,
     scopeIdentifiers,

--- a/packages/gatsby-plugin-mdx/utils/__tests__/__snapshots__/import-parser.js.snap
+++ b/packages/gatsby-plugin-mdx/utils/__tests__/__snapshots__/import-parser.js.snap
@@ -1,0 +1,899 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 0 1`] = `
+Object {
+  "input": "import foo from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "foo",
+    ],
+    "segments": Array [
+      "foo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 1 1`] = `
+Object {
+  "input": "import foo as bar from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "bar",
+    ],
+    "segments": Array [
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 2 1`] = `
+Object {
+  "input": "import * as foo from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "foo",
+    ],
+    "segments": Array [
+      "* as foo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 3 1`] = `
+Object {
+  "input": "import {foo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "foo",
+    ],
+    "segments": Array [
+      "foo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 4 1`] = `
+Object {
+  "input": "import {foo as bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "bar",
+    ],
+    "segments": Array [
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 5 1`] = `
+Object {
+  "input": "import {foo, bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "foo",
+      "bar",
+    ],
+    "segments": Array [
+      "foo",
+      "bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 6 1`] = `
+Object {
+  "input": "import {foo, bar as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "foo",
+      "boo",
+    ],
+    "segments": Array [
+      "foo",
+      "bar as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 7 1`] = `
+Object {
+  "input": "import {foo as bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "bar",
+    ],
+    "segments": Array [
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 8 1`] = `
+Object {
+  "input": "import {foo as bar, baz} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "bar",
+      "baz",
+    ],
+    "segments": Array [
+      "foo as bar",
+      "baz",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 9 1`] = `
+Object {
+  "input": "import {foo as bar, baz as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "bar",
+      "boo",
+    ],
+    "segments": Array [
+      "foo as bar",
+      "baz as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 10 1`] = `
+Object {
+  "input": "import ding, {foo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "ding",
+      "foo",
+    ],
+    "segments": Array [
+      "ding",
+      "foo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 11 1`] = `
+Object {
+  "input": "import ding, {foo as bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "ding",
+      "bar",
+    ],
+    "segments": Array [
+      "ding",
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 12 1`] = `
+Object {
+  "input": "import ding, {foo, bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "ding",
+      "foo",
+      "bar",
+    ],
+    "segments": Array [
+      "ding",
+      "foo",
+      "bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 13 1`] = `
+Object {
+  "input": "import ding, {foo, bar as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "ding",
+      "foo",
+      "boo",
+    ],
+    "segments": Array [
+      "ding",
+      "foo",
+      "bar as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 14 1`] = `
+Object {
+  "input": "import ding, {foo as bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "ding",
+      "bar",
+    ],
+    "segments": Array [
+      "ding",
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 15 1`] = `
+Object {
+  "input": "import ding, {foo as bar, baz} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "ding",
+      "bar",
+      "baz",
+    ],
+    "segments": Array [
+      "ding",
+      "foo as bar",
+      "baz",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 16 1`] = `
+Object {
+  "input": "import ding, {foo as bar, baz as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "ding",
+      "bar",
+      "boo",
+    ],
+    "segments": Array [
+      "ding",
+      "foo as bar",
+      "baz as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 17 1`] = `
+Object {
+  "input": "import ding as dong, {foo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "foo",
+    ],
+    "segments": Array [
+      "ding as dong",
+      "foo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 18 1`] = `
+Object {
+  "input": "import ding as dong, {foo as bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "bar",
+    ],
+    "segments": Array [
+      "ding as dong",
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 19 1`] = `
+Object {
+  "input": "import ding as dong, {foo, bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "foo",
+      "bar",
+    ],
+    "segments": Array [
+      "ding as dong",
+      "foo",
+      "bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 20 1`] = `
+Object {
+  "input": "import ding as dong, {foo, bar as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "foo",
+      "boo",
+    ],
+    "segments": Array [
+      "ding as dong",
+      "foo",
+      "bar as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 21 1`] = `
+Object {
+  "input": "import ding as dong, {foo as bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "bar",
+    ],
+    "segments": Array [
+      "ding as dong",
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 22 1`] = `
+Object {
+  "input": "import ding as dong, {foo as bar, baz} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "bar",
+      "baz",
+    ],
+    "segments": Array [
+      "ding as dong",
+      "foo as bar",
+      "baz",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 23 1`] = `
+Object {
+  "input": "import ding as dong, {foo as bar, baz as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "bar",
+      "boo",
+    ],
+    "segments": Array [
+      "ding as dong",
+      "foo as bar",
+      "baz as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 24 1`] = `
+Object {
+  "input": "import * as dong, {foo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "foo",
+    ],
+    "segments": Array [
+      "* as dong",
+      "foo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 25 1`] = `
+Object {
+  "input": "import * as dong, {foo as bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "bar",
+    ],
+    "segments": Array [
+      "* as dong",
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 26 1`] = `
+Object {
+  "input": "import * as dong, {foo, bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "foo",
+      "bar",
+    ],
+    "segments": Array [
+      "* as dong",
+      "foo",
+      "bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 27 1`] = `
+Object {
+  "input": "import * as dong, {foo, bar as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "foo",
+      "boo",
+    ],
+    "segments": Array [
+      "* as dong",
+      "foo",
+      "bar as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 28 1`] = `
+Object {
+  "input": "import * as dong, {foo as bar} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "bar",
+    ],
+    "segments": Array [
+      "* as dong",
+      "foo as bar",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 29 1`] = `
+Object {
+  "input": "import * as dong, {foo as bar, baz} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "bar",
+      "baz",
+    ],
+    "segments": Array [
+      "* as dong",
+      "foo as bar",
+      "baz",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 30 1`] = `
+Object {
+  "input": "import * as dong, {foo as bar, baz as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "bar",
+      "boo",
+    ],
+    "segments": Array [
+      "* as dong",
+      "foo as bar",
+      "baz as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 31 1`] = `
+Object {
+  "input": "import * as $, {_ as bar, baz as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "$",
+      "bar",
+      "boo",
+    ],
+    "segments": Array [
+      "* as $",
+      "_ as bar",
+      "baz as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 32 1`] = `
+Object {
+  "input": "import _, {foo as $} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "_",
+      "$",
+    ],
+    "segments": Array [
+      "_",
+      "foo as $",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 33 1`] = `
+Object {
+  "input": "import _ as $ from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "$",
+    ],
+    "segments": Array [
+      "_ as $",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 34 1`] = `
+Object {
+  "input": "import {_, $ as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "_",
+      "boo",
+    ],
+    "segments": Array [
+      "_",
+      "$ as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 35 1`] = `
+Object {
+  "input": "import {_ as $, baz as boo} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "$",
+      "boo",
+    ],
+    "segments": Array [
+      "_ as $",
+      "baz as boo",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 36 1`] = `
+Object {
+  "input": "import {_, $} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "_",
+      "$",
+    ],
+    "segments": Array [
+      "_",
+      "$",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 37 1`] = `
+Object {
+  "input": "import as from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "as",
+    ],
+    "segments": Array [
+      "as",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 38 1`] = `
+Object {
+  "input": "import * as as from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "as",
+    ],
+    "segments": Array [
+      "* as as",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 39 1`] = `
+Object {
+  "input": "import from from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "from",
+    ],
+    "segments": Array [
+      "from",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 40 1`] = `
+Object {
+  "input": "import * as from from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "from",
+    ],
+    "segments": Array [
+      "* as from",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 41 1`] = `
+Object {
+  "input": "import as, {from} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "as",
+      "from",
+    ],
+    "segments": Array [
+      "as",
+      "from",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 42 1`] = `
+Object {
+  "input": "import as as x, {from as y} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "x",
+      "y",
+    ],
+    "segments": Array [
+      "as as x",
+      "from as y",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 43 1`] = `
+Object {
+  "input": "import x as as, {x as from} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "as",
+      "from",
+    ],
+    "segments": Array [
+      "x as as",
+      "x as from",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 44 1`] = `
+Object {
+  "input": "import from, {as} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "from",
+      "as",
+    ],
+    "segments": Array [
+      "from",
+      "as",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 45 1`] = `
+Object {
+  "input": "import from as x, {as as y} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "x",
+      "y",
+    ],
+    "segments": Array [
+      "from as x",
+      "as as y",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 46 1`] = `
+Object {
+  "input": "import x as from, {x as as} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "from",
+      "as",
+    ],
+    "segments": Array [
+      "x as from",
+      "x as as",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 47 1`] = `
+Object {
+  "input": "import {as, from} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "as",
+      "from",
+    ],
+    "segments": Array [
+      "as",
+      "from",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 48 1`] = `
+Object {
+  "input": "import {from, as} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "from",
+      "as",
+    ],
+    "segments": Array [
+      "from",
+      "as",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 49 1`] = `
+Object {
+  "input": "import {as as x, from as y} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "x",
+      "y",
+    ],
+    "segments": Array [
+      "as as x",
+      "from as y",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 50 1`] = `
+Object {
+  "input": "import {from as x, as as y} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "x",
+      "y",
+    ],
+    "segments": Array [
+      "from as x",
+      "as as y",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 51 1`] = `
+Object {
+  "input": "import {x as as, y as from} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "as",
+      "from",
+    ],
+    "segments": Array [
+      "x as as",
+      "y as from",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 52 1`] = `
+Object {
+  "input": "import {x as from, y as as} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "from",
+      "as",
+    ],
+    "segments": Array [
+      "x as from",
+      "y as as",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 53 1`] = `
+Object {
+  "input": "import {import as x} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "x",
+    ],
+    "segments": Array [
+      "import as x",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 54 1`] = `
+Object {
+  "input": "import {import as x, y} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "x",
+      "y",
+    ],
+    "segments": Array [
+      "import as x",
+      "y",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 55 1`] = `
+Object {
+  "input": "import {x, import as y} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "x",
+      "y",
+    ],
+    "segments": Array [
+      "x",
+      "import as y",
+    ],
+  },
+}
+`;

--- a/packages/gatsby-plugin-mdx/utils/__tests__/__snapshots__/import-parser.js.snap
+++ b/packages/gatsby-plugin-mdx/utils/__tests__/__snapshots__/import-parser.js.snap
@@ -897,3 +897,38 @@ Object {
   },
 }
 `;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 56 1`] = `
+Object {
+  "input": "import Events from \\"@components/events/events\\"",
+  "result": Object {
+    "bindings": Array [
+      "Events",
+    ],
+    "segments": Array [
+      "Events",
+    ],
+  },
+}
+`;
+
+exports[`regex import scanner syntactic coverage should parse brute force regular case 57 1`] = `
+Object {
+  "input": "import multi as dong, {foo} from 'bar'
+import as as x, {from as y} from 'bar'",
+  "result": Object {
+    "bindings": Array [
+      "dong",
+      "foo",
+      "x",
+      "y",
+    ],
+    "segments": Array [
+      "multi as dong",
+      "foo",
+      "as as x",
+      "from as y",
+    ],
+  },
+}
+`;

--- a/packages/gatsby-plugin-mdx/utils/__tests__/import-parser.js
+++ b/packages/gatsby-plugin-mdx/utils/__tests__/import-parser.js
@@ -1,0 +1,111 @@
+const { parseImportBindings } = require(`../import-parser`)
+
+function getBruteForceCases() {
+  // These cases will be individually tested in four different ways;
+  // - as is
+  // - replace all spaces by newlines
+  // - minified (drop all spaces that are not mandatory)
+  // - replace all spaces by three spaces
+
+  const bruteForceCases = `
+    import foo from 'bar'
+    import foo as bar from 'bar'
+    import * as foo from 'bar'
+    import {foo} from 'bar'
+    import {foo as bar} from 'bar'
+    import {foo, bar} from 'bar'
+    import {foo, bar as boo} from 'bar'
+    import {foo as bar} from 'bar'
+    import {foo as bar, baz} from 'bar'
+    import {foo as bar, baz as boo} from 'bar'
+    import ding, {foo} from 'bar'
+    import ding, {foo as bar} from 'bar'
+    import ding, {foo, bar} from 'bar'
+    import ding, {foo, bar as boo} from 'bar'
+    import ding, {foo as bar} from 'bar'
+    import ding, {foo as bar, baz} from 'bar'
+    import ding, {foo as bar, baz as boo} from 'bar'
+    import ding as dong, {foo} from 'bar'
+    import ding as dong, {foo as bar} from 'bar'
+    import ding as dong, {foo, bar} from 'bar'
+    import ding as dong, {foo, bar as boo} from 'bar'
+    import ding as dong, {foo as bar} from 'bar'
+    import ding as dong, {foo as bar, baz} from 'bar'
+    import ding as dong, {foo as bar, baz as boo} from 'bar'
+    import * as dong, {foo} from 'bar'
+    import * as dong, {foo as bar} from 'bar'
+    import * as dong, {foo, bar} from 'bar'
+    import * as dong, {foo, bar as boo} from 'bar'
+    import * as dong, {foo as bar} from 'bar'
+    import * as dong, {foo as bar, baz} from 'bar'
+    import * as dong, {foo as bar, baz as boo} from 'bar'
+    import * as $, {_ as bar, baz as boo} from 'bar'
+    import _, {foo as $} from 'bar'
+    import _ as $ from 'bar'
+    import {_, $ as boo} from 'bar'
+    import {_ as $, baz as boo} from 'bar'
+    import {_, $} from 'bar'
+    import as from 'bar'
+    import * as as from 'bar'
+    import from from 'bar'
+    import * as from from 'bar'
+    import as, {from} from 'bar'
+    import as as x, {from as y} from 'bar'
+    import x as as, {x as from} from 'bar'
+    import from, {as} from 'bar'
+    import from as x, {as as y} from 'bar'
+    import x as from, {x as as} from 'bar'
+    import {as, from} from 'bar'
+    import {from, as} from 'bar'
+    import {as as x, from as y} from 'bar'
+    import {from as x, as as y} from 'bar'
+    import {x as as, y as from} from 'bar'
+    import {x as from, y as as} from 'bar'
+    import {import as x} from 'bar'
+    import {import as x, y} from 'bar'
+    import {x, import as y} from 'bar'
+  `
+    .trim()
+    .split(/\n/g)
+    .map(s => s.trim())
+
+  return bruteForceCases
+}
+
+describe(`regex import scanner`, () => {
+  describe(`syntactic coverage`, () => {
+    const cases = getBruteForceCases()
+
+    cases.forEach((input, i) => {
+      it(`should parse brute force regular case ${i}`, () => {
+        const output = parseImportBindings(input, true)
+        const bindings = output.bindings
+
+        expect(output.bindings.length).not.toBe(0)
+        // Note: putting everything in the snapshot makes reviews easier
+        expect({ input, result: output }).toMatchSnapshot()
+        expect(
+          // All bindings should be non-empty and trimmed
+          output.bindings.every(
+            binding => binding !== `` && binding === binding.trim()
+          )
+        ).toBe(true)
+
+        // Confirm that the parser works when all spaces become newlines
+        const newlined = input.replace(/ /g, `\n`)
+        expect(parseImportBindings(newlined)).toEqual(bindings)
+
+        // Confirm that the parser works with a minimal amount of spacing
+        const minified = input.replace(
+          /(?<=[_\w$]) (?![_\w$])|(?<![_\w$]) (?=[_\w$])|(?<![_\w$]) (?![_\w$])/g,
+          ``
+        )
+        expect(parseImportBindings(minified)).toEqual(bindings)
+
+        // Confirm that the parser works with an excessive amount of spacing
+        const blown = input.replace(/ /g, `   `)
+        expect(parseImportBindings(blown)).toEqual(bindings)
+      })
+    })
+  })
+})

--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -9,6 +9,7 @@ const getSourcePluginsAsRemarkPlugins = require(`./get-source-plugins-as-remark-
 const htmlAttrToJSXAttr = require(`./babel-plugin-html-attr-to-jsx-attr`)
 const removeExportKeywords = require(`./babel-plugin-remove-export-keywords`)
 const BabelPluginPluckImports = require(`./babel-plugin-pluck-imports`)
+const { parseImportBindings } = require(`./import-parser`)
 
 /*
  * function mutateNode({
@@ -39,7 +40,7 @@ const BabelPluginPluckImports = require(`./babel-plugin-pluck-imports`)
  * }
  *  */
 
-module.exports = async function genMDX(
+async function genMDX(
   {
     isLoader,
     node,
@@ -189,3 +190,83 @@ ${code}`
   }
   return results
 }
+
+module.exports = genMDX // Legacy API, drop in v3 in favor of named export
+module.exports.genMDX = genMDX
+
+async function findImports({
+  node,
+  options,
+  getNode,
+  getNodes,
+  getNodesByType,
+  reporter,
+  cache,
+  pathPrefix,
+  ...helpers
+}) {
+  const { content } = grayMatter(node.rawBody)
+
+  const gatsbyRemarkPluginsAsremarkPlugins = await getSourcePluginsAsRemarkPlugins(
+    {
+      gatsbyRemarkPlugins: options.gatsbyRemarkPlugins,
+      mdxNode: node,
+      getNode,
+      getNodes,
+      getNodesByType,
+      reporter,
+      cache,
+      pathPrefix,
+      compiler: {
+        parseString: () => compiler.parse.bind(compiler),
+        generateHTML: ast => mdx(ast, options),
+      },
+      ...helpers,
+    }
+  )
+
+  const compilerOptions = {
+    filepath: node.fileAbsolutePath,
+    ...options,
+    remarkPlugins: [
+      ...options.remarkPlugins,
+      ...gatsbyRemarkPluginsAsremarkPlugins,
+    ],
+  }
+  const compiler = mdx.createCompiler(compilerOptions)
+
+  const fileOpts = { contents: content }
+  if (node.fileAbsolutePath) {
+    fileOpts.path = node.fileAbsolutePath
+  }
+
+  const mdast = await compiler.parse(fileOpts)
+
+  // Assuming valid code, identifiers must be unique (they are consts) so
+  // we don't need to dedupe the symbols here.
+  const identifiers = []
+  const imports = []
+
+  mdast.children.forEach(node => {
+    if (node.type !== `import`) return
+
+    const importCode = node.value
+
+    imports.push(importCode)
+
+    const bindings = parseImportBindings(importCode)
+    identifiers.push(...bindings)
+  })
+
+  if (!identifiers.includes(`React`)) {
+    identifiers.push(`React`)
+    imports.push(`import * as React from 'react'`)
+  }
+
+  return {
+    scopeImports: imports,
+    scopeIdentifiers: identifiers,
+  }
+}
+
+module.exports.findImports = findImports

--- a/packages/gatsby-plugin-mdx/utils/import-parser.js
+++ b/packages/gatsby-plugin-mdx/utils/import-parser.js
@@ -1,0 +1,48 @@
+/**
+ * Parse source code containing (just) ES6 import declarations and return the
+ * names of all bindings created by such a declaration.
+ * The function will assume strict ES6 import code.
+ * First it strips the irrelevant bits (like `import`, curly brackets, and
+ * `from` tail. What's left ought to be a string in the form of
+ * `id[ as id] [, id[ as id]]`
+ * (where the brackets represent optional repeating parts). The left-most id
+ * might also contain star (namespaced import).
+ * The second part will trim and split the string on comma, then each segment
+ * is split on `as` (in a proper way) and the right-most identifier is returned.
+ *
+ * For testing purposes you can also request the segments, after split on comma.
+ *
+ * @param {string} importCode
+ * @param {boolean=false} returnSegments
+ * @returns {Array<string> | {bindings: Array<string>, segments: Array<string>}}
+ */
+function parseImportBindings(importCode, returnSegments = false) {
+  // const match = importCode.match(reImportParser)
+  // const bindings = distillBindings(match)
+
+  const str = importCode.replace(
+    /^\s*import|[{}]|\s*from\s*['"][^'"]*['"].*$/g,
+    ``
+  )
+  const segments = str.trim().split(/\s*,\s*/g)
+  const bindings = segments.map(
+    segment =>
+      // `s` is either an ident (the binding), or `a as b` where `b` is the
+      // binding. We split on `as` (taking spacing edge cases into account)
+      // and return the right-most ident that is left, trimmed.
+      // If `as` is used, it must be followed by some kind of spacing.
+      // Notable edge case: `*as as` is legit, namespace importing to var `as`
+      segment.split(/as\s+(?=[\w\d$_]+$)/).pop()
+    // Note: since `s` was trimmed, and the split consumed any spacing after
+    // the `as`, the result ident must be trimmed.
+  )
+  if (returnSegments) {
+    // For snapshot testing
+    return { bindings, segments }
+  }
+  return bindings
+}
+
+module.exports = {
+  parseImportBindings,
+}

--- a/packages/gatsby-plugin-mdx/utils/import-parser.js
+++ b/packages/gatsby-plugin-mdx/utils/import-parser.js
@@ -2,6 +2,7 @@
  * Parse source code containing (just) ES6 import declarations and return the
  * names of all bindings created by such a declaration.
  * The function will assume strict ES6 import code.
+ * The input may contain multiple import statements, each starting on a new line
  * First it strips the irrelevant bits (like `import`, curly brackets, and
  * `from` tail. What's left ought to be a string in the form of
  * `id[ as id] [, id[ as id]]`
@@ -21,10 +22,13 @@ function parseImportBindings(importCode, returnSegments = false) {
   // const bindings = distillBindings(match)
 
   const str = importCode.replace(
-    /^\s*import|[{}]|\s*from\s*['"][^'"]*['"].*$/g,
-    ``
+    /^\s*import|[{},]|\s*from\s*['"][^'"]*?['"]\s*$/gm,
+    ` , `
   )
-  const segments = str.trim().split(/\s*,\s*/g)
+  const segments = str
+    .trim()
+    .split(/\s*,\s*/g)
+    .filter(s => s !== ``)
   const bindings = segments.map(
     segment =>
       // `s` is either an ident (the binding), or `a as b` where `b` is the

--- a/packages/gatsby-plugin-mdx/utils/import-parser.js
+++ b/packages/gatsby-plugin-mdx/utils/import-parser.js
@@ -18,9 +18,6 @@
  * @returns {Array<string> | {bindings: Array<string>, segments: Array<string>}}
  */
 function parseImportBindings(importCode, returnSegments = false) {
-  // const match = importCode.match(reImportParser)
-  // const bindings = distillBindings(match)
-
   const str = importCode.replace(
     /^\s*import|[{},]|\s*from\s*['"][^'"]*?['"]\s*$/gm,
     ` , `


### PR DESCRIPTION
The mdx plugin was doing its default parsing step for every time it got called. At sourcing time it's only called to retrieve the import bindings and for this we can be much faster by manually processing the import statements. So that's what this does.

This change __reduces _baseline_ mdx processing by 30%__ by skipping a Babel parse step in one of the bootstrap steps

A very simple flat no-image mdx benchmark cuts down sourcing time in half for this change.

## Benchmark numbers

This are the numbers for a simple, flat, local sourced, zero-image, mdx benchmark where each mdx file is automatically generated and look like this:

```
---
articleNumber: 1
title: "Maiores iusto autem dolorum."
path: 'maiores-iusto-autem-dolorum.'
date: 2018-04-14
---

import { Link } from "gatsby"

<Link to="/">Go Home</Link>

Reiciendis assumenda molestiae a. Ea aperiam aut numquam id. Ratione sint saepe illum est porro asperiores quas ut tempora. Minima sit enim deserunt maxime.
 
Earum iure et explicabo quis qui inventore modi commodi qui. Dolorem ab quo minima neque suscipit voluptas odio deleniti occaecati. Dolore temporibus ut fugiat facilis maiores dignissimos ut eius. Eius similique eos aut magnam quaerat modi. Autem dolor saepe quibusdam reprehenderit error et aut illo.
```

So there's a header, an import, a link, and two paragraphs of random garble (pre-generated, not part of the timings). The benchmark can run with an arbitrary number of pages (`N=1000 yarn bench`) so that's what we do for 1k, 2k, 4k, 8k, and 16k. By 2x-ing every step we can detect logaritmic perf problems easier. While the baseline Gatsby pipeline holds for a million pages easily, for mdx that ceiling is a lot lower right now (that's what I'm trying to improve :p )

The benchmark runs on a dedicated Intel NUC, which is a headless linux setup, specifically to benchmark, so numbers ought to be fairly consistent relative to other runs.

## Data

Master is currently roughly on gatsby-plugin-mdx@1.2.19 and gatsby@2.23.12 ( + whatever is unpublished).

The raw data for both runs can be found in two gists:
- master: https://gist.github.com/pvdz/10eb6b92f58a32233c10dd9f8810d7b3
- this PR: https://gist.github.com/pvdz/b1556a3b51476af05500d4f0ba433c91

----

- 1000 pages:
  - master: 
    - sourcing: 30s
    - bootstrap: 33s
    - finished: 59s
  - PR:
    - sourcing: 14s
    - bootstrap: 17s
    - finished: 45s
  - delta: -14s
  - e2e page speed 16p/s -> 22p/s
- 2000 pages:
  - master
    - sourcing: 55s
    - bootstrap: 59s
    - finished: 104s
  - PR:
    - sourcing: 25s
    - bootstrap: 29s
    - finished: 76s
  - delta: -28s
  - e2e page speed 19p/s -> 26p/s
- 4000 pages:
  - master
    - sourcing: 107s
    - bootstrap: 112s
    - finished: 193s
  - PR:
    - sourcing: 48s
    - bootstrap: 52s
    - finished: 137s
  - delta: -56s
  - e2e page speed 20p/s -> 29p/s
- 8000 pages:
  - master
    - sourcing: 221s
    - bootstrap: 227s
    - finished: 388s
  - PR:
    - sourcing: 104s
    - bootstrap: 110s
    - finished: 281s
  - delta: -107s
  - e2e page speed 20p/s -> 28p/s
- 16000 pages:
  - master
    - sourcing: 464s
    - bootstrap: 474s
    - finished: 819s
  - PR:
    - sourcing: 218s
    - bootstrap: 226s
    - finished: 572s
  - delta: -247s
  - e2e page speed 19p/s -> 27p/s (I mean, 27.97 ...)
