### PR TITLE
feat(gatsby-image): Art Direction SSR fix (compliments hydration fix PR)

### DIFF
--- a/packages/gatsby-image/src/art-direction.js
+++ b/packages/gatsby-image/src/art-direction.js
@@ -1,0 +1,75 @@
+import React from "react"
+import GatsbyImage from "index"
+
+const isBrowser = typeof window !== `undefined`
+
+// DJB2a (XOR variant) is a simple hashing function, reduces input to 32-bits
+// Same hashing algorithm as used by `styled-components`.
+const SEED = 5381
+function djb2a(str) {
+  let hash = SEED
+
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i)
+  }
+
+  // Cast to 32-bit uint
+  return hash >>> 0
+}
+
+// Converts string input to a 32-bit base36 string (0-9, a-z)
+// '_' prefix to prevent invalid first chars for CSS class names
+const getShortKey = input => `_` + djb2a(input).toString(36)
+
+// Creates the `<style>` element to support media queries.
+// `emotion` does similar with `<style>`, it is not HTML5 spec compliant,
+// however web browsers do support using `<style>` outside of `<head>`.
+const ResponsiveQueries = ({ imageVariants, selectorClass }) => {
+  const variantRule = ({ width, height, aspectRatio }) => {
+    // '!important' required due to overriding inline styles
+    // 'aspectRatio' == fluid data
+    const styleOverride = aspectRatio
+      ? `padding-bottom: ${100 / aspectRatio}% !important;`
+      : `width: ${width}px !important; height: ${height}px !important;`
+
+    return `.${selectorClass} { ${styleOverride} }`
+  }
+
+  // If there is an image without a `media` condition, the first result
+  // is used as the base style.
+  const base = variantRule(imageVariants.find(v => !v.media))
+  return (
+    <>
+      {base && <style>{base}</style>}
+      {imageVariants
+        .filter(v => v.media)
+        .map(v => (
+          <style media={v.media}>{variantRule(v)}</style>
+        ))}
+    </>
+  )
+}
+
+// Supports Art Direction feature with `<style>` CSS media queries
+// to correctly render image variant dimensions until React is ready.
+const withArtDirection = props => {
+  const { className, ...rest } = props
+  const cn = className ? `${className}` : ``
+
+  const imageVariants = props.fluid || props.fixed
+  const uniqueKey = !isBrowser
+    ? getShortKey(imageVariants.map(v => v.srcSet).join(``))
+    : ``
+
+  return (
+    <>
+      <ResponsiveQueries
+        imageVariants={imageVariants}
+        selectorClass={uniqueKey}
+      />
+      <GatsbyImage {...rest} className={`${uniqueKey} ${cn}`} />
+    </>
+  )
+}
+
+export default withArtDirection

--- a/packages/gatsby-image/src/art-direction.js
+++ b/packages/gatsby-image/src/art-direction.js
@@ -44,7 +44,9 @@ const ResponsiveQueries = ({ imageVariants, selectorClass }) => {
       {imageVariants
         .filter(v => v.media)
         .map(v => (
-          <style media={v.media}>{variantRule(v)}</style>
+          <style key={`${selectorClass}-${v.media}`} media={v.media}>
+            {variantRule(v)}
+          </style>
         ))}
     </>
   )

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -544,6 +544,7 @@ class Image extends React.Component {
       ? imageVariants[0]
       : getCurrentSrcData(imageVariants)
 
+    const activeVariant = getShortKey(image.srcSet)
     const uniqueKey = this.uniqueKey
 
     if (fluid) {
@@ -560,7 +561,7 @@ class Image extends React.Component {
             ...style,
           }}
           ref={this.handleRef}
-          key={`fluid-${JSON.stringify(image.srcSet)}`}
+          key={activeVariant}
         >
           {uniqueKey && (
             <ResponsiveQueries
@@ -681,7 +682,7 @@ class Image extends React.Component {
           } gatsby-image-wrapper`}
           style={divStyle}
           ref={this.handleRef}
-          key={`fixed-${JSON.stringify(image.srcSet)}`}
+          key={activeVariant}
         >
           {uniqueKey && (
             <ResponsiveQueries


### PR DESCRIPTION
## Description

Complimentary PR to [`gatsby-image` hydration fix](https://github.com/gatsbyjs/gatsby/pull/26097), this larger PR fixes the issue prior to React being available while loading HTML. 

If additional details about lines are needed, check individual commits for extra details or logical grouping.

## Notes

#### Potential changes up for discussion
As media queries cannot be inline styles, `<style>` elements are used within `<body>`(unless there is an API to add to `<head>`?), or rather each `gatsby-image` component instance. These are removed once React hydrates, so only valid in SSR output. Could change that if there's value in keeping around in the client?

The hash could also be used for cache keys instead of `img.src` if any value in that. 

#### Hash function implementation

The hash method DJB2a which is the same as what `styled-components` uses should be fine, there isn't any expectation for the results to be compatible with other DJB2a implementations, which might happen if the filepath strings contain chars that exceed a single byte(some languages, emoji, etc), that can be supported if desired but requires more code and adds perf overhead.

Further related details in my original PR comments:

- Originally considered/implemented base64 and FNV1a-32 before DJB2a for short CSS classes: https://github.com/gatsbyjs/gatsby/pull/24811#issuecomment-654543710
- DJB2a implementation notes, benchmark tests, etc: https://github.com/gatsbyjs/gatsby/pull/24811#issuecomment-654589043

#### `<noscript>` support not added

<details>
<summary>Old comments</summary>

This has not presently catered for `<noscript>`, which if desired, I'll revert to a previous `ResponsiveQueries` components in my original PR that used string concatenation with all CSS in a single `<style>` instead of one `<style>` per media condition + fallback/base. 

There is presently a PR actively discussing if `<noscript>` logic can be changed to drop the string variants supporting it without bumping the min React to 16.5+, or we can alternatively hold off until a v3 with breaking changes. 

Let me know if catering to `<noscript>` is presently worth the time(it's already partly out of sync IIRC).
</details>

**EDIT:** Shouldn't actually be a problem since this is only relevant for the SSR payload, and targets the root tag of the component.

#### Not exactly HTML spec compliant, but other popular packages use same approach

While browsers support this approach(and that libraries like Emotion apparently use this technique), `<style>` elements within body is technically against spec, and thus may be flagged if anyone has some CI / validation checks on HTML spec conformance. 

There's not much we can do about this without some SSR API improvements, or adopting some CSS-in-JS library.

Prior comment in original PR about `<style>` approach considerations: https://github.com/gatsbyjs/gatsby/pull/24811#issuecomment-643844535

## Related Issues

Related: https://github.com/gatsbyjs/gatsby/issues/24748#issuecomment-650181549

> While this kinda works, it results in a flash of the wrong image until the JS kicks in. If the `paddingBottom` was determined via media queries instead that would eliminate the issue.

Related: https://github.com/gatsbyjs/gatsby/pull/24811 (Original PR)