### PR TITLE
docs: Updated gatsby-plugin-offline README with correct default workbox config

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -146,13 +146,9 @@ const options = {
       handler: `CacheFirst`,
     },
     {
-      // page-data.json files are not content hashed
-      urlPattern: /^https?:.*\page-data\/.*\/page-data\.json/,
-      handler: `StaleWhileRevalidate`,
-    },
-    {
-      // app-data.json is not content hashed
-      urlPattern: /^https?:.*\/page-data\/app-data\.json/,
+      // page-data.json files, static query results and app-data.json
+      // are not content hashed
+      urlPattern: /^https?:.*\/page-data\/.*\.json/,
       handler: `StaleWhileRevalidate`,
     },
     {

--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -148,7 +148,12 @@ const options = {
     {
       // page-data.json files are not content hashed
       urlPattern: /^https?:.*\page-data\/.*\/page-data\.json/,
-      handler: `NetworkFirst`,
+      handler: `StaleWhileRevalidate`,
+    },
+    {
+      // app-data.json is not content hashed
+      urlPattern: /^https?:.*\/page-data\/app-data\.json/,
+      handler: `StaleWhileRevalidate`,
     },
     {
       // Add runtime caching of various other page resources


### PR DESCRIPTION
## Description
Updated `README.md` of `gatsby-plugin-offline` with current default workbox config as in https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-offline/src/gatsby-node.js#L121