### PR TITLE
chore(gatsby): remove not used code (requires-writer -> startListening)

### DIFF
--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -6,7 +6,6 @@ import { slash } from "gatsby-core-utils"
 import reporter from "gatsby-cli/lib/reporter"
 import { match } from "@reach/router/lib/utils"
 import { joinPath } from "gatsby-core-utils"
-import { store, emitter } from "../redux/"
 import { IGatsbyState, IGatsbyPage } from "../redux/types"
 import {
   writeModule,
@@ -258,47 +257,4 @@ const preferDefault = m => m && m.default || m
   ])
 
   return true
-}
-
-const debouncedWriteAll = _.debounce(
-  async (): Promise<void> => {
-    const activity = reporter.activityTimer(`write out requires`, {
-      id: `requires-writer`,
-    })
-    activity.start()
-    await writeAll(store.getState())
-    activity.end()
-  },
-  500,
-  {
-    // using "leading" can cause double `writeAll` call - particularly
-    // when refreshing data using `/__refresh` hook.
-    leading: false,
-  }
-)
-
-/**
- * Start listening to CREATE/DELETE_PAGE events so we can rewrite
- * files as required
- */
-export const startListener = (): void => {
-  emitter.on(`CREATE_PAGE`, (): void => {
-    reporter.pendingActivity({ id: `requires-writer` })
-    debouncedWriteAll()
-  })
-
-  emitter.on(`CREATE_PAGE_END`, (): void => {
-    reporter.pendingActivity({ id: `requires-writer` })
-    debouncedWriteAll()
-  })
-
-  emitter.on(`DELETE_PAGE`, (): void => {
-    reporter.pendingActivity({ id: `requires-writer` })
-    debouncedWriteAll()
-  })
-
-  emitter.on(`DELETE_PAGE_BY_PATH`, (): void => {
-    reporter.pendingActivity({ id: `requires-writer` })
-    debouncedWriteAll()
-  })
 }


### PR DESCRIPTION
## Description

One of state machine PRs ( https://github.com/gatsbyjs/gatsby/pull/25479 ) moved triggering `requires-writer` to state machine flow, and `startListener` was no longer called but it just wasn't removed. So this is just maintenance removal, nothing should change.