### PR TITLE
chore: Update normalize-path dependency

### DIFF
--- a/packages/gatsby-remark-code-repls/package.json
+++ b/packages/gatsby-remark-code-repls/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.3",
     "lz-string": "^1.4.4",
-    "normalize-path": "^2.1.1",
+    "normalize-path": "^3.0.0",
     "npm-package-arg": "^6.1.1",
     "recursive-readdir": "^2.2.2",
     "unist-util-map": "^1.0.5",

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.3",
-    "normalize-path": "^2.1.1",
+    "normalize-path": "^3.0.0",
     "parse-numeric-range": "^0.0.2",
     "unist-util-map": "^1.0.5"
   },

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -105,7 +105,7 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.27.0",
     "name-all-modules-plugin": "^1.0.1",
-    "normalize-path": "^2.1.1",
+    "normalize-path": "^3.0.0",
     "null-loader": "^3.0.0",
     "opentracing": "^0.14.4",
     "optimize-css-assets-webpack-plugin": "^5.0.3",


### PR DESCRIPTION
No breaking changes in this release: https://github.com/jonschlinkert/normalize-path#v30