### PR TITLE
enhancement(docs): Remove excited.gif from the dictionary

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -632,7 +632,6 @@ Evoq
 ex-PayPal-ers
 Ex-PayPal-ers
 exampleValue
-excited-gif
 executables
 EXIF
 ExitWP

--- a/docs/blog/2019-02-20-introducing-use-static-query/index.md
+++ b/docs/blog/2019-02-20-introducing-use-static-query/index.md
@@ -122,7 +122,7 @@ const Header = () => {
 
 Isn't that neat?
 
-![excited-gif](./images/excited.gif)
+![Animation of someone looking excited](./images/excited.gif)
 
 And if there's a change to the structure of that data, you only need to change the query in one place!
 


### PR DESCRIPTION
## Description

This removes "excited.gif" from the dictionary, and replaces "excited.gif" alt text in a blog post's index.md with a more descriptive phrase.

### Documentation

No documentation required for this change.


## Related Issues


Addresses #25290.