### PR TITLE
chore(gatsby-recipes): update snapshot

### DIFF
--- a/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/plugin.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/plugin.test.js.snap
@@ -898,7 +898,7 @@ date: \\"2017-09-18T23:19:51.246Z\\"
 <p>Is he in the stable or down by the stream?</p>
 \`\`\`
 
-Then specify \`MARKDOWN\` as the format in your graphql query:
+Then specify \`MARKDOWN\` as the format in your GraphQL query:
 
 \`\`\`graphql
 {


### PR DESCRIPTION
Recent spelling update ( https://github.com/gatsbyjs/gatsby/pull/26693 ) caused some snapshots to get out of sync - this sync it back up.

This is just to unblock main branch. Ideally there is follow up to adjust those tests to not snapshot test content of other package's README (or at least some mock package is used, and not package that still receive frequent updates)