### PR TITLE
Fix a link to the reference guide overview pages

### DIFF
--- a/docs/contributing/translation/maintainers.md
+++ b/docs/contributing/translation/maintainers.md
@@ -34,7 +34,7 @@ The repo creation script will create a progress issue listing the list of [core 
 
 The Gatsby learning team is in charge of determining priorities for which docs should be translated. Refer to the [i18n page spreadsheet](https://docs.google.com/spreadsheets/d/1u2amGnqFLKxJuL5h9UrDblUueFgg0EBt7xbau4n8iTM/edit) to get the most up-to-date priority list, which includes frequently-visited pages in the Gatsby docs, tutorial, recipes, and other important pages.
 
-[Reference guide overview pages](/contributing/docs-templates/how-to-write-a-reference-guide/#what-are-reference-guide-overview-pages) are also worth translating to establish a fully translated path to a frequently visited [reference guide](/contributing/how-to-write-a-reference-guide/#what-are-reference-guide-articles), though overview pages are listed at a lower priority.
+[Reference guide overview pages](/contributing/how-to-write-a-reference-guide/#what-are-reference-guide-overview-pages) are also worth translating to establish a fully translated path to a frequently visited [reference guide](/contributing/how-to-write-a-reference-guide/#what-are-reference-guide-articles), though overview pages are listed at a lower priority.
 
 ### Ask for help
 


### PR DESCRIPTION
## Description
Fix a broken link to the article "How to Write a Reference Guide".

