### PR TITLE
chore(www): tidy <Card />, <CardHeadline /> and <FuturaParagraph /> components

### DIFF
--- a/www/src/components/card-headline.js
+++ b/www/src/components/card-headline.js
@@ -1,16 +1,16 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 
-const CardHeadline = ({ children }) => (
-  <h2
-    sx={{
-      fontSize: 4,
-      lineHeight: `dense`,
-      mt: 0,
-    }}
-  >
-    {children}
-  </h2>
-)
-
-export default CardHeadline
+export default function CardHeadline({ children }) {
+  return (
+    <h2
+      sx={{
+        fontSize: 4,
+        lineHeight: `dense`,
+        mt: 0,
+      }}
+    >
+      {children}
+    </h2>
+  )
+}

--- a/www/src/components/card.js
+++ b/www/src/components/card.js
@@ -3,44 +3,38 @@ import { jsx } from "theme-ui"
 
 import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
-const Card = ({ children }) => (
-  <div
-    sx={{
-      boxSizing: `border-box`,
-      display: `flex`,
-      transform: `translateZ(0)`,
-      [mediaQueries.md]: {
-        flex: `0 0 auto`,
-        maxWidth: `50%`,
-        boxShadow: t => `0 1px 0 0 ${t.colors.ui.border}`,
-        "&:nth-of-type(5), &:nth-of-type(6)": { boxShadow: `none` },
-        "&:nth-of-type(2n)": {
-          borderLeft: t => `1px solid ${t.colors.ui.border}`,
-        },
-      },
-      [mediaQueries.xl]: {
-        flex: `0 0 auto`,
-        maxWidth: `33.33333333%`,
-        borderLeft: t => `1px solid ${t.colors.ui.border}`,
-        "&:nth-of-type(4)": { boxShadow: `none` },
-        "&:nth-of-type(3n+1)": { borderLeft: 0 },
-      },
-    }}
-  >
-    <div
-      sx={{
-        pt: 8,
-        px: 0,
-        transform: `translateZ(0)`,
-        [mediaQueries.sm]: {
-          px: 8,
-          py: 8,
-        },
-      }}
-    >
-      {children}
-    </div>
-  </div>
-)
+const outerContainerStyles = {
+  display: `flex`,
+  transform: `translateZ(0)`,
+  maxWidth: [null, null, null, `50%`, null, `33.33333333%`],
+  flex: [null, null, null, `0 0 auto`],
+  [mediaQueries.md]: {
+    boxShadow: t => `0 1px 0 0 ${t.colors.ui.border}`,
+    "&:nth-of-type(5), &:nth-of-type(6)": { boxShadow: `none` },
+    "&:nth-of-type(2n)": {
+      borderLeft: 1,
+      borderColor: `ui.border`,
+    },
+  },
+  [mediaQueries.xl]: {
+    borderLeft: 1,
+    borderColor: `ui.border`,
+    "&:nth-of-type(4)": { boxShadow: `none` },
+    "&:nth-of-type(3n+1)": { borderLeft: 0 },
+  },
+}
 
-export default Card
+const innerContainerStyles = {
+  px: [0, null, 8],
+  py: [null, null, 8],
+  pt: 8,
+  transform: `translateZ(0)`,
+}
+
+export default function Card({ children }) {
+  return (
+    <div sx={outerContainerStyles}>
+      <div sx={innerContainerStyles}>{children}</div>
+    </div>
+  )
+}

--- a/www/src/components/futura-paragraph.js
+++ b/www/src/components/futura-paragraph.js
@@ -1,16 +1,16 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 
-const FuturaParagraph = ({ children }) => (
-  <p
-    sx={{
-      fontFamily: `heading`,
-      fontSize: 3,
-      mb: 0,
-    }}
-  >
-    {children}
-  </p>
-)
-
-export default FuturaParagraph
+export default function FuturaParagraph({ children }) {
+  return (
+    <p
+      sx={{
+        fontFamily: `heading`,
+        fontSize: 3,
+        mb: 0,
+      }}
+    >
+      {children}
+    </p>
+  )
+}


### PR DESCRIPTION
## Description

1. Clean up the styles in `<Card/>` component
2. Export `<Card />`, `<CardHeadline />` and `<FuturaParagraph />` as function declaration

### Screenshots(s)

#### Desktop

<img width="960" alt="card-desktop" src="https://user-images.githubusercontent.com/19193724/86531831-36d47100-bee2-11ea-9459-1b3da6762d3e.png">

#### iPad

![card-iPad](https://user-images.githubusercontent.com/19193724/86531841-51a6e580-bee2-11ea-8959-cf3fd19637bc.png)

#### iPhone(X)

![card-iPhoneX](https://user-images.githubusercontent.com/19193724/86531847-5b304d80-bee2-11ea-9078-7e138455df27.png)

### How to test

Go to the following link mentioned below and scroll down a little bit, the component should work same in both the local and production link, just the implementation of component is now different.

**Local URL:** http://localhost:8000
**Production URL:** https://www.gatsbyjs.org