### PR TITLE
Make a GraphqlEmbed MDX component to use in docs.

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -902,6 +902,7 @@ graphiql-code-exporter
 graphiql-filesystem
 GraphQL
 GraphQL-based
+GraphqlEmbed
 graphql-compose
 graphql-js
 Graphql-js

--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -168,18 +168,38 @@ When you're new to Gatsby there can be a lot of words to learn...
 
 There are embedded examples in a few places in the docs (like the [GraphQL Reference guide](/docs/graphql-reference/)) that provide a working version of the code described. In the specific example of the GraphQL Query Options Reference page, these examples of the GraphiQL interface show how data can be queried from Gatsby's data layer.
 
-To write a new GraphQL example, a CodeSandbox project with a Gatsby site can be opened at its server container link, for example: https://711808k40x.sse.codesandbox.io/. Because CodeSandbox is running a Gatsby site in [`develop` mode instead of `build` mode](/docs/overview-of-the-gatsby-build-process/) you can navigate to GraphiQL by adding `/___graphql` to the link. Write an example query, and when you have a query you are satisfied with, the query fields and names will be saved as URL parameters so you can share the link. Copy the URL and use it as the `src` of an iframe:
+To write a new GraphQL example, a CodeSandbox project with a Gatsby site can be opened at its server container link, for example: https://711808k40x.sse.codesandbox.io/. Because CodeSandbox is running a Gatsby site in [`develop` mode instead of `build` mode](/docs/overview-of-the-gatsby-build-process/) you can navigate to GraphiQL by adding `/___graphql` to the link. There's a custom component that you can use to add the `Graphiql` iframe here in the markdown, it is called `GraphqlEmbed`. To add it you need to use it like this:
 
-<!-- prettier-ignore -->
-```mdx
-Here's an example of a GraphQL query inline:
-
-<iframe src="https://711808k40x.sse.codesandbox.io/___graphql?query=query%20TitleQuery%20%7B%0A%20%20site%20%7B%0A%20%20%20%20siteMetadata%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false&operationName=TitleQuery" /> // highlight-line
-
-More markdown content...
+```graphql
+# Component Props
+# title (string): Required, Title attribute for the iframe
+# query (string): Required, String with the graphql query you want to use
+# url (string): Optional, default is https://711808k40x.sse.codesandbox.io/___graphql
+# lazy (boolean): Optional, sets the iframe loading attribute, to lazy.
+<GraphqlEmbed
+  title="TitleQuery"
+  query={`query TitleQuery {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }`}
+/>
 ```
 
-> Note that you should set the `explorerIsOpen` parameter in the URL to `false` if it isn't already.
+Use it here in the markdown without any code highlight syntax and it will produce the following:
+
+<GraphqlEmbed
+  title="TitleQuery"
+  query={`query TitleQuery {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }`}
+/>
 
 ## Docs renaming instructions
 

--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -2,6 +2,8 @@
 title: Docs Contributions
 ---
 
+import GraphqlEmbed from "@components/graphql-embed"
+
 Gatsby, unsurprisingly, uses Gatsby for its documentation website. Thank you in advance and cheers for contributing to Gatsby documentation! As of June 2020, over 2,100 people have contributed. It's people like you that make this community great!
 
 > _When deciding where to contribute to Gatsby (docs or [blog](/contributing/blog-contributions/)?), check out the [docs templates](/contributing/docs-templates/) page._
@@ -175,7 +177,7 @@ To write a new GraphQL example, a CodeSandbox project with a Gatsby site can be 
 # title (string): Required, Title attribute for the iframe
 # query (string): Required, String with the graphql query you want to use
 # url (string): Optional, default is https://711808k40x.sse.codesandbox.io/___graphql
-# lazy (boolean): Optional, sets the iframe loading attribute, to lazy.
+# lazy (boolean): Optional, sets the iframe loading attribute, to lazy, default is false.
 <GraphqlEmbed
   title="TitleQuery"
   query={`query TitleQuery {
@@ -198,7 +200,7 @@ Use it here in the markdown without any code highlight syntax and it will produc
         title
       }
     }
-  }`}
+}`}
 />
 
 ## Docs renaming instructions

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -2,6 +2,8 @@
 title: GraphQL Query Options Reference
 ---
 
+import GraphqlEmbed from "@components/graphql-embed"
+
 ## Intro
 
 This page will walk you through a series of GraphQL queries, each designed to demonstrate a particular feature of GraphQL. You'll be querying the _real_ schema used on [graphql-reference example](https://github.com/gatsbyjs/gatsby/tree/master/examples/graphql-reference) so feel free to experiment and poke around the innards of the site! You can also open the [CodeSandbox version](https://codesandbox.io/s/github/gatsbyjs/gatsby/tree/master/examples/graphql-reference) ([Direct link to GraphiQL](<https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20site%20%7B%0A%20%20%20%20siteMetadata%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%20%20description%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20books%3A%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Btitle%3A%20%7Bne%3A%20%22%22%7D%7D%7D)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(fromNow%3A%20true)%0A%20%20%20%20%20%20%20%20%20%20author%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20authors%3A%20allAuthorYaml%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20bio%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A>)) of it.
@@ -14,13 +16,17 @@ For more information, read about [why Gatsby uses GraphQL](/docs/why-gatsby-uses
 
 Start with the basics, pulling up the site `title` from your `gatsby-config.js`'s `siteMetadata`. Here the query is on the left and the results are on the right.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="A basic query"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20site%20%7B%0A%20%20%20%20siteMetadata%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  site {
+    siteMetadata {
+      title
+    }
+  }
+}`}
+/>
 
 Try editing the query to include the `description` from `siteMetadata`. When typing in the query editor you can use `Ctrl + Space` to see autocomplete options and `Ctrl + Enter` to run the current query.
 
@@ -28,60 +34,112 @@ Try editing the query to include the `description` from `siteMetadata`. When typ
 
 Gatsby structures its content as collections of `nodes`, which are connected to each other with `edges`. In this query you ask for the total count of plugins in this Gatsby site, along with specific information about each one.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="A longer query"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allSitePlugin%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20version%0A%20%20%20%20%20%20%20%20packageJson%20%7B%0A%20%20%20%20%20%20%20%20%20%20description%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allSitePlugin {
+    totalCount
+    edges {
+      node {
+        name
+        version
+        packageJson {
+          description
+        }
+      }
+    }
+  }
+}`}
+/>
 
 Try using the editor's autocomplete (`Ctrl + Space`) to get extended details from the `packageJson` nodes.
 
 If you're using Gatsby version `2.2.0` or later, you can remove `edges` and `node` from your query and replace it with `nodes`. The query will still work and the returned object will reflect the `nodes` structure.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="A longer query with nodes"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allSitePlugin%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20nodes%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20version%0A%20%20%20%20%20%20%20%20packageJson%20%7B%0A%20%20%20%20%20%20%20%20%20%20description%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-></iframe>
+  query={`{
+  allSitePlugin {
+    totalCount
+    nodes {
+        name
+        version
+        packageJson {
+          description
+        }
+    }
+  }
+}`}
+/>
 
 ## Limit
 
 There are several ways to reduce the number of results from a query. Here `totalCount` tells you there's 8 results, but `limit` is used to show only the first three.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using limit"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(limit%3A%203)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(limit: 3) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}`}
+/>
 
 ## Skip
 
 Skip over a number of results. In this query `skip` is used to omit the first 3 results.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using skip"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(skip%3A%203)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(skip: 3) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}`}
+/>
 
 ## Filter
 
 In this query `filter` and the `ne` (not equals) operator is used to show only results that have a title. You can find a good video tutorial on this [here](https://www.youtube.com/watch?v=Lg1bom99uGM).
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using a filter"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7Btitle%3A%20%7Bne%3A%20%22%22%7D%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    filter: {
+      frontmatter: {title: {ne: ""}}
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}`}
+/>
 
 Gatsby relies on [Sift](https://www.npmjs.com/package/sift) to enable MongoDB-like query syntax for object filtering. This allows Gatsby to support operators like `eq`, `ne`, `in`, `regex` and querying nested fields through the `__` connector.
 
@@ -93,23 +151,60 @@ filter: { contentType: { in: ["post", "page"] }, draft: { eq: false } }
 
 In this query the fields `categories` and `title` are filtered to find the book that has `Fantastic` in its title and belongs to the `magical creatures` category.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using multiple filters"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20categories%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20in%3A%20%5B%22magical%20creatures%22%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20title%3A%20%7Bregex%3A%20%22%2FFantastic%2F%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    filter: {
+      frontmatter: {
+        categories: {
+          in: ["magical creatures"]
+        }
+        title: {regex: "/Fantastic/"
+        }
+      }
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}`}
+/>
 
 You can also combine the mentioned operators. This query filters on `/History/` for the `regex` operator. The result is `Hogwarts: A History` and `History of Magic`. You can filter out the latter with the `ne` operator.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using multiple operators in filters"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20title%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20regex%3A%20%22%2FHistory%2F%22%0A%20%20%20%20%20%20%20%20%20%20ne%3A%20%22History%20of%20Magic%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    filter: {
+      frontmatter: {
+        title: {
+          regex: "/History/"
+          ne: "History of Magic"
+        }
+      }
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}`}
+/>
 
 ### Complete list of possible operators
 
@@ -141,35 +236,80 @@ If you want to understand more how these filters work, looking at the correspond
 
 The ordering of your results can be specified with `sort`. Here the results are sorted in ascending order of `frontmatter`'s `date` field.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using sort"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20sort%3A%20%7B%0A%20%20%20%20%20%20fields%3A%20%5Bfrontmatter___date%5D%0A%20%20%20%20%20%20order%3A%20ASC%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    sort: {
+      fields: [frontmatter___date]
+      order: ASC
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+          date
+        }
+      }
+    }
+  }
+}`}
+/>
 
 You can also sort on multiple fields but the `sort` keyword can only be used once. The second sort field gets evaluated when the first field (here: `date`) is identical. The results of the following query are sorted in ascending order of `date` and `title` field.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Sorting on multiple fields"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20sort%3A%20%7B%0A%20%20%20%20%20%20fields%3A%20%5Bfrontmatter___date%2C%20frontmatter___title%5D%0A%20%20%20%20%20%20order%3A%20ASC%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    sort: {
+      fields: [frontmatter___date, frontmatter___title]
+      order: ASC
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+          date
+        }
+      }
+    }
+  }
+}`}
+/>
 
 `Children's Anthology of Monsters` and `Break with Banshee` both have the same date (`1992-01-02`) but in the first query (only one sort field) the latter comes after the first. The additional sorting on the `title` puts `Break with Banshee` in the right order.
 
 By default, sort `fields` will be sorted in ascending order. Optionally, you can specify a sort `order` per field by providing an array of `ASC` (for ascending) or `DESC` (for descending) values. For example, to sort by `frontmatter.date` in ascending order, and additionally by `frontmatter.title` in descending order, you would use `sort: { fields: [frontmatter___date, frontmatter___title], order: [ASC, DESC] }`. Note that if you only provide a single sort `order` value, this will affect the first sort field only, the rest will be sorted in default ascending order.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Setting sorting order"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20sort%3A%20%7B%0A%20%20%20%20%20%20fields%3A%20%5Bfrontmatter___date%2C%20frontmatter___title%5D%0A%20%20%20%20%20%20order%3A%20%5BASC%2C%20DESC%5D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    sort: {
+      fields: [frontmatter___date, frontmatter___title]
+      order: [ASC, DESC]
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+          date
+        }
+      }
+    }
+  }
+}`}
+/>
 
 ## Format
 
@@ -177,61 +317,140 @@ By default, sort `fields` will be sorted in ascending order. Optionally, you can
 
 Dates can be formatted using the `formatString` function.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Formatting dates"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(formatString%3A%20%22dddd%20DD%20MMMM%20YYYY%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    filter: {frontmatter: {date: {ne: null}}}
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(formatString: "dddd DD MMMM YYYY")
+        }
+      }
+    }
+  }
+}`}
+/>
 
 Gatsby relies on [Moment.js](https://momentjs.com/) to format the dates. This allows you to use any tokens in your string. See [moment.js documentation](https://momentjs.com/docs/#/displaying/format/) for more tokens.
 
 You can also pass in a `locale` to adapt the output to your language. The above query gives you the English output for the weekdays, this example outputs them in German.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using locale"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(%0A%20%20%20%20%20%20%20%20%20%20%20%20formatString%3A%20%22dddd%20DD%20MMMM%20YYYY%22%0A%20%20%20%20%20%20%20%20%20%20%20%20locale%3A%20%22de-DE%22%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    filter: {frontmatter: {date: {ne: null}}}
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(
+            formatString: "dddd DD MMMM YYYY"
+            locale: "de-DE"
+          )
+        }
+      }
+    }
+  }
+}`}
+/>
 
 Example: [`anotherDate(formatString: "dddd, MMMM Do YYYY, h:mm:ss a") # Sunday, August 5th 2018, 10:56:14 am`](<https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(formatString%3A%20%22dddd%2C%20MMMM%20Do%20YYYY%2C%20h%3Amm%3Ass%20a%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A>)
 
 Dates also accept the `fromNow` and `difference` function. The former returns a string generated with Moment.js' [`fromNow`](https://momentjs.com/docs/#/displaying/fromnow/) function, the latter returns the difference between the date and current time (using Moment.js' [`difference`](https://momentjs.com/docs/#/displaying/difference/) function).
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using date functions"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20one%3A%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20%20%20limit%3A%202%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(fromNow%3A%20true)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20two%3A%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20%20%20limit%3A%202%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(difference%3A%20%22days%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  one: allMarkdownRemark(
+    filter: {frontmatter: {date: {ne: null}}}
+    limit: 2
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(fromNow: true)
+        }
+      }
+    }
+  }
+  two: allMarkdownRemark(
+    filter: {frontmatter: {date: {ne: null}}}
+    limit: 2
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(difference: "days")
+        }
+      }
+    }
+  }
+}`}
+/>
 
 ### Excerpt
 
 Excerpts accept three options: `pruneLength`, `truncate`, and `format`. `format` can be `PLAIN` or `HTML`.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using excerpts"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20%20%20limit%3A%205%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20excerpt(%0A%20%20%20%20%20%20%20%20%20%20format%3A%20PLAIN%0A%20%20%20%20%20%20%20%20%20%20pruneLength%3A%20200%0A%20%20%20%20%20%20%20%20%20%20truncate%3A%20true%0A%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    filter: {frontmatter: {date: {ne: null}}}
+    limit: 5
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+        excerpt(
+          format: PLAIN
+          pruneLength: 200
+          truncate: true
+        )
+      }
+    }
+  }
+}`}
+/>
 
 ## Sort, filter, limit & format together
 
 This query combines sorting, filtering, limiting and formatting together.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Combining sorting, filtering, limiting and formatting"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20limit%3A%203%0A%20%20%20%20filter%3A%20%7B%20frontmatter%3A%20%7B%20date%3A%20%7B%20ne%3A%20null%20%7D%20%7D%20%7D%0A%20%20%20%20sort%3A%20%7B%20fields%3A%20%5Bfrontmatter___date%5D%2C%20order%3A%20DESC%20%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(formatString%3A%20%22dddd%20DD%20MMMM%20YYYY%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(
+    limit: 3
+    filter: { frontmatter: { date: { ne: null } } }
+    sort: { fields: [frontmatter___date], order: DESC }
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(formatString: "dddd DD MMMM YYYY")
+        }
+      }
+    }
+  }
+}`}
+/>
 
 ## Query variables
 
@@ -241,13 +460,28 @@ The query below is the same one as the previous example, but with the input argu
 
 To add variables to page component queries, pass these in the `context` object [when creating pages](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs).
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using query variables"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=query%20GetBlogPosts(%0A%20%20%24limit%3A%20Int%2C%20%24filter%3A%20MarkdownRemarkFilterInput%2C%20%24sort%3A%20MarkdownRemarkSortInput%0A)%20%7B%0A%09allMarkdownRemark(%0A%20%20%20%20limit%3A%20%24limit%2C%0A%20%20%20%20filter%3A%20%24filter%2C%0A%20%20%20%20sort%3A%20%24sort%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(formatString%3A%20%22dddd%20DD%20MMMM%20YYYY%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=GetBlogPosts&variables=%7B%0A%20%20%22limit%22%3A%205%2C%0A%20%20%22filter%22%3A%20%7B%0A%20%20%20%20%22frontmatter%22%3A%20%7B%0A%20%20%20%20%20%20%22date%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22ne%22%3A%20null%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22sort%22%3A%20%7B%0A%20%20%20%20%22fields%22%3A%20%22frontmatter___title%22%2C%0A%20%20%20%20%22order%22%3A%20%22DESC%22%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`query GetBlogPosts(
+  $limit: Int, $filter: MarkdownRemarkFilterInput, $sort: MarkdownRemarkSortInput
+) {
+	allMarkdownRemark(
+    limit: $limit,
+    filter: $filter,
+    sort: $sort
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(formatString: "dddd DD MMMM YYYY")
+        }
+      }
+    }
+  }
+}`}
+/>
 
 ## Group
 
@@ -255,13 +489,31 @@ You can also group values on the basis of a field e.g. the title, date or catego
 
 The query below gets you all categories (`fieldValue`) applied to a book and how many books (`totalCount`) a given category is applied to. In addition you are grabbing the `title` of books in a given category. You can see for example that there are 3 books in the `magical creatures` category.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Grouping values"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Btitle%3A%20%7Bne%3A%20%22%22%7D%7D%7D)%20%7B%0A%20%20%20%20group(field%3A%20frontmatter___categories)%20%7B%0A%20%20%20%20%20%20fieldValue%0A%20%20%20%20%20%20totalCount%0A%20%20%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20nodes%20%7B%0A%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20categories%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(filter: {frontmatter: {title: {ne: ""}}}) {
+    group(field: frontmatter___categories) {
+      fieldValue
+      totalCount
+      edges {
+        node {
+          frontmatter {
+            title
+          }
+        }
+      }
+    }
+    nodes {
+      frontmatter {
+        title
+        categories
+      }
+    }
+  }
+}`}
+/>
 
 ## Fragments
 
@@ -269,37 +521,71 @@ Fragments are a way to save frequently used queries for re-use. To create a frag
 
 The query below defines a fragment to get the site title, and then uses the fragment to access this information.
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using fragments"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=fragment%20fragmentName%20on%20Site%20%7B%0A%20%20siteMetadata%20%7B%0A%20%20%20%20title%0A%20%20%7D%0A%7D%0A%0A%7B%0A%20%20site%20%7B%0A%20%20%20%20...fragmentName%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`fragment fragmentName on Site {
+  siteMetadata {
+    title
+  }
+}
+{
+  site {
+    ...fragmentName
+  }
+}`}
+/>
 
 ## Aliasing
 
 Want to run two queries on the same datasource? You can do this by aliasing your queries. See the query below for an example:
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using aliases"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20someEntries%3A%20allMarkdownRemark(skip%3A%203%2C%20limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20someMoreEntries%3A%20allMarkdownRemark(limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  someEntries: allMarkdownRemark(skip: 3, limit: 3) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+  someMoreEntries: allMarkdownRemark(limit: 3) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}`}
+/>
 
 When you use your data, you will be able to reference it using the alias instead of the root query name. In this example, that would be `data.someEntries` or `data.someMoreEntries` instead of `data.allMarkdownRemark`.
 
 The same works for fields inside a query. Take this example:
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using aliases for fields"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(skip%3A%203%2C%20limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20header%3A%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%20%20relativeDate%3A%20date(fromNow%3A%20true)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`{
+  allMarkdownRemark(skip: 3, limit: 3) {
+    edges {
+      node {
+        frontmatter {
+          header: title
+          date
+          relativeDate: date(fromNow: true)
+        }
+      }
+    }
+  }
+}`}
+/>
 
 Instead of receiving `title` you'll get `header`. This is especially useful when you want to display the same field in different ways as the `date` shows. You both get `date` and `relativeDate` from the same source.
 
@@ -309,25 +595,61 @@ GraphQL allows you to skip a piece of a query depending on variables. This is ha
 
 Try changing variable `withDate` in the example query below:
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using conditionals"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=query%20GetBlogPosts%20(%24withDate%3ABoolean%20%3D%20false)%20%7B%0A%20%20allMarkdownRemark(limit%3A%203%2C%20skip%3A%201)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%20%40include(if%3A%24withDate)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&operationName=GetBlogPosts&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`query GetBlogPosts ($withDate:Boolean = false) {
+  allMarkdownRemark(limit: 3, skip: 1) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date @include(if:$withDate)
+        }
+      }
+    }
+  }
+}`}
+/>
 
 Use directive `@include(if: $variable)` to conditionally include a part of a query or `@skip(if: $variable)` to exclude it.
 
 You can use those directives on any level of the query and even on fragments. Take a look at an advanced example:
 
-<iframe
+<GraphqlEmbed
+  lazy
   title="Using conditionals: Advanced"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=query%20GetBlogPosts%20(%24preview%3ABoolean%20%3D%20true)%20%7B%0A%20%20allMarkdownRemark(limit%3A%203%2C%20skip%3A%201)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20...BlogPost%20%40skip(if%3A%24preview)%0A%20%20%20%20%20%20%20%20...BlogPostPreview%20%40include(if%3A%24preview)%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20allFile(limit%3A2)%20%40skip(if%3A%24preview)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20relativePath%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%0Afragment%20BlogPost%20on%20MarkdownRemark%20%7B%0A%20%20html%0A%20%20frontmatter%20%7B%0A%20%20%20%20title%0A%20%20%20%20date%0A%20%20%7D%0A%7D%0A%0Afragment%20BlogPostPreview%20on%20MarkdownRemark%20%7B%0A%20%20excerpt%0A%20%20frontmatter%20%7B%0A%20%20%20%20title%0A%20%20%7D%0A%7D&operationName=GetBlogPosts&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+  query={`query GetBlogPosts ($preview:Boolean = true) {
+    allMarkdownRemark(limit: 3, skip: 1) {
+      edges {
+        node {
+          ...BlogPost @skip(if:$preview)
+          ...BlogPostPreview @include(if:$preview)
+        }
+      }
+    }
+    allFile(limit:2) @skip(if:$preview) {
+      edges {
+        node {
+          relativePath
+        }
+      }
+    }
+  }
+  fragment BlogPost on MarkdownRemark {
+    html
+    frontmatter {
+      title
+      date
+    }
+  }
+  fragment BlogPostPreview on MarkdownRemark {
+    excerpt
+    frontmatter {
+      title
+    }
+}`}
+/>
 
 ## Where next?
 

--- a/docs/docs/recipes/querying-data.md
+++ b/docs/docs/recipes/querying-data.md
@@ -3,6 +3,8 @@ title: "Recipes: Querying Data"
 tableOfContentsDepth: 1
 ---
 
+import GraphqlEmbed from "@components/graphql-embed"
+
 Gatsby lets you access your data across all sources using a single GraphQL interface.
 
 ## Querying data with a Page Query
@@ -199,11 +201,18 @@ To limit data, you'll need a Gatsby site with some nodes in the GraphQL data lay
 - [Gatsby GraphQL reference for limiting](/docs/graphql-reference/#limit)
 - Live example:
 
-<iframe
+<GraphqlEmbed
   title="Limiting returned data"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allSitePage(limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20path%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="300"
+  query={`{
+    allSitePage(limit: 3) {
+      edges {
+        node {
+          id
+          path
+        }
+      }
+    }
+}`}
 />
 
 ## Sorting with GraphQL
@@ -260,11 +269,18 @@ For this recipe, you'll need a Gatsby site with a collection of nodes to sort in
 - Learn about [nodes in Gatsby's GraphQL data API](/docs/node-interface/)
 - Live example:
 
-<iframe
+<GraphqlEmbed
   title="Sorting data"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allSitePage(sort%3A%20%7Bfields%3A%20path%2C%20order%3A%20ASC%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20path%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="300"
+  query={`{
+    allSitePage(sort: {fields: path, order: ASC}) {
+      edges {
+        node {
+          id
+          path
+        }
+      }
+    }
+}`}
 />
 
 ## Filtering with GraphQL
@@ -325,11 +341,20 @@ For this recipe, you'll need a Gatsby site with a collection of nodes to filter 
 - Learn about [nodes in Gatsby's GraphQL data API](/docs/node-interface/)
 - Live example:
 
-<iframe
+<GraphqlEmbed
   title="Filtering data"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Bcategories%3A%20%7Beq%3A%20%22magical%20creatures%22%7D%7D%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20categories%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="300"
+  query={`{
+    allMarkdownRemark(filter: {frontmatter: {categories: {eq: "magical creatures"}}}) {
+      edges {
+        node {
+          frontmatter {
+            title
+            categories
+          }
+        }
+      }
+    }
+}`}
 />
 
 ## GraphQL Query Aliases
@@ -379,11 +404,18 @@ If you would like to run two queries on the same datasource, you can use an alia
 - [Gatsby GraphQL reference for aliasing](/docs/graphql-reference/#aliasing)
 - Live example:
 
-<iframe
+<GraphqlEmbed
   title="Using aliases"
-  src="https://711808k40x.sse.codesandbox.io/___graphql?query=%7B%0A%20%20fileCount%3A%20allFile%20%7B%20%0A%20%20%20%20totalCount%0A%20%20%7D%0A%20%20filePageInfo%3A%20allFile%20%7B%0A%20%20%20%20pageInfo%20%7B%0A%20%20%20%20%20%20currentPage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="300"
+  query={`{
+    fileCount: allFile {
+      totalCount
+    }
+    filePageInfo: allFile {
+      pageInfo {
+        currentPage
+      }
+    }
+}`}
 />
 
 ## GraphQL Query Fragments

--- a/docs/docs/recipes/sourcing-data.md
+++ b/docs/docs/recipes/sourcing-data.md
@@ -122,11 +122,20 @@ This is my first Gatsby post written in Markdown!
 }
 ```
 
-<iframe
+<GraphqlEmbed
   title="Query for all markdown"
-  src="https://q4xpb.sse.codesandbox.io/___graphql?explorerIsOpen=false&query=%7B%0A%20%20allMarkdownRemark%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20path%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D"
-  width="600"
-  height="300"
+  url="https://q4xpb.sse.codesandbox.io/___graphql"
+  query={`{
+    allMarkdownRemark {
+      edges {
+        node {
+          frontmatter {
+            path
+          }
+        }
+      }
+    }
+  }`}
 />
 
 4. Add the JavaScript code to generate pages from Markdown posts at build time by copying the GraphQL query into `gatsby-node.js` and looping through the results:

--- a/www/src/components/graphql-embed.js
+++ b/www/src/components/graphql-embed.js
@@ -1,10 +1,14 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { useRef, useState, useCallback, useEffect } from "react"
-import PropTypes from "prop-types"
 
-export default function GraphqlEmbed({ lazy, title, url, query }) {
-  const ASPECT_RATIO = 2 / 3
+export default function GraphqlEmbed({
+  lazy = false,
+  title,
+  url = `https://711808k40x.sse.codesandbox.io/___graphql`,
+  query,
+}) {
+  const ASPECT_RATIO = 1 / 2
 
   const [iframeWidth, setIframeWidth] = useState(0)
   const iframeRef = useRef()
@@ -34,16 +38,4 @@ export default function GraphqlEmbed({ lazy, title, url, query }) {
       {...(lazy && { loading: `lazy` })}
     />
   )
-}
-
-GraphqlEmbed.defaultProps = {
-  lazy: false,
-  url: `https://711808k40x.sse.codesandbox.io/___graphql`,
-}
-
-GraphqlEmbed.propTypes = {
-  lazy: PropTypes.bool,
-  title: PropTypes.string.isRequired,
-  url: PropTypes.string,
-  query: PropTypes.string.isRequired,
 }

--- a/www/src/components/graphql-embed.js
+++ b/www/src/components/graphql-embed.js
@@ -1,0 +1,49 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui"
+import { useRef, useState, useCallback, useEffect } from "react"
+import PropTypes from "prop-types"
+
+export default function GraphqlEmbed({ lazy, title, url, query }) {
+  const ASPECT_RATIO = 2 / 3
+
+  const [iframeWidth, setIframeWidth] = useState(0)
+  const iframeRef = useRef()
+
+  const handleResize = useCallback(
+    () => setIframeWidth(iframeRef.current.clientWidth),
+    [iframeRef.current]
+  )
+
+  useEffect(() => {
+    handleResize()
+    window.addEventListener(`resize`, handleResize)
+
+    return () => {
+      window.removeEventListener(`resize`, handleResize)
+    }
+  }, [iframeRef.current])
+
+  return (
+    <iframe
+      height={iframeWidth * ASPECT_RATIO}
+      ref={iframeRef}
+      src={`${url}?query=${encodeURIComponent(query)}&explorerIsOpen=false`}
+      sx={{ border: `none`, width: `100%` }}
+      title={title}
+      width={iframeWidth}
+      {...(lazy && { loading: `lazy` })}
+    />
+  )
+}
+
+GraphqlEmbed.defaultProps = {
+  lazy: false,
+  url: `https://711808k40x.sse.codesandbox.io/___graphql`,
+}
+
+GraphqlEmbed.propTypes = {
+  lazy: PropTypes.bool,
+  title: PropTypes.string.isRequired,
+  url: PropTypes.string,
+  query: PropTypes.string.isRequired,
+}

--- a/www/src/gatsby-plugin-theme-ui/components.js
+++ b/www/src/gatsby-plugin-theme-ui/components.js
@@ -6,6 +6,7 @@ import CloudCallout from "../components/shared/cloud-callout"
 import GuideList from "../components/guide-list.js"
 import Pullquote from "../components/shared/pullquote"
 import EggheadEmbed from "../components/shared/egghead-embed"
+import GraphqlEmbed from "../components/graphql-embed"
 import ComponentModel from "../components/layer-model/component-model"
 
 export default {
@@ -13,6 +14,7 @@ export default {
   GuideList,
   Pullquote,
   EggheadEmbed,
+  GraphqlEmbed,
   ComponentModel,
   a: MdxLink,
   pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,

--- a/www/src/gatsby-plugin-theme-ui/components.js
+++ b/www/src/gatsby-plugin-theme-ui/components.js
@@ -6,7 +6,6 @@ import CloudCallout from "../components/shared/cloud-callout"
 import GuideList from "../components/guide-list.js"
 import Pullquote from "../components/shared/pullquote"
 import EggheadEmbed from "../components/shared/egghead-embed"
-import GraphqlEmbed from "../components/graphql-embed"
 import ComponentModel from "../components/layer-model/component-model"
 
 export default {
@@ -14,7 +13,6 @@ export default {
   GuideList,
   Pullquote,
   EggheadEmbed,
-  GraphqlEmbed,
   ComponentModel,
   a: MdxLink,
   pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,


### PR DESCRIPTION
#24089  Description

In order to address issue [21256](https://github.com/gatsbyjs/gatsby/issues/21256), I added a new component called `GraphqlEmbed` that will allow contributors to use the code sandbox environment and be able to inject the queries in the markdown without writing an ugly iframe snippet, this work rely on the `EggheadEmbed` component and this [PR](https://github.com/gatsbyjs/gatsby/pull/21609), it is pretty similar, just added a few extra props to make it customizable.

### Documentation

Docs files updated in the PR to use the new component.

## Related Issues

  Link to an issue that is partially addressed by this PR (if there are any)
  Addresses issue [21256](https://github.com/gatsbyjs/gatsby/issues/21256)

