### PR TITLE
Changed the order of the pages in doc-links.yaml

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -159,12 +159,12 @@
             - title: Using the Static Folder
               link: /docs/static-folder/
               breadcrumbTitle: Static Folder
+            - title: Working with Images in Gatsby
+              link: /docs/working-with-images/
             - title: Using gatsby-image
               link: /docs/using-gatsby-image/
             - title: Using Cloudinary Image service
               link: /docs/using-cloudinary-image-service/
-            - title: Working with Images in Gatsby
-              link: /docs/working-with-images/
               breadcrumbTitle: Images in Gatsby
             - title: Preoptimizing Your Images
               link: /docs/preoptimizing-images/


### PR DESCRIPTION
## Description

Change the order of the pages in `doc-links.yaml`
- placed "Working with Images in Gatsby" at first, then "Using gatsby-image".



## Related Issues

Fixes #25829 

Signed by - @[Neilblaze](https://github.com/Neilblaze)