### PR TITLE
Update adding-page-transitions-with-plugin-transition-link.md

### DIFF
--- a/docs/docs/adding-page-transitions-with-plugin-transition-link.md
+++ b/docs/docs/adding-page-transitions-with-plugin-transition-link.md
@@ -97,7 +97,7 @@ You can specify a `trigger` function that will handle the animation. This is use
 
 ### Using passed props
 
-The exiting and entering pages/templates involved in the transition will receive props indicating the current transition status, as well as the `exit` or `enter` props defined on the `TransitionLink`.
+The exiting and entering pages/templates involved in the transition will receive props indicating the current transition status, as well as the `exit` or `entry` props defined on the `TransitionLink`.
 
 ```jsx
 const PageOrTemplate = ({ children, transitionStatus, entry, exit }) => {
@@ -121,10 +121,10 @@ const Box = posed.div({
 })
 
 <TransitionState>
-      {({ transitionStatus, exit, enter, mount }) => {
+      {({ transitionStatus, exit, entry, mount }) => {
         console.log("current page's transition status is", transitionStatus)
         console.log("exit object is", exit)
-        console.log("enter object is", enter)
+        console.log("entry object is", entry)
 
         return (
             <Box


### PR DESCRIPTION
'enter' is not given to TransitionState as a prop, it should be 'entry', to match the format of the TransitionLink component. It took an embarrassingly long time for me to work out why TransitionState wasn't working to realise this.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
