### PR TITLE
tests(gatsby): Add unit tests for develop state machine

### DIFF
--- a/docs/docs/deploying-to-digitalocean-droplet.md
+++ b/docs/docs/deploying-to-digitalocean-droplet.md
@@ -28,27 +28,27 @@ Follow these instructions for installs on an Ubuntu droplet.
 
 2. Install Node
 
-   ```bash
+   ```shell
    sudo apt-get update
    sudo apt-get install node
    ```
 
 3. Install npm
 
-   ```bash
+   ```shell
    sudo apt-get install npm
    ```
 
    To view the version of Node and npm installed, run,
 
-   ```bash
+   ```shell
    node -v
    npm -v
    ```
 
 4. To install the latest stable Node.js release using the `n` package (Required),
 
-   ```bash
+   ```shell
    sudo npm install -g n
    sudo n stable
    ```
@@ -56,14 +56,14 @@ Follow these instructions for installs on an Ubuntu droplet.
    `Note`: If you check the version now, you would see the older versions of node and npm from the cache.
    You can either exit and restart your terminal or refresh the cache by following commands,
 
-   ```bash
+   ```shell
    hash node
    hash npm
    ```
 
 5. Install the gatsby-cli now globally. This will be useful ahead in building the Gatsby site for production.
 
-   ```bash
+   ```shell
    sudo npm install -g gatsby-cli
    ```
 
@@ -71,19 +71,19 @@ Follow these instructions for installs on an Ubuntu droplet.
 
 The next step is to clone the repository containing your Gatsby app (Replace `<your-github-repo-site>` with your GitHub repository link)
 
-```bash
+```shell
 git clone <your-github-repo-site>
 ```
 
 > Note: Copy the path where your `<your-github-repo-site>` is cloned, for future reference.
 
-```bash
+```shell
 pwd
 ```
 
 In case of a warning related to "Permission denied", check if `<your non-root user>` has `sudo` privileges. Or before cloning your repository, [change permissions](https://help.ubuntu.com/community/FilePermissions) for `<your non-root user>` to access the `.config` directory of under `/home/<your non-root user>/`:
 
-```bash
+```shell
 cd ~/
 sudo chown -R $(whoami) .config
 ```
@@ -98,14 +98,14 @@ The static files will be hosted publicly on the droplet. The `gatsby build` comm
 
 1. Install dependencies.
 
-```bash
+```shell
 cd <my-gatsby-app>
 sudo npm install
 ```
 
 2. Run build to generate static files.
 
-```bash
+```shell
 sudo gatsby build
 ```
 
@@ -117,32 +117,32 @@ Nginx is web-server. It provides the infrastructure code for handling client req
 
 1. Install Nginx.
 
-   ```bash
+   ```shell
    sudo apt-get install nginx
    ```
 
 2. Configure firewall settings of the droplet to listen to HTTP and HTTPS requests on port 80 and 443 respectively.
 
-   ```bash
+   ```shell
    sudo ufw allow 'Nginx HTTP'
    sudo ufw allow 'Nginx HTTPS'
    ```
 
 3. To check the access,
 
-   ```bash
+   ```shell
    sudo ufw app list
    ```
 
 4. If `ufw` status is disabled/inactive, you can enable it with the following command:
 
-   ```bash
+   ```shell
    sudo ufw enable
    ```
 
    Allow the OpenSSH if not already done, to not disconnect from your droplet.
 
-   ```bash
+   ```shell
    sudo ufw allow 'OpenSSH'
    ```
 
@@ -152,13 +152,13 @@ Change the root directory configuration of Nginx in the default server block fil
 
 1. Go to `/etc/nginx/sites-available/`
 
-   ```bash
+   ```shell
    cd /etc/nginx/sites-available/
    ```
 
 2. Open the file default in Vim ([shortcut cheat sheet](https://devhints.io/vim))
 
-   ```bash
+   ```shell
    sudo vim default
    ```
 
@@ -180,7 +180,7 @@ Change the root directory configuration of Nginx in the default server block fil
 
 4. Restart the Nginx service
 
-   ```bash
+   ```shell
    sudo systemctl restart nginx
    ```
 
@@ -198,7 +198,7 @@ Follow the below steps to configure your site with a free SSL/TLS certificate fr
 
    You'll need to add the Certbot PPA (Personal Package Archives) to your list of repositories. To do so, run the following commands:
 
-   ```bash
+   ```shell
    sudo apt-get update
    sudo add-apt-repository ppa:certbot/certbot
    sudo apt-get update
@@ -206,7 +206,7 @@ Follow the below steps to configure your site with a free SSL/TLS certificate fr
 
    Run the following commands to install Certbot.
 
-   ```bash
+   ```shell
    sudo apt-get install certbot python3-certbot-nginx
    ```
 
@@ -214,7 +214,7 @@ Follow the below steps to configure your site with a free SSL/TLS certificate fr
 
    Run the following command:
 
-   ```bash
+   ```shell
    sudo certbot --nginx
    ```
 
@@ -229,7 +229,7 @@ Follow the below steps to configure your site with a free SSL/TLS certificate fr
 
 5. Restart the Nginx service.
 
-   ```bash
+   ```shell
    sudo systemctl restart nginx
    ```
 

--- a/packages/gatsby/src/state-machines/__tests__/develop.ts
+++ b/packages/gatsby/src/state-machines/__tests__/develop.ts
@@ -1,0 +1,46 @@
+import { developMachine } from "../develop"
+import { interpret } from "xstate"
+import { IProgram } from "../../commands/types"
+
+const actions = {
+  assignStoreAndWorkerPool: jest.fn(),
+  markNodesDirty: jest.fn(),
+  callApi: jest.fn(),
+}
+
+const services = {
+  initialize: jest.fn(),
+  initializeData: jest.fn(),
+}
+
+const machine = developMachine.withConfig(
+  {
+    actions,
+    services,
+  },
+  {
+    program: {} as IProgram,
+  }
+)
+
+describe(`the develop state machine`, () => {
+  it(`initialises`, async () => {
+    const payload = { foo: 1 }
+    const service = interpret(machine)
+    const transitionWatcher = jest.fn()
+    service.onTransition(transitionWatcher)
+    service.start()
+    expect(service.state.value).toBe(`initializing`)
+    service.send(`done.invoke.initialize`)
+    expect(service.state.value).toBe(`initializingData`)
+    expect(actions.assignStoreAndWorkerPool).toHaveBeenCalled()
+    service.send(`ADD_NODE_MUTATION`, payload)
+    expect(actions.callApi).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: `ADD_NODE_MUTATION`, ...payload }),
+      expect.anything()
+    )
+
+    expect(transitionWatcher).toHaveBeenCalledWith({})
+  })
+})

--- a/packages/gatsby/src/state-machines/__tests__/develop.ts
+++ b/packages/gatsby/src/state-machines/__tests__/develop.ts
@@ -1,16 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { developMachine } from "../develop"
 import { interpret } from "xstate"
 import { IProgram } from "../../commands/types"
 
 const actions = {
   assignStoreAndWorkerPool: jest.fn(),
-  markNodesDirty: jest.fn(),
+  assignServiceResult: jest.fn(),
   callApi: jest.fn(),
+  finishParentSpan: jest.fn(),
+  saveDbState: jest.fn(),
 }
 
 const services = {
   initialize: jest.fn(),
   initializeData: jest.fn(),
+  reloadData: jest.fn(),
+  runQueries: jest.fn(),
+  startWebpackServer: jest.fn(),
+  recompile: jest.fn(),
+  waitForMutations: jest.fn(),
+  recreatePages: jest.fn(),
 }
 
 const machine = developMachine.withConfig(
@@ -23,24 +32,144 @@ const machine = developMachine.withConfig(
   }
 )
 
+const resetMocks = (mocks: Record<string, jest.Mock>): void =>
+  Object.values(mocks).forEach(mock => mock.mockReset())
+
+const resetAllMocks = (): void => {
+  resetMocks(services)
+  resetMocks(actions)
+}
+
 describe(`the develop state machine`, () => {
+  beforeEach(() => {
+    resetAllMocks()
+  })
+
   it(`initialises`, async () => {
-    const payload = { foo: 1 }
     const service = interpret(machine)
-    const transitionWatcher = jest.fn()
-    service.onTransition(transitionWatcher)
     service.start()
     expect(service.state.value).toBe(`initializing`)
+  })
+
+  it(`runs node mutation during initialising data state`, () => {
+    const payload = { foo: 1 }
+    const service = interpret(machine)
+
+    service.start()
     service.send(`done.invoke.initialize`)
     expect(service.state.value).toBe(`initializingData`)
-    expect(actions.assignStoreAndWorkerPool).toHaveBeenCalled()
     service.send(`ADD_NODE_MUTATION`, payload)
     expect(actions.callApi).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ type: `ADD_NODE_MUTATION`, ...payload }),
       expect.anything()
     )
+    expect(service.state.context.nodesMutatedDuringQueryRun).toBeTruthy()
+  })
 
-    expect(transitionWatcher).toHaveBeenCalledWith({})
+  it(`marks source file as dirty during node sourcing`, () => {
+    const service = interpret(machine)
+
+    service.start()
+    expect(service.state.value).toBe(`initializing`)
+    service.send(`done.invoke.initialize`)
+    expect(service.state.value).toBe(`initializingData`)
+    expect(service.state.context.sourceFilesDirty).toBeFalsy()
+    service.send(`SOURCE_FILE_CHANGED`)
+    expect(service.state.context.sourceFilesDirty).toBeTruthy()
+  })
+
+  // This is current behaviour, but it will be queued in future
+  it(`handles a webhook during node sourcing`, () => {
+    const webhookBody = { foo: 1 }
+    const service = interpret(machine)
+    service.start()
+    expect(service.state.value).toBe(`initializing`)
+    service.send(`done.invoke.initialize`)
+    expect(service.state.value).toBe(`initializingData`)
+    expect(service.state.context.webhookBody).toBeUndefined()
+    service.send(`WEBHOOK_RECEIVED`, { payload: { webhookBody } })
+    expect(service.state.context.webhookBody).toEqual(webhookBody)
+    expect(services.reloadData).toHaveBeenCalled()
+  })
+
+  it(`queues a node mutation during query running`, () => {
+    const payload = { foo: 1 }
+
+    const service = interpret(machine)
+    service.start()
+    service.send(`done.invoke.initialize`)
+    service.send(`done.invoke.initialize-data`)
+    expect(service.state.context.nodeMutationBatch).toBeUndefined()
+    service.send(`ADD_NODE_MUTATION`, { payload })
+    expect(service.state.context.nodeMutationBatch).toEqual(
+      expect.arrayContaining([payload])
+    )
+  })
+
+  it(`starts webpack if there is no compiler`, () => {
+    const service = interpret(machine)
+    service.start()
+    service.send(`done.invoke.initialize`)
+    service.send(`done.invoke.initialize-data`)
+    expect(service.state.context.compiler).toBeUndefined()
+    services.startWebpackServer.mockReset()
+    service.send(`done.invoke.run-queries`)
+    expect(services.startWebpackServer).toHaveBeenCalled()
+  })
+
+  it(`recompiles if source files have changed`, () => {
+    const service = interpret(machine)
+    service.start()
+    service.send(`done.invoke.initialize`)
+    service.send(`SOURCE_FILE_CHANGED`)
+
+    service.send(`done.invoke.initialize-data`)
+    // So we don't start webpack instead
+    service.state.context.compiler = {} as any
+    services.recompile.mockReset()
+    service.send(`done.invoke.run-queries`)
+    expect(services.startWebpackServer).not.toHaveBeenCalled()
+    expect(services.recompile).toHaveBeenCalled()
+  })
+
+  it(`skips compilation if source files are unchanged`, () => {
+    const service = interpret(machine)
+    service.start()
+    service.send(`done.invoke.initialize`)
+    service.send(`done.invoke.initialize-data`)
+    service.state.context.compiler = {} as any
+    services.recompile.mockReset()
+    service.send(`done.invoke.run-queries`)
+    expect(services.startWebpackServer).not.toHaveBeenCalled()
+    expect(services.recompile).not.toHaveBeenCalled()
+  })
+
+  it(`recreates pages when waiting is complete`, () => {
+    const service = interpret(machine)
+    service.start()
+    service.send(`done.invoke.initialize`)
+    service.send(`done.invoke.initialize-data`)
+    service.state.context.compiler = {} as any
+    service.send(`done.invoke.run-queries`)
+    service.send(`done.invoke.waiting`)
+
+    expect(services.recreatePages).toHaveBeenCalled()
+  })
+
+  it(`extracts queries when waiting requests it`, () => {
+    const service = interpret(machine)
+    service.start()
+    service.send(`done.invoke.initialize`)
+    service.send(`done.invoke.initialize-data`)
+    service.state.context.compiler = {} as any
+    service.send(`done.invoke.run-queries`)
+    service.send(`EXTRACT_QUERIES_NOW`)
+    expect(services.runQueries).toHaveBeenCalled()
   })
 })
+
+// const transitionWatcher = jest.fn()
+// service.onTransition(transitionWatcher)
+
+// expect(transitionWatcher).toHaveBeenCalledWith({})

--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -57,6 +57,7 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         },
       },
       invoke: {
+        id: `initialize-data`,
         src: `initializeData`,
         data: ({
           parentSpan,

--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -206,7 +206,6 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         },
         onError: {
           actions: `panic`,
-          target: `waiting`,
         },
       },
     },

--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -40,6 +40,7 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         WEBHOOK_RECEIVED: undefined,
       },
       invoke: {
+        id: `initialize`,
         src: `initialize`,
         onDone: {
           target: `initializingData`,


### PR DESCRIPTION
This PR adds unit tests for the top-level develop state machine. The child machines will follow. This PR also includes the top level error handling in the state machine from #25995, but this could be merged as one.