### PR TITLE
Centered the Banner Content

### DIFF
--- a/www/src/components/banner.js
+++ b/www/src/components/banner.js
@@ -9,6 +9,7 @@ function BannerContent() {
         color: `whiteFade.80`,
         fontFamily: `heading`,
         px: 6,
+        textAlign: `center`,
         whiteSpace: `nowrap`,
       }}
     >
@@ -31,6 +32,7 @@ function BannerContent() {
 
 const innerContainerStyles = {
   display: `flex`,
+  textAlign: `center`,
   alignItems: `center`,
   justifyContent: [`center`, null, `flex-start`],
   height: `100%`,


### PR DESCRIPTION
Initially, the banner content was located on the left of the screen which was less seen and less focused, fixed the text alignment to center.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixed in WWW/src/components/banner.js

In-home screen the topmost component with src= www/src/components/banner.js the banner content was previously fixed to left managed to align the text item to center which looks good and gains the focus of users.

Added the textAlign: `center` prop which will let the text be centered to gain more focus and helps the user to know the updates

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues



<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
