### PR TITLE
fix(gatsby): fix setting total in progress activities created by plugins

### DIFF
--- a/packages/gatsby/src/utils/__tests__/api-runner-node.js
+++ b/packages/gatsby/src/utils/__tests__/api-runner-node.js
@@ -160,8 +160,8 @@ it(`Ends activities if plugin didn't end them`, async () => {
   })
   await apiRunnerNode(`testAPIHook`)
 
-  expect(mockActivity.start).toBeCalledTimes(6)
+  expect(start).toBeCalledTimes(6)
   // we called end same amount of times we called start, even tho plugins
   // didn't call end/done themselves
-  expect(mockActivity.end).toBeCalledTimes(6)
+  expect(end).toBeCalledTimes(6)
 })

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -179,36 +179,44 @@ const runAPI = async (plugin, api, args, activity) => {
       activityTimer: (...args) => {
         const activity = reporter.activityTimer.apply(reporter, args)
 
-        return {
-          ...activity,
-          start: () => {
-            activity.start()
-            runningActivities.add(activity)
-          },
-          end: () => {
-            activity.end()
-            runningActivities.delete(activity)
-          },
+        const originalStart = activity.start
+        const originalEnd = activity.end
+
+        activity.start = () => {
+          originalStart.apply(activity)
+          runningActivities.add(activity)
         }
+
+        activity.end = () => {
+          originalEnd.apply(activity)
+          runningActivities.delete(activity)
+        }
+
+        return activity
       },
       createProgress: (...args) => {
         const activity = reporter.createProgress.apply(reporter, args)
 
-        return {
-          ...activity,
-          start: () => {
-            activity.start()
-            runningActivities.add(activity)
-          },
-          end: () => {
-            activity.end()
-            runningActivities.delete(activity)
-          },
-          done: () => {
-            activity.done()
-            runningActivities.delete(activity)
-          },
+        const originalStart = activity.start
+        const originalEnd = activity.end
+        const originalDone = activity.done
+
+        activity.start = () => {
+          originalStart.apply(activity)
+          runningActivities.add(activity)
         }
+
+        activity.end = () => {
+          originalEnd.apply(activity)
+          runningActivities.delete(activity)
+        }
+
+        activity.done = () => {
+          originalDone.apply(activity)
+          runningActivities.delete(activity)
+        }
+
+        return activity
       },
     }
 


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/25470 introduced regression where setting `total` on progress activities in plugins just doesn't do anything

This is because of creating new activity with spreading, and it appears that spreading doesn't preserve setters:
![Screenshot 2020-07-09 at 17 27 13](https://user-images.githubusercontent.com/419821/87060558-f55a0380-c20a-11ea-8f2d-b430829d6a2a.png)

And `total` is using setter: https://github.com/gatsbyjs/gatsby/blob/b7ed68bb3b1ac9f23dd0703941c1f51ff3579d14/packages/gatsby-cli/src/reporter/reporter-progress.ts#L126-L129

Instead of creating copy of activity, this mutates `start`/`end`/`done` to achieve same tracking mechanism