### PR TITLE
fix(reporter): add missing verbose/debug log handler to yurnalist logger

### DIFF
--- a/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
+++ b/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
@@ -30,6 +30,7 @@ export function initializeYurnalistLogger(): void {
     [LogLevels.Error]: yurnalist.error.bind(yurnalist),
     [LogLevels.Info]: yurnalist.info.bind(yurnalist),
     [LogLevels.Success]: yurnalist.success.bind(yurnalist),
+    [LogLevels.Debug]: yurnalist.verbose.bind(yurnalist),
     [ActivityLogLevels.Success]: yurnalist.success.bind(yurnalist),
     [ActivityLogLevels.Failed]: (text: string): void => {
       yurnalist.log(`${chalk.red(`failed`)} ${text}`)


### PR DESCRIPTION
## Description

Yurnalist logger have unexpected output when using `reporter.verbose` (and using `--verbose` flag):
![Screenshot 2020-08-12 at 11 49 36](https://user-images.githubusercontent.com/419821/90001601-e9da7c00-dc91-11ea-8786-47f7d317aa4b.png)

This change result in following output:
![Screenshot 2020-08-12 at 11 50 20](https://user-images.githubusercontent.com/419821/90001673-04145a00-dc92-11ea-972a-d14e91ae1805.png)

---
For reference - this is output when using Ink:
![Screenshot 2020-08-12 at 11 50 53](https://user-images.githubusercontent.com/419821/90002136-8dc42780-dc92-11ea-9c9e-955b48087c4c.png)

It's not exactly the same (yurnalist seems to add timing informtion, which is quite neat and potentially helpful, but I think it's workable (if anything I would think of adding timing info to ink as well)