### PR TITLE
chore(gatsby-recipes): add missing ink-box dependency

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -52,6 +52,7 @@
     "graphql-type-json": "^0.3.2",
     "hicat": "^0.7.0",
     "html-tag-names": "^1.1.5",
+    "ink-box": "^1.0.0",
     "is-binary-path": "^2.1.0",
     "is-url": "^1.2.4",
     "isomorphic-fetch": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6067,6 +6067,20 @@ boxen@^1.2.1:
     term-size "^1.2.0"
     widest-line "^2.0.0"
 
+boxen@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-3.2.0.tgz#fbdff0de93636ab4450886b6ff45b92d098f45eb"
+  integrity sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==
+  dependencies:
+    ansi-align "^3.0.0"
+    camelcase "^5.3.1"
+    chalk "^2.4.2"
+    cli-boxes "^2.2.0"
+    string-width "^3.0.0"
+    term-size "^1.2.0"
+    type-fest "^0.3.0"
+    widest-line "^2.0.0"
+
 boxen@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
@@ -9896,11 +9910,6 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
   integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
 
-eventemitter3@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.4.tgz#b5463ace635a083d018bdc7c917b4c5f10a85384"
-  integrity sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==
-
 events@^1.1.0, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -12858,6 +12867,14 @@ init-package-json@^1.10.3:
     semver "2.x || 3.x || 4 || 5"
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
+
+ink-box@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ink-box/-/ink-box-1.0.0.tgz#8cbcb5541d32787d08d43acf1a9907e86e3572f3"
+  integrity sha512-wD2ldWX9lcE/6+flKbAJ0TZF7gKbTH8CRdhEor6DD8d+V0hPITrrGeST2reDBpCia8wiqHrdxrqTyafwtmVanA==
+  dependencies:
+    boxen "^3.0.0"
+    prop-types "^15.7.2"
 
 ink-select-input@^4.0.0:
   version "4.0.0"
@@ -17824,14 +17841,6 @@ p-queue@^6.3.0:
   integrity sha512-X7ddxxiQ+bLR/CUt3/BVKrGcJDNxBr0pEEFKHHB6vTPWNUhgDv36GpIH18RmGM3YGPpBT+JWGjDDqsVGuF0ERw==
   dependencies:
     eventemitter3 "^4.0.0"
-    p-timeout "^3.1.0"
-
-p-queue@^6.4.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.0.tgz#263f2b73add4cefca81d8d6b2696ee74b326de2f"
-  integrity sha512-zPHXPNy9jZsiym0PpJjvnHQysx1fSd/QdaNVwiDRLU2KFChD6h9CkCB6b8i3U8lBwJyA+mHgNZCzcy77glUssQ==
-  dependencies:
-    eventemitter3 "^4.0.4"
     p-timeout "^3.1.0"
 
 p-reduce@^1.0.0:


### PR DESCRIPTION
Running `yarn workspace gatsby-admin develop` on a fresh pull and yarn install of master results in this error:

```
~/projects/gatsbyjs/gatsby 
❯ yarn workspace gatsby-admin develop
yarn workspace v1.21.0
yarn run v1.21.0
$ gatsby develop
/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-cli/node_modules/yoga-layout-prebuilt/yoga-layout/build/Release/nbind.js:53
        throw ex;
        ^
Error: Cannot find module 'ink-box'
Require stack:
- /Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-recipes/dist/cli.js
- /Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-recipes/dist/index.js
- /Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-cli/lib/recipes.js
- /Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-cli/lib/create-cli.js
- /Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-cli/lib/index.js
- /Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby/dist/bin/gatsby.js
- /Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby/cli.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:965:15)
    at Function.Module._load (internal/modules/cjs/loader.js:841:27)
    at Module.require (internal/modules/cjs/loader.js:1025:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-recipes/dist/cli.js:13:15)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Module.require (internal/modules/cjs/loader.js:1025:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-recipes/dist/cli.js',
    '/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-recipes/dist/index.js',
    '/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-cli/lib/recipes.js',
    '/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-cli/lib/create-cli.js',
    '/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby-cli/lib/index.js',
    '/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby/dist/bin/gatsby.js',
    '/Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby/cli.js'
  ]
}
```

This fixes that error by adding the missing dependency to `gatsby-recipes`.