### PR TITLE
Fix(www): scope isOfficialPackage() helper to monorepo to prevent broken links

### DIFF
--- a/www/src/utils/is-official-package.js
+++ b/www/src/utils/is-official-package.js
@@ -3,6 +3,6 @@ module.exports = function isOfficialPackage(pkg) {
   return (
     pkg.repository &&
     !pkg.name.startsWith(`@`) &&
-    pkg.repository.url.startsWith(`https://github.com/gatsbyjs`)
+    pkg.repository.url.startsWith(`https://github.com/gatsbyjs/gatsby`)
   )
 }

--- a/www/src/utils/is-official-package.js
+++ b/www/src/utils/is-official-package.js
@@ -3,6 +3,6 @@ module.exports = function isOfficialPackage(pkg) {
   return (
     pkg.repository &&
     !pkg.name.startsWith(`@`) &&
-    pkg.repository.url.startsWith(`https://github.com/gatsbyjs/gatsby`)
+    pkg.repository.url.startsWith(`https://github.com/gatsbyjs/gatsby/`)
   )
 }

--- a/www/src/utils/is-official-package.js
+++ b/www/src/utils/is-official-package.js
@@ -3,6 +3,11 @@ module.exports = function isOfficialPackage(pkg) {
   return (
     pkg.repository &&
     !pkg.name.startsWith(`@`) &&
-    pkg.repository.url.startsWith(`https://github.com/gatsbyjs/gatsby/`)
+    // if the repo url is the Gatsby monorepo
+    (pkg.repository.url === `https://github.com/gatsbyjs/gatsby` ||
+      // or the repo url is a specific package in the monorepo
+      pkg.repository.url.startsWith(
+        `https://github.com/gatsbyjs/gatsby/tree/master/packages/`
+      ))
   )
 }


### PR DESCRIPTION
Scope isOfficialPackage() helper to monorepo to prevent broken links for /gatsbyjs packages outside the monorepo.

For example the "View on GitHub" link for `gatsby-source-wordpress-experimental` is broken here https://www.gatsbyjs.org/packages/gatsby-source-wordpress-experimental/?=gatsby-source-wordpress-experimental