### PR TITLE
fix(structured-logging): fix wrongly reporting status as success when we should still be in pending state

### DIFF
--- a/packages/gatsby-cli/src/reporter/redux/__tests__/integration.ts
+++ b/packages/gatsby-cli/src/reporter/redux/__tests__/integration.ts
@@ -1,0 +1,71 @@
+import { ActivityStatuses, ActivityTypes } from "../../constants"
+import { ISetStatus } from "../types"
+
+jest.useFakeTimers()
+
+describe(`integration`, () => {
+  let dispatchSpy, internalActions
+
+  const getDispatchedSetStatusActions = (): Array<ISetStatus> =>
+    dispatchSpy.mock.calls
+      .map(args => args[0])
+      .filter(action => action.type === `SET_STATUS`)
+
+  beforeEach(async () => {
+    jest.resetModules()
+    const { getStore } = require(`../`)
+    dispatchSpy = jest.spyOn(getStore(), `dispatch`)
+    internalActions = await import(`../actions`)
+  })
+
+  test(`Doesn't dispatch pre-emptive SUCCESS `, async () => {
+    const {
+      createPendingActivity,
+      endActivity,
+      startActivity,
+    } = internalActions
+
+    startActivity({
+      id: `activity-1`,
+      text: `activity-1`,
+      type: ActivityTypes.Spinner,
+    })
+    endActivity({ id: `activity-1`, status: ActivityStatuses.Success })
+    startActivity({
+      id: `activity-2`,
+      text: `activity-2`,
+      type: ActivityTypes.Spinner,
+    })
+    createPendingActivity({ id: `pending-activity` })
+    endActivity({ id: `activity-2`, status: ActivityStatuses.Success })
+
+    jest.runOnlyPendingTimers()
+
+    let dispatchedSetStatusActions = getDispatchedSetStatusActions()
+
+    // we don't expect to see SET_STATUS other than initial IN_PROGRESS
+    // as we still have pending activity
+    expect(dispatchedSetStatusActions.length).toEqual(1)
+    expect(dispatchedSetStatusActions[0]).toEqual({
+      type: `SET_STATUS`,
+      payload: `IN_PROGRESS`,
+      timestamp: expect.any(String),
+    })
+
+    endActivity({ id: `pending-activity`, status: ActivityStatuses.Cancelled })
+    jest.runOnlyPendingTimers()
+
+    dispatchedSetStatusActions = getDispatchedSetStatusActions()
+    expect(dispatchedSetStatusActions.length).toEqual(2)
+    expect(dispatchedSetStatusActions[0]).toEqual({
+      type: `SET_STATUS`,
+      payload: `IN_PROGRESS`,
+      timestamp: expect.any(String),
+    })
+    expect(dispatchedSetStatusActions[1]).toEqual({
+      type: `SET_STATUS`,
+      payload: `SUCCESS`,
+      timestamp: expect.any(String),
+    })
+  })
+})

--- a/packages/gatsby-cli/src/reporter/redux/__tests__/internal-actions.ts
+++ b/packages/gatsby-cli/src/reporter/redux/__tests__/internal-actions.ts
@@ -1,0 +1,113 @@
+import { Dispatch, CombinedState } from "redux"
+
+import { ActivityStatuses } from "../../constants"
+import { ISetStatus, IGatsbyCLIState } from "../types"
+import { GatsbyCLIStore } from "../"
+
+jest.useFakeTimers()
+
+describe(`setStatus action creator`, () => {
+  let mockStatus: ActivityStatuses | "" = ``
+  let setStatus
+
+  const dispatchMockFn: Dispatch<ISetStatus> = <T extends ISetStatus>(
+    action: T
+  ): T => {
+    mockStatus = action.payload
+    return action
+  }
+
+  const dispatch = jest.fn(dispatchMockFn)
+
+  const setStatusWithDispatch = <T extends ISetStatus>(
+    status: ActivityStatuses | ""
+  ): T => setStatus(status)(dispatch)
+
+  beforeAll(async () => {
+    jest.doMock(`../`, () => {
+      return {
+        getStore: (): Partial<GatsbyCLIStore> => {
+          return {
+            getState: (): CombinedState<{ logs: IGatsbyCLIState }> => {
+              return {
+                logs: { status: mockStatus, messages: [], activities: {} },
+              }
+            },
+          }
+        },
+      }
+    })
+    jest.resetModules()
+    setStatus = (await import(`../internal-actions`)).setStatus
+  })
+
+  afterAll(() => {
+    jest.unmock(`../`)
+  })
+
+  beforeEach(() => {
+    mockStatus = ``
+    dispatch.mockClear()
+  })
+
+  it(`debounces SUCCESS in case activities don't overlap`, () => {
+    setStatusWithDispatch(ActivityStatuses.InProgress)
+    setStatusWithDispatch(ActivityStatuses.Success)
+    setStatusWithDispatch(ActivityStatuses.InProgress)
+    setStatusWithDispatch(ActivityStatuses.Success)
+
+    // we should only emit initial IN_PROGRESS event
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
+      type: `SET_STATUS`,
+      payload: ActivityStatuses.InProgress,
+    })
+
+    jest.runOnlyPendingTimers()
+
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch).toHaveBeenNthCalledWith(2, {
+      type: `SET_STATUS`,
+      payload: ActivityStatuses.Success,
+    })
+  })
+
+  it(`debounces FAILED in case activities don't overlap`, () => {
+    setStatusWithDispatch(ActivityStatuses.InProgress)
+    setStatusWithDispatch(ActivityStatuses.Success)
+    setStatusWithDispatch(ActivityStatuses.InProgress)
+    setStatusWithDispatch(ActivityStatuses.Failed)
+
+    // we should only emit initial IN_PROGRESS event
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
+      type: `SET_STATUS`,
+      payload: ActivityStatuses.InProgress,
+    })
+
+    jest.runOnlyPendingTimers()
+
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch).toHaveBeenNthCalledWith(2, {
+      type: `SET_STATUS`,
+      payload: ActivityStatuses.Failed,
+    })
+  })
+
+  it(`doesn't wrongly emit SUCCESS when we are still in progress `, () => {
+    setStatusWithDispatch(ActivityStatuses.InProgress)
+    setStatusWithDispatch(ActivityStatuses.Success)
+    setStatusWithDispatch(ActivityStatuses.InProgress)
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
+      type: `SET_STATUS`,
+      payload: ActivityStatuses.InProgress,
+    })
+
+    jest.runOnlyPendingTimers()
+
+    //we are still in progress, so we shouldn't emit anything other than initial IN_PROGRESS
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -11,7 +11,7 @@ let store = createStore(
   {}
 )
 
-type GatsbyCLIStore = typeof store
+export type GatsbyCLIStore = typeof store
 type StoreListener = (store: GatsbyCLIStore) => void
 type ActionLogListener = (action: ActionsUnion) => any
 type Thunk = (...args: any[]) => ActionsUnion

--- a/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
+++ b/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
@@ -44,23 +44,40 @@ signalExit(() => {
 })
 
 let cancelDelayedSetStatus: (() => void) | null
-// TODO: THIS IS NOT WORKING ATM
+
+let pendingStatus: ActivityStatuses | "" = ``
+
+// We debounce "done" statuses because activities don't always overlap
+// and there is timing window after one activity ends and before next one starts
+// where technically we are "done" (all activities are done).
+// We don't want to emit multiple SET_STATUS events that would toggle between
+// IN_PROGRESS and SUCCESS/FAILED in short succession in those cases.
 export const setStatus = (
   status: ActivityStatuses | "",
   force: boolean = false
 ) => (dispatch: Dispatch<ISetStatus>): void => {
   const currentStatus = getStore().getState().logs.status
+
   if (cancelDelayedSetStatus) {
     cancelDelayedSetStatus()
     cancelDelayedSetStatus = null
   }
-  if (status !== currentStatus) {
-    if (status === `IN_PROGRESS` || force || weShouldExit) {
-      dispatch({
-        type: Actions.SetStatus,
-        payload: status,
-      })
-    } else {
+
+  if (
+    status !== currentStatus &&
+    (status === ActivityStatuses.InProgress || force || weShouldExit)
+  ) {
+    dispatch({
+      type: Actions.SetStatus,
+      payload: status,
+    })
+    pendingStatus = ``
+  } else {
+    // use pending status if truthy, fallback to current status if we don't have pending status
+    const pendingOrCurrentStatus = pendingStatus || currentStatus
+
+    if (status !== pendingOrCurrentStatus) {
+      pendingStatus = status
       cancelDelayedSetStatus = delayedCall(() => {
         setStatus(status, true)(dispatch)
       }, 1000)
@@ -135,26 +152,18 @@ export const createPendingActivity = ({
   id: string
   status?: ActivityStatuses
 }): ActionsToEmit => {
-  const actionsToEmit: ActionsToEmit = []
-
-  const logsState = getStore().getState().logs
-
   const globalStatus = getGlobalStatus(id, status)
-
-  if (globalStatus !== logsState.status) {
-    actionsToEmit.push(setStatus(globalStatus))
-  }
-
-  actionsToEmit.push({
-    type: Actions.PendingActivity,
-    payload: {
-      id,
-      type: ActivityTypes.Pending,
-      status,
+  return [
+    setStatus(globalStatus),
+    {
+      type: Actions.PendingActivity,
+      payload: {
+        id,
+        type: ActivityTypes.Pending,
+        status,
+      },
     },
-  })
-
-  return actionsToEmit
+  ]
 }
 
 type QueuedStartActivityActions = Array<
@@ -175,32 +184,25 @@ export const startActivity = ({
   current?: number
   total?: number
 }): QueuedStartActivityActions => {
-  const actionsToEmit: QueuedStartActivityActions = []
-
-  const logsState = getStore().getState().logs
-
   const globalStatus = getGlobalStatus(id, status)
 
-  if (globalStatus !== logsState.status) {
-    actionsToEmit.push(setStatus(globalStatus))
-  }
-
-  actionsToEmit.push({
-    type: Actions.StartActivity,
-    payload: {
-      id,
-      uuid: uuidv4(),
-      text,
-      type,
-      status,
-      startTime: process.hrtime(),
-      statusText: ``,
-      current,
-      total,
+  return [
+    setStatus(globalStatus),
+    {
+      type: Actions.StartActivity,
+      payload: {
+        id,
+        uuid: uuidv4(),
+        text,
+        type,
+        status,
+        startTime: process.hrtime(),
+        statusText: ``,
+        current,
+        total,
+      },
     },
-  })
-
-  return actionsToEmit
+  ]
 }
 
 type QueuedEndActivity = Array<
@@ -276,13 +278,8 @@ export const endActivity = ({
     }
   }
 
-  const logsState = getStore().getState().logs
-
   const globalStatus = getGlobalStatus(id, status)
-
-  if (globalStatus !== logsState.status) {
-    actionsToEmit.push(setStatus(globalStatus))
-  }
+  actionsToEmit.push(setStatus(globalStatus))
 
   return actionsToEmit
 }


### PR DESCRIPTION
## Description

The `setStatus` action creator calls are not working correctly right now. This PR aims to add bunch of tests first (some of which will fail), and add code changes showing that hose fixes some problems later.
