### PR TITLE
feat(gatsby-image): Responsive Art Direction

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -365,6 +365,31 @@ class Image extends React.Component {
     this.placeholderRef = props.placeholderRef || React.createRef()
     this.handleImageLoaded = this.handleImageLoaded.bind(this)
     this.handleRef = this.handleRef.bind(this)
+
+    // Supports Art Direction feature to correctly render image variants
+    const imageVariants = props.fluid || props.fixed
+    if (hasArtDirectionSupport(imageVariants)) {
+      // When image variant changes, adapt via render immediately instead of delaying
+      // until new image request triggers 'onload' event.
+      // Can be verified on 'slow 3G' with no initial cache.
+      if (isBrowser) {
+        this.handleVariantChange = this.handleVariantChange.bind(this)
+        const base = imageVariants.find(v => !v.media)
+
+        this.mq = { base }
+        this.mq.queries = imageVariants.filter(v => v.media)
+        this.mq.queries.forEach(v => {
+          this.mq[v.media] = v
+          const mql = window.matchMedia(v.media)
+          if (mql.addEventListener) {
+            mql.addEventListener(`change`, this.handleVariantChange)
+          } else {
+            // Deprecated 'MediaQueryList' API, <Safari 14, IE, <Edge 16
+            mql.addListener(this.handleVariantChange)
+          }
+        })
+      }
+    }
   }
 
   componentDidMount() {
@@ -429,6 +454,22 @@ class Image extends React.Component {
     if (this.props.onLoad) {
       this.props.onLoad()
     }
+  }
+
+  // 'window.matchMedia()' events on image variants media conditions.
+  // If variant is not in image cache when triggered, resets the image
+  // loading state so that the placeholder is visible instead of blank.
+  handleVariantChange(e) {
+    const match =
+      (e.matches && this.mq[e.media]) ||
+      this.mq.queries.find(matchesMedia) ||
+      this.mq.base
+
+    this.seenBefore = imageCache[match.src]
+    this.setState({
+      imgLoaded: this.seenBefore,
+      imgCached: this.seenBefore,
+    })
   }
 
   render() {

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -449,7 +449,9 @@ class Image extends React.Component {
   handleImageLoaded() {
     activateCacheForImage(this.props)
 
-    this.setState({ imgLoaded: true })
+    if (!this.state.imgLoaded) {
+      this.setState({ imgLoaded: true })
+    }
 
     if (this.props.onLoad) {
       this.props.onLoad()

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -87,7 +87,7 @@ const getImageCacheKey = ({ fluid, fixed }) => {
  * @return {{src: string, media?: string, maxWidth?: Number, maxHeight?: Number}}
  */
 const getCurrentSrcData = currentData => {
-  if (isBrowser && hasArtDirectionSupport(currentData)) {
+  if (this.isArtDirected) {
     // Do we have an image for the current Viewport?
     const foundMedia = currentData.findIndex(matchesMedia)
     if (foundMedia !== -1) {
@@ -368,28 +368,26 @@ class Image extends React.Component {
 
     // Supports Art Direction feature to correctly render image variants
     const imageVariants = props.fluid || props.fixed
-    this.isArtDirected = hasArtDirectionSupport(imageVariants)
+    this.isArtDirected = isBrowser && hasArtDirectionSupport(imageVariants)
     if (this.isArtDirected) {
       // When image variant changes, adapt via render immediately instead of delaying
       // until new image request triggers 'onload' event.
       // Can be verified on 'slow 3G' with no initial cache.
-      if (isBrowser) {
-        this.handleVariantChange = this.handleVariantChange.bind(this)
-        const base = imageVariants.find(v => !v.media)
+      this.handleVariantChange = this.handleVariantChange.bind(this)
+      const base = imageVariants.find(v => !v.media)
 
-        this.mq = { base }
-        this.mq.queries = imageVariants.filter(v => v.media)
-        this.mq.queries.forEach(v => {
-          this.mq[v.media] = v
-          const mql = window.matchMedia(v.media)
-          if (mql.addEventListener) {
-            mql.addEventListener(`change`, this.handleVariantChange)
-          } else {
-            // Deprecated 'MediaQueryList' API, <Safari 14, IE, <Edge 16
-            mql.addListener(this.handleVariantChange)
-          }
-        })
-      }
+      this.mq = { base }
+      this.mq.queries = imageVariants.filter(v => v.media)
+      this.mq.queries.forEach(v => {
+        this.mq[v.media] = v
+        const mql = window.matchMedia(v.media)
+        if (mql.addEventListener) {
+          mql.addEventListener(`change`, this.handleVariantChange)
+        } else {
+          // Deprecated 'MediaQueryList' API, <Safari 14, IE, <Edge 16
+          mql.addListener(this.handleVariantChange)
+        }
+      })
     }
   }
 

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -368,7 +368,8 @@ class Image extends React.Component {
 
     // Supports Art Direction feature to correctly render image variants
     const imageVariants = props.fluid || props.fixed
-    if (hasArtDirectionSupport(imageVariants)) {
+    this.isArtDirected = hasArtDirectionSupport(imageVariants)
+    if (this.isArtDirected) {
       // When image variant changes, adapt via render immediately instead of delaying
       // until new image request triggers 'onload' event.
       // Can be verified on 'slow 3G' with no initial cache.
@@ -393,9 +394,12 @@ class Image extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({
-      isHydrated: isBrowser,
-    })
+    // Should only be required internally for supporting Art Direction
+    if (this.isArtDirected) {
+      this.setState({
+        isHydrated: isBrowser,
+      })
+    }
 
     if (this.state.isVisible && typeof this.props.onStartLoad === `function`) {
       this.props.onStartLoad({ wasCached: inImageCache(this.props) })

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -468,6 +468,11 @@ class Image extends React.Component {
       this.mq.base
 
     this.seenBefore = imageCache[match.src]
+
+    if (this.state.isVisible && typeof this.props.onStartLoad === `function`) {
+      this.props.onStartLoad({ wasCached: this.seenBefore })
+    }
+
     this.setState({
       imgLoaded: this.seenBefore,
       imgCached: this.seenBefore,


### PR DESCRIPTION
## Description

Presently, a render is triggered from an `onload` event calling `handleImageLoaded()` and fluid type `aspectRatio` or fixed type `width` & `height` state values for CSS are only updated to the new variant after it's loaded.

Placeholder lazy loading state is also not reset as the component isn't aware of when loading a new variant begins. If the image variant is cached, there is still a delay with the `onload` event until the image request has returned a response from the server; a noticeable delay on high latency connections - breaking layout (as the content/component has not been updated yet to fit the new breakpoint).

`matchMedia()` resolves that. We can then detect if the image has been cached internally and then trigger a render which might leverage browser cache detection, otherwise reset the lazy load placeholder behavior.

See individual commits for more logical grouping and further details related to those additions.

May need to rebase after the following PRs are merged:
- [x] Dependent on https://github.com/gatsbyjs/gatsby/pull/26118 to pass tests.
- [x] Implements a related conditional as [this PR](https://github.com/gatsbyjs/gatsby/pull/26117).

My "deprecated" comment for [`MediaQueryListListener`](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryListListener)(note, modern browsers alias this for now) is not quite correct, [MDN encourages using the newer standard event mechanism](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener), the older non-standard API is kept by browsers for backward compatibility. A newer version of Safari that's to be released this year will also [support the newer API](https://github.com/microsoft/TypeScript/issues/32210#issuecomment-652745256). [MDN browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#Browser_compatibility)

## Related Issues

Originally implemented [in this PR](https://github.com/gatsbyjs/gatsby/pull/24811#issuecomment-657387494), which has been split out into several smaller ones.