### PR TITLE
feat(gatsby-cli): log what activities prevent from transitioning to idle when stuck

### DIFF
--- a/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
+++ b/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
@@ -54,7 +54,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
   )
 
   if (!stuckStatusDiagnosticTimeoutDelay && !stuckStatusWatchdogTimeoutDelay) {
-    // none of timers are enabled, so this is middleware is no-op
+    // none of timers are enabled, so this is no-op middleware
     return (): void => {}
   }
 

--- a/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
+++ b/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
@@ -1,0 +1,183 @@
+import { ActionsUnion } from "./types"
+import { ActivityStatuses } from "../constants"
+import { calcElapsedTime } from "../../util/calc-elapsed-time"
+import type { Reporter } from "../reporter"
+import type { GatsbyCLIStore } from "./"
+
+function calculateTimeoutDelay(
+  envVarValue: string | undefined,
+  defaultValue: number,
+  min: number
+): number {
+  if (!envVarValue) {
+    return 0
+  } else if (envVarValue === `1`) {
+    // Toggling env vars with "1" is quite common - because we allow to set
+    // specific timeout values with env var, this special case is added
+    // (1ms timeout makes little sense - that's too low value to be used as-is)
+    return defaultValue
+  }
+
+  const parsedToNumber = parseInt(envVarValue, 10)
+  if (isNaN(parsedToNumber)) {
+    // It's truthy, but not a number - let's enable it with default value
+    return defaultValue
+  }
+
+  // Allow to custom specific timeout value, but also put some minimal
+  // timeout bound as there is little usefulness of setting it to
+  // something less than few seconds.
+  return Math.max(parsedToNumber, min)
+}
+
+type DiagnosticsMiddleware = (action: ActionsUnion) => void
+
+const FIVE_MINUTES = 1000 * 60 * 5
+const FIVE_SECONDS = 1000 * 5
+const TEN_MINUTES = 1000 * 60 * 10
+const TEN_SECONDS = 1000 * 10
+
+export function createStructuredLoggingDiagnosticsMiddleware(
+  store: GatsbyCLIStore
+): DiagnosticsMiddleware {
+  const stuckStatusDiagnosticTimeoutDelay = calculateTimeoutDelay(
+    process.env.GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT,
+    FIVE_MINUTES, // default timeout
+    FIVE_SECONDS // minimal timeout (this is mostly useful for debugging diagnostic code itself)
+  )
+
+  const stuckStatusWatchdogTimeoutDelay = calculateTimeoutDelay(
+    process.env.GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT,
+    TEN_MINUTES, // default timeout
+    TEN_SECONDS // minimal timeout (this is mostly useful for debugging diagnostic code itself)
+  )
+
+  if (!stuckStatusDiagnosticTimeoutDelay && !stuckStatusWatchdogTimeoutDelay) {
+    // none of timers are enabled, so this is middleware is no-op
+    return (): void => {}
+  }
+
+  let displayedStuckStatusDiagnosticWarning = false
+  let displayingStuckStatusDiagnosticWarning = false
+  let stuckStatusDiagnosticTimer: NodeJS.Timeout
+  let stuckStatusWatchdogTimer: NodeJS.Timeout
+  let reporter: Reporter
+
+  function generateStuckStatusDiagnosticMessage(): string {
+    const { activities } = store.getState().logs
+
+    return JSON.stringify(
+      Object.values(activities)
+        .filter(
+          activity =>
+            activity.status === ActivityStatuses.InProgress ||
+            activity.status === ActivityStatuses.NotStarted
+        )
+        .map(activity => {
+          if (!activity.startTime) {
+            return activity
+          }
+
+          return {
+            ...activity,
+            diagnostics_elapsed_seconds: calcElapsedTime(activity.startTime),
+          }
+        }),
+      null,
+      2
+    )
+  }
+
+  return function diagnosticMiddleware(action: ActionsUnion): void {
+    // ignore diagnostic logs, otherwise diagnostic message itself will reset
+    // the timers
+    if (!displayingStuckStatusDiagnosticWarning) {
+      const currentStatus = store.getState().logs.status
+
+      if (!reporter) {
+        // yuck, we have situation of circular dependencies here
+        // so this `reporter` import is delayed until it's actually needed
+        reporter = require(`../reporter`).reporter
+      }
+
+      if (stuckStatusDiagnosticTimeoutDelay) {
+        if (stuckStatusDiagnosticTimer) {
+          clearTimeout(stuckStatusDiagnosticTimer)
+        }
+
+        if (displayedStuckStatusDiagnosticWarning) {
+          // using nextTick here to prevent infinite recursion (report.warn would
+          // result in another call of this function and so on)
+          process.nextTick(() => {
+            const activitiesDiagnosticsMessage = generateStuckStatusDiagnosticMessage()
+            reporter.warn(
+              `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nThere was activity since last diagnostic message. Log action:\n\n${JSON.stringify(
+                action,
+                null,
+                2
+              )}\n\nCurrently Gatsby is in: "${
+                store.getState().logs.status
+              }" state.${
+                activitiesDiagnosticsMessage.length > 0
+                  ? `\n\nActivities preventing Gatsby from transitioning to idle state:\n\n${activitiesDiagnosticsMessage}`
+                  : ``
+              }`
+            )
+          })
+          displayedStuckStatusDiagnosticWarning = false
+        }
+
+        if (currentStatus === ActivityStatuses.InProgress) {
+          stuckStatusDiagnosticTimer = setTimeout(
+            function logStuckStatusDiagnostic() {
+              displayingStuckStatusDiagnosticWarning = true
+              reporter.warn(
+                `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nGatsby is in "${
+                  store.getState().logs.status
+                }" state without any updates for ${(
+                  stuckStatusDiagnosticTimeoutDelay / 1000
+                ).toFixed(
+                  3
+                )} seconds. Activities preventing Gatsby from transitioning to idle state:\n\n${generateStuckStatusDiagnosticMessage()}${
+                  stuckStatusWatchdogTimeoutDelay
+                    ? `\n\nProcess will be terminated in ${(
+                        (stuckStatusWatchdogTimeoutDelay -
+                          stuckStatusDiagnosticTimeoutDelay) /
+                        1000
+                      ).toFixed(3)} seconds if nothing will change.`
+                    : ``
+                }`
+              )
+              displayingStuckStatusDiagnosticWarning = false
+              displayedStuckStatusDiagnosticWarning = true
+            },
+            stuckStatusDiagnosticTimeoutDelay
+          )
+        }
+      }
+
+      if (stuckStatusWatchdogTimeoutDelay) {
+        if (stuckStatusWatchdogTimer) {
+          clearTimeout(stuckStatusWatchdogTimer)
+        }
+
+        if (currentStatus === ActivityStatuses.InProgress) {
+          stuckStatusWatchdogTimer = setTimeout(
+            function fatalStuckStatusHandler() {
+              reporter.panic(
+                `Terminating the process (due to GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT):\n\nGatsby is in "${
+                  store.getState().logs.status
+                }" state without any updates for ${(
+                  stuckStatusWatchdogTimeoutDelay / 1000
+                ).toFixed(
+                  3
+                )} seconds. Activities preventing Gatsby from transitioning to idle state:\n\n${generateStuckStatusDiagnosticMessage()}`
+              )
+            },
+            stuckStatusWatchdogTimeoutDelay
+          )
+        }
+      }
+    }
+  }
+}

--- a/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
+++ b/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
@@ -1,6 +1,7 @@
 import { ActionsUnion } from "./types"
 import { ActivityStatuses } from "../constants"
 import { calcElapsedTime } from "../../util/calc-elapsed-time"
+import { isActivityInProgress } from "./utils"
 import type { Reporter } from "../reporter"
 import type { GatsbyCLIStore } from "./"
 
@@ -68,11 +69,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
 
     return JSON.stringify(
       Object.values(activities)
-        .filter(
-          activity =>
-            activity.status === ActivityStatuses.InProgress ||
-            activity.status === ActivityStatuses.NotStarted
-        )
+        .filter(activity => isActivityInProgress(activity.status))
         .map(activity => {
           if (!activity.startTime) {
             return activity

--- a/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
+++ b/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
@@ -60,8 +60,8 @@ export function createStructuredLoggingDiagnosticsMiddleware(
 
   let displayedStuckStatusDiagnosticWarning = false
   let displayingStuckStatusDiagnosticWarning = false
-  let stuckStatusDiagnosticTimer: NodeJS.Timeout
-  let stuckStatusWatchdogTimer: NodeJS.Timeout
+  let stuckStatusDiagnosticTimer: NodeJS.Timeout | null = null
+  let stuckStatusWatchdogTimer: NodeJS.Timeout | null = null
   let reporter: Reporter
 
   function generateStuckStatusDiagnosticMessage(): string {
@@ -100,6 +100,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
       if (stuckStatusDiagnosticTimeoutDelay) {
         if (stuckStatusDiagnosticTimer) {
           clearTimeout(stuckStatusDiagnosticTimer)
+          stuckStatusDiagnosticTimer = null
         }
 
         if (displayedStuckStatusDiagnosticWarning) {
@@ -156,6 +157,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
       if (stuckStatusWatchdogTimeoutDelay) {
         if (stuckStatusWatchdogTimer) {
           clearTimeout(stuckStatusWatchdogTimer)
+          stuckStatusWatchdogTimer = null
         }
 
         if (currentStatus === ActivityStatuses.InProgress) {

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -2,7 +2,8 @@ import { createStore, combineReducers } from "redux"
 import { reducer } from "./reducer"
 import { ActionsUnion, ISetLogs } from "./types"
 import { isInternalAction } from "./utils"
-import { Actions } from "../constants"
+import { Actions, ActivityStatuses } from "../constants"
+import { setTimeout } from "timers"
 
 let store = createStore(
   combineReducers({
@@ -10,6 +11,64 @@ let store = createStore(
   }),
   {}
 )
+
+function calculateTimeoutDelay(
+  envVarValue: string | undefined,
+  defaultValue: number,
+  min: number
+): number | null {
+  if (!envVarValue) {
+    return null
+  } else if (envVarValue === `1`) {
+    // toggling env vars with "1" is quite common - because we allow to set
+    // specific timeout values with env var, this special case is added
+    // (1ms timeout makes little sense - that's too low value to be used as-is)
+    return defaultValue
+  }
+
+  const parsedToNumber = parseInt(envVarValue)
+  if (isNaN(parsedToNumber)) {
+    // it's truthy, but not a number - let's enable it with default value
+    return defaultValue
+  }
+
+  // allow to custom specific timeout value, but also keep in mind that
+  // setting env var to "1" is common way of toggling features
+  // and we don't want to set to 1ms in those cases
+  return Math.max(parsedToNumber, min)
+}
+
+const stuckStatusDiagnosticTimeoutDelay = calculateTimeoutDelay(
+  process.env.GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT,
+  1000 * 60 * 5, // 5 minutes default timeout
+  1000 * 5 // 5 seconds minimal value (this is mostly useful for debugging diagnostic code itself)
+)
+
+// console.log(`stuck stuff`, stuckStatusDiagnosticTimeoutDelay)
+
+const stuckStatusWatchdogTimeoutDelay = calculateTimeoutDelay(
+  process.env.GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT,
+  1000 * 60 * 10, // 10 minutes default timeout
+  1000 * 10 // 10 seconds minimal value (this is mostly useful for debugging diagnostic code itself)
+)
+
+let displayedStuckStatusDiagnosticWarning = false
+let displayingStuckStatusDiagnosticWarning = false
+let stuckStatusDiagnosticTimer: NodeJS.Timeout
+let stuckStatusWatchdogTimer: NodeJS.Timeout
+function generateStuckStatusDiagnosticMessage(): string {
+  const { activities } = store.getState().logs
+
+  return JSON.stringify(
+    Object.values(activities).filter(
+      activity =>
+        activity.status === ActivityStatuses.InProgress ||
+        activity.status === ActivityStatuses.NotStarted
+    ),
+    null,
+    2
+  )
+}
 
 export type GatsbyCLIStore = typeof store
 type StoreListener = (store: GatsbyCLIStore) => void
@@ -45,6 +104,88 @@ export const dispatch = (action: ActionsUnion | Thunk): void => {
   } as ActionsUnion
 
   store.dispatch(action)
+
+  // ignore diagnostic logs, otherwise diagnostic message itself will reset
+  // the timers
+  if (!displayingStuckStatusDiagnosticWarning) {
+    const currentStatus = store.getState().logs.status
+
+    // yuck, we have situation of circular dependencies here
+    // so this is `reporter` import is delayed until it's actually needed
+    const { reporter } = require(`../reporter`)
+
+    if (stuckStatusDiagnosticTimeoutDelay) {
+      if (stuckStatusDiagnosticTimer) {
+        clearTimeout(stuckStatusDiagnosticTimer)
+      }
+
+      if (displayedStuckStatusDiagnosticWarning) {
+        process.nextTick(() => {
+          const { status } = store.getState().logs
+          const activitiesDiagnosticsMessage = generateStuckStatusDiagnosticMessage()
+          reporter.warn(
+            `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nThere was activity since last diagnostic message. Currently Gatsby is in: "${status}" state.${
+              activitiesDiagnosticsMessage.length > 0
+                ? `\n\nActivities preventing Gatsby from transitioning to idle state:\n\n${activitiesDiagnosticsMessage}`
+                : ``
+            }`
+          )
+        })
+        displayedStuckStatusDiagnosticWarning = false
+      }
+
+      if (currentStatus === ActivityStatuses.InProgress) {
+        stuckStatusDiagnosticTimer = setTimeout(
+          function logStuckStatusDiagnostic() {
+            displayingStuckStatusDiagnosticWarning = true
+            reporter.warn(
+              `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nGatsby is in "${
+                store.getState().logs.status
+              }" state without any updates for ${(
+                (stuckStatusDiagnosticTimeoutDelay ?? 0) / 1000
+              ).toFixed(
+                3
+              )} seconds. Activities preventing Gatsby from transitioning to idle state:\n\n${generateStuckStatusDiagnosticMessage()}${
+                stuckStatusWatchdogTimeoutDelay
+                  ? `\n\nProcess will be terminated in ${(
+                      (stuckStatusWatchdogTimeoutDelay -
+                        stuckStatusDiagnosticTimeoutDelay) /
+                      1000
+                    ).toFixed(3)} seconds if nothing will change.`
+                  : ``
+              }`
+            )
+            displayingStuckStatusDiagnosticWarning = false
+            displayedStuckStatusDiagnosticWarning = true
+          },
+          stuckStatusDiagnosticTimeoutDelay
+        )
+      }
+    }
+
+    if (stuckStatusWatchdogTimeoutDelay) {
+      if (stuckStatusWatchdogTimer) {
+        clearTimeout(stuckStatusWatchdogTimer)
+      }
+
+      if (currentStatus === ActivityStatuses.InProgress) {
+        stuckStatusWatchdogTimer = setTimeout(
+          function fatalStuckStatusHandler() {
+            reporter.panic(
+              `Terminating the process (due to GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT):\n\nGatsby is in "${
+                store.getState().logs.status
+              }" state without any updates for ${(
+                (stuckStatusWatchdogTimeoutDelay ?? 0) / 1000
+              ).toFixed(
+                3
+              )} seconds. Activities preventing Gatsby from transitioning to idle state:\n\n${generateStuckStatusDiagnosticMessage()}\n\n`
+            )
+          },
+          stuckStatusWatchdogTimeoutDelay
+        )
+      }
+    }
+  }
 
   if (isInternalAction(action)) {
     // consumers (ipc, yurnalist, json logger) shouldn't have to

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -2,6 +2,7 @@ import { createStore, combineReducers } from "redux"
 import { reducer } from "./reducer"
 import { ActionsUnion, ISetLogs } from "./types"
 import { isInternalAction } from "./utils"
+import { calcElapsedTime } from "../../util/calc-elapsed-time"
 import { Actions, ActivityStatuses } from "../constants"
 import { setTimeout } from "timers"
 
@@ -60,11 +61,23 @@ function generateStuckStatusDiagnosticMessage(): string {
   const { activities } = store.getState().logs
 
   return JSON.stringify(
-    Object.values(activities).filter(
-      activity =>
-        activity.status === ActivityStatuses.InProgress ||
-        activity.status === ActivityStatuses.NotStarted
-    ),
+    Object.values(activities)
+      .filter(
+        activity =>
+          activity.status === ActivityStatuses.InProgress ||
+          activity.status === ActivityStatuses.NotStarted
+      )
+      .map(activity => {
+        if (!activity.startTime) {
+          return activity
+        }
+
+        const diagnostics_elapsed_seconds = calcElapsedTime(activity.startTime)
+        return {
+          ...activity,
+          diagnostics_elapsed_seconds,
+        }
+      }),
     null,
     2
   )

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -2,9 +2,8 @@ import { createStore, combineReducers } from "redux"
 import { reducer } from "./reducer"
 import { ActionsUnion, ISetLogs } from "./types"
 import { isInternalAction } from "./utils"
-import { calcElapsedTime } from "../../util/calc-elapsed-time"
-import { Actions, ActivityStatuses } from "../constants"
-import { setTimeout } from "timers"
+import { createStructuredLoggingDiagnosticsMiddleware } from "./diagnostics"
+import { Actions } from "../constants"
 
 let store = createStore(
   combineReducers({
@@ -13,72 +12,9 @@ let store = createStore(
   {}
 )
 
-function calculateTimeoutDelay(
-  envVarValue: string | undefined,
-  defaultValue: number,
-  min: number
-): number | null {
-  if (!envVarValue) {
-    return null
-  } else if (envVarValue === `1`) {
-    // toggling env vars with "1" is quite common - because we allow to set
-    // specific timeout values with env var, this special case is added
-    // (1ms timeout makes little sense - that's too low value to be used as-is)
-    return defaultValue
-  }
-
-  const parsedToNumber = parseInt(envVarValue, 10)
-  if (isNaN(parsedToNumber)) {
-    // it's truthy, but not a number - let's enable it with default value
-    return defaultValue
-  }
-
-  // allow to custom specific timeout value, but also keep in mind that
-  // setting env var to "1" is common way of toggling features
-  // and we don't want to set to 1ms in those cases
-  return Math.max(parsedToNumber, min)
-}
-
-const stuckStatusDiagnosticTimeoutDelay = calculateTimeoutDelay(
-  process.env.GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT,
-  1000 * 60 * 5, // 5 minutes default timeout
-  1000 * 5 // 5 seconds minimal value (this is mostly useful for debugging diagnostic code itself)
+const diagnosticsMiddleware = createStructuredLoggingDiagnosticsMiddleware(
+  store
 )
-
-const stuckStatusWatchdogTimeoutDelay = calculateTimeoutDelay(
-  process.env.GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT,
-  1000 * 60 * 10, // 10 minutes default timeout
-  1000 * 10 // 10 seconds minimal value (this is mostly useful for debugging diagnostic code itself)
-)
-
-let displayedStuckStatusDiagnosticWarning = false
-let displayingStuckStatusDiagnosticWarning = false
-let stuckStatusDiagnosticTimer: NodeJS.Timeout
-let stuckStatusWatchdogTimer: NodeJS.Timeout
-function generateStuckStatusDiagnosticMessage(): string {
-  const { activities } = store.getState().logs
-
-  return JSON.stringify(
-    Object.values(activities)
-      .filter(
-        activity =>
-          activity.status === ActivityStatuses.InProgress ||
-          activity.status === ActivityStatuses.NotStarted
-      )
-      .map(activity => {
-        if (!activity.startTime) {
-          return activity
-        }
-
-        return {
-          ...activity,
-          diagnostics_elapsed_seconds: calcElapsedTime(activity.startTime),
-        }
-      }),
-    null,
-    2
-  )
-}
 
 export type GatsbyCLIStore = typeof store
 type StoreListener = (store: GatsbyCLIStore) => void
@@ -115,94 +51,7 @@ export const dispatch = (action: ActionsUnion | Thunk): void => {
 
   store.dispatch(action)
 
-  // ignore diagnostic logs, otherwise diagnostic message itself will reset
-  // the timers
-  if (!displayingStuckStatusDiagnosticWarning) {
-    const currentStatus = store.getState().logs.status
-
-    // yuck, we have situation of circular dependencies here
-    // so this is `reporter` import is delayed until it's actually needed
-    const { reporter } = require(`../reporter`)
-
-    if (stuckStatusDiagnosticTimeoutDelay) {
-      if (stuckStatusDiagnosticTimer) {
-        clearTimeout(stuckStatusDiagnosticTimer)
-      }
-
-      if (displayedStuckStatusDiagnosticWarning) {
-        // using nextTick here to prevent infinite recursion (report.warn would
-        // result in another call of this function and so on)
-        process.nextTick(() => {
-          const activitiesDiagnosticsMessage = generateStuckStatusDiagnosticMessage()
-          reporter.warn(
-            `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nThere was activity since last diagnostic message. Log action:\n\n${JSON.stringify(
-              action,
-              null,
-              2
-            )}\n\nCurrently Gatsby is in: "${
-              store.getState().logs.status
-            }" state.${
-              activitiesDiagnosticsMessage.length > 0
-                ? `\n\nActivities preventing Gatsby from transitioning to idle state:\n\n${activitiesDiagnosticsMessage}`
-                : ``
-            }`
-          )
-        })
-        displayedStuckStatusDiagnosticWarning = false
-      }
-
-      if (currentStatus === ActivityStatuses.InProgress) {
-        stuckStatusDiagnosticTimer = setTimeout(
-          function logStuckStatusDiagnostic() {
-            displayingStuckStatusDiagnosticWarning = true
-            reporter.warn(
-              `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nGatsby is in "${
-                store.getState().logs.status
-              }" state without any updates for ${(
-                (stuckStatusDiagnosticTimeoutDelay ?? 0) / 1000
-              ).toFixed(
-                3
-              )} seconds. Activities preventing Gatsby from transitioning to idle state:\n\n${generateStuckStatusDiagnosticMessage()}${
-                stuckStatusWatchdogTimeoutDelay
-                  ? `\n\nProcess will be terminated in ${(
-                      (stuckStatusWatchdogTimeoutDelay -
-                        stuckStatusDiagnosticTimeoutDelay) /
-                      1000
-                    ).toFixed(3)} seconds if nothing will change.`
-                  : ``
-              }`
-            )
-            displayingStuckStatusDiagnosticWarning = false
-            displayedStuckStatusDiagnosticWarning = true
-          },
-          stuckStatusDiagnosticTimeoutDelay
-        )
-      }
-    }
-
-    if (stuckStatusWatchdogTimeoutDelay) {
-      if (stuckStatusWatchdogTimer) {
-        clearTimeout(stuckStatusWatchdogTimer)
-      }
-
-      if (currentStatus === ActivityStatuses.InProgress) {
-        stuckStatusWatchdogTimer = setTimeout(
-          function fatalStuckStatusHandler() {
-            reporter.panic(
-              `Terminating the process (due to GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT):\n\nGatsby is in "${
-                store.getState().logs.status
-              }" state without any updates for ${(
-                (stuckStatusWatchdogTimeoutDelay ?? 0) / 1000
-              ).toFixed(
-                3
-              )} seconds. Activities preventing Gatsby from transitioning to idle state:\n\n${generateStuckStatusDiagnosticMessage()}`
-            )
-          },
-          stuckStatusWatchdogTimeoutDelay
-        )
-      }
-    }
-  }
+  diagnosticsMiddleware(action)
 
   if (isInternalAction(action)) {
     // consumers (ipc, yurnalist, json logger) shouldn't have to

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -45,8 +45,6 @@ const stuckStatusDiagnosticTimeoutDelay = calculateTimeoutDelay(
   1000 * 5 // 5 seconds minimal value (this is mostly useful for debugging diagnostic code itself)
 )
 
-// console.log(`stuck stuff`, stuckStatusDiagnosticTimeoutDelay)
-
 const stuckStatusWatchdogTimeoutDelay = calculateTimeoutDelay(
   process.env.GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT,
   1000 * 60 * 10, // 10 minutes default timeout

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -120,11 +120,18 @@ export const dispatch = (action: ActionsUnion | Thunk): void => {
       }
 
       if (displayedStuckStatusDiagnosticWarning) {
+        // using nextTick here to prevent infinite recursion (report.warn would
+        // result in another call of this function and so on)
         process.nextTick(() => {
-          const { status } = store.getState().logs
           const activitiesDiagnosticsMessage = generateStuckStatusDiagnosticMessage()
           reporter.warn(
-            `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nThere was activity since last diagnostic message. Currently Gatsby is in: "${status}" state.${
+            `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nThere was activity since last diagnostic message. Log action:\n\n${JSON.stringify(
+              action,
+              null,
+              2
+            )}\n\nCurrently Gatsby is in: "${
+              store.getState().logs.status
+            }" state.${
               activitiesDiagnosticsMessage.length > 0
                 ? `\n\nActivities preventing Gatsby from transitioning to idle state:\n\n${activitiesDiagnosticsMessage}`
                 : ``
@@ -178,7 +185,7 @@ export const dispatch = (action: ActionsUnion | Thunk): void => {
                 (stuckStatusWatchdogTimeoutDelay ?? 0) / 1000
               ).toFixed(
                 3
-              )} seconds. Activities preventing Gatsby from transitioning to idle state:\n\n${generateStuckStatusDiagnosticMessage()}\n\n`
+              )} seconds. Activities preventing Gatsby from transitioning to idle state:\n\n${generateStuckStatusDiagnosticMessage()}`
             )
           },
           stuckStatusWatchdogTimeoutDelay

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -72,10 +72,9 @@ function generateStuckStatusDiagnosticMessage(): string {
           return activity
         }
 
-        const diagnostics_elapsed_seconds = calcElapsedTime(activity.startTime)
         return {
           ...activity,
-          diagnostics_elapsed_seconds,
+          diagnostics_elapsed_seconds: calcElapsedTime(activity.startTime),
         }
       }),
     null,

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -27,7 +27,7 @@ function calculateTimeoutDelay(
     return defaultValue
   }
 
-  const parsedToNumber = parseInt(envVarValue)
+  const parsedToNumber = parseInt(envVarValue, 10)
   if (isNaN(parsedToNumber)) {
     // it's truthy, but not a number - let's enable it with default value
     return defaultValue

--- a/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
+++ b/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
@@ -160,6 +160,7 @@ export const createPendingActivity = ({
       payload: {
         id,
         type: ActivityTypes.Pending,
+        startTime: process.hrtime(),
         status,
       },
     },

--- a/packages/gatsby-cli/src/reporter/redux/reducer.ts
+++ b/packages/gatsby-cli/src/reporter/redux/reducer.ts
@@ -51,6 +51,7 @@ export const reducer = (
           ...state.activities,
           [id]: {
             ...activity,
+            id,
             ...rest,
           },
         },

--- a/packages/gatsby-cli/src/reporter/redux/types.ts
+++ b/packages/gatsby-cli/src/reporter/redux/types.ts
@@ -70,6 +70,7 @@ export interface IPendingActivity {
     id: string
     type: ActivityTypes
     status: ActivityStatuses
+    startTime?: [number, number]
   }
 }
 

--- a/packages/gatsby-cli/src/reporter/redux/utils.ts
+++ b/packages/gatsby-cli/src/reporter/redux/utils.ts
@@ -4,6 +4,15 @@ import { Actions, ActivityTypes, ActivityStatuses } from "../constants"
 import { ActionsUnion, IActivity } from "./types"
 import signalExit from "signal-exit"
 
+export function isActivityInProgress(
+  activityStatus: ActivityStatuses
+): boolean {
+  return (
+    activityStatus === ActivityStatuses.InProgress ||
+    activityStatus === ActivityStatuses.NotStarted
+  )
+}
+
 export const getGlobalStatus = (
   id: string,
   status: ActivityStatuses
@@ -20,10 +29,7 @@ export const getGlobalStatus = (
       const activityStatus =
         activityId === id ? status : logs.activities[activityId].status
 
-      if (
-        activityStatus === ActivityStatuses.InProgress ||
-        activityStatus === ActivityStatuses.NotStarted
-      ) {
+      if (isActivityInProgress(activityStatus)) {
         return ActivityStatuses.InProgress
       } else if (
         activityStatus === ActivityStatuses.Failed &&


### PR DESCRIPTION
## Description

This PR allows to run Gatsby with following env vars (you can use one of those or both or ... well none):
 - `GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT` - to just log information when Gatsby is stuck in `IN_PROGRESS`
 - `GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT` - to terminate the process when stuck in `IN_PROGRESS`

Way it determines wether Gatsby is stuck is by (re)setting timer(s) on every log activity - it might mean log line, it might be `tick()` in progress bar, it might even be things not visible to users (setting activity as pending or using one of those hidden activities that are too fine grained to display in UI).

Few notes about usage:
 - when setting env var to a number (just any other than "1" - more about it in a sec) - it will try to use those numbers as timeout delay (but I did add, so at minimum it's 5s for diagnostic logs and 10s for termination)
 - when setting env var to truthy or "1" (which I reckon is quite popular way of "toggling" env vars), it will use some default timeouts (5 minutes for diagnostic logs and 10 minutes for termination).

In terminal results might look a little like this:

<details>
<summary>Both flags:</summary>

```shell
$ ENABLE_GATSBY_REFRESH_ENDPOINT=1 GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT=10000 GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT=5000  gatsby develop

[...]

success write out requires - 0.001s
success run page queries - 0.010s - 1/1 102.49/s
warn This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):

Gatsby is in "IN_PROGRESS" state without any updates for 5.000 seconds. Activities preventing Gatsby from transitioning to idle state:

[
  {
    "id": "pending-but-not-really-running",
    "type": "pending",
    "startTime": [
      167025,
      903782122
    ],
    "status": "NOT_STARTED",
    "diagnostics_elapsed_seconds": "5.236"
  },
  {
    "id": "hidden one",
    "uuid": "eae76780-6d77-4685-aa0a-d8e959b53124",
    "text": "hidden one",
    "type": "hidden",
    "status": "IN_PROGRESS",
    "startTime": [
      167025,
      904008910
    ],
    "statusText": "",
    "diagnostics_elapsed_seconds": "5.236"
  }
]

Process will be terminated in 5.000 seconds if nothing will change.
warn This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):

There was activity since last diagnostic message. Log action:

{
  "type": "ACTIVITY_END",
  "payload": {
    "uuid": "eae76780-6d77-4685-aa0a-d8e959b53124",
    "id": "hidden one",
    "status": "SUCCESS",
    "duration": 7.51006542,
    "type": "hidden"
  },
  "timestamp": "2020-08-24T14:32:25.307Z"
}

Currently Gatsby is in: "IN_PROGRESS" state.

Activities preventing Gatsby from transitioning to idle state:

[
  {
    "id": "pending-but-not-really-running",
    "type": "pending",
    "startTime": [
      167025,
      903782122
    ],
    "status": "NOT_STARTED",
    "diagnostics_elapsed_seconds": "7.512"
  }
]
warn This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):

Gatsby is in "IN_PROGRESS" state without any updates for 5.000 seconds. Activities preventing Gatsby from transitioning to idle state:

[
  {
    "id": "pending-but-not-really-running",
    "type": "pending",
    "startTime": [
      167025,
      903782122
    ],
    "status": "NOT_STARTED",
    "diagnostics_elapsed_seconds": "12.515"
  }
]

Process will be terminated in 5.000 seconds if nothing will change.

 ERROR 

Terminating the process (due to GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT):

Gatsby is in "IN_PROGRESS" state without any updates for 10.000 seconds. Activities preventing Gatsby from transitioning to idle state:

[
  {
    "id": "pending-but-not-really-running",
    "type": "pending",
    "startTime": [
      167025,
      903782122
    ],
    "status": "NOT_STARTED",
    "diagnostics_elapsed_seconds": "17.516"
  }
]
```
</details>

<details>
<summary>Just `GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT`:</summary>

```shell
$ ENABLE_GATSBY_REFRESH_ENDPOINT=1 GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT=5000  gatsby develop

[...]

success write out requires - 0.001s
success run page queries - 0.010s - 1/1 103.75/s
warn This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):

Gatsby is in "IN_PROGRESS" state without any updates for 5.000 seconds. Activities preventing Gatsby from transitioning to idle state:

[
  {
    "id": "pending-but-not-really-running",
    "type": "pending",
    "startTime": [
      167090,
      531910219
    ],
    "status": "NOT_STARTED",
    "diagnostics_elapsed_seconds": "5.249"
  },
  {
    "id": "hidden one",
    "uuid": "8e952af8-dd37-418a-9b99-55fd49c331db",
    "text": "hidden one",
    "type": "hidden",
    "status": "IN_PROGRESS",
    "startTime": [
      167090,
      532129975
    ],
    "statusText": "",
    "diagnostics_elapsed_seconds": "5.249"
  }
]
warn This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):

There was activity since last diagnostic message. Log action:

{
  "type": "ACTIVITY_END",
  "payload": {
    "uuid": "8e952af8-dd37-418a-9b99-55fd49c331db",
    "id": "hidden one",
    "status": "SUCCESS",
    "duration": 7.506380937,
    "type": "hidden"
  },
  "timestamp": "2020-08-24T14:33:29.933Z"
}

Currently Gatsby is in: "IN_PROGRESS" state.

Activities preventing Gatsby from transitioning to idle state:

[
  {
    "id": "pending-but-not-really-running",
    "type": "pending",
    "startTime": [
      167090,
      531910219
    ],
    "status": "NOT_STARTED",
    "diagnostics_elapsed_seconds": "7.507"
  }
]
warn This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):

Gatsby is in "IN_PROGRESS" state without any updates for 5.000 seconds. Activities preventing Gatsby from transitioning to idle state:

[
  {
    "id": "pending-but-not-really-running",
    "type": "pending",
    "startTime": [
      167090,
      531910219
    ],
    "status": "NOT_STARTED",
    "diagnostics_elapsed_seconds": "12.508"
  }
]
```
</details>

<details>
<summary>Just `GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT`:</summary>

```shell
$ ENABLE_GATSBY_REFRESH_ENDPOINT=1 GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT=10000  gatsby develop

[...]

success write out requires - 0.002s
success run page queries - 0.010s - 1/1 101.11/s

 ERROR 

Terminating the process (due to GATSBY_WATCHDOG_STUCK_STATUS_TIMEOUT):

Gatsby is in "IN_PROGRESS" state without any updates for 10.000 seconds. Activities preventing Gatsby from transitioning to idle state:

[
  {
    "id": "pending-but-not-really-running",
    "type": "pending",
    "startTime": [
      167245,
      698002618
    ],
    "status": "NOT_STARTED",
    "diagnostics_elapsed_seconds": "17.517"
  }
]
```
</details>

[ch14090]