### PR TITLE
fix(gatsby-recipes): fix NPMScript for parallel calls

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -58,6 +58,7 @@
     "isomorphic-fetch": "^2.1.0",
     "jest-diff": "^25.5.0",
     "lodash": "^4.17.15",
+    "lock": "^1.0.0",
     "mitt": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-fetch": "^2.5.0",

--- a/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/site-metadata.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/site-metadata.test.js.snap
@@ -337,3 +337,19 @@ module.exports = {
 ",
 }
 `;
+
+exports[`gatsby-plugin resource handles multiple parallel create calls 1`] = `
+Object {
+  "id": "husky",
+  "name": "husky",
+  "value": "\\"hi\\"",
+}
+`;
+
+exports[`gatsby-plugin resource handles multiple parallel create calls 2`] = `
+Object {
+  "id": "husky2",
+  "name": "husky2",
+  "value": "\\"hi\\"",
+}
+`;

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.js
@@ -9,6 +9,7 @@ const prettier = require(`prettier`)
 const resolveCwd = require(`resolve-cwd`)
 const { slash } = require(`gatsby-core-utils`)
 
+const lock = require(`../lock`)
 const getDiff = require(`../utils/get-diff`)
 const resourceSchema = require(`../resource-schema`)
 
@@ -194,6 +195,7 @@ class MissingInfoError extends Error {
 }
 
 const create = async ({ root }, { name, options, key }) => {
+  const release = await lock(`gatsby-config.js`)
   // TODO generalize this — it's for the demo.
   if (options?.accessToken === `(Known after install)`) {
     throw new MissingInfoError({ name, options, key })
@@ -206,7 +208,9 @@ const create = async ({ root }, { name, options, key }) => {
 
   await fs.writeFile(getConfigPath(root), code)
 
-  return await read({ root }, key || name)
+  const config = await read({ root }, key || name)
+  release()
+  return config
 }
 
 const read = async ({ root }, id) => {

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
@@ -166,8 +166,11 @@ describe(`gatsby-plugin resource`, () => {
       },
     }
 
-    await plugin.create(context, fooPlugin)
-    await plugin.create(context, barPlugin)
+    const createPromise1 = plugin.create(context, fooPlugin)
+    const createPromise2 = plugin.create(context, barPlugin)
+
+    await createPromise1
+    await createPromise2
 
     const barResult = await plugin.read(context, barPlugin.key)
     const fooResult = await plugin.read(context, fooPlugin.key)

--- a/packages/gatsby-recipes/src/providers/gatsby/site-metadata.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/site-metadata.test.js
@@ -39,4 +39,35 @@ describe(`gatsby-plugin resource`, () => {
       partialUpdate: { name: `author`, value: `Velma` },
     })
   })
+
+  test(`handles multiple parallel create calls`, async () => {
+    const root = starterBlogRoot
+    const resultPromise = plugin.create(
+      {
+        root,
+      },
+      {
+        name: `husky`,
+        value: `hi`,
+      }
+    )
+    const result2Promise = plugin.create(
+      {
+        root,
+      },
+      {
+        name: `husky2`,
+        value: `hi`,
+      }
+    )
+
+    const result = await resultPromise
+    const result2 = await result2Promise
+
+    expect(result).toMatchSnapshot()
+    expect(result2).toMatchSnapshot()
+
+    await plugin.destroy({ root }, result)
+    await plugin.destroy({ root }, result2)
+  })
 })

--- a/packages/gatsby-recipes/src/providers/lock.js
+++ b/packages/gatsby-recipes/src/providers/lock.js
@@ -1,0 +1,10 @@
+const lock = require(`lock`).Lock
+const lockInstance = lock()
+
+module.exports = resources =>
+  new Promise(resolve =>
+    lockInstance(resources, release => {
+      const releaseLock = release(() => {})
+      resolve(releaseLock)
+    })
+  )

--- a/packages/gatsby-recipes/src/providers/npm/__snapshots__/package-json.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/npm/__snapshots__/package-json.test.js.snap
@@ -13,24 +13,31 @@ exports[`packageJson resource e2e package resource test: PackageJson create plan
 Object {
   "currentState": "{
   \\"name\\": \\"test\\",
-  \\"scripts\\": {}
+  \\"scripts\\": {},
+  \\"husky2\\": {
+    \\"hooks\\": {}
+  }
 }",
   "describe": "Add husky to package.json",
   "diff": "- Original  - 0
 + Modified  + 3
 
+@@ -1,4 +1,7 @@
   Object {
 +   \\"husky\\": \\"{
 +   /\\"hooks/\\": {}
 + }\\",
-    \\"name\\": \\"test\\",
-    \\"scripts\\": Object {},
-  }",
+    \\"husky2\\": Object {
+      \\"hooks\\": Object {},
+    },",
   "id": "husky",
   "name": "husky",
   "newState": "{
   \\"name\\": \\"test\\",
   \\"scripts\\": {},
+  \\"husky2\\": {
+    \\"hooks\\": {}
+  },
   \\"husky\\": \\"{/n  /\\"hooks/\\": {}/n}\\"
 }",
 }
@@ -52,6 +59,9 @@ Object {
   "currentState": "{
   \\"name\\": \\"test\\",
   \\"scripts\\": {},
+  \\"husky2\\": {
+    \\"hooks\\": {}
+  },
   \\"husky\\": \\"{/n  /\\"hooks/\\": {}/n}\\"
 }",
   "describe": "Add husky to package.json",
@@ -66,14 +76,39 @@ Object {
 +     /\\"pre-commit/\\": /\\"lint-staged/\\"
 +   }
   }\\",
-    \\"name\\": \\"test\\",
-    \\"scripts\\": Object {},",
+    \\"husky2\\": Object {
+      \\"hooks\\": Object {},",
   "id": "husky",
   "name": "husky",
   "newState": "{
   \\"name\\": \\"test\\",
   \\"scripts\\": {},
+  \\"husky2\\": {
+    \\"hooks\\": {}
+  },
   \\"husky\\": \\"{/n  /\\"hooks/\\": {/n    /\\"pre-commit/\\": /\\"lint-staged/\\"/n  }/n}\\"
+}",
+}
+`;
+
+exports[`packageJson resource handles multiple parallel create calls 1`] = `
+Object {
+  "_message": "Wrote key \\"husky\\" to package.json",
+  "id": "husky",
+  "name": "husky",
+  "value": "{
+  \\"hooks\\": {}
+}",
+}
+`;
+
+exports[`packageJson resource handles multiple parallel create calls 2`] = `
+Object {
+  "_message": "Wrote key \\"husky2\\" to package.json",
+  "id": "husky2",
+  "name": "husky2",
+  "value": "{
+  \\"hooks\\": {}
 }",
 }
 `;

--- a/packages/gatsby-recipes/src/providers/npm/__snapshots__/package-json.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/npm/__snapshots__/package-json.test.js.snap
@@ -13,31 +13,24 @@ exports[`packageJson resource e2e package resource test: PackageJson create plan
 Object {
   "currentState": "{
   \\"name\\": \\"test\\",
-  \\"scripts\\": {},
-  \\"husky2\\": {
-    \\"hooks\\": {}
-  }
+  \\"scripts\\": {}
 }",
   "describe": "Add husky to package.json",
   "diff": "- Original  - 0
 + Modified  + 3
 
-@@ -1,4 +1,7 @@
   Object {
 +   \\"husky\\": \\"{
 +   /\\"hooks/\\": {}
 + }\\",
-    \\"husky2\\": Object {
-      \\"hooks\\": Object {},
-    },",
+    \\"name\\": \\"test\\",
+    \\"scripts\\": Object {},
+  }",
   "id": "husky",
   "name": "husky",
   "newState": "{
   \\"name\\": \\"test\\",
   \\"scripts\\": {},
-  \\"husky2\\": {
-    \\"hooks\\": {}
-  },
   \\"husky\\": \\"{/n  /\\"hooks/\\": {}/n}\\"
 }",
 }
@@ -59,9 +52,6 @@ Object {
   "currentState": "{
   \\"name\\": \\"test\\",
   \\"scripts\\": {},
-  \\"husky2\\": {
-    \\"hooks\\": {}
-  },
   \\"husky\\": \\"{/n  /\\"hooks/\\": {}/n}\\"
 }",
   "describe": "Add husky to package.json",
@@ -76,16 +66,13 @@ Object {
 +     /\\"pre-commit/\\": /\\"lint-staged/\\"
 +   }
   }\\",
-    \\"husky2\\": Object {
-      \\"hooks\\": Object {},",
+    \\"name\\": \\"test\\",
+    \\"scripts\\": Object {},",
   "id": "husky",
   "name": "husky",
   "newState": "{
   \\"name\\": \\"test\\",
   \\"scripts\\": {},
-  \\"husky2\\": {
-    \\"hooks\\": {}
-  },
   \\"husky\\": \\"{/n  /\\"hooks/\\": {/n    /\\"pre-commit/\\": /\\"lint-staged/\\"/n  }/n}\\"
 }",
 }

--- a/packages/gatsby-recipes/src/providers/npm/__snapshots__/script.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/npm/__snapshots__/script.test.js.snap
@@ -55,3 +55,21 @@ Object {
   "newState": "\\"apple\\": \\"foot2\\"",
 }
 `;
+
+exports[`npm script resource handles multiple parallel create calls 1`] = `
+Object {
+  "_message": "Added script \\"husky\\" to your package.json",
+  "command": "hi",
+  "id": "husky",
+  "name": "husky",
+}
+`;
+
+exports[`npm script resource handles multiple parallel create calls 2`] = `
+Object {
+  "_message": "Added script \\"husky2\\" to your package.json",
+  "command": "hi",
+  "id": "husky2",
+  "name": "husky2",
+}
+`;

--- a/packages/gatsby-recipes/src/providers/npm/fixtures/package.json
+++ b/packages/gatsby-recipes/src/providers/npm/fixtures/package.json
@@ -1,7 +1,4 @@
 {
   "name": "test",
-  "scripts": {},
-  "husky2": {
-    "hooks": {}
-  }
+  "scripts": {}
 }

--- a/packages/gatsby-recipes/src/providers/npm/fixtures/package.json
+++ b/packages/gatsby-recipes/src/providers/npm/fixtures/package.json
@@ -1,4 +1,7 @@
 {
   "name": "test",
-  "scripts": {}
+  "scripts": {},
+  "husky2": {
+    "hooks": {}
+  }
 }

--- a/packages/gatsby-recipes/src/providers/npm/package-json.test.js
+++ b/packages/gatsby-recipes/src/providers/npm/package-json.test.js
@@ -61,6 +61,7 @@ describe(`packageJson resource`, () => {
     expect(result2).toMatchSnapshot()
 
     await pkgJson.destroy({ root }, result)
+    await pkgJson.destroy({ root }, result2)
   })
 
   test(`handles object values`, async () => {

--- a/packages/gatsby-recipes/src/providers/npm/package-json.test.js
+++ b/packages/gatsby-recipes/src/providers/npm/package-json.test.js
@@ -34,6 +34,35 @@ describe(`packageJson resource`, () => {
     })
   })
 
+  test(`handles multiple parallel create calls`, async () => {
+    const resultPromise = pkgJson.create(
+      {
+        root,
+      },
+      {
+        name: `husky`,
+        value: JSON.parse(initialValue),
+      }
+    )
+    const result2Promise = pkgJson.create(
+      {
+        root,
+      },
+      {
+        name: `husky2`,
+        value: JSON.parse(initialValue),
+      }
+    )
+
+    const result = await resultPromise
+    const result2 = await result2Promise
+
+    expect(result).toMatchSnapshot()
+    expect(result2).toMatchSnapshot()
+
+    await pkgJson.destroy({ root }, result)
+  })
+
   test(`handles object values`, async () => {
     const result = await pkgJson.create(
       {

--- a/packages/gatsby-recipes/src/providers/npm/script.js
+++ b/packages/gatsby-recipes/src/providers/npm/script.js
@@ -1,6 +1,7 @@
 const fs = require(`fs-extra`)
 const path = require(`path`)
 const Joi = require(`@hapi/joi`)
+const lock = require(`../lock`)
 
 const getDiff = require(`../utils/get-diff`)
 const resourceSchema = require(`../resource-schema`)
@@ -18,12 +19,15 @@ const writePackageJson = async (root, obj) => {
 }
 
 const create = async ({ root }, { name, command }) => {
+  const release = await lock(`package.json`)
   const pkg = await readPackageJson(root)
   pkg.scripts = pkg.scripts || {}
   pkg.scripts[name] = command
   await writePackageJson(root, pkg)
 
-  return await read({ root }, name)
+  const readPackagejson = await read({ root }, name)
+  release()
+  return readPackagejson
 }
 
 const read = async ({ root }, id) => {

--- a/packages/gatsby-recipes/src/providers/npm/script.test.js
+++ b/packages/gatsby-recipes/src/providers/npm/script.test.js
@@ -15,4 +15,34 @@ describe(`npm script resource`, () => {
       partialUpdate: { command: `foot2` },
     })
   })
+
+  test(`handles multiple parallel create calls`, async () => {
+    const resultPromise = script.create(
+      {
+        root,
+      },
+      {
+        name: `husky`,
+        command: `hi`,
+      }
+    )
+    const result2Promise = script.create(
+      {
+        root,
+      },
+      {
+        name: `husky2`,
+        command: `hi`,
+      }
+    )
+
+    const result = await resultPromise
+    const result2 = await result2Promise
+
+    expect(result).toMatchSnapshot()
+    expect(result2).toMatchSnapshot()
+
+    await script.destroy({ root }, result)
+    await script.destroy({ root }, result2)
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -15364,6 +15364,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lock@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lock/-/lock-1.1.0.tgz#53157499d1653b136ca66451071fca615703fa55"
+  integrity sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU=
+
 lockfile@1.0.4, lockfile@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"


### PR DESCRIPTION
Found this was problem similar to NPMPackageJSON in https://github.com/gatsbyjs/gatsby/pull/26281

Did fancy batching technique there like with NPMPackage but realized that was overkill if writing is cheap.

Install npm package is very expensive so we want to batch those. Writing to package.json is extreamly cheap
so using a simple locking mechanism is a lot easier so added that to NPMScript & replaced the batching
code in NPMPackageJSON to use the same locking (which was necessary anyways to make sure NPMScript & NPMPackageJSON
don't clobber each other).