### PR TITLE
Fix(www): added gatsby logo and updated links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <a href="https://www.gatsbyjs.com">
+    <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />
+  </a>
+</p>
+
 ## Read docs at https://www.gatsbyjs.com/docs
 
 We intend the docs to be read on gatsbyjs.com — You can read them here of course

--- a/www/README.md
+++ b/www/README.md
@@ -1,13 +1,19 @@
-# gatsbyjs.org
+<p align="center">
+  <a href="https://www.gatsbyjs.com">
+    <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />
+  </a>
+</p>
 
-The main Gatsby site at gatsbyjs.org
+# gatsbyjs.com
+
+The main Gatsby site at gatsbyjs.com
 
 Run locally with:
 
 - `yarn install`
 - `gatsby develop`
 
-See the full contributing instructions at https://www.gatsbyjs.org/contributing/how-to-contribute/
+See the full contributing instructions at https://www.gatsbyjs.com/contributing/how-to-contribute/
 
 ## Environment variables
 
@@ -31,7 +37,7 @@ _Note:_ For `gatsby build` to be able to run you also need a `.env.production` f
 
 ### Enabling guess.js
 
-Guess.js is disabled by default and can be enabled by setting `ANALYTICS_SERVICE_ACCOUNT` and `ANALYTICS_SERVICE_ACCOUNT_KEY` env variables. These variables need to have access to the gatsbyjs.org analytics.
+Guess.js is disabled by default and can be enabled by setting `ANALYTICS_SERVICE_ACCOUNT` and `ANALYTICS_SERVICE_ACCOUNT_KEY` env variables. These variables need to have access to the gatsbyjs.com analytics.
 
 If you have access to the keys, add them like so:
 
@@ -94,15 +100,15 @@ Add the following env variable to your `.env.development` file to enable placeho
 GATSBY_SCREENSHOT_PLACEHOLDER=true
 ```
 
-For more information checkout [`gatsby-transformer-screenshot` docs](https://www.gatsbyjs.org/packages/gatsby-transformer-screenshot#placeholder-image).
+For more information checkout [`gatsby-transformer-screenshot` docs](https://www.gatsbyjs.com/packages/gatsby-transformer-screenshot#placeholder-image).
 
 ## `theme-ui`, CSS authoring, and dark mode
 
-Since [#18027](https://github.com/gatsbyjs/gatsby/pull/18027), we are using [`theme-ui`](https://theme-ui.com/) (via [`gatsby-plugin-theme-ui`](https://www.gatsbyjs.org/packages/gatsby-plugin-theme-ui/?=gatsby-plugin-theme)) to handle theming, CSS authoring, and to provide a dark color mode.
+Since [#18027](https://github.com/gatsbyjs/gatsby/pull/18027), we are using [`theme-ui`](https://theme-ui.com/) (via [`gatsby-plugin-theme-ui`](https://www.gatsbyjs.com/packages/gatsby-plugin-theme-ui/?=gatsby-plugin-theme)) to handle theming, CSS authoring, and to provide a dark color mode.
 
 - Please use the [`sx` prop](https://theme-ui.com/sx-prop) and theme values to style elements and components wherever possible. The prop is "enabled" by adding `theme-ui`'s [JSX pragma](https://theme-ui.com/jsx-pragma).
 - It is still okay to directly import tokens, e.g. `mediaQueries` or `colors` directly from `www/src/gatsby-plugin-theme-ui` if it helps your specific use case — for example when global CSS is required, when passing theme values to other libraries or plugins, when authoring complex responsive styles, etc.
 - It is also perfectly fine to follow the [`theme-ui` approach for responsive styles](https://theme-ui.com/getting-started/#responsive-styles)!
 - If you need to add fields to the [theme](https://theme-ui.com/theme-spec), you can do so in (the work-in-progress) `www/src/gatsby-plugin-theme-ui`. As things settle down, we will eventually migrate changed and added role-based tokens to https://www.npmjs.com/package/gatsby-design-tokens.
 - Please keep the dark mode in mind when editing existing or adding new components.
-- Please bear with us while we adjust https://www.gatsbyjs.org/guidelines/design-tokens/ to document the `theme-ui` values next to the raw token values.
+- Please bear with us while we adjust https://www.gatsbyjs.com/guidelines/design-tokens/ to document the `theme-ui` values next to the raw token values.

--- a/www/README.md
+++ b/www/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# gatsbyjs.com
+<h2 align="center"> gatsbyjs.com </h2>
 
 The main Gatsby site at gatsbyjs.com
 


### PR DESCRIPTION
Added gatsby logo to the top of some of the READMEs and changed old links .org to .com for faster website delivery.
