### PR TITLE
Allow for double slashes on windows

### DIFF
--- a/packages/gatsby/src/utils/__tests__/test-require-error.ts
+++ b/packages/gatsby/src/utils/__tests__/test-require-error.ts
@@ -20,7 +20,12 @@ describe(`test-require-error`, () => {
     }
   })
   it(`handles windows paths with double slashes`, () => {
-    expect(testRequireError(`C:\\fixtures\\nothing`, `Error: Cannot find module 'C:\\\\fixtures\\\\nothing'`)).toEqual(true);
+    expect(
+      testRequireError(
+        `C:\\fixtures\\nothing`,
+        `Error: Cannot find module 'C:\\\\fixtures\\\\nothing'`
+      )
+    ).toEqual(true)
   })
   it(`Only returns true on not found errors for actual module not "not found" errors of requires inside the module`, () => {
     try {

--- a/packages/gatsby/src/utils/__tests__/test-require-error.ts
+++ b/packages/gatsby/src/utils/__tests__/test-require-error.ts
@@ -19,6 +19,9 @@ describe(`test-require-error`, () => {
       ).toEqual(true)
     }
   })
+  it(`handles windows paths with double slashes`, () => {
+    expect(testRequireError(`C:\\fixtures\\nothing`, `Error: Cannot find module 'C:\\\\fixtures\\\\nothing'`)).toEqual(true);
+  })
   it(`Only returns true on not found errors for actual module not "not found" errors of requires inside the module`, () => {
     try {
       require(`./fixtures/bad-module-require`)

--- a/packages/gatsby/src/utils/test-require-error.ts
+++ b/packages/gatsby/src/utils/test-require-error.ts
@@ -16,6 +16,6 @@ export const testRequireError = (moduleName: string, err: any): boolean => {
       `\\$&`
     )}`
   )
-  const firstLine = err.toString().replace(/\\\\/g, `\\`).split(`\n`)[0];
+  const firstLine = err.toString().replace(/\\\\/g, `\\`).split(`\n`)[0]
   return regex.test(firstLine)
 }

--- a/packages/gatsby/src/utils/test-require-error.ts
+++ b/packages/gatsby/src/utils/test-require-error.ts
@@ -16,6 +16,6 @@ export const testRequireError = (moduleName: string, err: any): boolean => {
       `\\$&`
     )}`
   )
-  const firstLine = err.toString().replace(/\\\\/g, `\\`).split(`\n`)[0]
-  return regex.test(firstLine)
+  const [ firstLine ] = err.toString().split(`\n`)
+  return regex.test(firstLine.replace(`\\\\`, `\\`))
 }

--- a/packages/gatsby/src/utils/test-require-error.ts
+++ b/packages/gatsby/src/utils/test-require-error.ts
@@ -9,13 +9,13 @@ export const testRequireError = (moduleName: string, err: any): boolean => {
   ) {
     return true
   }
-
   const regex = new RegExp(
     `Error:\\s(\\S+\\s)?[Cc]annot find module\\s.${moduleName.replace(
       /[-/\\^$*+?.()|[\]{}]/g,
       `\\$&`
     )}`
   )
+
   const [firstLine] = err.toString().split(`\n`)
-  return regex.test(firstLine.replace(`\\\\`, `\\`))
+  return regex.test(firstLine.replace(/\\\\/g, `\\`))
 }

--- a/packages/gatsby/src/utils/test-require-error.ts
+++ b/packages/gatsby/src/utils/test-require-error.ts
@@ -16,6 +16,6 @@ export const testRequireError = (moduleName: string, err: any): boolean => {
       `\\$&`
     )}`
   )
-  const firstLine = err.toString().split(`\n`)[0]
+  const firstLine = err.toString().replace(/\\\\/g, '\\').split(`\n`)[0];
   return regex.test(firstLine)
 }

--- a/packages/gatsby/src/utils/test-require-error.ts
+++ b/packages/gatsby/src/utils/test-require-error.ts
@@ -16,6 +16,6 @@ export const testRequireError = (moduleName: string, err: any): boolean => {
       `\\$&`
     )}`
   )
-  const [ firstLine ] = err.toString().split(`\n`)
+  const [firstLine] = err.toString().split(`\n`)
   return regex.test(firstLine.replace(`\\\\`, `\\`))
 }


### PR DESCRIPTION
Windows powershell users will come across a false positive because of the double `\\` in file paths. 

More details on this fix here: https://github.com/gatsbyjs/gatsby/issues/17008

And the underlying issue + reproduction here: https://github.com/wesbos/master-gatsby/issues/28