### PR TITLE
fix(gatsby): IE11 arrow function syntax fix

### DIFF
--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -217,9 +217,9 @@ const preferDefault = m => m && m.default || m
         c.component
       )
 
-      return `  "${c.componentChunkName}": () => import("${slash(
+      return `  "${c.componentChunkName}": function() { return import("${slash(
         `./${relativeComponentPath}`
-      )}" /* webpackChunkName: "${c.componentChunkName}" */)`
+      )}" /* webpackChunkName: "${c.componentChunkName}" */) }`
     })
     .join(`,\n`)}
 }\n\n`


### PR DESCRIPTION
## Description

After recent updates, the gatsby project in the organization I work for started to have IE11 syntax errors coming from async-requires.js. After few days of banging our heads against the wall, we learned that `babel-plugin-dynamic-import-node` transpiles the import statement, but the arrow syntax does not change, and the string append mechanism is happening after the hooks transpiling it are run. This change shouldn't make any functional change in other browser environments, downside being this is bit "uglier" code.

Not supporting IE11 is totally valid argument in 2020, but last I checked the end of life is end of 2020, so let's bear this headache for just few more months :v: 
