### PR TITLE
feat(gatsby): add `Site` and `SiteSiteMetadata` to built-in GraphQL types

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/types/site-data.js
+++ b/e2e-tests/development-runtime/cypress/integration/types/site-data.js
@@ -1,0 +1,37 @@
+describe(`the site data object`, () => {
+  beforeEach(() => {
+    cy.visit(`/site-data`)
+  })
+
+  it(`includes the title`, () => {
+    cy.getTestElement(`title`)
+      .invoke(`text`)
+      .should(`equal`, `Gatsby Default Starter`)
+  })
+
+  it(`includes site host`, () => {
+    cy.getTestElement(`host`).invoke(`text`).should(`equal`, `localhost`)
+  })
+
+  it(`default description is null`, () => {
+    cy.getTestElement(`description`)
+      .invoke(`text`)
+      .should(`equal`, `description is null`)
+  })
+
+  it(`includes nested metadata`, () => {
+    cy.getTestElement(`twitter`).invoke(`text`).should(`equal`, `kylemathews`)
+  })
+
+  it(`can recognise valid date strings`, () => {
+    cy.getTestElement(`validdate`)
+      .invoke(`text`)
+      .should(`equal`, `Invalid dates can be detected`)
+  })
+
+  it(`includes valid build time`, () => {
+    cy.getTestElement(`buildtime`)
+      .invoke(`text`)
+      .should(`equal`, `buildTime is valid`)
+  })
+})

--- a/e2e-tests/development-runtime/gatsby-config.js
+++ b/e2e-tests/development-runtime/gatsby-config.js
@@ -6,7 +6,6 @@ require(`isomorphic-fetch`)
 module.exports = {
   siteMetadata: {
     title: `Gatsby Default Starter`,
-    description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
     author: `@gatsbyjs`,
     social: {
       twitter: `kylemathews`,

--- a/e2e-tests/development-runtime/src/pages/site-data.js
+++ b/e2e-tests/development-runtime/src/pages/site-data.js
@@ -1,0 +1,47 @@
+import React from "react"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+import { useStaticQuery } from "gatsby"
+
+const SiteType = () => {
+  const data = useStaticQuery(graphql`
+    query SiteTypeQuery {
+      site {
+        buildTime
+        host
+        siteMetadata {
+          description
+          social {
+            twitter
+          }
+          title
+        }
+      }
+    }
+  `)
+
+  return (
+    <Layout>
+      <SEO title="Site Data" />
+      <p data-testid="title">{data.site.siteMetadata.title}</p>
+      <p data-testid="description">
+        {data.site.siteMetadata.description === null
+          ? "description is null"
+          : "description is not null"}
+      </p>
+      <p data-testid="twitter">{data.site.siteMetadata.social.twitter}</p>
+      <p data-testid="buildtime">
+        {new Date(data.site.buildTime).toString() !== "Invalid Date" &&
+          "buildTime is valid"}
+      </p>
+      <p data-testid="validdate">
+        {new Date("Invalid").toString() === "Invalid Date" &&
+          "Invalid dates can be detected"}
+      </p>
+      <p data-testid="host">{data.site.host}</p>
+    </Layout>
+  )
+}
+
+export default SiteType

--- a/e2e-tests/production-runtime/cypress/integration/types/site-data.js
+++ b/e2e-tests/production-runtime/cypress/integration/types/site-data.js
@@ -1,0 +1,29 @@
+describe(`the site data object`, () => {
+  beforeEach(() => {
+    cy.visit(`/site-data`)
+  })
+
+  it(`includes the title`, () => {
+    cy.getTestElement(`title`)
+      .invoke(`text`)
+      .should(`equal`, `Gatsby Default Starter`)
+  })
+
+  it(`description is overriden by value in config`, () => {
+    cy.getTestElement(`description`)
+      .invoke(`text`)
+      .should(`equal`, `This is site for production runtime e2e tests`)
+  })
+
+  it(`can recognise valid date strings`, () => {
+    cy.getTestElement(`validdate`)
+      .invoke(`text`)
+      .should(`equal`, `Invalid dates can be detected`)
+  })
+
+  it(`includes valid build time`, () => {
+    cy.getTestElement(`buildtime`)
+      .invoke(`text`)
+      .should(`equal`, `buildTime is valid`)
+  })
+})

--- a/e2e-tests/production-runtime/src/pages/site-data.js
+++ b/e2e-tests/production-runtime/src/pages/site-data.js
@@ -1,7 +1,6 @@
 import React from "react"
 
 import Layout from "../components/layout"
-import SEO from "../components/seo"
 import { useStaticQuery, graphql } from "gatsby"
 
 const SiteType = () => {
@@ -9,12 +8,8 @@ const SiteType = () => {
     query SiteTypeQuery {
       site {
         buildTime
-        host
         siteMetadata {
           description
-          social {
-            twitter
-          }
           title
         }
       }
@@ -23,14 +18,8 @@ const SiteType = () => {
 
   return (
     <Layout>
-      <SEO title="Site Data" />
       <p data-testid="title">{data.site.siteMetadata.title}</p>
-      <p data-testid="description">
-        {data.site.siteMetadata.description === null
-          ? "description is null"
-          : "description is not null"}
-      </p>
-      <p data-testid="twitter">{data.site.siteMetadata.social.twitter}</p>
+      <p data-testid="description">{data.site.siteMetadata.description}</p>
       <p data-testid="buildtime">
         {new Date(data.site.buildTime).toString() !== "Invalid Date" &&
           "buildTime is valid"}
@@ -39,7 +28,6 @@ const SiteType = () => {
         {new Date("Invalid").toString() === "Invalid Date" &&
           "Invalid dates can be detected"}
       </p>
-      <p data-testid="host">{data.site.host}</p>
     </Layout>
   )
 }

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
@@ -36,7 +36,6 @@ Array [
     "name": "internal-data-bridge",
     "nodeAPIs": Array [
       "sourceNodes",
-      "createSchemaCustomization",
       "createResolvers",
       "onCreatePage",
     ],
@@ -250,7 +249,6 @@ Array [
     "name": "internal-data-bridge",
     "nodeAPIs": Array [
       "sourceNodes",
-      "createSchemaCustomization",
       "createResolvers",
       "onCreatePage",
     ],
@@ -494,7 +492,6 @@ Array [
     "name": "internal-data-bridge",
     "nodeAPIs": Array [
       "sourceNodes",
-      "createSchemaCustomization",
       "createResolvers",
       "onCreatePage",
     ],

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -143,16 +143,6 @@ exports.sourceNodes = ({ createContentDigest, actions, store }) => {
   })
 }
 
-exports.createSchemaCustomization = ({ actions }) => {
-  const { createTypes } = actions
-  const typeDefs = `
-    type Site implements Node {
-      buildTime: Date @dateformat
-    }
-  `
-  createTypes(typeDefs)
-}
-
 exports.createResolvers = ({ createResolvers }) => {
   const resolvers = {
     Site: {

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
@@ -897,8 +897,164 @@ type Query {
   allFile(filter: FileFilterInput, sort: FileSortInput, skip: Int, limit: Int): FileConnection!
   directory(sourceInstanceName: StringQueryOperatorInput, absolutePath: StringQueryOperatorInput, relativePath: StringQueryOperatorInput, extension: StringQueryOperatorInput, size: IntQueryOperatorInput, prettySize: StringQueryOperatorInput, modifiedTime: DateQueryOperatorInput, accessTime: DateQueryOperatorInput, changeTime: DateQueryOperatorInput, birthTime: DateQueryOperatorInput, root: StringQueryOperatorInput, dir: StringQueryOperatorInput, base: StringQueryOperatorInput, ext: StringQueryOperatorInput, name: StringQueryOperatorInput, relativeDirectory: StringQueryOperatorInput, dev: IntQueryOperatorInput, mode: IntQueryOperatorInput, nlink: IntQueryOperatorInput, uid: IntQueryOperatorInput, gid: IntQueryOperatorInput, rdev: IntQueryOperatorInput, ino: FloatQueryOperatorInput, atimeMs: FloatQueryOperatorInput, mtimeMs: FloatQueryOperatorInput, ctimeMs: FloatQueryOperatorInput, atime: DateQueryOperatorInput, mtime: DateQueryOperatorInput, ctime: DateQueryOperatorInput, birthtime: DateQueryOperatorInput, birthtimeMs: FloatQueryOperatorInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): Directory
   allDirectory(filter: DirectoryFilterInput, sort: DirectorySortInput, skip: Int, limit: Int): DirectoryConnection!
+  site(buildTime: DateQueryOperatorInput, siteMetadata: SiteSiteMetadataFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): Site
+  allSite(filter: SiteFilterInput, sort: SiteSortInput, skip: Int, limit: Int): SiteConnection!
   sitePage(path: StringQueryOperatorInput, component: StringQueryOperatorInput, internalComponentName: StringQueryOperatorInput, componentChunkName: StringQueryOperatorInput, matchPath: StringQueryOperatorInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): SitePage
   allSitePage(filter: SitePageFilterInput, sort: SitePageSortInput, skip: Int, limit: Int): SitePageConnection!
+}
+
+type Site implements Node {
+  buildTime(
+    \\"\\"\\"
+    Format the date using Moment.js' date tokens, e.g. \`date(formatString: \\"YYYY
+    MMMM DD\\")\`. See https://momentjs.com/docs/#/displaying/format/ for
+    documentation for different tokens.
+    \\"\\"\\"
+    formatString: String
+
+    \\"\\"\\"Returns a string generated with Moment.js' \`fromNow\` function\\"\\"\\"
+    fromNow: Boolean
+
+    \\"\\"\\"
+    Returns the difference between this date and the current time. Defaults to
+    \\"milliseconds\\" but you can also pass in as the measurement \\"years\\",
+    \\"months\\", \\"weeks\\", \\"days\\", \\"hours\\", \\"minutes\\", and \\"seconds\\".
+    \\"\\"\\"
+    difference: String
+
+    \\"\\"\\"Configures the locale Moment.js will use to format the date.\\"\\"\\"
+    locale: String
+  ): Date
+  siteMetadata: SiteSiteMetadata
+  id: ID!
+  parent: Node
+  children: [Node!]!
+  internal: Internal!
+}
+
+type SiteConnection {
+  totalCount: Int!
+  edges: [SiteEdge!]!
+  nodes: [Site!]!
+  pageInfo: PageInfo!
+  distinct(field: SiteFieldsEnum!): [String!]!
+  group(skip: Int, limit: Int, field: SiteFieldsEnum!): [SiteGroupConnection!]!
+}
+
+type SiteEdge {
+  next: Site
+  node: Site!
+  previous: Site
+}
+
+enum SiteFieldsEnum {
+  buildTime
+  siteMetadata___title
+  siteMetadata___description
+  id
+  parent___id
+  parent___parent___id
+  parent___parent___parent___id
+  parent___parent___parent___children
+  parent___parent___children
+  parent___parent___children___id
+  parent___parent___children___children
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___children
+  parent___children___id
+  parent___children___parent___id
+  parent___children___parent___children
+  parent___children___children
+  parent___children___children___id
+  parent___children___children___children
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  children
+  children___id
+  children___parent___id
+  children___parent___parent___id
+  children___parent___parent___children
+  children___parent___children
+  children___parent___children___id
+  children___parent___children___children
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___children
+  children___children___id
+  children___children___parent___id
+  children___children___parent___children
+  children___children___children
+  children___children___children___id
+  children___children___children___children
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+}
+
+input SiteFilterInput {
+  buildTime: DateQueryOperatorInput
+  siteMetadata: SiteSiteMetadataFilterInput
+  id: StringQueryOperatorInput
+  parent: NodeFilterInput
+  children: NodeFilterListInput
+  internal: InternalFilterInput
+}
+
+type SiteGroupConnection {
+  totalCount: Int!
+  edges: [SiteEdge!]!
+  nodes: [Site!]!
+  pageInfo: PageInfo!
+  field: String!
+  fieldValue: String
 }
 
 type SitePage implements Node {
@@ -1045,6 +1201,21 @@ type SitePageGroupConnection {
 
 input SitePageSortInput {
   fields: [SitePageFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+type SiteSiteMetadata {
+  title: String
+  description: String
+}
+
+input SiteSiteMetadataFilterInput {
+  title: StringQueryOperatorInput
+  description: StringQueryOperatorInput
+}
+
+input SiteSortInput {
+  fields: [SiteFieldsEnum]
   order: [SortOrderEnum] = [ASC]
 }
 

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
@@ -80,6 +80,16 @@ type Directory implements Node @dontInfer {
   birthtimeMs: Float @deprecated(reason: \\"Use \`birthTime\` instead\\")
 }
 
+type Site implements Node @dontInfer {
+  buildTime: Date @dateformat
+  siteMetadata: SiteSiteMetadata
+}
+
+type SiteSiteMetadata {
+  title: String
+  description: String
+}
+
 type SitePage implements Node @dontInfer {
   path: String!
   component: String!
@@ -210,6 +220,16 @@ type Directory implements Node @dontInfer {
   ctime: Date! @dateformat
   birthtime: Date @deprecated(reason: \\"Use \`birthTime\` instead\\")
   birthtimeMs: Float @deprecated(reason: \\"Use \`birthTime\` instead\\")
+}
+
+type Site implements Node @dontInfer {
+  buildTime: Date @dateformat
+  siteMetadata: SiteSiteMetadata
+}
+
+type SiteSiteMetadata {
+  title: String
+  description: String
 }
 
 type SitePage implements Node @dontInfer {
@@ -344,6 +364,16 @@ type Directory implements Node @dontInfer {
   ctime: Date! @dateformat
   birthtime: Date @deprecated(reason: \\"Use \`birthTime\` instead\\")
   birthtimeMs: Float @deprecated(reason: \\"Use \`birthTime\` instead\\")
+}
+
+type Site implements Node @dontInfer {
+  buildTime: Date @dateformat
+  siteMetadata: SiteSiteMetadata
+}
+
+type SiteSiteMetadata {
+  title: String
+  description: String
 }
 
 type SitePage implements Node @dontInfer {

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
@@ -897,8 +897,164 @@ type Query {
   allFile(filter: FileFilterInput, sort: FileSortInput, skip: Int, limit: Int): FileConnection!
   directory(sourceInstanceName: StringQueryOperatorInput, absolutePath: StringQueryOperatorInput, relativePath: StringQueryOperatorInput, extension: StringQueryOperatorInput, size: IntQueryOperatorInput, prettySize: StringQueryOperatorInput, modifiedTime: DateQueryOperatorInput, accessTime: DateQueryOperatorInput, changeTime: DateQueryOperatorInput, birthTime: DateQueryOperatorInput, root: StringQueryOperatorInput, dir: StringQueryOperatorInput, base: StringQueryOperatorInput, ext: StringQueryOperatorInput, name: StringQueryOperatorInput, relativeDirectory: StringQueryOperatorInput, dev: IntQueryOperatorInput, mode: IntQueryOperatorInput, nlink: IntQueryOperatorInput, uid: IntQueryOperatorInput, gid: IntQueryOperatorInput, rdev: IntQueryOperatorInput, ino: FloatQueryOperatorInput, atimeMs: FloatQueryOperatorInput, mtimeMs: FloatQueryOperatorInput, ctimeMs: FloatQueryOperatorInput, atime: DateQueryOperatorInput, mtime: DateQueryOperatorInput, ctime: DateQueryOperatorInput, birthtime: DateQueryOperatorInput, birthtimeMs: FloatQueryOperatorInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): Directory
   allDirectory(filter: DirectoryFilterInput, sort: DirectorySortInput, skip: Int, limit: Int): DirectoryConnection!
+  site(buildTime: DateQueryOperatorInput, siteMetadata: SiteSiteMetadataFilterInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): Site
+  allSite(filter: SiteFilterInput, sort: SiteSortInput, skip: Int, limit: Int): SiteConnection!
   sitePage(path: StringQueryOperatorInput, component: StringQueryOperatorInput, internalComponentName: StringQueryOperatorInput, componentChunkName: StringQueryOperatorInput, matchPath: StringQueryOperatorInput, id: StringQueryOperatorInput, parent: NodeFilterInput, children: NodeFilterListInput, internal: InternalFilterInput): SitePage
   allSitePage(filter: SitePageFilterInput, sort: SitePageSortInput, skip: Int, limit: Int): SitePageConnection!
+}
+
+type Site implements Node {
+  buildTime(
+    \\"\\"\\"
+    Format the date using Moment.js' date tokens, e.g. \`date(formatString: \\"YYYY
+    MMMM DD\\")\`. See https://momentjs.com/docs/#/displaying/format/ for
+    documentation for different tokens.
+    \\"\\"\\"
+    formatString: String
+
+    \\"\\"\\"Returns a string generated with Moment.js' \`fromNow\` function\\"\\"\\"
+    fromNow: Boolean
+
+    \\"\\"\\"
+    Returns the difference between this date and the current time. Defaults to
+    \\"milliseconds\\" but you can also pass in as the measurement \\"years\\",
+    \\"months\\", \\"weeks\\", \\"days\\", \\"hours\\", \\"minutes\\", and \\"seconds\\".
+    \\"\\"\\"
+    difference: String
+
+    \\"\\"\\"Configures the locale Moment.js will use to format the date.\\"\\"\\"
+    locale: String
+  ): Date
+  siteMetadata: SiteSiteMetadata
+  id: ID!
+  parent: Node
+  children: [Node!]!
+  internal: Internal!
+}
+
+type SiteConnection {
+  totalCount: Int!
+  edges: [SiteEdge!]!
+  nodes: [Site!]!
+  pageInfo: PageInfo!
+  distinct(field: SiteFieldsEnum!): [String!]!
+  group(skip: Int, limit: Int, field: SiteFieldsEnum!): [SiteGroupConnection!]!
+}
+
+type SiteEdge {
+  next: Site
+  node: Site!
+  previous: Site
+}
+
+enum SiteFieldsEnum {
+  buildTime
+  siteMetadata___title
+  siteMetadata___description
+  id
+  parent___id
+  parent___parent___id
+  parent___parent___parent___id
+  parent___parent___parent___children
+  parent___parent___children
+  parent___parent___children___id
+  parent___parent___children___children
+  parent___parent___internal___content
+  parent___parent___internal___contentDigest
+  parent___parent___internal___description
+  parent___parent___internal___fieldOwners
+  parent___parent___internal___ignoreType
+  parent___parent___internal___mediaType
+  parent___parent___internal___owner
+  parent___parent___internal___type
+  parent___children
+  parent___children___id
+  parent___children___parent___id
+  parent___children___parent___children
+  parent___children___children
+  parent___children___children___id
+  parent___children___children___children
+  parent___children___internal___content
+  parent___children___internal___contentDigest
+  parent___children___internal___description
+  parent___children___internal___fieldOwners
+  parent___children___internal___ignoreType
+  parent___children___internal___mediaType
+  parent___children___internal___owner
+  parent___children___internal___type
+  parent___internal___content
+  parent___internal___contentDigest
+  parent___internal___description
+  parent___internal___fieldOwners
+  parent___internal___ignoreType
+  parent___internal___mediaType
+  parent___internal___owner
+  parent___internal___type
+  children
+  children___id
+  children___parent___id
+  children___parent___parent___id
+  children___parent___parent___children
+  children___parent___children
+  children___parent___children___id
+  children___parent___children___children
+  children___parent___internal___content
+  children___parent___internal___contentDigest
+  children___parent___internal___description
+  children___parent___internal___fieldOwners
+  children___parent___internal___ignoreType
+  children___parent___internal___mediaType
+  children___parent___internal___owner
+  children___parent___internal___type
+  children___children
+  children___children___id
+  children___children___parent___id
+  children___children___parent___children
+  children___children___children
+  children___children___children___id
+  children___children___children___children
+  children___children___internal___content
+  children___children___internal___contentDigest
+  children___children___internal___description
+  children___children___internal___fieldOwners
+  children___children___internal___ignoreType
+  children___children___internal___mediaType
+  children___children___internal___owner
+  children___children___internal___type
+  children___internal___content
+  children___internal___contentDigest
+  children___internal___description
+  children___internal___fieldOwners
+  children___internal___ignoreType
+  children___internal___mediaType
+  children___internal___owner
+  children___internal___type
+  internal___content
+  internal___contentDigest
+  internal___description
+  internal___fieldOwners
+  internal___ignoreType
+  internal___mediaType
+  internal___owner
+  internal___type
+}
+
+input SiteFilterInput {
+  buildTime: DateQueryOperatorInput
+  siteMetadata: SiteSiteMetadataFilterInput
+  id: StringQueryOperatorInput
+  parent: NodeFilterInput
+  children: NodeFilterListInput
+  internal: InternalFilterInput
+}
+
+type SiteGroupConnection {
+  totalCount: Int!
+  edges: [SiteEdge!]!
+  nodes: [Site!]!
+  pageInfo: PageInfo!
+  field: String!
+  fieldValue: String
 }
 
 type SitePage implements Node {
@@ -1045,6 +1201,21 @@ type SitePageGroupConnection {
 
 input SitePageSortInput {
   fields: [SitePageFieldsEnum]
+  order: [SortOrderEnum] = [ASC]
+}
+
+type SiteSiteMetadata {
+  title: String
+  description: String
+}
+
+input SiteSiteMetadataFilterInput {
+  title: StringQueryOperatorInput
+  description: StringQueryOperatorInput
+}
+
+input SiteSortInput {
+  fields: [SiteFieldsEnum]
   order: [SortOrderEnum] = [ASC]
 }
 

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -23,6 +23,7 @@ const { getNode, getNodesByType } = require(`../redux/nodes`)
 const apiRunner = require(`../utils/api-runner-node`)
 const report = require(`gatsby-cli/lib/reporter`)
 const { addNodeInterfaceFields } = require(`./types/node-interface`)
+const { overridableBuiltInTypeNames } = require(`./types/built-in-types`)
 const { addInferredType, addInferredTypes } = require(`./infer`)
 const {
   findOne,
@@ -341,10 +342,14 @@ const mergeTypes = ({
   // The merge is considered safe when a user or a plugin owning the type extend this type
   // TODO: add proper conflicts detection and reporting (on the field level)
   const typeOwner = typeComposer.getExtension(`plugin`)
+  const isOverridableBuiltInType =
+    !typeOwner && overridableBuiltInTypeNames.has(typeComposer.getTypeName())
+
   const isSafeMerge =
     !plugin ||
     plugin.name === `default-site-plugin` ||
-    plugin.name === typeOwner
+    plugin.name === typeOwner ||
+    isOverridableBuiltInType
 
   if (!isSafeMerge) {
     if (typeOwner) {

--- a/packages/gatsby/src/schema/types/built-in-types.ts
+++ b/packages/gatsby/src/schema/types/built-in-types.ts
@@ -72,6 +72,20 @@ const directoryType = `
   }
 `
 
+const site = `
+  type Site implements Node @infer {
+    buildTime: Date @dateformat
+    siteMetadata: SiteSiteMetadata
+  }
+`
+
+const siteSiteMetadata = `
+  type SiteSiteMetadata {
+    title: String
+    description: String
+  }
+`
+
 const sitePageType = `
   type SitePage implements Node @infer {
     path: String!
@@ -82,5 +96,15 @@ const sitePageType = `
   }
 `
 
+const allSdlTypes = [
+  fileType,
+  directoryType,
+  site,
+  siteSiteMetadata,
+  sitePageType,
+]
+
+export const overridableBuiltInTypeNames = new Set([`SiteSiteMetadata`])
+
 export const builtInTypeDefinitions = (): Array<DocumentNode> =>
-  [fileType, directoryType, sitePageType].map(type => parse(type))
+  allSdlTypes.map(type => parse(type))


### PR DESCRIPTION
## Description

An alternative to #26854 (and a follow up for #26864)

It should improve DX for cases when people delete `siteMetadata` from their `gatsby-config`. Before this PR they would've seen the build error: `Cannot query field "siteMetadata" on type "Site"`.

This PR does several things:

1. Moves the `Site` type definition from internal-data-bridge to built-in Gatsby types. 
2. Adds built-in `SiteSiteMetadata` type
3. Adds a way to mark some built-in types as overridable (which suppresses a warning when a plugin tries to provide its own definition for this type)

## Related Issues

See #9802 (pretty sure there were other reports about it as well)