### PR TITLE
(www): Feature table legend refactor for accessibility

### DIFF
--- a/www/src/components/features/evaluation-table-section-header-top.js
+++ b/www/src/components/features/evaluation-table-section-header-top.js
@@ -36,14 +36,14 @@ export default function HeaderTop({ columnHeaders }) {
   return (
     <tr>
       {columnHeaders.map((header, i) => (
-        <td
+        <th
           key={i}
           sx={{
             ...tdStyles,
           }}
         >
           <span>{header}</span>
-        </td>
+        </th>
       ))}
     </tr>
   )

--- a/www/src/components/features/legend-table.js
+++ b/www/src/components/features/legend-table.js
@@ -75,7 +75,19 @@ const legendText = [
 
 export default function LegendTable() {
   return (
-    <div>
+    <table>
+      <caption
+        id="legend"
+        sx={{
+          fontWeight: `body`,
+          letterSpacing: `tracked`,
+          textTransform: `uppercase`,
+          textAlign: `left`,
+          marginBottom: `1.5rem`,
+        }}
+      >
+        Legend
+      </caption>
       <div
         sx={{
           display: [`none`, null, `table`],
@@ -99,6 +111,6 @@ export default function LegendTable() {
           </div>
         ))}
       </div>
-    </div>
+    </table>
   )
 }

--- a/www/src/components/features/legend-table.js
+++ b/www/src/components/features/legend-table.js
@@ -124,19 +124,20 @@ export default function LegendTable() {
         }}
       >
         <tr>
+          sx={{ ...legendBallCellStyle, ...legendHeaderStyle }}
           <th
             sx={{ ...legendBallCellStyle, ...legendHeaderStyle }}
             key={`${legendBallCellStyle}-1`}
             scope="col"
           >
-            <h4 sx={{ m: 0 }}>Icon</h4>
+            Icon
           </th>
           <th
             sx={{ ...legendExplanationCellStyle, ...legendHeaderStyle }}
             key={`legendExplanationCell-1`}
             scope="col"
           >
-            <h4 sx={{ m: 0 }}>Feature Availability</h4>
+            Feature Availability
           </th>
         </tr>
         {[0, 1, 2, 3, 4].map(i => (

--- a/www/src/components/features/legend-table.js
+++ b/www/src/components/features/legend-table.js
@@ -10,7 +10,6 @@ const legendBallStyle = {
 }
 
 const baseCellStyle = {
-  display: `table-cell`,
   verticalAlign: `middle`,
   textAlign: `center`,
   p: 3,
@@ -38,44 +37,38 @@ const legendExplanationCellStyle = {
 }
 
 const balls = [
-  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-1`}>
-    <h4 sx={{ m: 0 }}>Icon</h4>
-  </div>,
-  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-2`}>
+  <td sx={legendBallCellStyle} key={`${legendBallCellStyle}-2`}>
     <EvaluationCell num="3" style={legendBallStyle} />
-  </div>,
-  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-3`}>
+  </td>,
+  <td sx={legendBallCellStyle} key={`${legendBallCellStyle}-3`}>
     <EvaluationCell num="2" style={legendBallStyle} />
-  </div>,
-  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-4`}>
+  </td>,
+  <td sx={legendBallCellStyle} key={`${legendBallCellStyle}-4`}>
     <EvaluationCell num="1" style={legendBallStyle} />
-  </div>,
-  <div sx={legendBallCellStyle} key={`${legendBallCellStyle}-5`}>
+  </td>,
+  <td sx={legendBallCellStyle} key={`${legendBallCellStyle}-5`}>
     <EvaluationCell num="0" style={legendBallStyle} />
-  </div>,
+  </td>,
 ]
 
 const legendText = [
-  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-1`}>
-    <h5 sx={{ m: 0 }}>Feature Availability</h5>
-  </div>,
-  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-2`}>
+  <td sx={legendExplanationCellStyle} key={`legendExplanationCell-2`}>
     Excellent (fully available)
-  </div>,
-  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-3`}>
+  </td>,
+  <td sx={legendExplanationCellStyle} key={`legendExplanationCell-3`}>
     Good (partially available, e.g. plugins)
-  </div>,
-  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-4`}>
+  </td>,
+  <td sx={legendExplanationCellStyle} key={`legendExplanationCell-4`}>
     Fair (needs customization or limited)
-  </div>,
-  <div sx={legendExplanationCellStyle} key={`legendExplanationCell-5`}>
+  </td>,
+  <td sx={legendExplanationCellStyle} key={`legendExplanationCell-5`}>
     Poor (not possible)
-  </div>,
+  </td>,
 ]
 
 export default function LegendTable() {
   return (
-    <table>
+    <table sx={{ ...legendTableContainerStyle, width: `100%` }}>
       <caption
         id="legend"
         sx={{
@@ -84,33 +77,66 @@ export default function LegendTable() {
           textTransform: `uppercase`,
           textAlign: `left`,
           marginBottom: `1.5rem`,
+          lineHeight: `1.5rem`,
         }}
       >
         Legend
       </caption>
-      <div
+      <tbody
         sx={{
           display: [`none`, null, `table`],
-          ...legendTableContainerStyle,
-          width: `100%`,
         }}
       >
-        <div sx={{ display: `table-row` }}>{balls}</div>
-        <div sx={{ display: `table-row` }}>{legendText}</div>
-      </div>
-      <div
+        <tr sx={{ display: `table-row` }}>
+          <th
+            sx={legendBallCellStyle}
+            key={`${legendBallCellStyle}-1`}
+            scope="row"
+          >
+            <h4 sx={{ m: 0 }}>Icon</h4>
+          </th>
+          {balls}
+        </tr>
+        <tr sx={{ display: `table-row` }}>
+          <th
+            sx={legendExplanationCellStyle}
+            key={`legendExplanationCell-1`}
+            scope="row"
+          >
+            <h4 sx={{ m: 0 }}>Feature Availability</h4>
+          </th>
+          {legendText}
+        </tr>
+      </tbody>
+      <tbody
         sx={{
           display: [`table`, null, `none`],
           ...legendTableContainerStyle,
         }}
       >
+        <tr>
+          <th
+            sx={legendBallCellStyle}
+            key={`${legendBallCellStyle}-1`}
+            scope="col"
+          >
+            <h4 sx={{ m: 0 }}>Icon</h4>
+          </th>
+          <th
+            sx={legendExplanationCellStyle}
+            key={`legendExplanationCell-1`}
+            scope="col"
+          >
+            <h4 sx={{ m: 0 }}>Feature Availability</h4>
+          </th>
+        </tr>
         {[0, 1, 2, 3, 4].map(i => (
-          <div sx={{ display: `table-row` }} key={i}>
+          <tr sx={{ display: `table-row` }} key={i}>
             {balls[i]}
             {legendText[i]}
-          </div>
+          </tr>
         ))}
-      </div>
+      </tbody>
     </table>
   )
 }

--- a/www/src/components/features/legend-table.js
+++ b/www/src/components/features/legend-table.js
@@ -2,6 +2,16 @@
 import { jsx } from "theme-ui"
 
 import EvaluationCell from "./evaluation-cell"
+import { h4, h3 } from "../../utils/styles/global"
+
+const legendTableCaptionStyle = {
+  fontWeight: `body`,
+  letterSpacing: `tracked`,
+  textTransform: `uppercase`,
+  textAlign: `left`,
+  marginBottom: `1.5rem`,
+  lineHeight: `1.5rem`,
+}
 
 const legendBallStyle = {
   float: `none`,
@@ -10,8 +20,8 @@ const legendBallStyle = {
 }
 
 const baseCellStyle = {
-  verticalAlign: `middle`,
-  textAlign: `center`,
+  verticalAlign: `baseline`,
+  textAlign: `left`,
   p: 3,
 }
 
@@ -36,6 +46,14 @@ const legendExplanationCellStyle = {
   borderColor: `ui.border`,
 }
 
+const legendHeaderStyle = {
+  ...baseCellStyle,
+  borderLeft: 1,
+  borderColor: `ui.border`,
+  ...h4,
+  m: 0,
+}
+
 const balls = [
   <td sx={legendBallCellStyle} key={`${legendBallCellStyle}-2`}>
     <EvaluationCell num="3" style={legendBallStyle} />
@@ -55,7 +73,10 @@ const legendText = [
   <td sx={legendExplanationCellStyle} key={`legendExplanationCell-2`}>
     Excellent (fully available)
   </td>,
-  <td sx={legendExplanationCellStyle} key={`legendExplanationCell-3`}>
+  <td
+    sx={legendExplanationCellStyle}
+    key={`legendExplanalegendBallCellStyletionCell-3`}
+  >
     Good (partially available, e.g. plugins)
   </td>,
   <td sx={legendExplanationCellStyle} key={`legendExplanationCell-4`}>
@@ -68,42 +89,30 @@ const legendText = [
 
 export default function LegendTable() {
   return (
-    <table sx={{ ...legendTableContainerStyle, width: `100%` }}>
-      <caption
-        id="legend"
-        sx={{
-          fontWeight: `body`,
-          letterSpacing: `tracked`,
-          textTransform: `uppercase`,
-          textAlign: `left`,
-          marginBottom: `1.5rem`,
-          lineHeight: `1.5rem`,
-        }}
-      >
-        Legend
-      </caption>
+    <table sx={{ ...legendTableContainerStyle, width: `100%` }} id="legend">
+      <caption sx={{ ...legendTableCaptionStyle }}>Legend</caption>
       <tbody
         sx={{
           display: [`none`, null, `table`],
         }}
       >
-        <tr sx={{ display: `table-row` }}>
+        <tr>
           <th
-            sx={legendBallCellStyle}
+            sx={{ ...legendBallCellStyle, ...legendHeaderStyle }}
             key={`${legendBallCellStyle}-1`}
             scope="row"
           >
-            <h4 sx={{ m: 0 }}>Icon</h4>
+            Icon
           </th>
           {balls}
         </tr>
-        <tr sx={{ display: `table-row` }}>
+        <tr>
           <th
-            sx={legendExplanationCellStyle}
+            sx={{ ...legendExplanationCellStyle, ...legendHeaderStyle }}
             key={`legendExplanationCell-1`}
             scope="row"
           >
-            <h4 sx={{ m: 0 }}>Feature Availability</h4>
+            Feature Availability
           </th>
           {legendText}
         </tr>
@@ -116,14 +125,14 @@ export default function LegendTable() {
       >
         <tr>
           <th
-            sx={legendBallCellStyle}
+            sx={{ ...legendBallCellStyle, ...legendHeaderStyle }}
             key={`${legendBallCellStyle}-1`}
             scope="col"
           >
             <h4 sx={{ m: 0 }}>Icon</h4>
           </th>
           <th
-            sx={legendExplanationCellStyle}
+            sx={{ ...legendExplanationCellStyle, ...legendHeaderStyle }}
             key={`legendExplanationCell-1`}
             scope="col"
           >
@@ -131,7 +140,7 @@ export default function LegendTable() {
           </th>
         </tr>
         {[0, 1, 2, 3, 4].map(i => (
-          <tr sx={{ display: `table-row` }} key={i}>
+          <tr key={i}>
             {balls[i]}
             {legendText[i]}
           </tr>

--- a/www/src/components/features/legend-table.js
+++ b/www/src/components/features/legend-table.js
@@ -2,7 +2,7 @@
 import { jsx } from "theme-ui"
 
 import EvaluationCell from "./evaluation-cell"
-import { h4, h3 } from "../../utils/styles/global"
+import { h4 } from "../../utils/styles/global"
 
 const legendTableCaptionStyle = {
   fontWeight: `body`,

--- a/www/src/components/features/legend-table.js
+++ b/www/src/components/features/legend-table.js
@@ -2,7 +2,6 @@
 import { jsx } from "theme-ui"
 
 import EvaluationCell from "./evaluation-cell"
-import { h4 } from "../../utils/styles/global"
 
 const legendTableCaptionStyle = {
   fontWeight: `body`,
@@ -50,7 +49,10 @@ const legendHeaderStyle = {
   ...baseCellStyle,
   borderLeft: 1,
   borderColor: `ui.border`,
-  ...h4,
+  color: `heading`,
+  letterSpacing: `tight`,
+  fontSize: 3,
+  fontWeight: `body`,
   m: 0,
 }
 
@@ -124,7 +126,6 @@ export default function LegendTable() {
         }}
       >
         <tr>
-          sx={{ ...legendBallCellStyle, ...legendHeaderStyle }}
           <th
             sx={{ ...legendBallCellStyle, ...legendHeaderStyle }}
             key={`${legendBallCellStyle}-1`}

--- a/www/src/pages/features.js
+++ b/www/src/pages/features.js
@@ -86,16 +86,6 @@ const FeaturesHeader = () => (
       representative from each category. Click on any row to see a more detailed
       explanation on that feature and our rating for each system.
     </p>
-    <h6
-      id="legend"
-      sx={{
-        fontWeight: `body`,
-        letterSpacing: `tracked`,
-        textTransform: `uppercase`,
-      }}
-    >
-      Legend
-    </h6>
     <LegendTable />
   </section>
 )


### PR DESCRIPTION
## Description

This PR is intended to fix one of the several accessibility issues raised in #25672, specifically the feature table legend not being a semantic html data table.

This component seemed quite messy originally with regards to styling props, I may have made it worse, hence the early PR for initial comments!

## Related Issues

#25672
