### PR TITLE
fix: Restore CLI port in use prompt feature

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -5,6 +5,7 @@ import tmp from "tmp"
 import { spawn, ChildProcess } from "child_process"
 import chokidar from "chokidar"
 import getRandomPort from "detect-port"
+import { detectPortInUseAndPrompt } from "../utils/detect-port-in-use-and-prompt"
 import socket from "socket.io"
 import fs from "fs-extra"
 import { isCI, slash } from "gatsby-core-utils"
@@ -163,6 +164,17 @@ const REGEX_IP = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25
 
 module.exports = async (program: IProgram): Promise<void> => {
   const developProcessPath = slash(require.resolve(`./develop-process`))
+
+  try {
+    program.port = await detectPortInUseAndPrompt(program.port)
+  } catch (e) {
+    if (e.message === `USER_REJECTED`) {
+      process.exit(0)
+    }
+
+    throw e
+  }
+
   // Run the actual develop server on a random port, and the proxy on the program port
   // which users will access
   const proxyPort = program.port

--- a/packages/gatsby/src/utils/detect-port-in-use-and-prompt.ts
+++ b/packages/gatsby/src/utils/detect-port-in-use-and-prompt.ts
@@ -5,11 +5,11 @@ import prompts from "prompts"
 export const detectPortInUseAndPrompt = async (
   port: number
 ): Promise<number> => {
-  let foundPort = port
-  const detectedPort = await detectPort(port).catch((err: Error) =>
+  let foundPort = typeof port === `string` ? parseInt(port, 10) : port
+  const detectedPort = await detectPort(foundPort).catch((err: Error) =>
     report.panic(err)
   )
-  if (port !== detectedPort) {
+  if (foundPort !== detectedPort) {
     report.log(`\nSomething is already running at port ${port}`)
     const response = await prompts({
       type: `confirm`,


### PR DESCRIPTION
## Description

Seems like it got accidentally removed during a big PR? DX with the `gatsby develop` command regressed as a result, if you had an existing process using port 8000, you would get the following:

```
$ gatsby develop

/.asdf/installs/nodejs/14.4.0/.npm/lib/node_modules/gatsby-cli/node_modules/yoga-layout-prebuilt/yoga-layout/build/Release/nbind.js:53
        throw ex;
        ^

Error: listen EADDRINUSE: address already in use 127.0.0.1:8000
    at Server.setupListenHandle [as _listen2] (net.js:1313:16)
    at listenInCluster (net.js:1361:12)
    at GetAddrInfoReqWrap.doListen [as callback] (net.js:1498:7)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:68:8)
Emitted 'error' event on Server instance at:
    at emitErrorNT (net.js:1340:8)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  code: 'EADDRINUSE',
  errno: -98,
  syscall: 'listen',
  address: '127.0.0.1',
  port: 8000
}
```

The above was also the output when run on the same project, where an appropriate error message should have been output. With this PR you'd now experience this:

```
$ gatsby develop

Something is already running at port 8000
✔ Would you like to run the app at another port instead? … yes

 ERROR 

Looks like develop for this site is already running. Try visiting http://localhost:8000/ maybe?
```

Now the correct error at the bottom is output to the terminal. Might be able to trigger that before the one this PR provides? Unclear as it wasn't triggering if the port was already in use (I assume it does if you specify a different port like this PR handles instead of crashing).

Unlike the same project error message, this PR prompt would still be useful if running multiple `develop` processes for different projects.

## Related Issues

Fixes #24854 

## Note

The `develop.ts` file has a comment in the first line:

> NOTE(@mxstbr): Do not use the reporter in this file, as that has side-effects on import which break structured logging 

The PR that removed this feature, kept the utility file active in the src, despite it not being used anymore, I'm not sure if that was intentional or just missed from the size of that PR. The above comment by @mxstbr may be relevant though as the utility does import the reporter, I'm not sure what the impact to users doing development is regarding breaking structured logging?

https://github.com/gatsbyjs/gatsby/blob/f1ace29f71bb2b9c25a2538f4fe2d8c8ebc89f9a/packages/gatsby/src/utils/detect-port-in-use-and-prompt.ts#L2
