### PR TITLE
Fix: Lint:Code script error

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "lerna": "lerna",
     "lerna-prepare": "lerna run prepare",
     "lint": "npm-run-all --continue-on-error -p lint:code lint:docs lint:other",
-    "lint:code": "eslint --cache --ext .js,.jsx,.ts,.tsx .",
+    "lint:code": "eslint --cache --ext .js,.jsx,.ts,.tsx",
     "lint:docs": "remark --quiet --frail \"./docs/\"",
     "lint:scripts": "sh scripts/lint-shell-scripts.sh",
     "lint:other": "npm run prettier -- --check",


### PR DESCRIPTION
Extraneous period causes script to fail.
