### PR TITLE
fix(deps): install deps as devDependencies on storybook recipe

### DIFF
--- a/packages/gatsby-recipes/recipes/storybook-js.mdx
+++ b/packages/gatsby-recipes/recipes/storybook-js.mdx
@@ -6,16 +6,16 @@
 
 Install babel plugins and presets as well as the Storybook React NPM packages and addons
 
-<NPMPackage name="babel-loader" />
-<NPMPackage name="@babel/preset-react" />
-<NPMPackage name="@babel/preset-env" />
-<NPMPackage name="@babel/plugin-proposal-class-properties" />
-<NPMPackage name="babel-plugin-remove-graphql-queries" />
-<NPMPackage name="babel-plugin-react-docgen" />
+<NPMPackage name="babel-loader" dependencyType="development" />
+<NPMPackage name="@babel/preset-react" dependencyType="development" />
+<NPMPackage name="@babel/preset-env" dependencyType="development" />
+<NPMPackage name="@babel/plugin-proposal-class-properties" dependencyType="development" />
+<NPMPackage name="babel-plugin-remove-graphql-queries" dependencyType="development" />
+<NPMPackage name="babel-plugin-react-docgen" dependencyType="development" />
 
-<NPMPackage name="@storybook/react" />
-<NPMPackage name="@storybook/addon-actions" />
-<NPMPackage name="@storybook/addon-docs" />
+<NPMPackage name="@storybook/react" dependencyType="development" />
+<NPMPackage name="@storybook/addon-actions" dependencyType="development" />
+<NPMPackage name="@storybook/addon-docs" dependencyType="development" />
 
 ---
 


### PR DESCRIPTION
## Description

As suggested in the storybook documentation, those dependencies should be added as devDependencies.
