### PR TITLE
perf(gatsby-source-contentful): use internal cache to get nodes by type

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
@@ -63,7 +63,7 @@ describe.only(`downloadContentfulAssets`, () => {
     }
     await downloadContentfulAssets({
       actions: { touchNode: jest.fn() },
-      getNodes: () => fixtures,
+      getNodesByType: () => fixtures,
       cache,
     })
 

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -25,20 +25,15 @@ const downloadContentfulAssets = async gatsbyFunctions => {
     store,
     cache,
     getCache,
-    getNodes,
+    getNodesByType,
     reporter,
   } = gatsbyFunctions
 
   // Any ContentfulAsset nodes will be downloaded, cached and copied to public/static
   // regardless of if you use `localFile` to link an asset or not.
-  const contentfulAssetNodes = getNodes().filter(
-    n =>
-      n.internal.owner === `gatsby-source-contentful` &&
-      n.internal.type === `ContentfulAsset`
-  )
 
   await Promise.all(
-    contentfulAssetNodes.map(async node => {
+    getNodesByType(`ContentfulAsset`).map(async node => {
       totalJobs += 1
       bar.total = totalJobs
 

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -39,6 +39,7 @@ exports.sourceNodes = async (
     actions,
     getNode,
     getNodes,
+    getNodesByType,
     createNodeId,
     store,
     cache,
@@ -263,7 +264,7 @@ exports.sourceNodes = async (
       store,
       cache,
       getCache,
-      getNodes,
+      getNodesByType,
       reporter,
     })
   }


### PR DESCRIPTION
Gatsby maintains an internal cache of nodes by type. Before this PR the Contentful plugin would do a `getNodes().filter(n => n.type === 'ContentfulAsset')`, which is doing that. The ``n.internal.owner === `gatsby-source-contentful` `` part is redundant because in the only function that calls this function all nodes are already tagged like that so this is never false.

The expected perf gain is minor but at scale this is one fewer times of looping through all nodes.