### PR TITLE
fix(gatsby): set correct content-type header for socket.io.js

### DIFF
--- a/packages/gatsby/src/utils/develop-proxy.ts
+++ b/packages/gatsby/src/utils/develop-proxy.ts
@@ -61,6 +61,7 @@ export const startDevelopProxy = (input: {
     }
 
     if (req.url === `/socket.io/socket.io.js`) {
+      res.setHeader(`Content-Type`, `application/javascript`)
       res.end(
         fs.readFileSync(require.resolve(`socket.io-client/dist/socket.io.js`))
       )


### PR DESCRIPTION
This is necessary in order for sites to run with nosniff, see #24862 for more context. Closes #24862 


