### PR TITLE
feat(gatsby): Add default schema type for siteMetadata

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/types/site-data.js
+++ b/e2e-tests/development-runtime/cypress/integration/types/site-data.js
@@ -1,0 +1,37 @@
+describe(`the site data object`, () => {
+  beforeEach(() => {
+    cy.visit(`/site-data`)
+  })
+
+  it(`includes the title`, () => {
+    cy.getTestElement(`title`)
+      .invoke(`text`)
+      .should(`equal`, `Gatsby Default Starter`)
+  })
+
+  it(`includes site host`, () => {
+    cy.getTestElement(`host`).invoke(`text`).should(`equal`, `localhost`)
+  })
+
+  it(`default description is null`, () => {
+    cy.getTestElement(`description`)
+      .invoke(`text`)
+      .should(`equal`, `description is null`)
+  })
+
+  it(`includes nested metadata`, () => {
+    cy.getTestElement(`twitter`).invoke(`text`).should(`equal`, `kylemathews`)
+  })
+
+  it(`can recognise valid date strings`, () => {
+    cy.getTestElement(`validdate`)
+      .invoke(`text`)
+      .should(`equal`, `Invalid dates can be detected`)
+  })
+
+  it(`includes valid build time`, () => {
+    cy.getTestElement(`buildtime`)
+      .invoke(`text`)
+      .should(`equal`, `buildTime is valid`)
+  })
+})

--- a/e2e-tests/development-runtime/gatsby-config.js
+++ b/e2e-tests/development-runtime/gatsby-config.js
@@ -6,7 +6,6 @@ require(`isomorphic-fetch`)
 module.exports = {
   siteMetadata: {
     title: `Gatsby Default Starter`,
-    description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
     author: `@gatsbyjs`,
     social: {
       twitter: `kylemathews`,

--- a/e2e-tests/development-runtime/src/pages/site-data.js
+++ b/e2e-tests/development-runtime/src/pages/site-data.js
@@ -1,0 +1,47 @@
+import React from "react"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+import { useStaticQuery } from "gatsby"
+
+const SiteType = () => {
+  const data = useStaticQuery(graphql`
+    query SiteTypeQuery {
+      site {
+        buildTime
+        host
+        siteMetadata {
+          description
+          social {
+            twitter
+          }
+          title
+        }
+      }
+    }
+  `)
+
+  return (
+    <Layout>
+      <SEO title="Site Data" />
+      <p data-testid="title">{data.site.siteMetadata.title}</p>
+      <p data-testid="description">
+        {data.site.siteMetadata.description === null
+          ? "description is null"
+          : "description is not null"}
+      </p>
+      <p data-testid="twitter">{data.site.siteMetadata.social.twitter}</p>
+      <p data-testid="buildtime">
+        {new Date(data.site.buildTime).toString() !== "Invalid Date" &&
+          "buildTime is valid"}
+      </p>
+      <p data-testid="validdate">
+        {new Date("Invalid").toString() === "Invalid Date" &&
+          "Invalid dates can be detected"}
+      </p>
+      <p data-testid="host">{data.site.host}</p>
+    </Layout>
+  )
+}
+
+export default SiteType

--- a/e2e-tests/production-runtime/cypress/integration/types/site-data.js
+++ b/e2e-tests/production-runtime/cypress/integration/types/site-data.js
@@ -1,0 +1,29 @@
+describe(`the site data object`, () => {
+  beforeEach(() => {
+    cy.visit(`/site-data`)
+  })
+
+  it(`includes the title`, () => {
+    cy.getTestElement(`title`)
+      .invoke(`text`)
+      .should(`equal`, `Gatsby Default Starter`)
+  })
+
+  it(`description is overriden by value in config`, () => {
+    cy.getTestElement(`description`)
+      .invoke(`text`)
+      .should(`equal`, `This is site for production runtime e2e tests`)
+  })
+
+  it(`can recognise valid date strings`, () => {
+    cy.getTestElement(`validdate`)
+      .invoke(`text`)
+      .should(`equal`, `Invalid dates can be detected`)
+  })
+
+  it(`includes valid build time`, () => {
+    cy.getTestElement(`buildtime`)
+      .invoke(`text`)
+      .should(`equal`, `buildTime is valid`)
+  })
+})

--- a/e2e-tests/production-runtime/src/pages/site-data.js
+++ b/e2e-tests/production-runtime/src/pages/site-data.js
@@ -1,7 +1,6 @@
 import React from "react"
 
 import Layout from "../components/layout"
-import SEO from "../components/seo"
 import { useStaticQuery, graphql } from "gatsby"
 
 const SiteType = () => {
@@ -9,12 +8,8 @@ const SiteType = () => {
     query SiteTypeQuery {
       site {
         buildTime
-        host
         siteMetadata {
           description
-          social {
-            twitter
-          }
           title
         }
       }
@@ -23,14 +18,8 @@ const SiteType = () => {
 
   return (
     <Layout>
-      <SEO title="Site Data" />
       <p data-testid="title">{data.site.siteMetadata.title}</p>
-      <p data-testid="description">
-        {data.site.siteMetadata.description === null
-          ? "description is null"
-          : "description is not null"}
-      </p>
-      <p data-testid="twitter">{data.site.siteMetadata.social.twitter}</p>
+      <p data-testid="description">{data.site.siteMetadata.description}</p>
       <p data-testid="buildtime">
         {new Date(data.site.buildTime).toString() !== "Invalid Date" &&
           "buildTime is valid"}
@@ -39,7 +28,6 @@ const SiteType = () => {
         {new Date("Invalid").toString() === "Invalid Date" &&
           "Invalid dates can be detected"}
       </p>
-      <p data-testid="host">{data.site.host}</p>
     </Layout>
   )
 }

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -148,6 +148,11 @@ exports.createSchemaCustomization = ({ actions }) => {
   const typeDefs = `
     type Site implements Node {
       buildTime: Date @dateformat
+      siteMetadata: SiteMetadata
+    }
+    type SiteMetadata {
+      title: String
+      description: String
     }
   `
   createTypes(typeDefs)

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -148,9 +148,9 @@ exports.createSchemaCustomization = ({ actions }) => {
   const typeDefs = `
     type Site implements Node {
       buildTime: Date @dateformat
-      siteMetadata: InternalSiteMetadata
+      siteMetadata: SiteSiteMetadata
     }
-    type InternalSiteMetadata {
+    type SiteSiteMetadata {
       title: String
       description: String
     }

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -148,9 +148,9 @@ exports.createSchemaCustomization = ({ actions }) => {
   const typeDefs = `
     type Site implements Node {
       buildTime: Date @dateformat
-      siteMetadata: SiteMetadata
+      siteMetadata: InternalSiteMetadata
     }
-    type SiteMetadata {
+    type InternalSiteMetadata {
       title: String
       description: String
     }

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -343,7 +343,8 @@ const mergeTypes = ({
   if (
     !plugin ||
     plugin.name === `default-site-plugin` ||
-    plugin.name === typeOwner
+    plugin.name === typeOwner ||
+    typeComposer.getTypeName() === `SiteSiteMetadata`
   ) {
     if (type instanceof ObjectTypeComposer) {
       mergeFields({ typeComposer, fields: type.getFields() })


### PR DESCRIPTION
All starters use the `siteMetadata` field on `Site` to get the title and description to put in the header. However, if you delete that section from gatsby-config then the schema for that field isn't inferred and you get a GraphQL error `Cannot query field "siteMetadata" on type "Site"`. This is a very common error in the wild. Papercuts!

This PR creates a schema customisation that adds default fields of `title` and `description` to `Site.siteMetadata`. These are nullable, which is fine, but the queries in all of our starters will no longer break if a user removes that part of the config. 