### PR TITLE
Fix(gatsby-plugin-catch-links): SVGAnimatedString may not be available in some browsers.

### DIFF
--- a/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/__tests__/catch-links.js
@@ -490,3 +490,41 @@ describe(`pathPrefix is handled if caught link to ${pathPrefix}/article navigate
     clickElement.dispatchEvent(clickEvent)
   })
 })
+
+describe(`navigation is routed through browser without SVGAnimatedString support`, () => {
+  let hrefHandler
+  let eventDestroyer
+  let oldSVGAnimatedString = SVGAnimatedString
+
+  beforeAll(() => {
+    hrefHandler = jest.fn()
+    eventDestroyer = catchLinks.default(window, {}, hrefHandler)
+    delete global.SVGAnimatedString
+  })
+
+  afterAll(() => {
+    eventDestroyer()
+    global.SVGAnimatedString = oldSVGAnimatedString
+  })
+
+  test(`works without throwing an error`, () => {
+    // create a click element to use for testing
+    const clickElement = document.createElement(`a`)
+    clickElement.setAttribute(`href`, `${window.location.href}/article`)
+    document.body.appendChild(clickElement)
+
+    // create the click event we'll be using for testing
+    const clickEvent = new MouseEvent(`click`, {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    })
+
+    // and trigger click
+    clickElement.dispatchEvent(clickEvent)
+
+    expect(() =>
+      catchLinks.routeThroughBrowserOrApp(jest.fn())(clickEvent)
+    ).not.toThrow()
+  })
+})

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -130,7 +130,10 @@ export const routeThroughBrowserOrApp = (
     destination.href = clickedAnchor.href
   }
 
-  if (clickedAnchor.href instanceof SVGAnimatedString) {
+  if (
+    `SVGAnimatedString` in window &&
+    clickedAnchor.href instanceof SVGAnimatedString
+  ) {
     destination.href = clickedAnchor.href.animVal
   }
 


### PR DESCRIPTION
## Description

In some browsers like Internet Explorer, Samsung Internet and Chrome Android, Opera Mini (see https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString), SVGAnimatedString is not available. This produces a runtime UndefinedVariableError.

I propose we check if `SVGAnimated` is available in `window` before checking if `clickedAnchor.href` is an instance of it.
