### PR TITLE
fix(gatsby): fix materialization edge case with nullish values

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -688,15 +688,17 @@ async function resolveRecursive(
       ) {
         innerValue = await Promise.all(
           innerValue.map(item =>
-            resolveRecursive(
-              nodeModel,
-              schemaComposer,
-              schema,
-              item,
-              gqlFieldType,
-              queryField,
-              _.isObject(fieldToResolve) ? fieldToResolve : queryField
-            )
+            item == null
+              ? item
+              : resolveRecursive(
+                  nodeModel,
+                  schemaComposer,
+                  schema,
+                  item,
+                  gqlFieldType,
+                  queryField,
+                  _.isObject(fieldToResolve) ? fieldToResolve : queryField
+                )
           )
         )
       }


### PR DESCRIPTION
## Description

Fixes an error in Gatsby materialization. Before this PR Gatsby fails with the following error when resolving an array of complex values containing nulls:

```
UNHANDLED REJECTION Cannot read property 'internal' of null
```

A test case in this PR demonstrates the situation that causes this issue.

## Related Issues

Reported in #23549