### PR TITLE
chore(docs): removed old info

### DIFF
--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -8,7 +8,7 @@ As of June 2020, the Gatsby community is comprised of over 3,300 contributors an
 
 Open source doesn’t always have the best reputation for being friendly and welcoming, and that makes us sad. **Everyone belongs in open source, and Gatsby is dedicated to making you feel welcome.**
 
-We will never judge, condescend, or exclude anyone. Instead, we will go above and beyond to support the community, through helping you contribute to the Gatsby ecosystem, offering [free swag for contributors](https://gatsby.dev/swag), giving control to the community by [auto-inviting all contributors to the Gatsby GitHub org](https://github.com/gatsbyjs/gatsby/pull/7699#issuecomment-416665803), an open and inclusive [code of conduct](/contributing/code-of-conduct/), and other means that empower and embrace the incredible community that makes Gatsby possible.
+We will never judge, condescend, or exclude anyone. Instead, we will go above and beyond to support the community, through helping you contribute to the Gatsby ecosystem, offering [free swag for contributors](https://gatsby.dev/swag), an open and inclusive [code of conduct](/contributing/code-of-conduct/), and other means that empower and embrace the incredible community that makes Gatsby possible.
 
 One of our community's values is that ["you belong here"](/blog/2018-09-07-gatsby-values/#you-belong-here).
 


### PR DESCRIPTION
Removed Doc part saying auto addition of contributors to organisation as policy has been updated.


## Description

As of about a week or two ago, the policy that contributors will be added to organisation after getting there PR merged was removed (See https://www.gatsbyjs.com/blog/2020-08-04-gh-community-permissions-changes-gatsbyjs ). I saw it was still mentioned here.

Fixes #26615