### PR TITLE
fix(gatsby-source-contentful): Add file-extension to remote cached items

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -61,7 +61,7 @@ const getBase64Image = imageProps => {
   // TODO: Find the best place for this step. This is definitely not it.
   fs.mkdirSync(CACHE_IMG_FOLDER, { recursive: true })
 
-  const cacheFile = path.join(CACHE_IMG_FOLDER, urlSha)
+  const cacheFile = path.join(CACHE_IMG_FOLDER, urlSha + ".base64")
 
   if (fs.existsSync(cacheFile)) {
     // TODO: against dogma, confirm whether readFileSync is indeed slower

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -61,7 +61,7 @@ const getBase64Image = imageProps => {
   // TODO: Find the best place for this step. This is definitely not it.
   fs.mkdirSync(CACHE_IMG_FOLDER, { recursive: true })
 
-  const cacheFile = path.join(CACHE_IMG_FOLDER, urlSha + ".base64")
+  const cacheFile = path.join(CACHE_IMG_FOLDER, urlSha + `.base64`)
 
   if (fs.existsSync(cacheFile)) {
     // TODO: against dogma, confirm whether readFileSync is indeed slower


### PR DESCRIPTION
## Description

This PR adds the .base64 file extension to all files created in the "remote_cache" directory (.cache/remote_cache/images)

### Documentation

We noticed when using Azure WebApps (Linux based) where we host preview server(s) using the instructions on [Running a Gatsby Preview Server](https://www.gatsbyjs.org/docs/running-a-gatsby-preview-server/) (Which are docker containers under the hood) we get alot of " no such file or directory, open '.cache/remote_cache/images/80f[0m  [0m[97m[41mcfcfd88d0e8d6272c698ab6dc2257c192c4b9'[0m" (Please ignore the color codes included in the logging, this is not the issue currently)

When you try to remove/access the file via one of the methods (viewing it on ssh/remote or via FTP) you also get an access denied errors and/or file not found. 

![12727-untitled](https://user-images.githubusercontent.com/16852398/88086051-06016680-cb87-11ea-82e1-05455ab6d310.png)

Since i noticed it was using extensionless files (and i assumed it might be an issue) i patched the file extend-node-type.js with a file extension and i noticed the problems going away :) So for this reason i thought it would be great to create a PR to improve this for everyone!

## Related Issues

Since this is such a small change i did not create a issue but rather create a PR, i could create one if required.

But it's an extension to the work done in #22551