### PR TITLE
feat(tagmanager): add option to use iframe sandbox attribute

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -21,6 +21,16 @@ plugins: [
       // Defaults to false meaning GTM will only be loaded in production.
       includeInDevelopment: false,
 
+      // Set the sandbox attribute on the GTM noscript iframe.
+      //
+      // Defaults to false which matches the GTM docs.
+      useIframeSandbox: false,
+
+      // Set a custom value for the sandbox attribute the GTM noscript iframe.
+      //
+      // Defaults to undefined, which results in no value.
+      iframeSandboxAttributes: "allow-top-navigation",
+
       // datalayer to be set before GTM is loaded
       // should be an object or a function that is executed in the browser
       //

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -8,8 +8,19 @@ const generateGTM = ({ id, environmentParamStr, dataLayerName }) => stripIndent`
   'https://www.googletagmanager.com/gtm.js?id='+i+dl+'${environmentParamStr}';f.parentNode.insertBefore(j,f);
   })(window,document,'script','${dataLayerName}', '${id}');`
 
-const generateGTMIframe = ({ id, environmentParamStr }) =>
-  oneLine`<iframe src="https://www.googletagmanager.com/ns.html?id=${id}${environmentParamStr}" height="0" width="0" style="display: none; visibility: hidden"></iframe>`
+const generateGTMIframe = ({
+  id,
+  environmentParamStr,
+  useIframeSandbox,
+  iframeSandboxAttributes,
+}) =>
+  oneLine`<iframe ${
+    useIframeSandbox
+      ? `sandbox${
+          iframeSandboxAttributes ? `="${iframeSandboxAttributes}"` : ``
+        } `
+      : ``
+  }src="https://www.googletagmanager.com/ns.html?id=${id}${environmentParamStr}" height="0" width="0" style="display: none; visibility: hidden"></iframe>`
 
 const generateDefaultDataLayer = (dataLayer, reporter, dataLayerName) => {
   let result = `window.${dataLayerName} = window.${dataLayerName} || [];`
@@ -36,6 +47,8 @@ exports.onRenderBody = (
   {
     id,
     includeInDevelopment = false,
+    useIframeSandbox = false,
+    iframeSandboxAttributes,
     gtmAuth,
     gtmPreview,
     defaultDataLayer,
@@ -74,7 +87,12 @@ exports.onRenderBody = (
       <noscript
         key="plugin-google-tagmanager"
         dangerouslySetInnerHTML={{
-          __html: generateGTMIframe({ id, environmentParamStr }),
+          __html: generateGTMIframe({
+            id,
+            environmentParamStr,
+            useIframeSandbox,
+            iframeSandboxAttributes,
+          }),
         }}
       />,
     ])


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This adds two options to the google tag manager plugin:
- `useIframeSandbox` - to enable the `sandbox` attribute on the iframe created by the plugin
- `iframeSandboxAttributes`, to allow manually enabling certain abilities in the iframe

The defaults match the current defaults (no sandbox attribute).

Some security scanning tools (e.g. Detectify), treat the absence of a `sandbox` attribute on iframes as a problem. It seems like a good idea to restrict the privileges of 3rd party code unless there is a good reason to grant certain abilities.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

README updated


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
