### PR TITLE
chore(gatsby-source-wordpress): add deprecation notice and link to beta WP source plugin

### DIFF
--- a/docs/tutorial/wordpress-image-tutorial.md
+++ b/docs/tutorial/wordpress-image-tutorial.md
@@ -2,6 +2,12 @@
 title: "Adding Images to a WordPress Site"
 ---
 
+<mark>Warning:</mark>
+
+The version of `gatsby-source-wordpress` that this tutorial uses will soon be deprecated and replaced with a complete rewrite in the next major version (v4). The reason for this is that we've adopted the use of WPGraphQL to support Preview and incremental builds as well as to make the schema generally more stable and consistent.
+
+Please follow the tutorial on [creating a new site with `gatsby-source-wordpress-experimental`](https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/docs/tutorials/building-a-new-site-wordpress-and-gatsby.md) instead, as that package is a beta of the next major version of `gatsby-source-wordpress`.
+
 ## What this tutorial covers:
 
 In this tutorial, you will install the several image plugins and components in order to pull image data from a WordPress account into your Gatsby site and render that data. This [Gatsby + WordPress demo site](https://using-wordpress.gatsbyjs.org/) shows you a sample of what you’re going to be building in this tutorial, although in this tutorial you’ll just focus on adding images.

--- a/docs/tutorial/wordpress-source-plugin-tutorial.md
+++ b/docs/tutorial/wordpress-source-plugin-tutorial.md
@@ -4,6 +4,12 @@ title: "WordPress Source Plugin Tutorial"
 
 ## How to create a site with data pulled from WordPress
 
+<mark>Warning:</mark>
+
+The version of `gatsby-source-wordpress` that this tutorial uses will soon be deprecated and replaced with a complete rewrite in the next major version (v4). The reason for this is that we've adopted the use of WPGraphQL to support Preview and incremental builds as well as to make the schema generally more stable and consistent.
+
+Please follow the tutorial on [creating a new site with `gatsby-source-wordpress-experimental`](https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/docs/tutorials/building-a-new-site-wordpress-and-gatsby.md) instead, as that package is a beta of the next major version of `gatsby-source-wordpress`.
+
 ### What this tutorial covers:
 
 In this tutorial, you will install the `gatsby-source-wordpress` plugin in order to pull blog and image data from a WordPress install into your Gatsby site and render that data. This [Gatsby + WordPress demo site](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-wordpress) shows you the source code for an example site similar to what you’re going to be building in this tutorial, although it’s missing the cool images you’ll be adding in the next part of this tutorial, [Adding Images to a WordPress Site](/tutorial/wordpress-image-tutorial/). :D

--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -1,3 +1,15 @@
+<mark>Warning:</mark>
+**The current version of this plugin will soon be deprecated** and replaced with a complete rewrite in the next version (v4). The reason for this is that we've adopted the use of WPGraphQL to support Preview and incremental builds as well as to make the schema generally more stable and consistent.
+
+Please upgrade to the beta of \`gatsby-source-wordpress@v4\` by installing \`gatsby-source-wordpress-experimental\`.
+
+These two packages are currently published under separate names to allow activating them side-by-side.
+This makes migration between the two simpler. Once the new plugin is stable it will be merged back in and be published as `gatsby-source-wordpress`.
+
+[Read this blog post for the beta announcement](https://www.gatsbyjs.org/blog/2020-07-07-wordpress-source-beta/)
+
+[Or get started with the new plugin here](https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/#readme)
+
 # gatsby-source-wordpress
 
 Source plugin for pulling data into [Gatsby](https://github.com/gatsbyjs) from

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -2,14 +2,29 @@ const fetch = require(`./fetch`)
 const normalize = require(`./normalize`)
 const normalizeBaseUrl = require(`./normalize-base-url`)
 
-exports.onPreBootstrap = ({ reporter }) => {
-  reporter.log(`\n`)
-  reporter.warn(`[gatsby-source-wordpress]\n\nThis version of \`gatsby-source-wordpress\` will be deprecated soon.\nThe next major version (v4) is a complete rewrite in order to take advantage of WPGraphQL.\nThis allows us to support features like Preview and incremental builds and provides a much more stable experience.\n\nPlease upgrade to the BETA of \`gatsby-source-wordpress@v4\` by installing \`gatsby-source-wordpress-experimental\`.\nThese two packages are currently published under separate names to allow activating them side-by-side.\nThis makes migration between the two simpler.\nOnce the new plugin is stable it will be merged back in and published as \`gatsby-source-wordpress\` going forward.
+exports.onPreBootstrap = ({ reporter }, { minimizeDeprecationNotice }) => {
+  if (!minimizeDeprecationNotice) {
+    reporter.log(`\n`)
+    reporter.warn(`[gatsby-source-wordpress]\n\nThis version of \`gatsby-source-wordpress\` will be deprecated soon.\nThe next major version (v4) is a complete rewrite in order to take advantage of WPGraphQL.\nThis allows us to support features like Preview and incremental builds and provides a much more stable experience.\n\nPlease upgrade to the BETA of \`gatsby-source-wordpress@v4\` by installing \`gatsby-source-wordpress-experimental\`.\nThese two packages are currently published under separate names to allow activating them side-by-side.\nThis makes migration between the two simpler.\nOnce the new plugin is stable it will be merged back in and published as \`gatsby-source-wordpress\` going forward.
 
-  Read this blog post for the beta announcement:\nhttps://www.gatsbyjs.org/blog/2020-07-07-wordpress-source-beta/
+Read this blog post for the beta announcement:\nhttps://www.gatsbyjs.org/blog/2020-07-07-wordpress-source-beta/
 
-  Or get started with the new plugin here:\nhttps://github.com/gatsbyjs/gatsby-source-wordpress-experimental/#readme
-  \n\n`)
+Or get started with the new plugin here:\nhttps://github.com/gatsbyjs/gatsby-source-wordpress-experimental/#readme
+
+You can minimize this notice using the minimizeDeprecationNotice plugin option:
+
+{
+  resolve: "gatsby-source-wordpress",
+  options: {
+    minimizeDeprecationNotice: true
+  },
+},
+\n\n`)
+  } else {
+    reporter.warn(
+      `[gatsby-source-wordpress] This version of gatsby-source-wordpress will soon be deprecated.\n\thttps://www.gatsbyjs.org/blog/2020-07-07-wordpress-source-beta/`
+    )
+  }
 }
 
 const typePrefix = `wordpress__`

--- a/packages/gatsby-source-wordpress/src/gatsby-node.js
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.js
@@ -2,6 +2,16 @@ const fetch = require(`./fetch`)
 const normalize = require(`./normalize`)
 const normalizeBaseUrl = require(`./normalize-base-url`)
 
+exports.onPreBootstrap = ({ reporter }) => {
+  reporter.log(`\n`)
+  reporter.warn(`[gatsby-source-wordpress]\n\nThis version of \`gatsby-source-wordpress\` will be deprecated soon.\nThe next major version (v4) is a complete rewrite in order to take advantage of WPGraphQL.\nThis allows us to support features like Preview and incremental builds and provides a much more stable experience.\n\nPlease upgrade to the BETA of \`gatsby-source-wordpress@v4\` by installing \`gatsby-source-wordpress-experimental\`.\nThese two packages are currently published under separate names to allow activating them side-by-side.\nThis makes migration between the two simpler.\nOnce the new plugin is stable it will be merged back in and published as \`gatsby-source-wordpress\` going forward.
+
+  Read this blog post for the beta announcement:\nhttps://www.gatsbyjs.org/blog/2020-07-07-wordpress-source-beta/
+
+  Or get started with the new plugin here:\nhttps://github.com/gatsbyjs/gatsby-source-wordpress-experimental/#readme
+  \n\n`)
+}
+
 const typePrefix = `wordpress__`
 const refactoredEntityTypes = {
   post: `${typePrefix}POST`,


### PR DESCRIPTION
This PR adds a deprecation notice to the cli output, the top of the README, and to the 2 tutorials. We're currently publishing the beta of `gatsby-source-wordpress@v4` on a separate package name to allow for an easy upgrade path. Users can install the beta alongside `gatsby-source-wordpress@v3` and have them both active at once during migration.

<img width="1279" alt="Screen Shot 2020-07-08 at 9 42 51 AM" src="https://user-images.githubusercontent.com/14190743/86966460-1264d880-c11e-11ea-89d7-c20f2729a411.png">
