### PR TITLE
docs(docs) Switch node definition language to TS and update some text

### DIFF
--- a/docs/docs/node-interface.md
+++ b/docs/docs/node-interface.md
@@ -9,20 +9,23 @@ Gatsby is modeled using nodes.
 
 The basic node data structure is as follows:
 
-```flow
-id: String,
-children: Array[String],
-parent: String,
-fields: Object,
-internal: {
-  contentDigest: String,
-  mediaType: String,
-  type: String,
-  owner: String,
-  fieldOwners: Object,
-  content: String,
+```ts
+interface Node {
+  id: string
+  children?: Array<string>
+  parent?: string
+  fields: object
+  internal: {
+    contentDigest: string
+    mediaType?: string
+    type: string
+    owner: string
+    fieldOwners: object
+    content?: string
+    description?: string
+  }
+  [key: string]: unknown // ...other fields specific to this type of node
 }
-...other fields specific to this type of node
 ```
 
 ### `parent`
@@ -54,6 +57,10 @@ Stores which plugins created which fields. This field is added by gatsby itself 
 ### `content`
 
 Optional field exposing the raw content for this node that transformer plugins can take and further process.
+
+### `description`
+
+Text description of the node.
 
 ## Source plugins
 


### PR DESCRIPTION
## Description

Switch the language of the node definition in `node-interface.md` to typescript, based on the actual definition in `index.d.ts`. I noticed that this was the only code block that used the `flow` language. Since we don't support flow any more and are switching to TS, I figure it would be good to update the docs to reflect that as well.