### PR TITLE
fix(gatsby): only enable debugger when argument is given

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -175,17 +175,23 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
         .option(`inspect`, {
           type: `number`,
           describe: `Opens a port for debugging. See https://www.gatsbyjs.org/docs/debugging-the-build-process/`,
-          default: 9229,
         })
         .option(`inspect-brk`, {
           type: `number`,
           describe: `Opens a port for debugging. Will block until debugger is attached. See https://www.gatsbyjs.org/docs/debugging-the-build-process/`,
-          default: 9229,
         }),
     handler: handlerP(
       getCommandHandler(`develop`, (args: yargs.Arguments, cmd: Function) => {
         process.env.NODE_ENV = process.env.NODE_ENV || `development`
         startGraphQLServer(siteInfo.directory, true)
+
+        if (args.hasOwnProperty(`inspect`)) {
+          args.inspect = args.inspect || 9229
+        }
+        if (args.hasOwnProperty(`inspect-brk`)) {
+          args.inspect = args.inspect || 9229
+        }
+
         cmd(args)
         // Return an empty promise to prevent handlerP from exiting early.
         // The development server shouldn't ever exit until the user directly

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -92,12 +92,12 @@ class ControllableScript {
     this.debugInfo = debugInfo
   }
   start(): void {
-    const args = []
     const tmpFileName = tmp.tmpNameSync({
       tmpdir: path.join(process.cwd(), `.cache`),
     })
     fs.outputFileSync(tmpFileName, this.script)
     this.isRunning = true
+    const args = [tmpFileName]
     // Passing --inspect isn't necessary for the child process to launch a port but it allows some editors to automatically attach
     if (this.debugInfo) {
       if (this.debugInfo.break) {

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -92,19 +92,19 @@ class ControllableScript {
     this.debugInfo = debugInfo
   }
   start(): void {
+    const args = []
     const tmpFileName = tmp.tmpNameSync({
       tmpdir: path.join(process.cwd(), `.cache`),
     })
     fs.outputFileSync(tmpFileName, this.script)
     this.isRunning = true
-    const args = [tmpFileName]
     // Passing --inspect isn't necessary for the child process to launch a port but it allows some editors to automatically attach
     if (this.debugInfo) {
-      args.push(
-        this.debugInfo.break
-          ? `--inspect-brk=${this.debugInfo.port}`
-          : `--inspect=${this.debugInfo.port}`
-      )
+      if (this.debugInfo.break) {
+        args.push(`--inspect-brk=${this.debugInfo.port}`)
+      } else {
+        args.push(`--inspect=${this.debugInfo.port}`)
+      }
     }
 
     this.process = spawn(`node`, args, {


### PR DESCRIPTION
## Description

Default arguments in yargs caused to always run node debugger when `gatsby develop` was run. This fixes it.
![image](https://user-images.githubusercontent.com/1120926/91493723-01337f00-e8b8-11ea-816d-9c73c4180c78.png)


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes https://github.com/gatsbyjs/gatsby/issues/26708