### PR TITLE
fix(gatsby-remark-images): Use pathPrefix also with WebP files

### DIFF
--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -218,8 +218,7 @@ module.exports = (
           { toFormat: `WEBP` },
           // override options if it's an object, otherwise just pass through defaults
           options.withWebp === true ? {} : options.withWebp,
-          pluginOptions,
-          DEFAULT_OPTIONS
+          options,
         ),
         reporter,
       })

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -218,7 +218,7 @@ module.exports = (
           { toFormat: `WEBP` },
           // override options if it's an object, otherwise just pass through defaults
           options.withWebp === true ? {} : options.withWebp,
-          options,
+          options
         ),
         reporter,
       })


### PR DESCRIPTION
## Description

As described in #26471, pictures are not shown on Gatsby sites with `pathPrefix` when `gatsby-remark-images` has `withWebp` enabled.

This PR just adds the parameter `{ pathPrefix }` to the args passed to [fluid](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sharp/src/index.js#L433) when building `webpFluidResult`, as is done when building `fluidResult` with the main `options` object (built in [line 38](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-images/src/index.js#L38))

### Documentation

Despite not beign oficially documented as a valid param, [gatsby-plugin-sharp](https://www.gatsbyjs.com/plugins/gatsby-plugin-sharp/), makes use of the `pathPrefix` param, as can be [seen](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-sharp/src/index.js#L541) on `fluid` and other functions.

## Related Issues

Fixes #26471
