### PR TITLE
feat(gatsby-plugin-catch-links): Add ability to exclude multiple link patterns

### DIFF
--- a/packages/gatsby-plugin-catch-links/README.md
+++ b/packages/gatsby-plugin-catch-links/README.md
@@ -26,13 +26,15 @@ plugins: [`gatsby-plugin-catch-links`]
 
 **`excludePattern`** [Regular Expression][optional]
 
-Regular expression for paths to be excluded from being handled by this plugin.
+Regular expression for paths to be excluded from being handled by this plugin. Multiple exclutions can be handled within an array.
 
 ```javascript
 {
   resolve: `gatsby-plugin-catch-links`,
   options: {
-    excludePattern: /(excluded-link|external)/,
+    excludePattern: /(excluded-link|external)/ | [
+      /(excluded-link|external)/
+    ],
   },
 },
 ```

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -152,19 +152,15 @@ export const routeThroughBrowserOrApp = (
 
   if (hashShouldBeFollowed(origin, destination)) return true
 
-  // Regex to test against exclude patterns
   if (pluginOptions.excludePattern) {
-    if (Array.isArray(pluginOptions.excludePattern)) {
-      pluginOptions.excludePattern.forEach(pattern => {
-        const excludeRegex = new RegExp(pattern)
-        if (excludeRegex.test(destination.pathname)) return true
-      })
-    } else {
-      const excludeRegex = new RegExp(pluginOptions.excludePattern)
-      if (excludeRegex.test(destination.pathname)) {
-        return true
-      }
-    }
+    const patterns = Array.isArray(pluginOptions.excludePattern)
+      ? pluginOptions.excludePattern
+      : [pluginOptions.excludePattern]
+    // eslint-disable-next-line consistent-return
+    patterns.foreach(pattern => {
+      const excludeRegex = new RegExp(pattern)
+      if (excludeRegex.test(destination.pathname)) return true
+    })
   }
 
   event.preventDefault()

--- a/packages/gatsby-plugin-catch-links/src/catch-links.js
+++ b/packages/gatsby-plugin-catch-links/src/catch-links.js
@@ -152,10 +152,18 @@ export const routeThroughBrowserOrApp = (
 
   if (hashShouldBeFollowed(origin, destination)) return true
 
+  // Regex to test against exclude patterns
   if (pluginOptions.excludePattern) {
-    const excludeRegex = new RegExp(pluginOptions.excludePattern)
-    if (excludeRegex.test(destination.pathname)) {
-      return true
+    if (Array.isArray(pluginOptions.excludePattern)) {
+      pluginOptions.excludePattern.forEach(pattern => {
+        const excludeRegex = new RegExp(pattern)
+        if (excludeRegex.test(destination.pathname)) return true
+      })
+    } else {
+      const excludeRegex = new RegExp(pluginOptions.excludePattern)
+      if (excludeRegex.test(destination.pathname)) {
+        return true
+      }
     }
   }
 


### PR DESCRIPTION
Adding possibility to exclude multiple paths in the catch links plugin.
refs to #14835