### PR TITLE
Update docs about globPatterns in manifest & offline plugin

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -316,7 +316,7 @@ In order to solve this, update your `gatsby-config.js` as follows:
    resolve: 'gatsby-plugin-offline',
    options: {
       workboxConfig: {
-         globPatterns: ['**/*']
+         globPatterns: ['**/icon-path*']
       }
    }
 }
@@ -324,6 +324,7 @@ In order to solve this, update your `gatsby-config.js` as follows:
 
 Updating `cache_busting_mode` is necessary. Otherwise, workbox will break while attempting to find the cached URLs.
 Adding the `globPatterns` makes sure that the offline plugin will cache everything.
+Note that you have to prefix your icon with `icon-path` or whatever you may call it
 
 #### Remove `theme-color` meta tag
 

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -233,7 +233,7 @@ In order to solve this, update your `gatsby-config.js` as follows:
    resolve: 'gatsby-plugin-offline',
    options: {
       workboxConfig: {
-         globPatterns: ['**/*']
+         globPatterns: ['**/icon-path*']
       }
    }
 }
@@ -241,3 +241,4 @@ In order to solve this, update your `gatsby-config.js` as follows:
 
 Updating `cache_busting_mode` is necessary. Otherwise, workbox will break while attempting to find the cached URLs.
 Adding the `globPatterns` makes sure that the offline plugin will cache everything.
+Note that you have to prefix your icon with `icon-path` or whatever you may call it


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I updated the README.md regarding issue about globPatterns caching everything in public folder
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
Docs can be found in `packages/gatsby-plugin-manifest` & `packages/gatsby-plugin-offline`

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
This PR fixes #24480 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
