### PR TITLE
fix(gatsby-source-filesystem): Support creating file nodes for paths containing folders

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
@@ -74,8 +74,8 @@ async function processBufferNode({
       ext = filetype ? `.${filetype.ext}` : `.bin`
     }
 
-    await fs.ensureDir(path.join(pluginCacheDir, hash))
     filename = createFilePath(path.join(pluginCacheDir, hash), name, ext)
+    await fs.ensureDir(path.dirname(filename))
 
     // Cache the buffer contents
     await writeBuffer(filename, buffer)


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I encountered a subtile bug in the logic for handling `createFileNodeFromBuffer`. My intention is to create file nodes nested inside folders. When I try this currently (without this PR), the containing folder hierarchy is not created, since the call to `fs.ensureDir` is passed a different directory than `writeBuffer`. This PR fixes that.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
The docs for `createFileNodeFromBuffer` are [here](https://www.gatsbyjs.org/packages/gatsby-source-filesystem/#createfilenodefrombuffer).
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
There are no related issues that I could find.
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
