### PR TITLE
refactor(www) factor out common doc page content to a fragment

### DIFF
--- a/www/src/components/docs-markdown-page.js
+++ b/www/src/components/docs-markdown-page.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import React from "react"
+import { graphql } from "gatsby"
 import { MDXRenderer } from "gatsby-plugin-mdx"
 import { mediaQueries } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
 
@@ -25,7 +25,7 @@ const containerStyles = {
   px: 9,
 }
 
-function DocsMarkdownPage({
+export default function DocsMarkdownPage({
   page,
   location,
   prev,
@@ -126,4 +126,18 @@ function DocsMarkdownPage({
   )
 }
 
-export default DocsMarkdownPage
+export const docPageContentFragment = graphql`
+  fragment DocPageContent on DocPage {
+    relativePath
+    slug
+    body
+    excerpt
+    timeToRead
+    tableOfContents
+    anchor
+    title
+    description
+    disableTableOfContents
+    tableOfContentsDepth
+  }
+`

--- a/www/src/templates/template-api-markdown.js
+++ b/www/src/templates/template-api-markdown.js
@@ -110,19 +110,9 @@ export default function APITemplate({ data, location, pageContext }) {
 export const pageQuery = graphql`
   query($path: String!, $jsdoc: [String], $apiCalls: String) {
     docPage(slug: { eq: $path }) {
-      relativePath
-      slug
-      body
-      excerpt
-      timeToRead
-      tableOfContents
-      anchor
-      title
-      description
+      ...DocPageContent
       contentsHeading
       showTopLevelSignatures
-      disableTableOfContents
-      tableOfContentsDepth
     }
     jsdoc: allFile(filter: { relativePath: { in: $jsdoc } }) {
       nodes {

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -24,18 +24,8 @@ export default DocsTemplate
 export const pageQuery = graphql`
   query($slug: String!) {
     docPage(slug: { eq: $slug }) {
-      relativePath
-      slug
-      body
-      excerpt
-      timeToRead
-      tableOfContents
-      anchor
-      title
-      description
+      ...DocPageContent
       issue
-      disableTableOfContents
-      tableOfContentsDepth
     }
   }
 `


### PR DESCRIPTION
## Description

Pull out common fields on `template-docs-markdown` and `template-api-markdown` to a GraphQL fragment.