### PR TITLE
chore: write fragments and schema to .cache directory

### DIFF
--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -16,6 +16,8 @@ import { markWebpackStatusAsPending } from "../utils/webpack-status"
 import { IProgram, IDebugInfo } from "./types"
 import { interpret } from "xstate"
 import { globalTracer } from "opentracing"
+import { writeFileSync } from "fs"
+import * as path from "path"
 import { developMachine } from "../state-machines/develop"
 import { logTransitions } from "../utils/state-machine-logging"
 
@@ -130,6 +132,29 @@ module.exports = async (program: IDevelopArgs): Promise<void> => {
   if (program.verbose) {
     logTransitions(service)
   }
+
+  const configJSONString = JSON.stringify(
+    {
+      schema: `./fullschema.graphql`,
+      documents: [`src/**/**.{ts,js,tsx,jsx,esm}`],
+      extensions: {
+        endpoints: {
+          default: {
+            url: `${program.https ? `https://` : `http://`}${program.host}:${
+              program.port
+            }/___graphql`,
+          },
+        },
+      },
+    },
+    null,
+    2
+  )
+
+  writeFileSync(
+    path.join(program.directory, `.cache`, `graphql-config.json`),
+    configJSONString
+  )
 
   service.start()
 }

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -1,9 +1,11 @@
 /* @flow */
-
+const fs = require(`fs`)
+const path = require(`path`)
 const tracer = require(`opentracing`).globalTracer()
 const { store } = require(`../redux`)
 const { getNodesByType, getTypes } = require(`../redux/nodes`)
 const { createSchemaComposer } = require(`./schema-composer`)
+const { printSchema } = require(`graphql`)
 const { buildSchema, rebuildSchemaWithSitePage } = require(`./schema`)
 const { builtInFieldExtensions } = require(`./extensions`)
 const { builtInTypeDefinitions } = require(`./types/built-in-types`)
@@ -96,6 +98,7 @@ const build = async ({ parentSpan, fullMetadataBuild = true }) => {
     schemaCustomization: { thirdPartySchemas, printConfig },
     inferenceMetadata,
     config: { mapping: typeMapping },
+    program,
   } = store.getState()
 
   const typeConflictReporter = new TypeConflictReporter()
@@ -124,7 +127,10 @@ const build = async ({ parentSpan, fullMetadataBuild = true }) => {
     type: `SET_SCHEMA`,
     payload: schema,
   })
-
+  fs.writeFileSync(
+    path.join(program.directory, `.cache`, `fullschema.graphql`),
+    printSchema(schema)
+  )
   span.finish()
 }
 


### PR DESCRIPTION
## Description

this writes a graphql config,  fragments and schema to file
further user config may be needed, for adding to the documents array

this allows us to support graphql-config, which means support for:
- vscode extension
- graphql codegen (for typescript definitions for queries)
- graphql eslint
- graphiql (eventually)

## Questions

- am I doing this in the right places? the schema one yields better results than the existing gatsby plugin for writing schema files.
- am I building paths correctly for our framework?
- am I building the url for graphiql correctly? what if there is a base path?

