### PR TITLE
fix(docs): missing comma in migrating-from-v1-to-v2.md

### DIFF
--- a/docs/docs/migrating-from-v1-to-v2.md
+++ b/docs/docs/migrating-from-v1-to-v2.md
@@ -801,7 +801,7 @@ export default function Page(props) {
 }
 ```
 
-Furthermore you can remove the package from the `package.json`.
+Furthermore, you can remove the package from the `package.json`.
 
 ```diff:title=package.json
 "dependencies": {


### PR DESCRIPTION
## Description

Was reading through and saw a missing comma.