### PR TITLE
fix(docs): #26449  Fetch Gatsby logo from gatsbyjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://gatsbyjs.org">
-    <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
+    <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />
   </a>
 </p>
 <h1 align="center">

--- a/starters/README-template.md
+++ b/starters/README-template.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.gatsbyjs.org">
-    <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
+    <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />
   </a>
 </p>
 <h1 align="center">

--- a/starters/README.md
+++ b/starters/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://gatsbyjs.org">
-    <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" width="60" />
+    <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />
   </a>
 </p>
 <h1 align="center">


### PR DESCRIPTION
## Description

Fetch Gastby monogram in README from the new Gatsbyjs.com website instead of the old Gatsbyjs.org address.

### Documentation
Not a feature, but the old svgs aren't loading from [https://www.gatsbyjs.org/monogram.svg](https://www.gatsbyjs.org/monogram.svg) so instead this fetches them from [https://www.gatsbyjs.com/Gatsby-Monogram.svg](https://www.gatsbyjs.com/Gatsby-Monogram.svg)

## Related Issues
Fixes #26449 as well as the non-autogenerated starter READMEs
