### PR TITLE
Update code snippet comments in README.md

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -92,6 +92,7 @@ Query a `ContentfulAsset`'s `localFile` field in GraphQL to gain access to the c
 
         # Query for a fluid image resource on this `ContentfulAsset` node
         fluid(maxWidth: 500){
+          # Query fragment included with the `gatsby-source-contentful` plugin, learn more about query fragments: https://www.gatsbyjs.com/plugins/gatsby-image/#fragments
           ...GatsbyContentfulFluid_withWebp
         }
 
@@ -104,6 +105,7 @@ Query a `ContentfulAsset`'s `localFile` field in GraphQL to gain access to the c
           # Use `gatsby-image` to create fluid image resource
           childImageSharp {
             fluid(maxWidth: 500) {
+              # Query fragment included with the `gatsby-transformer-sharp` plugin, learn more about query fragments: https://www.gatsbyjs.com/plugins/gatsby-image/#fragments
               ...GatsbyImageSharpFluid
           }
         }


### PR DESCRIPTION
Added comments in a code snippet which contained query fragments, the comments should help newbies by letting them know what plugin the query fragment was included from.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
