### PR TITLE
docs(gatsby-link): Clarify that navigate() accepts a pathname, not a full URL.

### DIFF
--- a/docs/docs/gatsby-link.md
+++ b/docs/docs/gatsby-link.md
@@ -193,7 +193,7 @@ Instead, Gatsby exports a `navigate` helper function that accepts `to` and `opti
 
 | Argument          | Required | Description                                                                                     |
 | ----------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| `to`              | yes      | The page to navigate to (e.g. `/blog/`).                                                        |
+| `to`              | yes      | The page to navigate to (e.g. `/blog/`). Note: it needs to be a pathname, not a full URL.       |
 | `options.state`   | no       | An object. Values passed here will be available in `location.state` in the target page’s props. |
 | `options.replace` | no       | A boolean value. If true, replaces the current URL in history.                                  |
 


### PR DESCRIPTION
Will hopefully save people time on issues like [this](https://github.com/gatsbyjs/gatsby/issues/26450).
