### PR TITLE
Fix typos and linter dictionary errors

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1,6 +1,6 @@
+0BSD
 ½
 ⅓
-0BSD
 1000px
 1000s
 1000x
@@ -244,6 +244,7 @@ bois
 Bolda
 Bölüm
 bool
+booleans
 bootcamp
 bootcamps
 bootstrapable
@@ -388,6 +389,9 @@ Commento
 Commentors
 CommonJS
 CommonMark
+comparator
+Comparator
+comparators
 compile-to-js
 componentChunkName
 componentChunkNames
@@ -429,8 +433,8 @@ Costa
 Costea
 Coughlan
 counterintuitive
-COVID-19
 COVID
+COVID-19
 cowpaths
 Coyier
 CPG
@@ -665,6 +669,7 @@ filesystem-based
 filesystem-explorer-options
 filesystem-query
 Fillerama
+filterValue
 FindCollabs
 findDirtyIds
 findIdsWithoutDataDependencies
@@ -1254,6 +1259,7 @@ METROGLAM
 Meuleman
 Michał
 Microfrontends
+micromatch
 microservices
 microsites
 middleware
@@ -1281,6 +1287,7 @@ modularizing
 modus
 Monahan
 mongo
+MongoDb
 monorepo
 monorepos
 Morby
@@ -1332,11 +1339,11 @@ Nicky
 Nie
 Nik
 no-brainer
+Node.js
 nodeId
 nodeID
 NodeID
 nodemailer
-Node.js
 NodeSchool
 nodesPromise
 Nolen

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -1287,7 +1287,6 @@ modularizing
 modus
 Monahan
 mongo
-MongoDb
 monorepo
 monorepos
 Morby

--- a/docs/docs/query-filters.md
+++ b/docs/docs/query-filters.md
@@ -8,9 +8,7 @@ title: Query Filters with GraphQL in Gatsby
 
 Gatsby stores all data loaded during the source-nodes phase in Redux and it allows you to write GraphQL queries to query that data. This data, stored as individual "nodes", can be searched through using a query language that is inspired by [MongoDB queries](https://docs.mongodb.com/manual/reference/operator/query/).
 
-Filtering is used in GraphQL root fields of Node types (e.g. for File type it would be `file` and `allFile`). `filter` GraphQL argument is passed to the filtering system and will return all the nodes that match each of the given filters. The rest of the processing, such as pagination, is handled on GraphQL resolver level.
-
-Filtering is used in GraphQL root fields of Node types (e.g. for File type it would be `file` and `allFile`). The GraphQL `filter` argument is passed to the filtering system and will return all the nodes that match each of the given filters. The rest of the processing, such as pagination, is handled on GraphQL resolver level.
+Filtering is used in GraphQL root fields of Node types (e.g. for File type it would be `file` and `allFile`). The GraphQL `filter` argument is passed to the filtering system and will return all the nodes that match each of the given filters. The rest of the processing, such as pagination, is handled on the GraphQL resolver level.
 
 ### History and Sift
 

--- a/docs/docs/query-filters.md
+++ b/docs/docs/query-filters.md
@@ -12,13 +12,13 @@ Filtering is used in GraphQL root fields of Node types (e.g. for File type it wo
 
 ### History and Sift
 
-For a long time Gatsby used the [sift.js](https://github.com/crcn/sift.js) library through which you can use [MongoDB queries](https://docs.mongoDB.com/manual/reference/operator/query/) in JavaScript.
+For a long time Gatsby used the [sift.js](https://github.com/crcn/sift.js) library through which you can use [MongoDB queries](https://docs.mongodb.com/manual/reference/operator/query/) in JavaScript.
 
 Unfortunately Sift did not align with how Gatsby used it and so a custom system was written to slowly replace it. This system was called "fast filters" and as of gatsby@2.23.0 (June 2020) the Sift library is no longer used.
 
 ## Query Language
 
-The syntax and API used by the filters is based on [the MongoDB query syntax](https://docs.mongoDB.com/manual/reference/operator/query/) but keep in mind only a subset of comparators is supported in Gatsby.
+The syntax and API used by the filters is based on [the MongoDB query syntax](https://docs.mongodb.com/manual/reference/operator/query/) but keep in mind only a subset of comparators is supported in Gatsby.
 
 In general a filter has a "filter path" component ending with a "comparator", and a "filter value". It's a way of programmatically asking "show me all nodes where `node[i].a.b.c` leads to a value less than `5`".
 

--- a/docs/docs/query-filters.md
+++ b/docs/docs/query-filters.md
@@ -8,7 +8,7 @@ title: Query Filters with GraphQL in Gatsby
 
 Gatsby stores all data loaded during the source-nodes phase in Redux and it allows you to write GraphQL queries to query that data. This data, stored as individual "nodes", can be searched through using a query language that is inspired by [MongoDb queries](https://docs.mongodb.com/manual/reference/operator/query/).
 
-Filtering is used in GraphQL root fields of Node types (e.g. for File type it would be `file` and `allFile`). `filter` GraphQL argument is passed to the filtering system and will return all the nodes that match each of the given filters. The resto of the processing, such as pagination, is handled on GraphQL resolver level.
+Filtering is used in GraphQL root fields of Node types (e.g. for File type it would be `file` and `allFile`). `filter` GraphQL argument is passed to the filtering system and will return all the nodes that match each of the given filters. The rest of the processing, such as pagination, is handled on GraphQL resolver level.
 
 Filtering is used in GraphQL root fields of Node types (e.g. for File type it would be `file` and `allFile`). The GraphQL `filter` argument is passed to the filtering system and will return all the nodes that match each of the given filters. The rest of the processing, such as pagination, is handled on GraphQL resolver level.
 
@@ -137,7 +137,7 @@ Specific rules:
   - Glob pattern is converted to a JavaScript RegExp with [micromatch](https://github.com/micromatch/micromatch)
   - The `regex` filterValue must be a stringified regular expression, including leading and trailing forward slash and optional flags; Like `"/foo/g"`
   - Never returns nodes with partial paths
-  - While testing, result values are explicitly casted to a string through `String(resultValue)` before passing it to `regex.test()`
+  - While testing, result values are explicitly cast to a string through `String(resultValue)` before passing it to `regex.test()`
 
 ### Nulls and partial paths
 

--- a/docs/docs/query-filters.md
+++ b/docs/docs/query-filters.md
@@ -6,7 +6,7 @@ title: Query Filters with GraphQL in Gatsby
 
 ## Summary
 
-Gatsby stores all data loaded during the source-nodes phase in Redux and it allows you to write GraphQL queries to query that data. This data, stored as individual "nodes", can be searched through using a query language that is inspired by [MongoDb queries](https://docs.mongodb.com/manual/reference/operator/query/).
+Gatsby stores all data loaded during the source-nodes phase in Redux and it allows you to write GraphQL queries to query that data. This data, stored as individual "nodes", can be searched through using a query language that is inspired by [MongoDB queries](https://docs.mongodb.com/manual/reference/operator/query/).
 
 Filtering is used in GraphQL root fields of Node types (e.g. for File type it would be `file` and `allFile`). `filter` GraphQL argument is passed to the filtering system and will return all the nodes that match each of the given filters. The rest of the processing, such as pagination, is handled on GraphQL resolver level.
 
@@ -14,13 +14,13 @@ Filtering is used in GraphQL root fields of Node types (e.g. for File type it wo
 
 ### History and Sift
 
-For a long time Gatsby used the [sift.js](https://github.com/crcn/sift.js) library through which you can use [MongoDb queries](https://docs.mongodb.com/manual/reference/operator/query/) in JavaScript.
+For a long time Gatsby used the [sift.js](https://github.com/crcn/sift.js) library through which you can use [MongoDB queries](https://docs.mongoDB.com/manual/reference/operator/query/) in JavaScript.
 
 Unfortunately Sift did not align with how Gatsby used it and so a custom system was written to slowly replace it. This system was called "fast filters" and as of gatsby@2.23.0 (June 2020) the Sift library is no longer used.
 
 ## Query Language
 
-The syntax and API used by the filters is based on [the MongoDB query syntax](https://docs.mongodb.com/manual/reference/operator/query/) but keep in mind only a subset of comparators is supported in Gatsby.
+The syntax and API used by the filters is based on [the MongoDB query syntax](https://docs.mongoDB.com/manual/reference/operator/query/) but keep in mind only a subset of comparators is supported in Gatsby.
 
 In general a filter has a "filter path" component ending with a "comparator", and a "filter value". It's a way of programmatically asking "show me all nodes where `node[i].a.b.c` leads to a value less than `5`".
 


### PR DESCRIPTION
Linter was failing on dictionary words. This fixes a handful of typos and adds the rest to the dictionary.