### PR TITLE
chore(gatsby-admin): remove all custom color treatment

### DIFF
--- a/packages/gatsby-admin/src/components/navbar.tsx
+++ b/packages/gatsby-admin/src/components/navbar.tsx
@@ -20,7 +20,7 @@ const Navbar: React.FC<{}> = () => {
       justifyContent="space-between"
       alignItems="center"
       sx={{
-        backgroundColor: `grey.90`,
+        backgroundColor: `gatsby`,
         borderBottom: `default`,
         paddingX: 6,
         paddingY: 5,
@@ -33,7 +33,7 @@ const Navbar: React.FC<{}> = () => {
             sx={{
               width: `1px`,
               height: `16px`,
-              backgroundColor: `grey.40`,
+              backgroundColor: `whiteFade.50`,
             }}
           />
         )}

--- a/packages/gatsby-admin/src/components/providers.tsx
+++ b/packages/gatsby-admin/src/components/providers.tsx
@@ -10,7 +10,7 @@ const theme = {
   ...baseTheme,
   colors: {
     ...baseTheme.colors,
-    background: baseTheme.colors.grey[90],
+    background: baseTheme.colors.primaryBackground,
   },
   fontWeights: {
     ...baseTheme.fontWeights,

--- a/packages/gatsby-admin/src/pages/index.tsx
+++ b/packages/gatsby-admin/src/pages/index.tsx
@@ -10,6 +10,7 @@ import {
   InputField,
   InputFieldControl,
   ButtonProps,
+  InputFieldLabel,
 } from "gatsby-interface"
 
 const SecondaryButton: React.FC<ButtonProps> = props => (
@@ -19,12 +20,6 @@ const SecondaryButton: React.FC<ButtonProps> = props => (
     sx={{
       paddingX: 6,
       paddingY: 4,
-      color: `whiteFade.80`,
-      border: `sixtywhite`,
-      "&:hover": {
-        color: `white`,
-        border: `white`,
-      },
     }}
     {...props}
   ></Button>
@@ -65,9 +60,7 @@ const InstallInput: React.FC<{ for: string }> = props => {
     >
       <InputField id={inputId}>
         <Flex gap={2} flexDirection="column">
-          <Text size="S" sx={{ color: `grey.40` }}>
-            <label htmlFor={inputId}>Install {props.for}:</label>
-          </Text>
+          <InputFieldLabel>Install {props.for}:</InputFieldLabel>
           <Flex gap={4} alignItems="center">
             <InputFieldControl
               placeholder={`gatsby-${props.for}-`}
@@ -75,15 +68,7 @@ const InstallInput: React.FC<{ for: string }> = props => {
               value={value}
               onChange={(e): void => setValue(e.target.value)}
               sx={{
-                backgroundColor: `background`,
-                borderColor: `grey.60`,
-                color: `white`,
                 width: `initial`,
-                "&:focus": {
-                  borderColor: `grey.40`,
-                  // TODO(@mxstbr): Fix this focus outline
-                  boxShadow: `none`,
-                },
               }}
             />
             <SecondaryButton
@@ -136,11 +121,7 @@ const DestroyButton: React.FC<{ name: string }> = ({ name }) => {
 }
 
 const SectionHeading: React.FC<HeadingProps> = props => (
-  <Heading
-    as="h1"
-    sx={{ color: `white`, fontWeight: `500`, fontSize: 5 }}
-    {...props}
-  />
+  <Heading as="h1" sx={{ fontWeight: `500`, fontSize: 5 }} {...props} />
 )
 
 const PluginCard: React.FC<{
@@ -149,12 +130,12 @@ const PluginCard: React.FC<{
   <Flex
     flexDirection="column"
     gap={6}
-    sx={{ backgroundColor: `grey.80`, padding: 5, borderRadius: 2 }}
+    sx={{ backgroundColor: `ui.background`, padding: 5, borderRadius: 2 }}
   >
-    <Heading as="h2" sx={{ color: `white`, fontWeight: `500`, fontSize: 3 }}>
+    <Heading as="h2" sx={{ fontWeight: `500`, fontSize: 3 }}>
       {plugin.name}
     </Heading>
-    <Text sx={{ color: `grey.40` }}>
+    <Text sx={{ color: `text.secondary` }}>
       {plugin.description || <em>No description.</em>}
     </Text>
     <Flex justifyContent="flex-end" sx={{ width: `100%` }}>


### PR DESCRIPTION
I implemented the color treatment (i.e. "dark mode") of Admin by manually overwriting the colors of every gatsby-interface components that I use, for example:

```js
<Button sx={{ color: `white` }} />
```

However, this is tech debt that doesn't scale. To skin even the Button component with all its states (!) is difficult this way, not to mention trying to do the same for the more complex compound components in gatsby-interface like the inputs.

Instead, the color treatment and style should always be determined by the global theme, which is why this PR removes most custom colors from the codebase (except where they make sense).

As we are still figuring Admin's specific style out, I'm not going to spend any time trying to match the current design with the global theme and instead simply use the gatsby-interface defaults. While this subjectively doesn't look as good visually right now, we can work on a global theme once we have a set direction instead of manually trying to overwrite everything.

**Before / After**

![Screenshot 2020-07-08 at 09 37 32](https://user-images.githubusercontent.com/7525670/86891543-4aa8ee80-c0ff-11ea-9796-4ba7b9fd4ed4.png)

![Screenshot 2020-07-08 at 09 37 26](https://user-images.githubusercontent.com/7525670/86891550-4c72b200-c0ff-11ea-854e-7ca349a5b7cb.png)
