### PR TITLE
fix(blog): gazette june - remove local domain, add plugin name in code fences

### DIFF
--- a/docs/blog/gazette-june-2020/index.md
+++ b/docs/blog/gazette-june-2020/index.md
@@ -9,7 +9,7 @@ tags: ["gatsby-gazette"]
 
 In June Gatsby decided to be [intentional and quieter in our social media channels](https://twitter.com/GatsbyJS/status/1267495726017323009) to make room for conversations around systemic racism.
 
-During that period Gatsby [matched donations](https://www.gatsbyjs.com/donation-matching/) to organizations that specialize in criminal justice reform, like the NAACP Legal Defense Fund and the ACLU. We also [launched Gatsby Voices](https://www.gatsbyjs.com/gatsby-voices/), a content series where members of the Gatsby community can share the story of their experiences in tech. (Please apply - those who are selected will be compensated \$500 USD for their work). We renewed our commitment to our core value of ["You Belong Here"](/docs/gatsby-core-philosophy/#you-belong-here) by taking internal action to expand our organizational identity, reevaluate our hiring and career advancement policies, bring in expert consultation, [and other steps](https://www.gatsbyjs.org/blog/2020-06-11-you-belong-here-commitment/).
+During that period Gatsby [matched donations](https://www.gatsbyjs.com/donation-matching/) to organizations that specialize in criminal justice reform, like the NAACP Legal Defense Fund and the ACLU. We also [launched Gatsby Voices](https://www.gatsbyjs.com/gatsby-voices/), a content series where members of the Gatsby community can share the story of their experiences in tech. (Please apply - those who are selected will be compensated \$500 USD for their work). We renewed our commitment to our core value of ["You Belong Here"](/docs/gatsby-core-philosophy/#you-belong-here) by taking internal action to expand our organizational identity, reevaluate our hiring and career advancement policies, bring in expert consultation, [and other steps](/blog/2020-06-11-you-belong-here-commitment/).
 
 The efforts above are just the beginning of the work were doing to ensure Black lives matter in our world, our industry, and our company.
 
@@ -77,7 +77,7 @@ WPGraphQL announced [it's path to 1.0](https://github.com/wp-graphql/wp-graphql/
 
 ## 💫 Next from Gatsby
 
-Be on the lookout for [gatsby-theme-blog 2.0](https://github.com/gatsbyjs/gatsby/issues/23910), our brand new [new routing API](https://www.youtube.com/watch?v=tAcAkqOcs3c) and best practices, and updates to how [headless WordPress](/docs/glossary/headless-wordpress) projects can work with Gatsby Cloud.
+Be on the lookout for [`gatsby-theme-blog` 2.0](https://github.com/gatsbyjs/gatsby/issues/23910), our brand new [new routing API](https://www.youtube.com/watch?v=tAcAkqOcs3c) and best practices, and updates to how [headless WordPress](/docs/glossary/headless-wordpress) projects can work with Gatsby Cloud.
 
 Want to help us build this stuff? Apply to our new position for [Senior Product Manager](https://www.gatsbyjs.com/careers/senior-product-manager--marketing---content-collaboration--4027422003) Or drop your résumé in our evergreen ["Dream Job" posting](https://www.gatsbyjs.com/careers/dream-job-4011361003).
 


### PR DESCRIPTION
## Description

changes:
- remove local domain
- plugin name in code fences

## Related Issues

- #25423 `(blog) Draft of June Gatsby Gazette`  
- #19267 `Add link checker for Gatsby Docs`
