### PR TITLE
docs(gatsby-plugin-netlify): update README with more detail for client only routes

### DIFF
--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -132,4 +132,6 @@ You can also create a `_redirects` file in the `static` folder for the same effe
 You can validate the `_redirects` config through the
 [Netlify playground app](https://play.netlify.com/redirects).
 
-Redirect rules are automatically added for [client only paths](https://www.gatsbyjs.org/docs/client-only-routes-and-user-authentication). If those rules are conflicting with custom rules or if you want to have more control over them you can disable them in [configuration](#configuration) by setting `generateMatchPathRewrites` to `false`.
+Redirect rules are automatically added for [client only paths](https://www.gatsbyjs.org/docs/client-only-routes-and-user-authentication). The plugin uses the [matchPath](https://www.gatsbyjs.org/docs/gatsby-internals-terminology/#matchpath) syntax to match all possible requests in the range of your client-side routes and serves the HTML file for the client-side route. Without it, only the exact route of the client-side route works.
+
+If those rules are conflicting with custom rules or if you want to have more control over them you can disable them in [configuration](#configuration) by setting `generateMatchPathRewrites` to `false`.


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

 A conversation between @KyleAMathews and @blainekasten resulted in this explanation from Kyle. I had a misunderstanding about what the plugin actually did for client only routes and figured it'd make sense to add a little more clarity.


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

A slack conversation 😬 
