### PR TITLE
WIP: Static image component

### DIFF
--- a/packages/gatsby-image/index.d.ts
+++ b/packages/gatsby-image/index.d.ts
@@ -53,7 +53,7 @@ interface GatsbyImageOptionalProps {
   loading?: `auto` | `lazy` | `eager`
   draggable?: boolean
 }
-  
+
 interface GatsbyImageFluidProps extends GatsbyImageOptionalProps {
   fluid: FluidObject | FluidObject[]
 }
@@ -68,3 +68,11 @@ export default class GatsbyImage extends React.Component<
   GatsbyImageProps,
   any
 > {}
+
+export interface GatsbyStaticImageProps extends GatsbyImageOptionalProps {
+  src: string
+  fixed?: boolean
+  fluid?: boolean
+}
+
+export const StaticImage: React.FC<GatsbyStaticImageProps>

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-
+export { StaticImage } from "./static-image"
 const logDeprecationNotice = (prop, replacement) => {
   if (process.env.NODE_ENV === `production`) {
     return

--- a/packages/gatsby-image/src/static-image.js
+++ b/packages/gatsby-image/src/static-image.js
@@ -1,0 +1,14 @@
+import React from "react"
+import { useStaticQuery } from "gatsby"
+import Image from "gatsby-image"
+
+// TODO: move into core-utils or somewhere else shared
+import { hashFromProps, splitProps } from "gatsby/dist/query/static-image"
+
+export function StaticImage(props) {
+  const hash = hashFromProps(props)
+  const { staticImage } = useStaticQuery(hash)
+  const { gatsbyImageProps } = splitProps(props)
+
+  return <Image {...gatsbyImageProps} {...staticImage.childImageSharp} />
+}

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -11,7 +11,6 @@ const {
   StringInterpolationNotAllowedError,
   EmptyGraphQLTagError,
   GraphQLSyntaxError,
-  murmurhash,
 } = require(`babel-plugin-remove-graphql-queries`)
 import { getLiteralPropValue } from "jsx-ast-utils"
 

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -301,7 +301,7 @@ const processDefinitions = ({
     const filePath = definitionsByName.get(name).filePath
     if (processedQueries.has(filePath)) {
       const otherQuery = processedQueries.get(filePath)
-
+      console.log(`filepath`, filePath)
       addError(
         multipleRootQueriesError(
           filePath,

--- a/packages/gatsby/src/query/static-image.ts
+++ b/packages/gatsby/src/query/static-image.ts
@@ -1,0 +1,281 @@
+import { murmurhash } from "babel-plugin-remove-graphql-queries/murmur"
+import {
+  removeDefaultValues,
+  healOptions,
+  getPluginOptions,
+} from "gatsby-plugin-sharp/plugin-options"
+
+export interface ISomeGatsbyImageProps {
+  fadeIn?: boolean
+  durationFadeIn?: number
+  title?: string
+  alt?: string
+  className?: string | object
+  critical?: boolean
+  crossOrigin?: string | boolean
+  style?: object
+  imgStyle?: object
+  placeholderStyle?: object
+  placeholderClassName?: string
+  backgroundColor?: string | boolean
+  onLoad?: () => void
+  onError?: (event: Event) => void
+  onStartLoad?: (param: { wasCached: boolean }) => void
+  Tag?: string
+  itemProp?: string
+  loading?: `auto` | `lazy` | `eager`
+  draggable?: boolean
+}
+
+export interface ICommonImageProps {
+  quality?: number
+  jpegQuality?: number
+  pngQuality?: number
+  webpQuality?: number
+  grayscale?: boolean
+  duotone?: false | { highlight: string; shadow: string }
+  toFormat?: "NO_CHANGE" | "JPG" | "PNG" | "WEBP"
+  cropFocus?:
+    | "CENTER"
+    | "NORTH"
+    | "NORTHEAST"
+    | "EAST"
+    | "SOUTHEAST"
+    | "SOUTH"
+    | "SOUTHWEST"
+    | "WEST"
+    | "NORTHWEST"
+    | "ENTROPY"
+    | "ATTENTION"
+  pngCompressionSpeed?: number
+  rotate?: number
+}
+
+export interface IFluidImageProps extends ICommonImageProps {
+  fluid?: true
+  maxWidth?: number
+  maxHeight?: number
+  srcSetBreakpoints?: Array<number>
+  fit?: number
+  background?: number
+}
+
+export interface IFixedImageProps extends ICommonImageProps {
+  fixed?: true
+  width?: number
+  height?: number
+}
+
+export type ImageProps = IFluidImageProps | IFixedImageProps
+export type AnyImageProps = (IFluidImageProps | IFixedImageProps) &
+  ICommonImageProps
+
+export type AllProps = IImageOptions &
+  IFluidImageProps &
+  IFixedImageProps &
+  ISomeGatsbyImageProps & { src: string }
+
+export interface IImageOptions {
+  webP?: boolean
+  base64?: boolean
+  tracedSVG?: boolean
+}
+
+export const splitProps = (
+  props: AllProps
+): {
+  commonOptions: ICommonImageProps
+  fluidOptions?: IFluidImageProps
+  fixedOptions?: IFixedImageProps
+  isFluid: boolean
+  isFixed: boolean
+  imageOptions: IImageOptions
+  gatsbyImageProps: ISomeGatsbyImageProps
+  src: string
+} => {
+  const {
+    fluid,
+    fixed,
+    quality,
+    jpegQuality,
+    pngQuality,
+    webpQuality,
+    grayscale,
+    duotone,
+    toFormat,
+    cropFocus,
+    pngCompressionSpeed,
+    maxWidth,
+    maxHeight,
+    srcSetBreakpoints,
+    fit,
+    background,
+    width,
+    height,
+    webP,
+    base64,
+    tracedSVG,
+    src,
+    ...gatsbyImageProps
+  } = props
+
+  const isFixed = fixed ?? !fluid
+
+  console.log({ isFixed, fixed, fluid })
+
+  const commonOptions: ICommonImageProps = {
+    quality,
+    jpegQuality,
+    pngQuality,
+    webpQuality,
+    grayscale,
+    duotone,
+    toFormat,
+    cropFocus,
+    pngCompressionSpeed,
+  }
+
+  const fluidOptions: IFluidImageProps | undefined = isFixed
+    ? undefined
+    : {
+        fluid: !isFixed as true,
+        maxWidth,
+        maxHeight,
+        srcSetBreakpoints,
+        fit,
+        background,
+      }
+
+  const imageOptions: IImageOptions = {
+    webP,
+    base64,
+    tracedSVG,
+  }
+
+  const fixedOptions: IFixedImageProps | undefined = isFixed
+    ? {
+        fixed: isFixed as true,
+        width,
+        height,
+      }
+    : undefined
+
+  return {
+    src,
+    commonOptions,
+    fluidOptions,
+    fixedOptions,
+    isFluid: !isFixed,
+    isFixed,
+    imageOptions,
+    gatsbyImageProps,
+  }
+}
+
+const quoteValue = (key: string, value: unknown): string =>
+  [`toFormat`, `cropFocus`].includes(key)
+    ? (value as string).toString().toUpperCase()
+    : JSON.stringify(value)
+
+const optionsFromProps = (props: AnyImageProps): string =>
+  (Object.keys(props) as Array<keyof AnyImageProps>)
+    .map(key => `${key}: ${quoteValue(key, props[key])}`)
+    .join(`, `)
+
+const imageFragmentFromProps = ({
+  webP,
+  base64 = true,
+  tracedSVG,
+}: IImageOptions): string => {
+  const parts: Array<string> = []
+  if (webP) {
+    parts.push(`_withWebp`)
+  }
+  if (tracedSVG) {
+    parts.push(`_tracedSVG`)
+  } else if (!base64) {
+    parts.push(`_noBase64`)
+  }
+  return parts.join(``)
+}
+
+const fluidFragment = (
+  props: IFluidImageProps & ICommonImageProps,
+  options: IImageOptions
+): string => `            
+fluid(${optionsFromProps(props)}) {
+    ...GatsbyImageSharpFluid${imageFragmentFromProps(options)}
+}
+`
+
+const fixedFragment = (
+  props: IFixedImageProps & ICommonImageProps,
+  options: IImageOptions
+): string => `            
+fixed(${optionsFromProps(props)}) {
+    ...GatsbyImageSharpFixed${imageFragmentFromProps(options)}
+}
+`
+
+export const queryFromProps = ({
+  fixed,
+  fluid,
+  ...props
+}: AllProps): string => {
+  if (!props.src) {
+    throw new Error(`Missing 'src' prop`)
+  }
+
+  const ext = (props.src as string).split(`.`).pop()
+
+  const { nodeType = `file`, toFormat: format, ...options } = healOptions(
+    getPluginOptions(),
+    props,
+    ext
+  )
+
+  if (format !== ext) {
+    options.toFormat = ext
+  }
+
+  const {
+    isFluid,
+    commonOptions,
+    fixedOptions,
+    fluidOptions,
+    imageOptions,
+  } = splitProps({ fixed, fluid, ...options })
+
+  console.log({
+    isFluid,
+    commonOptions,
+    fixedOptions,
+    fluidOptions,
+    imageOptions,
+  })
+
+  const fragment = isFluid
+    ? fluidFragment(
+        removeDefaultValues({ ...fluidOptions, ...commonOptions }, {}),
+        imageOptions
+      )
+    : fixedFragment(
+        removeDefaultValues({ ...fixedOptions, ...commonOptions }, {}),
+        imageOptions
+      )
+
+  return `
+query {
+    staticImage: ${nodeType}(relativePath: { eq: "${props.src}" }) {
+        childImageSharp {
+            ${fragment}
+        }
+    }
+}
+`
+}
+
+export const hashFromQuery = (query: string): number => murmurhash(query, 0)
+
+export const hashFromProps = (props: AllProps): number =>
+  hashFromQuery(queryFromProps(props))

--- a/packages/gatsby/src/utils/babel-parse-to-ast.ts
+++ b/packages/gatsby/src/utils/babel-parse-to-ast.ts
@@ -9,6 +9,7 @@ const PARSER_OPTIONS: ParserOptions = {
   plugins: [
     `jsx`,
     `flow`,
+    `estree`,
     `doExpressions`,
     `objectRestSpread`,
     [


### PR DESCRIPTION
This PR adds a new `StaticImage` component to `gatsby-image`, which allows a `"src"` attribute to be passed along with other props to control format etc.

Compare the current way, with `useStaticQuery`:

```js
import React from "react";
import Img from "gatsby-image";

export const Dino = () => {
  const data = useStaticQuery(graphql`
    query LogoQuery {
      file(relativePath: { eq: "trex.png" }) {
        childImageSharp {
          fixed(height: 100) {
            ...GatsbyImageSharpFixed
          }
        }
      }
    }
  `);

  return <Img fixed={data?.file?.childImageSharp?.fixed} alt="T-Rex" />;
};
```

This component lets you write this instead:

```js
import React from "react";
import { StaticImage as Img } from "gatsby-image";

export const Dino = () => <Img height={100} src="trex.png" alt="T-Rex" />;
```

You can pass in options that match ones passed to the `ImageSharp` query:

```js
import React from "react";
import { StaticImage as Img } from "gatsby-image";

export const Dino = () => (
  <Img
    src="trex.png"
    base64={false}
    fluid
    webP
    grayscale
    maxWidth={200}
    alt="T-Rex"
  />
);
```

...is equivalent to:

```js
import React from "react";
import Img from "gatsby-image";

export const Dino = () => {
  const data = useStaticQuery(graphql`
    query LogoQuery {
      file(relativePath: { eq: "trex.png" }) {
        childImageSharp {
          fluid(maxWidth: 200, grayscale: true) {
            ...GatsbyImageSharpFixed_withWebp_noBase64
          }
        }
      }
    }
  `);

  return <Img fixed={data?.file?.childImageSharp?.fixed} alt="T-Rex" />;
};
```

## How does it work?

This PR adds an extra `traverse` step to query extraction. Any `StaticImage` components are found and the props are used to generate a static query. This query is returned and processed in the same way as one extracted from the file, but never exists on disk. 

On the front-end, the `StaticImage` component uses the same algorithm to take the props and use them to calculate the query hash. It then passes this to `useStaticQuery`, which loads the query data from context in the same way as it would for a regular query.

### Are there restrictions to how this is used?

Because the props values are extracted at query extraction time, the values need to be statically-analyzable. This means you can't pass variables or use computed values.

Right now there is minimal checking for this.