### PR TITLE
chore(docs): Update visual-testing-with-storybook

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -114,6 +114,8 @@ global.___loader = {
   enqueue: () => {},
   hovering: () => {},
 }
+// This global variable is prevents the "__BASE_PATH__ is not defined" error inside Storybook.
+global.__BASE_PATH__ = "/"
 
 // Navigating through a gatsby app using gatsby-link or any other gatsby component will use the `___navigate` method.
 // In Storybook it makes more sense to log an action than doing an actual navigate. Checkout the actions addon docs for more info: https://github.com/storybookjs/storybook/tree/master/addons/actions.


### PR DESCRIPTION
Add global.__BASE_PATH__ Variable

Adding this prevents the following error message (which appears as soon as you use the Link Component) inside Storybook: 
```
__BASE_PATH__ is not defined
ReferenceError: __BASE_PATH__ is not defined
    at getGlobalBasePrefix (http://localhost:6006/vendors~main.469e315f5400e05928a7.bundle.js:91271:3)
    at withPrefix (http://localhost:6006/vendors~main.469e315f5400e05928a7.bundle.js:91249:14)
    at rewriteLinkPath (http://localhost:6006/vendors~main.469e315f5400e05928a7.bundle.js:91300:33)
    at http://localhost:6006/vendors~main.469e315f5400e05928a7.bundle.js:91432:24
    at LocationProvider.render (webpack://storybook_docs_dll//Users/shilman/projects/baseline/storybook/node_modules/@reach/router/es/index.js?:203:41)
    at finishClassComponent (webpack://storybook_docs_dll//Users/shilman/projects/baseline/storybook/node_modules/react-dom/cjs/react-dom.development.js?:2768:100)
    at updateClassComponent (webpack://storybook_docs_dll//Users/shilman/projects/baseline/storybook/node_modules/react-dom/cjs/react-dom.development.js?:2760:220)
    at beginWork (webpack://storybook_docs_dll//Users/shilman/projects/baseline/storybook/node_modules/react-dom/cjs/react-dom.development.js?:3049:934)
    at HTMLUnknownElement.callCallback (webpack://storybook_docs_dll//Users/shilman/projects/baseline/storybook/node_modules/react-dom/cjs/react-dom.development.js?:70:102)
    at Object.invokeGuardedCallbackDev (webpack://storybook_docs_dll//Users/shilman/projects/baseline/storybook/node_modules/react-dom/cjs/react-dom.development.js?:90:45)

```