### PR TITLE
fix(gatsby): end activity if plugin didn't do it

### DIFF
--- a/packages/gatsby/src/utils/__tests__/api-runner-node.js
+++ b/packages/gatsby/src/utils/__tests__/api-runner-node.js
@@ -1,0 +1,122 @@
+const apiRunnerNode = require(`../api-runner-node`)
+
+jest.mock(`../../redux`, () => {
+  return {
+    store: {
+      getState: jest.fn(),
+    },
+    emitter: {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn(),
+    },
+  }
+})
+
+const start = jest.fn()
+const end = jest.fn()
+
+const mockActivity = {
+  start,
+  end,
+  done: end,
+}
+
+jest.mock(`gatsby-cli/lib/reporter`, () => {
+  return {
+    activityTimer: jest.fn(() => mockActivity),
+    createProgress: jest.fn(() => mockActivity),
+  }
+})
+
+const { store, emitter } = require(`../../redux`)
+
+beforeEach(() => {
+  store.getState.mockClear()
+  emitter.on.mockClear()
+  emitter.off.mockClear()
+  emitter.emit.mockClear()
+  mockActivity.start.mockClear()
+  mockActivity.end.mockClear()
+})
+
+it(`Ends activities if plugin didn't end them`, async () => {
+  jest.doMock(
+    `test-plugin-correct/gatsby-node`,
+    () => {
+      return {
+        testAPIHook: ({ reporter }) => {
+          const spinnerActivity = reporter.activityTimer(
+            `control spinner activity`
+          )
+          spinnerActivity.start()
+          // calling activity.end() to make sure api runner doesn't call it more than needed
+          spinnerActivity.end()
+
+          const progressActivity = reporter.createProgress(
+            `control progress activity`
+          )
+          progressActivity.start()
+          // calling activity.done() to make sure api runner doesn't call it more than needed
+          progressActivity.done()
+        },
+      }
+    },
+    { virtual: true }
+  )
+  jest.doMock(
+    `test-plugin-spinner/gatsby-node`,
+    () => {
+      return {
+        testAPIHook: ({ reporter }) => {
+          const activity = reporter.activityTimer(`spinner activity`)
+          activity.start()
+          // not calling activity.end() - api runner should do end it
+        },
+      }
+    },
+    { virtual: true }
+  )
+  jest.doMock(
+    `test-plugin-progress/gatsby-node`,
+    () => {
+      return {
+        testAPIHook: ({ reporter }) => {
+          const activity = reporter.createProgress(`spinner activity`, 100, 0)
+          activity.start()
+          // not calling activity.end() or done() - api runner should do end it
+        },
+      }
+    },
+    { virtual: true }
+  )
+  store.getState.mockImplementation(() => {
+    return {
+      program: {},
+      config: {},
+      flattenedPlugins: [
+        {
+          name: `test-plugin-correct`,
+          resolve: `test-plugin-correct`,
+          nodeAPIs: [`testAPIHook`],
+        },
+        {
+          name: `test-plugin-spinner`,
+          resolve: `test-plugin-spinner`,
+          nodeAPIs: [`testAPIHook`],
+        },
+        {
+          name: `test-plugin-progress`,
+          resolve: `test-plugin-progress`,
+          nodeAPIs: [`testAPIHook`],
+        },
+      ],
+    }
+  })
+  await apiRunnerNode(`testAPIHook`)
+
+  expect(mockActivity.start).toBeCalledTimes(4)
+  // we called end same amount of times we called start, even tho plugins
+  // didn't call end/done themselves
+  expect(mockActivity.end).toBeCalledTimes(4)
+})

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -174,7 +174,7 @@ const runAPI = (plugin, api, args, activity) => {
 
     let runningActivities = new Set()
 
-    const localReporterThatCleansUpAfterMisbahavingPlugins = {
+    const localReporterThatCleansUpAfterMisbehavingPlugins = {
       ...localReporter,
       activityTimer: (...args) => {
         const activity = reporter.activityTimer(...args)
@@ -231,7 +231,7 @@ const runAPI = (plugin, api, args, activity) => {
         getNode,
         getNodesByType,
         hasNodeChanged,
-        reporter: localReporterThatCleansUpAfterMisbahavingPlugins,
+        reporter: localReporterThatCleansUpAfterMisbehavingPlugins,
         getNodeAndSavePathDependency,
         cache,
         createNodeId: namespacedCreateNodeId,

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -85,7 +85,7 @@ const getLocalReporter = (activity, reporter) =>
     ? { ...reporter, panicOnBuild: activity.panicOnBuild.bind(activity) }
     : reporter
 
-const runAPI = (plugin, api, args, activity) => {
+const runAPI = async (plugin, api, args, activity) => {
   const gatsbyNode = require(`${plugin.resolve}/gatsby-node`)
   if (gatsbyNode[api]) {
     const parentSpan = args && args.parentSpan
@@ -271,12 +271,13 @@ const runAPI = (plugin, api, args, activity) => {
         }
       })
     } else {
-      const result = gatsbyNode[api](...apiCallArgs)
-      pluginSpan.finish()
-      return Promise.resolve(result).finally(() => {
+      try {
+        return await gatsbyNode[api](...apiCallArgs)
+      } finally {
+        pluginSpan.finish()
         apiFinished = true
         endInProgressActivitiesCreatedByThisRun()
-      })
+      }
     }
   }
 

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -172,12 +172,12 @@ const runAPI = async (plugin, api, args, activity) => {
     }
     const localReporter = getLocalReporter(activity, reporter)
 
-    let runningActivities = new Set()
+    const runningActivities = new Set()
 
     const localReporterThatCleansUpAfterMisbehavingPlugins = {
       ...localReporter,
       activityTimer: (...args) => {
-        const activity = reporter.activityTimer(...args)
+        const activity = reporter.activityTimer.apply(reporter, args)
 
         return {
           ...activity,
@@ -192,7 +192,7 @@ const runAPI = async (plugin, api, args, activity) => {
         }
       },
       createProgress: (...args) => {
-        const activity = reporter.createProgress(...args)
+        const activity = reporter.createProgress.apply(reporter, args)
 
         return {
           ...activity,
@@ -213,7 +213,7 @@ const runAPI = async (plugin, api, args, activity) => {
     }
 
     const endInProgressActivitiesCreatedByThisRun = () => {
-      runningActivities.forEach(timer => timer.end())
+      runningActivities.forEach(activity => activity.end())
     }
 
     const apiCallArgs = [


### PR DESCRIPTION
## Description

In cases when plugins don't `.end()` all activities that they started, we end up with always in progress spinner / progress bars. This change make sure that if activity was started in one of gatsby-node lifecycle hooks, core will end any still in-progress activities

Open question is if this should be applied to all lifecycles. Not yet tested this out with `gatsby-plugin-sharp` which wants to actually have long running progress activity that is not tied to lifecycles, so if this would cause troubles - this is where I could see them.

## Related Issues

This is catch-all code (for all plugins) that recently was implemented in drupal plugin ( https://github.com/gatsbyjs/gatsby/pull/25447 ) - it's still better to fix this in plugins than rely on this, because plugins can know if they should fail activity or not - core have no idea about that and it can mark activities as finished 
