### PR TITLE
chore: add tests to static-query filepaths

### DIFF
--- a/packages/gatsby/src/utils/__tests__/map-templates-to-static-query-hashes.js
+++ b/packages/gatsby/src/utils/__tests__/map-templates-to-static-query-hashes.js
@@ -1,0 +1,78 @@
+import path from "path"
+import { slash } from "gatsby-core-utils"
+import mapTemplatesToStaticQueryHashes from "../map-templates-to-static-query-hashes"
+
+const page1 = slash(`${process.cwd()}/src/pages/index.js`)
+const page2 = slash(`${process.cwd()}/src/pages/pages-2.js`)
+const components = new Map()
+components.set(page1, {
+  componentPath: page1,
+  query: ``,
+  pages: new Set([`/`]),
+})
+
+components.set(page2, {
+  componentPath: page2,
+  query: ``,
+  pages: new Set([`/`]),
+})
+
+const staticQueryComponents = new Map()
+staticQueryComponents.set(`sq--src-components-image-js`, {
+  id: `sq--src-components-image-js`,
+  componentPath: slash(`${process.cwd()}/src/components/image.js`),
+  query: `query { placeholderImage: file(relativePath: {eq: "gatsby-astronaut.png"}) { public { publicUrl } } }`,
+  hash: 1,
+})
+staticQueryComponents.set(`sq--src-components-seo-js`, {
+  id: `sq--src-components-seo-js`,
+  componentPath: slash(`${process.cwd()}/src/components/seo.js`),
+  query: `query { site { siteMetadata { title } } }`,
+  hash: 2,
+})
+
+const createModule = (resource, reasons = []) => {
+  return {
+    hasReasons: () => !!reasons.length,
+    identifier: () => resource,
+    resource: path.join(process.cwd(), resource),
+    reasons: reasons.map(r => {
+      return {
+        module: r,
+      }
+    }),
+  }
+}
+
+describe(`map-templates-to-static-query-hashes`, () => {
+  it(`should map static-queries to a component file on all platforms`, () => {
+    const asyncRequires = createModule(
+      `_this_is_virtual_fs_path_/$virtual/async-requires.js`
+    )
+
+    const templateMap = mapTemplatesToStaticQueryHashes(
+      {
+        components,
+        staticQueryComponents,
+      },
+      {
+        modules: [
+          createModule(`src/components/layout.js`, [
+            createModule(`src/pages/index.js`, [asyncRequires]),
+            createModule(`src/pages/pages-2.js`, [asyncRequires]),
+          ]),
+          createModule(`src/components/image.js`, [
+            createModule(`src/pages/index.js`, [asyncRequires]),
+          ]),
+          createModule(`src/components/seo.js`, [
+            createModule(`src/pages/pages-2.js`, [asyncRequires]),
+          ]),
+        ],
+      }
+    )
+
+    expect(templateMap.size).toBe(2)
+    expect(templateMap.get(page1)).toEqual([`1`])
+    expect(templateMap.get(page2)).toEqual([`2`])
+  })
+})

--- a/packages/gatsby/src/utils/map-templates-to-static-query-hashes.ts
+++ b/packages/gatsby/src/utils/map-templates-to-static-query-hashes.ts
@@ -1,4 +1,6 @@
 import { uniqBy, List } from "lodash"
+import path from "path"
+import { slash } from "gatsby-core-utils"
 import { IGatsbyState } from "../redux/types"
 import { Stats } from "webpack"
 
@@ -107,11 +109,11 @@ export default function mapTemplatesToStaticQueryHashes(
 
       for (const uniqDependent of uniqDependents) {
         if (uniqDependent.resource) {
-          result.add(uniqDependent.resource)
+          result.add(slash(uniqDependent.resource))
           // Queries used in gatsby-browser are global and should be added to all pages
           if (isGatsbyBrowser(uniqDependent)) {
             if (staticQueryModuleComponentPath) {
-              globalStaticQueries.add(staticQueryModuleComponentPath)
+              globalStaticQueries.add(slash(staticQueryModuleComponentPath))
             }
           } else {
             seen.add(uniqDependent.resource)
@@ -131,10 +133,12 @@ export default function mapTemplatesToStaticQueryHashes(
 
   // For every known static query, we get its dependents.
   staticQueryComponents.forEach(({ componentPath }) => {
-    const staticQueryComponentModule = modules.find(
-      m => m.resource === componentPath
-    )
+    // componentPaths are slashed by gatsby-core-utils we undo it
+    const nonSlashedPath = path.resolve(componentPath)
 
+    const staticQueryComponentModule = modules.find(
+      m => m.resource === nonSlashedPath
+    )
     const dependants = staticQueryComponentModule
       ? getDeps(staticQueryComponentModule)
       : new Set()


### PR DESCRIPTION
## Description
Windows static query paths generation is broken. Gatsby uses slash utility to convert component paths to unix based ones. Webpack has windows file paths so they never match.

I added a simple test to it to illustrate the problem and the fix. The feature itself has great e2e coverage so that's why this is just a simple test.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/25909
Fixes https://github.com/gatsbyjs/gatsby/issues/25920
Fixes https://github.com/gatsbyjs/gatsby/issues/25949
