### PR TITLE
fix(gatsby-image): Only include `<noscript>` in SSR, not client renders

### DIFF
--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -42,9 +42,6 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
         width="100"
       />
     </picture>
-    <noscript>
-      &lt;picture&gt;&lt;source type='image/webp' srcset="some srcSetWebp" /&gt;&lt;source srcset="some srcSet" /&gt;&lt;img loading="lazy" width="100" height="100" srcset="some srcSet" src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
-    </noscript>
   </div>
 </div>
 `;
@@ -91,9 +88,6 @@ exports[`<Image /> should render fixed size images 1`] = `
         width="100"
       />
     </picture>
-    <noscript>
-      &lt;picture&gt;&lt;source type='image/webp' srcset="some srcSetWebp" /&gt;&lt;source srcset="some srcSet" /&gt;&lt;img loading="lazy" width="100" height="100" srcset="some srcSet" src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
-    </noscript>
   </div>
 </div>
 `;
@@ -145,9 +139,6 @@ exports[`<Image /> should render fluid images 1`] = `
         title="Title for the image"
       />
     </picture>
-    <noscript>
-      &lt;picture&gt;&lt;source type='image/webp' srcset="some srcSetWebp" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;source srcset="some srcSet" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;img loading="lazy" sizes="(max-width: 600px) 100vw, 600px" srcset="some srcSet" src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
-    </noscript>
   </div>
 </div>
 `;
@@ -211,9 +202,6 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
         width="100"
       />
     </picture>
-    <noscript>
-      &lt;picture&gt;&lt;source type='image/webp' media="only screen and (min-width: 768px)" srcset="some other srcSetWebp" /&gt;&lt;source media="only screen and (min-width: 768px)" srcset="some other srcSet" /&gt;&lt;source type='image/webp' srcset="some srcSetWebp" /&gt;&lt;source srcset="some srcSet" /&gt;&lt;img loading="lazy" width="100" height="100" srcset="some srcSet" src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
-    </noscript>
   </div>
 </div>
 `;
@@ -284,9 +272,6 @@ exports[`<Image /> should render multiple fluid image variants 1`] = `
         title="Title for the image"
       />
     </picture>
-    <noscript>
-      &lt;picture&gt;&lt;source type='image/webp' media="only screen and (min-width: 768px)" srcset="some other srcSetWebp" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;source media="only screen and (min-width: 768px)" srcset="some other srcSet" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;source type='image/webp' srcset="some srcSetWebp" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;source srcset="some srcSet" sizes="(max-width: 600px) 100vw, 600px" /&gt;&lt;img loading="lazy" sizes="(max-width: 600px) 100vw, 600px" srcset="some srcSet" src="test_image.jpg" alt="Alt text for the image" title="Title for the image" style="position:absolute;top:0;left:0;opacity:1;width:100%;height:100%;object-fit:cover;object-position:center"/&gt;&lt;/picture&gt;
-    </noscript>
   </div>
 </div>
 `;

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -336,7 +336,7 @@ class Image extends React.Component {
 
     this.isCritical = props.loading === `eager` || props.critical
 
-    this.addNoScript = !(this.isCritical && !props.fadeIn)
+    this.addNoScript = !isBrowser && !(this.isCritical && !props.fadeIn)
     this.useIOSupport =
       !hasNativeLazyLoadSupport &&
       hasIOSupport &&


### PR DESCRIPTION
## Description

Only useful during SSR, once JS is available on client side, no point in rendering `<noscript>`.