### PR TITLE
chore(www): fix regex in gatsby-config

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -250,7 +250,7 @@ module.exports = {
       resolve: `gatsby-plugin-react-svg`,
       options: {
         rule: {
-          include: /assets\/(guidelines|icons|ornaments)\/.*.svg$/,
+          include: /assets\/(guidelines|icons|ornaments)\/.*\.svg$/,
         },
       },
     },


### PR DESCRIPTION
## Description

changes:

- fix regex `.*.svg` -> `.*\.svg`

## Alternative

- `.*.svg` -> `.*svg`, but i think the previous is more precise for fileextension

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

- #25282 `maintenance(www): use gatsby-plugin-react-svg for icons`

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
