### PR TITLE
chore(starters): add gatsby-starter-react-three-fiber-minimal

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6923,7 +6923,7 @@
     - Uses site metadata to populate About page
     - Resume page generated using template Markdown files
 - url: https://gatsby-starter-r3f-minimal.netlify.app/
-  repo: https://github.com/gatsby-starter-r3f-minimal
+  repo: https://github.com/WilliamOfSweden/gatsby-starter-r3f-minimal
   description: A barebones Gatsby starter with example React Three Fiber boilerplate.
   tags:
     - Onepage

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6923,7 +6923,7 @@
     - Uses site metadata to populate About page
     - Resume page generated using template Markdown files
 - url: https://gatsby-starter-r3f-minimal.netlify.app/
-  repo: https://github.com/WilliamOfSweden/gatsby-starter-r3f-minimal
+  repo: https://github.com/WilliamOfSweden/gatsby-starter-react-three-fiber-minimal
   description: A barebones Gatsby starter with example React Three Fiber boilerplate.
   tags:
     - Onepage

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -6922,3 +6922,13 @@
     - Blog posts page features a live filter tool
     - Uses site metadata to populate About page
     - Resume page generated using template Markdown files
+- url: https://gatsby-starter-r3f-minimal.netlify.app/
+  repo: https://github.com/gatsby-starter-r3f-minimal
+  description: A barebones Gatsby starter with example React Three Fiber boilerplate.
+  tags:
+    - Onepage
+    - Landing Page
+  features:
+    - Basic setup for React Three Fiber
+    - Styled Components
+    - Desktop and mobile responsive layout


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Pull request regarding adding a gatsby starter.

### Documentation
https://github.com/react-spring/react-three-fiber/blob/master/api.md
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
