### PR TITLE
fix(showcase): 404 link ellingtonhammond.com -> ellington-hammond.com

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -11256,8 +11256,8 @@
   built_by_url: https://draftbox.co
   featured: false
 - title: Ellington Hammond
-  main_url: https://ellingtonhammond.com
-  url: https://ellingtonhammond.com
+  main_url: https://ellington-hammond.com
+url: https://ellington-hammond.com
   description: >
     Ellington Hammond is a photographer and film director based in the United States.
   categories:

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -11308,7 +11308,7 @@ url: https://ellington-hammond.com
   built_by_url: https://siekierski.ml
 - title: Lidabox
   description: >-
-    website for the sale of medical supplies and biosafety supplies.
+    Website for the sale of medical supplies and biosafety supplies.
   main_url: https://lidabox.com/
   url: https://lidabox.com/
   featured: false

--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -11257,7 +11257,7 @@
   featured: false
 - title: Ellington Hammond
   main_url: https://ellington-hammond.com
-url: https://ellington-hammond.com
+  url: https://ellington-hammond.com
   description: >
     Ellington Hammond is a photographer and film director based in the United States.
   categories:


### PR DESCRIPTION
## Description

changes:

- fix 404 link ellingtonhammond.com -> ellington-hammond.com
- one typo

## Related Issues

- #25301 `chore(showcase): add ellingtonhammond.com`
- #25357 `chore(showcase): https://lidabox.com website` 