### PR TITLE
fix(gatsby): Check if page data exists when hash matches

### DIFF
--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -13,6 +13,7 @@ import errorParser from "./error-parser"
 
 import { GraphQLRunner } from "./graphql-runner"
 import { IExecutionResult, PageContext } from "./types"
+import { pageDataExists } from "../utils/page-data"
 
 const resultHashes = new Map()
 
@@ -147,7 +148,12 @@ export const queryRunner = async (
     .createHash(`sha1`)
     .update(resultJSON)
     .digest(`base64`)
-  if (resultHash !== resultHashes.get(queryJob.id)) {
+
+  if (
+    resultHash !== resultHashes.get(queryJob.id) ||
+    (queryJob.isPage &&
+      !pageDataExists(path.join(program.directory, `public`), queryJob.id))
+  ) {
     resultHashes.set(queryJob.id, resultHash)
 
     if (queryJob.isPage) {

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -53,6 +53,10 @@ export async function removePageData(
   return Promise.resolve()
 }
 
+export function pageDataExists(publicDir: string, pagePath: string): boolean {
+  return fs.existsSync(getFilePath(publicDir, pagePath))
+}
+
 export async function writePageData(
   publicDir: string,
   { componentChunkName, matchPath, path: pagePath }: IPageData


### PR DESCRIPTION
Currently we skip writing queries if the result hash matches the hash of an existing query with that ID (i.e. the data is unchanged). However, both inc builds and conditional page builds delete `page-data.json` when pages are deleted. In the scenario where a page is unpublished and then republished with identical content, the query runner thinks that the query is already in the cache, so skips writing it out. However it no longer exists on disk, so the page build will fail.

This PR adds a check to see if the page data actually exists before skipping the write. 