### PR TITLE
fix(gatsby): fix timing issue around marking webpack as pending due to requires-writer run

### DIFF
--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -9,7 +9,6 @@ import { joinPath } from "gatsby-core-utils"
 import { store, emitter } from "../redux/"
 import { IGatsbyState, IGatsbyPage } from "../redux/types"
 import { writeModule } from "../utils/gatsby-webpack-virtual-modules"
-import { markWebpackStatusAsPending } from "../utils/webpack-status"
 
 interface IGatsbyPageComponent {
   component: string
@@ -264,11 +263,7 @@ const debouncedWriteAll = _.debounce(
       id: `requires-writer`,
     })
     activity.start()
-    const didRequiresChange = await writeAll(store.getState())
-    if (didRequiresChange) {
-      reporter.pendingActivity({ id: `webpack-develop` })
-      markWebpackStatusAsPending()
-    }
+    await writeAll(store.getState())
     activity.end()
   },
   500,


### PR DESCRIPTION
The async `writeAll()` function can cause webpack invalidation. Right now we mark webpack run as pending after we finish writing every file to disk. But depending on timing, webpack can start running in the middle of `writeAll` execution which means that we mark webpack as pending too late. With virtual modules webpack receives `invalid` event immediately so moving activity pending call to `invalid` hook is much more reliable.

It also feels much better approach that webpack service mark itself as pending, as opposed to different service marking it as pending