### PR TITLE
docs: use hello-world starter in quick start guide instead of default starter

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -22,13 +22,13 @@ npm install -g gatsby-cli
 ### Create a new site
 
 ```shell
-gatsby new gatsby-site
+gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world 
 ```
 
 ### Change directories into site folder
 
 ```shell
-cd gatsby-site
+cd hello-world
 ```
 
 ### Start development server
@@ -39,7 +39,7 @@ gatsby develop
 
 Gatsby will start a hot-reloading development environment accessible by default at `http://localhost:8000`.
 
-Try editing the JavaScript pages in `src/pages`. Saved changes will live reload in the browser.
+Try editing the home page in `src/pages/index.js`. Saved changes will live reload in the browser.
 
 ### Create a production build
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -22,13 +22,13 @@ npm install -g gatsby-cli
 ### Create a new site
 
 ```shell
-gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
+gatsby new gatsby-site https://github.com/gatsbyjs/gatsby-starter-hello-world
 ```
 
 ### Change directories into site folder
 
 ```shell
-cd hello-world
+cd gatsby-site
 ```
 
 ### Start development server

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -22,7 +22,7 @@ npm install -g gatsby-cli
 ### Create a new site
 
 ```shell
-gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world 
+gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
 ```
 
 ### Change directories into site folder


### PR DESCRIPTION

## Description
An update to the quick start page to direct users to use the hello world starter to try to ease the onboarding. As of 7.21.20, 62,438 users have failed to ever run `gatsby develop` because they run into the following error:
```
There was a problem loading the local develop command. Gatsby may not be installed in your site's "node_modules" directory. Perhaps you need to run "npm install"? You might need to delete your "package-lock.json" as well.
```
After some analysis with @DSchau, we concluded that this is most likely due to an `npm install` failure resulting in an incomplete install. Most often that failure comes from `image-sharp` failing.

Since the default starter uses `gatsby-image` and requires `image-sharp`, we wanted to run an experiment to see if directing Quick Start users to use the hello-world starter in lieu of the default starter would naturally drive down this specific error and its affect on users actually getting started with Gatsby.

### Documentation
This is a documentation change.

## Related Issues
_None initially, but feel free to comment and connect in any issues._