### PR TITLE
chore(monorepo): update cross-env

### DIFF
--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@testing-library/cypress": "^4.0.4",
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "cypress": "3.4.1",
     "fs-extra": "^7.0.1",
     "gatsby-cypress": "^0.1.7",

--- a/e2e-tests/gatsby-image/package.json
+++ b/e2e-tests/gatsby-image/package.json
@@ -32,7 +32,7 @@
     "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "gatsby-cypress": "^0.1.7",
     "is-ci": "^2.0.0",
     "prettier": "2.0.4",

--- a/e2e-tests/mdx/package.json
+++ b/e2e-tests/mdx/package.json
@@ -28,7 +28,7 @@
     "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "gatsby-cypress": "^0.1.7",
     "is-ci": "^2.0.0",
     "prettier": "2.0.4",

--- a/e2e-tests/path-prefix/package.json
+++ b/e2e-tests/path-prefix/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "cpy-cli": "^2.0.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "del-cli": "^3.0.0",
     "gatsby-cypress": "^0.1.7",
     "is-ci": "^2.0.0",

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -39,7 +39,7 @@
     "cy:run:slow": "cross-env CYPRESS_CONNECTION_TYPE=slow cypress run --browser chrome --config testFiles=prefetching.js"
   },
   "devDependencies": {
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "fs-extra": "^7.0.1",
     "is-ci": "^2.0.0",
     "prettier": "2.0.4",

--- a/e2e-tests/themes/development-runtime/package.json
+++ b/e2e-tests/themes/development-runtime/package.json
@@ -25,7 +25,7 @@
     "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "cypress": "^3.1.3",
     "gatsby-cypress": "^0.2.2",
     "is-ci": "^2.0.0",

--- a/e2e-tests/themes/production-runtime/package.json
+++ b/e2e-tests/themes/production-runtime/package.json
@@ -22,7 +22,7 @@
     "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
-    "cross-env": "^5.2.0",
+    "cross-env": "^7.0.2",
     "cypress": "^3.1.3",
     "gatsby-cypress": "^0.1.7",
     "is-ci": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-jest": "^24.9.0",
     "chalk": "^2.4.2",
     "chokidar": "^3.4.0",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "danger": "^8.0.0",
     "date-fns": "^1.30.1",
     "eslint": "^5.16.0",

--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -12,7 +12,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0"

--- a/packages/babel-preset-gatsby/package.json
+++ b/packages/babel-preset-gatsby/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@babel/cli": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "slash": "^3.0.0"
   },
   "engines": {

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -56,7 +56,7 @@
     "@types/hosted-git-info": "^3.0.0",
     "@types/yargs": "^15.0.4",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "rimraf": "^3.0.2",
     "typescript": "^3.9.5"
   },

--- a/packages/gatsby-codemods/package.json
+++ b/packages/gatsby-codemods/package.json
@@ -30,7 +30,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "jscodeshift": "^0.7.0"
   },
   "engines": {

--- a/packages/gatsby-core-utils/package.json
+++ b/packages/gatsby-core-utils/package.json
@@ -41,7 +41,7 @@
     "@babel/core": "^7.10.3",
     "@types/ci-info": "2.0.0",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "typescript": "^3.9.5"
   },
   "engines": {

--- a/packages/gatsby-cypress/package.json
+++ b/packages/gatsby-cypress/package.json
@@ -21,7 +21,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-design-tokens/package.json
+++ b/packages/gatsby-design-tokens/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "agadoo": "^1.1.0",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "microbundle": "^0.12.2",
     "preval.macro": "^3.0.0"
   },

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -28,7 +28,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-dev-cli#readme",
   "keywords": [

--- a/packages/gatsby-graphiql-explorer/package.json
+++ b/packages/gatsby-graphiql-explorer/package.json
@@ -40,7 +40,7 @@
     "babel-loader": "^8.1.0",
     "babel-preset-gatsby-package": "^0.5.2",
     "core-js": "^3.6.5",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "css-loader": "^1.0.1",
     "graphiql": "^0.17.5",
     "graphiql-code-exporter": "^2.0.8",

--- a/packages/gatsby-image/package.json
+++ b/packages/gatsby-image/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "^7.10.3",
     "@testing-library/react": "^9.5.0",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image#readme",
   "keywords": [

--- a/packages/gatsby-legacy-polyfills/package.json
+++ b/packages/gatsby-legacy-polyfills/package.json
@@ -34,7 +34,7 @@
     "codegen.macro": "^4.0.0",
     "core-js": "^3.6.5",
     "cpy-cli": "^3.1.1",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "execa": "^4.0.2",
     "fs-extra": "^9.0.1",
     "microbundle": "^0.12.0",

--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "^7.10.3",
     "@testing-library/react": "^9.5.0",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "peerDependencies": {
     "@reach/router": "^1.3.3",

--- a/packages/gatsby-page-utils/package.json
+++ b/packages/gatsby-page-utils/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "^7.10.3",
     "@types/micromatch": "^4.0.1",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "files": [
     "dist/*"

--- a/packages/gatsby-plugin-canonical-urls/package.json
+++ b/packages/gatsby-plugin-canonical-urls/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-canonical-urls#readme",
   "keywords": [

--- a/packages/gatsby-plugin-catch-links/package.json
+++ b/packages/gatsby-plugin-catch-links/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-catch-links#readme",
   "keywords": [

--- a/packages/gatsby-plugin-coffeescript/package.json
+++ b/packages/gatsby-plugin-coffeescript/package.json
@@ -19,7 +19,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-coffeescript#readme",
   "keywords": [

--- a/packages/gatsby-plugin-create-client-paths/package.json
+++ b/packages/gatsby-plugin-create-client-paths/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-create-client-paths#readme",
   "keywords": [

--- a/packages/gatsby-plugin-cxs/package.json
+++ b/packages/gatsby-plugin-cxs/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "cxs": "^6.2.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-cxs#readme",

--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/gatsby-plugin-facebook-analytics/package.json
+++ b/packages/gatsby-plugin-facebook-analytics/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-facebook-analytics#readme",
   "keywords": [

--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -17,7 +17,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-feed#readme",
   "keywords": [

--- a/packages/gatsby-plugin-flow/package.json
+++ b/packages/gatsby-plugin-flow/package.json
@@ -31,7 +31,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/gatsby-plugin-fullstory/package.json
+++ b/packages/gatsby-plugin-fullstory/package.json
@@ -30,7 +30,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0"

--- a/packages/gatsby-plugin-glamor/package.json
+++ b/packages/gatsby-plugin-glamor/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-glamor#readme",
   "keywords": [

--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -15,7 +15,7 @@
     "@babel/core": "^7.10.3",
     "@testing-library/react": "^9.5.0",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics#readme",
   "keywords": [

--- a/packages/gatsby-plugin-google-gtag/package.json
+++ b/packages/gatsby-plugin-google-gtag/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag#readme",
   "keywords": [

--- a/packages/gatsby-plugin-google-tagmanager/package.json
+++ b/packages/gatsby-plugin-google-tagmanager/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager#readme",
   "keywords": [

--- a/packages/gatsby-plugin-guess-js/package.json
+++ b/packages/gatsby-plugin-guess-js/package.json
@@ -35,7 +35,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0"

--- a/packages/gatsby-plugin-jss/package.json
+++ b/packages/gatsby-plugin-jss/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-jss#readme",
   "keywords": [

--- a/packages/gatsby-plugin-layout/package.json
+++ b/packages/gatsby-plugin-layout/package.json
@@ -30,7 +30,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/gatsby-plugin-less/package.json
+++ b/packages/gatsby-plugin-less/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-less#readme",
   "keywords": [

--- a/packages/gatsby-plugin-lodash/package.json
+++ b/packages/gatsby-plugin-lodash/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-lodash#readme",
   "keywords": [

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-manifest#readme",
   "keywords": [

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -21,7 +21,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },

--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -23,7 +23,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify#readme",
   "keywords": [

--- a/packages/gatsby-plugin-nprogress/package.json
+++ b/packages/gatsby-plugin-nprogress/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-nprogress#readme",
   "keywords": [

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -20,7 +20,7 @@
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
     "cpx": "^1.5.0",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "rewire": "^4.0.1"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline#readme",

--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -36,7 +36,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0"

--- a/packages/gatsby-plugin-postcss/package.json
+++ b/packages/gatsby-plugin-postcss/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-postcss#readme",
   "keywords": [

--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -15,7 +15,7 @@
     "@babel/core": "^7.10.3",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.3.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact#readme",
   "keywords": [

--- a/packages/gatsby-plugin-preload-fonts/package.json
+++ b/packages/gatsby-plugin-preload-fonts/package.json
@@ -23,7 +23,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preload-fonts#readme",
   "keywords": [

--- a/packages/gatsby-plugin-react-css-modules/package.json
+++ b/packages/gatsby-plugin-react-css-modules/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-css-modules#readme",
   "keywords": [

--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-react-helmet#readme",
   "keywords": [

--- a/packages/gatsby-plugin-remove-trailing-slashes/package.json
+++ b/packages/gatsby-plugin-remove-trailing-slashes/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes#readme",
   "keywords": [

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass#readme",
   "keywords": [

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -30,7 +30,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sharp#readme",
   "keywords": [

--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap#readme",
   "keywords": [

--- a/packages/gatsby-plugin-styled-components/package.json
+++ b/packages/gatsby-plugin-styled-components/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-components#readme",
   "keywords": [

--- a/packages/gatsby-plugin-styled-jsx/package.json
+++ b/packages/gatsby-plugin-styled-jsx/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-styled-jsx#readme",
   "keywords": [

--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -10,7 +10,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "styletron-engine-atomic": "^1.4.6",
     "styletron-react": "^5.2.7"
   },

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-stylus#readme",
   "keywords": [

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -30,7 +30,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/gatsby-plugin-twitter/package.json
+++ b/packages/gatsby-plugin-twitter/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter#readme",
   "keywords": [

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -22,7 +22,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript#readme",
   "keywords": [

--- a/packages/gatsby-plugin-typography/package.json
+++ b/packages/gatsby-plugin-typography/package.json
@@ -13,7 +13,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-typography": "^0.16.19",

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -14,7 +14,7 @@
     "@babel/core": "^7.10.3",
     "babel-plugin-dev-expression": "^0.2.2",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "history": "^4.7.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-react-router-scroll#readme",

--- a/packages/gatsby-remark-autolink-headers/package.json
+++ b/packages/gatsby-remark-autolink-headers/package.json
@@ -17,7 +17,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-autolink-headers#readme",
   "keywords": [

--- a/packages/gatsby-remark-code-repls/package.json
+++ b/packages/gatsby-remark-code-repls/package.json
@@ -19,7 +19,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-code-repls#readme",
   "keywords": [

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -20,7 +20,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "remark": "^10.0.1",
     "remark-mdx": "^1.6.6"
   },

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "rimraf": "^3.0.2",
     "unist-util-find": "^1.0.1"
   },

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet#readme",
   "keywords": [

--- a/packages/gatsby-remark-graphviz/package.json
+++ b/packages/gatsby-remark-graphviz/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "hast-util-to-html": "^4.0.1",
     "mdast-util-to-hast": "^3.0.4",
     "remark": "^9.0.0",

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -29,7 +29,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "keywords": [
     "contentful",

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -23,7 +23,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "hast-util-to-html": "^6.1.0",
     "mdast-util-to-hast": "^6.0.2"
   },

--- a/packages/gatsby-remark-katex/package.json
+++ b/packages/gatsby-remark-katex/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "katex": "^0.11.1"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex#readme",

--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
     "cheerio": "^1.0.0-rc.3",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "prismjs": "^1.20.0",
     "remark": "^9.0.0"
   },

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -17,7 +17,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "remark": "^10.0.1",
     "remark-mdx": "^1.6.6",
     "unist-util-find": "^1.0.1"

--- a/packages/gatsby-remark-smartypants/package.json
+++ b/packages/gatsby-remark-smartypants/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-smartypants#readme",
   "keywords": [

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -29,7 +29,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#readme",
   "keywords": [

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -19,7 +19,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal#readme",
   "keywords": [

--- a/packages/gatsby-source-faker/package.json
+++ b/packages/gatsby-source-faker/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-faker#readme",
   "keywords": [

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -27,7 +27,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-filesystem#readme",
   "keywords": [

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -23,7 +23,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql#readme",
   "keywords": [

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-hacker-news#readme",
   "keywords": [

--- a/packages/gatsby-source-lever/package.json
+++ b/packages/gatsby-source-lever/package.json
@@ -21,7 +21,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-lever#readme",
   "keywords": [

--- a/packages/gatsby-source-medium/package.json
+++ b/packages/gatsby-source-medium/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-medium#readme",
   "keywords": [

--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -20,7 +20,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-mongodb#readme",
   "keywords": [

--- a/packages/gatsby-source-npm-package-search/package.json
+++ b/packages/gatsby-source-npm-package-search/package.json
@@ -18,7 +18,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "dependencies": {
     "babel-preset-gatsby-package": "^0.5.2",

--- a/packages/gatsby-source-wikipedia/package.json
+++ b/packages/gatsby-source-wikipedia/package.json
@@ -37,7 +37,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -25,7 +25,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wordpress#readme",
   "keywords": [

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.10.3",
     "babel-jest": "^24.9.0",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
     "jest-junit": "^6.4.0"

--- a/packages/gatsby-transformer-asciidoc/package.json
+++ b/packages/gatsby-transformer-asciidoc/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "lodash": "^4.17.15"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-asciidoc#readme",

--- a/packages/gatsby-transformer-csv/package.json
+++ b/packages/gatsby-transformer-csv/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "json2csv": "^3.11"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-csv#readme",

--- a/packages/gatsby-transformer-documentationjs/package.json
+++ b/packages/gatsby-transformer-documentationjs/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-documentationjs#readme",
   "keywords": [

--- a/packages/gatsby-transformer-excel/package.json
+++ b/packages/gatsby-transformer-excel/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-excel#readme",
   "keywords": [

--- a/packages/gatsby-transformer-hjson/package.json
+++ b/packages/gatsby-transformer-hjson/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-hjson#readme",
   "keywords": [

--- a/packages/gatsby-transformer-javascript-frontmatter/package.json
+++ b/packages/gatsby-transformer-javascript-frontmatter/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-transformer-javascript-static-exports/package.json
+++ b/packages/gatsby-transformer-javascript-static-exports/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-javascript-static-exports#readme",
   "keywords": [

--- a/packages/gatsby-transformer-json/package.json
+++ b/packages/gatsby-transformer-json/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-json#readme",
   "keywords": [

--- a/packages/gatsby-transformer-pdf/package.json
+++ b/packages/gatsby-transformer-pdf/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-pdf#readme",
   "keywords": [

--- a/packages/gatsby-transformer-react-docgen/package.json
+++ b/packages/gatsby-transformer-react-docgen/package.json
@@ -18,7 +18,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "lodash": "^4.17.15"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-react-docgen#readme",

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -33,7 +33,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark#readme",
   "keywords": [

--- a/packages/gatsby-transformer-screenshot/package.json
+++ b/packages/gatsby-transformer-screenshot/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-screenshot#readme",
   "keywords": [

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -19,7 +19,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sharp#readme",
   "keywords": [

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -20,7 +20,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "debug": "^3.2.6"
   },
   "peerDependencies": {

--- a/packages/gatsby-transformer-toml/package.json
+++ b/packages/gatsby-transformer-toml/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-toml#readme",
   "keywords": [

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-xml#readme",
   "keywords": [

--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -16,7 +16,7 @@
     "@babel/cli": "^7.10.3",
     "@babel/core": "^7.10.3",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1"
+    "cross-env": "^7.0.2"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-yaml#readme",
   "keywords": [

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -167,7 +167,7 @@
     "@types/webpack-dev-middleware": "^3.7.1",
     "@types/webpack-virtual-modules": "^0.1.0",
     "babel-preset-gatsby-package": "^0.5.2",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "documentation": "^12.3.0",
     "enhanced-resolve": "^4.2.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",

--- a/plop-templates/package/package.json.hbs
+++ b/plop-templates/package/package.json.hbs
@@ -28,6 +28,6 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.9.6",
     "babel-preset-gatsby-package": "^0.1.1",
-    "cross-env": "^5.0.5"
+    "cross-env": "^7.0.2"
   }
 }

--- a/www/package.json
+++ b/www/package.json
@@ -130,7 +130,7 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-macros": "^2.8.0",
     "babel-preset-gatsby": "^0.2.36",
-    "cross-env": "^5.2.1",
+    "cross-env": "^7.0.2",
     "front-matter": "^2.3.0",
     "github-api": "^3.3.0",
     "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7845,12 +7845,12 @@ createerror@1.3.0, createerror@^1.2.0, createerror@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/createerror/-/createerror-1.3.0.tgz#c666bd4cd6b94e35415396569d4649dd0cdb3313"
 
-cross-env@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.1.tgz#b2c76c1ca7add66dc874d11798466094f551b34d"
-  integrity sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==
+cross-env@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
+  integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
   dependencies:
-    cross-spawn "^6.0.5"
+    cross-spawn "^7.0.1"
 
 cross-fetch@2.2.2:
   version "2.2.2"
@@ -7889,6 +7889,15 @@ cross-spawn@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
## Description

Updates cross-env from v5 to v7. Only affects development within Gatsby monorepo. No code changes; all tests pass.

### Relevant Breaking Changes

[cross-env v6:](/kentcdodds/cross-env/releases/tag/v6.0.0) require Node 8; no API changes
[cross-env v7:](/kentcdodds/cross-env/releases/tag/v7.0.0) require Node 10; no API changes