### PR TITLE
fix(www) Promise.all for api sections

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -18,11 +18,7 @@ const sections = [docs, blog, showcase, starters, creators, packages, features]
 // Run the provided API on all defined sections of the site
 async function runApiForSections(api, helpers) {
   await Promise.all(
-    sections.map(section => {
-      if (section[api]) {
-        section[api](helpers)
-      }
-    })
+    sections.map(section => section[api] && section[api](helpers))
   )
 }
 


### PR DESCRIPTION
## Description

Make sure to *return* the promise that is mapped to `Promise.all`. This was causing an issue in #25588 where the the console would [spam createPages](https://github.com/gatsbyjs/gatsby/pull/25588#issuecomment-655913280).