### PR TITLE
Update index.md

### DIFF
--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -49,6 +49,12 @@ There are two main steps to using a plugin: Installing and configuring.
 npm install --save gatsby-plugin-typography react-typography typography typography-theme-fairy-gates
 ```
 
+> Note: If you chose to use yarn (instead of npm), you will need to replace each npm shell command with "yarn", as well as replacing any "npm install" with "yarn add":
+
+```shell
+yarn add
+```
+
 > Note: Typography.js requires a few additional packages, so those are included in the instructions. Additional requirements like this will be listed in the "install" instructions of each plugin.
 
 2. Edit the file `gatsby-config.js` at the root of your project to the following:


### PR DESCRIPTION
adds a note for those using yarn instead of npm to use the 'yarn add' shell command instead of 'npm install'

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
