### PR TITLE
refactor(www): clean up get-prev-and-next

### DIFF
--- a/www/src/utils/get-prev-and-next.js
+++ b/www/src/utils/get-prev-and-next.js
@@ -14,12 +14,12 @@ function flattenList(itemList) {
 
 function flattenFilterList(itemList) {
   const flattened = flattenList(itemList)
-  return flattened.filter(item => item.link && !item.link.includes(`#`))
+  return flattened.filter(item => !item.link || !item.link.includes(`#`))
 }
 
 const flattenedNavs = {
   docs: flattenFilterList(docLinks[0].items),
-  tutorials: flattenFilterList(tutorialLinks[0].items),
+  tutorial: flattenFilterList(tutorialLinks[0].items),
   contributing: flattenFilterList(contributingLinks[0].items),
 }
 

--- a/www/src/utils/get-prev-and-next.js
+++ b/www/src/utils/get-prev-and-next.js
@@ -14,7 +14,7 @@ function flattenList(itemList) {
 
 function flattenFilterList(itemList) {
   const flattened = flattenList(itemList)
-  return flattened.filter(item => !item.link || !item.link.includes(`#`))
+  return flattened.filter(item => item.link && !item.link.includes(`#`))
 }
 
 const flattenedNavs = {

--- a/www/src/utils/get-prev-and-next.js
+++ b/www/src/utils/get-prev-and-next.js
@@ -20,7 +20,7 @@ function flattenList(itemList) {
 
 function flattenFilterList(itemList) {
   const flattened = flattenList(itemList)
-  return flattened.filter(item => !item.link.includes("#"))
+  return flattened.filter(item => !item.link.includes(`#`))
 }
 
 const flattenedNavs = {
@@ -38,16 +38,16 @@ function findDoc(doc) {
 }
 
 function getPrevAndNext(slug) {
-  const section = slug.split("/")[1]
+  const section = slug.split(`/`)[1]
   const sectionNav = flattenedNavs[section]
   if (!sectionNav) return null
   const index = sectionNav.findIndex(findDoc, { link: slug })
   if (index < 0) {
-    return
+    return null
   }
   return {
     prev: index === 0 ? null : flattenedNavs[index - 1],
-    next: index === flattenedNavs.length - 1 ? null : flattenedNav[index + 1],
+    next: index === flattenedNavs.length - 1 ? null : flattenedNavs[index + 1],
   }
 }
 

--- a/www/src/utils/get-prev-and-next.js
+++ b/www/src/utils/get-prev-and-next.js
@@ -20,7 +20,7 @@ function flattenList(itemList) {
 
 function flattenFilterList(itemList) {
   const flattened = flattenList(itemList)
-  return flattened.filter(item => !item.link.includes(`#`))
+  return flattened.filter(item => item.link && !item.link.includes(`#`))
 }
 
 const flattenedNavs = {

--- a/www/src/utils/get-prev-and-next.js
+++ b/www/src/utils/get-prev-and-next.js
@@ -1,13 +1,7 @@
 const { loadYaml } = require(`./load-yaml`)
-const docLinksData = loadYaml(`src/data/sidebars/doc-links.yaml`)
-const tutorialLinksData = loadYaml(`src/data/sidebars/tutorial-links.yaml`)
-const contributingLinksData = loadYaml(
-  `src/data/sidebars/contributing-links.yaml`
-)
-
-const docLinks = docLinksData[0].items
-const tutorialLinks = tutorialLinksData[0].items
-const contributingLinks = contributingLinksData[0].items
+const docLinks = loadYaml(`src/data/sidebars/doc-links.yaml`)
+const tutorialLinks = loadYaml(`src/data/sidebars/tutorial-links.yaml`)
+const contributingLinks = loadYaml(`src/data/sidebars/contributing-links.yaml`)
 
 // flatten sidebar links trees for easier next/prev link calculation
 function flattenList(itemList) {
@@ -24,9 +18,9 @@ function flattenFilterList(itemList) {
 }
 
 const flattenedNavs = {
-  docs: flattenFilterList(docLinks),
-  tutorials: flattenFilterList(tutorialLinks),
-  contributing: flattenFilterList(contributingLinks),
+  docs: flattenFilterList(docLinks[0].items),
+  tutorials: flattenFilterList(tutorialLinks[0].items),
+  contributing: flattenFilterList(contributingLinks[0].items),
 }
 
 function findDoc(doc) {
@@ -46,8 +40,8 @@ function getPrevAndNext(slug) {
     return null
   }
   return {
-    prev: index === 0 ? null : flattenedNavs[index - 1],
-    next: index === flattenedNavs.length - 1 ? null : flattenedNavs[index + 1],
+    prev: index === 0 ? null : sectionNav[index - 1],
+    next: index === sectionNav.length - 1 ? null : sectionNav[index + 1],
   }
 }
 

--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -150,7 +150,6 @@ exports.onCreateNode = async ({
   const section = slug.split(`/`)[1]
   // fields for blog pages are handled in `utils/node/blog.js`
   if (section === `blog`) return
-  console.log({ slug, nav: getPrevAndNext(slug) })
 
   const fieldData = {
     ...node.frontmatter,

--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -150,6 +150,7 @@ exports.onCreateNode = async ({
   const section = slug.split(`/`)[1]
   // fields for blog pages are handled in `utils/node/blog.js`
   if (section === `blog`) return
+  console.log({ slug, nav: getPrevAndNext(slug) })
 
   const fieldData = {
     ...node.frontmatter,


### PR DESCRIPTION
## Description

Clean up and simplify the get-prev-and-next utility function used to calculate the previous and next doc page. This also fixes a small bug where [Docs and Blog Components](https://www.gatsbyjs.org/contributing/docs-and-blog-components/) leads to a link that does not exist.