### PR TITLE
chore(gatsby-telemetry): Migrate is-truthy to TypeScript

### DIFF
--- a/packages/gatsby-telemetry/src/__tests__/is-truthy.ts
+++ b/packages/gatsby-telemetry/src/__tests__/is-truthy.ts
@@ -1,4 +1,4 @@
-const isTruthy = require(`../is-truthy`)
+import { isTruthy } from "../is-truthy"
 
 describe(`isTruthy`, () => {
   it(`handles Booleans`, () => {

--- a/packages/gatsby-telemetry/src/event-storage.js
+++ b/packages/gatsby-telemetry/src/event-storage.js
@@ -5,7 +5,7 @@ const fetch = require(`node-fetch`)
 const Configstore = require(`configstore`)
 const { ensureDirSync } = require(`fs-extra`)
 
-const isTruthy = require(`./is-truthy`)
+import { isTruthy } from "./is-truthy"
 
 /* The events data collection is a spooled process that
  * buffers events to a local fs based buffer

--- a/packages/gatsby-telemetry/src/is-truthy.ts
+++ b/packages/gatsby-telemetry/src/is-truthy.ts
@@ -1,6 +1,6 @@
 // Returns true for `true`, true, positive numbers
 // Returns false for `false`, false, 0, negative integers and anything else
-const isTruthy = value => {
+export function isTruthy(value: any): boolean {
   // Return if Boolean
   if (typeof value === `boolean`) return value
 
@@ -19,5 +19,3 @@ const isTruthy = value => {
   // Default to false
   return false
 }
-
-module.exports = isTruthy


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Simple transition for `isTruthy` and test

## Related Issues

#21995 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
