### PR TITLE
chore(gatsby): update semver

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -40,7 +40,7 @@
     "react": "^16.8.0",
     "redux": "^4.0.5",
     "resolve-cwd": "^3.0.0",
-    "semver": "^6.3.0",
+    "semver": "^7.3.2",
     "signal-exit": "^3.0.3",
     "source-map": "0.7.3",
     "stack-trace": "^0.0.10",

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.10.3",
     "gatsby-core-utils": "^1.3.15",
-    "semver": "^5.7.1",
+    "semver": "^7.3.2",
     "sharp": "^0.25.1"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -21,7 +21,7 @@
     "potrace": "^2.1.8",
     "probe-image-size": "^4.1.1",
     "progress": "^2.0.3",
-    "semver": "^5.7.1",
+    "semver": "^7.3.2",
     "sharp": "^0.25.1",
     "svgo": "1.3.2",
     "uuid": "^3.4.0"

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -21,7 +21,7 @@
     "cheerio": "^1.0.0-rc.3",
     "is-relative-url": "^3.0.0",
     "lodash": "^4.17.15",
-    "semver": "^5.7.1",
+    "semver": "^7.3.2",
     "sharp": "^0.25.1",
     "unist-util-select": "^1.5.0"
   },

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -12,7 +12,7 @@
     "fs-extra": "^8.1.0",
     "potrace": "^2.1.8",
     "probe-image-size": "^4.1.1",
-    "semver": "^5.7.1",
+    "semver": "^7.3.2",
     "sharp": "^0.25.1"
   },
   "devDependencies": {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -125,7 +125,7 @@
     "react-refresh": "^0.7.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
-    "semver": "^5.7.1",
+    "semver": "^7.3.2",
     "shallow-compare": "^1.2.2",
     "signal-exit": "^3.0.3",
     "slugify": "^1.4.4",


### PR DESCRIPTION
Upgrades semver across the board. Changelog: https://github.com/npm/node-semver/blob/master/CHANGELOG.md

Relevant breaking changes:

7.0.0 - removes node 6 support (no longer a concern for gatsby)
6.0.0 - changes `intersects` logic (not used by gatsby)

Uses of semver:

`satisfies`, `lt`, `gt`. All of which are still supported and appear unchanged
