### PR TITLE
feat(gatsby): add flag to disable schema rebuilding

### DIFF
--- a/packages/gatsby/src/services/build-schema.ts
+++ b/packages/gatsby/src/services/build-schema.ts
@@ -4,7 +4,14 @@ import { IDataLayerContext } from "../state-machines/data-layer/types"
 
 export async function buildSchema({
   parentSpan,
+  refresh,
 }: Partial<IDataLayerContext>): Promise<void> {
+  if (
+    refresh &&
+    Boolean(process.env.GATSBY_EXPERIMENTAL_DISABLE_SCHEMA_REBUILD)
+  ) {
+    return
+  }
   const activity = reporter.activityTimer(`building schema`, {
     parentSpan,
   })


### PR DESCRIPTION
## Description

This PR adds a flag `GATSBY_EXPERIMENTAL_DISABLE_SCHEMA_REBUILD` that allows disabling schema rebuilding on data refresh.

By default, Gatsby rebuilds the schema in `develop` when data structure changes. It makes sense in `develop` as it allows a developer to modify his code according to the latest schema changes without the node process restart.

But this adds unnecessary overhead in Gatsby Preview. Even if the schema changes, the code remains the same and so it doesn't matter if you rebuild the schema or not.

In some cases, schema rebuilding becomes quite costly, so it makes sense to disable it.
