### PR TITLE
In Tutorial Docs Step 0, wrong git clone URL is used

### DIFF
--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -211,7 +211,7 @@ Now you are ready to use the Gatsby CLI tool to create your first Gatsby site. U
 2. Create a new site from a starter:
 
 ```shell
-gatsby new hello-world https://github.com/gatsbyjs/gatsby/tree/master/starters/hello-world
+gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
 ```
 
 > 💡 What happened?


### PR DESCRIPTION

## Description

The very first chance a user has to download the starter repo in the tutorials, they point to the un-clone-able monorepo folder instead of the actual repo like the other docs pages point to, requiring the user to hopefully Google and find the correct link.

Example of correct clone link:
https://www.gatsbyjs.com/tutorial/part-two/#creating-global-styles-with-standard-css-files

@gatsbyjs/learning
