### PR TITLE
add Paths.io to showcase

### DIFF
--- a/docs/sites.yml
+++ b/docs/sites.yml
@@ -11448,3 +11448,15 @@
     - Productivity
   built_by: Sankarsan Kampa
   built_by_url: https://traction.one
+- title: Paths.io
+  url: https://paths.io/
+  main_url: https://paths.io/
+  description: >
+    Paths enables a new type of career discovery, in addition to being a better way to find work.
+  categories:
+    - Data
+    - Technology
+    - Landing Page
+  built_by: HiringSolved
+  built_by_url: https://hiringsolved.com/home/
+  featured: false


### PR DESCRIPTION
We just launched the beta of our new Paths application and would love to have our landing page featured in the Gatsby showcase. If I missed anything or is have any questions, please let me know. Thanks in advance for your time and support. 
