### PR TITLE
chore(tutorial): fix wording to .com in body text

### DIFF
--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -12,7 +12,7 @@ In this part, you'll learn about Gatsby plugins and creating "layout" components
 
 Gatsby plugins are JavaScript packages that help add functionality to a Gatsby site. Gatsby is designed to be extensible, which means plugins are able to extend and modify just about everything Gatsby does.
 
-Layout components are for sections of your site that you want to share across multiple pages. For example, sites will commonly have a layout component with a shared header and footer. Other common things to add to layouts are a sidebar and/or navigation menu. On this page for example, the header at the top is part of gatsbyjs.org's layout component.
+Layout components are for sections of your site that you want to share across multiple pages. For example, sites will commonly have a layout component with a shared header and footer. Other common things to add to layouts are a sidebar and/or navigation menu. On this page for example, the header at the top is part of gatsbyjs.com's layout component.
 
 Let's dive into part three.
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

A slight wording change needs to be made in the tutorial to reflect the unified site that lives on a .com domain. This was pointed out by @gris

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/26467
