### PR TITLE
fix(gatsby-plugin-page-creator) Add missing chokidar dependency

### DIFF
--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator#readme",
   "dependencies": {
     "@babel/traverse": "^7.10.2",
+    "chokidar": "^3.4.2",
     "fs-exists-cached": "^1.0.0",
     "gatsby-page-utils": "^0.2.24",
     "globby": "^11.0.1",


### PR DESCRIPTION
## Description

Currently it is not possible to build projects using the latest version of the plugin, because the dependency `chokidar` is missing.

```
  Error: Cannot find module 'chokidar'
  Require stack:
  - /home/dev/node_modules/gatsby-plugin-page-creator/watch-collection-builder.js
  - /home/dev/node_modules/gatsby-plugin-page-creator/create-pages-from-collection-builder.js
  - /home/dev/node_modules/gatsby-plugin-page-creator/create-page-wrapper.js
  - /home/dev/node_modules/gatsby-plugin-page-creator/gatsby-node.js
  - /home/dev/node_modules/gatsby/dist/bootstrap/resolve-module-exports.js
  - /home/dev/node_modules/gatsby/dist/bootstrap/load-plugins/validate.js
  - /home/dev/node_modules/gatsby/dist/bootstrap/load-plugins/load.js
  - /home/dev/node_modules/gatsby/dist/bootstrap/load-plugins/index.js
  - /home/dev/node_modules/gatsby/dist/services/initialize.js
  - /home/dev/node_modules/gatsby/dist/services/index.js
  - /home/dev/node_modules/gatsby/dist/state-machines/develop/services.js
  - /home/dev/node_modules/gatsby/dist/state-machines/develop/index.js
  - /home/dev/node_modules/gatsby/dist/commands/develop-process.js
  - /home/dev/.cache/tmp-144390-9cgpJd2WaxiQ
```

Chokidar is used e.g. in [watch-collection-builder.ts](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-page-creator/src/watch-collection-builder.ts#L2).

This PR adds it as a dependency.
