### PR TITLE
Add dictionary to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,7 @@
 # All docs must be reviewed by the docs team.
 /docs/                                          @gatsbyjs/learning
 **/README.md                                    @gatsbyjs/learning
+dictionary.txt                                  @gatsbyjs/learning
 
 # Benchmarks
 /benchmarks/                                    @duffn @pvdz @smthomas


### PR DESCRIPTION
## Description

New words that we want the linter to recognize need to be added to `dictionary.txt`. This file is in the root `gatsby` directory and therefore the Core team is automatically tagged when it gets updated. This change assigns ownership to the `@gatsbyjs/learning` (Documentation) team.

### Documentation

More info on [updating the dictionary](https://www.gatsbyjs.org/contributing/gatsby-style-guide/#updating-the-dictionary) may be found in the Style Guide.