### PR TITLE
chore(docs): add Deploying to Bip tutorial

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -225,6 +225,7 @@ bigtime
 bikeshed
 bindActionCreators
 Bing
+Bip
 Biscardi
 BitBalloon
 Bitbucket

--- a/docs/docs/deploying-to-bip.md
+++ b/docs/docs/deploying-to-bip.md
@@ -1,0 +1,36 @@
+---
+title: Deploying to Bip
+---
+
+[Bip](https://bip.sh) is a commercial hosting service which provides zero downtime deployment, a global CDN, SSL, unlimited bandwidth and more for Gatsby websites. Plans are available on a pay as you go, per domain basis.
+
+The following guide will show you how to deploy your Gatsby site to Bip in just a couple simple steps.
+
+## Prerequisites
+
+* You have a Gatsby project ready to deploy and share with the world. If you need a project, use the [Quick Start](/docs/quick-start) before continuing.
+* You have the Bip CLI installed, along with a Bip account and domain ready to use. Visit the [Bip Get Started guide](https://bip.sh/getstarted) for further instructions.
+
+## Step 1: Initial setup
+
+You'll first need to initialise your project with Bip. This only needs to be done once.
+
+```shell
+bip init
+```
+
+Follow the prompts, where you'll be asked which domain you'd like to deploy to. Bip will detect that you're using Gatsby, and set project settings like the source file directory automatically.
+
+## Step 2: Deploy
+
+You're now ready to deploy your website. To do so, run:
+
+```shell
+gatsby build && bip deploy
+```
+
+That's it! After a few moments, your website will be deployed.
+
+## References:
+
+- [Bip Get Started Guide](https://bip.sh/getstarted)

--- a/docs/docs/deploying-to-bip.md
+++ b/docs/docs/deploying-to-bip.md
@@ -8,12 +8,12 @@ The following guide will show you how to deploy your Gatsby site to Bip in just 
 
 ## Prerequisites
 
-* You have a Gatsby project ready to deploy and share with the world. If you need a project, use the [Quick Start](/docs/quick-start) before continuing.
-* You have the Bip CLI installed, along with a Bip account and domain ready to use. Visit the [Bip Get Started guide](https://bip.sh/getstarted) for further instructions.
+- You have a Gatsby project ready to deploy and share with the world. If you need a project, use the [Quick Start](/docs/quick-start) before continuing.
+- You have the Bip CLI installed, along with a Bip account and domain ready to use. Visit the [Bip Get Started guide](https://bip.sh/getstarted) for further instructions.
 
 ## Step 1: Initial setup
 
-You'll first need to initialise your project with Bip. This only needs to be done once.
+You'll first need to initialize your project with Bip. This only needs to be done once.
 
 ```shell
 bip init

--- a/www/src/data/sidebars/doc-links.yaml
+++ b/www/src/data/sidebars/doc-links.yaml
@@ -104,6 +104,9 @@
             - title: Deploying to Surge
               link: /docs/deploying-to-surge/
               breadcrumbTitle: Surge
+            - title: Deploying to Bip
+              link: /docs/deploying-to-bip/
+              breadcrumbTitle: Bip
             - title: Deploying to IIS
               link: /docs/deploying-to-iis/
               breadcrumbTitle: IIS


### PR DESCRIPTION
## Description

Added a short tutorial on how to deploy to [Bip](https://bip.sh). Bip contains automatic framework detection for Gatsby, so this is reflected in the guide. 

An example Gatsby project hosted on Bip is available at https://gatsbyexample.bip.sh, which utilises the [gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog)