### PR TITLE
chore: changes according to policy update -> removed old info

### DIFF
--- a/peril/README.md
+++ b/peril/README.md
@@ -34,7 +34,7 @@ The Peril instance can also be configured to run events on a schedule.
 ### What is this project?
 
 - [EmptyBody](./rules/emptybody.ts): Automatically requests more information from a user who opens a new issue with a blank body.
-- [InviteCollaborator](./rules/invite-collaborator.ts): Automatically invite all contributors who merge a PR into the GatsbyJS org to become members of the [@gatsbyjs/maintainers](https://github.com/orgs/gatsbyjs/teams/maintainers) team.
+
 
 ### To Develop
 

--- a/peril/README.md
+++ b/peril/README.md
@@ -35,7 +35,6 @@ The Peril instance can also be configured to run events on a schedule.
 
 - [EmptyBody](./rules/emptybody.ts): Automatically requests more information from a user who opens a new issue with a blank body.
 
-
 ### To Develop
 
 ```shell


### PR DESCRIPTION
Removed Doc part saying auto addition of contributors to organisation as policy has been updated.

Description
As of now, the policy that contributors will be added to organisation after getting there PR merged was removed (See https://www.gatsbyjs.com/blog/2020-08-04-gh-community-permissions-changes-gatsbyjs ). I saw it was still mentioned here.

related issue: #26615