### PR TITLE
Docs update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -14,7 +14,6 @@ labels: "type: documentation"
   Gatsby has several community support channels, try asking your question on:
 
   - Discord: https://gatsby.dev/discord
-  - Spectrum: https://spectrum.chat/gatsby-js
   - Twitter: https://twitter.com/gatsbyjs
 
   Before opening a new issue, please search existing issues https://github.com/gatsbyjs/gatsby/issues

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -14,7 +14,6 @@ labels: "type: question or discussion"
   Gatsby has several community support channels, try asking your question on:
 
   - Discord: https://gatsby.dev/discord
-  - Spectrum: https://spectrum.chat/gatsby-js
   - Twitter: https://twitter.com/gatsbyjs
 
   Before opening a new issue, please search existing issues https://github.com/gatsbyjs/gatsby/issues


### PR DESCRIPTION
## Description

This PR removes references and links to the Gatsby Spectrum community from github issue templates. Specifically, the link to Spectrum still exists in the `documentation.md` issue template and `question.md` issue template.

### Documentation

No applicable - this is a change to github issue templates; no change to any Gatsby code.

## Related Issues

Fixes #26276 
