### PR TITLE
fix(gatsby-source-contentful): dont ship fixtures when publishing

### DIFF
--- a/packages/gatsby-source-contentful/.npmignore
+++ b/packages/gatsby-source-contentful/.npmignore
@@ -27,7 +27,8 @@ build/Release
 node_modules
 *.un~
 yarn.lock
-src/__tests__
+__tests__
+__fixtures__
 flow-typed
 coverage
 decls


### PR DESCRIPTION
It wasn't ignoring the fixtures. I also made it ignore any `__tests__` rather than just the one in `src`.