### PR TITLE
fix(blog): July gazette:  brand names, files in code fences....

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1248,7 +1248,6 @@ metacompiler
 metadescription
 metafields
 Metalsmith
-metatags
 METROGLAM
 Meuleman
 Michał
@@ -1645,7 +1644,6 @@ redux
 Redux
 Reduxjs
 ReferenceError
-ReflexJS
 reformats
 reframe
 rehydrate

--- a/docs/blog/gazette-july-2020/index.md
+++ b/docs/blog/gazette-july-2020/index.md
@@ -9,11 +9,11 @@ tags: ["gatsby-gazette"]
 
 July was full of ordinary items [revealed to be cakes 🍰](https://www.esquire.com/entertainment/tv/a33313974/cake-meme-explained/), and extraordinary websites powered by Gatsby Themes!
 
-It’s been a year since we unveiled [Gatsby Themes](/docs/themes/what-are-gatsby-themes/) and celebrated the release with “Theme Jam”, a hackathon that produced dozens of [powerful and beautiful projects](https://themejam.gatsbyjs.org/showcase). A Gatsby Theme is like a Gatsby plugin that includes a gatsby-config.js file, and can add pre-configured functionality, data sourcing, and/or UI code to Gatsby sites. In the beginning we saw most developers focus on the UI capabilities of themes. A year later we see themes package, split, and combine functionality for every common website use case you can think of! [Search “theme” in the plugins directory](https://www.gatsbyjs.org/plugins/?=theme) to discovery over 400 Gatsby Themes you can use for your own projects.
+It’s been a year since we unveiled [Gatsby Themes](/docs/themes/what-are-gatsby-themes/) and celebrated the release with “Theme Jam”, a hackathon that produced dozens of [powerful and beautiful projects](https://themejam.gatsbyjs.org/showcase). A Gatsby Theme is like a Gatsby plugin that includes a `gatsby-config.js` file, and can add pre-configured functionality, data sourcing, and/or UI code to Gatsby sites. In the beginning we saw most developers focus on the UI capabilities of themes. A year later we see themes package, split, and combine functionality for every common website use case you can think of! [Search “theme” in the plugins directory](https://www.gatsbyjs.org/plugins/?=theme) to discovery over 400 Gatsby Themes you can use for your own projects.
 
-July was also a huge month for official Gatsby Themes. We [updated our popular Blog Theme to 2.0](/blog/2020-07-08-blog-2.0/) and introduced better image support, search engine optimization, webfont configuration, and more. We also made it easier to swap styles for your blog, using Theme-UI presets. Don’t be fooled by the name “blog” though. This theme is the perfect add-on for any site that needs to continually publish content. The lead engineer on the theme, [Laurie Barth](https://laurieontech.com/) also revamped [the step-by-step Gatsby Blog Theme tutorial](https://www.gatsbyjs.org/tutorial/using-a-theme/), so you can get started customizing this theme quickly.
+July was also a huge month for official Gatsby Themes. We [updated our popular Blog Theme to 2.0](/blog/2020-07-08-blog-2.0/) and introduced better image support, search engine optimization, webfont configuration, and more. We also made it easier to swap styles for your blog, using Theme UI presets. Don’t be fooled by the name “blog” though. This theme is the perfect add-on for any site that needs to continually publish content. The lead engineer on the theme, [Laurie Barth](https://laurieontech.com/) also revamped [the step-by-step Gatsby Blog Theme tutorial](https://www.gatsbyjs.org/tutorial/using-a-theme/), so you can get started customizing this theme quickly.
 
-Also this month, we released a new official theme for adding [i18n support to your Gatsby site](https://www.gatsbyjs.org/blog/2020-07-28-introducing-gatsby-i18n-theme/)! This i18n theme gives you access to specialized React components that help with building a multilingual site. The lead developer on this theme, [Lennart Jörgens](/https://www.lekoarts.de/) also created 3 “child themes” for popular translation libraries. The i18n theme is great to use for any project that requires localization, but is also a solid example to study if you want to [build your own Gatsby Theme](/tutorial/building-a-theme/).
+Also this month, we released a new official theme for adding [i18n support to your Gatsby site](https://www.gatsbyjs.org/blog/2020-07-28-introducing-gatsby-i18n-theme/)! This i18n theme gives you access to specialized React components that help with building a multilingual site. The lead developer on this theme, [Lennart Jörgens](https://www.lekoarts.de/) also created 3 “child themes” for popular translation libraries. The i18n theme is great to use for any project that requires localization, but is also a solid example to study if you want to [build your own Gatsby Theme](/tutorial/building-a-theme/).
 
 ## 🚀 New in Gatsby and Gatsby Cloud!
 
@@ -46,11 +46,12 @@ Previously [static query](https://www.gatsbyjs.org/docs/static-query/) results i
 ## 🌍 New from the Gatsby Community
 
 [Alexandra Spalato](https://alexandraspalato.com/) and [Paulina Hetman](https://pehaa.com/) appeared [on the Party Corgi Podcast](https://party-corgi-podcast.simplecast.com/episodes/the-first-commercial-gatsby-wordpress-themes-with-alexandra-spalato-and-paulina-hetman) to talk about making premium [Gatsby Themes for WordPress](https://gatsbywpthemes.com/). We’ve seen a sneak peek of their work, and both the Gatsby and WordPress communities are going to be blown away by these projects 🚀.
+
 https://twitter.com/partycorgipod/status/1288087382504419335
 
 [Matías Hernández Arellano](https://matiashernandez.dev/) authored an Egghead course on creating a Gatsby source plugin. You can watch it in [English](https://egghead.io/playlists/creating-a-gatsby-source-plugin-3f01) or [in Spanish](https://egghead.io/playlists/creacion-de-un-plugin-de-gatsby-desde-cero-5c8b).
 
-Arshad is back with another Gatsby Theme for to his growing [ReflexJS](https://reflexjs.org/) collection. This new theme adds a video section to your site, and is optimized with SEO, OG and Twitter metatags. Reflex also comes with beautiful, [ready-to-use components](https://reflexjs.org/library/blocks) so you can customize the style and layout of your site quickly.
+Arshad is back with another Gatsby Theme for to his growing [Reflex](https://reflexjs.org/) collection. This new theme adds a video section to your site, and is optimized with SEO, OG and Twitter meta tags. Reflex also comes with beautiful, [ready-to-use components](https://reflexjs.org/library/blocks) so you can customize the style and layout of your site quickly.
 
 ![Reflex screenshot](./reflex.png)
 
@@ -60,7 +61,7 @@ Arshad is back with another Gatsby Theme for to his growing [ReflexJS](https://r
 
 ### Rewrite of GraphCMS’s source plugin
 
-We helped GraphCMS build their new source plugin ([using our new GraphQL toolkit](http://github.com/vladar/gatsby-graphql-toolkitgithub.com/vladar/gatsby-graphql-toolkit)). Head to the repo, and [give it a try](https://github.com/GraphCMS/gatsby-source-graphcms/).
+We helped GraphCMS build their new source plugin ([using our new GraphQL toolkit](http://github.com/vladar/gatsby-graphql-toolkit)). Head to the repo, and [give it a try](https://github.com/GraphCMS/gatsby-source-graphcms/).
 
 ### Strapi's Gatsby Blog Starter
 
@@ -74,7 +75,7 @@ Ink, a project that enables you to build command-line apps using React [released
 
 ### New alpha for Gatsby Recipes
 
-In the coming weeks look out for exciting updates to [Gatsby Recipes](/blog/2020-04-15-announcing-gatsby-recipes/), our new [infrastructure-as-code](docs/glossary/infrastructure-as-code/) project. You can follow along with our progress in our [public GitHub Project](https://github.com/gatsbyjs/gatsby/projects/20)
+In the coming weeks look out for exciting updates to [Gatsby Recipes](/blog/2020-04-15-announcing-gatsby-recipes/), our new [infrastructure-as-code](/docs/glossary/infrastructure-as-code/) project. You can follow along with our progress in our [public GitHub Project](https://github.com/gatsbyjs/gatsby/projects/20)
 
 ### MDX Mini-Conference
 


### PR DESCRIPTION
## Description

changes:
- file name in code fences
- brand name `Theme-UI` -> `Theme UI`
- line before Twitter link so that it can embedded
- brand name `ReflexJS` -> `Reflex`
- spelling: `metatags` -> `meta tags`

*fixed Links should be already included with #26224*

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

- #26171 `(blog) Gatsby Gazette for July` 