### PR TITLE
Add __BASE_PATH__ definition to storybook config

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -115,8 +115,9 @@ global.___loader = {
   hovering: () => {},
 }
 
-// __PATH_PREFIX__ is used inside gatsby-link an other various places. For storybook not to crash, you need to set it as well.
+// __PATH_PREFIX__ and __BASE_PATH__ are used inside gatsby-link an other various places. For storybook not to crash, you need to set it as well.
 global.__PATH_PREFIX__ = ""
+global.__BASE_PATH__ = ""
 
 // Navigating through a gatsby app using gatsby-link or any other gatsby component will use the `___navigate` method.
 // In Storybook it makes more sense to log an action than doing an actual navigate. Checkout the actions addon docs for more info: https://github.com/storybookjs/storybook/tree/master/addons/actions.

--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -115,10 +115,6 @@ global.___loader = {
   hovering: () => {},
 }
 
-// __PATH_PREFIX__ and __BASE_PATH__ are used inside gatsby-link an other various places. For storybook not to crash, you need to set it as well.
-global.__PATH_PREFIX__ = ""
-global.__BASE_PATH__ = ""
-
 // Navigating through a gatsby app using gatsby-link or any other gatsby component will use the `___navigate` method.
 // In Storybook it makes more sense to log an action than doing an actual navigate. Checkout the actions addon docs for more info: https://github.com/storybookjs/storybook/tree/master/addons/actions.
 


### PR DESCRIPTION
## Description

Addition of the `__BASE_PATH__` definition to the storybook configuration in order to prevent some other storybook errors as mentioned on [this comment](https://github.com/gatsbyjs/gatsby/issues/10668#issuecomment-639014099) in issue #10668

### Documentation

This is only an update to the documentation page for Visual testing with Storybook

## Related Issues

 - [This comment](https://github.com/gatsbyjs/gatsby/issues/10668#issuecomment-639014099) in issue #10668 