### PR TITLE
fix(tutorial): Fixing constant for page query

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -245,7 +245,7 @@ export default function About({ data }) {
 }
 
 // highlight-start
-export const query = graphql`
+export const data = graphql`
   query {
     site {
       siteMetadata {


### PR DESCRIPTION
The graphql query was incorrectly assigning the query results

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In tutorial Part 4, when creating the page query there was an inconsistency between the named constant that the data was being assigned to, and the constant being passed into the component.  This caused the query to not work, as 'data' was undefined.

### Documentation

No new documentation needed.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Could not find any related issues.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
