### PR TITLE
fix(docs): revert starter url in tutorial

### DIFF
--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -211,7 +211,7 @@ Now you are ready to use the Gatsby CLI tool to create your first Gatsby site. U
 2. Create a new site from a starter:
 
 ```shell
-gatsby new hello-world https://github.com/gatsbyjs/gatsby/tree/master/starters/hello-world
+gatsby new hello-world https://github.com/gatsbyjs/gatsby-starter-hello-world
 ```
 
 > 💡 What happened?


### PR DESCRIPTION
Code on L.214 doesn't work on my environment and this behaviour is expected to be common in many other environments.

Indeed, the page https://github.com/gatsbyjs/gatsby/tree/master/starters shows a proper code:
`gatsby new my-blazing-fast-site https://github.com/gatsbyjs/gatsby-starter-hello-world`,
instead of the previous one `gatsby new hello-world https://github.com/gatsbyjs/gatsby/tree/master/starters/hello-world`.

Then I propose the change also on the index.md.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
