### PR TITLE
Fix gatsby-plugin-mdx not running plugins on findImports(...)

### DIFF
--- a/packages/gatsby-plugin-mdx/utils/__tests__/fixtures/test-plugin.js
+++ b/packages/gatsby-plugin-mdx/utils/__tests__/fixtures/test-plugin.js
@@ -1,0 +1,14 @@
+function createImportAST(name, filePath) {
+  return {
+    type: `import`,
+    value: `import ${name} from '${filePath}'`,
+  }
+}
+
+module.exports = ({ markdownAST }) => {
+  markdownAST.children = [
+    createImportAST(`* as testInjection`, `@private/test-inject`),
+    ...markdownAST.children,
+  ]
+  return markdownAST
+}

--- a/packages/gatsby-plugin-mdx/utils/__tests__/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/__tests__/gen-mdx.js
@@ -1,0 +1,59 @@
+const path = require(`path`)
+const { findImports } = require(`../gen-mdx`)
+
+const markdownContent = `---
+title: Introduction
+---
+
+# Header 1
+## Header 2
+### Header 3
+
+\`\`\`js
+console.log('hello world')
+\`\`\`
+`
+
+describe(`find imports`, () => {
+  it(`allows injecting imports via plugins`, async () => {
+    const results = await findImports({
+      node: {
+        id: `bbffffbb-bfff-bfff-bfff-dededededede`,
+        children: [],
+        parent: `bbffffbb-bfff-bfff-bfff-dededededebb`,
+        internal: {
+          content: markdownContent,
+          type: `Mdx`,
+          contentDigest: `6433c536b5eb922ad01f8d420bcabf6d`,
+          counter: 38,
+          owner: `gatsby-plugin-mdx`,
+        },
+        frontmatter: { title: `Introduction` },
+        excerpt: undefined,
+        exports: {},
+        rawBody: markdownContent,
+        fileAbsolutePath: `/path/to/getting-started.mdx`,
+      },
+      options: {
+        remarkPlugins: [],
+        gatsbyRemarkPlugins: [
+          { resolve: path.join(__dirname, `fixtures`, `test-plugin`) },
+        ],
+      },
+      getNode: () => null,
+      getNodes: () => [],
+      getNodesByType: () => [],
+      repoter: () => {},
+      cache: () => {},
+      pathPrefix: ``,
+    })
+
+    expect(results).toEqual({
+      scopeImports: [
+        `import * as testInjection from '@private/test-inject'`,
+        `import * as React from 'react'`,
+      ],
+      scopeIdentifiers: [`testInjection`, `React`],
+    })
+  })
+})

--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -240,7 +240,8 @@ async function findImports({
     fileOpts.path = node.fileAbsolutePath
   }
 
-  const mdast = await compiler.parse(fileOpts)
+  let mdast = await compiler.parse(fileOpts)
+  mdast = await compiler.run(mdast)
 
   // Assuming valid code, identifiers must be unique (they are consts) so
   // we don't need to dedupe the symbols here.


### PR DESCRIPTION
## Description

This makes `findImports(...)` also run the `run(...)` phase from `unified`/`remark`. This is needed to allow plugins to inject ESM imports via AST modifications. I have also added a test to cover this use case.

### Documentation

#25437 broke a use case that I had a custom plugin for. Basically, I need to inject imports via a plugin to enable code demos.