### PR TITLE
chore(requires-writer): update auto-generated code to not trigger no-mixed-operators eslint warnings/errors

### DIFF
--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -195,7 +195,7 @@ export const writeAll = async (state: IGatsbyState): Promise<boolean> => {
   let syncRequires = `${hotImport}
 
 // prefer default export if available
-const preferDefault = m => m && m.default || m
+const preferDefault = m => (m && m.default) || m
 \n\n`
   syncRequires += `exports.components = {\n${components
     .map(
@@ -209,7 +209,7 @@ const preferDefault = m => m && m.default || m
 
   // Create file with async requires of components/json files.
   let asyncRequires = `// prefer default export if available
-const preferDefault = m => m && m.default || m
+const preferDefault = m => (m && m.default) || m
 \n`
   asyncRequires += `exports.components = {\n${components
     .map((c: IGatsbyPageComponent): string => {


### PR DESCRIPTION
## Description

Code we generate in `(a)sync-requires.js` (virtual) modules currently doesn't pass `no-mixed-operators` eslint rule. This is quick change to make it pass. This is for cases when users might use some custom eslint setups (tho I probably should follow up and see if we have documentation for `eslint-loader` modifications anywhere and possibly adjust `ignore` setting there to ignore modules from `_this_is_virtual_fs_path_/$virtual` (as user might have very speciffic rules that would warn/error on code we autogenerate)

## Related Issues

Fixes #26319
