### PR TITLE
fix(gatsby-source-shopify): Fix typo "Shopfiy" in package description

### DIFF
--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-source-shopify",
   "version": "3.2.26",
-  "description": "Gatsby source plugin for building websites using Shopfiy as a data source.",
+  "description": "Gatsby source plugin for building websites using Shopify as a data source.",
   "scripts": {
     "build": "babel src --out-dir . --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",


### PR DESCRIPTION
## Description

Fix typo "Shopfiy" in gatsby-source-shopify package description. It looks like this got missed back when the package was originally renamed (https://github.com/angeloashmore/gatsby-source-shopify/commit/66af94a62373800b30d4ee9e1ba48d8948872479) This was the only instance of the typo I found.

