### PR TITLE
Remove themes directory from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,6 @@
 # Themes
 
 /docs/docs/themes/                              @gatsbyjs/themes-core
-/themes/                                        @gatsbyjs/themes-core
 /packages/gatsby-plugin-mdx/                    @gatsbyjs/themes-core
 /packages/gatsby/src/bootstrap/load-themes      @gatsbyjs/themes-core
 /packages/gatsby-recipes/                       @gatsbyjs/themes-core


### PR DESCRIPTION
Now that themes are no longer a part of the monorepo we can remove this line from the CODEOWNERS file.