### PR TITLE
docs(gatsby-image): Deprecate `sizes` and `resolutions` props

### DIFF
--- a/docs/tutorial/gatsby-image-tutorial/index.md
+++ b/docs/tutorial/gatsby-image-tutorial/index.md
@@ -352,10 +352,10 @@ These examples should handle a fair number of use cases. A couple of bonus thing
 `gatsby-image` has a feature that gives you the ability to set an aspect ratio to constrain image proportions. This can be used for fixed or fluid processed images; it doesn't matter.
 
 ```jsx
-<Img sizes={{ ...data.banner.childImageSharp.fluid, aspectRatio: 21 / 9 }} />
+<Img fluid={{ ...data.banner.childImageSharp.fluid, aspectRatio: 21 / 9 }} />
 ```
 
-This example uses the `sizes` option on the `Img` component to specify the `aspectRatio` option along with the fluid image data. This processing is made possible by `gatsby-plugin-sharp`.
+This example uses the `fluid` option on the `Img` component to specify the `aspectRatio` option along with the fluid image data. This processing is made possible by `gatsby-plugin-sharp`.
 
 ## Bonus Error
 

--- a/docs/tutorial/wordpress-image-tutorial.md
+++ b/docs/tutorial/wordpress-image-tutorial.md
@@ -149,7 +149,7 @@ Here’s an example of creating specific widths and heights for images:
             localFile {
               childImageSharp {
                 # Try editing the "width" and "height" values.
-                resolutions(width: 200, height: 200) {
+                fixed(width: 200, height: 200) {
                   # In the GraphQL explorer, use field names
                   # like "src". In your site's code, remove them
                   # and use the fragments provided by Gatsby.
@@ -157,7 +157,7 @@ Here’s an example of creating specific widths and heights for images:
 
                   # This fragment won't work in the GraphQL
                   # explorer, but you can use it in your site.
-                  # ...GatsbyImageSharpResolutions_withWebp
+                  # ...GatsbyImageSharpFixed_withWebp
                 }
               }
             }
@@ -215,8 +215,7 @@ import Img from "gatsby-image"
 const IndexPage = ({ data }) => {
   const imagesResolutions = data.allWordpressPost.edges.map(
     edge =>
-      edge.node.childWordPressAcfPostPhoto.photo.localFile.childImageSharp
-        .resolutions
+      edge.node.childWordPressAcfPostPhoto.photo.localFile.childImageSharp.fixed
   )
   return (
     <div>
@@ -224,7 +223,7 @@ const IndexPage = ({ data }) => {
       <p>Welcome to your new Gatsby site.</p>
       <p>Now go build something great.</p>
       {imagesResolutions.map(imageRes => (
-        <Img resolutions={imageRes} key={imageRes.src} />
+        <Img fixed={imageRes} key={imageRes.src} />
       ))}
       <Link to="/page-2/">Go to page 2</Link>
     </div>
@@ -243,8 +242,8 @@ export const query = graphql`
               localFile {
                 childImageSharp {
                   # edit the maxWidth value to generate resized images
-                  resolutions(width: 500, height: 500) {
-                    ...GatsbyImageSharpResolutions_withWebp_tracedSVG
+                  fixed(width: 500, height: 500) {
+                    ...GatsbyImageSharpFixed_withWebp_tracedSVG
                   }
                 }
               }

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -25,10 +25,12 @@ const convertProps = props => {
 
   if (resolutions) {
     convertedProps.fixed = resolutions
+    logDeprecationNotice(`resolutions`, `the gatsby-image v2 prop "fixed"`)
     delete convertedProps.resolutions
   }
   if (sizes) {
     convertedProps.fluid = sizes
+    logDeprecationNotice(`sizes`, `the gatsby-image v2 prop "fluid"`)
     delete convertedProps.sizes
   }
 


### PR DESCRIPTION
## Description

[Some users are still using these props accidentally](https://github.com/gatsbyjs/gatsby/pull/25371#issuecomment-670830933) due to their visibility in guides.

For context, these two props were [deprecated once v2 arrived](https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-responsive-image-queries).

## Related Issues

My old PR: https://github.com/gatsbyjs/gatsby/pull/14158/commits/844a496aefec6e46405c109563568c5b402f9004#r285505388

Originally during review this was pointed out if it should also log deprecation notices for these two props, but it was resolved and merged without a response. I've included that in this PR in the event I've missed some other old docs, or users try following dated third-party guides for some reason.