### PR TITLE
chore(gatsby): revert #26636; and pin uuid to v3.4.0

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -46,7 +46,7 @@
     "stack-trace": "^0.0.10",
     "strip-ansi": "^5.2.0",
     "update-notifier": "^4.1.0",
-    "uuid": "^8.3.0",
+    "uuid": "3.4.0",
     "yargs": "^15.3.1",
     "yurnalist": "^1.1.2"
   },

--- a/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
+++ b/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 
-import { v4 as uuidv4 } from "uuid"
+import uuidv4 from "uuid"
 import { trackCli } from "gatsby-telemetry"
 import signalExit from "signal-exit"
 import { Dispatch } from "redux"

--- a/packages/gatsby-plugin-benchmark-reporting/package.json
+++ b/packages/gatsby-plugin-benchmark-reporting/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "fast-glob": "^3.2.4",
     "node-fetch": "^2.6.0",
-    "uuid": "^8.3.0"
+    "uuid": "3.4.0"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore \"**/__tests__\"",

--- a/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
+++ b/packages/gatsby-plugin-benchmark-reporting/src/gatsby-node.js
@@ -2,7 +2,7 @@ const { performance } = require(`perf_hooks`)
 
 const { sync: glob } = require(`fast-glob`)
 const nodeFetch = require(`node-fetch`)
-const { v4: uuidv4 } = require(`uuid`)
+const uuidv4 = require(`uuid/v4`)
 const { execSync } = require(`child_process`)
 const fs = require(`fs`)
 

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -24,7 +24,7 @@
     "semver": "^7.3.2",
     "sharp": "^0.25.4",
     "svgo": "1.3.2",
-    "uuid": "^8.3.0"
+    "uuid": "3.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",

--- a/packages/gatsby-plugin-sharp/src/scheduler.js
+++ b/packages/gatsby-plugin-sharp/src/scheduler.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require(`uuid`)
+const uuidv4 = require(`uuid/v4`)
 const path = require(`path`)
 const fs = require(`fs-extra`)
 const got = require(`got`)

--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -82,7 +82,7 @@
     "unist-util-remove": "^2.0.0",
     "unist-util-visit": "^2.0.2",
     "urql": "^1.9.7",
-    "uuid": "^8.3.0",
+    "uuid": "3.4.0",
     "ws": "^7.3.0",
     "xstate": "^4.9.1",
     "yoga-layout-prebuilt": "^1.9.6",

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -17,7 +17,7 @@
     "graphql": "^14.6.0",
     "invariant": "^2.2.4",
     "node-fetch": "^1.7.3",
-    "uuid": "^8.3.0"
+    "uuid": "3.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",

--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require(`uuid`)
+const uuidv4 = require(`uuid/v4`)
 const { buildSchema, printSchema } = require(`gatsby/graphql`)
 const {
   wrapSchema,

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -21,7 +21,7 @@
     "is-docker": "^2.1.1",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.0",
-    "uuid": "^8.3.0"
+    "uuid": "3.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",

--- a/packages/gatsby-telemetry/src/in-memory-store.ts
+++ b/packages/gatsby-telemetry/src/in-memory-store.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid"
+import uuidv4 from "uuid"
 import os from "os"
 import { join } from "path"
 

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid"
+import uuidv4 from "uuid/v4"
 import os from "os"
 import { isCI, getCIName } from "gatsby-core-utils"
 import {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -143,7 +143,7 @@
     "type-of": "^2.0.1",
     "url-loader": "^1.1.2",
     "util.promisify": "^1.0.1",
-    "uuid": "^8.3.0",
+    "uuid": "3.4.0",
     "v8-compile-cache": "^1.1.2",
     "webpack": "^4.44.1",
     "webpack-dev-middleware": "^3.7.2",

--- a/packages/gatsby/src/redux/__tests__/jobsv2.js
+++ b/packages/gatsby/src/redux/__tests__/jobsv2.js
@@ -1,11 +1,7 @@
 const jobsManager = require(`../../utils/jobs-manager`)
 jest.spyOn(jobsManager, `enqueueJob`)
 jest.spyOn(jobsManager, `removeInProgressJob`)
-jest.mock(`uuid`, () => {
-  return {
-    v4: () => `1234`,
-  }
-})
+jest.mock(`uuid/v4`, () => () => `1234`)
 
 import { jobsV2Reducer as jobsReducer } from "../reducers/jobsv2"
 

--- a/packages/gatsby/src/utils/__tests__/jobs-manager.js
+++ b/packages/gatsby/src/utils/__tests__/jobs-manager.js
@@ -35,18 +35,16 @@ jest.mock(
   { virtual: true }
 )
 
-jest.mock(`uuid`, () => {
-  return {
-    v4: jest.fn().mockImplementation(jest.requireActual(`uuid`).v4),
-  }
-})
+jest.mock(`uuid/v4`, () =>
+  jest.fn().mockImplementation(jest.requireActual(`uuid/v4`))
+)
 
 const worker = require(`/node_modules/gatsby-plugin-test/gatsby-worker.js`)
 const reporter = require(`gatsby-cli/lib/reporter`)
 const hasha = require(`hasha`)
 const fs = require(`fs-extra`)
 const pDefer = require(`p-defer`)
-const { v4: uuidv4 } = require(`uuid`)
+const uuidv4 = require(`uuid/v4`)
 
 fs.ensureDir = jest.fn().mockResolvedValue(true)
 

--- a/packages/gatsby/src/utils/create-node-id.ts
+++ b/packages/gatsby/src/utils/create-node-id.ts
@@ -1,4 +1,4 @@
-import { v5 as uuidv5 } from "uuid"
+import uuidv5 from "uuid/v5"
 import report from "gatsby-cli/lib/reporter"
 
 const seedConstant = `638f7a53-c567-4eca-8fc1-b23efb1cfb2b`

--- a/packages/gatsby/src/utils/jobs-manager.ts
+++ b/packages/gatsby/src/utils/jobs-manager.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid"
+import uuidv4 from "uuid/v4"
 import path from "path"
 import hasha from "hasha"
 import fs from "fs-extra"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24746,7 +24746,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
+uuid@3.4.0, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -24755,11 +24755,6 @@ uuid@^7.0.0:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
-uuid@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 v8-compile-cache@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Note: this was a manual revert since github would not let me automate it.

The bump to v8 as applied in #26636 gave us no benefits and are giving problems with imports in certain cases. Maintainers have made it clear they won't offer any support for node 13, which we will want to support for a while as well.

In due time we'll replace this library with something simpler as the maintenance burden will be too high. For now we revert and pin to 3.4.0, the last stable version that does what we want.

Fixes #26812
