### PR TITLE
Fix links in mdx documentation section

### DIFF
--- a/docs/docs/mdx/getting-started.md
+++ b/docs/docs/mdx/getting-started.md
@@ -31,7 +31,7 @@ your site.
 ## Add MDX to an existing Gatsby site
 
 If you already have a Gatsby site that you'd like to add MDX to, you
-can follow these steps for configuring the [gatsby-plugin-mdx](/packages/gatsby-plugin-mdx/) plugin.
+can follow these steps for configuring the [gatsby-plugin-mdx](/plugins/gatsby-plugin-mdx/) plugin.
 
 Alternatively, you may be looking to configure an existing blog site to use MDX. [This blog post](/blog/2019-11-21-how-to-convert-an-existing-gatsby-blog-to-use-mdx/) walks you through those steps in detail.
 

--- a/docs/docs/mdx/importing-and-using-components.md
+++ b/docs/docs/mdx/importing-and-using-components.md
@@ -50,7 +50,7 @@ export default function Layout({ children }) {
 }
 ```
 
-All MDX components passed into the `components` prop of the `MDXProvider` will be made available to MDX documents that are nested under the provider. The `MDXProvider` in this example is in a layout component that wraps all MDX pages, you can read about this pattern in [the layout section of the `gatsby-plugin-mdx` README](/packages/gatsby-plugin-mdx/#default-layouts).
+All MDX components passed into the `components` prop of the `MDXProvider` will be made available to MDX documents that are nested under the provider. The `MDXProvider` in this example is in a layout component that wraps all MDX pages, you can read about this pattern in [the layout section of the `gatsby-plugin-mdx` README](/plugins/gatsby-plugin-mdx/#default-layouts).
 
 Now, you can include components in your MDX without importing them:
 
@@ -79,7 +79,7 @@ Because the `<Message />` and `<Chart />` components were passed into the provid
 
 When you use components in your `.mdx` files, Gatsby will bundle them into the main application bundle. This can cause performance problems.
 
-In the future, [`gatsby-plugin-mdx`](/packages/gatsby-plugin-mdx) will address this. In the meantime, it can be prudent to lazy-load very large dependencies. The following snippet provides an example for lazy-loading an imaginary `Thing` component:
+In the future, [`gatsby-plugin-mdx`](/plugins/gatsby-plugin-mdx) will address this. In the meantime, it can be prudent to lazy-load very large dependencies. The following snippet provides an example for lazy-loading an imaginary `Thing` component:
 
 ```jsx:title=src/components/LazyThing.js
 import React from "react"

--- a/docs/docs/mdx/markdown-syntax.md
+++ b/docs/docs/mdx/markdown-syntax.md
@@ -170,7 +170,7 @@ This pattern is appropriate for [decorative or repetitive images](https://www.w3
 ## Processing Markdown and MDX in Gatsby:
 
 - In order to process and use Markdown or MDX in Gatsby, you can use the [gatsby-source-filesystem](/docs/sourcing-from-the-filesystem) plugin
-- You can check out the package [README](/packages/gatsby-source-filesystem) for more information on how it works!
+- You can check out the package [README](/plugins/gatsby-source-filesystem) for more information on how it works!
 
 ## Frontmatter
 

--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -5,7 +5,7 @@ title: MDX Plugins
 ## Gatsby remark plugins
 
 `gatsby-plugin-mdx` is compatible with all of the [gatsby-remark
-plugins](/packages/gatsby-remark-images/?=gatsby-remark),
+plugins](/plugins/gatsby-remark-images/?=gatsby-remark),
 including
 [`gatsby-remark-images`](https://next.gatsbyjs.org/packages/gatsby-remark-images/?=gatsby-remark).
 

--- a/docs/docs/mdx/programmatically-creating-pages.md
+++ b/docs/docs/mdx/programmatically-creating-pages.md
@@ -24,7 +24,7 @@ root.
 
 > **Note**: `gatsby-plugin-mdx` uses `.mdx` by default as a file extension to
 > recognize which files to use. You can also [use `.md` as a file
-> extension](/packages/gatsby-plugin-mdx#extensions) if you want.
+> extension](/plugins/gatsby-plugin-mdx#extensions) if you want.
 
 ```javascript:title=gatsby-config.js
 module.exports = {
@@ -46,7 +46,7 @@ module.exports = {
 ```
 
 You can read about
-[`gatsby-source-filesystem`](/packages/gatsby-source-filesystem)
+[`gatsby-source-filesystem`](/plugins/gatsby-source-filesystem)
 if you'd like to learn more.
 
 ## Add MDX files

--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -48,7 +48,7 @@ query {
 
 > **Note:** To query `MDX` content, it must be included in the node system using a
 > source like the `gatsby-source-filesystem` plugin first. Instructions for sourcing
-> content from somewhere like your `/src/pages` directory can be found on the [plugin's README](/packages/gatsby-source-filesystem/).
+> content from somewhere like your `/src/pages` directory can be found on the [plugin's README](/plugins/gatsby-source-filesystem/).
 
 Frontmatter is also available in `props.pageContext.frontmatter` and
 can be accessed in blocks of JSX in your MDX document:
@@ -186,7 +186,7 @@ query MdxExports {
 
 ### Defining a layout
 
-If you have [provided a default layout](/packages/gatsby-plugin-mdx/?=mdx#default-layouts) in your `gatsby-config.js`
+If you have [provided a default layout](/plugins/gatsby-plugin-mdx/?=mdx#default-layouts) in your `gatsby-config.js`
 through the `gatsby-plugin-mdx` plugin options, the exported component you define
 from this file will replace the default.
 


### PR DESCRIPTION
## Description

The links were broken because they were pointing to `/package` instead of `/plugins`. 

The fixed links are somewhere on these pages:

- https://www.gatsbyjs.com/docs/mdx/getting-started/
- https://www.gatsbyjs.com/docs/mdx/importing-and-using-components/
- https://www.gatsbyjs.com/docs/mdx/markdown-syntax/
- https://www.gatsbyjs.com/docs/mdx/plugins/
- https://www.gatsbyjs.com/docs/mdx/programmatically-creating-pages/ 
- https://www.gatsbyjs.org/docs/mdx/writing-pages

## Related Issues

None.
