### PR TITLE
Added extra markup

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -2,16 +2,16 @@
 title: Glossary
 disableTableOfContents: true
 ---
-```js
+
 import HorizontalNavList from "@components/horizontal-nav-list"
-```
+
 When you're new to Gatsby there can be a lot of words to learn. This glossary aims to give you a 10,000-foot overview of common terms and what they mean for Gatsby sites.
-```js
+
 <HorizontalNavList
   items={"ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")}
   slug={props.slug}
 />
-```
+
 
 ## A
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -2,15 +2,16 @@
 title: Glossary
 disableTableOfContents: true
 ---
-
+```js
 import HorizontalNavList from "@components/horizontal-nav-list"
-
+```
 When you're new to Gatsby there can be a lot of words to learn. This glossary aims to give you a 10,000-foot overview of common terms and what they mean for Gatsby sites.
-
+```js
 <HorizontalNavList
   items={"ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")}
   slug={props.slug}
 />
+```
 
 ## A
 
@@ -58,7 +59,7 @@ Client-side refers to operations that are performed by the user's browser in a [
 
 ### Client-side rendering
 
-The practice of using JavaScript to render pages on the [client-side](#client-side), as opposed to [server-side rendering](/docs/glossary/server-side-rendering/) alone. Gatsby uses [React](#react) and the `@reach/router` library to enhance HTML pages compiled at [build time](#build) to navigate site pages in a web browser without traditional page reloads, enabling performance techniques like preloading and [pre-fetching](/docs/routing/#performance-and-prefetching), [intersection observer and responsive `srcset`](/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/#modern-apis-in-gatsby) for images, and more. See also: [routing](#routing), which is handled on the client-side in Gatsby by default.
+The practice of using JavaScript to render pages on the [client-side](#client-side), as opposed to [server-side rendering](/docs/glossary/server-side-rendering/) alone. Gatsby uses [React](#react) and the [`@reach/router`](https://reach.tech/router/) library to enhance HTML pages compiled at [build time](#build) to navigate site pages in a web browser without traditional page reloads, enabling performance techniques like preloading and [pre-fetching](/docs/routing/#performance-and-prefetching), [intersection observer and responsive `srcset`](/blog/2019-04-02-behind-the-scenes-what-makes-gatsby-great/#modern-apis-in-gatsby) for images, and more. See also: [routing](#routing), which is handled on the client-side in Gatsby by default.
 
 ### CMS
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -12,7 +12,6 @@ When you're new to Gatsby there can be a lot of words to learn. This glossary ai
   slug={props.slug}
 />
 
-
 ## A
 
 ### AST


### PR DESCRIPTION
I found some js code which was not highlighted so I wrapped it in js code block,
secondly, I added the link to reach/router as it was confusing if its react/router or reach/router

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
