### PR TITLE
chore(docs): Adding FastComments to comments doc

### DIFF
--- a/docs/docs/adding-comments.md
+++ b/docs/docs/adding-comments.md
@@ -9,6 +9,7 @@ There are many options out there for adding comment functionality, several of th
 - [Disqus](https://disqus.com)
 - [Commento](https://commento.io)
 - [Facebook Comments](https://www.npmjs.com/package/react-facebook)
+- [FastComments](https://fastcomments.com/) with Gatsby examples [here](https://github.com/FastComments/fastcomments-gatsbyjs-example/blob/master/src/pages/index.tsx#L11).
 - [Staticman](https://staticman.net)
 - [TalkYard](https://www.talkyard.io)
 - [Gitalk](https://gitalk.github.io)

--- a/docs/docs/adding-comments.md
+++ b/docs/docs/adding-comments.md
@@ -9,7 +9,7 @@ There are many options out there for adding comment functionality, several of th
 - [Disqus](https://disqus.com)
 - [Commento](https://commento.io)
 - [Facebook Comments](https://www.npmjs.com/package/react-facebook)
-- [FastComments](https://fastcomments.com/) with Gatsby examples [here](https://github.com/FastComments/fastcomments-gatsbyjs-example/blob/master/src/pages/index.tsx#L11).
+- [FastComments](https://fastcomments.com/) with [Gatsby examples](https://github.com/FastComments/fastcomments-gatsbyjs-example/blob/master/src/pages/index.tsx#L11).
 - [Staticman](https://staticman.net)
 - [TalkYard](https://www.talkyard.io)
 - [Gitalk](https://gitalk.github.io)

--- a/docs/docs/adding-comments.md
+++ b/docs/docs/adding-comments.md
@@ -9,7 +9,7 @@ There are many options out there for adding comment functionality, several of th
 - [Disqus](https://disqus.com)
 - [Commento](https://commento.io)
 - [Facebook Comments](https://www.npmjs.com/package/react-facebook)
-- [Fast Comments](https://fastcomments.com/) with [Gatsby examples](https://github.com/FastComments/fastcomments-gatsbyjs-example/blob/master/src/pages/index.tsx#L11).
+- [Fast Comments](https://fastcomments.com/)
 - [Staticman](https://staticman.net)
 - [TalkYard](https://www.talkyard.io)
 - [Gitalk](https://gitalk.github.io)

--- a/docs/docs/adding-comments.md
+++ b/docs/docs/adding-comments.md
@@ -9,7 +9,7 @@ There are many options out there for adding comment functionality, several of th
 - [Disqus](https://disqus.com)
 - [Commento](https://commento.io)
 - [Facebook Comments](https://www.npmjs.com/package/react-facebook)
-- [FastComments](https://fastcomments.com/) with [Gatsby examples](https://github.com/FastComments/fastcomments-gatsbyjs-example/blob/master/src/pages/index.tsx#L11).
+- [Fast Comments](https://fastcomments.com/) with [Gatsby examples](https://github.com/FastComments/fastcomments-gatsbyjs-example/blob/master/src/pages/index.tsx#L11).
 - [Staticman](https://staticman.net)
 - [TalkYard](https://www.talkyard.io)
 - [Gitalk](https://gitalk.github.io)


### PR DESCRIPTION
At FastComments we've recently launched our React plugin, and have been testing it with Gatsby (which you can see [here](https://github.com/FastComments/fastcomments-gatsbyjs-example)).

I've included the link to the example usage as part of this change.

I thought it would be helpful to add FastComments to the list of supported solutions. :)
