### PR TITLE
fix(docs): tutorial theme - fix url 404

### DIFF
--- a/docs/tutorial/using-a-theme.md
+++ b/docs/tutorial/using-a-theme.md
@@ -20,7 +20,7 @@ Navigate to the root of your project inside your terminal and install the theme 
 
 ## Configure the theme
 
-In your `gatsby-config.js` file, add `gatsby-theme-blog`. This theme takes optional dependencies that you can find in the [README](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-theme-blog#theme-options). However, you won't need to use them here.
+In your `gatsby-config.js` file, add `gatsby-theme-blog`. This theme takes optional dependencies that you can find in the [README](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-blog#theme-options). However, you won't need to use them here.
 
 ```javascript:title=gatsby-config.js
 module.exports = {


### PR DESCRIPTION
## Description

changes:
- fix 404 link

## Related Issues

- #25076 `Documentation: Tutorial changes for blog theme 2.0`
- #19267 `Add link checker for Gatsby Docs`