### PR TITLE
fix(gatsby) write empty files when no pages created or no pages removed

### DIFF
--- a/docs/docs/conditional-page-builds.md
+++ b/docs/docs/conditional-page-builds.md
@@ -42,8 +42,6 @@ Done in 154.501 sec
   - `newPages.txt` will contain a list of new or changed paths
   - `deletedPages.txt` will contain a list of deleted paths
 
-If there are no changed or deleted paths, then the relevant files will not be created in the `.cache` folder.
-
 ## More information
 
 - This feature works by comparing the page data from the previous build to the new page data. This creates a list of page directories that are passed to the static build process.

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -315,23 +315,23 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
       `${program.directory}/.cache`,
       `newPages.txt`
     )
+    const createdFilesContent = pagePaths.length
+      ? `${pagePaths.join(`\n`)}\n`
+      : ``
+
     const deletedFilesPath = path.resolve(
       `${program.directory}/.cache`,
       `deletedPages.txt`
     )
+    const deletedFilesContent = deletedPageKeys.length
+      ? `${deletedPageKeys.join(`\n`)}\n`
+      : ``
 
-    if (pagePaths.length) {
-      await fs.writeFile(createdFilesPath, `${pagePaths.join(`\n`)}\n`, `utf8`)
-      report.info(`.cache/newPages.txt created`)
-    }
-    if (deletedPageKeys.length) {
-      await fs.writeFile(
-        deletedFilesPath,
-        `${deletedPageKeys.join(`\n`)}\n`,
-        `utf8`
-      )
-      report.info(`.cache/deletedPages.txt created`)
-    }
+    await fs.writeFile(createdFilesPath, createdFilesContent, `utf8`)
+    report.info(`.cache/newPages.txt created`)
+
+    await fs.writeFile(deletedFilesPath, deletedFilesContent, `utf8`)
+    report.info(`.cache/deletedPages.txt created`)
   }
 
   if (await userPassesFeedbackRequestHeuristic()) {


### PR DESCRIPTION
## Description

Context: When using the experimental page build on data changes, the output files `newPages.txt` and `deletedPages.txt` are generated when new pages were added, pages were updated or pages were deleted during the build process.

Problem: The output files `newPages.txt` and `deletedPages.txt` are not up to date on subsequent builds, if there are no changes to them. Using these files for anything post-build (e.g. generating a report) might result in wrong feedback. 

Resolution: The files get written with empty contents if they do not change during the new build.

### Documentation

Removed documentation saying the files are not being generated in `docs/docs/conditional-page-builds.md`.
