### PR TITLE
Update React-chart and MDX versions

### DIFF
--- a/examples/using-MDX/package.json
+++ b/examples/using-MDX/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
-    "@mdx-js/mdx": "^1.6.6",
+    "@mdx-js/mdx": "^1.6.11",
     "@mdx-js/react": "^1.6.6",
     "gatsby": "^2.23.12",
     "gatsby-image": "^2.4.9",
@@ -18,7 +18,8 @@
     "gatsby-transformer-sharp": "^2.5.7",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
-    "react-charts": "^2.0.1",
+    "react-charts": "^2.0.0-beta.7",
+    "react-chat-elements": "^10.9.2",
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1"
   },


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This PR updates versions of react-charts and MDX that were causing /examples/using-mdx breaking. 
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
/examples/using-mdx
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

