### PR TITLE
feat(gatsby): start telemetry server on gatsby develop for Admin

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -184,6 +184,9 @@ module.exports = async (program: IProgram): Promise<void> => {
   // So we want to early just force it to a number to ensure we always act on a correct type.
   program.port = parseInt(program.port + ``, 10)
   const developProcessPath = slash(require.resolve(`./develop-process`))
+  const telemetryServerPath = slash(
+    require.resolve(`../utils/telemetry-server`)
+  )
 
   try {
     program.port = await detectPortInUseAndPrompt(program.port)
@@ -206,8 +209,13 @@ module.exports = async (program: IProgram): Promise<void> => {
   // It is exposed for environments where port access needs to be explicit, such as with Docker.
   // As the port is meant for internal usage only, any attempt to interface with features
   // it exposes via third-party software is not supported.
-  const [statusServerPort, developPort] = await Promise.all([
+  const [
+    statusServerPort,
+    developPort,
+    telemetryServerPort,
+  ] = await Promise.all([
     getRandomPort(process.env.INTERNAL_STATUS_PORT),
+    getRandomPort(),
     getRandomPort(),
   ])
 
@@ -273,6 +281,13 @@ module.exports = async (program: IProgram): Promise<void> => {
     debugInfo
   )
 
+  const telemetryServerProcess = new ControllableScript(
+    `require(${JSON.stringify(telemetryServerPath)}).default(${JSON.stringify(
+      telemetryServerPort
+    )})`,
+    null
+  )
+
   let unlocks: Array<UnlockFn> = []
   if (!isCI()) {
     const statusUnlock = await createServiceLock(
@@ -287,6 +302,13 @@ module.exports = async (program: IProgram): Promise<void> => {
       `developproxy`,
       {
         port: proxyPort,
+      }
+    )
+    const telemetryUnlock = await createServiceLock(
+      program.directory,
+      `telemetryserver`,
+      {
+        port: telemetryServerPort,
       }
     )
     await updateSiteMetadata({
@@ -307,7 +329,7 @@ module.exports = async (program: IProgram): Promise<void> => {
       process.exit(1)
     }
 
-    unlocks = unlocks.concat([statusUnlock, developUnlock])
+    unlocks = unlocks.concat([statusUnlock, developUnlock, telemetryUnlock])
   }
 
   const statusServer = http.createServer().listen(statusServerPort)
@@ -344,6 +366,8 @@ module.exports = async (program: IProgram): Promise<void> => {
 
   developProcess.start()
   developProcess.onMessage(handleChildProcessIPC)
+
+  telemetryServerProcess.start()
 
   // Plugins can call `process.exit` which would be sent to `develop-process` (child process)
   // This needs to be propagated back to the parent process
@@ -411,6 +435,7 @@ module.exports = async (program: IProgram): Promise<void> => {
     await shutdownServices(
       {
         developProcess,
+        telemetryServerProcess,
         unlocks,
         statusServer,
         proxy,
@@ -426,6 +451,7 @@ module.exports = async (program: IProgram): Promise<void> => {
     await shutdownServices(
       {
         developProcess,
+        telemetryServerProcess,
         unlocks,
         statusServer,
         proxy,
@@ -441,6 +467,7 @@ module.exports = async (program: IProgram): Promise<void> => {
     shutdownServices(
       {
         developProcess,
+        telemetryServerProcess,
         unlocks,
         statusServer,
         proxy,
@@ -451,11 +478,19 @@ module.exports = async (program: IProgram): Promise<void> => {
   })
 }
 function shutdownServices(
-  { statusServer, developProcess, proxy, unlocks, watcher },
+  {
+    statusServer,
+    developProcess,
+    proxy,
+    unlocks,
+    watcher,
+    telemetryServerProcess,
+  },
   signal: NodeJS.Signals
 ): Promise<void> {
   const services = [
     developProcess.stop(signal),
+    telemetryServerProcess.stop(),
     watcher?.close(),
     new Promise(resolve => statusServer.close(resolve)),
     new Promise(resolve => proxy.server.close(resolve)),

--- a/packages/gatsby/src/utils/telemetry-server.ts
+++ b/packages/gatsby/src/utils/telemetry-server.ts
@@ -22,12 +22,19 @@ const ROUTES = {
   trackEvent: trackCli,
 }
 
-const port = process.env.PORT
-if (!port)
-  throw new Error(
-    `Please specify the PORT environment variable to use the telemetry-server.`
-  )
 const app = express()
+
+// Overview over all possible routes at /
+app.get(`/`, (req, res) => {
+  res.set(`Content-Type`, `text/html`)
+  res.send(
+    `<ul>
+      ${Object.keys(ROUTES)
+        .map(route => `<li><a href="/${route}">/${route}</a></li>`)
+        .join(`\n`)}
+    </ul>`
+  )
+})
 
 Object.keys(ROUTES).map(route => {
   app.post(`/${route}`, bodyParser.json(), (req, res) => {
@@ -51,6 +58,7 @@ Object.keys(ROUTES).map(route => {
   })
 })
 
-startBackgroundUpdate()
-app.listen(port)
-console.log(`Telemetry service listening at http://localhost:${port}.`)
+export default function startTelemetryServer(port: number): void {
+  startBackgroundUpdate()
+  app.listen(port)
+}


### PR DESCRIPTION
As we noticed in #26627, gatsby-telemetry can only run in a node context. In order to add telemetry to Admin we created a HTTP server that exposes the telemetry methods for Admin to POST to in #26832.

This PR starts said telemetry server on `gatsby develop` and stores it as a service for Admin to discover.
