### PR TITLE
fix(gatsby-plugin-netlify): Do not cache static query data

### DIFF
--- a/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
+++ b/packages/gatsby-plugin-netlify/src/__tests__/__snapshots__/build-headers-program.js.snap
@@ -30,6 +30,8 @@ X-Frame-Options
   Cache-Control: public, max-age=31536000, immutable
 /static/*
   Cache-Control: public, max-age=31536000, immutable
+/static/d/*
+  Cache-Control: public, max-age=0, must-revalidate
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
@@ -118,6 +120,8 @@ exports[`build-headers-program with caching headers 1`] = `
   Cache-Control: public, max-age=31536000, immutable
 /static/*
   Cache-Control: public, max-age=31536000, immutable
+/static/d/*
+  Cache-Control: public, max-age=0, must-revalidate
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
@@ -208,6 +212,8 @@ exports[`build-headers-program with manifest['pages-manifest'] 1`] = `
   Cache-Control: public, max-age=31536000, immutable
 /static/*
   Cache-Control: public, max-age=31536000, immutable
+/static/d/*
+  Cache-Control: public, max-age=0, must-revalidate
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/
@@ -285,6 +291,8 @@ exports[`build-headers-program with security headers 1`] = `
   Cache-Control: public, max-age=31536000, immutable
 /static/*
   Cache-Control: public, max-age=31536000, immutable
+/static/d/*
+  Cache-Control: public, max-age=0, must-revalidate
 /sw.js
   Cache-Control: no-cache
 /offline-plugin-app-shell-fallback/

--- a/packages/gatsby-plugin-netlify/src/constants.js
+++ b/packages/gatsby-plugin-netlify/src/constants.js
@@ -26,9 +26,11 @@ export const SECURITY_HEADERS = {
 }
 
 export const IMMUTABLE_CACHING_HEADER = `Cache-Control: public, max-age=31536000, immutable`
+const NO_CACHING_HEADER = `Cache-Control: public, max-age=0, must-revalidate`
 
 export const CACHING_HEADERS = {
   "/static/*": [IMMUTABLE_CACHING_HEADER],
+  "/static/d/*": [NO_CACHING_HEADER],
   "/sw.js": [`Cache-Control: no-cache`],
 }
 


### PR DESCRIPTION
## Description

I recently ran into some strange issues on my site that boiled down to queries that came from `useStaticQuery` being immutably cached. The underlying data fetched by the static queries had changed after a redeploy, but when the page loaded in browsers with a warm cache, the relevant components showed the stale data after a brief flash of the new data from the HTML (before JS had loaded).

Since static queries are given a deterministic query hash based on the query itself (not the query results) and written to `/static/d/{queryHash}.json`, the resulting file is cached indefinitely per the `/static/*` caching header.

This PR gives these files the same cache headers as the `page-data.json` files generated by Gatsby, since their purpose is similar.