### PR TITLE
Gatsby plugin google tagmanager

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -37,6 +37,10 @@ plugins: [
       //
       // Defaults to gatsby-route-change
       routeChangeEventName: "YOUR_ROUTE_CHANGE_EVENT_NAME",
+
+      // This will include the anti-flicker snippet if you have integrated the
+      // optimize with your GTM. See https://developers.google.com/optimize
+      optimizeId: "", // This is your Optimize Container ID (e.g., "GTM-XXXXXX")
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -38,9 +38,14 @@ plugins: [
       // Defaults to gatsby-route-change
       routeChangeEventName: "YOUR_ROUTE_CHANGE_EVENT_NAME",
 
+      // This is your Optimize Container ID (e.g., "GTM-XXXXXX")
       // This will include the anti-flicker snippet if you have integrated the
       // optimize with your GTM. See https://developers.google.com/optimize
-      optimizeId: "", // This is your Optimize Container ID (e.g., "GTM-XXXXXX")
+      optimizeId: "",
+      // The amount of time Optimize will wait before removing the `.async-hide` class.
+      // It will be ignored if the `optimizeId` is empty.
+      // The default is 4000 milliseconds.
+      antiFlickerSnippetDelay: 4000,
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -1,10 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a function as defaultDatalayer 1`] = `"window.dataLayer = window.dataLayer || [];window.dataLayer.push((function () { return { pageCategory: window.pageType }; })()); (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer', 'undefined');"`;
+exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a function as defaultDatalayer 1`] = `"window.dataLayer = window.dataLayer || [];window.dataLayer.push((function () { return { pageCategory: window.pageType }; })());"`;
 
-exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a renamed dataLayer 1`] = `"window.TEST_DATA_LAYER_NAME = window.TEST_DATA_LAYER_NAME || [];window.TEST_DATA_LAYER_NAME.push({\\"pageCategory\\":\\"home\\"}); (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','TEST_DATA_LAYER_NAME', 'undefined');"`;
+exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a renamed dataLayer 1`] = `"window.TEST_DATA_LAYER_NAME = window.TEST_DATA_LAYER_NAME || [];window.TEST_DATA_LAYER_NAME.push({\\"pageCategory\\":\\"home\\"});"`;
 
-exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a static object as defaultDatalayer 1`] = `"window.dataLayer = window.dataLayer || [];window.dataLayer.push({\\"pageCategory\\":\\"home\\"}); (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer', 'undefined');"`;
+exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a static object as defaultDatalayer 1`] = `"window.dataLayer = window.dataLayer || [];window.dataLayer.push({\\"pageCategory\\":\\"home\\"});"`;
+
+exports[`gatsby-plugin-google-tagmanager should include anti-flicker between dataLayerInit and gtmInit 1`] = `"window.dataLayer = window.dataLayer || [];window.dataLayer.push({\\"pageCategory\\":\\"home\\"});"`;
+
+exports[`gatsby-plugin-google-tagmanager should include anti-flicker between dataLayerInit and gtmInit 2`] = `".async-hide { opacity: 0 !important}"`;
+
+exports[`gatsby-plugin-google-tagmanager should include anti-flicker between dataLayerInit and gtmInit 3`] = `
+"(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+})(window,document.documentElement,'async-hide','dataLayer',4000,
+{GTM-TEST:true});"
+`;
+
+exports[`gatsby-plugin-google-tagmanager should include anti-flicker between dataLayerInit and gtmInit 4`] = `"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer', 'undefined');"`;
+
+exports[`gatsby-plugin-google-tagmanager should include anti-flicker between dataLayerInit and gtmInit 5`] = `"<iframe src=\\"https://www.googletagmanager.com/ns.html?id=undefined\\" height=\\"0\\" width=\\"0\\" style=\\"display: none; visibility: hidden\\"></iframe>"`;
 
 exports[`gatsby-plugin-google-tagmanager should load gtm 1`] = `"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer', 'undefined');"`;
 

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -2,9 +2,15 @@
 
 exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a function as defaultDatalayer 1`] = `"window.dataLayer = window.dataLayer || [];window.dataLayer.push((function () { return { pageCategory: window.pageType }; })());"`;
 
+exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a function as defaultDatalayer 2`] = `"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer', 'undefined');"`;
+
 exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a renamed dataLayer 1`] = `"window.TEST_DATA_LAYER_NAME = window.TEST_DATA_LAYER_NAME || [];window.TEST_DATA_LAYER_NAME.push({\\"pageCategory\\":\\"home\\"});"`;
 
+exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a renamed dataLayer 2`] = `"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','TEST_DATA_LAYER_NAME', 'undefined');"`;
+
 exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a static object as defaultDatalayer 1`] = `"window.dataLayer = window.dataLayer || [];window.dataLayer.push({\\"pageCategory\\":\\"home\\"});"`;
+
+exports[`gatsby-plugin-google-tagmanager defaultDatalayer should add a static object as defaultDatalayer 2`] = `"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer', 'undefined');"`;
 
 exports[`gatsby-plugin-google-tagmanager should include anti-flicker between dataLayerInit and gtmInit 1`] = `"window.dataLayer = window.dataLayer || [];window.dataLayer.push({\\"pageCategory\\":\\"home\\"});"`;
 
@@ -15,7 +21,7 @@ exports[`gatsby-plugin-google-tagmanager should include anti-flicker between dat
 h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
 (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
 })(window,document.documentElement,'async-hide','dataLayer',4000,
-{GTM-TEST:true});"
+{'GTM-TEST':true});"
 `;
 
 exports[`gatsby-plugin-google-tagmanager should include anti-flicker between dataLayerInit and gtmInit 4`] = `"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'';f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer', 'undefined');"`;

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-ssr.js
@@ -95,11 +95,14 @@ describe(`gatsby-plugin-google-tagmanager`, () => {
       }
 
       onRenderBody(mocks, pluginOptions)
-      const [headConfig] = mocks.setHeadComponents.mock.calls[0][0]
-      expect(headConfig.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
-      expect(headConfig.props.dangerouslySetInnerHTML.__html).toContain(
+      const [dataLayerInit, gtmInit] = mocks.setHeadComponents.mock.calls[0][0]
+      expect(
+        dataLayerInit.props.dangerouslySetInnerHTML.__html
+      ).toMatchSnapshot()
+      expect(dataLayerInit.props.dangerouslySetInnerHTML.__html).toContain(
         `window.dataLayer`
       )
+      expect(gtmInit.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
     })
 
     it(`should add a function as defaultDatalayer`, () => {
@@ -120,11 +123,14 @@ describe(`gatsby-plugin-google-tagmanager`, () => {
       const datalayerFuncAsString = oneLine`${pluginOptions.defaultDataLayer.value}`
 
       onRenderBody(mocks, pluginOptions)
-      const [headConfig] = mocks.setHeadComponents.mock.calls[0][0]
-      expect(headConfig.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
-      expect(headConfig.props.dangerouslySetInnerHTML.__html).toContain(
+      const [dataLayerInit, gtmInit] = mocks.setHeadComponents.mock.calls[0][0]
+      expect(
+        dataLayerInit.props.dangerouslySetInnerHTML.__html
+      ).toMatchSnapshot()
+      expect(dataLayerInit.props.dangerouslySetInnerHTML.__html).toContain(
         `window.dataLayer.push((${datalayerFuncAsString})());`
       )
+      expect(gtmInit.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
     })
 
     it(`should report an error when data is not valid`, () => {
@@ -175,10 +181,16 @@ describe(`gatsby-plugin-google-tagmanager`, () => {
       }
 
       onRenderBody(mocks, pluginOptions)
-      const [headConfig] = mocks.setHeadComponents.mock.calls[0][0]
-      expect(headConfig.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
-      expect(headConfig.props.dangerouslySetInnerHTML.__html).toContain(
+      const [dataLayerInit, gtmInit] = mocks.setHeadComponents.mock.calls[0][0]
+      expect(
+        dataLayerInit.props.dangerouslySetInnerHTML.__html
+      ).toMatchSnapshot()
+      expect(dataLayerInit.props.dangerouslySetInnerHTML.__html).toContain(
         `window.${dataLayerName}`
+      )
+      expect(gtmInit.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
+      expect(gtmInit.props.dangerouslySetInnerHTML.__html).toContain(
+        `gtm.start`
       )
     })
   })

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-ssr.js
@@ -23,6 +23,42 @@ describe(`gatsby-plugin-google-tagmanager`, () => {
     )
   })
 
+  it(`should include anti-flicker between dataLayerInit and gtmInit`, () => {
+    const mocks = {
+      setHeadComponents: jest.fn(),
+      setPreBodyComponents: jest.fn(),
+    }
+    const pluginOptions = {
+      includeInDevelopment: true,
+      optimizeId: `GTM-TEST`,
+      defaultDataLayer: {
+        type: `object`,
+        value: { pageCategory: `home` },
+      },
+    }
+
+    onRenderBody(mocks, pluginOptions)
+    const [
+      dataLayerInit,
+      antiFlickerCss,
+      antiFlickerJs,
+      gtmInit,
+    ] = mocks.setHeadComponents.mock.calls[0][0]
+    const [preBodyConfig] = mocks.setPreBodyComponents.mock.calls[0][0]
+
+    expect(dataLayerInit.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
+    expect(
+      antiFlickerCss.props.dangerouslySetInnerHTML.__html
+    ).toMatchSnapshot()
+    expect(antiFlickerJs.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
+    expect(gtmInit.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
+    expect(preBodyConfig.props.dangerouslySetInnerHTML.__html).toMatchSnapshot()
+    // check if no newlines were added
+    expect(preBodyConfig.props.dangerouslySetInnerHTML.__html).not.toContain(
+      `\n`
+    )
+  })
+
   describe(`defaultDatalayer`, () => {
     it(`should add no dataLayer by default`, () => {
       const mocks = {

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -35,7 +35,11 @@ const generateDefaultDataLayer = (dataLayer, reporter, dataLayerName) => {
 // code.
 //
 // See https://developers.google.com/optimize#the_anti-flicker_snippet_code
-const generateOptimizeAntiFlickerSnippet = optimizeId => {
+const generateOptimizeAntiFlickerSnippet = ({
+  optimizeId,
+  dataLayerName,
+  antiFlickerSnippetDelay,
+}) => {
   if (!optimizeId) {
     return []
   }
@@ -54,7 +58,7 @@ const generateOptimizeAntiFlickerSnippet = optimizeId => {
 (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
 h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
 (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-})(window,document.documentElement,'async-hide','dataLayer',4000,
+})(window,document.documentElement,'async-hide',${dataLayerName},${antiFlickerSnippetDelay},
 {${optimizeId}:true});`,
       }}
     />,
@@ -71,6 +75,7 @@ exports.onRenderBody = (
     gtmPreview,
     defaultDataLayer,
     dataLayerName = `dataLayer`,
+    antiFlickerSnippetDelay = 4000,
   }
 ) => {
   if (process.env.NODE_ENV === `production` || includeInDevelopment) {
@@ -104,7 +109,13 @@ exports.onRenderBody = (
     }
 
     if (optimizeId) {
-      headComponents.push(...generateOptimizeAntiFlickerSnippet(optimizeId))
+      headComponents.push(
+        ...generateOptimizeAntiFlickerSnippet({
+          optimizeId,
+          dataLayerName,
+          antiFlickerSnippetDelay,
+        })
+      )
     }
 
     headComponents.push(

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -58,8 +58,8 @@ const generateOptimizeAntiFlickerSnippet = ({
 (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
 h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
 (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-})(window,document.documentElement,'async-hide',${dataLayerName},${antiFlickerSnippetDelay},
-{${optimizeId}:true});`,
+})(window,document.documentElement,'async-hide','${dataLayerName}',${antiFlickerSnippetDelay},
+{'${optimizeId}':true});`,
       }}
     />,
   ]


### PR DESCRIPTION
## Description

When using Google Optimize with GTM, it needs to use the anti flicker snippet to avoid flickering. However, the anti flicker snippet should be located between the dataLayer initialization and the GTM initialization code.

But, the current plugin sets dataLayer initialization and gtm initialization in a single `<script />`, so a user cannot add the flickering snippet between.

See https://developers.google.com/optimize#the_anti-flicker_snippet_code

### Documentation

- gatsby-plugin-google-tagmanager README has been updated.

## Related Issues

Related to https://github.com/gatsbyjs/gatsby/issues/24121
