### PR TITLE
fix(gatsby-plugin-mdx): Specify new minimum peerDep version for MDX

### DIFF
--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -14,8 +14,8 @@
     "directory": "packages/gatsby-plugin-mdx"
   },
   "peerDependencies": {
-    "@mdx-js/mdx": "^1.0.0",
-    "@mdx-js/react": "^1.0.0"
+    "@mdx-js/mdx": "^1.5.9",
+    "@mdx-js/react": "^1.5.9"
   },
   "dependencies": {
     "@babel/core": "^7.10.3",


### PR DESCRIPTION
We recently began using a new API in MDX with #25437 which
doesn't exist for all versions below 1.5.9. This updates the
peer dep for MDX to ensure that the new minimum version is
specified.

Fixes #25691
