### PR TITLE
fix(gatsby-plugin-page-creator): juggle reporter dont depend on cli

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -15,7 +15,7 @@ describe(`isValidCollectionPathImplementation`, () => {
     `%o passes`,
     path => {
       expect(() =>
-        isValidCollectionPathImplementation(compatiblePath(path))
+        isValidCollectionPathImplementation(compatiblePath(path), reporter)
       ).not.toThrow()
     }
   )
@@ -29,7 +29,7 @@ describe(`isValidCollectionPathImplementation`, () => {
   ])(`%o throws as expected`, path => {
     const part = path.split(`/`)[2]
 
-    isValidCollectionPathImplementation(compatiblePath(path))
+    isValidCollectionPathImplementation(compatiblePath(path), reporter)
     expect(reporter.panicOnBuild)
       .toBeCalledWith(`Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.
 filePath: ${compatiblePath(path)}`)

--- a/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
@@ -4,6 +4,7 @@ import { createClientOnlyPage } from "./create-client-only-page"
 import { createPagesFromCollectionBuilder } from "./create-pages-from-collection-builder"
 import systemPath from "path"
 import { trackFeatureIsUsed } from "gatsby-telemetry"
+import { Reporter } from "gatsby"
 
 function pathIsCollectionBuilder(path: string): boolean {
   return path.includes(`{`)
@@ -18,7 +19,8 @@ export function createPage(
   pagesDirectory: string,
   actions: Actions,
   ignore: string[],
-  graphql: CreatePagesArgs["graphql"]
+  graphql: CreatePagesArgs["graphql"],
+  reporter: Reporter
 ): void {
   // Filter out special components that shouldn't be made into
   // pages.
@@ -41,7 +43,13 @@ export function createPage(
         `PageCreator: Found a collection route, but the proper env was not set to enable this experimental feature. Please run again with \`GATSBY_EXPERIMENTAL_ROUTING_APIS=1\` to enable.`
       )
     }
-    createPagesFromCollectionBuilder(filePath, absolutePath, actions, graphql)
+    createPagesFromCollectionBuilder(
+      filePath,
+      absolutePath,
+      actions,
+      graphql,
+      reporter
+    )
     return
   }
 

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -8,18 +8,24 @@ import { derivePath } from "./derive-path"
 import { watchCollectionBuilder } from "./watch-collection-builder"
 import { collectionExtractQueryString } from "./collection-extract-query-string"
 import { isValidCollectionPathImplementation } from "./is-valid-collection-path-implementation"
-import reporter from "gatsby-cli/lib/reporter"
 
 // TODO: Do we need the ignore argument?
 export async function createPagesFromCollectionBuilder(
   filePath: string,
   absolutePath: string,
   actions: Actions,
-  graphql: CreatePagesArgs["graphql"]
+  graphql: CreatePagesArgs["graphql"],
+  reporter
 ): Promise<void> {
-  if (isValidCollectionPathImplementation(absolutePath) === false) {
+  if (isValidCollectionPathImplementation(absolutePath, reporter) === false) {
     watchCollectionBuilder(absolutePath, ``, [], actions, () =>
-      createPagesFromCollectionBuilder(filePath, absolutePath, actions, graphql)
+      createPagesFromCollectionBuilder(
+        filePath,
+        absolutePath,
+        actions,
+        graphql,
+        reporter
+      )
     )
     return
   }
@@ -30,7 +36,13 @@ export async function createPagesFromCollectionBuilder(
   // 1.a  If the query string is not findable, we can't move on. So we stop and watch
   if (queryString === null) {
     watchCollectionBuilder(absolutePath, ``, [], actions, () =>
-      createPagesFromCollectionBuilder(filePath, absolutePath, actions, graphql)
+      createPagesFromCollectionBuilder(
+        filePath,
+        absolutePath,
+        actions,
+        graphql,
+        reporter
+      )
     )
     return
   }
@@ -51,7 +63,13 @@ ${errors.map(error => error.message).join(`\n`)}`.trim()
     )
 
     watchCollectionBuilder(absolutePath, queryString, [], actions, () =>
-      createPagesFromCollectionBuilder(filePath, absolutePath, actions, graphql)
+      createPagesFromCollectionBuilder(
+        filePath,
+        absolutePath,
+        actions,
+        graphql,
+        reporter
+      )
     )
 
     return
@@ -97,6 +115,12 @@ ${errors.map(error => error.message).join(`\n`)}`.trim()
   })
 
   watchCollectionBuilder(absolutePath, queryString, paths, actions, () =>
-    createPagesFromCollectionBuilder(filePath, absolutePath, actions, graphql)
+    createPagesFromCollectionBuilder(
+      filePath,
+      absolutePath,
+      actions,
+      graphql,
+      reporter
+    )
   )
 }

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -8,6 +8,7 @@ import { derivePath } from "./derive-path"
 import { watchCollectionBuilder } from "./watch-collection-builder"
 import { collectionExtractQueryString } from "./collection-extract-query-string"
 import { isValidCollectionPathImplementation } from "./is-valid-collection-path-implementation"
+import { Reporter } from "gatsby"
 
 // TODO: Do we need the ignore argument?
 export async function createPagesFromCollectionBuilder(
@@ -15,7 +16,7 @@ export async function createPagesFromCollectionBuilder(
   absolutePath: string,
   actions: Actions,
   graphql: CreatePagesArgs["graphql"],
-  reporter
+  reporter: Reporter
 ): Promise<void> {
   if (isValidCollectionPathImplementation(absolutePath, reporter) === false) {
     watchCollectionBuilder(absolutePath, ``, [], actions, () =>

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -67,7 +67,7 @@ Please pick a path to an existing directory.`)
   // Get initial list of files.
   let files = await glob(pagesGlob, { cwd: pagesPath })
   files.forEach(file => {
-    createPage(file, pagesDirectory, actions, ignore, graphql)
+    createPage(file, pagesDirectory, actions, ignore, graphql, reporter)
   })
 
   watchDirectory(
@@ -75,7 +75,14 @@ Please pick a path to an existing directory.`)
     pagesGlob,
     addedPath => {
       if (!_.includes(files, addedPath)) {
-        createPage(addedPath, pagesDirectory, actions, ignore, graphql)
+        createPage(
+          addedPath,
+          pagesDirectory,
+          actions,
+          ignore,
+          graphql,
+          reporter
+        )
         files.push(addedPath)
       }
     },

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -1,12 +1,15 @@
 import sysPath from "path"
-import reporter from "gatsby-cli/lib/reporter"
+import { Reporter } from "gatsby"
 
 // This file is a helper for consumers. It's going to log an error to them if they
 // in any way have an incorrect filepath setup for us to predictably use collection
 // querying.
 //
 // Without this, users will can get mystic errors.
-export function isValidCollectionPathImplementation(filePath: string): boolean {
+export function isValidCollectionPathImplementation(
+  filePath: string,
+  reporter: Reporter
+): boolean {
   const parts = filePath.split(sysPath.sep)
   let passing = true
 


### PR DESCRIPTION
Resolves an issue where something was imported from `gatsby-cli` without depending on it.

We'd rather not have a plugin depend on the cli directly and since the `reporter` is already passed on into it we'd rather juggle it forward.

Fixes #26345