### PR TITLE
fix(docs): 404 links to gatsby-themes

### DIFF
--- a/docs/blog/2019-07-15-theme-jam-contest/index.md
+++ b/docs/blog/2019-07-15-theme-jam-contest/index.md
@@ -15,11 +15,11 @@ To celebrate the [stable release of Gatsby Themes](/blog/2019-07-03-announcing-s
 
 Gatsby Themes are pre-built, installable packages for setting up a site’s default styling, components, plugins, and overall configuration that can be reused across multiple Gatsby sites. They’re a great way to simplify the early steps of configuring a new site; and, when it’s time to update your site’s styling or functionality, you only have to edit your theme or swap it out entirely with another compatible theme. You can find a more detailed explanation in the [Themes section of Gatsby’s documentation](/docs/themes/).
 
-If you’d like to see an example, check out Gatsby’s official [blog theme](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-theme-blog) or [notes theme](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-theme-notes).
+If you’d like to see an example, check out Gatsby’s official [blog theme](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-blog) or [notes theme](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-notes).
 
 ## How to build your Gatsby theme
 
-If you’re planning to build a theme for the contest, you may want to start with this [Gatsby Theme Jam Submission Example repository](https://github.com/jlengstorf/gatsby-theme-jam-example). You can build a child theme of an existing Gatsby theme (e.g. the [blog theme](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-theme-blog) or [notes theme](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-theme-notes)) with updated styling or added functionality, for example, or it can be a completely new theme.
+If you’re planning to build a theme for the contest, you may want to start with this [Gatsby Theme Jam Submission Example repository](https://github.com/jlengstorf/gatsby-theme-jam-example). You can build a child theme of an existing Gatsby theme (e.g. the [blog theme](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-blog) or [notes theme](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-notes)) with updated styling or added functionality, for example, or it can be a completely new theme.
 
 Here are some resources with detailed instructions on how to build a Gatsby theme:
 

--- a/docs/docs/configuring-usage-with-plugin-options.md
+++ b/docs/docs/configuring-usage-with-plugin-options.md
@@ -52,7 +52,7 @@ The following table lists possible options values and an example plugin that mak
 | Array     | `["/about-us/", "/projects/*"]`  | [`gatsby-plugin-offline`](/packages/gatsby-plugin-offline/)       |
 | Object    | `{ default: "./src/layout.js" }` | [`gatsby-plugin-mdx`](/packages/gatsby-plugin-mdx/)               |
 
-**Note**: Themes (which are a type of plugin) are able to receive options from a site's `gatsby-config` to be used in its `gatsby-config` in order to allow themes to be composed together. This is done by exporting the `gatsby-config` as a function instead of an object. You can see an example of this in the [`gatsby-theme-blog`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-theme-blog) and [`gatsby-theme-blog-core`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-theme-blog-core) repositories. Plugins are not capable of this functionality.
+**Note**: Themes (which are a type of plugin) are able to receive options from a site's `gatsby-config` to be used in its `gatsby-config` in order to allow themes to be composed together. This is done by exporting the `gatsby-config` as a function instead of an object. You can see an example of this in the [`gatsby-theme-blog`](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-blog) and [`gatsby-theme-blog-core`](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-blog-core) repositories. Plugins are not capable of this functionality.
 
 ## Additional resources
 

--- a/docs/docs/naming-a-plugin.md
+++ b/docs/docs/naming-a-plugin.md
@@ -16,7 +16,7 @@ There are five standard plugin naming conventions for Gatsby:
   - Example: [`gatsby-remark-images`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-images)
   - Docs: [creating a remark plugin](/tutorial/remark-plugin-tutorial/)
 - **`gatsby-theme-*`** — this naming convention is used for [Gatsby themes](/docs/themes/), which are a type of plugin. This naming convention is used for plugins that own a section, a page, or part of a page on a site or expose files and components for [shadowing](/docs/themes/shadowing/).
-  - Example: [`gatsby-theme-blog`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-theme-blog)
+  - Example: [`gatsby-theme-blog`](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-blog)
   - Docs: [creating a theme](/tutorial/building-a-theme/)
 - **`gatsby-plugin-*`** — this is the most general plugin type. Use this naming convention if your plugin doesn’t meet the requirements of any other plugin types.
   - Example: [`gatsby-plugin-sharp`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fixes 404 links in docs which still pointed to this repo `https://github.com/gatsbyjs/gatsby/tree/master/packages`. Affected themes: gatsby-theme-blog, gatsby-theme-blog-core and gatsby-theme-notes.

This PR points them to the new repo `https://github.com/gatsbyjs/themes/tree/master/packages`.
