### PR TITLE
Adds back peer dependency

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -88,6 +88,9 @@
     "yoga-layout-prebuilt": "^1.9.6",
     "yup": "^0.27.0"
   },
+  "peerDependencies": {
+    "react": "^16.12.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.10.3",
     "@babel/plugin-transform-runtime": "^7.0.0",


### PR DESCRIPTION
## Description

The peer dependency got removed in https://github.com/gatsbyjs/gatsby/pull/24595/files, but it's not clear why since it's still a mandatory dependency, so it being missing causes the resolution to fail, or generally be incorrect.

## Related Issues

https://github.com/yarnpkg/berry/runs/944500417