### PR TITLE
fix: a11y in gatsby-remark-prismjs

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-prismjs/src/__tests__/__snapshots__/index.js.snap
@@ -94,7 +94,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\"><pre class=\\"custom-js\\"><code class=\\"custom-js\\"><span class=\\"token comment\\">// Fake</span></code></pre></div>",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\" tabindex=\\"0\\"><pre class=\\"custom-js\\"><code class=\\"custom-js\\"><span class=\\"token comment\\">// Fake</span></code></pre></div>",
     },
   ],
   "position": Object {
@@ -135,7 +135,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"javascript\\"><pre class=\\"language-javascript\\"><code class=\\"language-javascript\\"><span class=\\"token comment\\">// Fake</span></code></pre></div>",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"javascript\\" tabindex=\\"0\\"><pre class=\\"language-javascript\\"><code class=\\"language-javascript\\"><span class=\\"token comment\\">// Fake</span></code></pre></div>",
     },
   ],
   "position": Object {
@@ -176,7 +176,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"foobar\\"><pre class=\\"language-foobar\\"><code class=\\"language-foobar\\">// Fake</code></pre></div>",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"foobar\\" tabindex=\\"0\\"><pre class=\\"language-foobar\\"><code class=\\"language-foobar\\">// Fake</code></pre></div>",
     },
   ],
   "position": Object {
@@ -217,7 +217,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\"><pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">// Fake</span></code></pre></div>",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\" tabindex=\\"0\\"><pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">// Fake</span></code></pre></div>",
     },
   ],
   "position": Object {
@@ -260,7 +260,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight has-highlighted-lines\\" data-language=\\"js\\"><pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">// 1</span>
+      "value": "<div class=\\"gatsby-highlight has-highlighted-lines\\" data-language=\\"js\\" tabindex=\\"0\\"><pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">// 1</span>
 <span class=\\"gatsby-highlight-code-line\\"><span class=\\"token comment\\">// 2</span></span><span class=\\"token comment\\">// 3</span></code></pre></div>",
     },
   ],
@@ -523,7 +523,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\"><pre style=\\"counter-reset: linenumber NaN\\" class=\\"language-js line-numbers\\"><code class=\\"language-js\\"><span class=\\"token comment\\">//.foo { </span>
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\" tabindex=\\"0\\"><pre style=\\"counter-reset: linenumber NaN\\" class=\\"language-js line-numbers\\"><code class=\\"language-js\\"><span class=\\"token comment\\">//.foo { </span>
 color<span class=\\"token operator\\">:</span> red<span class=\\"token punctuation\\">;</span>
  <span class=\\"token punctuation\\">}</span>\`</code><span aria-hidden=\\"true\\" class=\\"line-numbers-rows\\" style=\\"white-space: normal; width: auto; left: 0;\\"><span></span><span></span><span></span></span></pre></div>",
     },
@@ -567,7 +567,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\"><pre style=\\"counter-reset: linenumber 4\\" class=\\"language-js line-numbers\\"><code class=\\"language-js\\"><span class=\\"token comment\\">//.foo { </span>
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\" tabindex=\\"0\\"><pre style=\\"counter-reset: linenumber 4\\" class=\\"language-js line-numbers\\"><code class=\\"language-js\\"><span class=\\"token comment\\">//.foo { </span>
 color<span class=\\"token operator\\">:</span> red<span class=\\"token punctuation\\">;</span>
  <span class=\\"token punctuation\\">}</span>\`</code><span aria-hidden=\\"true\\" class=\\"line-numbers-rows\\" style=\\"white-space: normal; width: auto; left: 0;\\"><span></span><span></span><span></span></span></pre></div>",
     },
@@ -611,7 +611,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\"><pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">//.foo { </span>
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"js\\" tabindex=\\"0\\"><pre class=\\"language-js\\"><code class=\\"language-js\\"><span class=\\"token comment\\">//.foo { </span>
 color<span class=\\"token operator\\">:</span> red<span class=\\"token punctuation\\">;</span>
  <span class=\\"token punctuation\\">}</span>\`</code></pre></div>",
     },
@@ -653,7 +653,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=root data-host=server></span></span><span class=\\"token builtin class-name\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\" tabindex=\\"0\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=root data-host=server></span></span><span class=\\"token builtin class-name\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
     },
   ],
   "position": Object {
@@ -693,7 +693,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=alice data-host=server></span></span><span class=\\"token builtin class-name\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\" tabindex=\\"0\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=alice data-host=server></span></span><span class=\\"token builtin class-name\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
     },
   ],
   "position": Object {
@@ -733,7 +733,7 @@ Object {
         },
       },
       "type": "html",
-      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=alice data-host=localhost></span></span><span class=\\"token builtin class-name\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
+      "value": "<div class=\\"gatsby-highlight\\" data-language=\\"bash\\" tabindex=\\"0\\"><pre class=\\"language-bash\\"><code class=\\"language-bash\\"><span class=\\"command-line-prompt\\"><span data-user=alice data-host=localhost></span></span><span class=\\"token builtin class-name\\">echo</span> <span class=\\"token string\\">'test'</span>\`\`\`</code></pre></div>",
     },
   ],
   "position": Object {

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -106,7 +106,7 @@ module.exports = (
 
     // prettier-ignore
     node.value = ``
-    + `<div class="${highlightClassName}" data-language="${languageName}">`
+    + `<div class="${highlightClassName}" data-language="${languageName}" tabindex="0">`
     +   `<pre${numLinesStyle} class="${className}${numLinesClass}">`
     +     `<code class="${className}">`
     +       `${useCommandLine ? commandLine(node.value, outputLines, promptUser, promptHost) : ``}`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

If you run axe on a blog post with prismjs that has scroll bars you get the
following a11y issue ` scrollable-region-focusable`.
 https://dequeuniversity.com/rules/axe/3.4/scrollable-region-focusable?application=axeAPI
 Ading in `tabindex=0` fixes this issue, as this allow user to navigate
 using keyboard.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
