### PR TITLE
fix(gatsby-plugin-netlify-cms) update copy-webpack-plugin to remove vulnerability

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
-    "copy-webpack-plugin": "^5.1.1",
+    "copy-webpack-plugin": "^6.0.4",
     "html-webpack-exclude-assets-plugin": "^0.0.7",
     "html-webpack-plugin": "^3.2.0",
     "html-webpack-tags-plugin": "^2.0.17",

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -252,8 +252,8 @@ exports.onCreateWebpackConfig = (
         CMS_PUBLIC_PATH: JSON.stringify(publicPath),
       }),
 
-      new CopyPlugin(
-        [].concat.apply(
+      new CopyPlugin({
+        patterns: [].concat.apply(
           [],
           externals.map(({ name, assetName, sourceMap, assetDir }) =>
             [
@@ -267,8 +267,8 @@ exports.onCreateWebpackConfig = (
               },
             ].filter(item => item)
           )
-        )
-      ),
+        ),
+      }),
 
       new HtmlWebpackTagsPlugin({
         tags: externals.map(({ assetName }) => assetName),


### PR DESCRIPTION
Should fix #26598.

## Description

The dependency copy-webpack-plugin has been updated to the latest version.
The code has been adapted to the new interface.

Can someone help with testing this?

## Related Issues
Fixes #26598.
