### PR TITLE
fix(www): Starter library dark mode set text colors

### DIFF
--- a/www/src/views/starter/details.js
+++ b/www/src/views/starter/details.js
@@ -61,7 +61,9 @@ const Details = ({
             // for that reason we are excluding it from our list of plugins
             /^gatsby-/.test(dep) && dep !== `gatsby-cypress` ? (
               <div key={dep}>
-                <Link to={`/packages/${dep}`} sx={styles.link}>{dep}</Link>
+                <Link to={`/packages/${dep}`} sx={styles.link}>
+                  {dep}
+                </Link>
               </div>
             ) : (
               <div key={dep}>
@@ -115,5 +117,5 @@ const styles = {
   },
   link: {
     color: `link.color`,
-  }
+  },
 }

--- a/www/src/views/starter/details.js
+++ b/www/src/views/starter/details.js
@@ -61,11 +61,11 @@ const Details = ({
             // for that reason we are excluding it from our list of plugins
             /^gatsby-/.test(dep) && dep !== `gatsby-cypress` ? (
               <div key={dep}>
-                <Link to={`/packages/${dep}`}>{dep}</Link>
+                <Link to={`/packages/${dep}`} sx={styles.link}>{dep}</Link>
               </div>
             ) : (
               <div key={dep}>
-                <a href={`https://npm.im/${dep}`}>
+                <a href={`https://npm.im/${dep}`} sx={styles.link}>
                   {`${dep} `}
                   <MdLaunch />
                 </a>
@@ -113,4 +113,7 @@ const styles = {
       color: `white`,
     },
   },
+  link: {
+    color: `link.color`,
+  }
 }

--- a/www/src/views/starter/header.js
+++ b/www/src/views/starter/header.js
@@ -37,7 +37,7 @@ const Header = ({ stub }) => (
       </Link>
     </div>
     <div>
-      <h1 sx={{ m: 0, display: `inline-block`, color: `heading`, }}>{stub}</h1>
+      <h1 sx={{ m: 0, display: `inline-block`, color: `heading` }}>{stub}</h1>
     </div>
   </div>
 )

--- a/www/src/views/starter/header.js
+++ b/www/src/views/starter/header.js
@@ -37,7 +37,7 @@ const Header = ({ stub }) => (
       </Link>
     </div>
     <div>
-      <h1 sx={{ m: 0, display: `inline-block` }}>{stub}</h1>
+      <h1 sx={{ m: 0, display: `inline-block`, color: `heading`, }}>{stub}</h1>
     </div>
   </div>
 )

--- a/www/src/views/starter/source.js
+++ b/www/src/views/starter/source.js
@@ -74,6 +74,7 @@ const Source = ({ startersYaml, repoUrl, starter }) => (
           "&&": {
             borderBottom: 0,
             mr: 4,
+            color: `link.color`,
           },
         }}
       >
@@ -86,6 +87,7 @@ const Source = ({ startersYaml, repoUrl, starter }) => (
         sx={{
           "&&": {
             borderBottom: 0,
+            color: `link.color`,
           },
         }}
       >


### PR DESCRIPTION
## Description
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

When selecting a starter from the starter library in dark mode, the page title is now white and links to CodeSandbox, Netlify, and the dependencies are purple to match the rest of the website.
@gatsbyjs/learning

### Existing
![localhost_8000_starters_zag_gatsby-starter-pod6_ (1)](https://user-images.githubusercontent.com/5782327/89106225-1078f700-d3f6-11ea-87a2-b5a7e675c38e.png)

### New
![localhost_8000_starters_zag_gatsby-starter-pod6_](https://user-images.githubusercontent.com/5782327/89106189-c09a3000-d3f5-11ea-8532-8f01cd26b6f4.png)

## Related Issues

Fixes #26182 