### PR TITLE
feat(gatsby-plugin-mdx): use query modules API in mdx plugin

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
@@ -54,28 +54,29 @@ module.exports = async (
 
   createNode(mdxNode)
   createParentChildLink({ parent: node, child: mdxNode })
-
-  // write scope files into .cache for later consumption
-  const { scopeImports, scopeIdentifiers } = await findImports({
-    node: mdxNode,
-    getNode,
-    getNodes,
-    reporter,
-    cache,
-    pathPrefix,
-    options,
-    loadNodeContent,
-    actions,
-    createNodeId,
-    ...helpers,
-  })
-  await cacheScope({
-    cache,
-    scopeIdentifiers,
-    scopeImports,
-    createContentDigest: contentDigest,
-    parentNode: node,
-  })
+  if (!process.env.GATSBY_EXPERIMENTAL_QUERY_MODULES) {
+    // write scope files into .cache for later consumption if query modules is not used
+    const { scopeImports, scopeIdentifiers } = await findImports({
+      node: mdxNode,
+      getNode,
+      getNodes,
+      reporter,
+      cache,
+      pathPrefix,
+      options,
+      loadNodeContent,
+      actions,
+      createNodeId,
+      ...helpers,
+    })
+    await cacheScope({
+      cache,
+      scopeIdentifiers,
+      scopeImports,
+      createContentDigest: contentDigest,
+      parentNode: node,
+    })
+  }
 }
 
 async function cacheScope({

--- a/packages/gatsby-plugin-mdx/utils/babel-plugin-pluck-imports/index.js
+++ b/packages/gatsby-plugin-mdx/utils/babel-plugin-pluck-imports/index.js
@@ -1,11 +1,13 @@
 const declare = require(`@babel/helper-plugin-utils`).declare
+const syspath = require(`path`)
 
 module.exports = class Plugin {
   constructor() {
+    const importSpecs = []
     const imports = []
     const identifiers = []
-    this.state = { imports: imports, identifiers: identifiers }
-    this.plugin = declare(api => {
+    this.state = { imports: imports, identifiers: identifiers, importSpecs }
+    this.plugin = declare((api, options) => {
       api.assertVersion(7)
 
       return {
@@ -19,6 +21,40 @@ module.exports = class Plugin {
                 }
               },
             })
+
+            if (process.env.GATSBY_EXPERIMENTAL_QUERY_MODULES) {
+              let source = path.node.source.value
+              if (options.mdxFileDirectory) {
+                if (source.startsWith(`.`)) {
+                  // convert relative path to absolute one
+                  source = syspath.resolve(options.mdxFileDirectory, source)
+                }
+              }
+
+              // handle relative paths ideally here to avoid extra babel parsing and traversal later
+              path.node.specifiers.forEach(specifier => {
+                if (specifier.type === `ImportDefaultSpecifier`) {
+                  importSpecs.push({
+                    source,
+                    type: `default`,
+                    local: specifier.local.name,
+                  })
+                } else if (specifier.type === `ImportNamespaceSpecifier`) {
+                  importSpecs.push({
+                    source,
+                    type: `namespace`,
+                    local: specifier.local.name,
+                  })
+                } else if (specifier.type === `ImportSpecifier`) {
+                  importSpecs.push({
+                    source,
+                    type: `named`,
+                    importName: specifier.imported.name,
+                    local: specifier.local.name,
+                  })
+                }
+              })
+            }
 
             //            const name = path.get("declaration.declarations.0").node.id.name;
 


### PR DESCRIPTION
This is initial attempt at adjusting mdx plugin to support query modules ( https://github.com/gatsbyjs/gatsby/pull/24903 ). 

One of goals here was to keep backward compatibility and use new (not yet released) APIs if they are available and toggle on.

For the most part this just skips writing scope files if query modules are enabled and instead use `context.pageModel.setModule` to let gatsby know what resources will be needed in which pages (and that's how this "fixes" problem of bundling everything in app chunk).

Note that this is not feature complete. Particularly `html` field will need adjustments too (that's the one used for `feed` plugin), but it's good enough for initial reactions

## Related Issues

- query modules API PR - https://github.com/gatsbyjs/gatsby/pull/24903
- MDX app bundle bloating umbrella issue - https://github.com/gatsbyjs/gatsby/issues/25069
