### PR TITLE
Fix gatsby-plugin-manifest using withAssetPrefix in manifest file link, where it gets improperly sanitized

### DIFF
--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-ssr.js
@@ -30,8 +30,9 @@ describe(`gatsby-plugin-manifest`, () => {
     headComponents = []
   })
 
-  it(`Creates href attributes using pathPrefix`, () => {
-    global.__PATH_PREFIX__ = `/path-prefix`
+  it(`Creates href attributes using full pathPrefix for non-webmanifest links`, () => {
+    global.__BASE_PATH__ = `/base-path`
+    global.__PATH_PREFIX__ = `http://path-prefix.com${global.__BASE_PATH__}`
 
     onRenderBody(ssrArgs, {
       icon: defaultIcon,
@@ -39,12 +40,34 @@ describe(`gatsby-plugin-manifest`, () => {
     })
 
     headComponents
-      .filter(component => component.type === `link`)
+      .filter(
+        component =>
+          component.type === `link` && component.props.rel !== `manifest`
+      )
       .forEach(component => {
         expect(component.props.href).toEqual(
-          expect.stringMatching(/^\/path-prefix\//)
+          expect.stringMatching(new RegExp(`^${global.__PATH_PREFIX__}`))
         )
       })
+  })
+
+  it(`Creates href attributes using pathPrefix without assetPrefix for the webmanifest link`, () => {
+    global.__BASE_PATH__ = `/base-path`
+    global.__PATH_PREFIX__ = `http://path-prefix.com${global.__BASE_PATH__}`
+
+    onRenderBody(ssrArgs, {
+      icon: defaultIcon,
+      theme_color: `#000000`,
+    })
+
+    const component = headComponents.find(
+      component =>
+        component.type === `link` && component.props.rel === `manifest`
+    )
+
+    expect(component.props.href).toEqual(
+      expect.stringMatching(new RegExp(`^${global.__BASE_PATH__}`))
+    )
   })
 
   describe(`Manifest Link Generation`, () => {

--- a/packages/gatsby-plugin-manifest/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-browser.js
@@ -1,11 +1,9 @@
 /* global __MANIFEST_PLUGIN_HAS_LOCALISATION__ */
-import { withPrefix as fallbackWithPrefix, withAssetPrefix } from "gatsby"
+import { withPrefix } from "gatsby"
 import getManifestForPathname from "./get-manifest-pathname"
 
 // when we don't have localisation in our manifest, we tree shake everything away
 if (__MANIFEST_PLUGIN_HAS_LOCALISATION__) {
-  const withPrefix = withAssetPrefix || fallbackWithPrefix
-
   exports.onRouteUpdate = function ({ location }, pluginOptions) {
     const { localize } = pluginOptions
     const manifestFilename = getManifestForPathname(location.pathname, localize)

--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -63,7 +63,7 @@ exports.onRenderBody = (
     <link
       key={`gatsby-plugin-manifest-link`}
       rel="manifest"
-      href={withPrefix(`/${manifestFileName}`)}
+      href={fallbackWithPrefix(`/${manifestFileName}`)}
       crossOrigin={crossOrigin}
     />
   )


### PR DESCRIPTION
## Description
`gatsby-plugin-manifest` adds a `<link>` element to the head (via `gatsby-ssr.js`'s `onRednerBody` export) which links to the `manifest.webmanifest` file that is created during build. In the `href` attribute, Gatsby's `withAssetPrefix` util is used, so as to prefix the file path both with a `pathPrefix` and an `assetPrefix`, if either or both are set. While this is appropriate for other files generated by this plugin (e.g. icon files), it's not appropriate in the case of the manifest file, because Gatsby's core utils run these components through a sanitation step that explicitly and specifically strips away the `assetPrefix` portion of a `<link>`'s `href` if and only if that element has `rel="manifest"`. For reference, see the source code where this sanitation occurs: https://github.com/gatsbyjs/gatsby/blob/a264c45f4fcab77ea81bc580d8af96b304ff1e29/packages/gatsby/cache-dir/static-entry.js#L114-L126 and [the docs](https://www.gatsbyjs.com/docs/asset-prefix/#usage-with-gatsby-plugin-offline) for the motivation.

If `assetPrefix` is set in the project's config, the result of it being stripped from the composite `href` string in the manifest file's `<link>` is a leftover leading slash, which makes the browser misinterpret it as an absolute URL instead of a path under the current host.

To reproduce:
1. clone [this minimal reproduction repo](https://github.com/nonAlgebraic/gatsby-bug-manifest-asset-strip-bug-repro), which has `assetPrefix` set to "`assets`" in `gatsby-config.js`.
2. run `yarn build` (to build the site with the `--prefix-paths` flag).
3. Observe the `<head>` section in the generated `index.html` page.

**Expected result**
The manifest file is linked with `<link rel="manifest" href="/manifest.webmanifest/" />`, or at the very least `<link rel="manifest" href="/assets/manifest.webmanifest/" />`, though the latter is somewhat problematic.

**Actual result**
The manifest file is linked with `<link rel="manifest" href="//manifest.webmanifest/" />` (note the double forward slash, a consequence of stripping only the string "`assets`" from the expected `href` value), which naturally causes a 404 error in the browser as it attempts to retrieve the file from "`http://manifest.webmanifest`".

This PR changes `gatsby-ssr.js` and `gatsby-browser.js` in the manifest plugin to use the non-asset-prefixed `withPrefix` Gatsby util, instead of `withAssetPrefix`, to prefix the path of the manifest file.