### PR TITLE
fix(gatsby): enable ipc messaging on develop

### DIFF
--- a/integration-tests/structured-logging/__tests__/ipc-send.js
+++ b/integration-tests/structured-logging/__tests__/ipc-send.js
@@ -1,0 +1,56 @@
+const { spawn } = require(`child_process`)
+const path = require(`path`)
+
+jest.setTimeout(20000) // 20s
+
+const gatsbyBin = path.join(
+  `node_modules`,
+  `gatsby`,
+  `dist`,
+  `bin`,
+  `gatsby.js`
+)
+
+describe(`IPC Send`, () => {
+  let gatsbyProcess
+
+  beforeAll(() => {
+    gatsbyProcess = spawn("node", [gatsbyBin, `develop`], {
+      stdio: [`ignore`, `ignore`, `ignore`, `ipc`],
+      env: {
+        ...process.env,
+        NODE_ENV: `development`,
+      },
+    })
+  })
+
+  afterAll(async () => {
+    gatsbyProcess.kill()
+  })
+
+  // TODO remove to a more global integration test but for now we want to make sure it gets an external send command
+  it(`should kill the develop process when exit command is given`, done => {
+    expect.assertions(1)
+    gatsbyProcess.on("exit", () => {
+      expect(true).toBe(true)
+      done()
+    })
+
+    let hasSentExitCode
+    gatsbyProcess.on("message", msg => {
+      if (hasSentExitCode) {
+        return
+      }
+
+      hasSentExitCode = true
+
+      gatsbyProcess.send({
+        type: "COMMAND",
+        action: {
+          type: "EXIT",
+          payload: "SIGINT",
+        },
+      })
+    })
+  })
+})

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -158,7 +158,7 @@ class ControllableScript {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   send(msg: any): void {
     if (!this.process) {
-      throw new Error(`Trying to attach exit handler before process started`)
+      throw new Error(`Trying to send a message before process started`)
     }
 
     this.process.send(msg)

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -155,6 +155,14 @@ class ControllableScript {
     }
     this.process.on(`exit`, callback)
   }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  send(msg: any): void {
+    if (!this.process) {
+      throw new Error(`Trying to attach exit handler before process starter`)
+    }
+
+    this.process.send(msg)
+  }
 }
 
 let isRestarting
@@ -368,6 +376,11 @@ module.exports = async (program: IProgram): Promise<void> => {
       })
     })
   }
+
+  // route ipc messaging to the original develop process
+  process.on(`message`, msg => {
+    developProcess.send(msg)
+  })
 
   process.on(`beforeExit`, async () => {
     await Promise.all([

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -143,7 +143,7 @@ class ControllableScript {
   }
   onMessage(callback: (msg: any) => void): void {
     if (!this.process) {
-      throw new Error(`Trying to attach message handler before process starter`)
+      throw new Error(`Trying to attach message handler before process started`)
     }
     this.process.on(`message`, callback)
   }
@@ -151,14 +151,14 @@ class ControllableScript {
     callback: (code: number | null, signal: NodeJS.Signals | null) => void
   ): void {
     if (!this.process) {
-      throw new Error(`Trying to attach exit handler before process starter`)
+      throw new Error(`Trying to attach exit handler before process started`)
     }
     this.process.on(`exit`, callback)
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   send(msg: any): void {
     if (!this.process) {
-      throw new Error(`Trying to attach exit handler before process starter`)
+      throw new Error(`Trying to attach exit handler before process started`)
     }
 
     this.process.send(msg)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This opens the door to enable jobs API for develop and not just `gatsby build` this was broken when develop got reworked.

You can test it with installing `yarn add gatsby@ipc-develop` and running it on https://github.com/wardpeet/gatsby-ipc-tester
