### PR TITLE
fix(gatsby-admin): small design tweaks

### DIFF
--- a/packages/gatsby-admin/src/pages/index.tsx
+++ b/packages/gatsby-admin/src/pages/index.tsx
@@ -44,7 +44,7 @@ const PluginCard: React.FC<{
   return (
     <Flex
       flexDirection="column"
-      gap={6}
+      gap={3}
       sx={{ backgroundColor: `ui.background`, padding: 5, borderRadius: 2 }}
     >
       <Flex justifyContent="space-between">
@@ -111,33 +111,32 @@ const Index: React.FC<{}> = () => {
   if (error) return <p>Oops something went wrong.</p>
 
   return (
-    <Flex gap={7} flexDirection="column" sx={{ paddingY: 7, paddingX: 6 }}>
-      <SectionHeading>Pages</SectionHeading>
-      <ul sx={{ pl: 0, listStyle: `none` }}>
-        {data.allGatsbyPage.nodes
-          .filter(page => page.path.indexOf(`/dev-404-page/`) !== 0)
-          .sort((a, b) => a.path.localeCompare(b.path))
-          .map(page => (
-            <li
-              key={page.path}
-              sx={{
-                py: 1,
-              }}
-            >
-              {page.path}
-            </li>
-          ))}
-      </ul>
+    <Flex gap={8} flexDirection="column" sx={{ paddingY: 7, paddingX: 6 }}>
+      <Flex gap={6} flexDirection="column">
+        <SectionHeading>Pages</SectionHeading>
+        <ul sx={{ pl: 0, listStyle: `none` }}>
+          {data.allGatsbyPage.nodes
+            .filter(page => page.path.indexOf(`/dev-404-page/`) !== 0)
+            .sort((a, b) => a.path.localeCompare(b.path))
+            .map(page => (
+              <li key={page.path} sx={{ p: 0 }}>
+                {page.path}
+              </li>
+            ))}
+        </ul>
+      </Flex>
 
-      <SectionHeading id="plugin-search-label">
-        Installed Plugins
-      </SectionHeading>
-      <Grid gap={6} columns={[1, 1, 1, 2, 3]}>
-        {data.allGatsbyPlugin.nodes.map(plugin => (
-          <PluginCard key={plugin.id} plugin={plugin} />
-        ))}
-      </Grid>
-      <PluginSearchBar />
+      <Flex gap={6} flexDirection="column">
+        <SectionHeading id="plugin-search-label">
+          Installed Plugins
+        </SectionHeading>
+        <Grid gap={6} columns={[1, 1, 1, 2, 3]}>
+          {data.allGatsbyPlugin.nodes.map(plugin => (
+            <PluginCard key={plugin.id} plugin={plugin} />
+          ))}
+        </Grid>
+        <PluginSearchBar />
+      </Flex>
     </Flex>
   )
 }


### PR DESCRIPTION
> The three quick design wins I can see are make the "install plugins" header the same size as the other headers, add just a little more space between the 3 sections of the page, and reduce the amount of space between the plugin name and its description by a bit!
>
> – @shannonbux in https://github.com/gatsbyjs/gatsby/pull/25744#issuecomment-662563128

