### PR TITLE
[docs][guides] other css frameworks

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -2148,6 +2148,7 @@ WXR
 wysiwyg
 x64
 Xcode
+XD
 XSL
 XSS
 XState

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -8,10 +8,10 @@ This guide provides a brief introduction and list of resources for some of the o
 
 The following criteria were used to determine which frameworks to include in this guide:
 
-* It must work with React and Gatsby.
-* It must impact the styling of a Gatsby site.
-* It should be a commonly requested or searched in the Gatsby docs.
-* It must consider accessibility and not promote UI anti-patterns.
+- It must work with React and Gatsby.
+- It must impact the styling of a Gatsby site.
+- It should be a commonly requested or searched in the Gatsby docs.
+- It must consider accessibility and not promote UI anti-patterns.
 
 ## Bootstrap
 
@@ -23,10 +23,10 @@ If you're using Bootstrap v4 or older, many of the JavaScript components will re
 
 **Browser-support warning:** Bootstrap v5 also dropped Internet Explorer support.
 
-If you're interested in using Bootstrap and want to host the CSS and JS files yourself, you can install the [Boostrap npm package](https://www.npmjs.com/package/bootstrap). Alternatively, if you'd rather not host the files yourself, you can source them using the [Boostrap Content Delivery Network (CDN)](https://www.bootstrapcdn.com/).
+If you're interested in using Bootstrap and want to host the CSS and JS files yourself, you can install the [Bootstrap npm package](https://www.npmjs.com/package/bootstrap). Alternatively, if you'd rather not host the files yourself, you can source them using the [Bootstrap Content Delivery Network (CDN)](https://www.bootstrapcdn.com/).
 
-* [Bootstrap documentation](https://getbootstrap.com/docs)
-* [Bootstrap repo on GitHub](https://github.com/twbs/bootstrap)
+- [Bootstrap documentation](https://getbootstrap.com/docs)
+- [Bootstrap repo on GitHub](https://github.com/twbs/bootstrap)
 
 ## Chakra UI
 
@@ -34,9 +34,9 @@ Chakra UI is built on top of the [Emotion styling library](https://emotion.sh/do
 
 If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui` documentation](/packages/gatsby-plugin-chakra-ui/?=chakra).
 
-* [Chakra UI documentation](https://chakra-ui.com/getting-started)
-* [Chakra UI repo on GitHub](https://github.com/chakra-ui/chakra-ui/)
-* [Setting Up Chakra UI in a GatsbyJS App (YouTube)](https://www.youtube.com/watch?v=PjQHqDWnzGw)
+- [Chakra UI documentation](https://chakra-ui.com/getting-started)
+- [Chakra UI repo on GitHub](https://github.com/chakra-ui/chakra-ui/)
+- [Setting Up Chakra UI in a GatsbyJS App (YouTube)](https://www.youtube.com/watch?v=PjQHqDWnzGw)
 
 ## Grommet
 
@@ -46,9 +46,9 @@ For designers, the [Grommet Design Kit](https://github.com/grommet/design-kit) p
 
 If you're interested in using Grommet, check out [Using Grommet with Gatsby (Hewlett Packard Enterprise)](https://developer.hpe.com/blog/using-grommet-with-gatsby).
 
-* [Grommet component documentation](https://v2.grommet.io/components)
-* [Grommet repo on GitHub](https://github.com/grommet/grommet)
-* [Grommet component examples on Storybook](https://storybook.grommet.io/)
+- [Grommet component documentation](https://v2.grommet.io/components)
+- [Grommet repo on GitHub](https://github.com/grommet/grommet)
+- [Grommet component examples on Storybook](https://storybook.grommet.io/)
 
 ## Material UI
 
@@ -56,6 +56,6 @@ Material UI provides a library of components designed using Google's [Material D
 
 If you're interested in using Material UI, check out the [`gatsby-plugin-material-ui` documentation](/packages/gatsby-plugin-material-ui/?=material%20ui).
 
-* [Material UI documentation](https://material-ui.com/)
-* [Material UI repo on GitHub](https://github.com/mui-org/material-ui)
-* [Material UI example projects](https://material-ui.com/getting-started/example-projects/)
+- [Material UI documentation](https://material-ui.com/)
+- [Material UI repo on GitHub](https://github.com/mui-org/material-ui)
+- [Material UI example projects](https://material-ui.com/getting-started/example-projects/)

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -23,7 +23,7 @@ If you're using Bootstrap v4 or older, many of the JavaScript components will re
 
 **Browser-support warning:** Bootstrap v5 also dropped Internet Explorer support.
 
-If you're interested in using Bootstrap and want to host the CSS and JS yourself, you can install the [Boostrap npm package](https://www.npmjs.com/package/bootstrap). Alternatively, if you'd rather not host the files yourself, you can source them using the [Boostrap Content Delivery Network (CDN)](https://www.bootstrapcdn.com/).
+If you're interested in using Bootstrap and want to host the CSS and JS files yourself, you can install the [Boostrap npm package](https://www.npmjs.com/package/bootstrap). Alternatively, if you'd rather not host the files yourself, you can source them using the [Boostrap Content Delivery Network (CDN)](https://www.bootstrapcdn.com/).
 
 * [Bootstrap documentation](https://getbootstrap.com/docs)
 * [Bootstrap repo on GitHub](https://github.com/twbs/bootstrap)
@@ -40,15 +40,15 @@ If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui
 
 ## Grommet
 
-Grommet is built on [Styled Components](https://styled-components.com/) and provides a library of modular, responsive components designed with a mobile-first approach. It also provides built-in support for the W3C Web Content Accessibility Guidelines (WCAG) 2.1 specification.
+Grommet is built on [Styled Components](https://styled-components.com/) and provides a library of modular, responsive components designed with a mobile-first approach. It also provides built-in support for the W3C [Web Content Accessibility Guidelines (WCAG) 2.1](http://www.w3.org/WAI/intro/wcag) specification.
 
 For designers, the [Grommet Design Kit](https://github.com/grommet/design-kit) provides sticker sheets and templates for a number of popular design tools, including Sketch, Figma, and Adobe XD.
 
 If you're interested in using Grommet, check out [Using Grommet with Gatsby (Hewlett Packard Enterprise)](https://developer.hpe.com/blog/using-grommet-with-gatsby).
 
 * [Grommet component documentation](https://v2.grommet.io/components)
-* [Grommet component examples on Storybook](https://storybook.grommet.io/)
 * [Grommet repo on GitHub](https://github.com/grommet/grommet)
+* [Grommet component examples on Storybook](https://storybook.grommet.io/)
 
 ## Material UI
 

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -1,0 +1,59 @@
+---
+title: Other CSS Frameworks
+---
+
+This guide provides a brief introduction and list of resources for some of the other popular styling libraries worth highlighting.
+
+## How These Frameworks Were Chosen
+
+The following criteria were used to determine which frameworks to include in this guide:
+
+* It must work with React and Gatsby.
+* It must impact the styling of a Gatsby site.
+* It should be a commonly requested or searched in the Gatsby docs.
+* It must consider accessibility and not promote UI anti-patterns.
+
+## Bootstrap
+
+* [Bootstrap documentation](https://getbootstrap.com/docs)
+* [Bootstrap repo on GitHub](https://github.com/twbs/bootstrap)
+
+Bootstrap, created by Twitter, pioneered responsive, mobile-first design. 
+
+Supports SASS and LESS
+
+How to use the optional JS code which includes jQuery (https://getbootstrap.com/docs/4.5/getting-started/download/) (https://getbootstrap.com/docs/4.5/getting-started/javascript/)
+
+## Chakra UI
+
+Chakra UI is built on top of the [Emotion styling library](https://emotion.sh/docs/introduction). It uses [Styled System](https://styled-system.com/) style props to override individual CSS properties for a component. Chakra UI supports theme customization, provides a library of components, and comes with dark mode out of the box.
+
+If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui` documentation](/packages/gatsby-plugin-chakra-ui/?=chakra).
+
+* [Chakra UI documentation](https://chakra-ui.com/getting-started)
+* [Chakra UI repo on GitHub](https://github.com/chakra-ui/chakra-ui/)
+* [Setting Up Chakra UI in a GatsbyJS App (YouTube)](https://www.youtube.com/watch?v=PjQHqDWnzGw)
+
+## Grommet
+
+Grommet is built on [Styled Components](https://styled-components.com/) and provides a library of modular, responsive components built with a mobile-first approach. It also provides built-in support for the W3C Web Content Accessibility Guidelines (WCAG) 2.1 specification!
+
+For designers, the [Grommet Design Kit](https://github.com/grommet/design-kit) provides sticker sheets and templates for a number of popular design tools, including Sketch, Figma, and Adobe XD.
+
+If you're interested in using Grommet, check out [Using Grommet with Gatsby (Hewlett Packard Enterprise)](https://developer.hpe.com/blog/using-grommet-with-gatsby).
+
+* [Grommet component documentation](https://v2.grommet.io/components)
+* [Grommet component examples on Storybook](https://storybook.grommet.io/)
+* [Grommet repo on GitHub](https://github.com/grommet/grommet)
+
+## Material UI
+
+* [Material UI component documentation](https://material-ui.com/)
+* [Material UI repo on GitHub](https://github.com/mui-org/material-ui)
+* [Material UI example projects](https://material-ui.com/getting-started/example-projects/)
+
+Components designed with [Material design system](https://material.io/design/introduction) (Google's best practices design system)
+
+Responsive out of the box (can define breakpoints in the theme) Customizing the [default theme](https://material-ui.com/customization/default-theme/#default-theme)
+
+If you're interested in using Material UI, check out the [`gatsby-plugin-material-ui` documentation](/packages/gatsby-plugin-material-ui/?=material%20ui).

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -33,7 +33,9 @@ If you're interested in using Bootstrap and want to host the CSS and JS files yo
 
 ## Chakra UI
 
-Chakra UI is built on top of the [Emotion styling library](/docs/emotion/). It uses [Styled System](https://styled-system.com/) style props to override individual CSS properties for a component. Chakra UI supports theme customization, provides a library of components, and comes with dark mode out of the box.
+Chakra UI is built on top of the [Emotion styling library](/docs/emotion/). It uses [Styled System](https://styled-system.com/) style props to override individual CSS properties for a component.
+
+Chakra UI provides a library of components, and it comes with dark mode out of the box. It also has a theme object which you can use to customize your site's color palette, typography, breakpoints, and more.
 
 If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui` documentation](/packages/gatsby-plugin-chakra-ui/?=chakra).
 

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -10,7 +10,7 @@ There's no one right answer for which framework you should use. Ultimately it's 
 
 Here are some things you might want to consider when choosing a styling framework:
 
-- Is it [accessible](https://www.gatsbyjs.org/docs/making-your-site-accessible/)?
+- Is it [accessible](/docs/making-your-site-accessible/)?
 - Is it responsive? How will it look on a mobile device?
 - Does it require additional dependencies?
 - Does it have good documentation?

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -17,7 +17,7 @@ The following criteria were used to determine which frameworks to include in thi
 
 Bootstrap is a widely used CSS and JS framework that was created at Twitter in 2010. It gained popularity for its support of responsive and mobile-first design.
 
-Under the hood, Bootstrap uses [Sass](https://sass-lang.com/). Unlike other frameworks in this guide, Bootstrap does not provide React components directly. Instead, it provides a set of pre-built CSS class names like `"btn-primary"` or `"dropdown"` that you can use to style HTML elements.
+Under the hood, Bootstrap uses [Sass](https://sass-lang.com/). Unlike other frameworks in this guide, Bootstrap does not provide React components directly. Instead, it provides a set of pre-built CSS class names like `btn-primary` or `dropdown` that you can use to style HTML elements.
 
 If you're using Bootstrap v4 or older, many of the JavaScript components will need you to also install jQuery to work correctly. As of [Bootstrap v5](https://blog.getbootstrap.com/2020/06/16/bootstrap-5-alpha/), the framework no longer depends on jQuery.
 

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -4,14 +4,16 @@ title: Other CSS Frameworks
 
 This guide introduces some other popular styling libraries that you might want to use in your project.
 
-## How these frameworks were chosen
+## How to choose a framework
 
-The following criteria were used to determine which frameworks to include in this guide:
+There's no one right answer for which framework you should use. Ultimately it's a matter of personal preference and what works best for your project.
 
-- It must work with React and Gatsby.
-- It must impact the styling of a Gatsby site.
-- It should be a commonly requested or searched in the Gatsby docs.
-- It must consider accessibility and not promote UI anti-patterns.
+Here are some things you might want to consider when choosing a styling framework:
+
+- Does it promote accessibility?
+- Does it use good UI patterns?
+- Does it require additional dependencies?
+- Does it have good documentation?
 
 ## Bootstrap
 

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -15,14 +15,18 @@ The following criteria were used to determine which frameworks to include in thi
 
 ## Bootstrap
 
+Bootstrap is a widely used CSS and JS framework that was created at Twitter in 2010. It gained popularity for its support of responsive and mobile-first design.
+
+Under the hood, Bootstrap uses [Sass](https://sass-lang.com/). Unlike other frameworks in this guide, Bootstrap does not provide React components directly. Instead, it provides a set of pre-built CSS class names like `"btn-primary"` or `"dropdown"` that you can use to style HTML elements.
+
+If you're using Bootstrap v4 or older, many of the JavaScript components will require you to also install jQuery to work correctly. However, as of [Bootstrap v5](https://blog.getbootstrap.com/2020/06/16/bootstrap-5-alpha/), the framework no longer depends on jQuery.
+
+**Browser-support warning:** Bootstrap v5 also dropped Internet Explorer support.
+
+If you're interested in using Bootstrap and want to host the CSS and JS yourself, you can install the [Boostrap npm package](https://www.npmjs.com/package/bootstrap). Alternatively, if you'd rather not host the files yourself, you can source them using the [Boostrap Content Delivery Network (CDN)](https://www.bootstrapcdn.com/).
+
 * [Bootstrap documentation](https://getbootstrap.com/docs)
 * [Bootstrap repo on GitHub](https://github.com/twbs/bootstrap)
-
-Bootstrap, created by Twitter, pioneered responsive, mobile-first design. 
-
-Supports SASS and LESS
-
-How to use the optional JS code which includes jQuery (https://getbootstrap.com/docs/4.5/getting-started/download/) (https://getbootstrap.com/docs/4.5/getting-started/javascript/)
 
 ## Chakra UI
 
@@ -36,7 +40,7 @@ If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui
 
 ## Grommet
 
-Grommet is built on [Styled Components](https://styled-components.com/) and provides a library of modular, responsive components built with a mobile-first approach. It also provides built-in support for the W3C Web Content Accessibility Guidelines (WCAG) 2.1 specification!
+Grommet is built on [Styled Components](https://styled-components.com/) and provides a library of modular, responsive components designed with a mobile-first approach. It also provides built-in support for the W3C Web Content Accessibility Guidelines (WCAG) 2.1 specification.
 
 For designers, the [Grommet Design Kit](https://github.com/grommet/design-kit) provides sticker sheets and templates for a number of popular design tools, including Sketch, Figma, and Adobe XD.
 
@@ -48,12 +52,10 @@ If you're interested in using Grommet, check out [Using Grommet with Gatsby (Hew
 
 ## Material UI
 
-* [Material UI component documentation](https://material-ui.com/)
-* [Material UI repo on GitHub](https://github.com/mui-org/material-ui)
-* [Material UI example projects](https://material-ui.com/getting-started/example-projects/)
-
-Components designed with [Material design system](https://material.io/design/introduction) (Google's best practices design system)
-
-Responsive out of the box (can define breakpoints in the theme) Customizing the [default theme](https://material-ui.com/customization/default-theme/#default-theme)
+Material UI provides a library of components designed using Google's [Material Design guidelines](https://material.io/design/introduction). It also supports customizing theme elements like color, typography, and breakpoints.
 
 If you're interested in using Material UI, check out the [`gatsby-plugin-material-ui` documentation](/packages/gatsby-plugin-material-ui/?=material%20ui).
+
+* [Material UI documentation](https://material-ui.com/)
+* [Material UI repo on GitHub](https://github.com/mui-org/material-ui)
+* [Material UI example projects](https://material-ui.com/getting-started/example-projects/)

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -2,9 +2,9 @@
 title: Other CSS Frameworks
 ---
 
-This guide provides a brief introduction and list of resources for some of the other popular styling libraries worth highlighting.
+This guide introduces some other popular styling libraries that you might want to use in your project.
 
-## How These Frameworks Were Chosen
+## How these frameworks were chosen
 
 The following criteria were used to determine which frameworks to include in this guide:
 
@@ -19,11 +19,11 @@ Bootstrap is a widely used CSS and JS framework that was created at Twitter in 2
 
 Under the hood, Bootstrap uses [Sass](https://sass-lang.com/). Unlike other frameworks in this guide, Bootstrap does not provide React components directly. Instead, it provides a set of pre-built CSS class names like `"btn-primary"` or `"dropdown"` that you can use to style HTML elements.
 
-If you're using Bootstrap v4 or older, many of the JavaScript components will require you to also install jQuery to work correctly. However, as of [Bootstrap v5](https://blog.getbootstrap.com/2020/06/16/bootstrap-5-alpha/), the framework no longer depends on jQuery.
+If you're using Bootstrap v4 or older, many of the JavaScript components will need you to also install jQuery to work correctly. As of [Bootstrap v5](https://blog.getbootstrap.com/2020/06/16/bootstrap-5-alpha/), the framework no longer depends on jQuery.
 
 **Browser-support warning:** Bootstrap v5 also dropped Internet Explorer support.
 
-If you're interested in using Bootstrap and want to host the CSS and JS files yourself, you can install the [Bootstrap npm package](https://www.npmjs.com/package/bootstrap). Alternatively, if you'd rather not host the files yourself, you can source them using the [Bootstrap Content Delivery Network (CDN)](https://www.bootstrapcdn.com/).
+If you're interested in using Bootstrap and want to host the CSS and JS files yourself, you can install the [Bootstrap npm package](https://www.npmjs.com/package/bootstrap). Or, if you'd rather not host the files yourself, you can source them using the [Bootstrap Content Delivery Network (CDN)](https://www.bootstrapcdn.com/).
 
 - [Bootstrap documentation](https://getbootstrap.com/docs)
 - [Bootstrap repo on GitHub](https://github.com/twbs/bootstrap)
@@ -40,9 +40,9 @@ If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui
 
 ## Grommet
 
-Grommet is built on [Styled Components](https://styled-components.com/) and provides a library of modular, responsive components designed with a mobile-first approach. It also provides built-in support for the W3C [Web Content Accessibility Guidelines (WCAG) 2.1](http://www.w3.org/WAI/intro/wcag) specification.
+Grommet is built on [Styled Components](https://styled-components.com/) and provides a library of modular, responsive components designed with a mobile-first approach. It also has built-in support for the W3C [Web Content Accessibility Guidelines (WCAG) 2.1](http://www.w3.org/WAI/intro/wcag) specification.
 
-For designers, the [Grommet Design Kit](https://github.com/grommet/design-kit) provides sticker sheets and templates for a number of popular design tools, including Sketch, Figma, and Adobe XD.
+For designers, the [Grommet Design Kit](https://github.com/grommet/design-kit) provides sticker sheets and templates for some popular design tools, including Sketch, Figma, and Adobe XD.
 
 If you're interested in using Grommet, check out [Using Grommet with Gatsby (Hewlett Packard Enterprise)](https://developer.hpe.com/blog/using-grommet-with-gatsby).
 

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -19,7 +19,7 @@ Bootstrap is a widely used CSS and JS framework that was created at Twitter in 2
 
 Under the hood, Bootstrap uses [Sass](https://sass-lang.com/). Unlike other frameworks in this guide, Bootstrap does not provide React components directly. Instead, it provides a set of pre-built CSS class names like `btn-primary` or `dropdown` that you can use to style HTML elements.
 
-If you're using Bootstrap v4 or older, many of the JavaScript components will need you to also install jQuery to work correctly. As of [Bootstrap v5](https://blog.getbootstrap.com/2020/06/16/bootstrap-5-alpha/), the framework no longer depends on jQuery.
+If you're using Bootstrap v4 or older, you'll also need to include jQuery to get many of the JavaScript components to work correctly. As of [Bootstrap v5](https://blog.getbootstrap.com/2020/06/16/bootstrap-5-alpha/), the framework no longer depends on jQuery.
 
 **Browser-support warning:** Bootstrap v5 also dropped Internet Explorer support.
 

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -24,7 +24,7 @@ Under the hood, Bootstrap uses [Sass](https://sass-lang.com/). Unlike other fram
 
 If you're using Bootstrap v4 or older, you'll also need to include jQuery to get many of the JavaScript components to work correctly. As of [Bootstrap v5](https://blog.getbootstrap.com/2020/06/16/bootstrap-5-alpha/), the framework no longer depends on jQuery.
 
-**Browser-support warning:** Bootstrap v5 also dropped Internet Explorer support.
+**Note:** Bootstrap v5 also dropped Internet Explorer support.
 
 If you're interested in using Bootstrap and want to host the CSS and JS files yourself, you can install the [Bootstrap npm package](https://www.npmjs.com/package/bootstrap). Or, if you'd rather not host the files yourself, you can source them using the [Bootstrap Content Delivery Network (CDN)](https://www.bootstrapcdn.com/).
 

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -54,7 +54,7 @@ If you're interested in using Grommet, check out [Using Grommet with Gatsby (Hew
 
 Material UI provides a library of components designed using Google's [Material Design guidelines](https://material.io/design/introduction). It also supports customizing theme elements like color, typography, and breakpoints.
 
-If you're interested in using Material UI, check out the [`gatsby-plugin-material-ui` documentation](/packages/gatsby-plugin-material-ui/?=material%20ui).
+If you're interested in using Material UI, check out the [`gatsby-plugin-material-ui` documentation](/packages/gatsby-plugin-material-ui).
 
 - [Material UI documentation](https://material-ui.com/)
 - [Material UI repo on GitHub](https://github.com/mui-org/material-ui)

--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -10,10 +10,11 @@ There's no one right answer for which framework you should use. Ultimately it's 
 
 Here are some things you might want to consider when choosing a styling framework:
 
-- Does it promote accessibility?
-- Does it use good UI patterns?
+- Is it [accessible](https://www.gatsbyjs.org/docs/making-your-site-accessible/)?
+- Is it responsive? How will it look on a mobile device?
 - Does it require additional dependencies?
 - Does it have good documentation?
+- Are there any browsers it doesn't support?
 
 ## Bootstrap
 
@@ -32,7 +33,7 @@ If you're interested in using Bootstrap and want to host the CSS and JS files yo
 
 ## Chakra UI
 
-Chakra UI is built on top of the [Emotion styling library](https://emotion.sh/docs/introduction). It uses [Styled System](https://styled-system.com/) style props to override individual CSS properties for a component. Chakra UI supports theme customization, provides a library of components, and comes with dark mode out of the box.
+Chakra UI is built on top of the [Emotion styling library](/docs/emotion/). It uses [Styled System](https://styled-system.com/) style props to override individual CSS properties for a component. Chakra UI supports theme customization, provides a library of components, and comes with dark mode out of the box.
 
 If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui` documentation](/packages/gatsby-plugin-chakra-ui/?=chakra).
 
@@ -42,7 +43,7 @@ If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui
 
 ## Grommet
 
-Grommet is built on [Styled Components](https://styled-components.com/) and provides a library of modular, responsive components designed with a mobile-first approach. It also has built-in support for the W3C [Web Content Accessibility Guidelines (WCAG) 2.1](http://www.w3.org/WAI/intro/wcag) specification.
+Grommet is built on [Styled Components](/docs/styled-components/) and provides a library of modular, responsive components designed with a mobile-first approach. It also has built-in support for the W3C [Web Content Accessibility Guidelines (WCAG) 2.1](http://www.w3.org/WAI/intro/wcag) specification.
 
 For designers, the [Grommet Design Kit](https://github.com/grommet/design-kit) provides sticker sheets and templates for some popular design tools, including Sketch, Figma, and Adobe XD.
 

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -358,6 +358,8 @@
                   link: /docs/bulma/
                 - title: Using Theme UI
                   link: /docs/theme-ui/
+                - title: Other CSS Frameworks
+                  link: /docs/other-css-frameworks/
         - title: Adding Components to Markdown with MDX
           link: /docs/mdx/
           breadcrumbTitle: MDX


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Adds a new Reference Guide to the [CSS Libraries and Frameworks](https://www.gatsbyjs.org/docs/css-libraries-and-frameworks/) section for Other CSS Frameworks. 

## Related Issues

Closes #21541