### PR TITLE
docs: Change SEO metadata testing tool as its deprecated

### DIFF
--- a/docs/docs/seo.md
+++ b/docs/docs/seo.md
@@ -70,7 +70,7 @@ For example, here is a structured data snippet (added with `react-helmet`) in th
 </Helmet>
 ```
 
-When using structured data, you'll need to test during development and the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) from Google is one recommended method.
+When using structured data, you'll need to test during development and the [Rich Results Test](https://search.google.com/test/rich-results) from Google is one recommended method.
 
 After deployment, their [Rich result status reports](https://support.google.com/webmasters/answer/7552505?hl=en) may help to monitor the health of your pages and mitigate any templating or serving issues.
 


### PR DESCRIPTION
## Description

This PR changes the linked metadata testing tool on the SEO page in the docs. The current tool shows a big banner in the bottom right corner saying "This tool is being shut down. Please use X instead."

This PR is implementing that change.

### Documentation

Docs-only.

## Related Issues

None
