### PR TITLE
chore(docs): Adds clearMocks to unit-testing

### DIFF
--- a/docs/docs/unit-testing.md
+++ b/docs/docs/unit-testing.md
@@ -47,6 +47,7 @@ module.exports = {
   },
   testURL: `http://localhost`,
   setupFiles: [`<rootDir>/loadershim.js`],
+  clearMocks: true,
 }
 ```
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Updates `unit-testing.md` to include the `clearMocks` property in `jest.config.js`. 

The instructions in step #3 suggest setting up a globally mocked gatsby object in the `__mocks__` directory at the root of the project. However, if anyone were to utilize these mocks, such as mocking the return value in a test, the state of the mocks would persist between tests, leading to unexpected outcomes. This change attempts to address this by adding the `clearMocks` configuration to the jest config so that developers following this tutorial will not need to manually reset the mocks on each test. 

### Documentation

[Jest clearMocks documentation](https://jestjs.io/docs/en/configuration#clearmocks-boolean)

## Related Issues

[Issue #26795 - Mocking gatsby in __mocks__ not cleaning up after tests](https://github.com/gatsbyjs/gatsby/issues/26795)
