### PR TITLE
fix(readme): gatsby-source-wordpress: remove escaping code fences

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -1,7 +1,7 @@
 <mark>Warning:</mark>
 **The current version of this plugin will soon be deprecated** and replaced with a complete rewrite in the next version (v4). The reason for this is that we've adopted the use of WPGraphQL to support Preview and incremental builds as well as to make the schema generally more stable and consistent.
 
-Please upgrade to the beta of \`gatsby-source-wordpress@v4\` by installing \`gatsby-source-wordpress-experimental\`.
+Please upgrade to the beta of `gatsby-source-wordpress@v4` by installing `gatsby-source-wordpress-experimental`.
 
 These two packages are currently published under separate names to allow activating them side-by-side.
 This makes migration between the two simpler. Once the new plugin is stable it will be merged back in and be published as `gatsby-source-wordpress`.


### PR DESCRIPTION
## Description

changes:
- remove escaping code fences



<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

- #25623 `chore(gatsby-source-wordpress): add deprecation notice and link to beta WP source plugin` 