### PR TITLE
chore(circleci): fix conditional step configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,8 +215,8 @@ jobs:
       # We should always assert on master
       - when:
           condition:
-            - not:
-                equal: [master, << pipeline.git.branch >>]
+            not:
+              equal: [master, << pipeline.git.branch >>]
           steps:
             - run: ./scripts/assert-changed-files.sh "packages/*|.circleci/*"
       - <<: *attach_to_bootstrap


### PR DESCRIPTION
## Description

Our config doesn't exactly match the circleCI schema - the `condition` should have single condition and we currently have array (of 1). This doesn't match the schema documented in https://circleci.com/docs/2.0/configuration-reference/#logic-statements and appears that CircleCi only just recently tighten config validation in this regard as we started to see CI errors like https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/45270/workflows/81dbbd81-7189-412d-b9f0-79dd5ad40fc3/jobs/460147