### PR TITLE
fix(gatsby-recipes): Add `file` note to fs provider describe

### DIFF
--- a/packages/gatsby-recipes/src/providers/fs/__snapshots__/file.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/fs/__snapshots__/file.test.js.snap
@@ -12,7 +12,7 @@ Object {
 exports[`file resource e2e file resource test: File create plan 1`] = `
 Object {
   "currentState": "",
-  "describe": "Write file.txt",
+  "describe": "Write file \\"file.txt\\"",
   "diff": "- Original  - 0
 + Modified  + 1
 
@@ -42,7 +42,7 @@ Object {
 exports[`file resource e2e file resource test: File update plan 1`] = `
 Object {
   "currentState": "Hello, world!",
-  "describe": "Write file.txt",
+  "describe": "Write file \\"file.txt\\"",
   "diff": "- Original  - 1
 + Modified  + 1
 
@@ -87,7 +87,7 @@ Object {
 exports[`file resource e2e remote file resource test: File create plan 1`] = `
 Object {
   "currentState": "",
-  "describe": "Write file.txt",
+  "describe": "Write file \\"file.txt\\"",
   "diff": "- Original  -  0
 + Modified  + 24
 
@@ -186,7 +186,7 @@ Object {
     }
   }  
 }",
-  "describe": "Write file.txt",
+  "describe": "Write file \\"file.txt\\"",
   "diff": "- Original  - 23
 + Modified  +  3
 

--- a/packages/gatsby-recipes/src/providers/fs/file.js
+++ b/packages/gatsby-recipes/src/providers/fs/file.js
@@ -98,7 +98,7 @@ module.exports.plan = async (context, { id, path: filePath, content }) => {
   const plan = {
     currentState: (currentResource && currentResource.content) || ``,
     newState,
-    describe: `Write ${filePath}`,
+    describe: `Write file "${filePath}"`,
     diff: ``,
   }
 

--- a/packages/gatsby-recipes/src/renderer/index.test.js
+++ b/packages/gatsby-recipes/src/renderer/index.test.js
@@ -20,7 +20,7 @@ describe(`renderer`, () => {
     expect(result[0]).toMatchInlineSnapshot(`
       Object {
         "currentState": "",
-        "describe": "Write foo.js",
+        "describe": "Write file \\"foo.js\\"",
         "diff": "- Original  - 0
       + Modified  + 1
 
@@ -36,7 +36,7 @@ describe(`renderer`, () => {
     expect(result[1]).toMatchInlineSnapshot(`
       Object {
         "currentState": "",
-        "describe": "Write foo2.js",
+        "describe": "Write file \\"foo2.js\\"",
         "diff": "- Original  - 0
       + Modified  + 1
 
@@ -74,7 +74,7 @@ describe(`renderer`, () => {
       Array [
         Object {
           "currentState": "",
-          "describe": "Write hi.md",
+          "describe": "Write file \\"hi.md\\"",
           "diff": "- Original  - 0
       + Modified  + 1
 
@@ -100,7 +100,7 @@ describe(`renderer`, () => {
       Array [
         Object {
           "currentState": "",
-          "describe": "Write foo.js",
+          "describe": "Write file \\"foo.js\\"",
           "diff": "- Original  - 0
       + Modified  + 1
 

--- a/packages/gatsby-recipes/src/renderer/render.test.js
+++ b/packages/gatsby-recipes/src/renderer/render.test.js
@@ -21,7 +21,7 @@ test(`renders to a plan`, async () => {
   expect(result[0]).toMatchInlineSnapshot(`
     Object {
       "currentState": "",
-      "describe": "Write red.js",
+      "describe": "Write file \\"red.js\\"",
       "diff": "- Original  - 0
     + Modified  + 1
 


### PR DESCRIPTION
## Description

suggestion:
- update description to be equal to directory

https://github.com/gatsbyjs/gatsby/blob/0f2be968c0e3b889650f5fa5dd05692b50cd7b2a/packages/gatsby-recipes/src/providers/fs/directory.js#L55


