### PR TITLE
chore: do not augment plugin-options

### DIFF
--- a/packages/gatsby-plugin-sharp/src/trace-svg.js
+++ b/packages/gatsby-plugin-sharp/src/trace-svg.js
@@ -130,7 +130,7 @@ exports.notMemoizedtraceSVG = async ({ file, args, fileArgs, reporter }) => {
       turnPolicy: potrace.Potrace.TURNPOLICY_MAJORITY,
     }
 
-    const optionsSVG = _.defaults(args, defaultArgs)
+    const optionsSVG = _.defaults({}, args, defaultArgs)
 
     // `srcset` attribute rejects URIs with literal spaces
     const encodeSpaces = str => str.replace(/ /gi, `%20`)

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -85,7 +85,7 @@ module.exports = (
   if (!validateDestinationDir(destinationDir))
     return Promise.reject(invalidDestinationDirMessage(destinationDir))
 
-  const options = _.defaults(pluginOptions, defaults)
+  const options = _.defaults({}, pluginOptions, defaults)
 
   const filesToCopy = new Map()
   // Copy linked files to the destination directory and modify the AST to point

--- a/packages/gatsby-remark-images-contentful/src/index.js
+++ b/packages/gatsby-remark-images-contentful/src/index.js
@@ -58,7 +58,7 @@ module.exports = async (
 
     const srcSplit = node.url.split(`/`)
     const fileName = srcSplit[srcSplit.length - 1]
-    const options = _.defaults(pluginOptions, defaults)
+    const options = _.defaults({}, pluginOptions, defaults)
 
     const optionsHash = createContentDigest(options)
 

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -35,7 +35,7 @@ module.exports = (
   },
   pluginOptions
 ) => {
-  const options = _.defaults(pluginOptions, { pathPrefix }, DEFAULT_OPTIONS)
+  const options = _.defaults({}, pluginOptions, { pathPrefix }, DEFAULT_OPTIONS)
 
   const findParentLinks = ({ children }) =>
     children.some(

--- a/packages/gatsby-remark-responsive-iframe/src/index.js
+++ b/packages/gatsby-remark-responsive-iframe/src/index.js
@@ -26,7 +26,7 @@ module.exports = async ({ markdownAST }, pluginOptions = {}) => {
   const defaults = {
     wrapperStyle: ``,
   }
-  const options = _.defaults(pluginOptions, defaults)
+  const options = _.defaults({}, pluginOptions, defaults)
   visit(markdownAST, [`html`, `jsx`], node => {
     const $ = cheerio.load(node.value)
     const iframe = $(`iframe, object`)


### PR DESCRIPTION
## Description

I was adding [hard-source-webpack-plugin](https://github.com/mzgoddard/hard-source-webpack-plugin) to gatsbyjs.com and I saw that our config changed sometimes out of the blue. There were some timing issues that augment pluginOptions and also the webpackConfig. This meant we we're rebuilding more than we needed.

