### PR TITLE
Fix(README.md): Changed old link gatsbyjs.org to gatsbyjs.com in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://gatsbyjs.org">
+  <a href="https://gatsbyjs.com">
     <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />
   </a>
 </p>
@@ -32,7 +32,7 @@
   <a href="https://npmcharts.com/compare/gatsby?minimal=true">
     <img src="https://img.shields.io/npm/dt/gatsby.svg" alt="Total downloads on npm." />
   </a>
-  <a href="https://gatsbyjs.org/contributing/how-to-contribute/">
+  <a href="https://gatsbyjs.com/contributing/how-to-contribute/">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />
   </a>
   <a href="https://twitter.com/intent/follow?screen_name=gatsbyjs">
@@ -41,17 +41,17 @@
 </p>
 
 <h3 align="center">
-  <a href="https://gatsbyjs.org/docs/">Quickstart</a>
+  <a href="https://gatsbyjs.com/docs/">Quickstart</a>
   <span> · </span>
-  <a href="https://gatsbyjs.org/tutorial/">Tutorial</a>
+  <a href="https://gatsbyjs.com/tutorial/">Tutorial</a>
   <span> · </span>
-  <a href="https://gatsbyjs.org/plugins/">Plugins</a>
+  <a href="https://gatsbyjs.com/plugins/">Plugins</a>
   <span> · </span>
-  <a href="https://gatsbyjs.org/starters/">Starters</a>
+  <a href="https://gatsbyjs.com/starters/">Starters</a>
   <span> · </span>
-  <a href="https://gatsbyjs.org/showcase/">Showcase</a>
+  <a href="https://gatsbyjs.com/showcase/">Showcase</a>
   <span> · </span>
-  <a href="https://gatsbyjs.org/contributing/how-to-contribute/">Contribute</a>
+  <a href="https://gatsbyjs.com/contributing/how-to-contribute/">Contribute</a>
   <span> · </span>
   Support: <a href="https://twitter.com/AskGatsbyJS">Twitter</a>
   <span> & </span>
@@ -80,7 +80,7 @@ Gatsby is a modern web framework for blazing fast websites.
   site on a CDN for a fraction of the cost of a server-rendered site. Many Gatsby sites can be
   hosted entirely free on services like GitHub Pages and Netlify.
 
-[**Learn how to use Gatsby for your next project.**](https://gatsbyjs.org/docs/)
+[**Learn how to use Gatsby for your next project.**](https://gatsbyjs.com/docs/)
 
 ## What’s In This Document
 
@@ -124,36 +124,36 @@ You can get a new Gatsby site up and running on your local dev environment in 5 
 
    Your site is now running at `http://localhost:8000`. Open the `my-blazing-fast-site` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes, and the browser will update in real time!
 
-At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://gatsbyjs.org/plugins/) and [the official tutorial](https://gatsbyjs.org/tutorial/).
+At this point, you’ve got a fully functional Gatsby website. For additional information on how you can customize your Gatsby site, see our [plugins](https://gatsbyjs.com/plugins/) and [the official tutorial](https://gatsbyjs.com/tutorial/).
 
 ## 🎓 Learning Gatsby
 
-Full documentation for Gatsby lives [on the website](https://gatsbyjs.org/).
+Full documentation for Gatsby lives [on the website](https://gatsbyjs.com/).
 
-- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://gatsbyjs.org/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
+- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://gatsbyjs.com/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
 
-- **To dive straight into code samples head [to our documentation](https://gatsbyjs.org/docs/).** In particular, check out the “<i>Guides</i>”, “<i>API Reference</i>”, and “<i>Advanced Tutorials</i>” sections in the sidebar.
+- **To dive straight into code samples head [to our documentation](https://gatsbyjs.com/docs/).** In particular, check out the “<i>Guides</i>”, “<i>API Reference</i>”, and “<i>Advanced Tutorials</i>” sections in the sidebar.
 
-We welcome suggestions for improving our docs. See the [“how to contribute”](https://gatsbyjs.org/contributing/how-to-contribute/) documentation for more details.
+We welcome suggestions for improving our docs. See the [“how to contribute”](https://gatsbyjs.com/contributing/how-to-contribute/) documentation for more details.
 
-**Start Learning Gatsby: [Follow the Tutorial](https://gatsbyjs.org/tutorial/) · [Read the Docs](https://gatsbyjs.org/docs/)**
+**Start Learning Gatsby: [Follow the Tutorial](https://gatsbyjs.com/tutorial/) · [Read the Docs](https://gatsbyjs.com/docs/)**
 
 ## 💼 Migration Guides
 
 Already have a Gatsby site? These handy guides will help you add the improvements of Gatsby v2 to your site without starting from scratch!
 
-- [Migrate a Gatsby site from v1 to v2](https://gatsbyjs.org/docs/migrating-from-v1-to-v2/)
-- Still on v0? Start here: [Migrate a Gatsby site from v0 to v1](https://gatsbyjs.org/docs/migrating-from-v0-to-v1/)
+- [Migrate a Gatsby site from v1 to v2](https://gatsbyjs.com/docs/migrating-from-v1-to-v2/)
+- Still on v0? Start here: [Migrate a Gatsby site from v0 to v1](https://gatsbyjs.com/docs/migrating-from-v0-to-v1/)
 
 ## ❗ Code of Conduct
 
-Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [**Code of Conduct**](https://gatsbyjs.org/contributing/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
+Gatsby is dedicated to building a welcoming, diverse, safe community. We expect everyone participating in the Gatsby community to abide by our [**Code of Conduct**](https://gatsbyjs.com/contributing/code-of-conduct/). Please read it. Please follow it. In the Gatsby community, we work hard to build each other up and create amazing things together. 💪💜
 
 ## 🤝 How to Contribute
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Gatsby community! :muscle::purple_heart:
 
-Check out our [**Contributing Guide**](https://gatsbyjs.org/contributing/how-to-contribute/) for ideas on contributing and setup steps for getting our repositories up and running on your local machine.
+Check out our [**Contributing Guide**](https://gatsbyjs.com/contributing/how-to-contribute/) for ideas on contributing and setup steps for getting our repositories up and running on your local machine.
 
 ### A note on how this repository is organized
 
@@ -169,4 +169,4 @@ Licensed under the [MIT License](./LICENSE).
 
 ## 💜 Thanks
 
-Thanks to our many contributors and to [Netlify](https://www.netlify.com/) for hosting [gatsbyjs.org](https://gatsbyjs.org) and our example sites.
+Thanks to our many contributors and to [Netlify](https://www.netlify.com/) for hosting [gatsbyjs.com](https://gatsbyjs.com) and our example sites.

--- a/docs/contributing/docs-contributions.md
+++ b/docs/contributing/docs-contributions.md
@@ -27,7 +27,7 @@ To address missing images, check the doc or tutorial source [in the Gatsby repo]
 
 If you find a broken link in the Gatsby docs, feel free to fix it and submit a PR!
 
-Keep in mind that some links in here are already correct because they work on gatsbyjs.org. While it would be nice for links in documentation to work on GitHub, having them working on gatsbyjs.org is a higher priority!
+Keep in mind that some links in here are already correct because they work on gatsbyjs.com. While it would be nice for links in documentation to work on GitHub, having them working on gatsbyjs.com is a higher priority!
 
 ## Headings
 


### PR DESCRIPTION
fixed old link (gatsbyjs.org) to gatsbyjs.com :smile: 

## Description

I was going through the gatsby repository and i came to know that the links in the file hasn't changed. I have changed the old links _gatsbyjs.org_ to _gatsbyjs.com_  

Sorry for the repeated edit of the PR title, its my first time ;-;
