### PR TITLE
tests(gatsby): fix feedback tests: random selection - randomNumberWithinQuarter

### DIFF
--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -32,7 +32,7 @@ const randomChanceToBeTrue = (): boolean => {
       // One quarter year in days (roughly)
       (30 * 3)
   )
-  const randomNumberWithinQuarter = randomNumber * currentQuarter
+  const randomNumberWithinQuarter = randomNumber + (30 * 3 * (currentQuarter-1))
 
   return randomNumberWithinQuarter === getDayOfYear(new Date())
 }

--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -32,7 +32,7 @@ const randomChanceToBeTrue = (): boolean => {
       // One quarter year in days (roughly)
       (30 * 3)
   )
-  const randomNumberWithinQuarter = randomNumber + (30 * 3 * (currentQuarter-1))
+  const randomNumberWithinQuarter = randomNumber + 30 * 3 * (currentQuarter-1)
 
   return randomNumberWithinQuarter === getDayOfYear(new Date())
 }

--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -32,7 +32,7 @@ const randomChanceToBeTrue = (): boolean => {
       // One quarter year in days (roughly)
       (30 * 3)
   )
-  const randomNumberWithinQuarter = randomNumber + 30 * 3 * (currentQuarter-1)
+  const randomNumberWithinQuarter = randomNumber + 30 * 3 * (currentQuarter - 1)
 
   return randomNumberWithinQuarter === getDayOfYear(new Date())
 }


### PR DESCRIPTION
## Description

changes:
- fix feedback test

problems:
- it was not calculating a day within a quarter (between startday/lastday of quarter)
- it becomes less chances to match on each new quarter (Q2:½ Q3:⅓ Q4:¼)
- it should be more within the 90days of a quarter roughly

## Related Issues

- https://github.com/gatsbyjs/gatsby/pull/21841#discussion_r389864028