### PR TITLE
docs(api-ssr-docs): Improve onRenderBody example

### DIFF
--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -98,7 +98,7 @@ exports.replaceRenderer = true
  *   setHeadComponents,
  *   setHtmlAttributes,
  *   setBodyAttributes
- * }) => {
+ * }, pluginOptions) => {
  *   setHtmlAttributes(HtmlAttributes)
  *   setHeadComponents(HeadComponents)
  *   setBodyAttributes(BodyAttributes)

--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -79,24 +79,20 @@ exports.replaceRenderer = true
  * is merged with other body props and passed to `html.js` as `bodyProps`.
  * @param {pluginOptions} pluginOptions
  * @example
- * const { Helmet } = require("react-helmet")
- *
- * exports.onRenderBody = (
- *   { setHeadComponents, setHtmlAttributes, setBodyAttributes },
- *   pluginOptions
- * ) => {
- *   const helmet = Helmet.renderStatic()
- *   setHtmlAttributes(helmet.htmlAttributes.toComponent())
- *   setBodyAttributes(helmet.bodyAttributes.toComponent())
- *   setHeadComponents([
- *     helmet.title.toComponent(),
- *     helmet.link.toComponent(),
- *     helmet.meta.toComponent(),
- *     helmet.noscript.toComponent(),
- *     helmet.script.toComponent(),
- *     helmet.style.toComponent(),
- *   ])
+ * // Object of props
+ * const HtmlAttributes = {
+ *   "data-whatever": "content"
  * }
+ *
+ * // Magic
+ * exports.onRenderBody = (
+ *   { setHtmlAttributes }
+ * ) => {
+ *    setHtmlAttributes(HtmlAttributes)
+ * }
+ *
+ * // Output
+ * <html data-whatever="content">
  */
 exports.onRenderBody = true
 

--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -79,20 +79,30 @@ exports.replaceRenderer = true
  * is merged with other body props and passed to `html.js` as `bodyProps`.
  * @param {pluginOptions} pluginOptions
  * @example
- * // Object of props
+ * // Import React so that you can use JSX in HeadComponents
+ * const React = require("react")
+ *
  * const HtmlAttributes = {
- *   "data-whatever": "content"
+ *   lang: "en"
  * }
  *
- * // Magic
- * exports.onRenderBody = (
- *   { setHtmlAttributes }
- * ) => {
- *    setHtmlAttributes(HtmlAttributes)
+ * const HeadComponents = [
+ *   <script key="my-script" src="https://gatsby.dev/my-script" />
+ * ]
+ *
+ * const BodyAttributes = {
+ *   "data-theme": "dark"
  * }
  *
- * // Output
- * <html data-whatever="content">
+ * exports.onRenderBody = ({
+ *   setHeadComponents,
+ *   setHtmlAttributes,
+ *   setBodyAttributes
+ * }) => {
+ *   setHtmlAttributes(HtmlAttributes)
+ *   setHeadComponents(HeadComponents)
+ *   setBodyAttributes(BodyAttributes)
+ * }
  */
 exports.onRenderBody = true
 


### PR DESCRIPTION
## Description

Improves the example for onRenderBody (https://www.gatsbyjs.org/docs/ssr-apis/#onRenderBody),

from:
```
const { Helmet } = require("react-helmet")

exports.onRenderBody = (
  { setHeadComponents, setHtmlAttributes, setBodyAttributes },
  pluginOptions
) => {
  const helmet = Helmet.renderStatic()
  setHtmlAttributes(helmet.htmlAttributes.toComponent())
  setBodyAttributes(helmet.bodyAttributes.toComponent())
  setHeadComponents([
    helmet.title.toComponent(),
    helmet.link.toComponent(),
    helmet.meta.toComponent(),
    helmet.noscript.toComponent(),
    helmet.script.toComponent(),
    helmet.style.toComponent(),
  ])
}
```


to:

```
// Object of props
const HtmlAttributes = {
  "data-whatever": "content"
}

// Magic
exports.onRenderBody = (
  { setHtmlAttributes }
) => {
   setHtmlAttributes(HtmlAttributes)
}

// Output
<html data-whatever="content">
```

## Related Issues

Fixes #26144
