### PR TITLE
Fix broken link and still stay linked

### DIFF
--- a/docs/blog/2020-07-07-wordpress-source-beta/index.mdx
+++ b/docs/blog/2020-07-07-wordpress-source-beta/index.mdx
@@ -29,7 +29,7 @@ The new source plugin for WordPress gives you the following enhanced developer a
 - Links and images within the HTML of content can be used with [gatsby-image](/docs/gatsby-image/) and [gatsby-link](/docs/gatsby-link/). This fixes a common complaint about the original source plugin for WordPress.
 - Limit the number of nodes fetched during development, so you can rapidly make changes to your site while creating new pages and features
 - Only images that are referenced in published content are processed by Gatsby, so a large media library won’t slow down your build times 
-- Any WPGraphQL extension automatically makes its data available to your Gatsby project. This means your site can leverage popular WordPress [SEO](https://github.com/ashhitch/wp-graphql-yoast-seo), [content modeling](https://docs.wpgraphql.com/extensions/wpgraphql-advanced-custom-fields/), [translation](https://github.com/valu-digital/wp-graphql-polylang), and [ecommerce](https://docs.wpgraphql.com/extensions/wpgraphql-woocommerce/) plugins through a single Gatsby source plugin.
+- Any WPGraphQL extension automatically makes its data available to your Gatsby project. This means your site can leverage popular WordPress [SEO](https://github.com/ashhitch/wp-graphql-yoast-seo), [content modeling](https://www.wpgraphql.com/acf/), [translation](https://github.com/valu-digital/wp-graphql-polylang), and [ecommerce](https://github.com/wp-graphql/wp-graphql-woocommerce) plugins through a single Gatsby source plugin.
 
 ## How to start using the new WordPress source plugin
 Follow the steps below to bring Gatsby Preview and Incremental Builds to your Gatsby/WordPress project:


### PR DESCRIPTION
@jasonbahl might want https://www.wpgraphql.com/ to stay linked to Gatsby blog for SEO and visibility reason. Could found only one plugin link on site.
This is an update to https://github.com/gatsbyjs/gatsby/pull/25869 just in case if it's useful.
