### PR TITLE
feat(gatsby): Add top-level error handling to state machine

### DIFF
--- a/packages/gatsby/src/state-machines/develop/actions.ts
+++ b/packages/gatsby/src/state-machines/develop/actions.ts
@@ -129,6 +129,20 @@ export const finishParentSpan = ({ parentSpan }: IBuildContext): void =>
 
 export const saveDbState = (): Promise<void> => saveState()
 
+export const logError: ActionFunction<IBuildContext, AnyEventObject> = (
+  _context,
+  event
+) => {
+  reporter.error(event.data)
+}
+
+export const panic: ActionFunction<IBuildContext, AnyEventObject> = (
+  _context,
+  event
+) => {
+  reporter.panic(event.data)
+}
+
 /**
  * Event handler used in all states where we're not ready to process a file change
  * Instead we add it to a batch to process when we're next idle
@@ -158,4 +172,6 @@ export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
   markSourceFilesClean,
   saveDbState,
   setQueryRunningFinished,
+  panic,
+  logError,
 }

--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -45,6 +45,9 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
           target: `initializingData`,
           actions: [`assignStoreAndWorkerPool`, `spawnMutationListener`],
         },
+        onError: {
+          actions: `panic`,
+        },
       },
     },
     // Sourcing nodes, customising and inferring schema, then running createPages
@@ -76,6 +79,10 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
             `finishParentSpan`,
           ],
           target: `runningQueries`,
+        },
+        onError: {
+          actions: `logError`,
+          target: `waiting`,
         },
       },
     },
@@ -126,6 +133,10 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
             target: `waiting`,
           },
         ],
+        onError: {
+          actions: `logError`,
+          target: `waiting`,
+        },
       },
     },
     // Recompile the JS bundle
@@ -134,6 +145,10 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         src: `recompile`,
         onDone: {
           actions: `markSourceFilesClean`,
+          target: `waiting`,
+        },
+        onError: {
+          actions: `logError`,
           target: `waiting`,
         },
       },
@@ -149,6 +164,10 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
             `spawnWebpackListener`,
             `markSourceFilesClean`,
           ],
+        },
+        onError: {
+          actions: `panic`,
+          target: `waiting`,
         },
       },
     },
@@ -182,6 +201,10 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         onDone: {
           actions: `assignServiceResult`,
           target: `recreatingPages`,
+        },
+        onError: {
+          actions: `panic`,
+          target: `waiting`,
         },
       },
     },
@@ -217,6 +240,10 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
           ],
           target: `runningQueries`,
         },
+        onError: {
+          actions: `logError`,
+          target: `waiting`,
+        },
       },
     },
     // Rebuild pages if a node has been mutated outside of sourceNodes
@@ -229,6 +256,10 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         onDone: {
           actions: `assignServiceResult`,
           target: `runningQueries`,
+        },
+        onError: {
+          actions: `logError`,
+          target: `waiting`,
         },
       },
     },


### PR DESCRIPTION
This adds top-level error handling to the state machine, to catch anything that isn't handled elsewhere and prevent us getting into a stuck state.