### PR TITLE
fix(docs) Add backticks on file extensions in docs

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1,13 +1,3 @@
-.env
-.html
-.jpg
-.js
-.md
-.mdx
-.png
-.scss
-.tsx
-.yaml
 ½
 ⅓
 1000px

--- a/docs/blog/2017-07-19-creating-a-blog-with-gatsby/index.md
+++ b/docs/blog/2017-07-19-creating-a-blog-with-gatsby/index.md
@@ -164,7 +164,7 @@ You only need one transformer plugin (for Markdown), so let's get that
 installed.
 
 - [gatsby-transformer-remark][gatsby-transformer-remark]
-  - Uses the [remark][remark] Markdown parser to transform .md files on disk
+  - Uses the [remark][remark] Markdown parser to transform `.md` files on disk
     into HTML; additionally, this transformer can optionally take plugins to
     further extend functionality--e.g. add syntax highlighting with
     `gatsby-remark-prismjs`, `gatsby-remark-copy-linked-files` to copy relative

--- a/docs/blog/2018-2-7-jam-out-your-blog/index.md
+++ b/docs/blog/2018-2-7-jam-out-your-blog/index.md
@@ -94,7 +94,7 @@ https://giphy.com/gifs/emmys-emmy-awards-emmys-2016-l0HlDtKDqfGGQtwic
 
 _**Yes, there’s more.**_
 
-Because Prose was built for Jekyll, it recognizes any headmatter you add to your .md files. This will give developers the ability to build queries and replicate familiar features from other CMS platforms. Say hello to publish states, publish date, article author and more.
+Because Prose was built for Jekyll, it recognizes any headmatter you add to your `.md` files. This will give developers the ability to build queries and replicate familiar features from other CMS platforms. Say hello to publish states, publish date, article author and more.
 
 I should also mention that Prose is an open source project that is available for download if you wish to self-host. Check out the [documentation on GitHub.](https://github.com/prose/prose)
 
@@ -154,7 +154,7 @@ With all of that said, this process has a few caveats related to working within 
 ![After image path change](after-post-title.png)
 
 3. You must commit a file by hitting the save icon or else the file is not saved. Posts cannot be saved as drafts in Prose. So, you will have to build the functionality within your headmatter and query posts based upon a draft/published state (if you need it).
-4. Whoever will be posting will need to manually add headmatter to each .md file. Be warned that there is no specific area to do so. But after it's added, a fourth icon appears in the right pane where you can then edit and add other post details.
+4. Whoever will be posting will need to manually add headmatter to each `.md` file. Be warned that there is no specific area to do so. But after it's added, a fourth icon appears in the right pane where you can then edit and add other post details.
 
 I hope you try playing around with this workflow yourself with a Gatsby starter and see if this works for you. Gatsby provides incredible tools that “just work” without sacrificing an exciting development environment. If you pair it with Netlify and Prose, you will cut overhead and manage content directly from a GitHub repository. Let this approach bring some order to the chaos.
 

--- a/docs/blog/2019-02-14-behind-the-scenes-q-and-a/index.md
+++ b/docs/blog/2019-02-14-behind-the-scenes-q-and-a/index.md
@@ -259,10 +259,10 @@ To watch the full recorded webinar, [register here](https://www.gatsbyjs.com/beh
 **Question:** Following up on upgrade path question—how would you upgrade between version of 2.~?
 **Answer:** You can bump the version # in your package.json and then you're done.
 
-**Question:** If my `.htaccess` file is configured to read .html files without the extension in the url, can Gatsby compile the links to pages without the .html ending?
+**Question:** If my `.htaccess` file is configured to read `.html` files without the extension in the url, can Gatsby compile the links to pages without the `.html` ending?
 **Answer:** We haven't added support for this yet.
 
-**Question:** Follow up to the `.htaccess` question, how do you manage to hide .html from your url on gatsbyjs.com?
+**Question:** Follow up to the `.htaccess` question, how do you manage to hide `.html` from your url on gatsbyjs.com?
 **Answer:** Many servers can do this. Generally the feature is called "clean urls".
 
 **Question:** No concern of the additional request for the SVG??

--- a/docs/docs/creating-a-source-plugin.md
+++ b/docs/docs/creating-a-source-plugin.md
@@ -405,7 +405,7 @@ module.exports = {
 }
 ```
 
-Then, the sharp plugins will automatically transform the File nodes created by `createRemoteFileNode` in `your-source-plugin` (which have supported image extensions like .jpg or .png). You can then query for the `remoteImage` field on your source type:
+Then, the sharp plugins will automatically transform the File nodes created by `createRemoteFileNode` in `your-source-plugin` (which have supported image extensions like `.jpg` or `.png`). You can then query for the `remoteImage` field on your source type:
 
 ```graphql
 query {

--- a/docs/docs/mdx/getting-started.md
+++ b/docs/docs/mdx/getting-started.md
@@ -4,7 +4,7 @@ title: Getting Started with MDX
 
 The fastest way to get started with Gatsby + MDX is to use the [MDX
 starter](https://github.com/ChristopherBiscardi/gatsby-starter-mdx-basic). This
-allows you to write .mdx files in `src/pages` in order to create new pages on
+allows you to write `.mdx` files in `src/pages` in order to create new pages on
 your site.
 
 ## 🚀 Quick start

--- a/docs/docs/mdx/programmatically-creating-pages.md
+++ b/docs/docs/mdx/programmatically-creating-pages.md
@@ -224,7 +224,7 @@ will be rendered as the template for all posts. There's a component,
 `MDXRenderer` which is used by `gatsby-plugin-mdx` that will be used to render any
 programmatically accessed MDX content.
 
-For now, to update imports within .mdx files, you should rerun your Gatsby development environment. Otherwise, it will raise a `ReferenceError`. To import things dynamically, you can use the `MDXProvider` component and provide it all the common components you'll be using, such as `Link`.
+For now, to update imports within `.mdx` files, you should rerun your Gatsby development environment. Otherwise, it will raise a `ReferenceError`. To import things dynamically, you can use the `MDXProvider` component and provide it all the common components you'll be using, such as `Link`.
 
 First, create a component that accepts the queried MDX data (which will be
 added in the next step).

--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -270,7 +270,7 @@ _Note: You can use Sass/SCSS files as modules too, like mentioned in the previou
 
 ### Additional resources
 
-- [Difference between .sass and .scss](https://responsivedesign.is/articles/difference-between-sass-and-scss/)
+- [Difference between `.sass` and `.scss`](https://responsivedesign.is/articles/difference-between-sass-and-scss/)
 - [Sass guide from the official Sass website](https://sass-lang.com/guide)
 - [A more complete installation tutorial on Sass with some more explanations and more resources](https://www.gatsbyjs.org/docs/sass/)
 

--- a/docs/docs/typescript.md
+++ b/docs/docs/typescript.md
@@ -4,7 +4,7 @@ title: TypeScript and Gatsby
 
 ## Introductory paragraph
 
-[TypeScript](https://www.typescriptlang.org/) is a JavaScript superset which extends the language to include type definitions allowing codebases to be statically checked for soundness. Gatsby provides an integrated experience out of the box, similar to an IDE. If you are new to TypeScript, adoption can _and should_ be incremental. Since Gatsby natively supports JavaScript and TypeScript, you can change files from .js to .tsx at any point to start adding types and gaining the benefits of a type system.
+[TypeScript](https://www.typescriptlang.org/) is a JavaScript superset which extends the language to include type definitions allowing codebases to be statically checked for soundness. Gatsby provides an integrated experience out of the box, similar to an IDE. If you are new to TypeScript, adoption can _and should_ be incremental. Since Gatsby natively supports JavaScript and TypeScript, you can change files from `.js` to `.tsx` at any point to start adding types and gaining the benefits of a type system.
 
 ## Example
 


### PR DESCRIPTION
## Description

Add backticks around names of file extensions such as `.html` or `.js` in docs.