### PR TITLE
fix(readme): gatsby-plugin-less - variable in code fences

### DIFF
--- a/packages/gatsby-plugin-less/README.md
+++ b/packages/gatsby-plugin-less/README.md
@@ -17,7 +17,7 @@ plugins: [`gatsby-plugin-less`]
 ```
 
 If you need to pass options to the Less loader use the `loaderOptions` and to Less use `lessOptions` object;
-see [less-loader](https://github.com/webpack-contrib/less-loader) for all available options.
+see [`less-loader`](https://github.com/webpack-contrib/less-loader) for all available options.
 
 ```javascript
 // in gatsby-config.js


### PR DESCRIPTION

## Description

changes:

- variable in code fences


## Related Issues

- #24893 `chore(gatsby-plugin-less): less-loader version 6.1.0 with tests and doc…` 
