### PR TITLE
fix(gatsby): character escape sequences in regex filter in graphql queries

### DIFF
--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -117,7 +117,7 @@ _In the playground below the list, there is an example query with a description 
 
 - `eq`: short for **equal**, must match the given data exactly
 - `ne`: short for **not equal**, must be different from the given data
-- `regex`: short for **regular expression**, must match the given pattern. Note that backslashes need to be escaped _twice_, so `/\w+/` needs to be written as `"/\\\\w+/"`.
+- `regex`: short for **regular expression**, must match the given pattern
 - `glob`: short for **global**, allows to use wildcard `*` which acts as a placeholder for any non-empty string
 - `in`: short for **in array**, must be an element of the array
 - `nin`: short for **not in array**, must NOT be an element of the array

--- a/packages/gatsby/src/schema/__tests__/fixtures/regex-query.js
+++ b/packages/gatsby/src/schema/__tests__/fixtures/regex-query.js
@@ -1,0 +1,11 @@
+exports.query = `{
+  allMarkdown(filter: { frontmatter: { authors: { elemMatch: { email: { regex: "/^\\w{6}\\d@\\w{7}\\.COM$/i" } } } } }) {
+    nodes {
+      frontmatter {
+        authors {
+          email
+        }
+      }
+    }
+  }
+}`

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -1579,4 +1579,102 @@ describe(`Query schema`, () => {
       expect(results.data).toEqual(expected)
     })
   })
+
+  describe(`with regex filter`, () => {
+    /**
+     * double-escape character escape sequences when written inline (test only)
+     * (see also the test src/utils/__tests__/prepare-regex.ts)
+     */
+    it(`escape sequences work when correctly escaped`, async () => {
+      const query = `
+        {
+          allMarkdown(filter: { frontmatter: { authors: { elemMatch: { email: { regex: "/^\\\\w{6}\\\\d@\\\\w{7}\\\\.COM$/i" } } } } }) {
+            nodes {
+              frontmatter {
+                authors {
+                  email
+                }
+              }
+            }
+          }
+        }
+      `
+      const results = await runQuery(query)
+      const expected = {
+        allMarkdown: {
+          nodes: [
+            {
+              frontmatter: {
+                authors: [
+                  {
+                    email: `author1@example.com`,
+                  },
+                  {
+                    email: `author2@example.com`,
+                  },
+                ],
+              },
+            },
+            {
+              frontmatter: {
+                authors: [
+                  {
+                    email: `author1@example.com`,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+
+    /**
+     * queries are read from file and parsed with babel
+     */
+    it.only(`escape sequences work when correctly escaped`, async () => {
+      const fs = require(`fs`)
+      const path = require(`path`)
+      const babel = require(`@babel/parser`)
+      const fileContent = fs.readFileSync(
+        path.join(__dirname, `./fixtures/regex-query.js`),
+        `utf-8`
+      )
+      const ast = babel.parse(fileContent)
+      const query = ast.program.body[0].expression.right.quasis[0].value.raw
+
+      const results = await runQuery(query)
+      const expected = {
+        allMarkdown: {
+          nodes: [
+            {
+              frontmatter: {
+                authors: [
+                  {
+                    email: `author1@example.com`,
+                  },
+                  {
+                    email: `author2@example.com`,
+                  },
+                ],
+              },
+            },
+            {
+              frontmatter: {
+                authors: [
+                  {
+                    email: `author1@example.com`,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+      expect(results.errors).toBeUndefined()
+      expect(results.data).toEqual(expected)
+    })
+  })
 })

--- a/packages/gatsby/src/utils/prepare-regex.ts
+++ b/packages/gatsby/src/utils/prepare-regex.ts
@@ -2,15 +2,6 @@ import _ from "lodash"
 
 export const prepareRegex = (str: string): RegExp => {
   const exploded = str.split(`/`)
-  const regex = new RegExp(
-    exploded
-      .slice(1, -1)
-      .join(`/`)
-      // Double escaping is needed to get past the GraphQL parser,
-      // but single escaping is needed for the RegExp constructor,
-      // i.e. `"\\\\w+"` for `/\w+/`.
-      .replace(/\\\\/, `\\`),
-    _.last(exploded)
-  )
+  const regex = new RegExp(exploded.slice(1, -1).join(`/`), _.last(exploded))
   return regex
 }


### PR DESCRIPTION
## Description

attempt to fix character escape sequences in `regex` filters, i.e. queries like:

```js
export const query = graphql`
{
  allFile(filter: {base: {regex: "/\\w+\\.PNG$/i"}}) {
    nodes { base }
  }
}
`
```

this is a follow-up to #25047 which was closed prematurely.

- removes the backslash `replace`ing from [`utils/prepare-regex.ts`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/prepare-regex.ts#L9-L12) which is not needed (any more? might have been before the switch away from relay)
- removes comment about double-escaping from the docs
- in tests, double-escaping is necessary when query is inline (see e.g. [this test here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/__tests__/prepare-regex.js#L21-L55)). i have added two query tests in this pr to illustrate this (double-escaping when query defined inline, normal escaping when read via `fs.readFile`). these are not strictly necessary and could be removed
- with these changes, queries with escape sequences will still break. this is an issue with `eslint-plugin-graphql` which gatsby uses - throws with "Syntax Error: Invalid character escape sequence`. disabling the plugin [here](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/eslint-config.ts#L18-L25) makes things work. i have opened https://github.com/apollographql/eslint-plugin-graphql/pull/282 upstream

## Related Issues

#25047