### PR TITLE
www: Remove sw

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -241,7 +241,7 @@ module.exports = {
         icon: `${__dirname}/src/assets/gatsby-icon.png`,
       },
     },
-    `gatsby-plugin-offline`,
+    `gatsby-plugin-remove-serviceworker`,
     `gatsby-transformer-csv`,
     `gatsby-plugin-twitter`,
     `gatsby-plugin-react-helmet`,

--- a/www/package.json
+++ b/www/package.json
@@ -43,6 +43,7 @@
     "gatsby-plugin-offline": "^3.2.21",
     "gatsby-plugin-react-helmet": "^3.3.10",
     "gatsby-plugin-react-svg": "^3.0.0",
+    "gatsby-plugin-remove-serviceworker": "^1.0.0",
     "gatsby-plugin-sharp": "^2.6.22",
     "gatsby-plugin-sitemap": "^2.4.11",
     "gatsby-plugin-theme-ui": "^0.3.0",


### PR DESCRIPTION
The new static query loading is problematic with `gatsby-plugin-offline`

Temporarily removing it till I patch gatsby-plugin-offline