### PR TITLE
Fix broken links

### DIFF
--- a/docs/docs/gatsby-image.md
+++ b/docs/docs/gatsby-image.md
@@ -2,7 +2,7 @@
 title: Gatsby Image API
 ---
 
-Part of what makes Gatsby sites so fast is its recommended approach to handling images. `gatsby-image` is a React component designed to work seamlessly with Gatsby’s [native image processing](https://image-processing.gatsbyjs.org/) capabilities powered by GraphQL and [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/) to easily and completely optimize image loading for your sites.
+Part of what makes Gatsby sites so fast is its recommended approach to handling images. `gatsby-image` is a React component designed to work seamlessly with Gatsby’s [native image processing](https://image-processing.gatsbyjs.org/) capabilities powered by GraphQL and [gatsby-plugin-sharp](/plugins/gatsby-plugin-sharp/) to easily and completely optimize image loading for your sites.
 
 > _Note: gatsby-image is **not** a drop-in replacement for `<img />`. It’s optimized for responsive fixed width/height images and images that stretch the full-width of a container. There are also other ways to [work with images](/docs/images-and-files/) in Gatsby that don't require GraphQL._
 
@@ -10,7 +10,7 @@ Demo: https://using-gatsby-image.gatsbyjs.org/
 
 ## Setting up Gatsby Image
 
-To start working with Gatsby Image, install the `gatsby-image` package along with necessary plugins `gatsby-transformer-sharp` and `gatsby-plugin-sharp`. Reference the packages in your `gatsby-config.js` file. You can also provide additional options to [`gatsby-plugin-sharp`](/packages/gatsby-plugin-sharp/) in your config file.
+To start working with Gatsby Image, install the `gatsby-image` package along with necessary plugins `gatsby-transformer-sharp` and `gatsby-plugin-sharp`. Reference the packages in your `gatsby-config.js` file. You can also provide additional options to [`gatsby-plugin-sharp`](/plugins/gatsby-plugin-sharp/) in your config file.
 
 A common way to source images is to install and use `gatsby-source-filesystem` to connect your local files, but other source plugins can be used as well, such as `gatsby-source-contentful`, `gatsby-source-datocms` and `gatsby-source-sanity`.
 
@@ -39,7 +39,7 @@ _For in-depth install instructions, check out the docs on [Using Gatsby Image](/
 
 To feed file data in to Gatsby Image, set up a [GraphQL query](/docs/graphql-reference/) and either pass it into a component as props or write it directly in the component. One technique is to leverage the [`useStaticQuery`](/docs/use-static-query/) hook.
 
-Common GraphQL queries for sourcing images include `file` from [gatsby-source-filesystem](/packages/gatsby-source-filesystem/), and both `imageSharp` and `allImageSharp` from [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/), but ultimately the options available to you will depend on your content sources.
+Common GraphQL queries for sourcing images include `file` from [gatsby-source-filesystem](/plugins/gatsby-source-filesystem/), and both `imageSharp` and `allImageSharp` from [gatsby-plugin-sharp](/plugins/gatsby-plugin-sharp/), but ultimately the options available to you will depend on your content sources.
 
 > Note: you can also use [GraphQL aliases](/docs/graphql-reference/#aliasing) for querying multiple images of the same type.
 
@@ -118,7 +118,7 @@ file(relativePath: { eq: "images/default.jpg" }) {
 }
 ```
 
-Read more about fixed image queries in the [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/#fixed) README.
+Read more about fixed image queries in the [gatsby-plugin-sharp](/plugins/gatsby-plugin-sharp/#fixed) README.
 
 ### Images that stretch across a _fluid_ container
 
@@ -192,7 +192,7 @@ file(relativePath: { eq: "images/default.jpg" }) {
 }
 ```
 
-Read more about fluid image queries in the [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/#fluid) README.
+Read more about fluid image queries in the [gatsby-plugin-sharp](/plugins/gatsby-plugin-sharp/#fluid) README.
 
 ### Resized images
 
@@ -228,19 +228,19 @@ allImageSharp {
 }
 ```
 
-Read more about resized image queries in the [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/#resize) README.
+Read more about resized image queries in the [gatsby-plugin-sharp](/plugins/gatsby-plugin-sharp/#resize) README.
 
 ### Shared query parameters
 
 In addition to `gatsby-plugin-sharp` settings in `gatsby-config.js`, there are additional query options that apply to _fluid_, _fixed_, and _resized_ images:
 
-- [`grayscale`](/packages/gatsby-plugin-sharp/#grayscale) (bool, default: false)
-- [`duotone`](/packages/gatsby-plugin-sharp/#duotone) (bool|obj, default: false)
-- [`toFormat`](/packages/gatsby-plugin-sharp/#toformat) (string, default: \`\`)
-- [`cropFocus`](/packages/gatsby-plugin-sharp/#cropfocus) (string, default: `ATTENTION`)
-- [`fit`](/packages/gatsby-plugin-sharp/#fit) (string, default: `COVER`)
-- [`pngCompressionSpeed`](/packages/gatsby-plugin-sharp/#pngcompressionspeed) (int, default: 4)
-- [`rotate`](/packages/gatsby-plugin-sharp/#rotate) (int, default: 0)
+- [`grayscale`](/plugins/gatsby-plugin-sharp/#grayscale) (bool, default: false)
+- [`duotone`](/plugins/gatsby-plugin-sharp/#duotone) (bool|obj, default: false)
+- [`toFormat`](/plugins/gatsby-plugin-sharp/#toformat) (string, default: \`\`)
+- [`cropFocus`](/plugins/gatsby-plugin-sharp/#cropfocus) (string, default: `ATTENTION`)
+- [`fit`](/plugins/gatsby-plugin-sharp/#fit) (string, default: `COVER`)
+- [`pngCompressionSpeed`](/plugins/gatsby-plugin-sharp/#pngcompressionspeed) (int, default: 4)
+- [`rotate`](/plugins/gatsby-plugin-sharp/#rotate) (int, default: 0)
 
 Here's an example of using the `duotone` option with a fixed image:
 
@@ -278,13 +278,13 @@ fixed(
   <figcaption>Grayscale | Before - After</figcaption>
 </figure>
 
-Read more about shared image query parameters in the [`gatsby-plugin-sharp`](/packages/gatsby-plugin-sharp/#shared-options) README.
+Read more about shared image query parameters in the [`gatsby-plugin-sharp`](/plugins/gatsby-plugin-sharp/#shared-options) README.
 
 ## Image query fragments
 
 GraphQL includes a concept called "query fragments", which are a part of a query that can be reused. To ease building with `gatsby-image`, Gatsby image processing plugins which support `gatsby-image` ship with fragments which you can easily include in your queries.
 
-> Note: using fragments in your queries depends on which data source(s) you have configured. Read more about image query fragments in the [gatsby-image](/packages/gatsby-image/#fragments) README.
+> Note: using fragments in your queries depends on which data source(s) you have configured. Read more about image query fragments in the [gatsby-image](/plugins/gatsby-image/#fragments) README.
 
 ### Common fragments with `gatsby-transformer-sharp`
 
@@ -335,7 +335,7 @@ For more info on how these options work, check out the Gatsby Image demo: https:
 
 #### Additional plugin fragments
 
-Additionally, plugins supporting `gatsby-image` currently include [gatsby-source-contentful](/packages/gatsby-source-contentful/), [gatsby-source-datocms](https://github.com/datocms/gatsby-source-datocms) and [gatsby-source-sanity](https://github.com/sanity-io/gatsby-source-sanity). See the [gatsby-image](/packages/gatsby-image/#fragments) README for more details.
+Additionally, plugins supporting `gatsby-image` currently include [gatsby-source-contentful](/plugins/gatsby-source-contentful/), [gatsby-source-datocms](https://github.com/datocms/gatsby-source-datocms) and [gatsby-source-sanity](https://github.com/sanity-io/gatsby-source-sanity). See the [gatsby-image](/plugins/gatsby-image/#fragments) README for more details.
 
 ## Gatsby-image props
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This docs page is linking to /packages/{several} but they seem to live at /plugins/{the thing}
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
