### PR TITLE
enhancement(docs): dictionary.txt -> .yml -> File names in code blocks

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -9,7 +9,6 @@
 .scss
 .tsx
 .yaml
-.yml
 ½
 ⅓
 1000px

--- a/docs/contributing/site-showcase-submissions.md
+++ b/docs/contributing/site-showcase-submissions.md
@@ -139,4 +139,4 @@ categories:
 
 ### Need to change your submission?
 
-If you want to edit anything in your site submission later, simply edit the .yml file by submitting another PR.
+If you want to edit anything in your site submission later, simply edit the `.yml` file by submitting another PR.

--- a/docs/contributing/submit-to-starter-library.md
+++ b/docs/contributing/submit-to-starter-library.md
@@ -48,7 +48,7 @@ If there are linting issues with your PR, you can fix them by running `npm run f
 
 ### Need to change details?
 
-If you want to edit anything in your site submission later, simply edit the .yml file by submitting another PR. GitHub data (like stars) will be automatically pulled and updated, but your starter description, tags, and feature list are up to you!
+If you want to edit anything in your site submission later, simply edit the `.yml` file by submitting another PR. GitHub data (like stars) will be automatically pulled and updated, but your starter description, tags, and feature list are up to you!
 
 ### Adding new tag
 

--- a/docs/docs/sourcing-from-netlify-cms.md
+++ b/docs/docs/sourcing-from-netlify-cms.md
@@ -142,7 +142,7 @@ backend:
   repo: your-username/your-repo-name
 ```
 
-Now you can save the config.yml file, commit the change, and push it to your GitHub repo.
+Now you can save the `config.yml` file, commit the change, and push it to your GitHub repo.
 
 ### Authenticating with GitLab
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In this PR we reference issue #25290 where they have asked to: put filenames like .yml in code blocks.

We do this by finding all instances of `.yml` that are not in code blocks yet and then add a code block around them. I then remove .yml from the dictionary.


### Documentation

No documentation is required for this

## Related Issues

Partially addresses #25290

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
