### PR TITLE
fix(gatsby): add an end-of-string assert in yaml webpack rule test

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -470,7 +470,7 @@ export const createWebpackUtils = (
 
   rules.yaml = (): RuleSetRule => {
     return {
-      test: /\.ya?ml/,
+      test: /\.ya?ml$/,
       use: [loaders.json(), loaders.yaml()],
     }
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I had an issue with consuming a third-party library packaged to ESM with a rollup. They use yaml files for some default configs and rollup bundles them as `module.yml.js`. Imports in distributed code look like this:
```
import ImportName from './module.yml.js'
```
With Gatsby's current webpack config for yaml loader, such import ends up being processed as a yaml module instead of a js module. The proposed change is a no brainer as it simply makes the yaml rule test more strict requiring module paths to end with yaml or yml, just like the rest of the rules Gatsby generates.

