### PR TITLE
Parameterise telemetry constructor 

### DIFF
--- a/packages/gatsby-telemetry/src/__tests__/telemetry.ts
+++ b/packages/gatsby-telemetry/src/__tests__/telemetry.ts
@@ -38,4 +38,22 @@ describe(`Telemetry`, () => {
       )
     })
   })
+
+  describe(`allows overriding defaults`, () => {
+    it(`allows overriding componentId`, () => {
+      const t = new AnalyticsTracker({
+        componentId: `desktop`,
+        gatsbyCliVersion: `1.2.3-beta1`,
+      })
+      t.buildAndStoreEvent(`demo`, {})
+      expect(
+        (EventStorage as jest.Mock).mock.instances[1].addEvent
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          componentId: `desktop`,
+          gatsbyCliVersion: `1.2.3-beta1`,
+        })
+      )
+    })
+  })
 })

--- a/packages/gatsby-telemetry/src/declarations.d.ts
+++ b/packages/gatsby-telemetry/src/declarations.d.ts
@@ -1,8 +1,2 @@
 type UUID = string
 
-declare namespace NodeJS {
-  interface Process {
-    gatsbyTelemetrySessionId: UUID;
-  }
-}
-

--- a/packages/gatsby-telemetry/src/declarations.d.ts
+++ b/packages/gatsby-telemetry/src/declarations.d.ts
@@ -1,2 +1,0 @@
-type UUID = string
-

--- a/packages/gatsby-telemetry/src/event-storage.ts
+++ b/packages/gatsby-telemetry/src/event-storage.ts
@@ -103,7 +103,7 @@ export class EventStorage {
     }
   }
 
-  getConfig(key: string): string | boolean | UUID | Record<string, unknown> {
+  getConfig(key: string): string | boolean | Record<string, unknown> {
     if (key) {
       return this.config.get(key)
     }

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -2,6 +2,8 @@ import { AnalyticsTracker, IAggregateStats } from "./telemetry"
 import * as express from "express"
 import { createFlush } from "./create-flush"
 
+export { AnalyticsTracker }
+
 const instance = new AnalyticsTracker()
 
 const flush = createFlush(instance.isTrackingEnabled())

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -2,6 +2,8 @@ import { AnalyticsTracker, IAggregateStats } from "./telemetry"
 import * as express from "express"
 import { createFlush } from "./create-flush"
 
+export { AnalyticsTracker } from "./telemetry"
+
 const instance = new AnalyticsTracker()
 
 const flush = createFlush(instance.isTrackingEnabled())

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -1,4 +1,9 @@
-import { AnalyticsTracker, IAggregateStats } from "./telemetry"
+import {
+  AnalyticsTracker,
+  IAggregateStats,
+  ITelemetryTagsPayload,
+  ITelemetryOptsPayload,
+} from "./telemetry"
 import * as express from "express"
 import { createFlush } from "./create-flush"
 
@@ -27,9 +32,14 @@ function tick(): void {
 export function trackFeatureIsUsed(name: string): void {
   instance.trackFeatureIsUsed(name)
 }
-export function trackCli(input, tags, opts): void {
+export function trackCli(
+  input: string | string[],
+  tags?: ITelemetryTagsPayload,
+  opts?: ITelemetryOptsPayload
+): void {
   instance.captureEvent(input, tags, opts)
 }
+
 export function trackError(input, tags): void {
   instance.captureError(input, tags)
 }
@@ -37,27 +47,35 @@ export function trackError(input, tags): void {
 export function trackBuildError(input, tags): void {
   instance.captureBuildError(input, tags)
 }
+
 export function setDefaultTags(tags): void {
   instance.decorateAll(tags)
 }
+
 export function decorateEvent(event, tags): void {
   instance.decorateNextEvent(event, tags)
 }
+
 export function setTelemetryEnabled(enabled): void {
   instance.setTelemetryEnabled(enabled)
 }
+
 export function startBackgroundUpdate(): void {
   setTimeout(tick, interval)
 }
+
 export function isTrackingEnabled(): boolean {
   return instance.isTrackingEnabled()
 }
+
 export function aggregateStats(data): IAggregateStats {
   return instance.aggregateStats(data)
 }
+
 export function addSiteMeasurement(event, obj): void {
   instance.addSiteMeasurement(event, obj)
 }
+
 export function expressMiddleware(source: string) {
   return function (_req: express.Request, _res: express.Response, next): void {
     try {

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -2,8 +2,6 @@ import { AnalyticsTracker, IAggregateStats } from "./telemetry"
 import * as express from "express"
 import { createFlush } from "./create-flush"
 
-export { AnalyticsTracker } from "./telemetry"
-
 const instance = new AnalyticsTracker()
 
 const flush = createFlush(instance.isTrackingEnabled())

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -2,8 +2,6 @@ import { AnalyticsTracker, IAggregateStats } from "./telemetry"
 import * as express from "express"
 import { createFlush } from "./create-flush"
 
-export { AnalyticsTracker }
-
 const instance = new AnalyticsTracker()
 
 const flush = createFlush(instance.isTrackingEnabled())
@@ -26,35 +24,62 @@ function tick(): void {
     .then(() => setTimeout(tick, interval))
 }
 
-module.exports = {
-  trackFeatureIsUsed: (name: string): void => instance.trackFeatureIsUsed(name),
-  trackCli: (input, tags, opts): void =>
-    instance.captureEvent(input, tags, opts),
-  trackError: (input, tags): void => instance.captureError(input, tags),
-  trackBuildError: (input, tags): void =>
-    instance.captureBuildError(input, tags),
-  setDefaultTags: (tags): void => instance.decorateAll(tags),
-  decorateEvent: (event, tags): void => instance.decorateNextEvent(event, tags),
-  setTelemetryEnabled: (enabled): void => instance.setTelemetryEnabled(enabled),
-  startBackgroundUpdate: (): void => {
-    setTimeout(tick, interval)
-  },
-  isTrackingEnabled: (): boolean => instance.isTrackingEnabled(),
-  aggregateStats: (data): IAggregateStats => instance.aggregateStats(data),
-  addSiteMeasurement: (event, obj): void =>
-    instance.addSiteMeasurement(event, obj),
-  expressMiddleware: function (source: string) {
-    return function (
-      _req: express.Request,
-      _res: express.Response,
-      next
-    ): void {
-      try {
-        instance.trackActivity(`${source}_ACTIVE`)
-      } catch (e) {
-        // ignore
-      }
-      next()
+export function trackFeatureIsUsed(name: string): void {
+  instance.trackFeatureIsUsed(name)
+}
+export function trackCli(input, tags, opts): void {
+  instance.captureEvent(input, tags, opts)
+}
+export function trackError(input, tags): void {
+  instance.captureError(input, tags)
+}
+
+export function trackBuildError(input, tags): void {
+  instance.captureBuildError(input, tags)
+}
+export function setDefaultTags(tags): void {
+  instance.decorateAll(tags)
+}
+export function decorateEvent(event, tags): void {
+  instance.decorateNextEvent(event, tags)
+}
+export function setTelemetryEnabled(enabled): void {
+  instance.setTelemetryEnabled(enabled)
+}
+export function startBackgroundUpdate(): void {
+  setTimeout(tick, interval)
+}
+export function isTrackingEnabled(): boolean {
+  return instance.isTrackingEnabled()
+}
+export function aggregateStats(data): IAggregateStats {
+  return instance.aggregateStats(data)
+}
+export function addSiteMeasurement(event, obj): void {
+  instance.addSiteMeasurement(event, obj)
+}
+export function expressMiddleware(source: string) {
+  return function (_req: express.Request, _res: express.Response, next): void {
+    try {
+      instance.trackActivity(`${source}_ACTIVE`)
+    } catch (e) {
+      // ignore
     }
-  },
+    next()
+  }
+}
+
+module.exports = {
+  trackFeatureIsUsed,
+  trackCli,
+  trackError,
+  trackBuildError,
+  setDefaultTags,
+  decorateEvent,
+  setTelemetryEnabled,
+  startBackgroundUpdate,
+  isTrackingEnabled,
+  aggregateStats,
+  addSiteMeasurement,
+  expressMiddleware,
 }

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -69,6 +69,15 @@ export function expressMiddleware(source: string) {
   }
 }
 
+// Internal
+export function setDefaultComponentId(componentId): void {
+  instance.componentId = componentId
+}
+
+export function setGatsbyCliVersion(version): void {
+  instance.gatsbyCliVersion = version
+}
+
 module.exports = {
   trackFeatureIsUsed,
   trackCli,

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -14,7 +14,7 @@ import { join, sep } from "path"
 import isDocker from "is-docker"
 import lodash from "lodash"
 
-const typedUUIDv4 = uuidV4 as () => UUID
+const typedUUIDv4 = uuidV4 as () => string
 
 const finalEventRegex = /(END|STOP)$/
 const dbEngine = `redux`
@@ -62,7 +62,7 @@ export class AnalyticsTracker {
   installedGatsbyVersion?: SemVer
   repositoryId?: IRepositoryId
   features = new Set<string>()
-  machineId: UUID
+  machineId: string
 
   constructor({
     componentId,

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -19,7 +19,7 @@ const typedUUIDv4 = uuidV4 as () => UUID
 const finalEventRegex = /(END|STOP)$/
 const dbEngine = `redux`
 
-type SemVer = string
+export type SemVer = string
 
 interface IOSInfo {
   nodeVersion: SemVer
@@ -88,11 +88,12 @@ export class AnalyticsTracker {
 
   // We might have two instances of this lib loaded, one from globally installed gatsby-cli and one from local gatsby.
   // Hence we need to use process level globals that are not scoped to this module
-  getSessionId(): UUID {
-    return (
-      process.gatsbyTelemetrySessionId ||
-      (process.gatsbyTelemetrySessionId = uuidV4())
-    )
+  getSessionId(): string {
+    const p = process as any
+    if (!p.gatsbyTelemetrySessionId) {
+      p.gatsbyTelemetrySessionId = uuidV4()
+    }
+    return p.gatsbyTelemetrySessionId
   }
 
   getRepositoryId(): IRepositoryId {
@@ -256,7 +257,7 @@ export class AnalyticsTracker {
     }
   }
 
-  getMachineId(): UUID {
+  getMachineId(): string {
     // Cache the result
     if (this.machineId) {
       return this.machineId

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -43,8 +43,14 @@ export interface IAggregateStats {
   skewness: number
 }
 
+interface IAnalyticsTrackerConstructorParameters {
+  componentId?: SemVer
+  gatsbyCliVersion?: SemVer
+}
+
 export class AnalyticsTracker {
   store = new EventStorage()
+  componentId: string
   debouncer = {}
   metadataCache = {}
   defaultTags = {}
@@ -58,7 +64,11 @@ export class AnalyticsTracker {
   features = new Set<string>()
   machineId: UUID
 
-  constructor() {
+  constructor({
+    componentId,
+    gatsbyCliVersion,
+  }: IAnalyticsTrackerConstructorParameters = {}) {
+    this.componentId = componentId || `gatsby-cli`
     try {
       if (this.store.isTrackingDisabled()) {
         this.trackingEnabled = false
@@ -68,7 +78,7 @@ export class AnalyticsTracker {
 
       // These may throw and should be last
       this.componentVersion = require(`../package.json`).version
-      this.gatsbyCliVersion = this.getGatsbyCliVersion()
+      this.gatsbyCliVersion = gatsbyCliVersion || this.getGatsbyCliVersion()
       this.installedGatsbyVersion = this.getGatsbyVersion()
     } catch (e) {
       // ignore
@@ -231,7 +241,7 @@ export class AnalyticsTracker {
       sessionId: this.sessionId,
       time: new Date(),
       machineId: this.getMachineId(),
-      componentId: `gatsby-cli`,
+      componentId: this.componentId,
       osInformation: this.getOsInfo(),
       componentVersion: this.componentVersion,
       dbEngine,

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -48,6 +48,41 @@ interface IAnalyticsTrackerConstructorParameters {
   gatsbyCliVersion?: SemVer
 }
 
+export interface ITelemetryTagsPayload {
+  name?: string
+  starterName?: string
+  pluginName?: string
+  exitCode?: number
+  duration?: number
+  uiSource?: string
+  valid?: boolean
+  plugins?: string[]
+  pathname?: string
+  error?: {
+    id?: string
+    code?: string
+    text: string
+    level?: string
+    type?: string
+    stack?: string
+    context?: string
+    error?: {
+      stack?: string
+    }
+  }
+  cacheStatus?: string
+  pluginCachePurged?: string
+  siteMeasurements?: {
+    pagesCount?: number
+    clientsCount?: number
+    paths?: string[]
+    bundleStats?: unknown
+    pageDataStats?: unknown
+    queryStats?: unknown
+  }
+  errorV2?: unknown
+}
+
 export class AnalyticsTracker {
   store = new EventStorage()
   componentId: string
@@ -147,7 +182,11 @@ export class AnalyticsTracker {
     return `-0.0.0`
   }
 
-  captureEvent(type = ``, tags = {}, opts = { debounce: false }): void {
+  captureEvent(
+    type: string | string[] = ``,
+    tags: ITelemetryTagsPayload = {},
+    opts = { debounce: false }
+  ): void {
     if (!this.isTrackingEnabled()) {
       return
     }
@@ -179,7 +218,7 @@ export class AnalyticsTracker {
     return finalEventRegex.test(event)
   }
 
-  captureError(type, tags = {}): void {
+  captureError(type: string, tags: ITelemetryTagsPayload = {}): void {
     if (!this.isTrackingEnabled()) {
       return
     }
@@ -191,7 +230,7 @@ export class AnalyticsTracker {
     this.formatErrorAndStoreEvent(eventType, lodash.merge({}, tags, decoration))
   }
 
-  captureBuildError(type, tags = {}): void {
+  captureBuildError(type: string, tags: ITelemetryTagsPayload = {}): void {
     if (!this.isTrackingEnabled()) {
       return
     }
@@ -202,7 +241,10 @@ export class AnalyticsTracker {
     this.formatErrorAndStoreEvent(eventType, lodash.merge({}, tags, decoration))
   }
 
-  formatErrorAndStoreEvent(eventType, tags): void {
+  formatErrorAndStoreEvent(
+    eventType: string,
+    tags: ITelemetryTagsPayload
+  ): void {
     if (tags.error) {
       // `error` ought to have been `errors` but is `error` in the database
       if (Array.isArray(tags.error)) {
@@ -233,7 +275,7 @@ export class AnalyticsTracker {
     this.buildAndStoreEvent(eventType, tags)
   }
 
-  buildAndStoreEvent(eventType, tags): void {
+  buildAndStoreEvent(eventType: string, tags: ITelemetryTagsPayload): void {
     const event = {
       installedGatsbyVersion: this.installedGatsbyVersion,
       gatsbyCliVersion: this.gatsbyCliVersion,
@@ -307,7 +349,7 @@ export class AnalyticsTracker {
     return osInfo
   }
 
-  trackActivity(source): void {
+  trackActivity(source: string): void {
     if (!this.isTrackingEnabled()) {
       return
     }
@@ -322,12 +364,12 @@ export class AnalyticsTracker {
     this.debouncer[source] = now
   }
 
-  decorateNextEvent(event, obj): void {
+  decorateNextEvent(event: string, obj): void {
     const cached = this.metadataCache[event] || {}
     this.metadataCache[event] = Object.assign(cached, obj)
   }
 
-  addSiteMeasurement(event, obj): void {
+  addSiteMeasurement(event: string, obj): void {
     const cachedEvent = this.metadataCache[event] || {}
     const cachedMeasurements = cachedEvent.siteMeasurements || {}
     this.metadataCache[event] = Object.assign(cachedEvent, {
@@ -335,7 +377,7 @@ export class AnalyticsTracker {
     })
   }
 
-  decorateAll(tags): void {
+  decorateAll(tags: ITelemetryTagsPayload): void {
     this.defaultTags = Object.assign(this.defaultTags, tags)
   }
 

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -83,6 +83,10 @@ export interface ITelemetryTagsPayload {
   errorV2?: unknown
 }
 
+export interface ITelemetryOptsPayload {
+  debounce?: boolean
+}
+
 export class AnalyticsTracker {
   store = new EventStorage()
   componentId: string
@@ -185,7 +189,7 @@ export class AnalyticsTracker {
   captureEvent(
     type: string | string[] = ``,
     tags: ITelemetryTagsPayload = {},
-    opts = { debounce: false }
+    opts: ITelemetryOptsPayload = { debounce: false }
   ): void {
     if (!this.isTrackingEnabled()) {
       return

--- a/packages/gatsby-telemetry/tsconfig.json
+++ b/packages/gatsby-telemetry/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true
+  }
 }


### PR DESCRIPTION
This PR 
* Makes it possible to customize the default metadata telemetry sends (componentId/version)
* Attempts to fix some TS issues with the imports

It seems that for proper TS support, we need to do the `exports function` for all methods exposed in src/index.js

However, apparently we need to also keep the module.exports for this. Please advise if there are nicer ways to do this.