### PR TITLE
chore(docs): add force install command

### DIFF
--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -78,4 +78,4 @@ Copy all modules/files in the gatsby source repo in packages/
 
 #### `--force-install`
 
-Force publish local packages and install them
+Disables copying files into node_modules and forces usage of local npm repository.

--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -75,3 +75,7 @@ Don't output anything except for a success message when used together with
 #### `--copy-all`
 
 Copy all modules/files in the gatsby source repo in packages/
+
+#### `--force-install`
+
+Force publish local packages and install them


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add missing command to the `gatsby-dev-cli` tool.

I did not find any reference anywhere, so I guess is missing. Please re-recheck my description, which might be not 100% accurate. 

### Documentation

https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-dev-cli/README.md

## Related Issues

No related issues found