### PR TITLE
fix(gatsby-plugin-offline): Update regex to catch new static query results

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -140,7 +140,7 @@ exports.onPostBuild = (
       },
       {
         // page-data.json files are not content hashed
-        urlPattern: /^https?:.*\page-data\/.*\/page-data\.json/,
+        urlPattern: /^https?:.*\/page-data\/.*\.json/,
         handler: `StaleWhileRevalidate`,
       },
       {

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -139,13 +139,9 @@ exports.onPostBuild = (
         handler: `CacheFirst`,
       },
       {
-        // page-data.json files are not content hashed
+        // page-data.json files, static query results and app-data.json
+        // are not content hashed
         urlPattern: /^https?:.*\/page-data\/.*\.json/,
-        handler: `StaleWhileRevalidate`,
-      },
-      {
-        // app-data.json is not content hashed
-        urlPattern: /^https?:.*\/page-data\/app-data\.json/,
         handler: `StaleWhileRevalidate`,
       },
       {


### PR DESCRIPTION
As a result of https://github.com/gatsbyjs/gatsby/pull/26242, static query results are now stored in `/public/page-data/sq/`

This PR adjusts the glob in `gatsby-plugin-offline` so that caches these files as well. 