### PR TITLE
feat(gatsby): Expose typescript transpiler to default site in plugin list

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
@@ -200,8 +200,12 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "default-site-plugin",
-    "nodeAPIs": Array [],
+    "name": "gatsby-plugin-typescript",
+    "nodeAPIs": Array [
+      "resolvableExtensions",
+      "onCreateBabelConfig",
+      "onCreateWebpackConfig",
+    ],
     "pluginOptions": Object {
       "plugins": Array [],
     },
@@ -212,12 +216,8 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "gatsby-plugin-typescript",
-    "nodeAPIs": Array [
-      "resolvableExtensions",
-      "onCreateBabelConfig",
-      "onCreateWebpackConfig",
-    ],
+    "name": "default-site-plugin",
+    "nodeAPIs": Array [],
     "pluginOptions": Object {
       "plugins": Array [],
     },
@@ -476,8 +476,12 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "default-site-plugin",
-    "nodeAPIs": Array [],
+    "name": "gatsby-plugin-typescript",
+    "nodeAPIs": Array [
+      "resolvableExtensions",
+      "onCreateBabelConfig",
+      "onCreateWebpackConfig",
+    ],
     "pluginOptions": Object {
       "plugins": Array [],
     },
@@ -488,12 +492,8 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "gatsby-plugin-typescript",
-    "nodeAPIs": Array [
-      "resolvableExtensions",
-      "onCreateBabelConfig",
-      "onCreateWebpackConfig",
-    ],
+    "name": "default-site-plugin",
+    "nodeAPIs": Array [],
     "pluginOptions": Object {
       "plugins": Array [],
     },
@@ -760,8 +760,12 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "default-site-plugin",
-    "nodeAPIs": Array [],
+    "name": "gatsby-plugin-typescript",
+    "nodeAPIs": Array [
+      "resolvableExtensions",
+      "onCreateBabelConfig",
+      "onCreateWebpackConfig",
+    ],
     "pluginOptions": Object {
       "plugins": Array [],
     },
@@ -772,12 +776,8 @@ Array [
   Object {
     "browserAPIs": Array [],
     "id": "",
-    "name": "gatsby-plugin-typescript",
-    "nodeAPIs": Array [
-      "resolvableExtensions",
-      "onCreateBabelConfig",
-      "onCreateWebpackConfig",
-    ],
+    "name": "default-site-plugin",
+    "nodeAPIs": Array [],
     "pluginOptions": Object {
       "plugins": Array [],
     },

--- a/packages/gatsby/src/bootstrap/load-plugins/load.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.ts
@@ -231,6 +231,21 @@ export function loadPlugins(
     )
   })
 
+  // TypeScript support by default! use the user-provided one if it exists
+  const typescriptPlugin = (config.plugins || []).find(
+    plugin =>
+      (plugin as IPluginRefObject).resolve === `gatsby-plugin-typescript` ||
+      plugin === `gatsby-plugin-typescript`
+  )
+
+  if (typescriptPlugin === undefined) {
+    plugins.push(
+      processPlugin({
+        resolve: require.resolve(`gatsby-plugin-typescript`),
+      })
+    )
+  }
+
   // Add the site's default "plugin" i.e. gatsby-x files in root of site.
   plugins.push({
     resolve: slash(process.cwd()),
@@ -262,21 +277,6 @@ export function loadPlugins(
       // override the options if there are any user specified options
       pageCreatorOptions = pageCreatorPlugin.options
     }
-  }
-
-  // TypeScript support by default! use the user-provided one if it exists
-  const typescriptPlugin = (config.plugins || []).find(
-    plugin =>
-      (plugin as IPluginRefObject).resolve === `gatsby-plugin-typescript` ||
-      plugin === `gatsby-plugin-typescript`
-  )
-
-  if (typescriptPlugin === undefined) {
-    plugins.push(
-      processPlugin({
-        resolve: require.resolve(`gatsby-plugin-typescript`),
-      })
-    )
   }
 
   plugins.push(


### PR DESCRIPTION
## Description

Provides an option to disable the automatic set up of `gatsby-plugin-typescript`.

When `gatsby-plugin-typescript` is enabled, it disallows the use of any other Typescript transpiler (with type-checking enabled).  This means that using something like `ts-loader` with Typescript transformer plugins is impossible.  In order to allow this again, `gatsby-plugin-typescript` needs to be disabled.

There were a few options I could see for achieving this:

1. Move the logic that adds `gatsby-plugin-typescript` to the plugin array above `default-site-plugin`.
    * :+1: Easiest method for developer.
    * :+1: Doesn't add any more surface area to the `gatsby-config` api.
    * :-1: While this would allow the default site to filter that plugin out, if it's desired, that process can be laborious and error prone.
    * :-1: Puts the onus on the end-user to reverse core setup.

2. ~Webpack config post-processing (i.e. after `onCreateWebpackConfig`)~
    * ~:+1: Automatically handle typescript loaders, no matter where they're added~
    * ~:-1: Very error prone.  Likely impossible to account for all circumstances~

3. ~Add a new "plugin filter" or "webpack loader filter" API~
    * ~:+1: More future proof~
    * ~:-1: Seemed like a pretty major API change~

4. ~Add a new configuration value to `gatsby-config`.~
    * ~:+1: Fixes the issue at the root~
    * ~:+1: End-user experience is much, much nicer~
    * ~:-1: Increases the surface area of the `gatsby-config` api.~

~I opted for number 4 because it just made the most sense to me.~
* ~The end-user experience is much better than the others.~
  * ~Why force the user to filter out a loader in the webpack config.  It's counter-intuitive to add loaders, then turn around and remove them.  Means more moving parts that don't really need to be there.~
* ~The default behavior remains the same as originally designed.  Unless people need it, they can continue on without ever caring that the feature exists.~
* ~Implementation itself was not difficult, nor is the process difficult to understand.~

### ~Documentation~

~docs/gatsby-config.md~

## Related Issues

Fixes #26027 
