### PR TITLE
Support https and custom certs on gatsby serve

### DIFF
--- a/integration-tests/gatsby-cli/__tests__/serve.js
+++ b/integration-tests/gatsby-cli/__tests__/serve.js
@@ -1,0 +1,96 @@
+import { GatsbyCLI } from "../test-helpers"
+
+const timeout = seconds =>
+  new Promise(resolve => {
+    setTimeout(resolve, seconds * 1000)
+  })
+
+const MAX_TIMEOUT = 2147483647
+jest.setTimeout(MAX_TIMEOUT)
+
+describe(`gatsby serve`, () => {
+  const cwd = `gatsby-sites/gatsby-develop`
+
+  beforeAll(async () => {
+    await GatsbyCLI.from(cwd).invoke(`clean`)
+    await GatsbyCLI.from(cwd).invoke(`build`)
+  })
+  afterAll(() => GatsbyCLI.from(cwd).invoke(`clean`))
+
+  it(`starts a gatsby server on port 9000`, async () => {
+    // 1. Start the `gatsby serve` command
+    const [childProcess, getLogs] = GatsbyCLI.from(cwd).invokeAsync(
+      `serve`,
+      log => log.includes(`http://localhost:9000/`)
+    )
+
+    // // 2. kill the `gatsby serve` command so we can get logs
+    await childProcess
+
+    // 3. Make sure logs for the user contain expected results
+    const logs = getLogs()
+    logs.should.contain(
+      `You can now view gatsby-starter-default-develop in the browser.`
+    )
+    logs.should.contain(` http://localhost:9000/`)
+  })
+
+  it(`starts a gatsby site on port 9001 with -p 9001`, async () => {
+    // 1. Start the `gatsby serve` command
+    const [childProcess, getLogs] = GatsbyCLI.from(cwd).invokeAsync(
+      [`serve`, `-p9001`],
+      log => log.includes(`http://localhost:9001/`)
+    )
+
+    // // 2. kill the `gatsby serve` command so we can get logs
+    await childProcess
+
+    // 3. Make sure logs for the user contain expected results
+    const logs = getLogs()
+    logs.should.contain(
+      `You can now view gatsby-starter-default-develop in the browser.`
+    )
+    logs.should.contain(` http://localhost:9001/`)
+  })
+
+  it.skip(`starts a gatsby site at a different host with --host`, async () => {
+    // TODO: figure out how to deal with EADDRNOTAVAIL when express starts with a hostname
+    // 1. Start the `gatsby serve` command
+    const [childProcess, getLogs] = GatsbyCLI.from(cwd).invokeAsync(
+      [`serve`, `--host=not.localhost.com`],
+      log => log.includes(`http://not.localhost.com:9000/`)
+    )
+
+    // // 2. kill the `gatsby serve` command so we can get logs
+    await childProcess
+
+    // 3. Make sure logs for the user contain expected results
+    const logs = getLogs()
+    logs.should.contain(
+      `You can now view gatsby-starter-default-develop in the browser.`
+    )
+    logs.should.contain(` http://not.localhost.com:9000/`)
+  })
+
+  it(`starts a gatsby site with ssl using --https`, async () => {
+    // 1. Start the `gatsby serve` command
+    const [childProcess, getLogs] = GatsbyCLI.from(cwd).invokeAsync(
+      [`serve`, `--https`],
+      log => log.includes(`https://localhost:9000/`)
+    )
+
+    // // 2. kill the `gatsby serve` command so we can get logs
+    await childProcess
+
+    // 3. Make sure logs for the user contain expected results
+    const logs = getLogs()
+    logs.should.contain(
+      `You can now view gatsby-starter-default-develop in the browser.`
+    )
+    logs.should.contain(` https://localhost:9000/`)
+  })
+
+  it.skip(`starts a gatsby site with cert file using -c`, () => {})
+  it.skip(`starts a gatsby site with key file using -k`, () => {})
+  it.skip(`starts a gatsby site with -open-tracing-config-file`, () => {})
+})

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -116,6 +116,7 @@ At the root of a Gatsby app run `gatsby serve` to serve the production build of 
 |  `-p`, `--port`  | Set port. Defaults to 9000                                                               |                               |
 |  `-o`, `--open`  | Open the site in your (default) browser for you                                          |                               |
 | `--prefix-paths` | Serve site with link paths prefixed (if built with pathPrefix in your gatsby-config.js). | `env.PREFIX_PATHS` or `false` |
+| `-S`, `--https`  | Use HTTPS                                                                                |                               |
 
 For prefixing paths, most will want to use the CLI flag (`gatsby build --prefix-paths`). For environments where you can't pass the --prefix-paths flag (ie Gatsby Cloud),the environment variable `PREFIX_PATHS` can be set to `true` to provide another way to prefix paths.
 

--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -268,6 +268,28 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
           type: `boolean`,
           describe: `Open the site in your (default) browser for you.`,
         })
+        .option(`S`, {
+          alias: `https`,
+          type: `boolean`,
+          describe: `Use HTTPS. See https://www.gatsbyjs.org/docs/local-https/ as a guide`,
+        })
+        .option(`c`, {
+          alias: `cert-file`,
+          type: `string`,
+          default: ``,
+          describe: `Custom HTTPS cert file (also required: --https, --key-file). See https://www.gatsbyjs.org/docs/local-https/`,
+        })
+        .option(`k`, {
+          alias: `key-file`,
+          type: `string`,
+          default: ``,
+          describe: `Custom HTTPS key file (also required: --https, --cert-file). See https://www.gatsbyjs.org/docs/local-https/`,
+        })
+        .option(`ca-file`, {
+          type: `string`,
+          default: ``,
+          describe: `Custom HTTPS CA certificate file (also required: --https, --cert-file, --key-file).  See https://www.gatsbyjs.org/docs/local-https/`,
+        })
         .option(`prefix-paths`, {
           type: `boolean`,
           default:


### PR DESCRIPTION
## Description

Allows serving static gatsby site via https with custom ssl certificates.

- [ ]  Get integration tests working

### Documentation
Added to gatsby-cli README 

## Related Issues

fixes: #8463
