### PR TITLE
chore: Remove `www` from Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,6 @@
   includePaths: [
     "package.json",
     "packages/**",
-    "www/package.json",
     "starters/**",
     "examples/**",
   ],
@@ -41,10 +40,6 @@
     {
       groupName: "packages",
       paths: ["package.json", "packages/**"],
-    },
-    {
-      groupName: "www",
-      paths: ["www/package.json"],
     },
     {
       groupName: "starters and examples",
@@ -86,40 +81,6 @@
       // not grouped
       groupName: "packages (<1.0.0 minor)",
       paths: ["package.json", "packages/**"],
-      masterIssueApproval: true,
-      updateTypes: ["minor"],
-      packageNames: [
-        // below is list of packages that use 0.X version range, any minor bump there can contain breaking changes, so we just ignore minor bumps for those packages and will need to bump them manually
-        "@reach/skip-nav",
-        "@theme-ui/prism",
-        "@theme-ui/typography",
-        "axios",
-        "babel-preset-gatsby",
-        "sharp",
-        "express-graphql",
-        "gatsby-plugin-theme-ui",
-        "graphiql-explorer",
-        "guess-webpack",
-        "jest-silent-reporter",
-        "js-combinatorics",
-        "jscodeshift",
-        "mini-css-extract-plugin",
-        "react-refresh",
-        "scroll-behavior",
-        "theme-ui",
-        "webpack-stats-plugin",
-        "xlsx",
-        "zipkin",
-        "zipkin-transport-http",
-        // below is list of packages that we use alpha/beta/next/canary, where it's not really safe to bump automatically and need extra caution
-        "react-docgen",
-      ],
-    },
-    {
-      // minor updates in packages <1.0.0 - need master issue approval
-      // not grouped
-      groupName: "www (<1.0.0 minor)",
-      paths: ["www/package.json"],
       masterIssueApproval: true,
       updateTypes: ["minor"],
       packageNames: [


### PR DESCRIPTION
## Description

With gatsbyjs.com living somewhere else, there's currently no need to run Renovate for `www`.
