### PR TITLE
feat: locales not found pages should be ordered at the end

### DIFF
--- a/packages/gatsby-plugin-netlify/src/create-redirects.js
+++ b/packages/gatsby-plugin-netlify/src/create-redirects.js
@@ -51,7 +51,7 @@ export default async function writeRedirectsFile(
   })
 
   rewrites = rewrites.map(
-    ({ fromPath, toPath }) => `${fromPath}  ${toPath}  200`
+    ({ fromPath, toPath, status }) => `${fromPath}  ${toPath}  ${status}`
   )
 
   let commentFound = false


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Hi,  I suppose the 404 matched rules should be placed at the end, for priority problem, I made a pr for that, can you review it?

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
