### PR TITLE
feat(gatsby-source-shopify): Add shopifyShop query

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -148,6 +148,7 @@ The following data types are available:
 | **ProductOption**  | Custom product property names.                                                                                        |
 | **ProductVariant** | Represents a different version of a product, such as differing sizes or differing colors.                             |
 | **ShopPolicy**     | Policy that a merchant has configured for their store, such as their refund or privacy policy.                        |
+| **ShopDetails**    | Name, Description and Currency that a merchant has configured for their store.                                        |
 
 For each data type listed above, `shopify${typeName}` and
 `allShopify${typeName}` is made available. Nodes that are closely related, such
@@ -385,6 +386,20 @@ Shopify merchants can create pages to hold static HTML content.
         bodySummary
       }
     }
+  }
+}
+```
+
+### Query shop details
+
+Shopify merchants can give their shop a name, description and a money format.
+
+```graphql
+{
+  shopifyShop {
+    name
+    description
+    moneyFormat
   }
 }
 ```

--- a/packages/gatsby-source-shopify/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-source-shopify/src/__tests__/__snapshots__/index.js.snap
@@ -2947,5 +2947,17 @@ Object {
     ],
     "vendor": "Gatsby Swag",
   },
+  "Shopify__Shop__undefined": Object {
+    "children": Array [],
+    "description": "",
+    "id": "Shopify__Shop__undefined",
+    "internal": Object {
+      "contentDigest": "7e8bd622d5376313766d087914010149",
+      "type": "ShopifyShop",
+    },
+    "moneyFormat": "",
+    "name": "",
+    "parent": "__SOURCE__",
+  },
 }
 `;

--- a/packages/gatsby-source-shopify/src/__tests__/fixtures/shop-details.json
+++ b/packages/gatsby-source-shopify/src/__tests__/fixtures/shop-details.json
@@ -1,0 +1,1 @@
+{ "shop": { "description": "", "name": "", "moneyFormat": "" } }

--- a/packages/gatsby-source-shopify/src/constants.js
+++ b/packages/gatsby-source-shopify/src/constants.js
@@ -12,6 +12,7 @@ export const PRODUCT_VARIANT = `ProductVariant`
 export const PRODUCT_METAFIELD = `ProductMetafield`
 export const PRODUCT_VARIANT_METAFIELD = `ProductVariantMetafield`
 export const SHOP_POLICY = `ShopPolicy`
+export const SHOP_DETAILS = `Shop`
 export const PAGE = `Page`
 export const SHOP = `shop`
 export const CONTENT = `content`

--- a/packages/gatsby-source-shopify/src/gatsby-node.js
+++ b/packages/gatsby-source-shopify/src/gatsby-node.js
@@ -15,6 +15,7 @@ import {
   ProductMetafieldNode,
   ProductVariantMetafieldNode,
   ShopPolicyNode,
+  ShopDetailsNode,
   PageNode,
 } from "./nodes"
 import {
@@ -26,6 +27,7 @@ import {
   COLLECTION,
   PRODUCT,
   SHOP_POLICY,
+  SHOP_DETAILS,
   PAGE,
 } from "./constants"
 import {
@@ -34,6 +36,7 @@ import {
   COLLECTIONS_QUERY,
   PRODUCTS_QUERY,
   SHOP_POLICIES_QUERY,
+  SHOP_DETAILS_QUERY,
   PAGES_QUERY,
 } from "./queries"
 
@@ -64,6 +67,7 @@ export const sourceNodes = async (
     collections: COLLECTIONS_QUERY,
     products: PRODUCTS_QUERY,
     shopPolicies: SHOP_POLICIES_QUERY,
+    shopDetails: SHOP_DETAILS_QUERY,
     pages: PAGES_QUERY,
   }
 
@@ -130,6 +134,7 @@ export const sourceNodes = async (
             )
         }),
         createShopPolicies(args),
+        createShopDetails(args),
       ])
     }
     if (includeCollections.includes(CONTENT)) {
@@ -185,6 +190,25 @@ const createNodes = async (
       await f(entity)
     }
   )
+  if (verbose) console.timeEnd(msg)
+}
+
+/**
+ * Fetch and create nodes for shop policies.
+ */
+const createShopDetails = async ({
+  client,
+  createNode,
+  formatMsg,
+  verbose,
+  queries,
+}) => {
+  // // Message printed when fetching is complete.
+  const msg = formatMsg(`fetched and processed ${SHOP_DETAILS} nodes`)
+
+  if (verbose) console.time(msg)
+  const { shop } = await queryOnce(client, queries.shopDetails)
+  createNode(ShopDetailsNode(shop))
   if (verbose) console.timeEnd(msg)
 }
 

--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -14,6 +14,7 @@ import {
   PRODUCT_METAFIELD,
   PRODUCT_VARIANT_METAFIELD,
   SHOP_POLICY,
+  SHOP_DETAILS,
   PAGE,
 } from "./constants"
 
@@ -173,5 +174,7 @@ export const ProductVariantMetafieldNode = _imageArgs =>
   createNodeFactory(PRODUCT_VARIANT_METAFIELD)
 
 export const ShopPolicyNode = createNodeFactory(SHOP_POLICY)
+
+export const ShopDetailsNode = createNodeFactory(SHOP_DETAILS)
 
 export const PageNode = createNodeFactory(PAGE)

--- a/packages/gatsby-source-shopify/src/queries.js
+++ b/packages/gatsby-source-shopify/src/queries.js
@@ -229,6 +229,16 @@ export const PRODUCTS_QUERY = `
   }
 `
 
+export const SHOP_DETAILS_QUERY = `
+query GetShop {
+  shop {
+    description
+    moneyFormat
+    name
+  }
+}
+`
+
 export const SHOP_POLICIES_QUERY = `
   query GetPolicies {
     shop {


### PR DESCRIPTION
## Description

Add a new GraphQL query to `gatsby-source-shopify` which returns the shop name, description and money format

### Documentation

The README has been updated to document the new query type
