### PR TITLE
enhancement(docs): Add documentation on the @childOf and @mimeTypes extensions

### DIFF
--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -245,11 +245,26 @@ type Mdx implements Node
 }
 ```
 
+The `mimeTypes` and `types` arguments can be combined as follows:
+
+```graphql
+# Adds `childMdx` as a child to `File` nodes *and* nodes with `@mimeTypes` set to "text/markdown" or "text/x-markdown"
+type Mdx implements Node
+  @childOf(types: ["File"], mimeTypes: ["text/markdown", "text/x-markdown"]) {
+  id: ID!
+}
+```
+
 If `many: true` is set, then instead of creating a single child field on the parent, it will create multiple:
 
 ```graphql
-# Adds `childrenMdx` as a field of `File`
-type Mdx implements Node @childOf(types: ["File"], many: true) {
+# Adds `childMdx1` with type `Mdx1` to `File`.
+type Mdx1 implements Node @childOf(types: ["File"]) {
+  id: ID!
+}
+
+# Adds `childrenMdx2` with type `[Mdx2]` as a field of `File`.
+type Mdx2 implements Node @childOf(types: ["File"], many: true) {
   id: ID!
 }
 ```

--- a/docs/docs/schema-customization.md
+++ b/docs/docs/schema-customization.md
@@ -209,6 +209,51 @@ Note that you don't need to explicitly provide the Node interface fields (`id`,
 > [specifying nullability](https://graphql.org/learn/schema/#lists-and-non-null)
 > in GraphQL, i.e. if a field value is allowed to be `null` or not.
 
+#### Defining media types
+
+You can specify the media types handled by a node type using the `@mimeTypes` extension:
+
+```graphql
+type Markdown implements Node
+  @mimeTypes(types: ["text/markdown", "text/x-markdown"]) {
+  id: ID!
+}
+```
+
+The types passed in are used to determine child relations of the node.
+
+#### Defining child relations
+
+The `@childOf` extension can be used to explicitly define what node types or media types a node is a child of and immediately add `child[MyType]` or `children[MyType]` as a field on the parent.
+
+The `types` argument takes an array of strings and determines what node types the node is a child of:
+
+```graphql
+# Adds `childMdx` as a field of `File` and `Markdown` nodes
+type Mdx implements Node @childOf(types: ["File", "Markdown"]) {
+  id: ID!
+}
+```
+
+The `mimeTypes` argument takes an array of strings and determines what media types the node is a child of:
+
+```graphql
+# Adds `childMdx` as a child of any node type with the `@mimeTypes` set to "text/markdown" or "text/x-markdown"
+type Mdx implements Node
+  @childOf(mimeTypes: ["text/markdown", "text/x-markdown"]) {
+  id: ID!
+}
+```
+
+If `many: true` is set, then instead of creating a single child field on the parent, it will create multiple:
+
+```graphql
+# Adds `childrenMdx` as a field of `File`
+type Mdx implements Node @childOf(types: ["File"], many: true) {
+  id: ID!
+}
+```
+
 #### Nested types
 
 So far, the example project has only been dealing with scalar values (`String` and `Date`;


### PR DESCRIPTION
## Description

Add documentation on `@childOf` and `@mimeTypes` schema extensions. We don't document these features *anywhere* in the docs — the only documentation that exists is the unit tests for these features. This will help plugin authors explicitly type their docs.