### PR TITLE
perf(gatsby-plugin-mdx): drop another babel step during sourcing

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
@@ -6,7 +6,6 @@ const { createContentDigest } = require(`gatsby-core-utils`)
 const defaultOptions = require(`../utils/default-options`)
 const createMDXNode = require(`../utils/create-mdx-node`)
 const { MDX_SCOPES_LOCATION } = require(`../constants`)
-const { findImports } = require(`../utils/gen-mdx`)
 
 const contentDigest = val => createContentDigest(val)
 
@@ -18,6 +17,7 @@ module.exports = async (
     createNodeId,
     getNode,
     getNodes,
+    getNodesByType,
     reporter,
     cache,
     pathPrefix,
@@ -46,20 +46,14 @@ module.exports = async (
 
   const content = await loadNodeContent(node)
 
-  const mdxNode = await createMDXNode({
+  const { mdxNode, scopeIdentifiers, scopeImports } = await createMDXNode({
     id: createNodeId(`${node.id} >>> Mdx`),
     node,
     content,
-  })
 
-  createNode(mdxNode)
-  createParentChildLink({ parent: node, child: mdxNode })
-
-  // write scope files into .cache for later consumption
-  const { scopeImports, scopeIdentifiers } = await findImports({
-    node: mdxNode,
     getNode,
     getNodes,
+    getNodesByType,
     reporter,
     cache,
     pathPrefix,
@@ -69,6 +63,11 @@ module.exports = async (
     createNodeId,
     ...helpers,
   })
+
+  createNode(mdxNode)
+  createParentChildLink({ parent: node, child: mdxNode })
+
+  // write scope files into .cache for later consumption
   await cacheScope({
     cache,
     scopeIdentifiers,

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -93,6 +93,7 @@ module.exports = async function (content) {
   const {
     getNode: rawGetNode,
     getNodes,
+    getNodesByType,
     reporter,
     cache,
     pathPrefix,
@@ -120,11 +121,15 @@ module.exports = async function (content) {
 
   let mdxNode
   try {
-    mdxNode = await createMDXNode({
+    // This node attempts to break the chicken-egg problem, where parsing mdx
+    // allows for custom plugins, which can receive a mdx node
+    ;({ mdxNode } = await createMDXNode({
       id: `fakeNodeIdMDXFileABugIfYouSeeThis`,
       node: fileNode,
       content,
-    })
+      options,
+      getNodesByType,
+    }))
   } catch (e) {
     return callback(e)
   }
@@ -168,6 +173,7 @@ ${contentWithoutFrontmatter}`
     node: { ...mdxNode, rawBody: code },
     getNode,
     getNodes,
+    getNodesByType,
     reporter,
     cache,
     pathPrefix,

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.test.js
@@ -16,9 +16,9 @@ array: [1,2,3]
 )`,
     namedExports: `export const meta = {author: "chris"}`,
     body: `# Some title
-    
+
 a bit of a paragraph
-    
+
 some content`,
   }
 

--- a/packages/gatsby-plugin-mdx/utils/create-mdx-node.js
+++ b/packages/gatsby-plugin-mdx/utils/create-mdx-node.js
@@ -1,20 +1,19 @@
 const { createContentDigest } = require(`gatsby-core-utils`)
 
-const mdx = require(`../utils/mdx`)
-const extractExports = require(`../utils/extract-exports`)
+const { findImportsExports } = require(`../utils/gen-mdx`)
 
-module.exports = async ({ id, node, content }) => {
-  let code
-  try {
-    code = await mdx(content)
-  } catch (e) {
-    // add the path of the file to simplify debugging error messages
-    e.message += `${node.absolutePath}: ${e.message}`
-    throw e
-  }
-
-  // extract all the exports
-  const { frontmatter, ...nodeExports } = extractExports(code)
+async function createMdxNode({ id, node, content, ...helpers }) {
+  const {
+    frontmatter,
+    scopeImports,
+    scopeExports,
+    scopeIdentifiers,
+  } = await findImportsExports({
+    mdxNode: node,
+    rawInput: content,
+    absolutePath: node.absolutePath,
+    ...helpers,
+  })
 
   const mdxNode = {
     id,
@@ -24,16 +23,14 @@ module.exports = async ({ id, node, content }) => {
       content: content,
       type: `Mdx`,
     },
+    excerpt: frontmatter.excerpt,
+    exports: scopeExports,
+    rawBody: content,
+    frontmatter: {
+      title: ``, // always include a title
+      ...frontmatter,
+    },
   }
-
-  mdxNode.frontmatter = {
-    title: ``, // always include a title
-    ...frontmatter,
-  }
-
-  mdxNode.excerpt = frontmatter.excerpt
-  mdxNode.exports = nodeExports
-  mdxNode.rawBody = content
 
   // Add path to the markdown file path
   if (node.internal.type === `File`) {
@@ -42,5 +39,7 @@ module.exports = async ({ id, node, content }) => {
 
   mdxNode.internal.contentDigest = createContentDigest(mdxNode)
 
-  return mdxNode
+  return { mdxNode, scopeIdentifiers, scopeImports }
 }
+
+module.exports = createMdxNode


### PR DESCRIPTION
This is the original PR plus some changes for backwards compatibility. There is a still a race condition in this code we need to solve for.

Fixes #25975 