### PR TITLE
fix(gatsby-image): do not render the source tag if no srcSet is provided

### DIFF
--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -369,4 +369,16 @@ describe(`<Image />`, () => {
     const placeholderImageTag = setup().querySelector(`picture img`)
     expect(placeholderImageTag.getAttribute(`aria-hidden`)).toBe(null)
   })
+
+  it(`should not have a "source" tag if no srcSet is provided`, () => {
+    jest.spyOn(global.console, `warn`)
+
+    const props = {
+      fixed: { ...fixedShapeMock, srcSet: null, srcSetWebp: null },
+    }
+    const sourceTag = setup(false, props).querySelector(`source`)
+    expect(sourceTag).toEqual(null)
+
+    expect(console.warn).toBeCalled()
+  })
 })

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -176,7 +176,7 @@ function generateImageSources(imageVariants) {
           sizes={sizes}
         />
       )}
-      <source media={media} srcSet={srcSet} sizes={sizes} />
+      {srcSet && <source media={media} srcSet={srcSet} sizes={sizes} />}
     </React.Fragment>
   ))
 }


### PR DESCRIPTION
According to the [spec](https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element), a `source` tag without the `srcset` attribute is invalid, this small PR makes sure the tag is not rendered in this case.
