### PR TITLE
fix(gatsby-recipes): add missing var for the recipes selector

### DIFF
--- a/packages/gatsby-recipes/src/cli/index.js
+++ b/packages/gatsby-recipes/src/cli/index.js
@@ -548,6 +548,7 @@ export default async ({
                   await createOperation({
                     recipePath: recipeItem.value,
                     projectRoot,
+                    isDevelopMode: false,
                   })
                 } catch (e) {
                   console.log(`error creating operation`, e)


### PR DESCRIPTION
Missed this in refactor