### PR TITLE
[contributing] add link to swag FAQ's in contributing section

### DIFF
--- a/docs/contributing/contributor-swag.md
+++ b/docs/contributing/contributor-swag.md
@@ -24,5 +24,6 @@ If you’ve contributed in other ways, such as giving talks about Gatsby, teachi
 - Not all items are eligible due to high cost to create the swag. We’ll make it clear which items are not eligible
 - There’s a limit of one free swag item per swag tier
 - Shipping is free worldwide
+- Additional details can be found in our [swag FAQs](https://github.com/gatsbyjs/store.gatsbyjs.org#frequently-asked-questions)
 
 > **NOTE:** Worldwide free shipping is a pilot program. If shipping costs get out of control, we may need to adjust this policy in the future.


### PR DESCRIPTION
## Description

There were some questions about what to do if you get the wrong t-shirt size through contributing, and the answer is on the swag store FAQ's. Rather than repeat the information, I added a link to more details. Open to other suggestions, though.

### Documentation

N/A

## Related Issues

Maintainer discussion: https://github.com/orgs/gatsbyjs/teams/maintainers/discussions/93