### PR TITLE
feat(gatsby-source-filesystem): improve wrong url rejection message

### DIFF
--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -76,7 +76,9 @@ describe(`create-remote-file-node`, () => {
           url: ``,
         })
 
-        expect(value).rejects.toMatch(`wrong url: `)
+        expect(value).rejects.toMatch(
+          `url passed to createRemoteFileNode is either missing or not a proper web uri: `
+        )
       })
 
       it(`does not increment progress bar total`, () => {
@@ -85,7 +87,9 @@ describe(`create-remote-file-node`, () => {
           url: ``,
         })
 
-        expect(value).rejects.toMatch(`wrong url: `)
+        expect(value).rejects.toMatch(
+          `url passed to createRemoteFileNode is either missing or not a proper web uri: `
+        )
 
         expect(progressBar.total).toBe(0)
         expect(progressBar.tick).not.toHaveBeenCalled()

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -362,7 +362,9 @@ module.exports = ({
   }
 
   if (!url || isWebUri(url) === undefined) {
-    return Promise.reject(`url passed to createRemoteFileNode is either missing or not a proper web uri: ${url}`)
+    return Promise.reject(
+      `url passed to createRemoteFileNode is either missing or not a proper web uri: ${url}`
+    )
   }
 
   if (totalJobs === 0) {

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -362,7 +362,7 @@ module.exports = ({
   }
 
   if (!url || isWebUri(url) === undefined) {
-    return Promise.reject(`wrong url: ${url}`)
+    return Promise.reject(`url passed to createRemoteFileNode is either missing or not a proper web uri: ${url}`)
   }
 
   if (totalJobs === 0) {


### PR DESCRIPTION
The existing message made tracing down a bug from within the new WP source plugin harder than necessary.

Old message: `wrong url: ${url}`

Updated message: `url passed to createRemoteFileNode is either missing or not a proper web uri: ${url}`