### PR TITLE
chore(e2e-dev-runtime): bump @testing-library/cypress and adjust current data updates testing setup

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/gatsby-preview/updating.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-preview/updating.js
@@ -15,9 +15,9 @@ describe(`Gatsby Preview (Updating)`, () => {
   it(`displays initial data`, () => {
     cy.get(`li:eq(0) a`).click().waitForRouteChange()
 
-    cy.queryByText(`Hello World (1)`).should(`exist`)
+    cy.findByText(`Hello World (1)`).should(`exist`)
 
-    cy.queryByText(`0`).should(`exist`)
+    cy.findByText(`0`).should(`exist`)
   })
 
   it(`updates and hot-reloads changes to content`, () => {
@@ -25,7 +25,7 @@ describe(`Gatsby Preview (Updating)`, () => {
 
     update()
 
-    cy.queryByText(`1`).should(`exist`)
+    cy.findByText(`1`).should(`exist`)
   })
 
   it(`updates and hot-reloads new content`, () => {
@@ -45,13 +45,9 @@ describe(`Gatsby Preview (Updating)`, () => {
     cy.get(`li`).its(`length`).should(`be`, 1)
   })
 
-  /*
-   * TODO: get this test passing in CI
-   * https://github.com/testing-library/cypress-testing-library/issues/23
-   */
-  it.skip(`can be triggered with webhook data`, () => {
+  it(`can be triggered with webhook data`, () => {
     cy.exec(`npm run update:webhook`)
 
-    cy.queryByText(`Hello World from a Webhook (999)`).should(`exist`)
+    cy.findByText(`Hello World from a Webhook (999)`).should(`exist`)
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/navigation/redirect.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/redirect.js
@@ -51,11 +51,11 @@ describe(`redirect`, () => {
     // this is sanity check for this group
     it(`make sure 404 is present`, () => {
       cy.visit(`/______not_existing_page`).waitForRouteChange()
-      cy.queryByText("Preview custom 404 page").click()
-      cy.queryByText("A custom 404 page wasn't detected", {
+      cy.findByText("Preview custom 404 page").click()
+      cy.findByText("A custom 404 page wasn't detected", {
         exact: false,
       }).should(`not.exist`)
-      cy.queryByText(
+      cy.findByText(
         "You just hit a route that does not exist... the sadness."
       ).should(`exist`)
     })
@@ -83,11 +83,11 @@ describe(`redirect`, () => {
 
     it(`make sure 404 is NOT present`, () => {
       cy.visit(`/______not_existing_page`).waitForRouteChange()
-      cy.queryByText("Preview custom 404 page").click()
-      cy.queryByText("A custom 404 page wasn't detected", {
+      cy.findByText("Preview custom 404 page").click()
+      cy.findByText("A custom 404 page wasn't detected", {
         exact: false,
       }).should(`exist`)
-      cy.queryByText(
+      cy.findByText(
         "You just hit a route that does not exist... the sadness.",
         { exact: false }
       ).should(`not.exist`)

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -34,10 +34,10 @@
     "test": "npm run start-server-and-test || (npm run reset && exit 1)",
     "posttest": "npm run reset",
     "reset": "node scripts/reset.js",
-    "reset:preview": "node plugins/gatsby-source-fake-data/reset.js && npm run update:preview",
+    "reset:preview": "curl -X POST http://localhost:8000/__refresh",
     "update": "node scripts/update.js",
     "update:webhook": "node scripts/webhook.js",
-    "update:preview": "curl -X POST http://localhost:8000/__refresh",
+    "update:preview": "curl -X POST -d '{ \"fake-data-update\": true }' -H \"Content-Type: application/json\" http://localhost:8000/__refresh",
     "start-server-and-test": "start-server-and-test develop http://localhost:8000 cy:run",
     "cy:open": "cypress open",
     "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -43,7 +43,7 @@
     "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
-    "@testing-library/cypress": "^4.0.4",
+    "@testing-library/cypress": "^6.0.0",
     "cross-env": "^5.2.0",
     "cypress": "3.4.1",
     "fs-extra": "^7.0.1",

--- a/e2e-tests/development-runtime/plugins/gatsby-source-fake-data/gatsby-node.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-source-fake-data/gatsby-node.js
@@ -29,6 +29,9 @@ exports.sourceNodes = async function sourceNodes({
     reporter.info(`Webhook data detected; creating nodes`)
     webhookBody.items.forEach(node => createNode(api.getNode(node, helpers)))
   } else {
+    if (!(webhookBody && webhookBody[`fake-data-update`])) {
+      await api.reset()
+    }
     const [updated, deleted = []] = await api.sync(helpers)
 
     updated.forEach(node => createNode(node))


### PR DESCRIPTION
## Description

This PR does 2 things:
 - bumping `@testing-library/cypress` fixes the problem that forced skipping one of the tests
 - it scopes data refreshes - this is to prepare dev-runtime e2e setup for addition of a plugin dedicated for testing https://github.com/gatsbyjs/gatsby/pull/24903 which would also use refresh endpoint for testing hot data/module updates. Changing/adding data on every refresh webhook as it is right now was problematic as depending on order of running test - those could just start failing (and also when writing and testing those I would occasionally get OOM because any refreshes would just append and append data :yikes:)
