### PR TITLE
chore: Use gatsbyjs.com instead of gatsbyjs.org for docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-## Read docs at https://www.gatsbyjs.org/docs
+## Read docs at https://www.gatsbyjs.com/docs
 
-We intend the docs to be read on gatsbyjs.org — You can read them here of course
+We intend the docs to be read on gatsbyjs.com — You can read them here of course
 :-) Just be warned that links won't often work and other things will be missing
 or less than optimal.
 


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

As everything is moving to gatsbyjs.com I think changing the docs link also to gatsbyjs.com will save many redirects.

### Documentation

Not any as only changing the link in the docs itself.

## Related Issues

NA
