### PR TITLE
feat(gatsby-cli): log pending activities when killing process externally

### DIFF
--- a/packages/gatsby-cli/src/reporter/catch-exit-signals.ts
+++ b/packages/gatsby-cli/src/reporter/catch-exit-signals.ts
@@ -5,11 +5,16 @@
 import signalExit from "signal-exit"
 import { getStore } from "./redux"
 import { createPendingActivity } from "./redux/actions"
-import { ActivityStatuses } from "./constants"
+import { ActivityStatuses, ActivityTypes } from "./constants"
 import { reporter } from "./reporter"
 
-const interruptActivities = (): void => {
+const interruptActivities = ({
+  showCancelledPendingActivities = false,
+}: {
+  showCancelledPendingActivities?: boolean
+} = {}): void => {
   const { activities } = getStore().getState().logs
+  const cancelledPendingActivitiesIds: Array<string> = []
   Object.keys(activities).forEach(activityId => {
     const activity = activities[activityId]
     if (
@@ -17,8 +22,26 @@ const interruptActivities = (): void => {
       activity.status === ActivityStatuses.NotStarted
     ) {
       reporter.completeActivity(activityId, ActivityStatuses.Interrupted)
+      if (activity.type === ActivityTypes.Pending) {
+        // pending activities are hidden from UI, so we construct
+        // list of pending activities to log them to make it easier
+        // to debug any timing issues related to reporting
+        // global status (SET_STATUS)
+        cancelledPendingActivitiesIds.push(`"${activityId}"`)
+      }
     }
   })
+
+  if (
+    showCancelledPendingActivities &&
+    cancelledPendingActivitiesIds.length > 0
+  ) {
+    reporter.warn(
+      `There were pending activities:\n${cancelledPendingActivitiesIds.join(
+        `, `
+      )}.\nPlease, create bug report, if you see this warning when exiting idle process.`
+    )
+  }
 }
 
 export const prematureEnd = (): void => {
@@ -35,8 +58,13 @@ export const prematureEnd = (): void => {
 
 export const catchExitSignals = (): void => {
   signalExit((code, signal) => {
-    if (code !== 0 && signal !== `SIGINT` && signal !== `SIGTERM`)
+    if (code !== 0 && signal !== `SIGINT` && signal !== `SIGTERM`) {
       prematureEnd()
-    else interruptActivities()
+    } else {
+      const isSignalled = signal === `SIGINT` || signal === `SIGTERM`
+      interruptActivities({
+        showCancelledPendingActivities: isSignalled,
+      })
+    }
   })
 }


### PR DESCRIPTION
## Description

This is meant to make it easier to debug timing issues related to `SET_STATUS` ipc messages not being fired when they should be - switching from "IN_PROGRESS" to idle ("SUCCESS" or "FAILED") would be "blocked" if there are any pending activities. Pending activities are hidden from output (or ipc) and it sometimes can be tricky to reproduce problems like this (as they can be timing related), so logging those should help with debugging of those cases.