### PR TITLE
fix(gatsby): place auto-generated virtual modules in `.cache`

### DIFF
--- a/packages/gatsby/src/utils/__tests__/map-templates-to-static-query-hashes.js
+++ b/packages/gatsby/src/utils/__tests__/map-templates-to-static-query-hashes.js
@@ -47,7 +47,7 @@ const createModule = (resource, reasons = []) => {
 describe(`map-templates-to-static-query-hashes`, () => {
   it(`should map static-queries to a component file on all platforms`, () => {
     const asyncRequires = createModule(
-      `_this_is_virtual_fs_path_/$virtual/async-requires.js`
+      `.cache/_this_is_virtual_fs_path_/$virtual/async-requires.js`
     )
 
     const templateMap = mapTemplatesToStaticQueryHashes(

--- a/packages/gatsby/src/utils/gatsby-webpack-virtual-modules.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-virtual-modules.ts
@@ -22,7 +22,7 @@ interface IGatsbyWebpackVirtualModulesContext {
 const fileContentLookup: Record<string, string> = {}
 const instances: IGatsbyWebpackVirtualModulesContext[] = []
 
-export const VIRTUAL_MODULES_BASE_PATH = `_this_is_virtual_fs_path_`
+export const VIRTUAL_MODULES_BASE_PATH = `.cache/_this_is_virtual_fs_path_`
 
 export class GatsbyWebpackVirtualModules {
   apply(compiler): void {

--- a/packages/gatsby/src/utils/map-templates-to-static-query-hashes.ts
+++ b/packages/gatsby/src/utils/map-templates-to-static-query-hashes.ts
@@ -25,7 +25,7 @@ interface IModule extends Omit<Stats.FnModules, "identifier" | "reasons"> {
  */
 const entryNodes = [
   `.cache/api-runner-browser-plugins.js`,
-  `.cache/async-requires.js`,
+  `.cache/_this_is_virtual_fs_path_/$virtual/async-requires.js`,
 ]
 
 /* This function takes the current Redux state and a compilation


### PR DESCRIPTION
## Description

There are some plugins that traditionally were excluding `.cache` directory from being checked (for example default configuration for `gatsby-plugin-eslint`). With the move to virtual modules, our autogenerated modules ( `(a)sync-requires.js`) where no longer "placed" in `.cache` resulting in quite a lot of problems for `gatsby-plugin-eslint` users. This PR moves autogenerated modules to back to `.cache` (virtually at least), so any custom webpack loaders that were using `.cache` in their configuration work as they did before introducing virtual modules.

## Related Issues

Fixes #26393
Fixes #26319
