### PR TITLE
grammar fix: make all list items start with a verb

### DIFF
--- a/docs/docs/gatsby-core-philosophy.md
+++ b/docs/docs/gatsby-core-philosophy.md
@@ -65,7 +65,7 @@ When a copywriter edits a headline in their CMS, a designer draws a button in th
 
 ### Build a better web
 
-Websites can have, or lack, many qualities. They can be fast, secure, maintainable, beautiful, accessible, and cheap (or not). They can be easy to build and iterate on, have great SEO, and fun to work on (or not).
+Websites can have, or lack, many qualities. They can be fast, secure, maintainable, beautiful, accessible, and cheap (or not). They can be easy to build and iterate on, have great SEO, and be fun to work on (or not).
 
 We believe that these qualities should be baked into frameworks, so they are delivered _by default_ rather than implemented on a per-site basis.
 


### PR DESCRIPTION
## Description

The original list in the corrected sentence shows 3 items. Here they are, listed:

"They can..."
1. "...be easy to build and iterate on"
2. "...have great SEO"
3. "...fun to work on"

The last one does not make sense, and should have "be" at the beginning. This PR adds that "be".