### PR TITLE
tests(gatsby-recipes): Mock loading of readme from unpkg

### DIFF
--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.test.js
@@ -4,6 +4,10 @@ const tmp = require(`tmp-promise`)
 const resourceSchema = require(`../resource-schema`)
 const Joi = require(`@hapi/joi`)
 const plugin = require(`./plugin`)
+jest.mock(`node-fetch`, () => require(`fetch-mock-jest`).sandbox())
+const { mockReadmeLoader } = require(`../../test-helper`)
+mockReadmeLoader()
+
 const {
   addPluginToConfig,
   getPluginsFromConfig,

--- a/packages/gatsby-recipes/src/providers/gatsby/shadow-file.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/shadow-file.test.js
@@ -1,5 +1,8 @@
 const path = require(`path`)
 const rimraf = require(`rimraf`)
+jest.mock(`node-fetch`, () => require(`fetch-mock-jest`).sandbox())
+const { mockReadmeLoader } = require(`../../test-helper`)
+mockReadmeLoader()
 
 const resourceTestHelper = require(`../resource-test-helper`)
 

--- a/packages/gatsby-recipes/src/providers/gatsby/site-metadata.test.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/site-metadata.test.js
@@ -3,6 +3,10 @@ const path = require(`path`)
 const tmp = require(`tmp-promise`)
 
 const plugin = require(`./site-metadata`)
+
+jest.mock(`node-fetch`, () => require(`fetch-mock-jest`).sandbox())
+const { mockReadmeLoader } = require(`../../test-helper`)
+mockReadmeLoader()
 const resourceTestHelper = require(`../resource-test-helper`)
 
 const STARTER_BLOG_FIXTURE = path.join(

--- a/packages/gatsby-recipes/src/test-helper.js
+++ b/packages/gatsby-recipes/src/test-helper.js
@@ -1,0 +1,6 @@
+jest.mock(`node-fetch`, () => require(`fetch-mock-jest`).sandbox())
+import fetch from "node-fetch"
+
+export function mockReadmeLoader() {
+  fetch.mock(/^https:\/\/unpkg.com\/.+/, `README`)
+}


### PR DESCRIPTION
The recipes plugin provider loads package READMEs from upkg.com. It's bad practice (and slow) to load things from the network in unit tests. This PR mocks node-fetch so that it returns a static value for READMEs when testing.