### PR TITLE
feat: add utc-offset to date schema type

### DIFF
--- a/packages/gatsby/src/schema/types/__tests__/date.js
+++ b/packages/gatsby/src/schema/types/__tests__/date.js
@@ -443,4 +443,34 @@ describe(`dateResolver`, () => {
       )
     ).toEqual(`Invalid date`)
   })
+
+  it.each([
+    [`2020-09-01T12:00:00.000+08:00`, 8],
+    [`2020-09-01T04:00:00.000+00:00`, 8],
+    [`2020-09-01T04:00:00.000Z`, 8],
+    [`2020-09-01T05:00:00.000Z`, 7],
+    [`2020-09-01T19:00:00.000Z`, -7],
+    [`2020-09-01T20:00:00.000Z`, -8],
+    [`2020-09-01T12:00:00.000Z`, 0],
+    [`2020-09-01T20:00:00.000+08:00`, 0],
+  ])(
+    `should return "Sep 01, 2020 12:00:00": %s`,
+    async (dateString, utcOffset) => {
+      const schema = await buildTestSchema()
+      const fields = schema.getType(`Test`).getFields()
+      expect(
+        await fields[`testDate`].resolve(
+          { date: dateString },
+          {
+            formatString: `MMM DD, YYYY HH:mm:ss`,
+            utcOffset,
+          },
+          withResolverContext({}, schema),
+          {
+            fieldName: `date`,
+          }
+        )
+      ).toEqual(`Sep 01, 2020 12:00:00`)
+    }
+  )
 })

--- a/packages/gatsby/src/schema/types/date.ts
+++ b/packages/gatsby/src/schema/types/date.ts
@@ -8,12 +8,14 @@ interface IFormatDateArgs {
   formatString?: string
   difference?: unitOfTime.Diff
   locale?: LocaleSpecifier
+  utcOffset?: number
 }
 interface IDateResolverOption {
   locale?: string
   formatString?: string
   fromNow?: string
   difference?: string
+  utcOffset?: number
   from?: string
   fromNode?: { type: string; defaultValue: boolean }
 }
@@ -214,21 +216,27 @@ const formatDate = ({
   difference,
   formatString,
   locale = `en`,
+  utcOffset = 0,
 }: IFormatDateArgs): string | number => {
   const normalizedDate = JSON.parse(JSON.stringify(date))
   if (formatString) {
     return moment
       .utc(normalizedDate, ISO_8601_FORMAT, true)
+      .utcOffset(utcOffset)
       .locale(locale)
       .format(formatString)
   } else if (fromNow) {
     return moment
       .utc(normalizedDate, ISO_8601_FORMAT, true)
+      .utcOffset(utcOffset)
       .locale(locale)
       .fromNow()
   } else if (difference) {
     return moment().diff(
-      moment.utc(normalizedDate, ISO_8601_FORMAT, true).locale(locale),
+      moment
+        .utc(normalizedDate, ISO_8601_FORMAT, true)
+        .utcOffset(utcOffset)
+        .locale(locale),
       difference
     )
   }
@@ -239,7 +247,7 @@ export const getDateResolver = (
   options: IDateResolverOption = {},
   fieldConfig: DateResolverFieldConfig
 ): { args: Record<string, any>; resolve: DateResolver } => {
-  const { locale, formatString, fromNow, difference } = options
+  const { locale, formatString, fromNow, difference, utcOffset } = options
   return {
     args: {
       ...fieldConfig.args,
@@ -272,6 +280,13 @@ export const getDateResolver = (
         description: oneLine`
         Configures the locale Moment.js will use to format the date.`,
         defaultValue: locale,
+      },
+      utcOffset: {
+        type: `Int`,
+        description: oneLine`
+        Configures the utcOffset Moment.js will use to format the date.
+        See https://momentjs.com/docs/#/manipulating/utc-offset/`,
+        defaultValue: utcOffset,
       },
     },
     async resolve(source, args, context, info): ReturnType<DateResolver> {


### PR DESCRIPTION
## Description
add utfOffset parameter to set the UTC offset


Usage:
```graphql
query MyQuery {
  allMdx {
    edges {
      node {
        frontmatter {
          title
          date(formatString: "YYYY-MM-DD HH:mm:ss", utcOffset: 8)
        }
      }
    }
  }
}
```