### PR TITLE
fix(gatsby): Added { default } to default exports

### DIFF
--- a/packages/gatsby/src/utils/validate-page-component.ts
+++ b/packages/gatsby/src/utils/validate-page-component.ts
@@ -81,7 +81,8 @@ export function validatePageComponent(
         fileContent.includes(`module.exports`) ||
         fileContent.includes(`exports.default`) ||
         fileContent.includes(`exports["default"]`) ||
-        fileContent.match(/export \{.* as default.*\}/s)
+        fileContent.match(/export \{.* as default.*\}/s) ||
+        fileContent.match(/export \{\s*default\s*\}/s)
 
       if (!includesDefaultExport) {
         return {


### PR DESCRIPTION
## Description
Page components don't support export { default } syntax #25927

Added condition to evaluate `export {default} from X` as valid

## Related Issues
  Fixes https://github.com/gatsbyjs/gatsby/issues/12384


