### PR TITLE
chore: do not compile js files with typescript

### DIFF
--- a/packages/gatsby-core-utils/tsconfig.json
+++ b/packages/gatsby-core-utils/tsconfig.json
@@ -6,5 +6,8 @@
     "src/__mocks__",
     "dist",
     "./node.d.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "declarationDir": "dist"
+  }
 }

--- a/packages/gatsby/tsconfig.json
+++ b/packages/gatsby/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   // This is for typegen purposes only. For now index.d.ts is manually-created, but gatsby/internal is auto-generated
-  "include": ["./src/internal.ts"]
+  "include": ["./src/internal.ts"],
+  "compilerOptions": {
+    "declarationDir": "dist"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "emitDeclarationOnly": true,
+    "declaration": true
   },
   "exclude": ["peril/*", "examples/*"]
 }


### PR DESCRIPTION
## Description

We don't use `tsc` to emit js files. Instead, we use `@babel/plugin-transform-typescript` for actual TS to JS compilation. For setups like this, we should have either `noEmit` or `emitDeclarationsOnly` set to `true`.

Otherwise, IDEs that rely on typescript service will keep compile JS files when working with Gatsby monorepo. This PR makes our TS setup friendlier when using with IDE.

I had to pick `emitDeclarationsOnly` as we do need declarations in our builds.