### PR TITLE
fix(docs): Fix broken mdx

### DIFF
--- a/docs/docs/deploying-to-digitalocean-droplet.md
+++ b/docs/docs/deploying-to-digitalocean-droplet.md
@@ -94,7 +94,7 @@ sudo chown -R $(whoami) .config
 
 The static files will be hosted publicly on the droplet. The `gatsby build` command provides utility to build the site and generate the static files in the `/public`.
 
-> Note: Go to the path where <my-gatsby-app> is. You can used the copied path for reference in a [previous step](#clone-your-repository-to-the-droplet).
+> Note: Go to the path where `<my-gatsby-app>` is. You can used the copied path for reference in a [previous step](#clone-your-repository-to-the-droplet).
 
 1. Install dependencies.
 


### PR DESCRIPTION
The MDX includes a non-escaped `<my-gatsby-app>` in the markdown, which means builds are failing for .org.