### PR TITLE
Fix 404 on initial plugins screen

### DIFF
--- a/www/src/components/rotator.js
+++ b/www/src/components/rotator.js
@@ -171,7 +171,7 @@ class Rotator extends Component {
           >
             There’s{` `}
             {pluginName ? (
-              <Link to={`/packages/` + pluginName}>a plugin</Link>
+              <Link to={`/plugins/` + pluginName}>a plugin</Link>
             ) : (
               `a plugin`
             )}


### PR DESCRIPTION
## Description

There's an old URL pointing to `/packages/*` instead of `/plugins/*` which causes a 404.