### PR TITLE
chore(starters): add gatsby-starter-netlify-docs

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -7,7 +7,6 @@
     - Documentation
     - MDX
     - Markdown
-    - Open Source
     - Netlify
   features:
     - Netlify CMS for Creating, Updating, and Deleting MDX files

--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1,3 +1,23 @@
+- url: https://mdx-cms-docs.netlify.app/
+  repo: https://github.com/danielcurtis/gatsby-starter-netlify-docs
+  description: An accessible and blazing fast documentation starter for Gatsby integrated with Netlify CMS.
+  tags:
+    - CMS:Netlify
+    - CMS:Headless
+    - Documentation
+    - MDX
+    - Markdown
+    - Open Source
+    - Netlify
+  features:
+    - Netlify CMS for Creating, Updating, and Deleting MDX files
+    - Fully-Configurable Landing Page from Netlify CMS
+    - Accessible and Fast with a Perfect Lighthouse Score
+    - Clean, Repsponsive User Interface
+    - Table of Contents & Toggleable Main-Menu
+    - Configurable Dark and Light Mode Themes
+    - Google Analytics Support
+    - MDX Embeds for Tweets, Repl.it, YouTube and More
 - url: https://gatsby-pod6.netlify.app/
   repo: https://github.com/zag/gatsby-starter-pod6
   description: A minimal, lightweight, and mobile-first starter for creating blogs with pod6 markup language.


### PR DESCRIPTION
## Description

Added gatsby-starter-netlify-docs, an MDX-based documentation starter integrated with Netlify CMS