### PR TITLE
chore(gatsby-admin): setup gatsby-telemetry

### DIFF
--- a/packages/gatsby-admin/package.json
+++ b/packages/gatsby-admin/package.json
@@ -24,6 +24,7 @@
     "gatsby-plugin-typescript": "^2.4.18",
     "gatsby-plugin-webfonts": "^1.1.3",
     "gatsby-source-graphql": "^2.7.1",
+    "gatsby-telemetry": "^1.3.27",
     "lodash-es": "^4.17.15",
     "ncp": "^2.0.0",
     "nodemon": "^2.0.4",

--- a/packages/gatsby-admin/src/components/layout.tsx
+++ b/packages/gatsby-admin/src/components/layout.tsx
@@ -1,9 +1,14 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 import { Flex } from "strict-ui"
+import { Helmet } from "react-helmet"
+import telemetry from "gatsby-telemetry"
+import pkgJson from "../../package.json"
 import Providers from "./providers"
 import Navbar from "./navbar"
-import { Helmet } from "react-helmet"
+
+telemetry.setDefaultComponentId(`gatsby-admin`)
+telemetry.setGatsbyCliVersion(pkgJson.version)
 
 function Layout({ children }: { children: React.ReactNode }): JSX.Element {
   return (


### PR DESCRIPTION
See https://gist.github.com/jamo/9f4fad612df7041c90254f9f4d6e8ac8 for background information

- [x] Setup gatsby-telemetry with correct componentId and version

@jamo @jsumnersmith do we know what we want to track in Admin yet? I figure page views and plugin (un)installs are a good start?