### PR TITLE
Update `tsc --init` to `typescript --init`

### DIFF
--- a/starters/default/src/pages/using-typescript.tsx
+++ b/starters/default/src/pages/using-typescript.tsx
@@ -16,7 +16,7 @@ const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path }) => (
     <SEO title="Using TypeScript" />
     <h1>Gatsby supports TypeScript by default!</h1>
     <p>This means that you can create and write <em>.ts/.tsx</em> files for your pages, components etc. Please note that the <em>gatsby-*.js</em> files (like gatsby-node.js) currently don't support TypeScript yet.</p>
-    <p>For type checking you'll want to install <em>typescript</em> via npm and run <em>tsc --init</em> to create a <em>.tsconfig</em> file.</p>
+    <p>For type checking you'll want to install <em>typescript</em> via npm and run <em>typescript --init</em> to create a <em>.tsconfig</em> file.</p>
     <p>You're currently on the page "{path}" which was built on {data.site.buildTime}.</p>
     <p>To learn more, head over to our <a href="https://www.gatsbyjs.org/docs/typescript/">documentation about TypeScript</a>.</p>
     <Link to="/">Go back to the homepage</Link>


### PR DESCRIPTION
`tsc --init` is outdated

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

`tsc --init` doesn't work anymore if you run `npx tsc --init`. It should be replaced with `typescript --init`
<!-- Write a brief description of the changes introduced by this PR -->

This is my first time checking out Gatsby and I noticed this wasn't working, so here is the change. If you need me to update anything else let me know, this is my first PR to Gatsby :slightly_smiling_face: 