### PR TITLE
Adds react as a peer dependency

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -70,6 +70,9 @@
     "ws": "^7.3.0",
     "xstate": "^4.11.0"
   },
+  "peerDependencies": {
+    "react": "^16.12.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.10.3",
     "react": "^16.12.0",


### PR DESCRIPTION
## Description

Ink-box requires React, so gatsby-recipes needs to provide it. The peer dependency is currently missing.

## Related Issues

https://github.com/yarnpkg/berry/runs/840615717?check_suite_focus=true