### PR TITLE
fix(gatsby): Support symlinks in static directories

### DIFF
--- a/packages/gatsby/src/utils/get-static-dir.ts
+++ b/packages/gatsby/src/utils/get-static-dir.ts
@@ -27,7 +27,11 @@ export const copyStaticDirs = (): void => {
     // filter out the static folders that don't exist
     .filter(themeStaticPath => fs.existsSync(themeStaticPath))
     // copy the files for each folder into the user's build
-    .map(folder => fs.copySync(folder, nodePath.join(process.cwd(), `public`)))
+    .map(folder =>
+      fs.copySync(folder, nodePath.join(process.cwd(), `public`), {
+        dereference: true,
+      })
+    )
 
   const staticDir = nodePath.join(process.cwd(), `static`)
   if (!fs.existsSync(staticDir)) return undefined


### PR DESCRIPTION
## Description

Adds `dereference: true` when copying static directories in order to support symlinks