### PR TITLE
feat(gatsby-image): add `type` attribute to source tag

### DIFF
--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -39,6 +39,7 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 1000ms;"
         title="Title for the image"
+        type="image/jpg"
         width="100"
       />
     </picture>
@@ -88,6 +89,7 @@ exports[`<Image /> should render fixed size images 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 500ms;"
         title="Title for the image"
+        type="image/jpg"
         width="100"
       />
     </picture>
@@ -143,6 +145,7 @@ exports[`<Image /> should render fluid images 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 500ms;"
         title="Title for the image"
+        type="image/jpg"
       />
     </picture>
     <noscript>
@@ -208,6 +211,7 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 500ms;"
         title="Title for the image"
+        type="image/jpg"
         width="100"
       />
     </picture>
@@ -282,6 +286,7 @@ exports[`<Image /> should render multiple fluid image variants 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 500ms;"
         title="Title for the image"
+        type="image/jpg"
       />
     </picture>
     <noscript>

--- a/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-image/src/__tests__/__snapshots__/index.js.snap
@@ -27,6 +27,7 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
       />
       <source
         srcset="some srcSet"
+        type="image/jpg"
       />
       <img
         alt="Alt text for the image"
@@ -39,7 +40,6 @@ exports[`<Image /> should have a transition-delay of 1sec 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 1000ms;"
         title="Title for the image"
-        type="image/jpg"
         width="100"
       />
     </picture>
@@ -77,6 +77,7 @@ exports[`<Image /> should render fixed size images 1`] = `
       />
       <source
         srcset="some srcSet"
+        type="image/jpg"
       />
       <img
         alt="Alt text for the image"
@@ -89,7 +90,6 @@ exports[`<Image /> should render fixed size images 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 500ms;"
         title="Title for the image"
-        type="image/jpg"
         width="100"
       />
     </picture>
@@ -133,6 +133,7 @@ exports[`<Image /> should render fluid images 1`] = `
       <source
         sizes="(max-width: 600px) 100vw, 600px"
         srcset="some srcSet"
+        type="image/jpg"
       />
       <img
         alt="Alt text for the image"
@@ -145,7 +146,6 @@ exports[`<Image /> should render fluid images 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 500ms;"
         title="Title for the image"
-        type="image/jpg"
       />
     </picture>
     <noscript>
@@ -193,6 +193,7 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
       <source
         media="only screen and (min-width: 768px)"
         srcset="some other srcSet"
+        type="image/jpg"
       />
       <source
         srcset="some srcSetWebp"
@@ -200,6 +201,7 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
       />
       <source
         srcset="some srcSet"
+        type="image/jpg"
       />
       <img
         alt="Alt text for the image"
@@ -211,7 +213,6 @@ exports[`<Image /> should render multiple fixed image variants 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 500ms;"
         title="Title for the image"
-        type="image/jpg"
         width="100"
       />
     </picture>
@@ -266,6 +267,7 @@ exports[`<Image /> should render multiple fluid image variants 1`] = `
         media="only screen and (min-width: 768px)"
         sizes="(max-width: 600px) 100vw, 600px"
         srcset="some other srcSet"
+        type="image/jpg"
       />
       <source
         sizes="(max-width: 600px) 100vw, 600px"
@@ -275,6 +277,7 @@ exports[`<Image /> should render multiple fluid image variants 1`] = `
       <source
         sizes="(max-width: 600px) 100vw, 600px"
         srcset="some srcSet"
+        type="image/jpg"
       />
       <img
         alt="Alt text for the image"
@@ -286,7 +289,6 @@ exports[`<Image /> should render multiple fluid image variants 1`] = `
         srcset="some srcSet"
         style="position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; object-fit: cover; object-position: center; opacity: 0; transition: opacity 500ms;"
         title="Title for the image"
-        type="image/jpg"
       />
     </picture>
     <noscript>

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -165,7 +165,7 @@ function getIO() {
   return io
 }
 
-function generateImageSources(imageVariants) {
+function generateImageSources(imageVariants, imageMediaType) {
   return imageVariants.map(({ src, srcSet, srcSetWebp, media, sizes }) => (
     <React.Fragment key={src}>
       {srcSetWebp && (
@@ -176,7 +176,12 @@ function generateImageSources(imageVariants) {
           sizes={sizes}
         />
       )}
-      <source media={media} srcSet={srcSet} sizes={sizes} />
+      <source
+        type={imageMediaType}
+        media={media}
+        srcSet={srcSet}
+        sizes={sizes}
+      />
     </React.Fragment>
   ))
 }
@@ -552,7 +557,7 @@ class Image extends React.Component {
           {/* Once the image is visible (or the browser doesn't support IntersectionObserver), start downloading the image */}
           {this.state.isVisible && (
             <picture>
-              {generateImageSources(imageVariants)}
+              {generateImageSources(imageVariants, imageMediaType)}
               <Img
                 alt={alt}
                 title={title}
@@ -567,7 +572,6 @@ class Image extends React.Component {
                 itemProp={itemProp}
                 loading={loading}
                 draggable={draggable}
-                type={imageMediaType}
               />
             </picture>
           )}
@@ -661,7 +665,7 @@ class Image extends React.Component {
           {/* Once the image is visible, start downloading the image */}
           {this.state.isVisible && (
             <picture>
-              {generateImageSources(imageVariants)}
+              {generateImageSources(imageVariants, imageMediaType)}
               <Img
                 alt={alt}
                 title={title}
@@ -678,7 +682,6 @@ class Image extends React.Component {
                 itemProp={itemProp}
                 loading={loading}
                 draggable={draggable}
-                type={imageMediaType}
               />
             </picture>
           )}

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -479,6 +479,11 @@ class Image extends React.Component {
     if (fluid) {
       const imageVariants = fluid
       const image = getCurrentSrcData(fluid)
+      const imageFileType = image.src.substring(
+        image.src.lastIndexOf(`.`) + 1,
+        image.src.length || image.src
+      )
+      const imageMediaType = imageMediaTypes[imageFileType]
 
       return (
         <Tag
@@ -562,6 +567,7 @@ class Image extends React.Component {
                 itemProp={itemProp}
                 loading={loading}
                 draggable={draggable}
+                type={imageMediaType}
               />
             </picture>
           )}
@@ -587,6 +593,11 @@ class Image extends React.Component {
     if (fixed) {
       const imageVariants = fixed
       const image = getCurrentSrcData(fixed)
+      const imageFileType = image.src.substring(
+        image.src.lastIndexOf(`.`) + 1,
+        image.src.length || image.src
+      )
+      const imageMediaType = imageMediaTypes[imageFileType]
 
       const divStyle = {
         position: `relative`,
@@ -667,6 +678,7 @@ class Image extends React.Component {
                 itemProp={itemProp}
                 loading={loading}
                 draggable={draggable}
+                type={imageMediaType}
               />
             </picture>
           )}
@@ -701,6 +713,16 @@ Image.defaultProps = {
   // We set it to `lazy` by default because it's best to default to a performant
   // setting and let the user "opt out" to `eager`
   loading: `lazy`,
+}
+
+const imageMediaTypes = {
+  apng: `image/apng`,
+  flif: `image/flif`,
+  gif: `image/gif`,
+  jpg: `image/jpg`,
+  jpeg: `image/jpg`,
+  png: `image/png`,
+  webp: `image/webp`,
 }
 
 const fixedObject = PropTypes.shape({


### PR DESCRIPTION
## Description

Adds type attribute in source tag of gatsby-image. To reiterate from #25740. According to specification:

    When a source element has a following sibling source element or img element with a srcset attribute specified,
    it must have at least one of the following:

    - A media attribute specified with a value that, after stripping leading and trailing ASCII whitespace,
      is not the empty string and is not an ASCII case-insensitive match for the string "all".
    - A type attribute specified.

Html validator shows no errors related to this issue. Previously, it had marked this behavior as an error:

    A source element that has a following sibling source element or img element with a srcset attribute must have a
    media attribute and/or type attribute.

This fix includes a map of common image types to image media type specifications for use in the `type` attribute of the described `source` element.

## Related Issues

Fixes #25740 