### PR TITLE
Fixed broken link in deploying-your-site.md

### DIFF
--- a/docs/docs/recipes/deploying-your-site.md
+++ b/docs/docs/recipes/deploying-your-site.md
@@ -185,4 +185,4 @@ module.exports = {
 
 ### Additional resources
 
-- [Adding Analytics](/docs/adding-analytics/)
+- [Adding Analytics](https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/adding-analytics.md)


### PR DESCRIPTION
The 'Adding Analytics' link in the Additional resources section linked to a 404 page. Made the necessary changes and fixed it.
