### PR TITLE
feat: add types to react helmet

### DIFF
--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -35,6 +35,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
+    "@types/react-helmet": "^5.0.15 || ^6.0.0",
     "gatsby": "^2.0.0",
     "react-helmet": "^5.1.3 || ^6.0.0"
   },


### PR DESCRIPTION
## Description
If we want gatsby to work with typescript out of the box we should add types for components that have been used inside gatsby boilerplate.


