### PR TITLE
chore(gatsby-telemetry): Generate typings

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -529,7 +529,7 @@ Creating a plugin:
           }),
 
       handler: handlerP(({ enable, disable }: yargs.Arguments) => {
-        const enabled = enable || !disable
+        const enabled = Boolean(enable) || !disable
         setTelemetryEnabled(enabled)
         report.log(`Telemetry collection ${enabled ? `enabled` : `disabled`}`)
       }),

--- a/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
@@ -32,9 +32,10 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     trackBuildError(`INK`, {
       error: {
-        stack: info.componentStack,
+        error: {
+          stack: info.componentStack,
+        },
         text: error.message,
-        context: {},
       },
     })
   }

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -31,7 +31,8 @@
     "cross-env": "^5.2.1",
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
-    "jest-junit": "^6.4.0"
+    "jest-junit": "^6.4.0",
+    "rimraf": "^3.0.2"
   },
   "files": [
     "lib/",

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -50,9 +50,10 @@
   },
   "scripts": {
     "build": "babel src --out-dir lib --ignore \"**/__tests__\",\"**/__mocks__\" --extensions \".ts,.js\"",
-    "prepare": "cross-env NODE_ENV=production npm run build",
+    "prepare": "cross-env NODE_ENV=production npm run build && npm run typegen",
     "jest": "jest",
     "postinstall": "node src/postinstall.js || true",
+    "typegen": "rimraf \"lib/**/*.d.ts\" && tsc --emitDeclarationOnly --declaration --declarationDir lib/",
     "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\",\"**/__mocks__\" --extensions \".ts,.js\""
   },
   "yargs": {

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -32,7 +32,8 @@
     "jest": "^24.9.0",
     "jest-cli": "^24.9.0",
     "jest-junit": "^6.4.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "typescript": "^3.9.5"
   },
   "files": [
     "lib/",

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -3,8 +3,9 @@ import {
   IAggregateStats,
   ITelemetryTagsPayload,
   ITelemetryOptsPayload,
+  IDefaultTelemetryTagsPayload,
 } from "./telemetry"
-import * as express from "express"
+import { Request, Response } from "express"
 import { createFlush } from "./create-flush"
 
 const instance = new AnalyticsTracker()
@@ -40,23 +41,29 @@ export function trackCli(
   instance.captureEvent(input, tags, opts)
 }
 
-export function trackError(input, tags): void {
+export function trackError(input: string, tags?: ITelemetryTagsPayload): void {
   instance.captureError(input, tags)
 }
 
-export function trackBuildError(input, tags): void {
+export function trackBuildError(
+  input: string,
+  tags?: ITelemetryTagsPayload
+): void {
   instance.captureBuildError(input, tags)
 }
 
-export function setDefaultTags(tags): void {
+export function setDefaultTags(tags: IDefaultTelemetryTagsPayload): void {
   instance.decorateAll(tags)
 }
 
-export function decorateEvent(event, tags): void {
+export function decorateEvent(
+  event: string,
+  tags?: Record<string, unknown>
+): void {
   instance.decorateNextEvent(event, tags)
 }
 
-export function setTelemetryEnabled(enabled): void {
+export function setTelemetryEnabled(enabled: boolean): void {
   instance.setTelemetryEnabled(enabled)
 }
 
@@ -68,16 +75,16 @@ export function isTrackingEnabled(): boolean {
   return instance.isTrackingEnabled()
 }
 
-export function aggregateStats(data): IAggregateStats {
+export function aggregateStats(data: Array<number>): IAggregateStats {
   return instance.aggregateStats(data)
 }
 
-export function addSiteMeasurement(event, obj): void {
+export function addSiteMeasurement(event: string, obj): void {
   instance.addSiteMeasurement(event, obj)
 }
 
 export function expressMiddleware(source: string) {
-  return function (_req: express.Request, _res: express.Response, next): void {
+  return function (_req: Request, _res: Response, next): void {
     try {
       instance.trackActivity(`${source}_ACTIVE`)
     } catch (e) {
@@ -88,11 +95,11 @@ export function expressMiddleware(source: string) {
 }
 
 // Internal
-export function setDefaultComponentId(componentId): void {
+export function setDefaultComponentId(componentId: string): void {
   instance.componentId = componentId
 }
 
-export function setGatsbyCliVersion(version): void {
+export function setGatsbyCliVersion(version: string): void {
   instance.gatsbyCliVersion = version
 }
 

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -48,6 +48,27 @@ interface IAnalyticsTrackerConstructorParameters {
   gatsbyCliVersion?: SemVer
 }
 
+export interface IStructuredError {
+  id?: string
+  code?: string
+  text: string
+  level?: string
+  type?: string
+  context?: unknown
+  error?: {
+    stack?: string
+  }
+}
+
+export interface IStructuredErrorV2 {
+  id?: string
+  text: string
+  level?: string
+  type?: string
+  context?: string
+  stack?: string
+}
+
 export interface ITelemetryTagsPayload {
   name?: string
   starterName?: string
@@ -58,29 +79,23 @@ export interface ITelemetryTagsPayload {
   valid?: boolean
   plugins?: string[]
   pathname?: string
-  error?: {
-    id?: string
-    code?: string
-    text: string
-    level?: string
-    type?: string
-    stack?: string
-    context?: string
-    error?: {
-      stack?: string
-    }
-  }
+  error?: IStructuredError | Array<IStructuredError>
   cacheStatus?: string
   pluginCachePurged?: string
   siteMeasurements?: {
     pagesCount?: number
     clientsCount?: number
-    paths?: string[]
+    paths?: Array<string | undefined>
     bundleStats?: unknown
     pageDataStats?: unknown
     queryStats?: unknown
   }
-  errorV2?: unknown
+  errorV2?: IStructuredErrorV2
+}
+
+export interface IDefaultTelemetryTagsPayload extends ITelemetryTagsPayload {
+  gatsbyCliVersion?: SemVer
+  installedGatsbyVersion?: SemVer
 }
 
 export interface ITelemetryOptsPayload {
@@ -390,7 +405,7 @@ export class AnalyticsTracker {
     this.store.updateConfig(`telemetry.enabled`, enabled)
   }
 
-  aggregateStats(data): IAggregateStats {
+  aggregateStats(data: Array<number>): IAggregateStats {
     const sum = data.reduce((acc, x) => acc + x, 0)
     const mean = sum / data.length || 0
     const median = data.sort()[Math.floor((data.length - 1) / 2)] || 0
@@ -419,14 +434,13 @@ export class AnalyticsTracker {
 
   async sendEvents(): Promise<boolean> {
     if (!this.isTrackingEnabled()) {
-      return Promise.resolve(true)
+      return true
     }
 
     return this.store.sendEvents()
   }
 
   trackFeatureIsUsed(name: string): void {
-    if (this.features.has(name)) return
     this.features.add(name)
   }
 }

--- a/packages/gatsby-telemetry/tsconfig.json
+++ b/packages/gatsby-telemetry/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": true
-  }
+  },
+  "exclude": ["node_modules", "src/__tests__", "src/__mocks__", "lib"]
 }


### PR DESCRIPTION
Add a typegen step to the gatsby-telemetry package, which is already fully converted to TS