### PR TITLE
fix(gatsby): Update TS types to allow Node 'parent' to be nullable

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1504,7 +1504,7 @@ export interface ServiceWorkerArgs extends BrowserPluginArgs {
 
 export interface NodeInput {
   id: string
-  parent?: string
+  parent?: string | null
   children?: string[]
   internal: {
     type: string
@@ -1517,7 +1517,7 @@ export interface NodeInput {
 }
 
 export interface Node extends NodeInput {
-  parent: string
+  parent: string | null
   children: string[]
   internal: NodeInput["internal"] & {
     owner: string


### PR DESCRIPTION
## Description
Update Typescript types for gatsby's Node and NodeInput interfaces to allow `parent` property to be nullable

## Related Issues
Fixes #26553 
