### PR TITLE
perf(gatsby-plugin-mdx): prevent dupe file writes and simplify Babel step

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
@@ -8,8 +8,6 @@ const createMDXNode = require(`../utils/create-mdx-node`)
 const { MDX_SCOPES_LOCATION } = require(`../constants`)
 const { findImports } = require(`../utils/gen-mdx`)
 
-const contentDigest = val => createContentDigest(val)
-
 module.exports = async (
   {
     node,
@@ -73,7 +71,6 @@ module.exports = async (
     cache,
     scopeIdentifiers,
     scopeImports,
-    createContentDigest: contentDigest,
     parentNode: node,
   })
 }
@@ -82,7 +79,6 @@ async function cacheScope({
   cache,
   scopeImports,
   scopeIdentifiers,
-  createContentDigest,
   parentNode,
 }) {
   // scope files are the imports from an MDX file pulled out and re-exported.


### PR DESCRIPTION
The cacheScope function would try to write the same file over and over again which is 10x more expensive than caching whether or not that file had already been written (or even fs.existsSync, but caching is much cheaper). Still needs some tweaking. This doesn't change much, it's just 4s on the 64k benchmark, so 0.1%, although it might be better for your disk :)

I'm not a super fan of the Map for caching this, though, since this means having to juggle it from a central point somehow. Or putting it global, which might also not be desirable. Additionally, the map needs to do file path + contents, not just contents (I think... but perhaps that's actually not necessary since the digest of the contents dictates the path).
    
Dropping the babel step in favor of a regex scrub saves a little bit more. Still only like 30s on the 64k benchmark (~1%).
    
The idea for the scrubbing is that the inputs must be valid ES6 import statements, which will have a `from` keyword followed by a quoted string. This is an invariant in the syntax and so it should be safe to run this regex on it rather than turn on the whole Babel engine. Note that the input strings may contain multiple import statements, hence the `g` flag and non-greedy match.
    
Need to verify this more thoroughly so shelving it before I go on vacation.

(This'll be two separate PRs)