### PR TITLE
fix(gatsby-recipes): remove trailing config as we do want it to run again to ensure all resource updates are flushed

### DIFF
--- a/packages/gatsby-recipes/src/renderer/render.js
+++ b/packages/gatsby-recipes/src/renderer/render.js
@@ -301,9 +301,7 @@ const render = (recipe, cb, inputs = {}, isApply, isStream, name) => {
     }
   }
 
-  const throttledRenderResources = lodash.throttle(renderResources, 100, {
-    trailing: false,
-  })
+  const throttledRenderResources = lodash.throttle(renderResources, 100)
 
   queue.on(`task_finish`, function (taskId, r, stats) {
     throttledRenderResources()


### PR DESCRIPTION
Further testing revealed this.