### PR TITLE
Update overview-of-the-gatsby-build-process.md

### DIFF
--- a/docs/docs/overview-of-the-gatsby-build-process.md
+++ b/docs/docs/overview-of-the-gatsby-build-process.md
@@ -155,7 +155,7 @@ A [cache](/docs/glossary#cache) is also used to detect changes to `gatsby-*.js` 
 
 ## What happens when you run `gatsby build`?
 
-To see the code where many of these processes are happening, refer to the code and comments in the [`build`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/commands/build.ts) and [`bootstrap`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/bootstrap/index.js) files of the repository.
+To see the code where many of these processes are happening, refer to the code and comments in the [`build`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/commands/build.ts) and [`bootstrap`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/bootstrap/index.ts) files of the repository.
 
 A Node.js server process powers things behind the scenes when you run the `gatsby build` command. The process of converting assets and pages into HTML that can be rendered in a browser by a [server-side](/docs/glossary#server-side) language like Node.js is referred to as server-side rendering, or SSR. Since Gatsby builds everything ahead of time, this creates an entire site with all of the data your pages need at once. When the site is deployed, it doesn't need to run with server-side processes because everything has been gathered up and compiled by Gatsby.
 


### PR DESCRIPTION
Fixed a small broken link. 
js extension was given instead of ts

Location in docs:
https://www.gatsbyjs.org/docs/overview-of-the-gatsby-build-process/#what-happens-when-you-run-gatsby-build
First paragraph
