### PR TITLE
remove surplus `and` from performance comma list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Gatsby is a modern web framework for blazing fast websites.
   to load your data, then develop using Gatsby’s uniform GraphQL interface.
 
 - **Performance Is Baked In.** Ace your performance audits by default. Gatsby automates code
-  splitting, image optimization, inlining critical styles, lazy-loading, and prefetching resources,
+  splitting, image optimization, inlining critical styles, lazy-loading, prefetching resources,
   and more to ensure your site is fast — no manual tuning required.
 
 - **Host at Scale for Pennies.** Gatsby sites don’t require servers so you can host your entire


### PR DESCRIPTION
## Description
Location: Repo's main README.md

Removing the word `and` from the second to last item in the performance list.  "and" should only be present after the last comma in the sentence for this use case.

```
Gatsby automates code splitting, image optimization, inlining critical styles, lazy-loading, ~~and~~ prefetching resources, and more to ensure your site is fast — no manual tuning required.

Gatsby automates code splitting, image optimization, inlining critical styles, lazy-loading, prefetching resources, and more to ensure your site is fast — no manual tuning required.
```