### PR TITLE
fix(gatsby): Handle node mutations immediately after file change

### DIFF
--- a/packages/gatsby/src/state-machines/waiting/index.ts
+++ b/packages/gatsby/src/state-machines/waiting/index.ts
@@ -54,6 +54,7 @@ export const waitingStates: MachineConfig<IWaitingContext, any, any> = {
       on: {
         ADD_NODE_MUTATION: {
           actions: `addNodeMutation`,
+          target: `batchingNodeMutations`,
         },
         SOURCE_FILE_CHANGED: {
           target: undefined,


### PR DESCRIPTION
Fix to ensure that if a node mutation arrives immediately after a file change, it correctly transitions to re-running queries. This was causing updates to go missing in develop for some sites. This fixes the `Warning: Event "xstate.after(1000)#waitingMachine.batchingNodeMutations" was sent to stopped service "waitingMachine". This service has already reached its final state, and will not transition.
Event: {"type":"xstate.after(1000)#waitingMachine.batchingNodeMutations"}` message too.

Related bugs: #26443, #26192, #26839