### PR TITLE
chore(gatsby-admin): fix built html not having layout wrappers

### DIFF
--- a/packages/gatsby-admin/gatsby-ssr.js
+++ b/packages/gatsby-admin/gatsby-ssr.js
@@ -1,0 +1,1 @@
+export { wrapPageElement } from "./gatsby-browser.js"


### PR DESCRIPTION
We have a `wrapPageElement` method in gatsby-browser.js that wraps every page in our `<Layout />` component, which adds some global styling and wraps the page in all kinds of context providers—most notably, the theme providers!

So far, that worked fine and looked alright. However, we started using some gatsby-interface components that rely on the theme being in the context during `gatsby build`. That suddenly broke the build process with errors such as [this](https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/47577/workflows/35caf132-f7d5-4f4c-b454-baed3c7b4d82/jobs/485815) and [this](https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/47662/workflows/a268e5b7-4090-431b-b9ad-1884bdac2ca4/jobs/486879), yet the develop process kept working fine.

I realised this morning that the fix is as simple as also adding the `wrapPageElement` to gatsby-ssr.js! 🤦  This unblocks #26195 and #26243.