### PR TITLE
fix(gatsby): Run actions while recreating pages and draining mutation queue

### DIFF
--- a/packages/gatsby/src/state-machines/data-layer/actions.ts
+++ b/packages/gatsby/src/state-machines/data-layer/actions.ts
@@ -2,7 +2,6 @@ import { assign, DoneInvokeEvent, ActionFunctionMap } from "xstate"
 import { createGraphQLRunner } from "../../bootstrap/create-graphql-runner"
 import reporter from "gatsby-cli/lib/reporter"
 import { IDataLayerContext } from "./types"
-import { callApi, markNodesDirty } from "../develop/actions"
 import { assertStore } from "../../utils/assert-store"
 import { GraphQLRunner } from "../../query/graphql-runner"
 
@@ -40,6 +39,4 @@ export const assignGraphQLRunners = assign<IDataLayerContext>(
 export const dataLayerActions: ActionFunctionMap<IDataLayerContext, any> = {
   assignChangedPages,
   assignGraphQLRunners,
-  callApi,
-  markNodesDirty,
 }

--- a/packages/gatsby/src/state-machines/data-layer/index.ts
+++ b/packages/gatsby/src/state-machines/data-layer/index.ts
@@ -45,7 +45,6 @@ const initialCreatePagesStates: StatesConfig<IDataLayerContext, any, any> = {
     },
   },
   creatingPages: {
-    on: { ADD_NODE_MUTATION: { actions: [`markNodesDirty`, `callApi`] } },
     invoke: {
       id: `creating-pages`,
       src: `createPages`,
@@ -94,7 +93,6 @@ const recreatePagesStates: StatesConfig<IDataLayerContext, any, any> = {
     },
   },
   creatingPages: {
-    on: { ADD_NODE_MUTATION: { actions: [`markNodesDirty`, `callApi`] } },
     invoke: {
       id: `creating-pages`,
       src: `createPages`,

--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -134,8 +134,8 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
             target: `waiting`,
             actions: `panicBecauseOfInfiniteLoop`,
             cond: ({
-              nodesMutatedDuringQueryRun,
-              nodesMutatedDuringQueryRunRecompileCount,
+              nodesMutatedDuringQueryRun = false,
+              nodesMutatedDuringQueryRunRecompileCount = 0,
             }: IBuildContext): boolean =>
               nodesMutatedDuringQueryRun &&
               nodesMutatedDuringQueryRunRecompileCount >= RECOMPILE_PANIC_LIMIT,
@@ -280,6 +280,12 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
     },
     // Rebuild pages if a node has been mutated outside of sourceNodes
     recreatingPages: {
+      on: {
+        // We need to run mutations immediately when in this state
+        ADD_NODE_MUTATION: {
+          actions: `callApi`,
+        },
+      },
       invoke: {
         id: `recreate-pages`,
         src: `recreatePages`,

--- a/packages/gatsby/src/state-machines/waiting/actions.ts
+++ b/packages/gatsby/src/state-machines/waiting/actions.ts
@@ -4,9 +4,16 @@ import {
   ActionFunctionMap,
   sendParent,
   AnyEventObject,
+  ActionFunction,
 } from "xstate"
 import { IWaitingContext } from "./types"
 import { AnyAction } from "redux"
+import { callRealApi } from "../../utils/call-deferred-api"
+
+export const callApi: ActionFunction<IWaitingContext, AnyEventObject> = (
+  { store },
+  event
+) => callRealApi(event.payload, store)
 
 /**
  * Event handler used when we're not ready to process node mutations.
@@ -29,4 +36,5 @@ export const extractQueries = sendParent<IWaitingContext, AnyEventObject>(
 export const waitingActions: ActionFunctionMap<IWaitingContext, AnyAction> = {
   addNodeMutation,
   extractQueries,
+  callApi,
 }

--- a/packages/gatsby/src/state-machines/waiting/index.ts
+++ b/packages/gatsby/src/state-machines/waiting/index.ts
@@ -4,7 +4,8 @@ import { waitingActions } from "./actions"
 import { waitingServices } from "./services"
 
 const NODE_MUTATION_BATCH_SIZE = 100
-const NODE_MUTATION_BATCH_TIMEOUT = 1000
+const NODE_MUTATION_BATCH_TIMEOUT = 500
+const FILE_CHANGE_AGGREGATION_TIMEOUT = 200
 
 export type WaitingResult = Pick<IWaitingContext, "nodeMutationBatch">
 
@@ -45,7 +46,7 @@ export const waitingStates: MachineConfig<IWaitingContext, any, any> = {
       // we won't pick up the changed files
       after: {
         // The aggregation timeout
-        200: {
+        [FILE_CHANGE_AGGREGATION_TIMEOUT]: {
           actions: `extractQueries`,
           target: `idle`,
         },
@@ -98,9 +99,9 @@ export const waitingStates: MachineConfig<IWaitingContext, any, any> = {
         }
       }),
       on: {
-        // While we're running the batch we need to batch any incoming mutations too
+        // While we're running the batch we will also run new actions, as these may be cascades
         ADD_NODE_MUTATION: {
-          actions: `addNodeMutation`,
+          actions: `callApi`,
         },
       },
       invoke: {


### PR DESCRIPTION
Previously we were batching node mutations when re-creating pages (i.e. running create pages after a data change), and while running a batch of enqueued mutations triggered in idle state. This was causing problems for MDX, which was having to repeatedly run builds as multiple cascading mutations were triggered and enqueued while rebuilding a page. This changes them to run immediately, meaning cascading actions can run in one go.