### PR TITLE
Update deploying-to-cloudflare-workers.md

### DIFF
--- a/docs/docs/deploying-to-cloudflare-workers.md
+++ b/docs/docs/deploying-to-cloudflare-workers.md
@@ -4,7 +4,7 @@ title: Deploying to Cloudflare Workers
 
 [Cloudflare Workers](https://workers.cloudflare.com/) is a serverless platform for creating entirely new applications or augmenting existing ones without configuring or maintaining infrastructure. With [Workers Sites](https://developers.cloudflare.com/workers/sites/start-from-existing/) you can deploy any static site including your Gatsby projects to a domain on Cloudflare or for free on your [workers.dev](https://workers.dev) subdomain.
 
-To enable the KV store required to serve the Gatsby files, you'll need the [Workers Unlimited plan](https://developers.cloudflare.com/workers/about/pricing/) for \$5/month.
+To enable the KV store required to serve the Gatsby files, you'll need the [Workers Unlimited plan](https://developers.cloudflare.com/workers/about/pricing/) for <span>&#36;</span>5/month.
 
 This guide will get you started in a few steps:
 


### PR DESCRIPTION
## Description
Simple, an extra slash was present in the docs for Cloudflare workers.

### Documentation

Not needed.

## Related Issues

Was a typo.

Fix for failed pull request https://github.com/gatsbyjs/gatsby/pull/25861
(Temporary fix for Prettier Bug https://github.com/prettier/prettier/issues/6213 )

![gatsby](https://user-images.githubusercontent.com/33004850/87913805-4aa8d700-ca8d-11ea-8209-428246644e9d.png)
