### PR TITLE
Increase verdaccio max_body_size

### DIFF
--- a/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio-config.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio-config.js
@@ -4,6 +4,7 @@ const os = require(`os`)
 const verdaccioConfig = {
   storage: path.join(os.tmpdir(), `verdaccio`, `storage`),
   port: 4873, // default
+  max_body_size: `1000mb`,
   web: {
     enable: true,
     title: `gatsby-dev`,


### PR DESCRIPTION
We're seeing payload size errors on tests for a few PRs. This should fix that.