### PR TITLE
Fix(Docs) :Changed old link to new

### DIFF
--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -8,7 +8,7 @@ As of June 2020, the Gatsby community is comprised of over 3,300 contributors an
 
 Open source doesn’t always have the best reputation for being friendly and welcoming, and that makes us sad. **Everyone belongs in open source, and Gatsby is dedicated to making you feel welcome.**
 
-We will never judge, condescend, or exclude anyone. Instead, we will go above and beyond to support the community, through helping you contribute to the Gatsby ecosystem, offering [free swag for contributors](https://gatsby.dev/swag), giving control to the community by [auto-inviting all contributors to the Gatsby GitHub org](https://github.com/gatsbyjs/gatsby/pull/7699#issuecomment-416665803), an open and inclusive [code of conduct](/contributing/code-of-conduct/), and other means that empower and embrace the incredible community that makes Gatsby possible.
+We will never judge, condescend, or exclude anyone. Instead, we will go above and beyond to support the community, through helping you contribute to the Gatsby ecosystem, offering [free swag for contributors](https://www.gatsbyjs.com/contributing/contributor-swag/), giving control to the community by [auto-inviting all contributors to the Gatsby GitHub org](https://github.com/gatsbyjs/gatsby/pull/7699#issuecomment-416665803), an open and inclusive [code of conduct](/contributing/code-of-conduct/), and other means that empower and embrace the incredible community that makes Gatsby possible.
 
 One of our community's values is that ["you belong here"](/blog/2018-09-07-gatsby-values/#you-belong-here).
 

--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -7,7 +7,7 @@ The best part of open source is the community, and every community is stronger w
 ## How community pair programming sessions work
 
 1. Select or create [an issue](https://github.com/gatsbyjs/gatsby/issues) you would like to work on and work on it yourself.
-2. [Create a pull request](https://www.gatsbyjs.org/contributing/how-to-open-a-pull-request/) when you encounter any problem.
+2. [Create a pull request](https://www.gatsbyjs.com/contributing/how-to-open-a-pull-request/) when you encounter any problem.
 3. Fill in your details in [the pair programming request form][form].
 4. You’ll be paired with a Gatsby team member and we'll establish a good time to pair on [Zoom](https://zoom.us).
 5. We'll help you with your pull request or issue!
@@ -22,8 +22,8 @@ If you're interested in support for a commercial Gatsby project, please [get in 
 We also expect the following from pair programming participants:
 
 - These sessions work best when you have a specific goal for the session. You should choose an issue or pull request that you'd like to work on.
-- If you're new to building with Gatsby we recommend [working through the tutorial](https://www.gatsbyjs.org/tutorial/) before your session. If you get stuck part way through that's a great time to book a pairing session.
-- If you're new to contributing to open source we recommend following the ["Setting Up Your Local Dev Environment" guide](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/) before your session.
+- If you're new to building with Gatsby we recommend [working through the tutorial](https://www.gatsbyjs.com/tutorial/) before your session. If you get stuck part way through that's a great time to book a pairing session.
+- If you're new to contributing to open source we recommend following the ["Setting Up Your Local Dev Environment" guide](https://www.gatsbyjs.com/contributing/setting-up-your-local-dev-environment/) before your session.
 - All participants are expected to adhere to [Gatsby’s code of conduct](/contributing/code-of-conduct/)
 - We will ask if it’s okay to record your session; you are _not_ required to let us record and we will work to find another solution that works for you. However, we think it's really valuable to surface these pairing sessions so more people can learn from them and they have a wider reach.
 - Check out our [previous sessions](https://www.youtube.com/playlist?list=PLCU2qJekvcN1f4CRTTMMW6XliGio1NcUD) to see if we've already covered what you're looking to learn! This list will grow over time and we're really excited to have lasting learning artifacts for contributing to Gatsby. Our very first recording was not an actual pairing session but was an [introduction to Gatsby's repository and internals](https://www.youtube.com/watch?v=9wM3pFtyTHw) and is a tremendous resource.


### PR DESCRIPTION
The `swag for contributors` link seems to be old and it takes time to redirect to the new link. Fixed it by changing them to latest link.
There were some more old links in other docs too, fixed them..