### PR TITLE
fix(gatsby): fix ceateNode hanging in custom resolvers

### DIFF
--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -101,6 +101,9 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         SOURCE_FILE_CHANGED: {
           actions: [forwardTo(`run-queries`), `markSourceFilesDirty`],
         },
+        ADD_NODE_MUTATION: {
+          actions: [forwardTo(`run-queries`)],
+        },
       },
       invoke: {
         id: `run-queries`,

--- a/packages/gatsby/src/state-machines/query-running/actions.ts
+++ b/packages/gatsby/src/state-machines/query-running/actions.ts
@@ -1,6 +1,7 @@
 import { IQueryRunningContext } from "./types"
 import { DoneInvokeEvent, assign, ActionFunctionMap } from "xstate"
 import { enqueueFlush } from "../../utils/page-data"
+import { callApi, markNodesDirty } from "../develop/actions"
 
 export const flushPageData = (): void => {
   enqueueFlush()
@@ -20,6 +21,8 @@ export const queryActions: ActionFunctionMap<
   IQueryRunningContext,
   DoneInvokeEvent<any>
 > = {
+  callApi,
+  markNodesDirty,
   assignDirtyQueries,
   flushPageData,
 }

--- a/packages/gatsby/src/state-machines/query-running/index.ts
+++ b/packages/gatsby/src/state-machines/query-running/index.ts
@@ -14,6 +14,9 @@ export const queryStates: MachineConfig<IQueryRunningContext, any, any> = {
     SOURCE_FILE_CHANGED: {
       target: `extractingQueries`,
     },
+    ADD_NODE_MUTATION: {
+      actions: [`markNodesDirty`, `callApi`],
+    },
   },
   context: {},
   states: {


### PR DESCRIPTION
## Description

A follow up for https://github.com/gatsbyjs/gatsby/pull/25479 and https://github.com/gatsbyjs/gatsby/pull/26138

This PR fixes a problem with query hanging when `createNode` is called and awaited within a custom resolver.

Before this PR `createNode` in a custom resolver was deferred until the machine reached the `waiting` state. But it couldn't reach this state because the custom resolver awaited for `createNode` to complete and so the query could never finish and leave the `runningQueries` state.

After this PR `createNode` calls (and other node mutation actions) are not deferred when the machine is in the `runningQueries` state.

**Caveat:** One downside of it is that now if some node is created outside of the query running loop (i.e. in some watcher or subscription) but DURING query running - it won't be deferred.


## Related Issues

Fixes #26530