### PR TITLE
Add Governance link to sidebar

### DIFF
--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -771,6 +771,8 @@
           link: /contributing/community/
         - title: How to Contribute
           link: /contributing/how-to-contribute/
+        - title: Governance
+          link: /contributing/governance/
     - title: Partnering With Gatsby
       link: /docs/partnering-with-gatsby/
       items:


### PR DESCRIPTION
Added link to Governance page link on sidebar. Related to this PR: https://github.com/gatsbyjs/gatsby/pull/25390

