### PR TITLE
fix(docs): Proper spelling of GraphiQL

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -897,8 +897,6 @@ Graf
 Grande
 Graph_i_QL
 GraphCMS
-Graphiql
-GraphiQl
 GraphiQL
 graphiql-code-exporter
 graphiql-filesystem

--- a/docs/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/index.md
+++ b/docs/blog/2017-10-01-migrating-my-blog-from-hexo-to-gatsby/index.md
@@ -168,7 +168,7 @@ excellent tool.
 Visit `http://localhost:8000/___graphql` in the browser and you'll be greeted
 with this lovely dev tool:
 
-![Gatsby Graphiql](https://dropsinn.s3.amazonaws.com/Screen%20Shot%202017-08-26%20at%201.31.08%20PM.png)
+![Gatsby GraphiQL](https://dropsinn.s3.amazonaws.com/Screen%20Shot%202017-08-26%20at%201.31.08%20PM.png)
 
 I recommend getting to know this tool if you're not already familiar. You will
 be coming back to this often to find the right query to pull data for your

--- a/docs/blog/2017-12-07-taking-gatsby-for-a-spin/index.md
+++ b/docs/blog/2017-12-07-taking-gatsby-for-a-spin/index.md
@@ -23,7 +23,7 @@ GatsbyJS is based on React which means that you'll be writing almost everything 
 
 Gatsby was my first introduction to [GraphQL](https://graphql.org/learn/) and I'm loving it already. GraphQL is a query language used by Gatsby to let you connect to all kinds of APIs. With it as an abstraction layer, you can pull in all the data you can think of and utilize it in your app. Gatsby comes with plugins to pull in data from several APIs, CMS systems and local files. With GraphQL, you're able to query data from all these sources in a clear and readable way. The data is instantly available in your components and that's just super cool. Also, it comes with a browser-based IDE called Graph_i_QL which starts along with your development environment. You can use it to see which queries are available, test them out, and see what data these queries return.
 
-![Screenshot of GraphiQl](./grahiql_screenshot.png "GraphiQL")
+![Screenshot of GraphiQL](./grahiql_screenshot.png "GraphiQL")
 
 ### Progressive Web App and PRPL Pattern (Blazing fast)
 

--- a/docs/docs/running-queries-with-graphiql.md
+++ b/docs/docs/running-queries-with-graphiql.md
@@ -28,7 +28,7 @@ When the development server is running for one of your Gatsby sites, open Graphi
 
 Make sure to check out the GraphiQL docs in the upper right-hand corner of the IDE. It's easy to miss them, but they're worth visiting!
 
-![A diagram pointing out where to find the GraphiQl docs](./images/graphiql-docs.png)
+![A diagram pointing out where to find the GraphiQL docs](./images/graphiql-docs.png)
 
 ## Using the GraphiQL Explorer
 


### PR DESCRIPTION
## Description

Make sure it's GraphiQL, not Graphiql or GraphiQl (it's mostly alt text that does this)