### PR TITLE
refactor(www) Override page object instead of passing in more props to docs-template

### DIFF
--- a/www/src/components/__tests__/docs-markdown-page.js
+++ b/www/src/components/__tests__/docs-markdown-page.js
@@ -46,12 +46,6 @@ Object.defineProperty(window, `matchMedia`, {
   }),
 })
 
-const tableOfContentsItems = [
-  {
-    url: `#section`,
-    title: `section`,
-  },
-]
 const page = {
   excerpt: `excerpt`,
   timeToRead: 1,
@@ -60,7 +54,7 @@ const page = {
   title: `title`,
   description: `description`,
   tableOfContents: {
-    items: tableOfContentsItems,
+    items: [{ url: `#section`, title: `section` }],
   },
   parent: {},
 }
@@ -92,8 +86,12 @@ it(`should display table of content if there are items and is not disabled`, () 
 })
 
 it(`should not display table of content if there are no items`, () => {
-  const tableOfContentsItems = []
-  const { queryByText } = setup({ tableOfContentsItems })
+  const { queryByText } = setup({
+    page: {
+      ...page,
+      tableOfContents: { items: [] },
+    },
+  })
 
   expect(queryByText(`Table of Contents`)).toBeNull()
 })

--- a/www/src/components/docs-markdown-page.js
+++ b/www/src/components/docs-markdown-page.js
@@ -30,14 +30,12 @@ export default function DocsMarkdownPage({
   location,
   prev,
   next,
-  tableOfContentsItems = page.tableOfContents.items,
-  tableOfContentsDepth = page.tableOfContentsDepth,
   children,
 }) {
   const [urlSegment] = page.slug.split(`/`).slice(1)
   const description = page.description || page.excerpt
   const isTOCVisible =
-    !page.disableTableOfContents && tableOfContentsItems?.length > 0
+    !page.disableTableOfContents && page.tableOfContents?.items?.length > 0
 
   return (
     <PageWithSidebar
@@ -98,8 +96,8 @@ export default function DocsMarkdownPage({
               }}
             >
               <TableOfContents
-                items={tableOfContentsItems}
-                depth={tableOfContentsDepth}
+                items={page.tableOfContents.items}
+                depth={page.tableOfContentsDepth}
                 location={location}
               />
             </div>

--- a/www/src/components/docs-markdown-page.js
+++ b/www/src/components/docs-markdown-page.js
@@ -35,7 +35,7 @@ export default function DocsMarkdownPage({
   const [urlSegment] = page.slug.split(`/`).slice(1)
   const description = page.description || page.excerpt
   const isTOCVisible =
-    !page.disableTableOfContents && page.tableOfContents?.items?.length > 0
+    !page.disableTableOfContents && page.tableOfContents?.items?.length
 
   return (
     <PageWithSidebar

--- a/www/src/templates/template-api-markdown.js
+++ b/www/src/templates/template-api-markdown.js
@@ -64,40 +64,39 @@ const mergeFunctions = (data, context) => {
 }
 
 export default function APITemplate({ data, location, pageContext }) {
+  const { docPage } = data
   const { prev, next } = pageContext
-  const page = data.docPage
   const heading = page.contentsHeading || `APIs`
   const headingId = `apis`
 
   // Cleanup graphql data for usage with API rendering components
   const mergedFuncs = mergeFunctions(data, pageContext)
 
-  // Generate table of content items for API entries
-  const items = page.tableOfContents.items || []
-  const tableOfContentsItems = [
-    ...items,
-    {
-      title: heading,
-      url: `#${headingId}`,
-      items: mergedFuncs.map(mergedFunc => {
-        return {
-          url: `#${mergedFunc.name}`,
-          title: mergedFunc.name,
-        }
-      }),
+  // Override the page with updates to the table of contents
+  const page = {
+    ...docPage,
+    tableOfContentsDepth: Math.max(docPage.tableOfContentsDepth, 2),
+    tableOfContents: {
+      ...docPage.tableOfContents,
+      // Generate table of content items for API entries
+      items: [
+        ...(docPage.tableOfContents.items || []),
+        {
+          title: heading,
+          url: `#${headingId}`,
+          items: mergedFuncs.map(mergedFunc => {
+            return {
+              url: `#${mergedFunc.name}`,
+              title: mergedFunc.name,
+            }
+          }),
+        },
+      ],
     },
-  ]
-  const tableOfContentsDepth = Math.max(page.tableOfContentsDepth, 2)
+  }
 
   return (
-    <DocsMarkdownPage
-      page={page}
-      location={location}
-      prev={prev}
-      next={next}
-      tableOfContentsItems={tableOfContentsItems}
-      tableOfContentsDepth={tableOfContentsDepth}
-    >
+    <DocsMarkdownPage page={page} location={location} prev={prev} next={next}>
       <h2 id={headingId}>{heading}</h2>
       <APIReference
         docs={mergedFuncs}

--- a/www/src/templates/template-api-markdown.js
+++ b/www/src/templates/template-api-markdown.js
@@ -66,7 +66,7 @@ const mergeFunctions = (data, context) => {
 export default function APITemplate({ data, location, pageContext }) {
   const { docPage } = data
   const { prev, next } = pageContext
-  const heading = page.contentsHeading || `APIs`
+  const heading = docPage.contentsHeading || `APIs`
   const headingId = `apis`
 
   // Cleanup graphql data for usage with API rendering components


### PR DESCRIPTION
## Description

Override page object passed in to `<DocMarkdownPage>` instead of having a totally separate prop for calculating table of contents.