### PR TITLE
fix(blog): WordPress V4 -> typos

### DIFF
--- a/docs/blog/2020-07-07-wordpress-source-beta/index.mdx
+++ b/docs/blog/2020-07-07-wordpress-source-beta/index.mdx
@@ -7,7 +7,7 @@ image: ./Gatsby-Wapuus.png
 showImageInArticle: false
 author: Hashim Warren
 twitterCard: summary
-excerpt: Today we are excited to announce that Gatsby’s new source plugin for WordPress has launched in beta! This new release delivers major improvements to our headless WordPress integration with Gatsby and Gatsby 
+excerpt: Today we are excited to announce that Gatsby’s new source plugin for WordPress has launched in beta! This new release delivers major improvements to our headless WordPress integration with Gatsby and Gatsby Cloud. 
 ---
 
 Today we are excited to announce that [Gatsby’s new source plugin for WordPress](https://github.com/gatsbyjs/gatsby-source-wordpress-experimental) has launched in beta! 
@@ -29,7 +29,7 @@ The new source plugin for WordPress gives you the following enhanced developer a
 - Links and images within the HTML of content can be used with [gatsby-image](/docs/gatsby-image/) and [gatsby-link](/docs/gatsby-link/). This fixes a common complaint about the original source plugin for WordPress.
 - Limit the number of nodes fetched during development, so you can rapidly make changes to your site while creating new pages and features
 - Only images that are referenced in published content are processed by Gatsby, so a large media library won’t slow down your build times 
-- Any WPGraphQL extension automatically makes its data available to your Gatsby project. This means your site can leverage popular WordPress [SEO](https://github.com/ashhitch/wp-graphql-yoast-seo), [content modeling](https://docs.wpgraphql.com/extensions/wpgraphql-advanced-custom-fields/)], [translation](https://github.com/valu-digital/wp-graphql-polylang), and [ecommerce](https://docs.wpgraphql.com/extensions/wpgraphql-woocommerce/) plugins through a single Gatsby source plugin.
+- Any WPGraphQL extension automatically makes its data available to your Gatsby project. This means your site can leverage popular WordPress [SEO](https://github.com/ashhitch/wp-graphql-yoast-seo), [content modeling](https://docs.wpgraphql.com/extensions/wpgraphql-advanced-custom-fields/), [translation](https://github.com/valu-digital/wp-graphql-polylang), and [ecommerce](https://docs.wpgraphql.com/extensions/wpgraphql-woocommerce/) plugins through a single Gatsby source plugin.
 
 ## How to start using the new WordPress source plugin
 Follow the steps below to bring Gatsby Preview and Incremental Builds to your Gatsby/WordPress project:


### PR DESCRIPTION
## Description

changes:
- add "Gatsby Cloud" to the Excerpt
- remove loftover `]` from commit 2a00a474d15b320f24802210e8abde52bc44f50c 


## Related Issues

- #25558 `(blog) New WordPress source plugin`
