### PR TITLE
fix(gatsby-cli): Fix typo (repeated ://)

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -301,8 +301,8 @@ module.exports = async (program: IProgram): Promise<void> => {
       const port = data?.port || 8000
       console.error(
         `Looks like develop for this site is already running, can you visit ${
-          program.ssl ? `https://` : `http://`
-        }://localhost:${port} ? If it is not, try again in five seconds!`
+          program.ssl ? `https:` : `http:`
+        }//localhost:${port} ? If it is not, try again in five seconds!`
       )
       process.exit(1)
     }


### PR DESCRIPTION
Console currently prints this error message (#26360):

```text
 ERROR 

Looks like develop for this site is already running, can you visit http://://localhost:8000 ? If it is not, try again in five seconds!
```

This tiny PR fixes the URL.