### PR TITLE
feat(gatsby-image): Image cache logic improvements

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -395,7 +395,6 @@ class Image extends React.Component {
 
       if (isCached) {
         this.setState({
-          imgLoaded: true,
           imgCached: true,
         })
       }
@@ -417,7 +416,6 @@ class Image extends React.Component {
         if (imageInCache) {
           this.setState({
             isVisible: true,
-            imgLoaded: true,
             imgCached: true,
           })
         } else {
@@ -485,7 +483,7 @@ class Image extends React.Component {
     }
 
     const imagePlaceholderStyle = {
-      opacity: this.state.imgLoaded ? 0 : 1,
+      opacity: this.state.imgCached || this.state.imgLoaded ? 0 : 1,
       ...(shouldFadeIn && delayHideStyle),
       ...imgStyle,
       ...placeholderStyle,

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -470,7 +470,8 @@ class Image extends React.Component {
 
     // In a browser-cached scenario prevents rendering initial placeholder.
     // Instead renders a blank image container or backgroundColor placeholder.
-    const shouldRevealPlaceholder = !isBrowser || this.state.isVisible
+    const shouldRenderPlaceholder = !isBrowser || this.state.isVisible
+    const shouldHidePlaceholder = this.state.imgCached || this.state.imgLoaded
 
     const imageStyle = {
       opacity: shouldReveal ? 1 : 0,
@@ -486,7 +487,7 @@ class Image extends React.Component {
     }
 
     const imagePlaceholderStyle = {
-      opacity: this.state.imgCached || this.state.imgLoaded ? 0 : 1,
+      opacity: shouldHidePlaceholder ? 0 : 1,
       ...(shouldFadeIn && delayHideStyle),
       ...imgStyle,
       ...placeholderStyle,
@@ -545,7 +546,7 @@ class Image extends React.Component {
           )}
 
           {/* Show the blurry base64 image. */}
-          {shouldRevealPlaceholder && image.base64 && (
+          {shouldRenderPlaceholder && image.base64 && (
             <Placeholder
               ariaHidden
               ref={this.placeholderRef}
@@ -557,7 +558,7 @@ class Image extends React.Component {
           )}
 
           {/* Show the traced SVG image. */}
-          {shouldRevealPlaceholder && image.tracedSVG && (
+          {shouldRenderPlaceholder && image.tracedSVG && (
             <Placeholder
               ariaHidden
               ref={this.placeholderRef}
@@ -648,7 +649,7 @@ class Image extends React.Component {
           )}
 
           {/* Show the blurry base64 image. */}
-          {shouldRevealPlaceholder && image.base64 && (
+          {shouldRenderPlaceholder && image.base64 && (
             <Placeholder
               ariaHidden
               ref={this.placeholderRef}
@@ -660,7 +661,7 @@ class Image extends React.Component {
           )}
 
           {/* Show the traced SVG image. */}
-          {shouldRevealPlaceholder && image.tracedSVG && (
+          {shouldRenderPlaceholder && image.tracedSVG && (
             <Placeholder
               ariaHidden
               ref={this.placeholderRef}

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -270,7 +270,7 @@ const Placeholder = React.forwardRef((props, ref) => {
   )
 
   return imageVariants.length > 1 ? (
-    <picture>
+    <picture className={`gatsby-image-placeholder`}>
       {generateSources(imageVariants)}
       {baseImage}
     </picture>

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -383,10 +383,13 @@ class Image extends React.Component {
     // this will reveal it immediately and skip the placeholder transition.
     const setCachedState = () => {
       // 'img.currentSrc' may be a falsy value, empty string or undefined(IE).
+      if (!this.imageRef.current) {
+        return
+      }
       // If image resides in the browser cache, this attribute is populated
       // without waiting on a network request response to update it.
       // Firefox does not behave in this way, no benefit there.
-      let isCached = this.imageRef.current && this.imageRef.current.currentSrc
+      let isCached = this.imageRef.current.currentSrc
 
       // For critical images 'img.complete' is more reliable
       if (this.isCritical) {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -464,6 +464,10 @@ class Image extends React.Component {
     const shouldReveal = this.state.fadeIn === false || this.state.imgLoaded
     const shouldFadeIn = this.state.fadeIn === true && !this.state.imgCached
 
+    // In a browser-cached scenario prevents rendering initial placeholder.
+    // Instead renders a blank image container or backgroundColor placeholder.
+    const shouldRevealPlaceholder = !isBrowser || this.state.isVisible
+
     const imageStyle = {
       opacity: shouldReveal ? 1 : 0,
       transition: shouldFadeIn ? `opacity ${durationFadeIn}ms` : `none`,
@@ -537,7 +541,7 @@ class Image extends React.Component {
           )}
 
           {/* Show the blurry base64 image. */}
-          {image.base64 && (
+          {shouldRevealPlaceholder && image.base64 && (
             <Placeholder
               ariaHidden
               ref={this.placeholderRef}
@@ -549,7 +553,7 @@ class Image extends React.Component {
           )}
 
           {/* Show the traced SVG image. */}
-          {image.tracedSVG && (
+          {shouldRevealPlaceholder && image.tracedSVG && (
             <Placeholder
               ariaHidden
               ref={this.placeholderRef}
@@ -640,7 +644,7 @@ class Image extends React.Component {
           )}
 
           {/* Show the blurry base64 image. */}
-          {image.base64 && (
+          {shouldRevealPlaceholder && image.base64 && (
             <Placeholder
               ariaHidden
               ref={this.placeholderRef}
@@ -652,7 +656,7 @@ class Image extends React.Component {
           )}
 
           {/* Show the traced SVG image. */}
-          {image.tracedSVG && (
+          {shouldRevealPlaceholder && image.tracedSVG && (
             <Placeholder
               ariaHidden
               ref={this.placeholderRef}

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -400,6 +400,9 @@ class Image extends React.Component {
         })
       }
     }
+
+    // Newer instances(mounts) of this image may be cached, using a different
+    // render path than Intersection Observer ('useIOSupport').
     // 'isVisible' guard skips this for already loaded art directed images.
     if (this.useIOSupport && !this.state.isVisible) {
       this.cleanUpListeners = listenToIntersections(ref, () => {
@@ -418,10 +421,10 @@ class Image extends React.Component {
             imgCached: true,
           })
         } else {
-          // imgCached and imgLoaded must update after isVisible,
-          // Once isVisible is true, imageRef becomes accessible, which imgCached needs access to.
-          // imgLoaded and imgCached are in a 2nd setState call to be changed together,
-          // avoiding initiating unnecessary animation frames from style changes.
+          // Begin loading real image, then check if image is in browser cache.
+          // Must first render with 'isVisible==true', then 'imageRef' exists.
+          // 'imgCached' needs access to 'imageRef' to work.
+          // Paired with 'imgLoaded' to avoid redundant animation frames.
           this.setState({ isVisible: true }, setCachedState)
         }
       })

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -378,15 +378,18 @@ class Image extends React.Component {
     }
   }
 
-  // Specific to IntersectionObserver based lazy-load support
+  // Triggers when wrapper element mounts(has a ref) and after unmounting(null)
   handleRef(ref) {
-    if (this.useIOSupport && ref) {
+    // Ignore calls from unmounts
+    if (!ref) {
+      return
+    }
+    // 'isVisible' guard skips this for already loaded art directed images.
+    if (this.useIOSupport && !this.state.isVisible) {
       this.cleanUpListeners = listenToIntersections(ref, () => {
         const imageInCache = inImageCache(this.props)
-        if (
-          !this.state.isVisible &&
-          typeof this.props.onStartLoad === `function`
-        ) {
+
+        if (typeof this.props.onStartLoad === `function`) {
           this.props.onStartLoad({ wasCached: imageInCache })
         }
 

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -270,7 +270,7 @@ const Placeholder = React.forwardRef((props, ref) => {
   )
 
   return imageVariants.length > 1 ? (
-    <picture className={`gatsby-image-placeholder`}>
+    <picture>
       {generateSources(imageVariants)}
       {baseImage}
     </picture>

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -364,12 +364,6 @@ class Image extends React.Component {
     if (this.state.isVisible && typeof this.props.onStartLoad === `function`) {
       this.props.onStartLoad({ wasCached: inImageCache(this.props) })
     }
-    if (this.isCritical) {
-      const img = this.imageRef.current
-      if (img && img.complete) {
-        this.handleImageLoaded()
-      }
-    }
   }
 
   componentWillUnmount() {
@@ -393,6 +387,11 @@ class Image extends React.Component {
       // without waiting on a network request response to update it.
       // Firefox does not behave in this way, no benefit there.
       let isCached = this.imageRef.current && this.imageRef.current.currentSrc
+
+      // For critical images 'img.complete' is more reliable
+      if (this.isCritical) {
+        isCached = this.imageRef.current.complete
+      }
 
       if (isCached) {
         this.setState({

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -426,13 +426,17 @@ class Image extends React.Component {
           this.setState({ isVisible: true }, setCachedState)
         }
       })
+    } else if (!this.state.imgCached) {
+      setCachedState()
     }
   }
 
   handleImageLoaded() {
     activateCacheForImage(this.props)
 
-    this.setState({ imgLoaded: true })
+    if (!this.state.imgLoaded) {
+      this.setState({ imgLoaded: true })
+    }
 
     if (this.props.onLoad) {
       this.props.onLoad()


### PR DESCRIPTION
## Problem

Using a placeholder such as base64 is nice to have for first retrieval of assets. However when they are cached this results in:

- Brief flicker during hydration due to inlined placeholder.
- When navigating to a page with an image if no hit within the internal `gatsby-image` cache:
  - Brief flicker for lazy loading via Intersection Observer.
  - Transition triggered for native lazy loading.

It's a minor UX issue, but it would be nice to smooth these out.

## Examples

![base64_flash_bug](https://user-images.githubusercontent.com/5098581/88139292-838aac80-cc43-11ea-8f5f-65c75bb9c99d.gif)

![gimagecachebug](https://user-images.githubusercontent.com/5098581/88774078-1e046600-d1d7-11ea-8e64-3c90c780bf51.gif)

## Description

When loading a Gatsby page with an image in the viewport, if the page has been previously visited and the browser has cached the image, there is still a flicker of a placeholder if used(base64/SVG), this can look unsightly/jarring and be unexpected.

This PR tries to resolve that issue as best as possible, favoring a blank(no placeholder) rendered frame over a frame with a placeholder. This is a React rendered frame, in that it can last longer than 16ms, dependent on when the next frame is rendered, often long enough to be visible for a moment that it's noticeable.

**Not fully tested**, nor is the approach a complete solution(`currentSrc` technique does not work for Firefox, a variety of other browsers that I've tested with are able to leverage it).

Individual commits provide better details on changes, and try to make for easier review.

## Related Issues

Original attempt prior to native image lazyloading in Chrome/Firefox: https://github.com/gatsbyjs/gatsby/issues/12254#issuecomment-471278211

A user mentions it was a problem for them when providing their Gatsby site for offline usage, they ended up switching to SVG resources: https://github.com/gatsbyjs/gatsby/issues/12254#issuecomment-502118451

Fixes: https://github.com/gatsbyjs/gatsby/issues/12836

> when the actual images load fast, the placeholder is more irritating then helpful.

Fixes: https://github.com/gatsbyjs/gatsby/issues/18858

> I noticed that the image flickers when I am changing between pages (eg. between home and page 2).

Previous PR by me introducing `imgCached`: https://github.com/gatsbyjs/gatsby/pull/12468

A prior PR of mine mentions the issue will exist for images not using Intersection Observer render path: https://github.com/gatsbyjs/gatsby/pull/14158

> `imgCached` will be false in situations that IO isn't used for lazy-load, thus `shouldFadeIn` won't be disabled, which afaik means we'll probably run into `#12254` again?

Fixes: https://github.com/gatsbyjs/gatsby/issues/25942 (recent issue by me looking into the issue)

Related: https://github.com/gatsbyjs/gatsby/pull/22255
- Unclear how to reproduce "crash", this PR addresses linked PR `TODO` comment.
