### PR TITLE
Docs links that start with docs/ rather than /docs/

### DIFF
--- a/docs/blog/2020-06-18-Gatsby-cli-survey-2/index.md
+++ b/docs/blog/2020-06-18-Gatsby-cli-survey-2/index.md
@@ -71,6 +71,6 @@ Requests for incremental builds and complaints about slow builds have decreased 
 
 Thank you again to all who have responded to the survey so far; your responses help guide the focus of the community to answer real-world needs. If you haven't filled out the survey yet, you can run `gatsby feedback` at any time after upgrading your version of `gatsby` in a project's `package.json` file, and then rerunning dependency and install commands. We would love to hear from you!
 
-Otherwise, wait to see the survey appear in a CLI near you! The plan is to do this every 3 months, at the most, and then report results. (If you'd like to opt out, visit [https://www.gatsbyjs.org/docs/CLI-feedback/#how-to-opt-out](docs/telemetry/#how-to-opt-out/)).
+Otherwise, wait to see the survey appear in a CLI near you! The plan is to do this every 3 months, at the most, and then report results. (If you'd like to opt out, visit [https://www.gatsbyjs.org/docs/CLI-feedback/#how-to-opt-out](/docs/telemetry/#how-to-opt-out/)).
 
 If you haven't used Gatsby yet, try it out and let us know what you think! You can install the Gatsby CLI using `npm install -g gatsby-cli` ([see the Quickstart Guide for more details](/docs/quick-start/)).

--- a/examples/using-multiple-themes/README.md
+++ b/examples/using-multiple-themes/README.md
@@ -11,7 +11,7 @@ This repository demonstrates how to use multiple themes in a Gatsby site
 
 ---
 
-In this section you will see how to compose multiple themes into a final site using [gatsby-theme-blog](/packages/gatsby-theme-blog/), [gatsby-theme-notes](/packages/gatsby-theme-notes/) and [gatsby-mdx-embed](/packages/@pauliescanlon/gatsby-mdx-embed/) as examples. It will also cover the concept of component shadowing with [Theme-UI](docs/theme-ui/) for styling.
+In this section you will see how to compose multiple themes into a final site using [gatsby-theme-blog](/packages/gatsby-theme-blog/), [gatsby-theme-notes](/packages/gatsby-theme-notes/) and [gatsby-mdx-embed](/packages/@pauliescanlon/gatsby-mdx-embed/) as examples. It will also cover the concept of component shadowing with [Theme-UI](/docs/theme-ui/) for styling.
 
 ## 🔧 Running locally
 


### PR DESCRIPTION
I greped the repo for `)[docs` and found the following two occurrences of non-absolute links to the documentation.
