### PR TITLE
(blog) Recipes link to infra-as-code 

### DIFF
--- a/docs/blog/2020-04-15-announcing-gatsby-recipes/index.md
+++ b/docs/blog/2020-04-15-announcing-gatsby-recipes/index.md
@@ -30,7 +30,7 @@ We want there to be 10s of thousands of recipes you can search, run, and remix p
 
 ## Human-friendly automation
 
-Recipes are written in [MDX](https://mdxjs.com/)—a combination of Markdown and React components—readable by both humans and machines. (Other “infrastructure as code” automations, like AWS CloudFormation, use kinda-sorta legible YAML templates that favor the machines). We picked MDX to make Gatsby Recipes instructions and explanations easily readable for humans while using React components syntax to _declare_ to Gatsby Recipes the desired state of the world. This means Gatsby Recipes read like actual little recipes. Writing and using them could be...dare we say it..._fun_.
+Recipes are written in [MDX](https://mdxjs.com/)—a combination of Markdown and React components—readable by both humans and machines. (Other “[infrastructure as code](/docs/glossary/infrastructure-as-code/)” automations, like AWS CloudFormation, use kinda-sorta legible YAML templates that favor the machines). We picked MDX to make Gatsby Recipes instructions and explanations easily readable for humans while using React components syntax to _declare_ to Gatsby Recipes the desired state of the world. This means Gatsby Recipes read like actual little recipes. Writing and using them could be...dare we say it..._fun_.
 
 We take a lot of inspiration from literate programming tools like [Eve](http://witheve.com/deepdives/literate.html) and [HyperCard](https://en.wikipedia.org/wiki/HyperCard).
 


### PR DESCRIPTION
I added a link from the Recipes launch blog post to the infrastructure as code glossary definition.