### PR TITLE
fix(blog): i18n themes - link to discord, indentions in diff, filename in code fences

### DIFF
--- a/docs/blog/2020-07-13-i18n-pain-points/index.md
+++ b/docs/blog/2020-07-13-i18n-pain-points/index.md
@@ -9,7 +9,7 @@ tags:
 
 During Gatsby Days Reconfigured last month [we previewed quite a few exciting projects](/blog/2020-06-23-Reconfiguring-Gatsby-Days/) to be released soon. These launches are aimed at helping developers transition their CMSs into the headless CMS era; enabling content creators to use Gatsby more easily and intuitively; and, simultaneously, improving the developer experience for our current and future users. One of these exciting new announcements actually ties all three of these goals together: a sneak peek at the development of our own [i18n theme](/blog/2020-06-23-Reconfiguring-Gatsby-Days/#i18n-theme). It's the first step towards having internationalization in Gatsby as a first-class citizen, and we are looking to launch by the end of the month.
 
-First, though, we’d like to share the research process we’ve followed in developing the i18n theme, and the pain points we sought to solve. The goal in sharing these findings is to start an open discussion and invite your feedback. If you’re interested in contributing, please join the [Gatsby Discord channel](https://gatsby.dev/discord) and add your voice to the conversation!
+First, though, we’d like to share the research process we’ve followed in developing the i18n theme, and the pain points we sought to solve. The goal in sharing these findings is to start an open discussion and invite your feedback. If you’re interested in contributing, please join the [Gatsby Discord channel](https://discord.gg/cQ2MPUz) and add your voice to the conversation!
 
 ## Why i18n?
 
@@ -23,7 +23,7 @@ As lead engineer on the Gatsby i18n initiative, I knew right from the start that
 
 Currently, high level pain points for our users are that they often have to choose between multiple plugins and then implement everything on their own. Scalability also presents a challenge, because having your site in two languages already doubles your page count. There are also numerous more specific issues affecting users seeking to implement i18n with their Gatsby sites or apps.
 
-This is a non-exhaustive list of issues I most commonly read and heard. Feel free to share any other problems with me (on [Discord](https://gatsby.dev/discord)) that you see as important to the overall development of Gatsby’s i18n strategy!
+This is a non-exhaustive list of issues I most commonly read and heard. Feel free to share any other problems with me (on [Discord](https://discord.gg/cQ2MPUz)) that you see as important to the overall development of Gatsby’s i18n strategy!
 
 1. **Generating separate pages for each locale requires greater effort and knowledge from the user than usual.** Passing around the necessary information via `pageContext`, creating new pages from existing ones, and creating some sort of config to control that is complicated. There are some pitfalls when using the `onCreatePage` API and `pageContext` that might lead to unexpected errors or performance degradation.
 
@@ -56,6 +56,6 @@ Most importantly the great variety of responses received thus far showed that ou
 
 ## What's next?
 
-The alpha of `gatsby-theme-i18n` and its child themes will be released very soon. Until then (and in the future, as well) you can join the [Discord channel](https://gatsby.dev/discord) to chat as more details on how to contribute will follow. Also, keep an eye out for the announcement post.
+The alpha of `gatsby-theme-i18n` and its child themes will be released very soon. Until then (and in the future, as well) you can join the [Discord channel](https://discord.gg/cQ2MPUz) to chat as more details on how to contribute will follow. Also, keep an eye out for the announcement post.
 
 I encourage all interested parties to try out the theme when it's ready and get involved in the process of refining it. And then show us the awesome things you build!

--- a/docs/blog/2020-07-13-i18n-pain-points/index.md
+++ b/docs/blog/2020-07-13-i18n-pain-points/index.md
@@ -9,7 +9,7 @@ tags:
 
 During Gatsby Days Reconfigured last month [we previewed quite a few exciting projects](/blog/2020-06-23-Reconfiguring-Gatsby-Days/) to be released soon. These launches are aimed at helping developers transition their CMSs into the headless CMS era; enabling content creators to use Gatsby more easily and intuitively; and, simultaneously, improving the developer experience for our current and future users. One of these exciting new announcements actually ties all three of these goals together: a sneak peek at the development of our own [i18n theme](/blog/2020-06-23-Reconfiguring-Gatsby-Days/#i18n-theme). It's the first step towards having internationalization in Gatsby as a first-class citizen, and we are looking to launch by the end of the month.
 
-First, though, we’d like to share the research process we’ve followed in developing the i18n theme, and the pain points we sought to solve. The goal in sharing these findings is to start an open discussion and invite your feedback. If you’re interested in contributing, please join the [Gatsby Discord channel](https://discord.gg/cQ2MPUz) and add your voice to the conversation!
+First, though, we’d like to share the research process we’ve followed in developing the i18n theme, and the pain points we sought to solve. The goal in sharing these findings is to start an open discussion and invite your feedback. If you’re interested in contributing, please join the [Gatsby Discord channel](https://gatsby.dev/discord) and add your voice to the conversation!
 
 ## Why i18n?
 
@@ -23,7 +23,7 @@ As lead engineer on the Gatsby i18n initiative, I knew right from the start that
 
 Currently, high level pain points for our users are that they often have to choose between multiple plugins and then implement everything on their own. Scalability also presents a challenge, because having your site in two languages already doubles your page count. There are also numerous more specific issues affecting users seeking to implement i18n with their Gatsby sites or apps.
 
-This is a non-exhaustive list of issues I most commonly read and heard. Feel free to share any other problems with me (on [Discord](https://discord.gg/cQ2MPUz)) that you see as important to the overall development of Gatsby’s i18n strategy!
+This is a non-exhaustive list of issues I most commonly read and heard. Feel free to share any other problems with me (on [Discord](https://gatsby.dev/discord)) that you see as important to the overall development of Gatsby’s i18n strategy!
 
 1. **Generating separate pages for each locale requires greater effort and knowledge from the user than usual.** Passing around the necessary information via `pageContext`, creating new pages from existing ones, and creating some sort of config to control that is complicated. There are some pitfalls when using the `onCreatePage` API and `pageContext` that might lead to unexpected errors or performance degradation.
 
@@ -56,6 +56,6 @@ Most importantly the great variety of responses received thus far showed that ou
 
 ## What's next?
 
-The alpha of `gatsby-theme-i18n` and its child themes will be released very soon. Until then (and in the future, as well) you can join the [Discord channel](https://discord.gg/cQ2MPUz) to chat as more details on how to contribute will follow. Also, keep an eye out for the announcement post.
+The alpha of `gatsby-theme-i18n` and its child themes will be released very soon. Until then (and in the future, as well) you can join the [Discord channel](https://gatsby.dev/discord) to chat as more details on how to contribute will follow. Also, keep an eye out for the announcement post.
 
 I encourage all interested parties to try out the theme when it's ready and get involved in the process of refining it. And then show us the awesome things you build!

--- a/docs/blog/2020-07-28-introducing-gatsby-i18n-theme/index.md
+++ b/docs/blog/2020-07-28-introducing-gatsby-i18n-theme/index.md
@@ -128,7 +128,7 @@ Time will tell what parts can be ported over to Gatsby’s codebase and what nee
 
 ### Why a theme and not a plugin?
 
-Composability is a major consideration for “Themes” and it should probably be more clear that you should work on top of it rather than it being a one-fits/one-click solution. We also might need to make use of `gatsby-config.js`which can only be used in a theme package.
+Composability is a major consideration for “Themes” and it should probably be more clear that you should work on top of it rather than it being a one-fits/one-click solution. We also might need to make use of `gatsby-config.js` which can only be used in a theme package.
 
 ### Can I use i18n library X with this theme?
 
@@ -146,4 +146,4 @@ We love our community and thus want to encourage all users to try the theme out.
 
 Since i18n is not only about the tooling but also processes we’re also interested in knowing how our users want to approach it from an organizational standpoint, e.g. wanting to create multiple sites or having everything in one project.
 
-If you want to help us and give us direct feedback, you can join this [Discord channel](https://gatsby.dev/discord).
+If you want to help us and give us direct feedback, you can join this [Discord channel](https://discord.gg/cQ2MPUz).

--- a/docs/blog/2020-07-28-introducing-gatsby-i18n-theme/index.md
+++ b/docs/blog/2020-07-28-introducing-gatsby-i18n-theme/index.md
@@ -77,23 +77,23 @@ And `de.json` with:
 Now you’re ready to localize content! Go to your `src/pages/index.js` file and reference the JSON files you just created. Import `useIntl` from `react-intl` and translate `Hello World`:
 
 ```diff:title=src/pages/index.js
-import * as React from "react"
-import { graphql } from "gatsby"
-import { LocalizedLink, LocalesList } from "gatsby-theme-i18n"
+  import * as React from "react"
+  import { graphql } from "gatsby"
+  import { LocalizedLink, LocalesList } from "gatsby-theme-i18n"
 + import { useIntl } from "react-intl"
-import Layout from "../components/layout"
-import SEO from "../components/seo"
+  import Layout from "../components/layout"
+  import SEO from "../components/seo"
 
-const Index = ({ data }) => {
-+  const intl = useIntl()
-  return (
-    <Layout>
-      <SEO title="Home" />
-+      <h1>{intl.formatMessage({ id: "helloWorld" })}</h1>
-      <p>This is in the Index page.</p>
+  const Index = ({ data }) => {
++   const intl = useIntl()
+    return (
+      <Layout>
+        <SEO title="Home" />
++       <h1>{intl.formatMessage({ id: "helloWorld" })}</h1>
+        <p>This is in the Index page.</p>
 ```
 
-After starting the development server, visit `localhost:8000` and `localhost:8000/de/` to see both texts.
+After starting the development server, visit `http://localhost:8000` and `http://localhost:8000/de/` to see both texts.
 
 ## FAQs
 
@@ -128,7 +128,7 @@ Time will tell what parts can be ported over to Gatsby’s codebase and what nee
 
 ### Why a theme and not a plugin?
 
-Composability is a major consideration for “Themes” and it should probably be more clear that you should work on top of it rather than it being a one-fits/one-click solution. We also might need to make use of gatsby-config.js which can only be used in a theme package.
+Composability is a major consideration for “Themes” and it should probably be more clear that you should work on top of it rather than it being a one-fits/one-click solution. We also might need to make use of `gatsby-config.js`which can only be used in a theme package.
 
 ### Can I use i18n library X with this theme?
 
@@ -146,4 +146,4 @@ We love our community and thus want to encourage all users to try the theme out.
 
 Since i18n is not only about the tooling but also processes we’re also interested in knowing how our users want to approach it from an organizational standpoint, e.g. wanting to create multiple sites or having everything in one project.
 
-If you want to help us and give us direct feedback, you can join this [Discord channel](https://discord.gg/cQ2MPUz).
+If you want to help us and give us direct feedback, you can join this [Discord channel](https://gatsby.dev/discord).


### PR DESCRIPTION
## Description

changes:
- use gatsby.dev/discord for links
- file name in code fences
- fix indention for diff code block
- `localhost` -> `http://localhost`


## Related Issues

- #26065 `chore(blog): Add i18n theme blog post`