### PR TITLE
fix(gatsby): Autotruncate long paths

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -420,26 +420,6 @@ const errors = {
     type: Type.PLUGIN,
     level: Level.ERROR,
   },
-  // Directory/file name exceeds OS character limit
-  "11331": {
-    text: (context): string =>
-      [
-        `One or more path segments are too long - they exceed OS filename length limit.\n`,
-        `Page path: "${context.path}"`,
-        `Invalid segments:\n${context.invalidPathSegments
-          .map(segment => ` - "${segment}"`)
-          .join(`\n`)}`,
-        ...(!context.isProduction
-          ? [
-              `\nThis will fail production builds, please adjust your paths.`,
-              `\nIn development mode gatsby truncated to: "${context.truncatedPath}"`,
-            ]
-          : []),
-      ]
-        .filter(Boolean)
-        .join(`\n`),
-    level: Level.ERROR,
-  },
   // node object didn't pass validation
   "11467": {
     text: (context): string =>

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -364,17 +364,17 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
 
   if (invalidPathSegments.length > 0) {
     const truncatedPath = truncatePath(page.path)
-    report.panicOnBuild({
-      id: `11331`,
-      context: {
-        path: page.path,
-        invalidPathSegments,
+    report.warn(
+      report.stripIndent(`
+        The path to the following page is longer than the supported limit on most 
+        operating systems and will cause an ENAMETOOLONG error. The path has been
+        truncated to prevent this. 
 
-        // we will only show truncatedPath in non-production scenario
-        isProduction: process.env.NODE_ENV === `production`,
-        truncatedPath,
-      },
-    })
+        Original Path: ${page.path}
+
+        Truncated Path: ${truncatedPath}
+      `)
+    )
     page.path = truncatedPath
   }
 


### PR DESCRIPTION
Several files that we write as part of the build process use the page path as a base for their names. Paths longer than filename limits hence cause a `ENAMETOOLONG` that fails the build process. This PR enables autotruncation for such paths. 

We were already panicking on build for these. Now we warn on both develop and build but _always_ autotruncate. 

Fixes https://github.com/gatsbyjs/gatsby/issues/4125
Fixes https://github.com/gatsbyjs/gatsby/issues/25647