### PR TITLE
fix(gatsby-recipes): speedup recipe runs for recipes with large numbers of resources

### DIFF
--- a/packages/gatsby-recipes/src/graphql-server/server.js
+++ b/packages/gatsby-recipes/src/graphql-server/server.js
@@ -76,19 +76,15 @@ const startRecipe = ({ recipePath, projectRoot }) => {
           event: state.event.type,
         })
       }
-      if (state.changed && state.event.type !== `onUpdate`) {
+      if (state.changed) {
         console.log(`===state.changed`, {
           state: state.value,
         })
         // Wait until plans are created before updating the UI
         if (
-          [
-            `presentPlan`,
-            `done`,
-            `doneError`,
-            `applyingPlan`,
-            `onUpdate`,
-          ].includes(state.value)
+          [`presentPlan`, `done`, `doneError`, `applyingPlan`].includes(
+            state.value
+          )
         ) {
           emitUpdate({
             context: state.context,

--- a/packages/gatsby-recipes/src/graphql-server/server.js
+++ b/packages/gatsby-recipes/src/graphql-server/server.js
@@ -70,14 +70,15 @@ const startRecipe = ({ recipePath, projectRoot }) => {
       recipeMachine.withContext(initialState.context)
     ).onTransition(state => {
       // Don't emit again unless there's a state change.
-      console.log(`===onTransition`, {
-        state: state.value,
-        event: state.event.type,
-      })
-      if (state.changed) {
+      if (state.event.type !== `onUpdate`) {
+        console.log(`===onTransition`, {
+          state: state.value,
+          event: state.event.type,
+        })
+      }
+      if (state.changed && state.event.type !== `onUpdate`) {
         console.log(`===state.changed`, {
           state: state.value,
-          currentStep: state.context.currentStep,
         })
         // Wait until plans are created before updating the UI
         if (

--- a/packages/gatsby-recipes/src/recipe-machine/index.js
+++ b/packages/gatsby-recipes/src/recipe-machine/index.js
@@ -7,6 +7,7 @@ const applyPlan = require(`../apply-plan`)
 const validateSteps = require(`../validate-steps`)
 const parser = require(`../parser`)
 const resolveRecipe = require(`../resolve-recipe`)
+const lodash = require(`lodash`)
 
 const recipeMachine = Machine(
   {
@@ -261,10 +262,10 @@ const recipeMachine = Machine(
         }
       }),
       addResourcesToContext: assign((context, event) => {
-        if (event.data) {
+        if (lodash.isArray(event.data) && event.data.length > 0) {
           let plan = context.plan || []
           plan = plan.map(p => {
-            const changedResource = event.data.find(c => {
+            const changedResource = event.data?.find(c => {
               if (c._uuid) {
                 return c._uuid === p._uuid
               } else {

--- a/packages/gatsby-recipes/src/recipe-machine/index.js
+++ b/packages/gatsby-recipes/src/recipe-machine/index.js
@@ -265,7 +265,7 @@ const recipeMachine = Machine(
         if (lodash.isArray(event.data) && event.data.length > 0) {
           let plan = context.plan || []
           plan = plan.map(p => {
-            const changedResource = event.data?.find(c => {
+            const changedResource = event.data.find(c => {
               if (c._uuid) {
                 return c._uuid === p._uuid
               } else {

--- a/packages/gatsby-recipes/src/renderer/render.js
+++ b/packages/gatsby-recipes/src/renderer/render.js
@@ -123,6 +123,7 @@ const handleResource = (resourceName, context, props) => {
   // Initialize
   const { mode, resultCache, inFlightCache, queue } = context
 
+  // TODO use session ID to ensure the IDs are unique
   const trueKey = props._key ? props._key : context._uuid
 
   let cacheKey

--- a/packages/gatsby-recipes/src/renderer/render.js
+++ b/packages/gatsby-recipes/src/renderer/render.js
@@ -315,7 +315,6 @@ const render = (recipe, cb, inputs = {}, isApply, isStream, name) => {
     return new Promise((resolve, reject) => {
       emitter.on(`*`, (type, e) => {
         if (type === `done`) {
-          // timer.flush()
           resolve(e)
         }
         if (type === `error`) {

--- a/packages/gatsby-recipes/src/renderer/render.js
+++ b/packages/gatsby-recipes/src/renderer/render.js
@@ -306,7 +306,7 @@ const render = (recipe, cb, inputs = {}, isApply, isStream, name) => {
     trailing: false,
   })
 
-  queue.on(`task_finish`, function(taskId, r, stats) {
+  queue.on(`task_finish`, function (taskId, r, stats) {
     throttledRenderResources()
   })
 

--- a/packages/gatsby-recipes/src/renderer/render.js
+++ b/packages/gatsby-recipes/src/renderer/render.js
@@ -123,7 +123,7 @@ const handleResource = (resourceName, context, props) => {
   // Initialize
   const { mode, resultCache, inFlightCache, queue } = context
 
-  // TODO use session ID to ensure the IDs are unique
+  // TODO use session ID to ensure the IDs are unique..
   const trueKey = props._key ? props._key : context._uuid
 
   let cacheKey

--- a/packages/gatsby-recipes/src/renderer/render.js
+++ b/packages/gatsby-recipes/src/renderer/render.js
@@ -228,13 +228,10 @@ const render = (recipe, cb, inputs = {}, isApply, isStream, name) => {
   const emitter = mitt()
   const plan = {}
 
-  const queue = new Queue(
-    async (job, cb) => {
-      const result = await job
-      cb(null, result)
-    },
-    { concurrent: 5 }
-  )
+  const queue = new Queue(async (job, cb) => {
+    const result = await job
+    cb(null, result)
+  })
 
   const resultCache = new Map()
   const inFlightCache = new Map()

--- a/packages/gatsby-recipes/src/renderer/render.js
+++ b/packages/gatsby-recipes/src/renderer/render.js
@@ -16,6 +16,8 @@ import { useRecipeStep } from "./step-component"
 import { InputProvider } from "./input-provider"
 import { ResourceProvider, useResourceContext } from "./resource-provider"
 
+const errorCache = new Map()
+
 const GlobalsContext = React.createContext({})
 const useGlobals = () => useContext(GlobalsContext)
 const GlobalsProvider = GlobalsContext.Provider
@@ -151,14 +153,17 @@ const handleResource = (resourceName, context, props) => {
   }
 
   let allResources = useResourceContext()
-  const error = validateResource(resourceName, context, props)
-  if (error) {
-    const result = {
-      error: `Validation error: ${error.details[0].message}`,
+  if (!errorCache.has(trueKey)) {
+    const error = validateResource(resourceName, context, props)
+    errorCache.set(trueKey, error)
+    if (error) {
+      const result = {
+        error: `Validation error: ${error.details[0].message}`,
+      }
+      updateResource(result)
+      resultCache.set(cacheKey, result)
+      return result
     }
-    updateResource(result)
-    resultCache.set(cacheKey, result)
-    return result
   }
 
   const cachedResult = resultCache.get(cacheKey)

--- a/packages/gatsby-recipes/src/renderer/render.js
+++ b/packages/gatsby-recipes/src/renderer/render.js
@@ -241,7 +241,6 @@ const render = (recipe, cb, inputs = {}, isApply, isStream, name) => {
   const inFlightCache = new Map()
 
   let result
-  let resourcesArray = []
 
   const recipeWithWrapper = (
     <Wrapper


### PR DESCRIPTION
- share validation cache
- run reconcilier less often

Before this change, a recipe with 200 resources took ~14 seconds to run, after the same recipe takes ~2.3s to run.