### PR TITLE
fix(gatsby-design-tokens): Add border definitions to theme

### DIFF
--- a/packages/gatsby-design-tokens/src/theme-gatsbyjs-org.js
+++ b/packages/gatsby-design-tokens/src/theme-gatsbyjs-org.js
@@ -322,6 +322,7 @@ const newTheme = {
 }
 
 export {
+  borders,
   breakpoints,
   fonts,
   fontSizes,

--- a/packages/gatsby-design-tokens/src/theme.js
+++ b/packages/gatsby-design-tokens/src/theme.js
@@ -1,6 +1,7 @@
 import {
   breakpointsArray as breakpoints,
   colors as colorsTokens,
+  borders,
   fonts,
   fontSizes,
   fontWeights,
@@ -46,22 +47,24 @@ const c = {
 }
 
 export const theme = {
-  breakpoints: breakpoints,
+  borders,
+  breakpoints,
   colors: c,
-  fonts: fonts,
-  fontSizes: fontSizes,
-  fontWeights: fontWeights,
-  letterSpacings: letterSpacings,
-  lineHeights: lineHeights,
-  mediaQueries: mediaQueries,
-  radii: radii,
-  shadows: shadows,
-  space: space,
-  transition: transition,
+  fonts,
+  fontSizes,
+  fontWeights,
+  letterSpacings,
+  lineHeights,
+  mediaQueries,
+  radii,
+  shadows,
+  space,
+  transition,
 }
 
 export {
   c as colors,
+  borders,
   breakpoints,
   fonts,
   fontSizes,

--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -17,7 +17,8 @@ function BannerContent() {
         href="https://www.gatsbyjs.com"
         sx={{
           color: `white`,
-          borderBottom: t => `1px solid ${t.colors.white}`,
+          borderBottom: 1,
+          borderColor: `white`,
           "&:hover": {
             borderBottom: 0,
           },

--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -17,8 +17,7 @@ function BannerContent() {
         href="https://www.gatsbyjs.com"
         sx={{
           color: `white`,
-          borderBottom: 1,
-          borderColor: `white`,
+          borderBottom: t => `1px solid ${t.colors.white}`,
           "&:hover": {
             borderBottom: 0,
           },


### PR DESCRIPTION
## Description

Add borders to the design tokens theme so that we can do stuff like #25460.

<img width="450" alt="Screenshot of gatsby homepage with dev tools open showing borders properly applied to the banner link" src="https://user-images.githubusercontent.com/1278991/86416183-2328d080-bc7e-11ea-8fc9-b059bc14f840.png">
