### PR TITLE
fix(gatsby-recipes): Set node version for recipes babelrc to earliest supported version

### DIFF
--- a/packages/gatsby-recipes/.babelrc.json
+++ b/packages/gatsby-recipes/.babelrc.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/env", { "modules": false, "targets": { "node": "current" } }],
+    ["@babel/env", { "modules": false, "targets": { "node": "10.13.0" } }],
     "@babel/preset-react"
   ],
   "plugins": ["@babel/plugin-transform-runtime"]


### PR DESCRIPTION
`node: "current"` isn't what we wanted