### PR TITLE
[docs] add redux doc to sidebar

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -421,6 +421,7 @@
               link: /docs/troubleshooting-common-errors/
         - title: Adding App and Website Functionality
           link: /docs/adding-app-and-website-functionality/
+          breadcrumbTitle: App and Website Functionality
           items:
             - title: Linking Between Pages
               link: /docs/linking-between-pages/
@@ -510,6 +511,8 @@
                   link: /docs/sourcing-from-etsy/
                 - title: Sourcing from WooCommerce
                   link: /docs/sourcing-from-woocommerce/
+            - title: Adding a Redux Store
+              link: /docs/adding-redux-store/
         - title: Improving Performance
           link: /docs/performance/
           items:


### PR DESCRIPTION
## Description

I noticed when replying to a GitHub issue about hybrid app pages with a link to the docs that the Redux store doc wasn't listed in the sidebar. There's no good reason why it shouldn't be listed, so I added it in this PR.

I also shortened the "Adding App and Website Functionality" breadcrumb title so it wouldn't be so repetitive. The E-commerce pages in particular were quite long, so making it shorter seemed like a fine idea.

### Documentation

N/A

## Related Issues

N/A