### PR TITLE
refactor(www) Move API call out to its own file

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -13,7 +13,18 @@ const starters = require(`./src/utils/node/starters.js`)
 const creators = require(`./src/utils/node/creators.js`)
 const packages = require(`./src/utils/node/packages.js`)
 const features = require(`./src/utils/node/features.js`)
-const sections = [docs, blog, showcase, starters, creators, packages, features]
+const apiCalls = require(`./src/utils/node/api-calls.js`)
+
+const sections = [
+  docs,
+  blog,
+  showcase,
+  starters,
+  creators,
+  packages,
+  features,
+  apiCalls,
+]
 
 // Run the provided API on all defined sections of the site
 async function runApiForSections(api, helpers) {

--- a/www/src/utils/node/api-calls.js
+++ b/www/src/utils/node/api-calls.js
@@ -1,0 +1,81 @@
+const minimatch = require(`minimatch`)
+const findApiCalls = require(`../find-api-calls`)
+
+// Create nodes for calls to Gatsby APIs to be consumed by the docs
+// TODO this should be it's own standalone plugin
+
+const ignorePatterns = [
+  `**/commonjs/**`,
+  `**/node_modules/**`,
+  `**/__tests__/**`,
+  `**/dist/**`,
+  `**/__mocks__/**`,
+  `babel.config.js`,
+  `graphql.js`,
+  `**/flow-typed/**`,
+]
+
+function isCodeFile(node) {
+  return (
+    node.internal.type === `File` &&
+    node.sourceInstanceName === `gatsby-core` &&
+    [`js`].includes(node.extension) &&
+    !ignorePatterns.some(ignorePattern =>
+      minimatch(node.relativePath, ignorePattern)
+    )
+  )
+}
+
+exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
+  createTypes(/* GraphQL */ `
+    type GatsbyAPICall implements Node @derivedTypes @dontInfer {
+      name: String
+      file: String
+      group: String
+      codeLocation: GatsbyAPICallCodeLocation
+    }
+
+    type GatsbyAPICallCodeLocation @dontInfer {
+      filename: Boolean
+      end: GatsbyAPICallEndpoint
+      start: GatsbyAPICallEndpoint
+    }
+
+    type GatsbyAPICallEndpoint @dontInfer {
+      column: Int
+      line: Int
+    }
+  `)
+}
+
+exports.onCreateNode = async ({
+  node,
+  actions,
+  getNode,
+  loadNodeContent,
+  createNodeId,
+  createContentDigest,
+}) => {
+  const { createNode, createParentChildLink } = actions
+
+  if (isCodeFile(node)) {
+    const calls = await findApiCalls({ node, loadNodeContent })
+    if (calls.length > 0) {
+      calls.forEach(call => {
+        const apiCallNode = {
+          id: createNodeId(`findApiCalls-${JSON.stringify(call)}`),
+          parent: node.id,
+          children: [],
+          ...call,
+          internal: {
+            type: `GatsbyAPICall`,
+          },
+        }
+        apiCallNode.internal.contentDigest = createContentDigest(apiCallNode)
+
+        createNode(apiCallNode)
+        createParentChildLink({ parent: node, child: apiCallNode })
+      })
+    }
+  }
+}

--- a/www/src/utils/node/api-calls.js
+++ b/www/src/utils/node/api-calls.js
@@ -51,7 +51,6 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
 exports.onCreateNode = async ({
   node,
   actions,
-  getNode,
   loadNodeContent,
   createNodeId,
   createContentDigest,

--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -1,31 +1,6 @@
-const minimatch = require(`minimatch`)
-
 const { getPrevAndNext } = require(`../get-prev-and-next.js`)
 const { getMdxContentSlug } = require(`../get-mdx-content-slug`)
 const { getTemplate } = require(`../get-template`)
-const findApiCalls = require(`../find-api-calls`)
-
-const ignorePatterns = [
-  `**/commonjs/**`,
-  `**/node_modules/**`,
-  `**/__tests__/**`,
-  `**/dist/**`,
-  `**/__mocks__/**`,
-  `babel.config.js`,
-  `graphql.js`,
-  `**/flow-typed/**`,
-]
-
-function isCodeFile(node) {
-  return (
-    node.internal.type === `File` &&
-    node.sourceInstanceName === `gatsby-core` &&
-    [`js`].includes(node.extension) &&
-    !ignorePatterns.some(ignorePattern =>
-      minimatch(node.relativePath, ignorePattern)
-    )
-  )
-}
 
 function mdxResolverPassthrough(fieldName) {
   return async (source, args, context, info) => {
@@ -71,24 +46,6 @@ exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
       tableOfContents: JSON
       excerpt: String!
     }
-
-    type GatsbyAPICall implements Node @derivedTypes @dontInfer {
-      name: String
-      file: String
-      group: String
-      codeLocation: GatsbyAPICallCodeLocation
-    }
-
-    type GatsbyAPICallCodeLocation @dontInfer {
-      filename: Boolean
-      end: GatsbyAPICallEndpoint
-      start: GatsbyAPICallEndpoint
-    }
-
-    type GatsbyAPICallEndpoint @dontInfer {
-      column: Int
-      line: Int
-    }
   `)
 }
 
@@ -120,28 +77,6 @@ exports.onCreateNode = async ({
   createContentDigest,
 }) => {
   const { createNode, createParentChildLink } = actions
-
-  if (isCodeFile(node)) {
-    const calls = await findApiCalls({ node, loadNodeContent })
-    if (calls.length > 0) {
-      calls.forEach(call => {
-        const apiCallNode = {
-          id: createNodeId(`findApiCalls-${JSON.stringify(call)}`),
-          parent: node.id,
-          children: [],
-          ...call,
-          internal: {
-            type: `GatsbyAPICall`,
-          },
-        }
-        apiCallNode.internal.contentDigest = createContentDigest(apiCallNode)
-
-        createNode(apiCallNode)
-        createParentChildLink({ parent: node, child: apiCallNode })
-      })
-    }
-    return
-  }
 
   const slug = getMdxContentSlug(node, getNode(node.parent))
   if (!slug) return

--- a/www/src/utils/node/docs.js
+++ b/www/src/utils/node/docs.js
@@ -72,7 +72,6 @@ exports.onCreateNode = async ({
   node,
   actions,
   getNode,
-  loadNodeContent,
   createNodeId,
   createContentDigest,
 }) => {


### PR DESCRIPTION
## Description

Move the related code for `api-call` out to its own section so that it doesn't clutter up `docs.js`. It's essentially its own plugin — we just can't make it a local plugin because themes/plugins can't have local plugins.