### PR TITLE
feat(gatsby): print node counts in CLI

### DIFF
--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -21,7 +21,6 @@ export async function createPages({
   activity.start()
   const timestamp = Date.now()
   const currentPages = new Map<string, IGatsbyPage>(store.getState().pages)
-
   await apiRunnerNode(
     `createPages`,
     {
@@ -33,13 +32,21 @@ export async function createPages({
     },
     { activity }
   )
-  reporter.verbose(
-    `Now have ${store.getState().nodes.size} nodes with ${
-      store.getState().nodesByType.size
-    } types, and ${
+
+  reporter.info(
+    `Total nodes: ${store.getState().nodes.size}, SitePage nodes: ${
       store.getState().nodesByType?.get(`SitePage`)?.size
-    } SitePage nodes`
+    } (use --verbose for breakdown)`
   )
+
+  reporter.verbose(
+    `Number of node types: ${
+      store.getState().nodesByType.size
+    }. Nodes per type: ${[...store.getState().nodesByType.entries()]
+      .map(([type, nodes]) => type + `: ` + nodes.size)
+      .join(`, `)}`
+  )
+
   activity.end()
 
   reporter.verbose(`Checking for deleted pages`)

--- a/packages/gatsby/src/services/source-nodes.ts
+++ b/packages/gatsby/src/services/source-nodes.ts
@@ -27,14 +27,6 @@ export async function sourceNodes({
     webhookBody,
   })
 
-  reporter.verbose(
-    `Now have ${store.getState().nodes.size} nodes with ${
-      store.getState().nodesByType.size
-    } types: [${[...store.getState().nodesByType.entries()]
-      .map(([type, nodes]) => type + `:` + nodes.size)
-      .join(`, `)}]`
-  )
-
   reporter.verbose(`Checking for deleted pages`)
 
   const tim = reporter.activityTimer(`Checking for changed pages`)


### PR DESCRIPTION
Prints the node counts as an `info`. In verbose mode also prints a breakdown of the node count per node type.