### PR TITLE
Add support for cache refresh via GraphiQL

### DIFF
--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -313,7 +313,7 @@ class App extends React.Component {
         Authorization: this.state.refreshToken,
       }
     }
-    return fetch("/__refresh", options)
+    return fetch(`/__refresh`, options)
   }
 
   render() {

--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -173,7 +173,11 @@ class App extends React.Component {
     graphQLFetcher({
       query: getIntrospectionQuery(),
     }).then(result => {
-      const newState = { schema: buildClientSchema(result.data) }
+      const newState = {
+        schema: buildClientSchema(result.data),
+        enableRefresh: result.extensions.enableRefresh,
+        refreshToken: result.extensions.refreshToken,
+      }
 
       if (this.state.query === null) {
         try {
@@ -302,6 +306,16 @@ class App extends React.Component {
     this.setState({ codeExporterIsOpen: newCodeExporterIsOpen })
   }
 
+  _refreshExternalDataSources = () => {
+    const options = { method: `post` }
+    if (this.state.refreshToken) {
+      options.headers = {
+        Authorization: this.state.refreshToken,
+      }
+    }
+    return fetch("/__refresh", options)
+  }
+
   render() {
     const { query, variables, schema, codeExporterIsOpen } = this.state
     const codeExporter = codeExporterIsOpen ? (
@@ -356,6 +370,13 @@ class App extends React.Component {
               label="Code Exporter"
               title="Toggle Code Exporter"
             />
+            {this.state.enableRefresh && (
+              <GraphiQL.Button
+                onClick={this._refreshExternalDataSources}
+                label="Refresh Data"
+                title="Refresh Data from External Sources"
+              />
+            )}
           </GraphiQL.Toolbar>
         </GraphiQL>
         {codeExporter}

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -161,10 +161,12 @@ export async function startServer(
         return {
           schema,
           graphiql: false,
-          extensions: () => ({
-            enableRefresh: process.env.ENABLE_GATSBY_REFRESH_ENDPOINT,
-            refreshToken: process.env.GATSBY_REFRESH_TOKEN
-          }),
+          extensions: () => {
+            return {
+              enableRefresh: process.env.ENABLE_GATSBY_REFRESH_ENDPOINT,
+              refreshToken: process.env.GATSBY_REFRESH_TOKEN,
+            }
+          },
           context: withResolverContext({
             schema,
             schemaComposer: schemaCustomization.composer,

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -161,6 +161,10 @@ export async function startServer(
         return {
           schema,
           graphiql: false,
+          extensions: () => ({
+            enableRefresh: process.env.ENABLE_GATSBY_REFRESH_ENDPOINT,
+            refreshToken: process.env.GATSBY_REFRESH_TOKEN
+          }),
           context: withResolverContext({
             schema,
             schemaComposer: schemaCustomization.composer,

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -161,7 +161,7 @@ export async function startServer(
         return {
           schema,
           graphiql: false,
-          extensions: () => {
+          extensions(): { [key: string]: unknown } {
             return {
               enableRefresh: process.env.ENABLE_GATSBY_REFRESH_ENDPOINT,
               refreshToken: process.env.GATSBY_REFRESH_TOKEN,


### PR DESCRIPTION
Adds a "Refresh Data" button to GraphiQL. This will only be visible if the `ENABLE_GATSBY_REFRESH_ENDPOINT` is enabled and will take into consideration the `GATSBY_REFRESH_TOKEN`

![image](https://user-images.githubusercontent.com/11328618/88218598-26e5bc80-cc58-11ea-9411-7fcfa6f2b502.png)
