### PR TITLE
Remove themes as docs codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,6 @@
 
 # Themes
 
-/docs/docs/themes/                              @gatsbyjs/themes-core
 /packages/gatsby-plugin-mdx/                    @gatsbyjs/themes-core
 /packages/gatsby/src/bootstrap/load-themes      @gatsbyjs/themes-core
 /packages/gatsby-recipes/                       @gatsbyjs/themes-core


### PR DESCRIPTION
The themes docs should be owned and triaged by @AishaBlake and team. They can tag in themes as necessary, but they shouldn't be separate from a domain perspective.

By removing this line the toplevel docs -> learning codeowner tag will be respected.