### PR TITLE
Fixed precondition where it adds perma cache to .json files

### DIFF
--- a/docs/docs/deploying-to-iis.md
+++ b/docs/docs/deploying-to-iis.md
@@ -60,7 +60,7 @@ you have to be careful to copy any changes to `web.config` on your server back t
                   <add input="{REQUEST_FILENAME}" pattern="(.*\.html)|(sw\.js)|(app\-data\.json)|(page\-data\.json)" />
                 </preCondition>
                 <preCondition name="IsCachePermanentlyFile">
-                  <add input="{REQUEST_FILENAME}" pattern="(.*\.js)|(.*\.css)" />
+                  <add input="{REQUEST_FILENAME}" pattern="((.*\.js)|(.*\.css))$" />
                 </preCondition>
               </preConditions>
             </outboundRules>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I've deployed my gatsby site with this web.config with few changes and noticed that `.json` files in other locations are getting cached. Culprit for that was this line,

```xml
<add input="{REQUEST_FILENAME}" pattern="(.*\.js)|(.*\.css)" />
```

Since this regex does not detect end of line, it take `.json` files also as `.js` and add permanent cache header to it. Fix for it is add tracking end of line to `IsCachePermanentlyFile` pre-condition like this,

```
<add input="{REQUEST_FILENAME}" pattern="((.*\.js)|(.*\.css))$" />
```

Suggesting to fix this for future users like me. 😊

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

This an update to documentation itself which address an issue when tracks file caching using `web.config`.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

None
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
