### PR TITLE
fix(recipes): Install storybook dependencies with development type on typescript recipe

### DIFF
--- a/packages/gatsby-recipes/recipes/storybook-ts.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-ts.mdx
@@ -9,17 +9,17 @@ This recipe adds support for JavaScript and TypeScript components.
 Install TypesScript + babel plugins and presets as well as the Storybook React NPM packages and addons
 
 <NPMPackage name="typescript" />
-<NPMPackage name="babel-loader" />
-<NPMPackage name="@babel/preset-react" />
-<NPMPackage name="@babel/preset-env" />
-<NPMPackage name="@babel/preset-typescript" />
-<NPMPackage name="@babel/plugin-proposal-class-properties" />
-<NPMPackage name="babel-plugin-remove-graphql-queries" />
-<NPMPackage name="react-docgen-typescript-loader" />
+<NPMPackage name="babel-loader" dependencyType="development" />
+<NPMPackage name="@babel/preset-react" dependencyType="development" />
+<NPMPackage name="@babel/preset-env" dependencyType="development" />
+<NPMPackage name="@babel/preset-typescript" dependencyType="development" />
+<NPMPackage name="@babel/plugin-proposal-class-properties" dependencyType="development" />
+<NPMPackage name="babel-plugin-remove-graphql-queries" dependencyType="development" />
+<NPMPackage name="react-docgen-typescript-loader" dependencyType="development" />
 
-<NPMPackage name="@storybook/react" />
-<NPMPackage name="@storybook/addon-actions" />
-<NPMPackage name="@storybook/addon-docs" />
+<NPMPackage name="@storybook/react" dependencyType="development" />
+<NPMPackage name="@storybook/addon-actions" dependencyType="development" />
+<NPMPackage name="@storybook/addon-docs" dependencyType="development" />
 
 ---
 


### PR DESCRIPTION
## Description

Dependencies were being added as direct dependencies, against what's suggested in the storybook documentation.