### PR TITLE
fix(gatsby): call predicate for the root ancestor in findRootNodeAncestor

### DIFF
--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -495,6 +495,14 @@ describe(`NodeModel`, () => {
         const result = nodeModel.findRootNodeAncestor(obj, predicate)
         expect(result.id).toBe(`file1`)
       })
+
+      it(`returns null when object's top-most ancestor doesn't match the provided predicate`, () => {
+        const node = nodeModel.getNodeById({ id: `post1` })
+        const obj = node.frontmatter.authors
+        const predicate = () => false
+        const result = nodeModel.findRootNodeAncestor(obj, predicate)
+        expect(result).toBe(null)
+      })
     })
 
     describe(`createPageDependency`, () => {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -445,7 +445,10 @@ class LocalNodeModel {
       const id = this._rootNodeMap.get(node)
       const trackedParent = getNodeById(id)
 
-      if (!parent && !trackedParent) return node
+      if (!parent && !trackedParent) {
+        const isMatchingRoot = !predicate || predicate(node)
+        return isMatchingRoot ? node : null
+      }
 
       node = parent || trackedParent
     }


### PR DESCRIPTION
## Description

This PR fixes a bug we've discovered via `gatsby-plugin-mdx` here:

https://github.com/gatsbyjs/gatsby/blob/ce0ec317b09bb6337ca26e0a4746813ffbb8a41b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js#L141-L144

The issue is that the `nodeWithContext` can be of any type here, not just `File` due to how `findRootNodeAncestor` is implemented (it doesn't check against the predicate for the top-most node).