### PR TITLE
Add createFilepathSlug to utils

### DIFF
--- a/packages/gatsby-core-utils/README.md
+++ b/packages/gatsby-core-utils/README.md
@@ -104,3 +104,13 @@ const requireUtil = createRequireFromPath("../src/utils/")
 requireUtil("./some-tool")
 // ...
 ```
+
+### createFilepathSlug
+
+Creates a valid slug from a filepath.
+
+```js
+const { createFilepathSlug } = require("gatsby-core-utils")
+
+const slug = createFilepathSlug("blog/myFirstPost.md")
+```

--- a/packages/gatsby-core-utils/package.json
+++ b/packages/gatsby-core-utils/package.json
@@ -34,7 +34,8 @@
     "fs-extra": "^8.1.0",
     "node-object-hash": "^2.0.0",
     "proper-lockfile": "^4.1.1",
-    "xdg-basedir": "^4.0.0"
+    "xdg-basedir": "^4.0.0",
+    "slugify": "^1.4.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",

--- a/packages/gatsby-core-utils/src/__tests__/create-filepath-slug.ts
+++ b/packages/gatsby-core-utils/src/__tests__/create-filepath-slug.ts
@@ -1,0 +1,35 @@
+import { createFilepathSlug } from "../create-filepath-slug"
+
+describe(`createFilepathSlug`, () => {
+  describe(`createPath`, () => {
+    it(`generates path`, () => {
+      const actual = createFilepathSlug(`add-filepath-slug.ts`)
+      const expected = `add-filepath-slug`
+      expect(actual).toBe(expected)
+    })
+
+    it(`handles directories`, () => {
+      const actual = createFilepathSlug(`blog/post.md`)
+      const expected = `blog/post`
+      expect(actual).toBe(expected)
+    })
+
+    it(`handles illegal characters`, () => {
+      const actual = createFilepathSlug("some illegal? \\ { } ` characters")
+      const expected = `some-illegal-characters`
+      expect(actual).toBe(expected)
+    })
+
+    it(`handles index pages`, () => {
+      const actual = createFilepathSlug(`index.html`)
+      const expected = ``
+      expect(actual).toBe(expected)
+    })
+
+    it(`handles nested index pages`, () => {
+      const actual = createFilepathSlug(`blog/index.html`)
+      const expected = `blog/`
+      expect(actual).toBe(expected)
+    })
+  })
+})

--- a/packages/gatsby-core-utils/src/create-filepath-slug.ts
+++ b/packages/gatsby-core-utils/src/create-filepath-slug.ts
@@ -1,0 +1,23 @@
+const slugify = require(`slugify`)
+const path = require(`path`)
+
+/**
+ * Creates a valid slug from a filepath.
+ *
+ * @param filepath Path to file
+ * @return Slug based on filepath
+ */
+export const createFilepathSlug = (filepath: string): string => {
+  const parsedPath = path.parse(filepath)
+
+  let relevantPath
+  if (parsedPath.name === `index`) {
+    relevantPath = filepath.replace(parsedPath.base, ``)
+  } else {
+    relevantPath = filepath.replace(parsedPath.ext, ``)
+  }
+
+  return slugify(relevantPath, {
+    remove: /[^\w\s$*_+~.()'"!\-:@/]/g, // this is the set of allowable characters
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6989,11 +6989,12 @@ content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-contentful-resolve-response@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/contentful-resolve-response/-/contentful-resolve-response-1.1.4.tgz#9eb656876eecb2cd00444f0adf26bd91a5ec1992"
+contentful-resolve-response@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/contentful-resolve-response/-/contentful-resolve-response-1.2.2.tgz#3f83a5f4742854de740e250a11020b4fb646da91"
+  integrity sha512-KyRz05f2YFJDSFs/L5jtsptbL5Fk3+ukSjRF94zFXq0FOtYoaxyCbqKgHhK2+3hlipxVQ+KGRus/tSaD6PoPMg==
   dependencies:
-    lodash "^4.17.4"
+    lodash "^4.17.15"
 
 contentful-sdk-core@^6.4.5:
   version "6.4.5"
@@ -7003,13 +7004,13 @@ contentful-sdk-core@^6.4.5:
     lodash "^4.17.10"
     qs "^6.5.2"
 
-contentful@^7.14.5:
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-7.14.5.tgz#ca8ff1301b1278b88bf475cfc87ee9ba9f196034"
-  integrity sha512-Ou3L6xcVXV2TjC9uaw9w5OGp4hHGeQ9wCwsuROKpPEhb53GdcY962zxVzMZ7YTt/WmKkMrZRFsGMWCi3yS6p9g==
+contentful@^7.14.6:
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-7.14.6.tgz#da692d68f361ceec14045c6114425579cddbfab9"
+  integrity sha512-7/Xqw/UT0/zW9DeVGAwtW4twGbThIc6rbLATrhUn7AXt/xTCFzgPiJxHgRU9gmr733q/Wckv663B51abDMS9Nw==
   dependencies:
     axios "^0.19.1"
-    contentful-resolve-response "^1.1.4"
+    contentful-resolve-response "^1.2.2"
     contentful-sdk-core "^6.4.5"
     json-stringify-safe "^5.0.1"
     lodash "^4.17.11"


### PR DESCRIPTION
## Description

Adds a util to generate a slug from a filepath which can be used by source and transformer plugins to add a default slug to File types. 

This is an initial implementation that only generates the filepath. At the moment, any plugins using the util will still have to add the generated filepath to the schema. Let me know if this is what you had in mind. 

### Documentation

Simple documentation is included in the `gatsby-core-utils` README.

## Related Issues

Addresses #25799 
