### PR TITLE
fix(gatsby-starter-blog): Use `ol` for blog post list

### DIFF
--- a/starters/blog/src/pages/index.js
+++ b/starters/blog/src/pages/index.js
@@ -26,7 +26,7 @@ const BlogIndex = ({ data, location }) => {
     <Layout location={location} title={siteTitle}>
       <SEO title="All posts" />
       <Bio />
-      <ol style={{ listStyle: `none`, margin: 0, padding: 0 }}>
+      <ol style={{ listStyle: `none` }}>
         {posts.map(post => {
           const title = post.frontmatter.title || post.fields.slug
 

--- a/starters/blog/src/pages/index.js
+++ b/starters/blog/src/pages/index.js
@@ -34,7 +34,6 @@ const BlogIndex = ({ data, location }) => {
           return (
             <li key={post.fields.slug}>
               <article
-                key={post.fields.slug}
                 className="post-list-item"
                 itemScope
                 itemType="http://schema.org/Article"

--- a/starters/blog/src/pages/index.js
+++ b/starters/blog/src/pages/index.js
@@ -1,5 +1,5 @@
-import { graphql, Link } from "gatsby"
 import React from "react"
+import { Link, graphql } from "gatsby"
 import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"

--- a/starters/blog/src/pages/index.js
+++ b/starters/blog/src/pages/index.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
+
 import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"

--- a/starters/blog/src/pages/index.js
+++ b/starters/blog/src/pages/index.js
@@ -1,6 +1,5 @@
+import { graphql, Link } from "gatsby"
 import React from "react"
-import { Link, graphql } from "gatsby"
-
 import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
@@ -27,34 +26,39 @@ const BlogIndex = ({ data, location }) => {
     <Layout location={location} title={siteTitle}>
       <SEO title="All posts" />
       <Bio />
-      {posts.map(post => {
-        const title = post.frontmatter.title || post.fields.slug
-        return (
-          <article
-            key={post.fields.slug}
-            className="post-list-item"
-            itemScope
-            itemType="http://schema.org/Article"
-          >
-            <header>
-              <h2>
-                <Link to={post.fields.slug} itemProp="url">
-                  <span itemProp="headline">{title}</span>
-                </Link>
-              </h2>
-              <small>{post.frontmatter.date}</small>
-            </header>
-            <section>
-              <p
-                dangerouslySetInnerHTML={{
-                  __html: post.frontmatter.description || post.excerpt,
-                }}
-                itemProp="description"
-              />
-            </section>
-          </article>
-        )
-      })}
+      <ol style={{ listStyle: `none`, margin: 0, padding: 0 }}>
+        {posts.map(post => {
+          const title = post.frontmatter.title || post.fields.slug
+
+          return (
+            <li key={post.fields.slug}>
+              <article
+                key={post.fields.slug}
+                className="post-list-item"
+                itemScope
+                itemType="http://schema.org/Article"
+              >
+                <header>
+                  <h2>
+                    <Link to={post.fields.slug} itemProp="url">
+                      <span itemProp="headline">{title}</span>
+                    </Link>
+                  </h2>
+                  <small>{post.frontmatter.date}</small>
+                </header>
+                <section>
+                  <p
+                    dangerouslySetInnerHTML={{
+                      __html: post.frontmatter.description || post.excerpt,
+                    }}
+                    itemProp="description"
+                  />
+                </section>
+              </article>
+            </li>
+          )
+        })}
+      </ol>
     </Layout>
   )
 }


### PR DESCRIPTION
## Description

Since posts are a collection of items that are **sorted/ordered** by date, they should be rendered as an ordered list in order to improve the page structure which will help search engines and screen readers to interpreter the content.

### Documentation

```html
<ol>
  <li>
    <article>…</article>
  </li>
</ol>
```
## Related Issues

Moved from https://github.com/gatsbyjs/gatsby-starter-blog/pull/202