### PR TITLE
fix(gatsby-source-graphql): use the latest version of graphql-tools

### DIFF
--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.10.3",
-    "@graphql-tools/links": "v6.0.9",
-    "@graphql-tools/utils": "v6.0.9",
-    "@graphql-tools/wrap": "v6.0.9",
+    "@graphql-tools/links": "^6.0.9",
+    "@graphql-tools/utils": "^6.0.9",
+    "@graphql-tools/wrap": "^6.0.9",
     "apollo-link": "1.2.14",
     "apollo-link-http": "^1.5.17",
     "dataloader": "^2.0.0",


### PR DESCRIPTION
## Description

Before this PR we were using specific version of `graphql-tools`. Turns out it may cause issues when there are multiple versions of graphql-tools in the project.

## Related Issues

Fixes #26313
