### PR TITLE
chore: update xstate and adjust code to not use deprecated transient transitions

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -70,7 +70,7 @@
     "unist-util-visit": "^2.0.2",
     "urql": "^1.9.8",
     "ws": "^7.3.0",
-    "xstate": "^4.10.0"
+    "xstate": "^4.11.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",

--- a/packages/gatsby-recipes/src/recipe-machine/index.js
+++ b/packages/gatsby-recipes/src/recipe-machine/index.js
@@ -163,22 +163,20 @@ const recipeMachine = Machine(
       },
       hasAnotherStep: {
         entry: [`incrementStep`],
-        on: {
-          "": [
-            {
-              target: `creatingPlan`,
-              // The 'searchValid' guard implementation details are
-              // specified in the machine config
-              cond: `hasNextStep`,
-            },
-            {
-              target: `done`,
-              // The 'searchValid' guard implementation details are
-              // specified in the machine config
-              cond: `atLastStep`,
-            },
-          ],
-        },
+        always: [
+          {
+            target: `creatingPlan`,
+            // The 'searchValid' guard implementation details are
+            // specified in the machine config
+            cond: `hasNextStep`,
+          },
+          {
+            target: `done`,
+            // The 'searchValid' guard implementation details are
+            // specified in the machine config
+            cond: `atLastStep`,
+          },
+        ],
       },
       done: {
         type: `final`,

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -21,7 +21,7 @@
     "progress": "^2.0.3",
     "read-chunk": "^3.2.0",
     "valid-url": "^1.0.9",
-    "xstate": "^4.10.0"
+    "xstate": "^4.11.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -150,7 +150,7 @@
     "webpack-hot-middleware": "^2.25.0",
     "webpack-merge": "^4.2.2",
     "webpack-stats-plugin": "^0.3.1",
-    "xstate": "^4.10.0",
+    "xstate": "^4.11.0",
     "yaml-loader": "^0.6.0"
   },
   "devDependencies": {

--- a/packages/gatsby/src/redux/machines/page-component.ts
+++ b/packages/gatsby/src/redux/machines/page-component.ts
@@ -74,15 +74,13 @@ export const componentMachine = machine<IContext, IState, IEvent>(
     },
     states: {
       inactive: {
-        on: {
-          // Transient transition
-          // Will transition to either 'inactiveWhileBootstrapping' or idle
-          // immediately upon entering 'inactive' state if the condition is met.
-          "": [
-            { target: `inactiveWhileBootstrapping`, cond: `isBootstrapping` },
-            { target: `idle`, cond: `isNotBootstrapping` },
-          ],
-        },
+        // Transient transition
+        // Will transition to either 'inactiveWhileBootstrapping' or idle
+        // immediately upon entering 'inactive' state if the condition is met.
+        always: [
+          { target: `inactiveWhileBootstrapping`, cond: `isBootstrapping` },
+          { target: `idle`, cond: `isNotBootstrapping` },
+        ],
       },
       inactiveWhileBootstrapping: {
         on: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19123,7 +19123,7 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
-regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
+regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
@@ -24828,10 +24828,10 @@ xss@^1.0.6:
     commander "^2.20.3"
     cssfilter "0.0.10"
 
-xstate@^4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.10.0.tgz#f87e4ef593fe40300b8eec50a5d9f0763aa4f622"
-  integrity sha512-nncQ9gW+xgk5iUEvpBOXhbzSCS0uwzzT4bOAXxo6oUoALgbxzqEyMmaMYwuvOHrabDTdMJYnF+xe2XD8RRgWmA==
+xstate@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.11.0.tgz#dc0bd31079fe22918c2c27c118d6310bef3dcd9e"
+  integrity sha512-v+S3jF2YrM2tFOit8o7+4N3FuFd9IIGcIKHyfHeeNjMlmNmwuiv/IbY9uw7ECifx7H/A9aGLcxPSr0jdjTGDww==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Description

`xstate@4.11.0` was released few hours ago and is causing some problems, this PR explicitly updates `xstate` (which users can install right now themselves if lock files are not used)

See https://github.com/davidkpiano/xstate/releases/tag/xstate%404.11.0 

In particular:
> New property introduced for eventless (transient) transitions: always, which indicates a transition that is always taken when in that state. Empty string transition configs for transient transitions are deprecated in favor of always
```diff
// ...
states: {
  playing: {
+   always: [
+     { target: 'win', cond: 'didPlayerWin' },
+     { target: 'lose', cond: 'didPlayerLose' },
+   ],
    on: {
      // ⚠️ Deprecation warning
-     '': [
-       { target: 'win', cond: 'didPlayerWin' },
-       { target: 'lose', cond: 'didPlayerLose' },
-     ]
    }
  }
}
// ...
```
Because those warnings are emitted in unfortunate timing they will cause infamous `Reducers may not dispatch actions.` error.

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/25478
