### PR TITLE
fix: use content type id by default to create reference gql types

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -146,7 +146,15 @@ exports.sourceNodes = async (
 
   const gqlTypes = contentTypeItems.map(contentTypeItem =>
     schema.buildObjectType({
-      name: _.upperFirst(_.camelCase(`Contentful ${contentTypeItem.name}`)),
+      name: _.upperFirst(
+        _.camelCase(
+          `Contentful ${
+            pluginConfig.get(`useNameForId`)
+              ? contentTypeItem.name
+              : contentTypeItem.sys.id
+          }`
+        )
+      ),
       fields: {
         contentful_id: { type: `String!` },
         id: { type: `ID!` },
@@ -349,7 +357,11 @@ exports.sourceNodes = async (
 
     if (entryList[i].length) {
       reporter.info(
-        `Creating ${entryList[i].length} Contentful ${contentTypeItem.name} nodes`
+        `Creating ${entryList[i].length} Contentful ${
+          pluginConfig.get(`useNameForId`)
+            ? contentTypeItem.name
+            : contentTypeItem.sys.id
+        } nodes`
       )
     }
 


### PR DESCRIPTION
and add support for the `useNameForId` option