### PR TITLE
fix(gatsby-core-utils): Catch exceptions when releasing service locks

### DIFF
--- a/packages/gatsby-core-utils/src/service-lock.ts
+++ b/packages/gatsby-core-utils/src/service-lock.ts
@@ -58,9 +58,15 @@ export const createServiceLock = async (
   try {
     await fs.writeFile(serviceDataFile, JSON.stringify(content))
 
-    const unlock = await lockfile.lock(serviceDataFile, lockfileOptions)
+    const release = await lockfile.lock(serviceDataFile, lockfileOptions)
 
-    return unlock
+    return async function unlockService(): Promise<void> {
+      try {
+        await release()
+      } catch (err) {
+        // We can silently ignore this, because the error will just be if it's already unlocked
+      }
+    }
   } catch (err) {
     return null
   }


### PR DESCRIPTION
If a service lock is released more than once then it throws an exception. This isn't needed, and is causing lots of errors for users. This PR catches those errors.