### PR TITLE
Revert "perf(gatsby-plugin-mdx): drop another babel step during sourcing"

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -94,7 +94,6 @@ module.exports = async function (content) {
   const {
     getNode: rawGetNode,
     getNodes,
-    getNodesByType,
     reporter,
     cache,
     pathPrefix,
@@ -122,15 +121,11 @@ module.exports = async function (content) {
 
   let mdxNode
   try {
-    // This node attempts to break the chicken-egg problem, where parsing mdx
-    // allows for custom plugins, which can receive a mdx node
-    ;({ mdxNode } = await createMDXNode({
+    mdxNode = await createMDXNode({
       id: `fakeNodeIdMDXFileABugIfYouSeeThis`,
       node: fileNode,
       content,
-      options,
-      getNodesByType,
-    }))
+    })
   } catch (e) {
     return callback(e)
   }
@@ -197,7 +192,6 @@ ${contentWithoutFrontmatter}`
     node: { ...mdxNode, rawBody: code },
     getNode,
     getNodes,
-    getNodesByType,
     reporter,
     cache,
     pathPrefix,

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
@@ -16,9 +16,9 @@ array: [1,2,3]
 )`,
     namedExports: `export const meta = {author: "chris"}`,
     body: `# Some title
-
+    
 a bit of a paragraph
-
+    
 some content`,
   }
 


### PR DESCRIPTION
Reverts gatsbyjs/gatsby#25757 due to #25975. Will create a backwards compatible option.