### PR TITLE
fix(gatsby-plugin-mdx): Fix not passing file path to remark plugins

### DIFF
--- a/e2e-tests/mdx/gatsby-config.js
+++ b/e2e-tests/mdx/gatsby-config.js
@@ -17,13 +17,23 @@ module.exports = {
         path: `${__dirname}/src/posts`,
       },
     },
-    {resolve: `gatsby-plugin-mdx`,
-    options: {
-      extensions: [`.mdx`, `.md`],
-      defaultLayouts: {
-        default: require.resolve("./src/components/layout.js"),
+    {
+      resolve: `gatsby-plugin-mdx`,
+      options: {
+        extensions: [`.mdx`, `.md`],
+        defaultLayouts: {
+          default: require.resolve("./src/components/layout.js"),
+        },
+        remarkPlugins: [remarkRequireFilePathPlugin],
       },
-    }
-  },
+    },
   ],
+}
+
+function remarkRequireFilePathPlugin() {
+  return function transformer(tree, file) {
+    if (!file.dirname) {
+      throw new Error("No directory name for this markdown file!")
+    }
+  }
 }

--- a/e2e-tests/mdx/gatsby-config.js
+++ b/e2e-tests/mdx/gatsby-config.js
@@ -30,6 +30,10 @@ module.exports = {
   ],
 }
 
+/**
+ * This is a test to ensure that `gatsby-plugin-mdx` correctly pass the `file` argument to the underlying remark plugins.
+ * See #26914 for more info.
+ */
 function remarkRequireFilePathPlugin() {
   return function transformer(tree, file) {
     if (!file.dirname) {

--- a/packages/gatsby-plugin-mdx/utils/gen-mdx.js
+++ b/packages/gatsby-plugin-mdx/utils/gen-mdx.js
@@ -241,7 +241,7 @@ async function findImports({
   }
 
   let mdast = await compiler.parse(fileOpts)
-  mdast = await compiler.run(mdast)
+  mdast = await compiler.run(mdast, fileOpts)
 
   // Assuming valid code, identifiers must be unique (they are consts) so
   // we don't need to dedupe the symbols here.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fix a regression where `gatsby-plugin-mdx` fails to pass the file path to remark plugins.

Tested both manually and using the added e2e test.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#remark-plugins

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Related to #21489
