### PR TITLE
fix(gatsby): Resolve node mutations in waiting state

### DIFF
--- a/packages/gatsby/src/services/run-mutation-batch.ts
+++ b/packages/gatsby/src/services/run-mutation-batch.ts
@@ -1,20 +1,5 @@
-import { IMutationAction } from "../state-machines/data-layer/types"
-import { Store, AnyAction } from "redux"
-import { IGatsbyState } from "../redux/types"
 import { IWaitingContext } from "../state-machines/waiting/types"
-import { assertStore } from "../utils/assert-store"
-import { actions } from "../redux/actions"
-
-const callRealApi = (
-  event: IMutationAction,
-  store?: Store<IGatsbyState, AnyAction>
-): void => {
-  assertStore(store)
-  const { type, payload } = event
-  if (type in actions) {
-    store.dispatch(actions[type](...payload))
-  }
-}
+import { callRealApi } from "../utils/call-deferred-api"
 
 // Consume the entire batch and run actions
 export const runMutationBatch = async ({

--- a/packages/gatsby/src/state-machines/develop/actions.ts
+++ b/packages/gatsby/src/state-machines/develop/actions.ts
@@ -6,39 +6,15 @@ import {
   ActionFunctionMap,
   DoneEventObject,
 } from "xstate"
-import { Store } from "redux"
-import { IBuildContext, IMutationAction } from "../../services"
-import { actions, boundActionCreators } from "../../redux/actions"
+import { IBuildContext } from "../../services"
+import { boundActionCreators } from "../../redux/actions"
 import { listenForMutations } from "../../services/listen-for-mutations"
 import { DataLayerResult } from "../data-layer"
-import { assertStore } from "../../utils/assert-store"
 import { saveState } from "../../db"
 import reporter from "gatsby-cli/lib/reporter"
 import { ProgramStatus } from "../../redux/types"
 import { createWebpackWatcher } from "../../services/listen-to-webpack"
-
-/**
- * These are the deferred redux actions sent from api-runner-node
- * They may include a `resolve` prop (if they are createNode actions).
- * If so, we resolve the promise when we're done
- */
-export const callRealApi = (event: IMutationAction, store?: Store): void => {
-  assertStore(store)
-  const { type, payload, resolve } = event
-  if (type in actions) {
-    // If this is a createNode action then this will be a thunk.
-    // No worries, we just dispatch it like any other
-    const action = actions[type](...payload)
-    const result = store.dispatch(action)
-    // Somebody may be waiting for this
-    if (resolve) {
-      resolve(result)
-    }
-  } else {
-    reporter.log(`Could not dispatch unknown action "${type}`)
-  }
-}
-
+import { callRealApi } from "../../utils/call-deferred-api"
 /**
  * Handler for when we're inside handlers that should be able to mutate nodes
  * Instead of queueing, we call it right away

--- a/packages/gatsby/src/utils/call-deferred-api.ts
+++ b/packages/gatsby/src/utils/call-deferred-api.ts
@@ -1,0 +1,26 @@
+import { assertStore } from "./assert-store"
+import { Store } from "redux"
+import { IMutationAction } from "../services"
+import { actions } from "../redux/actions"
+import reporter from "gatsby-cli/lib/reporter"
+/**
+ * These are the deferred redux actions sent from api-runner-node
+ * They may include a `resolve` prop (if they are createNode actions).
+ * If so, we resolve the promise when we're done
+ */
+export const callRealApi = (event: IMutationAction, store?: Store): void => {
+  assertStore(store)
+  const { type, payload, resolve } = event
+  if (type in actions) {
+    // If this is a createNode action then this will be a thunk.
+    // No worries, we just dispatch it like any other
+    const action = actions[type](...payload)
+    const result = store.dispatch(action)
+    // Somebody may be waiting for this
+    if (resolve) {
+      resolve(result)
+    }
+  } else {
+    reporter.log(`Could not dispatch unknown action "${type}`)
+  }
+}


### PR DESCRIPTION
There are two places where the node mutation queue is drained. Previously there were two versions of the callRealApi function that performed the actual call, once of which didn't include promise resolution. This was an oversight, and caused a bug where createNode called triggered during waiting never resolved. This PR moves the function to a shared util.