### PR TITLE
chore(docs): Remove "simply" wordpress-source-plugin-tutorial

### DIFF
--- a/docs/tutorial/wordpress-source-plugin-tutorial.md
+++ b/docs/tutorial/wordpress-source-plugin-tutorial.md
@@ -288,7 +288,7 @@ export const query = graphql`
 `
 ```
 
-What is this file doing? After importing your dependencies, it constructs the layout of the post with JSX. It wraps everything in the `Layout` component, so the style is the same throughout the site. Then, it simply adds the post title and the post content. You can add anything you want and can query for here (e.g. feature image, post meta, custom fields, etc.).
+What is this file doing? After importing your dependencies, it constructs the layout of the post with JSX. It wraps everything in the `Layout` component, so the style is the same throughout the site. Then, it adds the post title and the post content. You can add anything you want and can query for here (e.g. feature image, post meta, custom fields, etc.).
 
 Below that, you can see the GraphQL query calling the specific post based on the `$slug`. This variable is passed to the `blog-post.js` template when the page is created in `gatsby-node.js`. To accomplish this, add the following code to the `gatsby-node.js` file:
 

--- a/integration-tests/gatsby-pipeline/README.md
+++ b/integration-tests/gatsby-pipeline/README.md
@@ -8,4 +8,4 @@ You can install all dependencies by running `yarn` or `npm install`.
 
 ## Tests
 
-To run our test suite you can simply run `yarn test`. If you want to test with the latest sources from the packages directory. You can use the [e2e-test.sh](https://github.com/gatsbyjs/gatsby/blob/master/scripts/e2e-test.sh) helper script that we use for CI. You can run it as `sh scripts/e2e-test.sh integration-tests/gatsby-pipeline` from the root directory.
+To run our test suite you can run `yarn test` or if you want to test with the latest sources from the packages directory, you can use the [e2e-test.sh](https://github.com/gatsbyjs/gatsby/blob/master/scripts/e2e-test.sh) helper script that we use for CI. You can run it as `sh scripts/e2e-test.sh integration-tests/gatsby-pipeline` from the root directory.


### PR DESCRIPTION
## Description
Removed the word 'simply' to make the tutorial more language inclusive

## Related Issues

  Related to #18702

