### PR TITLE
refactor(gatsby): Move store assertion into helper

### DIFF
--- a/packages/gatsby/src/services/build-schema.ts
+++ b/packages/gatsby/src/services/build-schema.ts
@@ -4,12 +4,8 @@ import { build } from "../schema"
 import reporter from "gatsby-cli/lib/reporter"
 
 export async function buildSchema({
-  store,
   parentSpan,
 }: Partial<IBuildContext>): Promise<void> {
-  if (!store) {
-    reporter.panic(`Cannot build schema before store initialization`)
-  }
   const activity = reporter.activityTimer(`building schema`, {
     parentSpan,
   })

--- a/packages/gatsby/src/services/calculate-dirty-queries.ts
+++ b/packages/gatsby/src/services/calculate-dirty-queries.ts
@@ -1,15 +1,14 @@
 import { calcInitialDirtyQueryIds, groupQueryIds } from "../query"
 import { IBuildContext, IGroupedQueryIds } from "./"
-import reporter from "gatsby-cli/lib/reporter"
+import { assertStore } from "../utils/assert-store"
 
 export async function calculateDirtyQueries({
   store,
 }: Partial<IBuildContext>): Promise<{
   queryIds: IGroupedQueryIds
 }> {
-  if (!store) {
-    reporter.panic(`Cannot run service without a redux store`)
-  }
+  assertStore(store)
+
   const state = store.getState()
   // TODO: Check filesDirty from context
 

--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -2,15 +2,14 @@ import { IBuildContext } from "./"
 
 import reporter from "gatsby-cli/lib/reporter"
 import apiRunnerNode from "../utils/api-runner-node"
+import { assertStore } from "../utils/assert-store"
 
 export async function createPages({
   parentSpan,
   gatsbyNodeGraphQLFunction,
   store,
 }: Partial<IBuildContext>): Promise<void> {
-  if (!store) {
-    reporter.panic(`store not initialized`)
-  }
+  assertStore(store)
   const activity = reporter.activityTimer(`createPages`, {
     parentSpan,
   })

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -1,6 +1,7 @@
 import { processPageQueries } from "../query"
 import { IBuildContext } from "./"
 import reporter from "gatsby-cli/lib/reporter"
+import { assertStore } from "../utils/assert-store"
 
 export async function runPageQueries({
   parentSpan,
@@ -9,9 +10,8 @@ export async function runPageQueries({
   program,
   graphqlRunner,
 }: Partial<IBuildContext>): Promise<void> {
-  if (!store) {
-    reporter.panic(`Cannot run service without a redux store`)
-  }
+  assertStore(store)
+
   if (!queryIds) {
     return
   }

--- a/packages/gatsby/src/services/run-static-queries.ts
+++ b/packages/gatsby/src/services/run-static-queries.ts
@@ -1,6 +1,7 @@
 import { processStaticQueries } from "../query"
 import { IBuildContext } from "./"
 import reporter from "gatsby-cli/lib/reporter"
+import { assertStore } from "../utils/assert-store"
 
 export async function runStaticQueries({
   parentSpan,
@@ -9,9 +10,8 @@ export async function runStaticQueries({
   program,
   graphqlRunner,
 }: Partial<IBuildContext>): Promise<void> {
-  if (!store) {
-    reporter.panic(`Cannot run service without a redux store`)
-  }
+  assertStore(store)
+
   if (!queryIds) {
     return
   }

--- a/packages/gatsby/src/services/source-nodes.ts
+++ b/packages/gatsby/src/services/source-nodes.ts
@@ -1,6 +1,7 @@
 import { IBuildContext } from "./"
 import sourceNodesAndRemoveStaleNodes from "../utils/source-nodes"
 import reporter from "gatsby-cli/lib/reporter"
+import { assertStore } from "../utils/assert-store"
 // import { findChangedPages } from "../utils/check-for-changed-pages"
 // import { IGatsbyPage } from "../redux/types"
 
@@ -9,9 +10,8 @@ export async function sourceNodes({
   webhookBody,
   store,
 }: Partial<IBuildContext>): Promise<void> {
-  if (!store) {
-    reporter.panic(`No redux store`)
-  }
+  assertStore(store)
+
   const activity = reporter.activityTimer(`source and transform nodes`, {
     parentSpan,
   })

--- a/packages/gatsby/src/services/write-out-requires.ts
+++ b/packages/gatsby/src/services/write-out-requires.ts
@@ -1,14 +1,14 @@
 import { IBuildContext } from "./"
 import reporter from "gatsby-cli/lib/reporter"
 import { writeAll } from "../bootstrap/requires-writer"
+import { assertStore } from "../utils/assert-store"
 
 export async function writeOutRequires({
   store,
   parentSpan,
 }: Partial<IBuildContext>): Promise<void> {
-  if (!store) {
-    reporter.panic(`No redux store`)
-  }
+  assertStore(store)
+
   // Write out files.
   const activity = reporter.activityTimer(`write out requires`, {
     parentSpan,

--- a/packages/gatsby/src/utils/assert-store.ts
+++ b/packages/gatsby/src/utils/assert-store.ts
@@ -1,0 +1,8 @@
+import { Store } from "redux"
+import reporter from "gatsby-cli/lib/reporter"
+
+export function assertStore(store?: Store): asserts store {
+  if (!store) {
+    reporter.panic(`Could not find Redux store`)
+  }
+}


### PR DESCRIPTION
Adds a helper function to assert the existence of a Redux store. I'd normally say we should make this more generic and pass in a message or something, but I have done this specific check so many times I think it justifies having a specific version that includes the error message. There are several files that use it in master, and a lot more in the state machine branches.