### PR TITLE
chore: use install instead of copy in e2e tests

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -9,7 +9,7 @@ command -v gatsby-dev || command -v sudo && sudo npm install -g gatsby-dev-cli |
 # setting up child integration test link to gatsby packages
 cd "$SRC_PATH" &&
 gatsby-dev --set-path-to-repo "$GATSBY_PATH" &&
-gatsby-dev --scan-once  && # copies _all_ files in gatsby/packages
+gatsby-dev --force-install --scan-once  && # install _all_ files in gatsby/packages
 chmod +x ./node_modules/.bin/gatsby && # this is sometimes necessary to ensure executable
 sh -c "$CUSTOM_COMMAND" &&
 echo "e2e test run succeeded"


### PR DESCRIPTION

## Description

Gatsby-dev copies files and installs them as well. For e2e we want the same experience as a user would install them. We use --force-install so only an installation is done.
