### PR TITLE
chore(gatsby-plugin-mdx): refactor mdx-loader async code

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -89,6 +89,7 @@ const hasDefaultExport = (str, options) => {
 }
 
 module.exports = async function (content) {
+  // Note: the context for this function is passed on by webpack (or test env)
   const {
     getNode: rawGetNode,
     getNodes,

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
@@ -16,9 +16,9 @@ array: [1,2,3]
 )`,
     namedExports: `export const meta = {author: "chris"}`,
     body: `# Some title
-    
+
 a bit of a paragraph
-    
+
 some content`,
   }
 
@@ -67,12 +67,6 @@ describe(`mdx-loader`, () => {
     `snapshot with %s`,
     async (filename, fakeGatsbyNode, content) => {
       const loader = mdxLoader.bind({
-        async() {
-          return (err, result) => {
-            expect(err).toBeNull()
-            expect(result).toMatchSnapshot()
-          }
-        },
         query: {
           getNodes(_type) {
             return fixtures.map(([, node]) => node)
@@ -92,7 +86,9 @@ describe(`mdx-loader`, () => {
         },
         resourcePath: fakeGatsbyNode.absolutePath,
       })
-      await loader(content)
+      return loader(content).then(result => {
+        expect(result).toMatchSnapshot()
+      })
     }
   )
 })


### PR DESCRIPTION
This function was not optimally using the syntactic sugar of `async` functions. It was manually creating and returning a promise, including dealing with exceptions. Instead, the `async` keyword takes care of all of that for you implicitly. So this simplifies the function a little bit.

Suggest to review without whitespace.