### PR TITLE
Update localization-i18n.md

### DIFF
--- a/docs/docs/localization-i18n.md
+++ b/docs/docs/localization-i18n.md
@@ -30,7 +30,7 @@ URL - /**en**/about
 
 React-intl is a part of the FormatJS set of i18n libraries and provides support for over 150+ languages. It builds on JavaScript's [Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) providing enhanced APIs and components. React-intl uses React context and HOCs (Higher Order Components) to provide translations allowing you to dynamically load language modules as you need them. There are also polyfill options available for older browsers that do not support the base JavaScript i18n API.
 
-More detailed information about react-intl's [APIs](https://github.com/formatjs/react-intl/blob/master/docs/API.md) and [components](https://github.com/formatjs/react-intl/blob/master/docs/Components.md), including [demos](https://github.com/formatjs/react-intl/tree/master/examples), are available in the [documentation](https://github.com/formatjs/react-intl/tree/master/docs).
+More detailed information about react-intl's [APIs](https://github.com/formatjs/formatjs/blob/main/website/docs/react-intl/api.md) and [components](https://github.com/formatjs/formatjs/blob/main/website/docs/react-intl/components.md), including [demos](https://github.com/formatjs/formatjs/tree/main/packages/react-intl/examples), are available in the [documentation](https://github.com/formatjs/formatjs/tree/main/website/docs/react-intl).
 
 ### react-i18next
 


### PR DESCRIPTION
Some important links for **React-intl** had broken due to update in repo whose links were given. Added the correct links to it.
 URL: https://www.gatsbyjs.org/docs/localization-i18n/#react-intl
Location: Second paragraph.