### PR TITLE
fix(gatsby-source-filesystem) Clarify createFilePath docs

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -119,6 +119,7 @@ createFilePath({
   // The parameter from `onCreateNode` should be passed in here
   getNode,
   // The base path for your files.
+  // It is relative to the `options.path` setting in the `gatsby-source-filesystem` entries of your gatsby-config.js
   // Defaults to `src/pages`. For the example above, you'd use `src/content`.
   basePath,
   // Whether you want your file paths to contain a trailing `/` slash

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -119,7 +119,7 @@ createFilePath({
   // The parameter from `onCreateNode` should be passed in here
   getNode,
   // The base path for your files.
-  // It is relative to the `options.path` setting in the `gatsby-source-filesystem` entries of your gatsby-config.js
+  // It is relative to the `options.path` setting in the `gatsby-source-filesystem` entries of your `gatsby-config.js`.
   // Defaults to `src/pages`. For the example above, you'd use `src/content`.
   basePath,
   // Whether you want your file paths to contain a trailing `/` slash


### PR DESCRIPTION
## Description

Just a minor update to the readme to clarify the usage of the `createFilePath()` `basePath` option.

## Related Issues

Fixes: #26470
