### PR TITLE
feat(gatsby): Handle webpack in state machine

### DIFF
--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -69,9 +69,7 @@ const openDebuggerPort = (debugInfo: IDebugInfo): void => {
 }
 
 module.exports = async (program: IDevelopArgs): Promise<void> => {
-  if (program.verbose) {
-    reporter.setVerbose(true)
-  }
+  reporter.setVerbose(program.verbose)
 
   if (program.debugInfo) {
     openDebuggerPort(program.debugInfo)

--- a/packages/gatsby/src/query/query-watcher.js
+++ b/packages/gatsby/src/query/query-watcher.js
@@ -237,13 +237,13 @@ const watch = async rootDir => {
       { ignoreInitial: true }
     )
     .on(`change`, path => {
-      emitter.emit(`QUERY_FILE_CHANGED`, path)
+      emitter.emit(`SOURCE_FILE_CHANGED`, path)
     })
     .on(`add`, path => {
-      emitter.emit(`QUERY_FILE_CHANGED`, path)
+      emitter.emit(`SOURCE_FILE_CHANGED`, path)
     })
     .on(`unlink`, path => {
-      emitter.emit(`QUERY_FILE_CHANGED`, path)
+      emitter.emit(`SOURCE_FILE_CHANGED`, path)
     })
 
   filesToWatch.forEach(filePath => watcher.add(filePath))

--- a/packages/gatsby/src/services/index.ts
+++ b/packages/gatsby/src/services/index.ts
@@ -19,6 +19,7 @@ import { runPageQueries } from "./run-page-queries"
 
 import { waitUntilAllJobsComplete } from "../utils/wait-until-jobs-complete"
 import { runMutationBatch } from "./run-mutation-batch"
+import { recompile } from "./recompile"
 
 export * from "./types"
 
@@ -40,6 +41,7 @@ export {
   startWebpackServer,
   rebuildSchemaWithSitePage,
   runMutationBatch,
+  recompile,
 }
 
 export const buildServices: Record<string, ServiceConfig<IBuildContext>> = {
@@ -59,4 +61,5 @@ export const buildServices: Record<string, ServiceConfig<IBuildContext>> = {
   writeOutRedirects,
   startWebpackServer,
   rebuildSchemaWithSitePage,
+  recompile,
 }

--- a/packages/gatsby/src/services/listen-for-mutations.ts
+++ b/packages/gatsby/src/services/listen-for-mutations.ts
@@ -6,12 +6,8 @@ export const listenForMutations: InvokeCallback = (callback: Sender<any>) => {
     callback({ type: `ADD_NODE_MUTATION`, payload: event })
   }
 
-  const emitFileChange = (event: unknown): void => {
+  const emitSourceChange = (event: unknown): void => {
     callback({ type: `SOURCE_FILE_CHANGED`, payload: event })
-  }
-
-  const emitQueryChange = (event: unknown): void => {
-    callback({ type: `QUERY_FILE_CHANGED`, payload: event })
   }
 
   const emitWebhook = (event: unknown): void => {
@@ -20,13 +16,11 @@ export const listenForMutations: InvokeCallback = (callback: Sender<any>) => {
 
   emitter.on(`ENQUEUE_NODE_MUTATION`, emitMutation)
   emitter.on(`WEBHOOK_RECEIVED`, emitWebhook)
-  emitter.on(`SOURCE_FILE_CHANGED`, emitFileChange)
-  emitter.on(`QUERY_FILE_CHANGED`, emitQueryChange)
+  emitter.on(`SOURCE_FILE_CHANGED`, emitSourceChange)
 
   return function unsubscribeFromMutationListening(): void {
     emitter.off(`ENQUEUE_NODE_MUTATION`, emitMutation)
-    emitter.off(`SOURCE_FILE_CHANGED`, emitFileChange)
     emitter.off(`WEBHOOK_RECEIVED`, emitWebhook)
-    emitter.off(`QUERY_FILE_CHANGED`, emitQueryChange)
+    emitter.off(`SOURCE_FILE_CHANGED`, emitSourceChange)
   }
 }

--- a/packages/gatsby/src/services/listen-to-webpack.ts
+++ b/packages/gatsby/src/services/listen-to-webpack.ts
@@ -1,0 +1,12 @@
+import { Compiler } from "webpack"
+import { InvokeCallback } from "xstate"
+import reporter from "gatsby-cli/lib/reporter"
+
+export const createWebpackWatcher = (compiler: Compiler): InvokeCallback => (
+  callback
+): void => {
+  compiler.hooks.invalid.tap(`file invalidation`, file => {
+    reporter.verbose(`Webpack file changed: ${file}`)
+    callback({ type: `SOURCE_FILE_CHANGED`, file })
+  })
+}

--- a/packages/gatsby/src/services/recompile.ts
+++ b/packages/gatsby/src/services/recompile.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-unused-expressions */
+import { IBuildContext } from "./types"
+import { Stats } from "webpack"
+import reporter from "gatsby-cli/lib/reporter"
+import { emitter } from "../redux"
+
+export async function recompile({
+  webpackWatching,
+}: IBuildContext): Promise<Stats> {
+  if (!webpackWatching) {
+    reporter.panic(`Missing compiler`)
+  }
+  // Promisify the event-based API. We do this using emitter
+  // because you can't "untap" a webpack watcher, and we just want
+  // one compilation.
+
+  return new Promise(resolve => {
+    function finish(stats: Stats): void {
+      emitter.off(`COMPILATION_DONE`, finish)
+      resolve(stats)
+    }
+    emitter.on(`COMPILATION_DONE`, finish)
+    webpackWatching.resume()
+    // Suspending is just a flag, so it's safe to re-suspend right away
+    webpackWatching.suspend()
+  })
+}

--- a/packages/gatsby/src/services/start-webpack-server.ts
+++ b/packages/gatsby/src/services/start-webpack-server.ts
@@ -22,6 +22,7 @@ import {
 } from "../utils/webpack-status"
 import { enqueueFlush } from "../utils/page-data"
 import mapTemplatesToStaticQueryHashes from "../utils/map-templates-to-static-query-hashes"
+import { emitter } from "../redux"
 
 export async function startWebpackServer({
   program,
@@ -42,6 +43,7 @@ export async function startWebpackServer({
     websocketManager,
     webpackWatching,
   } = await startServer(program, app, workerPool)
+  webpackWatching.suspend()
 
   compiler.hooks.invalid.tap(`log compiling`, function () {
     if (!webpackActivity) {
@@ -160,6 +162,7 @@ export async function startWebpackServer({
 
       markWebpackStatusAsDone()
       done()
+      emitter.emit(`COMPILATION_DONE`, stats)
       resolve({ compiler, websocketManager, webpackWatching })
     })
   })

--- a/packages/gatsby/src/services/types.ts
+++ b/packages/gatsby/src/services/types.ts
@@ -37,5 +37,7 @@ export interface IBuildContext {
   compiler?: Compiler
   websocketManager?: WebsocketManager
   webpackWatching?: IWebpackWatchingPauseResume
+  webpackListener?: Actor<unknown, AnyEventObject>
   queryFilesDirty?: boolean
+  sourceFilesDirty?: boolean
 }

--- a/packages/gatsby/src/state-machines/develop/actions.ts
+++ b/packages/gatsby/src/state-machines/develop/actions.ts
@@ -15,6 +15,7 @@ import { assertStore } from "../../utils/assert-store"
 import { saveState } from "../../db"
 import reporter from "gatsby-cli/lib/reporter"
 import { ProgramStatus } from "../../redux/types"
+import { createWebpackWatcher } from "../../services/listen-to-webpack"
 
 /**
  * These are the deferred redux actions sent from api-runner-node
@@ -79,6 +80,14 @@ export const markQueryFilesDirty = assign<IBuildContext>({
   queryFilesDirty: true,
 })
 
+export const markSourceFilesDirty = assign<IBuildContext>({
+  sourceFilesDirty: true,
+})
+
+export const markSourceFilesClean = assign<IBuildContext>({
+  sourceFilesDirty: false,
+})
+
 export const assignServiceResult = assign<IBuildContext, DoneEventObject>(
   (_context, { data }): DataLayerResult => data
 )
@@ -97,6 +106,15 @@ export const assignServers = assign<IBuildContext, AnyEventObject>(
     }
   }
 )
+
+export const spawnWebpackListener = assign<IBuildContext, AnyEventObject>({
+  webpackListener: ({ compiler }) => {
+    if (!compiler) {
+      return undefined
+    }
+    return spawn(createWebpackWatcher(compiler))
+  },
+})
 
 export const assignWebhookBody = assign<IBuildContext, AnyEventObject>({
   webhookBody: (_context, { payload }) => payload?.webhookBody,
@@ -135,6 +153,9 @@ export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
   assignWebhookBody,
   clearWebhookBody,
   finishParentSpan,
+  spawnWebpackListener,
+  markSourceFilesDirty,
+  markSourceFilesClean,
   saveDbState,
   setQueryRunningFinished,
 }

--- a/packages/gatsby/src/state-machines/develop/services.ts
+++ b/packages/gatsby/src/state-machines/develop/services.ts
@@ -1,4 +1,9 @@
-import { IBuildContext, startWebpackServer, initialize } from "../../services"
+import {
+  IBuildContext,
+  startWebpackServer,
+  initialize,
+  recompile,
+} from "../../services"
 import {
   initializeDataMachine,
   reloadDataMachine,
@@ -15,5 +20,6 @@ export const developServices: Record<string, ServiceConfig<IBuildContext>> = {
   initialize: initialize,
   runQueries: queryRunningMachine,
   waitForMutations: waitingMachine,
-  startWebpackServer: startWebpackServer,
+  startWebpackServer,
+  recompile,
 }

--- a/packages/gatsby/src/state-machines/query-running/index.ts
+++ b/packages/gatsby/src/state-machines/query-running/index.ts
@@ -10,6 +10,11 @@ import { queryActions } from "./actions"
 export const queryStates: MachineConfig<IQueryRunningContext, any, any> = {
   initial: `extractingQueries`,
   id: `queryRunningMachine`,
+  on: {
+    SOURCE_FILE_CHANGED: {
+      target: `extractingQueries`,
+    },
+  },
   context: {},
   states: {
     extractingQueries: {


### PR DESCRIPTION
Instead of allowing the webpack dev server to recompile any changed files whenever they change, this PR moves the handling of these into the state machine. We listen to the webpack `invalid` event, which means that a file has been invalidated (i.e. changed). We use this to set a flag in context, which means that we rebuild the JS bundle when we get to that stage in the build process, and if we're currently idle we kick off a build. 