### PR TITLE
chore(monorepo): do not apply the "triage needed" label to already-labeled PRs

### DIFF
--- a/peril/rules/apply-triage-needed.ts
+++ b/peril/rules/apply-triage-needed.ts
@@ -33,7 +33,8 @@ export const applyStatusTriageNeededLabel = async () => {
     if (
       issueOrPullRequest &&
       !issueOrPullRequest.labels.some(
-        (label: GitHubIssueLabel) => label.name === triageNeededLabel
+        (label: GitHubIssueLabel) =>
+          label.name === triageNeededLabel || label.name.indexOf(`topic:`) === 0
       )
     ) {
       const opts = {


### PR DESCRIPTION
*Note: this PR is meant to kick off a discussion, I'm not saying we have to do this, it just annoyed me enough that I figured I'd try to fix it :grimacing:*

This changes our Peril rules to only apply the `status: triage needed` label when no _topic_ for the PR/issue has already been selected.

The reason I would like this is because I _always_ have to manually remove the `status: triage needed` label on my PRs even though I already label them with `topic: admin` when I create them. For example: #25598

![Screenshot 2020-07-08 at 10 47 31](https://user-images.githubusercontent.com/7525670/86898067-81373700-c108-11ea-99d5-8a48d908b128.png)

It's already triaged Gatsbot!! Please don't make me remove the label :cry: 

I am not too up-to-speed about the core triage process, so this may be an oversimplification of when this label should be applied. I'm fine with even just adding a special case for `topic: admin` if that makes more sense than doing it for all topic labels :blush:

Like I said at the top, totally open for discussion, just annoyed me enough times now that I wanted to fix it :grimacing: