### PR TITLE
chore(eslint): ignore generated gatsby/gatsby-admin-public folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -25,3 +25,4 @@ packages/gatsby-plugin-preload-fonts/prepare/*.js
 packages/gatsby-image/withIEPolyfill/index.js
 packages/gatsby/cache-dir/commonjs/**/*
 packages/gatsby-admin/public
+packages/gatsby/gatsby-admin-public


### PR DESCRIPTION
You'd get errors locally after bootstrapping when running `yarn lint:code` because this folder was not ignored.