### PR TITLE
fix(docs): css-framworks: fix brand name

### DIFF
--- a/docs/docs/other-css-frameworks.md
+++ b/docs/docs/other-css-frameworks.md
@@ -55,12 +55,12 @@ If you're interested in using Grommet, check out [Using Grommet with Gatsby (Hew
 - [Grommet repo on GitHub](https://github.com/grommet/grommet)
 - [Grommet component examples on Storybook](https://storybook.grommet.io/)
 
-## Material UI
+## Material-UI
 
-Material UI provides a library of components designed using Google's [Material Design guidelines](https://material.io/design/introduction). It also supports customizing theme elements like color, typography, and breakpoints.
+Material-UI provides a library of components designed using Google's [Material Design guidelines](https://material.io/design/introduction). It also supports customizing theme elements like color, typography, and breakpoints.
 
-If you're interested in using Material UI, check out the [`gatsby-plugin-material-ui` documentation](/packages/gatsby-plugin-material-ui).
+If you're interested in using Material-UI, check out the [`gatsby-plugin-material-ui` documentation](/packages/gatsby-plugin-material-ui).
 
-- [Material UI documentation](https://material-ui.com/)
-- [Material UI repo on GitHub](https://github.com/mui-org/material-ui)
-- [Material UI example projects](https://material-ui.com/getting-started/example-projects/)
+- [Material-UI documentation](https://material-ui.com/)
+- [Material-UI repo on GitHub](https://github.com/mui-org/material-ui)
+- [Material-UI example projects](https://material-ui.com/getting-started/example-projects/)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

changes:
- change `Material UI` to `Material-UI`

<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->


- #26087 `[docs][guides] other css frameworks`