### PR TITLE
fix: Position "Install command" button to prevent Safari overflow

### DIFF
--- a/www/src/views/starter/installation.js
+++ b/www/src/views/starter/installation.js
@@ -48,7 +48,7 @@ const StarterInstallation = ({ repoName, repoUrl }) => {
           <Copy
             fileName="Install command"
             content={content}
-            sx={{ borderRadius: 1 }}
+            sx={{ borderRadius: 1, position: `relative` }}
           />
         </code>
       </pre>


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
Position 'Install command' copy button as relative so it does not extend past div on horizontal overflow for Safari when screen size is < 750px.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->
Added inline style in `views/starter/installation.js` file
@gatsbyjs/learning

#### Before
![Screen Shot 2020-08-04 at 2 48 11 PM](https://user-images.githubusercontent.com/5782327/89332783-f6435100-d661-11ea-82b3-81f5ba9dc437.png)
![Screen Shot 2020-08-04 at 2 48 18 PM](https://user-images.githubusercontent.com/5782327/89332790-f8a5ab00-d661-11ea-92e6-721621f6d204.png)


#### After
![Screen Shot 2020-08-04 at 2 47 56 PM](https://user-images.githubusercontent.com/5782327/89332800-fd6a5f00-d661-11ea-91bd-e312b7703079.png)


## Related Issues
Fixes #26184