### PR TITLE
add note for local font

### DIFF
--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -294,6 +294,8 @@ _Note: You can use Sass/SCSS files as modules too, like mentioned in the previou
 }
 ```
 
+**Note** If you use Gatsby, it will not work including <Global> a local css file is required
+
 **Note:** Make sure the font name is referenced from the relevant CSS, e.g.:
 
 ```css:title=src/components/layout.css


### PR DESCRIPTION
Trying to add a local font, I realized that if I performed the font-face in em> global> of Emotion when deploying the fonts appeared with a 404 error. It was solved by adding a general css file with the font-faces.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
