### PR TITLE
chore(gatsby-plugin-mdx): Add img alt to excerpts and remove extra whitespace

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -186,7 +186,7 @@ module.exports = (
           }
           const { mdast } = await processMDX({ node: mdxNode })
 
-          let excerptNodes = []
+          const excerptNodes = []
           visit(mdast, node => {
             if (node.type === `text` || node.type === `inlineCode`) {
               excerptNodes.push(node.value)

--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -186,19 +186,22 @@ module.exports = (
           }
           const { mdast } = await processMDX({ node: mdxNode })
 
-          const excerptNodes = []
+          let excerptNodes = []
           visit(mdast, node => {
             if (node.type === `text` || node.type === `inlineCode`) {
               excerptNodes.push(node.value)
+            }
+            if (node.type === `image`) {
+              excerptNodes.push(node.alt)
             }
             return
           })
 
           if (!truncate) {
-            return prune(excerptNodes.join(` `), pruneLength, `…`)
+            return prune(excerptNodes.join(``), pruneLength, `…`)
           }
 
-          return _.truncate(excerptNodes.join(` `), {
+          return _.truncate(excerptNodes.join(``), {
             length: pruneLength,
             omission: `…`,
           })


### PR DESCRIPTION
## Description
When an MDX file includes a link that would be shown in the plaintext excerpt, an extra space is added after the link.

## Related Issues
Same problem as #12398 which was fixed in #12878.

Fixes #16035.