### PR TITLE
fix(gatsby): catch when lock already unlocked

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -465,5 +465,7 @@ function shutdownServices(
     services.push(unlock())
   })
 
-  return Promise.all(services).then(() => {})
+  return Promise.all(services)
+    .catch(() => {})
+    .then(() => {})
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

It's a hotfix to remove the uncaught exception thrown on MacOS when `gatsby develop` is run with npm.
This just swallows the error message. It's not a proper fix but it will do for now.

You can test it using `npm install gatsby@lockfile --registry=https://registry.wardpeet.dev`

I could test it with:
1) rm -rf node_modules
1) npm install
1) npm run develop
1) wait until localhost is ready and hit ctrl+c

## Related Issues

Fixes #26792
