### PR TITLE
chore(docs): Fix file name typo

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -228,7 +228,7 @@ Update the transform in `jest.config.js` to run `jest-preprocess` on files in yo
     "^.+\\.[jt]sx?$": "<rootDir>/jest-preprocess.js",
 ```
 
-Also update `jest.preprocess.js` with the following Babel preset to look like this:
+Also update `jest-preprocess.js` with the following Babel preset to look like this:
 
 ```js:title=jest-preprocess.js
 const babelOptions = {


### PR DESCRIPTION
`jest.preprocess.js` should be `jest-preprocess.js`

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
