### PR TITLE
chore(gatsby-admin): move sitemap to /pages

### DIFF
--- a/packages/gatsby-admin/src/pages/index.tsx
+++ b/packages/gatsby-admin/src/pages/index.tsx
@@ -5,7 +5,6 @@ import { Spinner } from "theme-ui"
 import { useQuery, useMutation } from "urql"
 import {
   Heading,
-  HeadingProps,
   Text,
   DropdownMenu,
   DropdownMenuButton,
@@ -13,10 +12,6 @@ import {
   DropdownMenuItems,
 } from "gatsby-interface"
 import PluginSearchBar from "../components/plugin-search"
-
-const SectionHeading: React.FC<HeadingProps> = props => (
-  <Heading as="h1" sx={{ fontWeight: `500`, fontSize: 5 }} {...props} />
-)
 
 const PluginCard: React.FC<{
   plugin: { name: string; description?: string }
@@ -88,14 +83,6 @@ const Index: React.FC<{}> = () => {
   const [{ data, fetching, error }] = useQuery({
     query: `
       {
-        allGatsbyPage {
-          nodes {
-            path
-            pluginCreator {
-              name
-            }
-          }
-        }
         allGatsbyPlugin {
           nodes {
             name
@@ -123,36 +110,13 @@ const Index: React.FC<{}> = () => {
   return (
     <Flex gap={8} flexDirection="column" sx={{ paddingY: 7, paddingX: 6 }}>
       <Flex gap={6} flexDirection="column">
-        <SectionHeading>Pages</SectionHeading>
-        <ul sx={{ pl: 0, listStyle: `none` }}>
-          {data.allGatsbyPage.nodes
-            .filter(page => page.path.indexOf(`/dev-404-page/`) !== 0)
-            .sort((a, b) => a.path.localeCompare(b.path))
-            .map(page => (
-              <li key={page.path} sx={{ p: 0 }}>
-                <Flex
-                  flexDirection="column"
-                  gap={3}
-                  sx={{
-                    backgroundColor: `ui.background`,
-                    padding: 5,
-                    borderRadius: 2,
-                  }}
-                >
-                  <Heading as="h3">{page.path}</Heading>
-                  <Text sx={{ color: `text.secondary` }}>
-                    Source: {page.pluginCreator.name}
-                  </Text>
-                </Flex>
-              </li>
-            ))}
-        </ul>
-      </Flex>
-
-      <Flex gap={6} flexDirection="column">
-        <SectionHeading id="plugin-search-label">
+        <Heading
+          as="h1"
+          sx={{ fontWeight: `500`, fontSize: 5 }}
+          id="plugin-search-label"
+        >
           Installed Plugins
-        </SectionHeading>
+        </Heading>
         <Grid gap={6} columns={[1, 1, 1, 2, 3]}>
           {data.allGatsbyPlugin.nodes.map(plugin => (
             <PluginCard key={plugin.id} plugin={plugin} />

--- a/packages/gatsby-admin/src/pages/pages.tsx
+++ b/packages/gatsby-admin/src/pages/pages.tsx
@@ -1,0 +1,69 @@
+/* @jsx jsx */
+import { jsx, Flex } from "strict-ui"
+import { useQuery } from "urql"
+import { Spinner } from "theme-ui"
+import { Heading, Text } from "gatsby-interface"
+import { FC } from "react"
+
+const Pages: FC<{}> = () => {
+  const [{ data, fetching, error }] = useQuery({
+    query: `
+      {
+        allGatsbyPage {
+          nodes {
+            path
+            pluginCreator {
+              name
+            }
+          }
+        }
+      }
+    `,
+  })
+
+  if (fetching) return <Spinner />
+
+  if (error) {
+    const errMsg =
+      (error.networkError && error.networkError.message) ||
+      (Array.isArray(error.graphQLErrors) &&
+        error.graphQLErrors.map(e => e.message).join(` | `))
+
+    return <p>Error: {errMsg}</p>
+  }
+
+  return (
+    <Flex gap={8} flexDirection="column" sx={{ paddingY: 7, paddingX: 6 }}>
+      <Flex gap={6} flexDirection="column">
+        <Heading as="h1" sx={{ fontWeight: `500`, fontSize: 5 }}>
+          Pages
+        </Heading>
+        <ul sx={{ pl: 0, listStyle: `none` }}>
+          {data.allGatsbyPage.nodes
+            .filter(page => page.path.indexOf(`/dev-404-page/`) !== 0)
+            .sort((a, b) => a.path.localeCompare(b.path))
+            .map(page => (
+              <li key={page.path} sx={{ p: 0 }}>
+                <Flex
+                  flexDirection="column"
+                  gap={3}
+                  sx={{
+                    backgroundColor: `ui.background`,
+                    padding: 5,
+                    borderRadius: 2,
+                  }}
+                >
+                  <Heading as="h3">{page.path}</Heading>
+                  <Text sx={{ color: `text.secondary` }}>
+                    Source: {page.pluginCreator.name}
+                  </Text>
+                </Flex>
+              </li>
+            ))}
+        </ul>
+      </Flex>
+    </Flex>
+  )
+}
+
+export default Pages


### PR DESCRIPTION
This moves the list of pages to a hidden page at /pages:

<img width="1178" alt="Screenshot 2020-07-30 at 06 55 36" src="https://user-images.githubusercontent.com/7525670/88882210-b92a2980-d231-11ea-969c-83c8d4461eee.png">
<img width="1178" alt="Screenshot 2020-07-30 at 06 55 40" src="https://user-images.githubusercontent.com/7525670/88882213-ba5b5680-d231-11ea-8805-5d446779e661.png">
