### PR TITLE
fix(gatsby): Defer node mutation in more APIs

### DIFF
--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -9,6 +9,7 @@ export async function createPages({
   parentSpan,
   gatsbyNodeGraphQLFunction,
   store,
+  deferNodeMutation,
 }: Partial<IDataLayerContext>): Promise<{
   deletedPages: string[]
   changedPages: string[]
@@ -28,6 +29,7 @@ export async function createPages({
       traceId: `initial-createPages`,
       waitForCascadingActions: true,
       parentSpan: activity.span,
+      deferNodeMutation,
     },
     { activity }
   )

--- a/packages/gatsby/src/services/customize-schema.ts
+++ b/packages/gatsby/src/services/customize-schema.ts
@@ -4,6 +4,7 @@ import { IDataLayerContext } from "../state-machines/data-layer/types"
 
 export async function customizeSchema({
   parentSpan,
+  deferNodeMutation,
   refresh, // webhookBody,//coming soon
 }: Partial<IDataLayerContext>): Promise<void> {
   const activity = reporter.activityTimer(`createSchemaCustomization`, {
@@ -13,6 +14,7 @@ export async function customizeSchema({
   await createSchemaCustomization({
     parentSpan,
     refresh,
+    deferNodeMutation,
     // webhookBody,
   })
   activity.end()

--- a/packages/gatsby/src/services/post-bootstrap.ts
+++ b/packages/gatsby/src/services/post-bootstrap.ts
@@ -6,12 +6,16 @@ import { boundActionCreators } from "../redux/actions"
 
 export async function postBootstrap({
   parentSpan,
+  deferNodeMutation,
 }: Partial<IDataLayerContext>): Promise<void> {
   const activity = reporter.activityTimer(`onPostBootstrap`, {
     parentSpan,
   })
   activity.start()
-  await apiRunnerNode(`onPostBootstrap`, { parentSpan: activity.span })
+  await apiRunnerNode(`onPostBootstrap`, {
+    parentSpan: activity.span,
+    deferNodeMutation,
+  })
   activity.end()
 
   reporter.info(reporter.stripIndent`

--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -235,6 +235,7 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
             parentSpan,
             store,
             webhookBody,
+            refresh: true,
             deferNodeMutation: true,
           }
         },

--- a/packages/gatsby/src/utils/create-schema-customization.ts
+++ b/packages/gatsby/src/utils/create-schema-customization.ts
@@ -5,15 +5,18 @@ import { Span } from "opentracing"
 export const createSchemaCustomization = async ({
   refresh = false,
   parentSpan,
+  deferNodeMutation,
 }: {
   refresh?: boolean
   parentSpan?: Span
+  deferNodeMutation?: boolean
 }): Promise<void> => {
   if (refresh) {
     store.dispatch({ type: `CLEAR_SCHEMA_CUSTOMIZATION` })
   }
   await apiRunnerNode(`createSchemaCustomization`, {
     parentSpan,
+    deferNodeMutation,
     traceId: !refresh
       ? `initial-createSchemaCustomization`
       : `refresh-createSchemaCustomization`,

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -270,7 +270,7 @@ export async function startServer(
     }, cors())
   }
 
-  await apiRunnerNode(`onCreateDevServer`, { app })
+  await apiRunnerNode(`onCreateDevServer`, { app, deferNodeMutation: true })
 
   // In case nothing before handled hot-update - send 404.
   // This fixes "Unexpected token < in JSON at position 0" runtime


### PR DESCRIPTION
Deferred node mutation is currently opt-in, because we don't want to use it during `gatsby build`. This PR enables deferral for more APIs. For example, we had encountered a bug where mutations inside `onCreateDevServer` were not triggering builds. This PR also ensure that `refresh` is passed to `createSchemaCustomization` after first run.