### PR TITLE
feat(gatsby-telemetry): Track if cache was purged

### DIFF
--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -5,6 +5,7 @@ import {
   Middleware,
 } from "redux"
 import _ from "lodash"
+import telemetry from "gatsby-telemetry"
 
 import { mett } from "../utils/mett"
 import thunk, { ThunkMiddleware } from "redux-thunk"
@@ -37,12 +38,24 @@ export const readState = (): IGatsbyState => {
     // changes. Explicitly delete it here to cover case where user
     // runs gatsby the first time after upgrading.
     delete state[`jsonDataPaths`]
+    telemetry.decorateEvent(`BUILD_END`, {
+      cacheStatus: `WARM`,
+    })
+    telemetry.decorateEvent(`DEVELOP_STOP`, {
+      cacheStatus: `WARM`,
+    })
     return state
   } catch (e) {
     // ignore errors.
   }
   // BUG: Would this not cause downstream bugs? seems likely. Why wouldn't we just
   // throw and kill the program?
+  telemetry.decorateEvent(`BUILD_END`, {
+    cacheStatus: `COLD`,
+  })
+  telemetry.decorateEvent(`DEVELOP_STOP`, {
+    cacheStatus: `COLD`,
+  })
   return {} as IGatsbyState
 }
 

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -268,6 +268,15 @@ export async function initialize({
     store.dispatch({
       type: `DELETE_CACHE`,
     })
+
+    // in future this should show which plugin's caches are purged
+    // possibly should also have which plugins had caches
+    telemetry.decorateEvent(`BUILD_END`, {
+      pluginCachesPurged: [`*`],
+    })
+    telemetry.decorateEvent(`DEVELOP_STOP`, {
+      pluginCachesPurged: [`*`],
+    })
   }
 
   // Update the store with the new plugins hash.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

We want to track cache status of builds with telemetry.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
