### PR TITLE
chore(tests): speedup gatsby tests

### DIFF
--- a/packages/gatsby/.npmignore
+++ b/packages/gatsby/.npmignore
@@ -1,3 +1,0 @@
-src
-flow-typed
-**/__tests__/**

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -195,7 +195,8 @@
     "scripts/postinstall.js",
     "utils.js",
     "internal.js",
-    "internal.d.ts"
+    "internal.d.ts",
+    "!cache-dir/__tests__/"
   ],
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby#readme",
   "keywords": [
@@ -231,8 +232,8 @@
     "postbuild": "node scripts/output-api-file.js && yarn workspace gatsby-admin build",
     "build:internal-plugins": "copyfiles -u 1 src/internal-plugins/**/package.json dist",
     "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
-    "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs --ignore \"**/__tests__\"",
-    "build:src": "babel src --out-dir dist --source-maps --verbose --ignore \"**/gatsby-cli.js,src/internal-plugins/dev-404-page/raw_dev-404-page.js,**/__tests__\" --extensions \".ts,.js\"",
+    "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs --ignore \"**/__tests__\" --ignore \"**/__mocks__\"",
+    "build:src": "babel src --out-dir dist --source-maps --verbose --ignore \"**/gatsby-cli.js,src/internal-plugins/dev-404-page/raw_dev-404-page.js,**/__tests__,**/__mocks__\" --extensions \".ts,.js\"",
     "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "prebuild": "rimraf dist && rimraf cache-dir/commonjs",

--- a/packages/gatsby/src/__mocks__/gatsby-telemetry.js
+++ b/packages/gatsby/src/__mocks__/gatsby-telemetry.js
@@ -1,0 +1,14 @@
+module.exports = {
+  trackFeatureIsUsed: jest.fn(),
+  trackCli: jest.fn(),
+  trackError: jest.fn(),
+  trackBuildError: jest.fn(),
+  setDefaultTags: jest.fn(),
+  decorateEvent: jest.fn(),
+  setTelemetryEnabled: jest.fn(),
+  startBackgroundUpdate: jest.fn(),
+  isTrackingEnabled: jest.fn(),
+  aggregateStats: jest.fn(),
+  addSiteMeasurement: jest.fn(),
+  expressMiddleware: jest.fn(),
+}


### PR DESCRIPTION
## Description

By mocking gatsby-telemetry in our tests we see a massive speed increase in our tests. Gatsby telemetry does a lot of things at bootup which we don't want in our tests.

Before:
![image](https://user-images.githubusercontent.com/1120926/91267688-2b7c2400-e774-11ea-85cf-7ceb9161ed88.png)

After:
![image](https://user-images.githubusercontent.com/1120926/91267698-3040d800-e774-11ea-9e2c-09e4606bf454.png)
