### PR TITLE
React-helmet can't be used as JSX

### DIFF
--- a/docs/tutorial/part-eight/index.md
+++ b/docs/tutorial/part-eight/index.md
@@ -170,6 +170,9 @@ Gatsby's [react helmet plugin](/packages/gatsby-plugin-react-helmet/) provides d
 
 ```shell
 npm install --save gatsby-plugin-react-helmet react-helmet
+
+// if using TypeScript install:
+npm install --save @types/react-helmet
 ```
 
 2. Make sure you have a `description` and an `author` configured inside your `siteMetadata` object. Also, add the `gatsby-plugin-react-helmet` plugin to the `plugins` array in your `gatsby-config.js` file.


### PR DESCRIPTION
I've had a lot of issues and didn't know how to solve, so I started researching for while then I found the missing library of TypeScript `@type/react-helmet`. I want you to keep this on the official docs please, those who don't know about this can solve in one shot, thanks!

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
