### PR TITLE
fix(gatsby): improve the log for service lock issues

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -288,7 +288,7 @@ module.exports = async (program: IProgram): Promise<void> => {
       const data = await getService(program.directory, `developproxy`)
       const port = data?.port || 8000
       console.error(
-        `Looks like develop for this site is already running, can you visit http://localhost:${port}? If it is not, try again in five seconds!`
+        `Looks like develop for this site is already running, can you visit ${program.ssl ? `https://` : `http://`}://localhost:${port} ? If it is not, try again in five seconds!`
       )
       process.exit(1)
     }

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -288,7 +288,9 @@ module.exports = async (program: IProgram): Promise<void> => {
       const data = await getService(program.directory, `developproxy`)
       const port = data?.port || 8000
       console.error(
-        `Looks like develop for this site is already running, can you visit ${program.ssl ? `https://` : `http://`}://localhost:${port} ? If it is not, try again in five seconds!`
+        `Looks like develop for this site is already running, can you visit ${
+          program.ssl ? `https://` : `http://`
+        }://localhost:${port} ? If it is not, try again in five seconds!`
       )
       process.exit(1)
     }

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -288,7 +288,7 @@ module.exports = async (program: IProgram): Promise<void> => {
       const data = await getService(program.directory, `developproxy`)
       const port = data?.port || 8000
       console.error(
-        `Looks like develop for this site is already running. Try visiting http://localhost:${port}/ maybe?`
+        `Looks like develop for this site is already running, can you visit http://localhost:${port}? If it is not, try again in five seconds!`
       )
       process.exit(1)
     }


### PR DESCRIPTION
See  #26214 for context:

> This appears to be an issue with our service discovery mechanism not correctly releasing locks on CTRL+C. While I don't know how to resolve that, we already use the minimum possible stale duration for the lockfiles of 5s so after five seconds it should work again.
> That means we could quickly patch this annoyance for users by changing the error log to something like "Looks like develop for this site is already running, can you visit http://localhost:8000? If it is not, try again in five seconds!"

Closes #26214 