### PR TITLE
feat(gatsby-plugin-google-analytics): Added cookie storage option

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -144,6 +144,7 @@ This plugin supports all optional Create Only Fields documented in [Google Analy
 - `legacyCookieDomain`: string
 - `legacyHistoryImport`: boolean
 - `allowLinker`: boolean
+- `storage`: string
 
 This plugin also supports several optional General fields documented in [Google Analytics](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#general):
 

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -13,6 +13,7 @@ const knownOptions = {
     legacyCookieDomain: `string`,
     legacyHistoryImport: `boolean`,
     allowLinker: `boolean`,
+    storage: `string`,
   },
   general: {
     allowAdFeatures: `boolean`,


### PR DESCRIPTION
##  Description

Added storage option as described [in this part of the docs](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id#disabling_cookies), from there it links to the full field reference page with an anchor link to #storage but the storage field is missing.

What it does is let you set 'storage' to 'none' which means no _ga cookies are ever set and combined with anonymize causes analytics to work more like a basic pageview tracker but with a lot more GDPR compliance.

### Documentation

https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id#disabling_cookies
