### PR TITLE
Add notice about required file to expose query

### DIFF
--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -87,6 +87,10 @@ In the asciidoc file you can insert your image just by using:
 
 ## How to query
 
+**IMPORTANT**
+
+- If there are no valid asciidoc files in your project, the `allAsciidoc` query will not be available.
+
 A sample GraphQL query to get AsciiDoc nodes:
 
 ```graphql


### PR DESCRIPTION
## Description

The behavior differences between this plugin and something like `gatsby-transformer-remark` can be confusing. `gatsby-transformer-remark` will automatically add the `allMarkdownRemark` query even if no md files are present. The `gatsby-transformer-asciidoc` requires a valid asciidoc file to be present in order to expose the query.

I'm not super familiar with the ecosystem, so I'm not sure if maintaining feature parity between the plugins makes sense. Had I at least seen this note, I'd have skipped some time debugging whether I'd installed/configured the package correctly.
