### PR TITLE
refactor(www): Enable API pages to be stubs as well

### DIFF
--- a/www/src/components/docs-markdown-page.js
+++ b/www/src/components/docs-markdown-page.js
@@ -115,6 +115,11 @@ export default function DocsMarkdownPage({
             <div>
               <MDXRenderer slug={page.slug}>{page.body}</MDXRenderer>
               {children}
+              {page.issue && (
+                <a href={page.issue} target="_blank" rel="noopener noreferrer">
+                  See the issue relating to this stub on GitHub
+                </a>
+              )}
               <MarkdownPageFooter path={page.relativePath} />
               <PrevAndNext sx={{ mt: 9 }} prev={prev} next={next} />
             </div>
@@ -139,5 +144,6 @@ export const docPageContentFragment = graphql`
     description
     disableTableOfContents
     tableOfContentsDepth
+    issue
   }
 `

--- a/www/src/templates/template-docs-markdown.js
+++ b/www/src/templates/template-docs-markdown.js
@@ -1,21 +1,17 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
-import React from "react"
 import { graphql } from "gatsby"
 
 import DocsMarkdownPage from "../components/docs-markdown-page"
 
 function DocsTemplate({ data, location, pageContext: { next, prev } }) {
-  const page = data.docPage
-
   return (
-    <DocsMarkdownPage page={page} location={location} prev={prev} next={next}>
-      {page.issue && (
-        <a href={page.issue} target="_blank" rel="noopener noreferrer">
-          See the issue relating to this stub on GitHub
-        </a>
-      )}
-    </DocsMarkdownPage>
+    <DocsMarkdownPage
+      page={data.docPage}
+      location={location}
+      prev={prev}
+      next={next}
+    />
   )
 }
 
@@ -25,7 +21,6 @@ export const pageQuery = graphql`
   query($slug: String!) {
     docPage(slug: { eq: $slug }) {
       ...DocPageContent
-      issue
     }
   }
 `


### PR DESCRIPTION
## Description

Move the "See the issue relating to this stub" link to `doc-markdown-page` so that API pages can have stubs as well.