### PR TITLE
Update babel plugin to polyfill core-js3 proposals

### DIFF
--- a/packages/babel-preset-gatsby/src/dependencies.ts
+++ b/packages/babel-preset-gatsby/src/dependencies.ts
@@ -37,7 +37,7 @@ export default (_?: unknown, options: IPresetOptions = {}) => {
           // Allow importing core-js in entrypoint and use browserlist to select polyfills
           // V3 change, make this entry
           useBuiltIns: `usage`,
-          corejs: 3,
+          corejs: { version: 3, proposals: true },
           modules: false,
           // debug: true,
           targets,


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I've been trying to debug #26867 and I think part of the problem is [`Promise.allSettled` is still considered a proposal](https://github.com/zloirock/core-js/blob/master/packages/core-js/proposals/promise-all-settled.js). I was thinking about enabling the [`shippedProposals` babel env flag](https://babeljs.io/docs/en/babel-preset-env#shippedproposals), but I think this would be a breaking change so didn't add that as part of the changeset.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

n/a

## Related Issues

#26867

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
