### PR TITLE
[PoC] Embed preview of all pages in Gatsby Admin

### DIFF
--- a/packages/gatsby-admin/.eslintignore
+++ b/packages/gatsby-admin/.eslintignore
@@ -1,0 +1,5 @@
+packages/*/*.js
+packages/gatsby-link/index.js
+packages/gatsby-legacy-polyfills/dist/**
+../gatsby-link/index.js
+../gatsby-legacy-polyfills/dist/**

--- a/packages/gatsby-admin/src/components/pageembed.tsx
+++ b/packages/gatsby-admin/src/components/pageembed.tsx
@@ -1,0 +1,22 @@
+/* @jsx jsx */
+import { jsx } from "theme-ui"
+
+const PageEmbed: React.FC<{ src: string; height: number }> = props => (
+  <iframe
+    src={props.src}
+    scrolling="no"
+    sx={{
+      border: `none`,
+      boxShadow: `floating`,
+      borderRadius: 2,
+      // NOTE(@mxstbr): This is a really hacky way to scale an iframe. Maybe there's a better one?
+      width: `200%`,
+      height: `${props.height}px`,
+      marginBottom: `-${props.height / 2}px`,
+      transform: `scale(0.5)`,
+      transformOrigin: `0 0`,
+    }}
+  />
+)
+
+export default PageEmbed

--- a/packages/gatsby-admin/src/components/providers.tsx
+++ b/packages/gatsby-admin/src/components/providers.tsx
@@ -17,6 +17,7 @@ const theme = {
     "500": 500,
   },
   borders: {
+    none: `none`,
     default: `1px solid ${baseTheme.colors.whiteFade[20]}`,
     sixtywhite: `1px solid ${baseTheme.colors.whiteFade[40]}`,
     white: `1px solid ${baseTheme.colors.white}`,

--- a/packages/gatsby-admin/src/pages/index.tsx
+++ b/packages/gatsby-admin/src/pages/index.tsx
@@ -12,6 +12,7 @@ import {
   ButtonProps,
   InputFieldLabel,
 } from "gatsby-interface"
+import PageEmbed from "../components/pageembed"
 
 const SecondaryButton: React.FC<ButtonProps> = props => (
   <Button
@@ -130,7 +131,12 @@ const PluginCard: React.FC<{
   <Flex
     flexDirection="column"
     gap={6}
-    sx={{ backgroundColor: `ui.background`, padding: 5, borderRadius: 2 }}
+    sx={{
+      backgroundColor: `ui.background`,
+      padding: 5,
+      borderRadius: 2,
+      boxShadow: `floating`,
+    }}
   >
     <Heading as="h2" sx={{ fontWeight: `500`, fontSize: 3 }}>
       {plugin.name}
@@ -157,6 +163,11 @@ const Index: React.FC<{}> = () => {
             shadowableFiles
           }
         }
+        allGatsbyPage {
+          nodes {
+            path
+          }
+        }
       }
     `,
   })
@@ -167,6 +178,26 @@ const Index: React.FC<{}> = () => {
 
   return (
     <Flex gap={7} flexDirection="column" sx={{ paddingY: 7, paddingX: 6 }}>
+      {!window ||
+        (!window.frameElement && (
+          <Flex gap={7} flexDirection="column">
+            <SectionHeading>Pages</SectionHeading>
+            <Grid gap={6} columns={[1, 1, 1, 2, 3]}>
+              {data.allGatsbyPage.nodes
+                .filter(page => page.path.indexOf(`/dev-404-page/`) !== 0)
+                .map(page => (
+                  <Flex
+                    gap={5}
+                    flexDirection="column"
+                    sx={{ width: `100%`, textAlign: `center` }}
+                  >
+                    <PageEmbed height={400} src={page.path} />
+                    <Text sx={{ color: `text.secondary` }}>{page.path}</Text>
+                  </Flex>
+                ))}
+            </Grid>
+          </Flex>
+        ))}
       <SectionHeading>Plugins</SectionHeading>
       <Grid gap={6} columns={[1, 1, 1, 2, 3]}>
         {data.allGatsbyPlugin.nodes


### PR DESCRIPTION
*Note: based on #25635, until that is merged you'll also see those changes here*

This is a proof of concept for a "sitemap" in Admin. It renders a list of all pages of a Gatsby site, including a preview of every one! :scream: Here is what the sitemap looks like for Admin itself (meta!):

![Screenshot 2020-07-09 at 10 48 26](https://user-images.githubusercontent.com/7525670/87018782-03d7f900-c1d2-11ea-9824-53e458387eef.png)

We don't necessarily have to merge this as-is, I'll leave that decision up to @shannonbux. However, this proves it's possible to show pages in Admin! :tada:

Technically, this uses the GatsbyPage provider I added to the recipes GraphQL API in #25248. I fetch that data and then render an `<iframe>`  for every page for the "preview" 🙈 We should definitely not this for a list of _all_ pages due to perf concerns with hundreds of iframes. However, doing it for one page at a time (or a truncated, scrollable list of pages where we only show 5-10 at a time) seems feasible!