### PR TITLE
fix(gatsby): Fixes process.env replacement for some packages

### DIFF
--- a/packages/gatsby/src/utils/__tests__/webpack.config.js
+++ b/packages/gatsby/src/utils/__tests__/webpack.config.js
@@ -90,7 +90,7 @@ describe(`environment variables`, () => {
 
     expect(DefinePlugin).toHaveBeenCalledWith(
       expect.objectContaining({
-        "process.env": `{}`,
+        "process.env": `({})`,
       })
     )
   })

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = async (
         return acc
       },
       {
-        "process.env": JSON.stringify({}),
+        "process.env": `({})`,
       }
     )
   }


### PR DESCRIPTION
## Description

Some packages make assignments to `process.env` in certain codepaths. While not a great practice, Gatsby currently generates code with syntax errors when that happens:

```
{}.FOO = 42;
```

This diff changes the replacement string from `{}` to `({})`, which makes it safe to use in most contexts. The only one that could be a problem is `process.env = foo` but I can't see a way to support it (I mean, there's `({a:{}}).a` but ... is it worth it?).

### Documentation

n/a 

## Related Issues

Found while investigating a problem in the TS playground.
