### PR TITLE
chore(www): refactor, tidy and convert Gatsby homepage to function component

### DIFF
--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -214,116 +214,124 @@ const Diagram = () => (
       }
     `}
     render={({ allStaticHostsYaml: { nodes: staticHosts } }) => (
-      <section
-        className="Diagram"
+      <div
         sx={{
-          flex: `1 1 100%`,
-          fontFamily: `heading`,
-          py: 6,
-          textAlign: `center`,
-          [mediaQueries.sm]: {
-            px: 6,
-          },
+          width: `100%`,
+          p: 8,
+          pt: 0,
         }}
       >
-        <h1
+        <section
+          className="Diagram"
           sx={{
-            fontWeight: `heading`,
-            mb: 6,
+            flex: `1 1 100%`,
+            fontFamily: `heading`,
+            py: 6,
+            textAlign: `center`,
+            [mediaQueries.sm]: {
+              px: 6,
+            },
           }}
         >
-          How Gatsby works
-        </h1>
-        <div sx={{ maxWidth: `30rem`, mt: 0, mx: `auto`, mb: 9 }}>
-          <FuturaParagraph>
-            Pull data from <em>anywhere</em>
-          </FuturaParagraph>
-        </div>
-
-        <Segment className="Source">
-          <SegmentTitle>Data Sources</SegmentTitle>
-          <SourceItems>
-            <SourceItem>
-              <ItemTitle>CMSs</ItemTitle>
-              <ItemDescription>
-                Contentful, Drupal, WordPress, etc.
-              </ItemDescription>
-            </SourceItem>
-            <SourceItem>
-              <ItemTitle>Markdown</ItemTitle>
-              <ItemDescription>Documentation, Posts, etc.</ItemDescription>
-            </SourceItem>
-            <SourceItem>
-              <ItemTitle>Data</ItemTitle>
-              <ItemDescription>
-                APIs, Databases, YAML, JSON, CSV, etc.
-              </ItemDescription>
-            </SourceItem>
-          </SourceItems>
-        </Segment>
-
-        <Segment className="Build">
-          <VerticalLine />
-          <SegmentTitle>Build</SegmentTitle>
-          <div
+          <h1
             sx={{
-              ...box,
-              backgroundColor: `purple.70`,
-              backgroundSize: t => `${t.sizes[10]} ${t.sizes[10]}`,
-              backgroundImage: t =>
-                `linear-gradient(45deg, ${t.colors.purple[80]} 25%, transparent 25%, transparent 50%, ${t.colors.purple[80]} 50%, ${t.colors.purple[80]} 75%, transparent 75%, transparent)`,
-              py: 0,
+              fontWeight: `heading`,
+              mb: 6,
             }}
           >
+            How Gatsby works
+          </h1>
+          <div sx={{ maxWidth: `30rem`, mt: 0, mx: `auto`, mb: 9 }}>
+            <FuturaParagraph>
+              Pull data from <em>anywhere</em>
+            </FuturaParagraph>
+          </div>
+
+          <Segment className="Source">
+            <SegmentTitle>Data Sources</SegmentTitle>
+            <SourceItems>
+              <SourceItem>
+                <ItemTitle>CMSs</ItemTitle>
+                <ItemDescription>
+                  Contentful, Drupal, WordPress, etc.
+                </ItemDescription>
+              </SourceItem>
+              <SourceItem>
+                <ItemTitle>Markdown</ItemTitle>
+                <ItemDescription>Documentation, Posts, etc.</ItemDescription>
+              </SourceItem>
+              <SourceItem>
+                <ItemTitle>Data</ItemTitle>
+                <ItemDescription>
+                  APIs, Databases, YAML, JSON, CSV, etc.
+                </ItemDescription>
+              </SourceItem>
+            </SourceItems>
+          </Segment>
+
+          <Segment className="Build">
             <VerticalLine />
-            <Gatsby />
-            <VerticalLine />
+            <SegmentTitle>Build</SegmentTitle>
             <div
               sx={{
-                ...borderAndBoxShadow,
-                ...boxPadding,
-                bg: `white`,
-                display: `inline-block`,
-                py: 3,
-                width: `auto`,
+                ...box,
+                backgroundColor: `purple.70`,
+                backgroundSize: t => `${t.sizes[10]} ${t.sizes[10]}`,
+                backgroundImage: t =>
+                  `linear-gradient(45deg, ${t.colors.purple[80]} 25%, transparent 25%, transparent 50%, ${t.colors.purple[80]} 50%, ${t.colors.purple[80]} 75%, transparent 75%, transparent)`,
+                py: 0,
               }}
             >
-              <ItemDescription color="grey.50">
-                HTML &middot; CSS &middot;
-                {` `}
-                <TechWithIcon icon={ReactJSIcon} height="1.1em">
-                  React
-                </TechWithIcon>
+              <VerticalLine />
+              <Gatsby />
+              <VerticalLine />
+              <div
+                sx={{
+                  ...borderAndBoxShadow,
+                  ...boxPadding,
+                  bg: `white`,
+                  display: `inline-block`,
+                  py: 3,
+                  width: `auto`,
+                }}
+              >
+                <ItemDescription color="grey.50">
+                  HTML &middot; CSS &middot;
+                  {` `}
+                  <TechWithIcon icon={ReactJSIcon} height="1.1em">
+                    React
+                  </TechWithIcon>
+                </ItemDescription>
+              </div>
+              <VerticalLine />
+            </div>
+          </Segment>
+
+          <Segment className="Deploy">
+            <VerticalLine />
+            <SegmentTitle>Deploy</SegmentTitle>
+            <div
+              sx={{
+                ...box,
+                pb: 5,
+              }}
+            >
+              <ItemTitle>Web Hosting</ItemTitle>
+              <ItemDescription>
+                {staticHosts.map((staticHost, index) => (
+                  <Fragment key={staticHost.url}>
+                    {index > 0 && `, `}
+                    <ItemDescriptionLink to={staticHost.url}>
+                      {staticHost.title}
+                    </ItemDescriptionLink>
+                  </Fragment>
+                ))}
+                {` `}& many more
               </ItemDescription>
             </div>
-            <VerticalLine />
-          </div>
-        </Segment>
-
-        <Segment className="Deploy">
-          <VerticalLine />
-          <SegmentTitle>Deploy</SegmentTitle>
-          <div
-            sx={{
-              ...box,
-              pb: 5,
-            }}
-          >
-            <ItemTitle>Web Hosting</ItemTitle>
-            <ItemDescription>
-              {staticHosts.map((staticHost, index) => (
-                <Fragment key={staticHost.url}>
-                  {index > 0 && `, `}
-                  <ItemDescriptionLink to={staticHost.url}>
-                    {staticHost.title}
-                  </ItemDescriptionLink>
-                </Fragment>
-              ))}
-              {` `}& many more
-            </ItemDescription>
-          </div>
-        </Segment>
-      </section>
+          </Segment>
+        </section>
+      </div>
     )}
   />
 )

--- a/www/src/components/diagram.js
+++ b/www/src/components/diagram.js
@@ -214,14 +214,14 @@ const Diagram = () => (
       }
     `}
     render={({ allStaticHostsYaml: { nodes: staticHosts } }) => (
-      <div
+      <section
         sx={{
           width: `100%`,
           p: 8,
           pt: 0,
         }}
       >
-        <section
+        <div
           className="Diagram"
           sx={{
             flex: `1 1 100%`,
@@ -330,8 +330,8 @@ const Diagram = () => (
               </ItemDescription>
             </div>
           </Segment>
-        </section>
-      </div>
+        </div>
+      </section>
     )}
   />
 )

--- a/www/src/components/homepage/homepage-get-started.js
+++ b/www/src/components/homepage/homepage-get-started.js
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+
+import { MdArrowForward as ArrowForwardIcon } from "react-icons/md"
+
+import Container from "../../components/container"
+import FuturaParagraph from "../../components/futura-paragraph"
+import Button from "../../components/button"
+
+export default function HomepageGetStarted() {
+  return (
+    <section sx={{ flex: `1 1 100%`, textAlign: `center` }}>
+      <Container withSidebar={false}>
+        <h1 sx={{ fontWeight: `heading`, mt: 0 }}>Curious yet?</h1>
+        <FuturaParagraph>
+          It only takes a few minutes to get up and running!
+        </FuturaParagraph>
+        <Button
+          secondary
+          variant="large"
+          to="/docs/"
+          tracking="Curious Yet -> Get Started"
+          overrideCSS={{ mt: 5 }}
+          icon={<ArrowForwardIcon />}
+        >
+          Get Started
+        </Button>
+      </Container>
+    </section>
+  )
+}

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -18,6 +18,13 @@ import {
   unobserveScrollers,
 } from "../utils/scrollers-observer"
 
+const homepageWrapperStyles = {
+  display: `flex`,
+  flexDirection: `row`,
+  flexWrap: `wrap`,
+  justifyContent: `space-between`,
+}
+
 const combineEcosystemFeaturedItems = ({
   starters,
   plugins,
@@ -80,15 +87,7 @@ export default function IndexRoute(props) {
   return (
     <>
       <PageMetadata description="Blazing fast modern site generator for React. Go beyond static sites: build blogs, e-commerce sites, full-blown apps, and more with Gatsby." />
-      <main
-        id={`reach-skip-nav`}
-        css={{
-          display: `flex`,
-          flexDirection: `row`,
-          flexWrap: `wrap`,
-          justifyContent: `space-between`,
-        }}
-      >
+      <main id={`reach-skip-nav`} sx={homepageWrapperStyles}>
         <MastheadContent />
         <Diagram />
         <HomepageLogoBanner />

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import React from "react"
+import React, { useEffect } from "react"
 import { graphql } from "gatsby"
 import { MdArrowForward as ArrowForwardIcon } from "react-icons/md"
 
@@ -21,116 +21,113 @@ import {
   unobserveScrollers,
 } from "../utils/scrollers-observer"
 
-class IndexRoute extends React.Component {
-  componentDidMount() {
-    setupScrollersObserver()
-  }
-
-  componentWillUnmount() {
-    unobserveScrollers()
-  }
-
-  combineEcosystemFeaturedItems = ({ starters, plugins, numFeatured = 3 }) =>
-    new Array(numFeatured)
-      .fill(undefined)
-      .reduce(
-        (merged, _, index) => merged.concat([starters[index], plugins[index]]),
-        []
-      )
-
-  render() {
-    const {
-      data: {
-        allMdx: { nodes: postsData },
-        allStartersYaml: { nodes: startersData },
-        allNpmPackage: { nodes: pluginsData },
-      },
-    } = this.props
-
-    const starters = startersData.map(item => {
-      const {
-        fields: {
-          starterShowcase: { slug, name, description, stars },
-        },
-        childScreenshot: {
-          screenshotFile: {
-            childImageSharp: { fixed: thumbnail },
-          },
-        },
-      } = item
-
-      return {
-        slug: `/starters${slug}`,
-        name,
-        description,
-        stars,
-        thumbnail,
-        type: `Starter`,
-      }
-    })
-
-    const plugins = pluginsData.map(item => {
-      item.type = `Plugin`
-
-      return item
-    })
-
-    const ecosystemFeaturedItems = this.combineEcosystemFeaturedItems({
-      plugins,
-      starters,
-    })
-
-    return (
-      <>
-        <PageMetadata description="Blazing fast modern site generator for React. Go beyond static sites: build blogs, e-commerce sites, full-blown apps, and more with Gatsby." />
-        <main
-          id={`reach-skip-nav`}
-          css={{
-            display: `flex`,
-            flexDirection: `row`,
-            flexWrap: `wrap`,
-            justifyContent: `space-between`,
-          }}
-        >
-          <MastheadContent />
-
-          <Diagram />
-          <HomepageLogoBanner />
-          <HomepageFeatures />
-          <div css={{ flex: `1 1 100%` }}>
-            <Container withSidebar={false}>
-              <section css={{ textAlign: `center` }}>
-                <h1 sx={{ fontWeight: `heading`, mt: 0 }}>Curious yet?</h1>
-                <FuturaParagraph>
-                  It only takes a few minutes to get up and running!
-                </FuturaParagraph>
-                <Button
-                  secondary
-                  variant="large"
-                  to="/docs/"
-                  tracking="Curious Yet -> Get Started"
-                  overrideCSS={{ mt: 5 }}
-                  icon={<ArrowForwardIcon />}
-                >
-                  Get Started
-                </Button>
-              </section>
-            </Container>
-          </div>
-
-          <HomepageEcosystem featuredItems={ecosystemFeaturedItems} />
-
-          <HomepageBlog posts={postsData} />
-
-          <HomepageNewsletter />
-        </main>
-        <FooterLinks />
-      </>
+const combineEcosystemFeaturedItems = ({
+  starters,
+  plugins,
+  numFeatured = 3,
+}) =>
+  new Array(numFeatured)
+    .fill(undefined)
+    .reduce(
+      (merged, _, index) => merged.concat([starters[index], plugins[index]]),
+      []
     )
-  }
-}
 
-export default IndexRoute
+export default function IndexRoute(props) {
+  const {
+    data: {
+      allMdx: { nodes: postsData },
+      allStartersYaml: { nodes: startersData },
+      allNpmPackage: { nodes: pluginsData },
+    },
+  } = props
+
+  useEffect(() => {
+    setupScrollersObserver()
+    return unobserveScrollers()
+  }, [])
+
+  const starters = startersData.map(item => {
+    const {
+      fields: {
+        starterShowcase: { slug, name, description, stars },
+      },
+      childScreenshot: {
+        screenshotFile: {
+          childImageSharp: { fixed: thumbnail },
+        },
+      },
+    } = item
+
+    return {
+      slug: `/starters${slug}`,
+      name,
+      description,
+      stars,
+      thumbnail,
+      type: `Starter`,
+    }
+  })
+
+  const plugins = pluginsData.map(item => {
+    item.type = `Plugin`
+
+    return item
+  })
+
+  const ecosystemFeaturedItems = combineEcosystemFeaturedItems({
+    plugins,
+    starters,
+  })
+
+  return (
+    <>
+      <PageMetadata description="Blazing fast modern site generator for React. Go beyond static sites: build blogs, e-commerce sites, full-blown apps, and more with Gatsby." />
+      <main
+        id={`reach-skip-nav`}
+        css={{
+          display: `flex`,
+          flexDirection: `row`,
+          flexWrap: `wrap`,
+          justifyContent: `space-between`,
+        }}
+      >
+        <MastheadContent />
+
+        <Diagram />
+        <HomepageLogoBanner />
+        <HomepageFeatures />
+        <div css={{ flex: `1 1 100%` }}>
+          <Container withSidebar={false}>
+            <section css={{ textAlign: `center` }}>
+              <h1 sx={{ fontWeight: `heading`, mt: 0 }}>Curious yet?</h1>
+              <FuturaParagraph>
+                It only takes a few minutes to get up and running!
+              </FuturaParagraph>
+              <Button
+                secondary
+                variant="large"
+                to="/docs/"
+                tracking="Curious Yet -> Get Started"
+                overrideCSS={{ mt: 5 }}
+                icon={<ArrowForwardIcon />}
+              >
+                Get Started
+              </Button>
+            </section>
+          </Container>
+        </div>
+
+        <HomepageEcosystem featuredItems={ecosystemFeaturedItems} />
+
+        <HomepageBlog posts={postsData} />
+
+        <HomepageNewsletter />
+      </main>
+      <FooterLinks />
+    </>
+  )
+}
 
 export const pageQuery = graphql`
   query IndexRouteQuery {

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -93,15 +93,8 @@ class IndexRoute extends React.Component {
           }}
         >
           <MastheadContent />
-          <div
-            sx={{
-              width: `100%`,
-              p: 8,
-              pt: 0,
-            }}
-          >
-            <Diagram />
-          </div>
+
+          <Diagram />
           <HomepageLogoBanner />
           <HomepageFeatures />
           <div css={{ flex: `1 1 100%` }}>

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -2,15 +2,12 @@
 import { jsx } from "theme-ui"
 import React, { useEffect } from "react"
 import { graphql } from "gatsby"
-import { MdArrowForward as ArrowForwardIcon } from "react-icons/md"
 
-import Container from "../components/container"
 import MastheadContent from "../components/masthead"
 import Diagram from "../components/diagram"
-import FuturaParagraph from "../components/futura-paragraph"
-import Button from "../components/button"
 import HomepageLogoBanner from "../components/homepage/homepage-logo-banner"
 import HomepageFeatures from "../components/homepage/homepage-features"
+import HomepageGetStarted from "../components/homepage/homepage-get-started"
 import HomepageEcosystem from "../components/homepage/homepage-ecosystem"
 import HomepageBlog from "../components/homepage/homepage-blog"
 import HomepageNewsletter from "../components/homepage/homepage-newsletter"
@@ -93,35 +90,12 @@ export default function IndexRoute(props) {
         }}
       >
         <MastheadContent />
-
         <Diagram />
         <HomepageLogoBanner />
         <HomepageFeatures />
-        <div css={{ flex: `1 1 100%` }}>
-          <Container withSidebar={false}>
-            <section css={{ textAlign: `center` }}>
-              <h1 sx={{ fontWeight: `heading`, mt: 0 }}>Curious yet?</h1>
-              <FuturaParagraph>
-                It only takes a few minutes to get up and running!
-              </FuturaParagraph>
-              <Button
-                secondary
-                variant="large"
-                to="/docs/"
-                tracking="Curious Yet -> Get Started"
-                overrideCSS={{ mt: 5 }}
-                icon={<ArrowForwardIcon />}
-              >
-                Get Started
-              </Button>
-            </section>
-          </Container>
-        </div>
-
+        <HomepageGetStarted />
         <HomepageEcosystem featuredItems={ecosystemFeaturedItems} />
-
         <HomepageBlog posts={postsData} />
-
         <HomepageNewsletter />
       </main>
       <FooterLinks />


### PR DESCRIPTION
## Description

1. Clean up the styles in `<IndexRoute/>` component
2. Create a separate component for Getting Started section
3. Move the `<Diagram/>` styles to the `<Diagram/>` component
4. Replace **css** to **sx** 
5. setupScrollersObserver & unobserveScrollers using useEffect() hook
6. Convert IndexRoute to function component

### How to test

Go to the following link mentioned below and scroll down a little bit, the component should work same in both the local and production link, just the implementation of component is now different.

**Local URL:** http://localhost:8000
**Production URL:** https://www.gatsbyjs.org