### PR TITLE
enhancement(docs, www): markdown syntax table

### DIFF
--- a/docs/docs/mdx/customizing-components.md
+++ b/docs/docs/mdx/customizing-components.md
@@ -2,6 +2,8 @@
 title: Customizing Markdown Components
 ---
 
+import MarkdownSyntaxTable from "@components/shared/markdown-syntax-table"
+
 Using MDX, you can replace every HTML element that Markdown renders with a
 custom implementation. This allows you to use a set of design system components
 when rendering.
@@ -32,37 +34,7 @@ export default function Layout({ children }) {
 
 The following components can be customized with the MDXProvider:
 
-<!-- remark lint doesn't realize the pipes in code blocks aren't table markers -->
-<!-- lint ignore table-pipe-alignment -->
-
-| Tag             | Name                                                                 | Syntax                                            |
-| --------------- | -------------------------------------------------------------------- | ------------------------------------------------- |
-| `p`             | [Paragraph](https://github.com/syntax-tree/mdast#paragraph)          |                                                   |
-| `h1`            | [Heading 1](https://github.com/syntax-tree/mdast#heading)            | `#`                                               |
-| `h2`            | [Heading 2](https://github.com/syntax-tree/mdast#heading)            | `##`                                              |
-| `h3`            | [Heading 3](https://github.com/syntax-tree/mdast#heading)            | `###`                                             |
-| `h4`            | [Heading 4](https://github.com/syntax-tree/mdast#heading)            | `####`                                            |
-| `h5`            | [Heading 5](https://github.com/syntax-tree/mdast#heading)            | `#####`                                           |
-| `h6`            | [Heading 6](https://github.com/syntax-tree/mdast#heading)            | `######`                                          |
-| `thematicBreak` | [Thematic break](https://github.com/syntax-tree/mdast#thematicbreak) | `***`                                             |
-| `blockquote`    | [Blockquote](https://github.com/syntax-tree/mdast#blockquote)        | `>`                                               |
-| `ul`            | [List](https://github.com/syntax-tree/mdast#list)                    | `-`                                               |
-| `ol`            | [Ordered list](https://github.com/syntax-tree/mdast#list)            | `1.`                                              |
-| `li`            | [List item](https://github.com/syntax-tree/mdast#listitem)           |                                                   |
-| `table`         | [Table](https://github.com/syntax-tree/mdast#table)                  | `--- | --- | --- | ---`                           |
-| `tr`            | [Table row](https://github.com/syntax-tree/mdast#tablerow)           | `This | is | a | table row`                       |
-| `td`/`th`       | [Table cell](https://github.com/syntax-tree/mdast#tablecell)         |                                                   |
-| `pre`           | [Pre](https://github.com/syntax-tree/mdast#code)                     | ` ```js console.log()``` `                        |
-| `code`          | [Code](https://github.com/syntax-tree/mdast#code)                    | `` `console.log()` ``                             |
-| `em`            | [Emphasis](https://github.com/syntax-tree/mdast#emphasis)            | `_emphasis_`                                      |
-| `strong`        | [Strong](https://github.com/syntax-tree/mdast#strong)                | `**strong**`                                      |
-| `delete`        | [Delete](https://github.com/syntax-tree/mdast#delete)                | `~~strikethrough~~`                               |
-| `code`          | [InlineCode](https://github.com/syntax-tree/mdast#inlinecode)        | `` `console.log()` ``                             |
-| `hr`            | [Break](https://github.com/syntax-tree/mdast#break)                  | `---`                                             |
-| `a`             | [Link](https://github.com/syntax-tree/mdast#link)                    | `https://mdxjs.com` or `[MDX](https://mdxjs.com)` |
-| `img`           | [Image](https://github.com/syntax-tree/mdast#image)                  | `![alt](https://mdx-logo.now.sh)`                 |
-
-<!-- lint enable table-pipe-alignment -->
+<MarkdownSyntaxTable />
 
 ## How does this work?
 

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -79,13 +79,6 @@ module.exports = {
     twitter: `@gatsbyjs`,
   },
   plugins: [
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `docs`,
-        path: `${__dirname}/../testdocs/`,
-      },
-    },
     `gatsby-plugin-theme-ui`,
     {
       resolve: `gatsby-alias-imports`,

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -79,6 +79,13 @@ module.exports = {
     twitter: `@gatsbyjs`,
   },
   plugins: [
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `docs`,
+        path: `${__dirname}/../testdocs/`,
+      },
+    },
     `gatsby-plugin-theme-ui`,
     {
       resolve: `gatsby-alias-imports`,

--- a/www/src/components/shared/markdown-syntax-table.js
+++ b/www/src/components/shared/markdown-syntax-table.js
@@ -1,0 +1,99 @@
+import React, { Fragment } from "react"
+
+/**
+ * Table of valid markdown syntax and the tags that are generated from them
+ */
+const components = [
+  { tag: `p`, name: "Paragraph" },
+  { tag: `h1`, name: "Heading 1", hash: `heading`, syntax: `#` },
+  { tag: `h2`, name: "Heading 2", hash: `heading`, syntax: `##` },
+  { tag: `h3`, name: "Heading 3", hash: `heading`, syntax: `###` },
+  { tag: `h4`, name: "Heading 4", hash: `heading`, syntax: `####` },
+  { tag: `h5`, name: "Heading 5", hash: `heading`, syntax: `#####` },
+  { tag: `h6`, name: "Heading 6", hash: `heading`, syntax: `######` },
+  { tag: `thematicBreak`, name: "Thematic break", syntax: `***` },
+  { tag: `blockquote`, name: "Blockquote", syntax: `>` },
+  { tag: `ul`, name: "List", syntax: `-` },
+  { tag: `ol`, name: "Ordered list", link: `list`, syntax: `1.` },
+  { tag: `li`, name: "List item" },
+  { tag: `table`, name: "Table", syntax: `--- | --- | --- | ---` },
+  { tag: `tr`, name: "Table row", syntax: `This | is | a | table row` },
+  {
+    tag: (
+      <Fragment>
+        <code>th</code>/<code>td</code>
+      </Fragment>
+    ),
+    name: "Table cell",
+  },
+  {
+    tag: `pre`,
+    name: `Pre`,
+    hash: `code`,
+    syntax: (syntax = "```console.log()```"),
+  },
+  { tag: `code`, name: `Inline code`, syntax: "`console.log()`" },
+  { tag: `em`, name: `Emphasis`, syntax: `_emphashis_` },
+  { tag: `strong`, name: `Strong`, syntax: `**strong**` },
+  { tag: `delete`, name: `Delete`, syntax: "~~strikethrough~~" },
+  { tag: `hr`, name: `Break`, syntax: `---` },
+  {
+    tag: `a`,
+    name: `Link`,
+    syntax: (
+      <Fragment>
+        <code>https://mdxjs.com</code> or <code>[MDX](https://mdxjs.com)</code>
+      </Fragment>
+    ),
+  },
+  { tag: `img`, name: `Image`, syntax: `![alt](https://mdx-logo.now.sh)` },
+]
+
+function getHash(name) {
+  return name.toLowerCase().replace(/ /g, "")
+}
+
+/**
+ * Wraps the given content in param blocks
+ */
+function CodeWrapper({ content }) {
+  if (typeof content === `string`) {
+    return <code>{content}</code>
+  }
+  return content
+}
+
+export default function MarkdownSyntaxTable() {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Tag</th>
+          <th>Name</th>
+          <th>Syntax</th>
+        </tr>
+      </thead>
+      <tbody>
+        {components.map(({ tag, name, hash = getHash(name), syntax }) => {
+          return (
+            <tr>
+              <td>
+                <CodeWrapper content={tag} />
+              </td>
+              <td>
+                <a
+                  href={`https://github.com/syntax-tree/mdast#${hash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {name}
+                </a>
+              </td>
+              <td>{syntax && <CodeWrapper content={syntax} />}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}

--- a/www/src/components/shared/markdown-syntax-table.js
+++ b/www/src/components/shared/markdown-syntax-table.js
@@ -4,38 +4,38 @@ import React, { Fragment } from "react"
  * Table of valid markdown syntax and the tags that are generated from them
  */
 const components = [
-  { tag: `p`, name: "Paragraph" },
-  { tag: `h1`, name: "Heading 1", hash: `heading`, syntax: `#` },
-  { tag: `h2`, name: "Heading 2", hash: `heading`, syntax: `##` },
-  { tag: `h3`, name: "Heading 3", hash: `heading`, syntax: `###` },
-  { tag: `h4`, name: "Heading 4", hash: `heading`, syntax: `####` },
-  { tag: `h5`, name: "Heading 5", hash: `heading`, syntax: `#####` },
-  { tag: `h6`, name: "Heading 6", hash: `heading`, syntax: `######` },
-  { tag: `thematicBreak`, name: "Thematic break", syntax: `***` },
-  { tag: `blockquote`, name: "Blockquote", syntax: `>` },
-  { tag: `ul`, name: "List", syntax: `-` },
-  { tag: `ol`, name: "Ordered list", link: `list`, syntax: `1.` },
-  { tag: `li`, name: "List item" },
-  { tag: `table`, name: "Table", syntax: `--- | --- | --- | ---` },
-  { tag: `tr`, name: "Table row", syntax: `This | is | a | table row` },
+  { tag: `p`, name: `Paragraph` },
+  { tag: `h1`, name: `Heading 1`, hash: `heading`, syntax: `#` },
+  { tag: `h2`, name: `Heading 2`, hash: `heading`, syntax: `##` },
+  { tag: `h3`, name: `Heading 3`, hash: `heading`, syntax: `###` },
+  { tag: `h4`, name: `Heading 4`, hash: `heading`, syntax: `####` },
+  { tag: `h5`, name: `Heading 5`, hash: `heading`, syntax: `#####` },
+  { tag: `h6`, name: `Heading 6`, hash: `heading`, syntax: `######` },
+  { tag: `thematicBreak`, name: `Thematic break`, syntax: `***` },
+  { tag: `blockquote`, name: `Blockquote`, syntax: `>` },
+  { tag: `ul`, name: `List`, syntax: `-` },
+  { tag: `ol`, name: `Ordered list`, link: `list`, syntax: `1.` },
+  { tag: `li`, name: `List item` },
+  { tag: `table`, name: `Table`, syntax: `--- | --- | --- | ---` },
+  { tag: `tr`, name: `Table row`, syntax: `This | is | a | table row` },
   {
     tag: (
       <Fragment>
         <code>th</code>/<code>td</code>
       </Fragment>
     ),
-    name: "Table cell",
+    name: `Table cell`,
   },
   {
     tag: `pre`,
     name: `Pre`,
     hash: `code`,
-    syntax: (syntax = "```console.log()```"),
+    syntax: `\`\`\`console.log()\`\`\``,
   },
-  { tag: `code`, name: `Inline code`, syntax: "`console.log()`" },
+  { tag: `code`, name: `Inline code`, syntax: `\`console.log()\`` },
   { tag: `em`, name: `Emphasis`, syntax: `_emphashis_` },
   { tag: `strong`, name: `Strong`, syntax: `**strong**` },
-  { tag: `delete`, name: `Delete`, syntax: "~~strikethrough~~" },
+  { tag: `delete`, name: `Delete`, syntax: `~~strikethrough~~` },
   { tag: `hr`, name: `Break`, syntax: `---` },
   {
     tag: `a`,
@@ -50,7 +50,7 @@ const components = [
 ]
 
 function getHash(name) {
-  return name.toLowerCase().replace(/ /g, "")
+  return name.toLowerCase().replace(/ /g, ``)
 }
 
 /**
@@ -74,25 +74,23 @@ export default function MarkdownSyntaxTable() {
         </tr>
       </thead>
       <tbody>
-        {components.map(({ tag, name, hash = getHash(name), syntax }) => {
-          return (
-            <tr>
-              <td>
-                <CodeWrapper content={tag} />
-              </td>
-              <td>
-                <a
-                  href={`https://github.com/syntax-tree/mdast#${hash}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {name}
-                </a>
-              </td>
-              <td>{syntax && <CodeWrapper content={syntax} />}</td>
-            </tr>
-          )
-        })}
+        {components.map(({ tag, name, hash = getHash(name), syntax }) => (
+          <tr key={name}>
+            <td>
+              <CodeWrapper content={tag} />
+            </td>
+            <td>
+              <a
+                href={`https://github.com/syntax-tree/mdast#${hash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {name}
+              </a>
+            </td>
+            <td>{syntax && <CodeWrapper content={syntax} />}</td>
+          </tr>
+        ))}
       </tbody>
     </table>
   )


### PR DESCRIPTION
## Description

* Create a custom `MarkdownSyntaxTable` component for listing customizable markdown in [Customizable Components](https://www.gatsbyjs.org/docs/mdx/customizing-components/) doc.
* Fix labelling of the `pre` and `code` block.

## Motivation

* This file isn't actually rendered correctly because of a [parsing error on remark on table pipes](https://github.com/gatsbyjs/gatsby/pull/25662#issuecomment-657136470)
* This makes it easier to add rows and change things around without error
* Gives us more flexibility for showing syntax. For example, we could do multiline syntax examples for lists and tables:

```md
- Item 1
- Item 2
```

```md
Heading 1 | Heading 2 | Heading 3
--- | --- | --- 
Row 1 | Row 2 | Row 3
```

## More possibilities

* If we want the actual table data to live in `docs/` I can turn it into YAML instead (though this would be harder for the markup content
* I can do the changes to support multiline syntax as mentioned above. Actually the syntax example for `pre` doesn't work:

````md
```console.log``` <!-- doesn't work: just generates inline code -->

```js
console.log()
```
````