### PR TITLE
fix(babel-preset-gatsby): enable transformer-regenerator

### DIFF
--- a/packages/babel-preset-gatsby/src/__tests__/__snapshots__/dependencies.ts.snap
+++ b/packages/babel-preset-gatsby/src/__tests__/__snapshots__/dependencies.ts.snap
@@ -22,7 +22,6 @@ Object {
         "corejs": 3,
         "exclude": Array [
           "transform-typeof-symbol",
-          "transform-regenerator",
           "es.symbol",
           "es.symbol.async-iterator",
           "es.symbol.has-instance",

--- a/packages/babel-preset-gatsby/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby/src/__tests__/__snapshots__/index.js.snap
@@ -47,7 +47,6 @@ Object {
         "corejs": 3,
         "exclude": Array [
           "transform-typeof-symbol",
-          "transform-regenerator",
           "transform-spread",
           "proposal-nullish-coalescing-operator",
           "proposal-optional-chaining",
@@ -319,7 +318,6 @@ Object {
         "corejs": 3,
         "exclude": Array [
           "transform-typeof-symbol",
-          "transform-regenerator",
           "transform-spread",
           "proposal-nullish-coalescing-operator",
           "proposal-optional-chaining",
@@ -583,7 +581,6 @@ Object {
         "corejs": 3,
         "exclude": Array [
           "transform-typeof-symbol",
-          "transform-regenerator",
           "transform-spread",
           "proposal-nullish-coalescing-operator",
           "proposal-optional-chaining",
@@ -847,7 +844,6 @@ Object {
         "corejs": 3,
         "exclude": Array [
           "transform-typeof-symbol",
-          "transform-regenerator",
           "transform-spread",
           "proposal-nullish-coalescing-operator",
           "proposal-optional-chaining",

--- a/packages/babel-preset-gatsby/src/dependencies.ts
+++ b/packages/babel-preset-gatsby/src/dependencies.ts
@@ -44,8 +44,6 @@ export default (_?: unknown, options: IPresetOptions = {}) => {
           exclude: [
             // Exclude transforms that make all code slower (https://github.com/facebook/create-react-app/pull/5278)
             `transform-typeof-symbol`,
-            // we have @babel/plugin-transform-runtime that takes care of this
-            `transform-regenerator`,
             ...polyfillsToExclude,
           ],
         },

--- a/packages/babel-preset-gatsby/src/index.js
+++ b/packages/babel-preset-gatsby/src/index.js
@@ -64,8 +64,6 @@ export default function preset(_, options = {}) {
           exclude: [
             // Exclude transforms that make all code slower (https://github.com/facebook/create-react-app/pull/5278)
             `transform-typeof-symbol`,
-            // we have @babel/plugin-transform-runtime that takes care of this
-            `transform-regenerator`,
             // we already have transforms for these
             `transform-spread`,
             `proposal-nullish-coalescing-operator`,


### PR DESCRIPTION
# Description

Re-enable transform-regenerator to properly transform generators. I made a mistake when adding polyfill chunk to disable transform-regenerator. I was confused with `regenerator` option in `plugin-transform-runtime`.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/25753
