### PR TITLE
fix(gatsby-admin): ignore build artifacts with eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -24,3 +24,4 @@ packages/*/*.js
 packages/gatsby-plugin-preload-fonts/prepare/*.js
 packages/gatsby-image/withIEPolyfill/index.js
 packages/gatsby/cache-dir/commonjs/**/*
+packages/gatsby-admin/public


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

eslint is complaining about gatsby-admin build artifacts as they are not ignored.
