### PR TITLE
chore(docs): Unification/doc updates

### DIFF
--- a/docs/contributing/code-contributions.md
+++ b/docs/contributing/code-contributions.md
@@ -12,7 +12,7 @@ To start setting up the Gatsby repo on your machine using git, Yarn and Gatsby-C
 
 Alternatively, you can skip the local setup and [use an online dev environment](/contributing/using-an-online-dev-environment/).
 
-To contribute to the blog, check out the setup steps on the [blog contributions](/contributing/blog-contributions/) page. For instructions on contributing to the docs, visit the [docs contributions page](/contributing/docs-contributions/). To contribute to the website, see the [website contributions](/contributing/website-contributions/) page.
+To contribute to the blog, check out the setup steps on the [blog contributions](/contributing/blog-contributions/) page. For instructions on contributing to the docs, visit the [docs contributions page](/contributing/docs-contributions/).
 
 ## Creating your own plugins and loaders
 

--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -8,7 +8,7 @@ As of June 2020, the Gatsby community is comprised of over 3,300 contributors an
 
 Open source doesn’t always have the best reputation for being friendly and welcoming, and that makes us sad. **Everyone belongs in open source, and Gatsby is dedicated to making you feel welcome.**
 
-We will never judge, condescend, or exclude anyone. Instead, we will go above and beyond to support the community, through helping you contribute to the Gatsby ecosystem, offering [free swag for contributors](https://gatsby.dev/swag), giving control to the community by [auto-inviting all contributors to the Gatsby GitHub org](https://github.com/gatsbyjs/gatsby/pull/7699#issuecomment-416665803), an open and inclusive [code of conduct](/contributing/code-of-conduct/), and other means that empower and embrace the incredible community that makes Gatsby possible.
+We will never judge, condescend, or exclude anyone. Instead, we will go above and beyond to support the community, through helping you contribute to the Gatsby ecosystem, offering [free swag for contributors](https://gatsby.dev/swag), an open and inclusive [code of conduct](/contributing/code-of-conduct/), and other means that empower and embrace the incredible community that makes Gatsby possible.
 
 One of our community's values is that ["you belong here"](/blog/2018-09-07-gatsby-values/#you-belong-here).
 

--- a/docs/contributing/pair-programming.md
+++ b/docs/contributing/pair-programming.md
@@ -7,7 +7,7 @@ The best part of open source is the community, and every community is stronger w
 ## How community pair programming sessions work
 
 1. Select or create [an issue](https://github.com/gatsbyjs/gatsby/issues) you would like to work on and work on it yourself.
-2. [Create a pull request](https://www.gatsbyjs.org/contributing/how-to-open-a-pull-request/) when you encounter any problem.
+2. [Create a pull request](/contributing/how-to-open-a-pull-request/) when you encounter any problem.
 3. Fill in your details in [the pair programming request form][form].
 4. You’ll be paired with a Gatsby team member and we'll establish a good time to pair on [Zoom](https://zoom.us).
 5. We'll help you with your pull request or issue!
@@ -17,13 +17,13 @@ The best part of open source is the community, and every community is stronger w
 
 These sessions are intended for people who would like to contribute to Gatsby. We will pair program together to solve an issue or pull request related to Gatsby.
 
-If you're interested in support for a commercial Gatsby project, please [get in touch via the contact page](https://www.gatsbyjs.com/contact-us/).
+If you're interested in support for a commercial Gatsby project, please [get in touch via the contact page](/contact-us/).
 
 We also expect the following from pair programming participants:
 
 - These sessions work best when you have a specific goal for the session. You should choose an issue or pull request that you'd like to work on.
-- If you're new to building with Gatsby we recommend [working through the tutorial](https://www.gatsbyjs.org/tutorial/) before your session. If you get stuck part way through that's a great time to book a pairing session.
-- If you're new to contributing to open source we recommend following the ["Setting Up Your Local Dev Environment" guide](https://www.gatsbyjs.org/contributing/setting-up-your-local-dev-environment/) before your session.
+- If you're new to building with Gatsby we recommend [working through the tutorial](/tutorial/) before your session. If you get stuck part way through that's a great time to book a pairing session.
+- If you're new to contributing to open source we recommend following the ["Setting Up Your Local Dev Environment" guide](/contributing/setting-up-your-local-dev-environment/) before your session.
 - All participants are expected to adhere to [Gatsby’s code of conduct](/contributing/code-of-conduct/)
 - We will ask if it’s okay to record your session; you are _not_ required to let us record and we will work to find another solution that works for you. However, we think it's really valuable to surface these pairing sessions so more people can learn from them and they have a wider reach.
 - Check out our [previous sessions](https://www.youtube.com/playlist?list=PLCU2qJekvcN1f4CRTTMMW6XliGio1NcUD) to see if we've already covered what you're looking to learn! This list will grow over time and we're really excited to have lasting learning artifacts for contributing to Gatsby. Our very first recording was not an actual pairing session but was an [introduction to Gatsby's repository and internals](https://www.youtube.com/watch?v=9wM3pFtyTHw) and is a tremendous resource.

--- a/docs/contributing/setting-up-your-local-dev-environment.md
+++ b/docs/contributing/setting-up-your-local-dev-environment.md
@@ -2,7 +2,7 @@
 title: Setting Up Your Local Dev Environment
 ---
 
-This page outlines how to get set up to contribute to Gatsby core and its ecosystem. For instructions on working with docs, visit the [docs contributions](/contributing/docs-contributions/) page. For website setup instructions, visit the [website contributions](/contributing/website-contributions/) page.
+This page outlines how to get set up to contribute to Gatsby core and its ecosystem. For instructions on working with docs, visit the [docs contributions](/contributing/docs-contributions/) page.
 
 > Gatsby uses a "monorepo" pattern to manage its many dependencies and relies on
 > [Lerna](https://lerna.js.org/) and [Yarn](https://yarnpkg.com/en/) to configure the repository for both active development and documentation infrastructure changes.

--- a/docs/contributing/where-to-participate.md
+++ b/docs/contributing/where-to-participate.md
@@ -14,7 +14,7 @@ We want contributing to Gatsby to be fun, enjoyable, and educational for anyone 
 - Adding unit or functional tests
 - Triaging [GitHub issues](https://github.com/gatsbyjs/gatsby/issues) -- especially determining whether an issue still persists or is reproducible
 - [Reporting bugs or issues](/contributing/how-to-file-an-issue/)
-- Searching for Gatsby on [Discord](https://gatsby.dev/discord) or [Spectrum](https://spectrum.chat/gatsby-js) and helping someone else who needs help
+- Visiting our [Discord](https://gatsby.dev/discord) server and helping someone else who needs help
 - Teaching others how to contribute to Gatsby's repo!
 
 As our way of saying “thank you” to our contributors, **_all contributors_ are eligible for [free Gatsby swag](/contributing/contributor-swag/)** — whether you’re contributing code, docs, a talk, an article, or something else that helps the Gatsby community. [Learn how to claim free swag for contributors.](/contributing/contributor-swag/)

--- a/docs/docs/cheat-sheet.md
+++ b/docs/docs/cheat-sheet.md
@@ -189,7 +189,7 @@ Get the PDF: <a href="/gatsby-cheat-sheet.pdf" download>gatsby-cheat-sheet.pdf</
     </tbody>
   </table>
   <p>
-    <a href="https://www.gatsbyjs.org/">gatsbyjs.org</a>
+    <a href="https://www.gatsbyjs.com/">gatsbyjs.com</a>
   </p>
   <p>
     <a href="https://twitter.com/gatsbyjs">twitter.com/gatsbyjs</a>

--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -48,7 +48,7 @@ gatsby new [<site-name> [<starter-url>]]
 gatsby new my-awesome-site
 ```
 
-- Create a Gatsby site named `my-awesome-blog-site`, using [gatsby-starter-blog](https://www.gatsbyjs.org/starters/gatsbyjs/gatsby-starter-blog/):
+- Create a Gatsby site named `my-awesome-blog-site`, using [gatsby-starter-blog](/starters/gatsbyjs/gatsby-starter-blog/):
 
 ```shell
 gatsby new my-awesome-blog-site https://github.com/gatsbyjs/gatsby-starter-blog
@@ -66,7 +66,7 @@ gatsby new
    (Use a different starter)
 ```
 
-See the [Gatsby starters docs](https://www.gatsbyjs.org/docs/gatsby-starters/) for more details.
+See the [Gatsby starters docs](/docs/gatsby-starters/) for more details.
 
 ### `develop`
 
@@ -97,7 +97,7 @@ gatsby develop -H 0.0.0.0
 Then the terminal will log information as usual, but will additionally include a URL that you can navigate to from a client on the same network to see how the site renders.
 
 ```shell
-You can now view gatsbyjs.org in the browser.
+You can now view gatsbyjs.com in the browser.
 ⠀
   Local:            http://0.0.0.0:8000/
   On Your Network:  http://192.168.0.212:8000/ // highlight-line

--- a/docs/docs/gatsby-magic.md
+++ b/docs/docs/gatsby-magic.md
@@ -6,7 +6,7 @@ This guide will explain the amazing features that may seem like “magic” and 
 
 ## Starters
 
-Starters are optional precompiled Gatsby sites that are maintained by Gatsby’s core team and growing open source community; they can be used for blogging, e-commerce, design, and documentation to allow users to create blazing fast sites. Gatsby offers over a hundred opinionated starters from a variety of categories such as Blog, SEO, Portfolio, WordPress, and Markdown. You can browse the selection [in Gatsby's Starter Library](https://www.gatsbyjs.org/starters/?v=2).
+Starters are optional precompiled Gatsby sites that are maintained by Gatsby’s core team and growing open source community; they can be used for blogging, e-commerce, design, and documentation to allow users to create blazing fast sites. Gatsby offers over a hundred opinionated starters from a variety of categories such as Blog, SEO, Portfolio, WordPress, and Markdown. You can browse the selection [in Gatsby's Starter Library](/starters/?v=2).
 
 A starter is a fully functional Gatsby site that can run on its own but is designed to be used by you as a jumping-off point for creating your own site. After selecting a starter, you can create your own site locally based on that project using the `gatsby new` CLI command, which handles cloning the project from Git for you. A cloned starter does not maintain a connection to the original source code, so they are helpful as starting points to customize heavily and create an entirely new Gatsby site.
 

--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -7,7 +7,7 @@ title: MDX Plugins
 `gatsby-plugin-mdx` is compatible with all of the [gatsby-remark
 plugins](/packages/gatsby-remark-images/?=gatsby-remark),
 including
-[`gatsby-remark-images`](https://next.gatsbyjs.org/packages/gatsby-remark-images/?=gatsby-remark).
+[`gatsby-remark-images`](/plugins/gatsby-remark-images/?=gatsby-remark).
 
 To enable `gatsby-remark-images`, you first need to install the relevant
 image plugins:

--- a/docs/docs/mdx/programmatically-creating-pages.md
+++ b/docs/docs/mdx/programmatically-creating-pages.md
@@ -132,11 +132,11 @@ that will result in:
 - `blog-1.mdx` => `http://localhost:8000/blog/blog-1/`
 - `blog-2.mdx` => `http://localhost:8000/blog/blog-2/`
 
-[`createFilePath`](https://www.gatsbyjs.org/packages/gatsby-source-filesystem/?=gatsby-source#createfilepath)
+[`createFilePath`](/plugins/gatsby-source-filesystem/?=gatsby-source#createfilepath)
 is a function from `gatsby-source-filesystem` that translates file
 paths to usable URLs.
 
-[`onCreateNode`](https://www.gatsbyjs.org/docs/node-apis/#onCreateNode)
+[`onCreateNode`](/docs/node-apis/#onCreateNode)
 is a Gatsby lifecycle method that gets called whenever a new node is
 created. In this case only `MDX` nodes are touched.
 
@@ -214,7 +214,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
 ```
 
 For further reading, check out the
-[createPages](https://www.gatsbyjs.org/docs/node-apis/#createPages)
+[createPages](/docs/node-apis/#createPages)
 API.
 
 ## Make a template for your posts

--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -98,7 +98,7 @@ sources
 ### Where do I start?
 
 The documentation offers guides for all different skill levels, you can
-find more info at the Gatsby's [Quick Start page](https://www.gatsbyjs.org/docs/quick-start)
+find more info at the Gatsby's [Quick Start page](https://www.gatsbyjs.com/docs/quick-start)
 
 <!-- This default export overrides the default layout ensuring -->
 <!--  that the FAQ component isn't wrapped by other elements -->

--- a/docs/docs/modifying-a-starter.md
+++ b/docs/docs/modifying-a-starter.md
@@ -141,7 +141,7 @@ const Layout = ({ children }) => {
         <footer>
           © {new Date().getFullYear()}, Built with
           {` `}
-          <a href="https://www.gatsbyjs.org">Gatsby</a>
+          <a href="https://www.gatsbyjs.com">Gatsby</a>
         </footer>
       </div>
     </>

--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -230,7 +230,7 @@ Sass will compile `.scss` and `.sass` files to `.css` files for you, so you can 
 
 ### Directions
 
-1. Install the Gatsby plugin [gatsby-plugin-sass](https://www.gatsbyjs.org/packages/gatsby-plugin-sass/) and `node-sass`.
+1. Install the Gatsby plugin [gatsby-plugin-sass](/plugins/gatsby-plugin-sass/) and `node-sass`.
 
 `npm install --save node-sass gatsby-plugin-sass`
 
@@ -272,7 +272,7 @@ _Note: You can use Sass/SCSS files as modules too, like mentioned in the previou
 
 - [Difference between `.sass` and `.scss`](https://responsivedesign.is/articles/difference-between-sass-and-scss/)
 - [Sass guide from the official Sass website](https://sass-lang.com/guide)
-- [A more complete installation tutorial on Sass with some more explanations and more resources](https://www.gatsbyjs.org/docs/sass/)
+- [A more complete installation tutorial on Sass with some more explanations and more resources](/docs/sass/)
 
 ## Adding a Local Font
 

--- a/docs/docs/seo.md
+++ b/docs/docs/seo.md
@@ -16,13 +16,13 @@ As a website owner, how do I test my site is serving its HTML correctly when `ga
 **on Windows (using PowerShell):**
 
 ```shell
-Invoke-WebRequest https://www.gatsbyjs.org/docs/seo | Select -ExpandProperty Content
+Invoke-WebRequest https://www.gatsbyjs.com/docs/seo | Select -ExpandProperty Content
 ```
 
 **on macOS/Linux:**
 
 ```shell
-curl https://www.gatsbyjs.org/docs/seo
+curl https://www.gatsbyjs.com/docs/seo
 ```
 
 ## Speed boost
@@ -35,7 +35,7 @@ In July 2018, [Google announced a new ranking factor for site speed](https://web
 
 Adding metadata to pages, such as page title, meta description, alt text and structured data using JSON-LD, helps search engines understand your content and when to show your pages in search results.
 
-A common way to add metadata to pages is to add [react-helmet](https://github.com/nfl/react-helmet) components (together with the [Gatsby React Helmet plugin](/packages/gatsby-plugin-react-helmet) for SSR support) to your page components. Here's a [guide on how to add an SEO component](https://www.gatsbyjs.org/docs/add-seo-component/) to your Gatsby app.
+A common way to add metadata to pages is to add [react-helmet](https://github.com/nfl/react-helmet) components (together with the [Gatsby React Helmet plugin](/plugins/gatsby-plugin-react-helmet) for SSR support) to your page components. Here's a [guide on how to add an SEO component](/docs/add-seo-component/) to your Gatsby app.
 
 Some examples using react-helmet:
 

--- a/docs/docs/themes/building-themes.md
+++ b/docs/docs/themes/building-themes.md
@@ -41,7 +41,7 @@ Yarn workspaces are a great way to set up a project for theme development becaus
 
 For Gatsby theme development, that means you can keep multiple themes and example sites together in a single project, and develop them locally.
 
-> 💡 If you prefer, you can develop themes as [local plugins](https://www.gatsbyjs.org/docs/creating-a-local-plugin/). Using `yarn link` or `npm link` are also viable alternatives. In general, Gatsby recommends the yarn workspaces approach for building themes, and that's what the starter and this guide will reflect.
+> 💡 If you prefer, you can develop themes as [local plugins](/docs/creating-a-local-plugin/). Using `yarn link` or `npm link` are also viable alternatives. In general, Gatsby recommends the yarn workspaces approach for building themes, and that's what the starter and this guide will reflect.
 
 > 💡 The starter takes care of all of the configuration for developing a theme using yarn workspaces. If you're interested in more detail on this setup, check out [this blog post](/blog/2019-05-22-setting-up-yarn-workspaces-for-theme-development/).
 
@@ -112,4 +112,4 @@ Check out how some existing themes are built:
 
 - The official [Gatsby blog theme](https://github.com/gatsbyjs/gatsby-starter-blog-theme)
 - The official [Gatsby notes theme](https://github.com/gatsbyjs/gatsby-starter-notes-theme)
-- The [Apollo themes](https://github.com/apollographql/gatsby-theme-apollo/tree/master/packages). (_You might also be interested in the [Apollo case study on themes](https://www.gatsbyjs.org/blog/2019-07-03-using-themes-for-distributed-docs/) on the blog._)
+- The [Apollo themes](https://github.com/apollographql/gatsby-theme-apollo/tree/master/packages). (_You might also be interested in the [Apollo case study on themes](/blog/2019-07-03-using-themes-for-distributed-docs/) on the blog._)

--- a/docs/docs/themes/getting-started.md
+++ b/docs/docs/themes/getting-started.md
@@ -37,7 +37,7 @@ module.exports = {
     title: "My Blog Title",
     author: "My Name",
     description: "My site description...",
-    siteUrl: "https://www.gatsbyjs.org/",
+    siteUrl: "https://www.gatsbyjs.com/",
     social: [
       {
         name: "twitter",

--- a/docs/docs/winning-over-content-creators.md
+++ b/docs/docs/winning-over-content-creators.md
@@ -27,11 +27,11 @@ Content creators may be curious about how common content management systems can 
 
 ### Better audience engagement and lead conversion
 
-> Site speed and performance has a huge impact on sales and customer engagement. A [recent Akamai study](https://www.akamai.com/uk/en/about/news/press/2017-press/akamai-releases-spring-2017-state-of-online-retail-performance-report.jsp) showed that a 100 millisecond delay in a site’s load time hurt conversion rates by 7%, and 53% of mobile users will leave pages that take more than 3 seconds to load. Gatsby sites are consistently 2-3x faster than similar sites built with different tools, and site owners have seen their [lead generation increase by up to 60% after transitioning to Gatsby](https://www.gatsbyjs.org/blog/2018-11-16-youfit-case-study/).
+> Site speed and performance has a huge impact on sales and customer engagement. A [recent Akamai study](https://www.akamai.com/uk/en/about/news/press/2017-press/akamai-releases-spring-2017-state-of-online-retail-performance-report.jsp) showed that a 100 millisecond delay in a site’s load time hurt conversion rates by 7%, and 53% of mobile users will leave pages that take more than 3 seconds to load. Gatsby sites are consistently 2-3x faster than similar sites built with different tools, and site owners have seen their [lead generation increase by up to 60% after transitioning to Gatsby](/blog/2018-11-16-youfit-case-study/).
 
 ### Improved search traffic
 
-> Site speed is one of the factors Google uses in its search ranking algorithm, and slow site speeds can have a negative snowball effect on your SEO. Slower sites take longer to be crawled and indexed by search engines, they have higher bounce rates, and lower conversion rates, all of which will hurt your rankings. Gatsby sites have [built-in web and mobile performance optimizations](https://www.gatsbyjs.org/blog/2018-11-07-gatsby-for-apps/#why-gatsby-for-apps). It actually takes more effort to make a Gatsby site perform badly. Learn more about [the impact of page speed on SEO on Moz](https://moz.com/learn/seo/page-speed).
+> Site speed is one of the factors Google uses in its search ranking algorithm, and slow site speeds can have a negative snowball effect on your SEO. Slower sites take longer to be crawled and indexed by search engines, they have higher bounce rates, and lower conversion rates, all of which will hurt your rankings. Gatsby sites have [built-in web and mobile performance optimizations](/blog/2018-11-07-gatsby-for-apps/#why-gatsby-for-apps). It actually takes more effort to make a Gatsby site perform badly. Learn more about [the impact of page speed on SEO on Moz](https://moz.com/learn/seo/page-speed).
 
 ### Choose the best tools for your content and your users
 

--- a/www/README.md
+++ b/www/README.md
@@ -15,7 +15,7 @@ Run locally with:
 - `yarn install`
 - `gatsby develop`
 
-See the full contributing instructions at https://www.gatsbyjs.org/contributing/how-to-contribute/
+See the full contributing instructions in the [documentation](https://www.gatsbyjs.com/contributing/how-to-contribute/).
 
 ## Environment variables
 

--- a/www/README.md
+++ b/www/README.md
@@ -1,6 +1,14 @@
-# gatsbyjs.org
+# gatsbyjs.org (Currently deprecated)
 
-The main Gatsby site at gatsbyjs.org
+Until the unification of gatsbyjs.org and gatsbyjs.com (see the [blogpost announcing the change](https://www.gatsbyjs.com/blog/announcing-unified-gatsby/)) the `www` portion of this monorepo contained the complete code for gatsbyjs.org.
+
+The code for gatsbyjs.com is not open-source at the moment and therefore this portion of the monorepo will exist for archival reasons. While you're still able to run this site and its contents, it doesn't represent the current/latest version of the website.
+
+The plan is to open-source parts of gatsbyjs.com (the previous gatsbyjs.org parts) again but we don't have any ETA on this yet.
+
+---
+
+**Below you can see the (old) instructions to run the site:**
 
 Run locally with:
 
@@ -29,17 +37,6 @@ GITHUB_API_TOKEN=YOUR_TOKEN_HERE
 
 _Note:_ For `gatsby build` to be able to run you also need a `.env.production` file with the same contents
 
-### Enabling guess.js
-
-Guess.js is disabled by default and can be enabled by setting `ANALYTICS_SERVICE_ACCOUNT` and `ANALYTICS_SERVICE_ACCOUNT_KEY` env variables. These variables need to have access to the gatsbyjs.org analytics.
-
-If you have access to the keys, add them like so:
-
-```shell
-ANALYTICS_SERVICE_ACCOUNT="service account@email.com"
-ANALYTICS_SERVICE_ACCOUNT_KEY="PEM KEY VALUE"
-```
-
 ### Enabling localizations
 
 Localizations are currently a work-in-progress and are thus disabled by default. They can be enabled by setting the `LOCALES` env variable to the locales you want to build:
@@ -53,26 +50,6 @@ The list of possible locales can be found at [i18n.json](/www/i18n.json).
 The default locale, English, is always on. There is currently no UI to link to the localizations, so you'll have to type in the name of the file you want to go to using the language code (e.g. /es/tutorial/part-one).
 
 ## Running slow build?
-
-### Disabling sourcing docs
-
-You can disable sourcing from the `docs/` and `packages/` directory by setting the following variable to `.env.development`:
-
-```shell
-DISABLE_SOURCE_DOCS=true
-```
-
-This will mean that the following URLs won't be generated:
-
-- docs/
-- tutorial/
-- blog/
-- features/
-- starters/
-- showcase/
-- creators/
-
-Use this option when you just want to test that the site builds or when working on a component that is not part of these sections (such as the homepage or the navigation).
 
 ### Disabling NPM search (plugins/packages)
 
@@ -95,14 +72,3 @@ GATSBY_SCREENSHOT_PLACEHOLDER=true
 ```
 
 For more information checkout [`gatsby-transformer-screenshot` docs](https://www.gatsbyjs.org/packages/gatsby-transformer-screenshot#placeholder-image).
-
-## `theme-ui`, CSS authoring, and dark mode
-
-Since [#18027](https://github.com/gatsbyjs/gatsby/pull/18027), we are using [`theme-ui`](https://theme-ui.com/) (via [`gatsby-plugin-theme-ui`](https://www.gatsbyjs.org/packages/gatsby-plugin-theme-ui/?=gatsby-plugin-theme)) to handle theming, CSS authoring, and to provide a dark color mode.
-
-- Please use the [`sx` prop](https://theme-ui.com/sx-prop) and theme values to style elements and components wherever possible. The prop is "enabled" by adding `theme-ui`'s [JSX pragma](https://theme-ui.com/jsx-pragma).
-- It is still okay to directly import tokens, e.g. `mediaQueries` or `colors` directly from `www/src/gatsby-plugin-theme-ui` if it helps your specific use case — for example when global CSS is required, when passing theme values to other libraries or plugins, when authoring complex responsive styles, etc.
-- It is also perfectly fine to follow the [`theme-ui` approach for responsive styles](https://theme-ui.com/getting-started/#responsive-styles)!
-- If you need to add fields to the [theme](https://theme-ui.com/theme-spec), you can do so in (the work-in-progress) `www/src/gatsby-plugin-theme-ui`. As things settle down, we will eventually migrate changed and added role-based tokens to https://www.npmjs.com/package/gatsby-design-tokens.
-- Please keep the dark mode in mind when editing existing or adding new components.
-- Please bear with us while we adjust https://www.gatsbyjs.org/guidelines/design-tokens/ to document the `theme-ui` values next to the raw token values.

--- a/www/README.md
+++ b/www/README.md
@@ -71,4 +71,4 @@ Add the following env variable to your `.env.development` file to enable placeho
 GATSBY_SCREENSHOT_PLACEHOLDER=true
 ```
 
-For more information checkout [`gatsby-transformer-screenshot` docs](https://www.gatsbyjs.org/packages/gatsby-transformer-screenshot#placeholder-image).
+For more information checkout [`gatsby-transformer-screenshot` docs](https://www.gatsbyjs.com/plugins/gatsby-transformer-screenshot#placeholder-image).


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

- Removed links to website-contribution doc
- Moved absolute .org links to relative links
- Changed a bunch of .org instances to .com
- Removed note that we auto-invite people to the github org
- Renamed packages to plugins
- Removed a spectrum notice
- Updated the `www` README