### PR TITLE
chore(docs): Update Deploy to Vercel documentation

### DIFF
--- a/docs/docs/deploying-to-vercel.md
+++ b/docs/docs/deploying-to-vercel.md
@@ -18,7 +18,7 @@ Once deployed, you will get a URL to see your app live, such as the following: h
 
 ## Step 2 (optional): Using a Custom Domain
 
-If you want to use a Custom Domain with your Vercel deployment, you can **Add** or **Transfer in** your domain via your Vercel [account Domain settings.](https://vercel.com/dashboard/domains) 
+If you want to use a Custom Domain with your Vercel deployment, you can **Add** or **Transfer in** your domain via your Vercel [account Domain settings.](https://vercel.com/dashboard/domains)
 
 To add your domain to your project, navigate to your [Project](https://vercel.com/docs/platform/projects) from the Vercel Dashboard. Once you have selected your project, click on the "Settings" tab, then select the **Domains** menu item. From your projects **Domain** page, enter the domain you wish to add to your project.
 

--- a/docs/docs/deploying-to-vercel.md
+++ b/docs/docs/deploying-to-vercel.md
@@ -18,7 +18,7 @@ Once deployed, you will get a URL to see your app live, such as the following: h
 
 ## Step 2 (optional): Using a Custom Domain
 
-If you want to use a Custom Domain with your Vercel deployment, you can **Add** or **Transfer in** your domain via your Vercel [account Domain settings.](https://vercel.com/dashboard/domains)
+If you want to use a Custom Domain with your Vercel deployment, you can **Add** or **Transfer in** your domain via your Vercel [account Domain settings](https://vercel.com/dashboard/domains).
 
 To add your domain to your project, navigate to your [Project](https://vercel.com/docs/platform/projects) from the Vercel Dashboard. Once you have selected your project, click on the "Settings" tab, then select the **Domains** menu item. From your projects **Domain** page, enter the domain you wish to add to your project.
 

--- a/docs/docs/deploying-to-vercel.md
+++ b/docs/docs/deploying-to-vercel.md
@@ -2,30 +2,37 @@
 title: Deploying to Vercel
 ---
 
-[Vercel](https://vercel.com/home) is a cloud platform for websites and serverless APIs, that you can use to deploy your Gatsby projects to your personal domain (or a free `.vercel.app` suffixed URL).
+This guide walks through how to deploy and host your next Gatsby project to Vercel.
 
-This guide will show you how to get started in a few quick steps:
+[Vercel](https://vercel.com/home) is a cloud platform that enables developers to host Jamstack websites and web services that deploy instantly, scale automatically, and requires no supervision, all with zero configuration. They provide a global edge network, SSL encryption, asset compression, cache invalidation, and more.
 
-## Step 1: Installing Vercel CLI
+## Step 1: Deploying your Gatsby project to Vercel
 
-To install their command-line interface with [npm](https://www.npmjs.com/), run the following command:
+To deploy your Gatsby project with a [Vercel for Git Integration](https://vercel.com/docs/git-integrations), make sure it has been pushed to a Git repository.
 
-```shell
-npm i -g vercel
-```
+Import the project into Vercel using the [Import Flow](https://vercel.com/import/git). During the import, you will find all relevant [options](https://vercel.com/docs/build-step#build-&-development-settings) preconfigured for you with the ability to change as needed.
 
-## Step 2: Deploying
+After your project has been imported, all subsequent pushes to branches will generate [Preview Deployments](https://vercel.com/docs/platform/deployments#preview), and all changes made to the [Production Branch](https://vercel.com/docs/git-integrations#production-branch) (commonly "master" or "main") will result in a [Production Deployment](https://vercel.com/docs/platform/deployments#production).
 
-You can deploy your application by running the following command in the root of the project directory:
+Once deployed, you will get a URL to see your app live, such as the following: https://gatsby-example.vercel.app/.
 
-```shell
-vercel
-```
+## Step 2 (optional): Using a Custom Domain
 
-That's all!
+If you want to use a Custom Domain with your Vercel deployment, you can **Add** or **Transfer in** your domain via your Vercel [account Domain settings.](https://vercel.com/dashboard/domains) 
 
-Your site will now deploy, and you will receive a link similar to the following: https://gatsby-functions.now-examples.now.sh
+To add your domain to your project, navigate to your [Project](https://vercel.com/docs/platform/projects) from the Vercel Dashboard. Once you have selected your project, click on the "Settings" tab, then select the **Domains** menu item. From your projects **Domain** page, enter the domain you wish to add to your project.
+
+Once the domain as been added, you will be presented with different methods for configuring it.
+
+## Deploying a fresh Gatsby project
+
+You can deploy a fresh Gatsby project, with a Git repository set up for you, with the following Deploy Button:
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/git?s=https%3A%2F%2Fgithub.com%2Fvercel%2Fvercel%2Ftree%2Fmaster%2Fexamples%2Fgatsby)
 
 ## References:
 
-- [Example Project](https://github.com/vercel/vercel/tree/master/examples/gatsby)
+- [Example Source](https://github.com/vercel/vercel/tree/master/examples/gatsby)
+- [Official Vercel Guide](https://vercel.com/guides/deploying-gatsby-with-vercel)
+- [Vercel Deployment Docs](https://vercel.com/docs)
+- [Vercel Custom Domain Docs](https://vercel.com/docs/custom-domains)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This pull request updates the Deploy to Vercel documentation to use the preferred method of deployment from Vercel, so that users have the best chance of success when deploying.

### Documentation

Current URL is here: https://www.gatsbyjs.com/docs/deploying-to-vercel/

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

N/A
