### PR TITLE
Added static prefix to graphiql-explore.mp4

### DIFF
--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -17,7 +17,7 @@ GraphiQL is the GraphQL integrated development environment (IDE). It's a powerfu
 You can access it when your site's development server is running—normally at `http://localhost:8000/___graphql`.
 
 <video controls="controls" autoplay="true" loop="true">
-  <source type="video/mp4" src="/graphiql-explore.mp4" />
+  <source type="video/mp4" src="/static/graphiql-explore.mp4" />
   <p>Your browser does not support the video element.</p>
 </video>
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This is addressing issue #26493 where video in `Introducing GraphiQL` not available in the build. I have found that this video is at `/www/static` folder, Added `/static/` prefix to the video URL so it would map to the correct file after build.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

This an issue related to documentation.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #26493
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
