### PR TITLE
fix(starters): Improve null checking & update to best practices

### DIFF
--- a/starters/blog/gatsby-node.js
+++ b/starters/blog/gatsby-node.js
@@ -1,10 +1,13 @@
 const path = require(`path`)
 const { createFilePath } = require(`gatsby-source-filesystem`)
 
-exports.createPages = async ({ graphql, actions }) => {
+exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
 
+  // Define a template for blog post
   const blogPost = path.resolve(`./src/templates/blog-post.js`)
+
+  // Get all markdown blog posts sorted by date
   const result = await graphql(
     `
       {
@@ -12,14 +15,12 @@ exports.createPages = async ({ graphql, actions }) => {
           sort: { fields: [frontmatter___date], order: DESC }
           limit: 1000
         ) {
-          edges {
-            node {
-              fields {
-                slug
-              }
-              frontmatter {
-                title
-              }
+          nodes {
+            fields {
+              slug
+            }
+            frontmatter {
+              title
             }
           }
         }
@@ -28,21 +29,23 @@ exports.createPages = async ({ graphql, actions }) => {
   )
 
   if (result.errors) {
-    throw result.errors
+    reporter.panicOnBuild(`There was an error loading your blog posts`, result.errors)
+    return
   }
 
-  // Create blog posts pages.
-  const posts = result.data.allMarkdownRemark.edges
+  const posts = result.data.allMarkdownRemark.nodes
 
+  // Create blog posts pages
+  // `context` is available in the template as a prop and as a variable in GraphQL
   posts.forEach((post, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const previous = index === posts.length - 1 ? null : posts[index + 1]
+    const next = index === 0 ? null : posts[index - 1]
 
     createPage({
-      path: post.node.fields.slug,
+      path: post.fields.slug,
       component: blogPost,
       context: {
-        slug: post.node.fields.slug,
+        slug: post.fields.slug,
         previous,
         next,
       },
@@ -55,10 +58,34 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
 
   if (node.internal.type === `MarkdownRemark`) {
     const value = createFilePath({ node, getNode })
+
     createNodeField({
       name: `slug`,
       node,
       value,
     })
   }
+}
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+
+  // Explicitly define the siteMetadata {} object
+  // This way those will always be defined even if removed from gatsby-config.js
+  createTypes(`
+    type SiteSiteMetadata {
+      author: Author
+      siteUrl: String
+      social: Social
+    }
+
+    type Author {
+      name: String
+      summary: String
+    }
+
+    type Social {
+      twitter: String
+    }
+  `)
 }

--- a/starters/blog/src/components/bio.js
+++ b/starters/blog/src/components/bio.js
@@ -36,6 +36,8 @@ const Bio = () => {
   `)
 
   const { author, social } = data.site.siteMetadata
+  const avatar = data.avatar?.childImageSharp?.fixed
+
   return (
     <div
       style={{
@@ -43,23 +45,25 @@ const Bio = () => {
         marginBottom: rhythm(2.5),
       }}
     >
-      <Image
-        fixed={data.avatar.childImageSharp.fixed}
-        alt={author.name}
-        style={{
-          marginRight: rhythm(1 / 2),
-          marginBottom: 0,
-          minWidth: 50,
-          borderRadius: `100%`,
-        }}
-        imgStyle={{
-          borderRadius: `50%`,
-        }}
-      />
+      {avatar && (
+        <Image
+          fixed={avatar}
+          alt={author?.name || ``}
+          style={{
+            marginRight: rhythm(1 / 2),
+            marginBottom: 0,
+            minWidth: 50,
+            borderRadius: `100%`,
+          }}
+          imgStyle={{
+            borderRadius: `50%`,
+          }}
+        />
+      )}
       <p>
-        Written by <strong>{author.name}</strong> {author.summary}
+        Written by <strong>{author?.name || `Author`}</strong> {author?.summary || `Author Summary`}
         {` `}
-        <a href={`https://twitter.com/${social.twitter}`}>
+        <a href={`https://twitter.com/${social?.twitter || ``}`}>
           You should follow him on Twitter
         </a>
       </p>

--- a/starters/blog/src/components/layout.js
+++ b/starters/blog/src/components/layout.js
@@ -61,7 +61,7 @@ const Layout = ({ location, title, children }) => {
       <footer>
         © {new Date().getFullYear()}, Built with
         {` `}
-        <a href="https://www.gatsbyjs.org">Gatsby</a>
+        <a href="https://www.gatsbyjs.com">Gatsby</a>
       </footer>
     </div>
   )

--- a/starters/blog/src/components/seo.js
+++ b/starters/blog/src/components/seo.js
@@ -35,7 +35,7 @@ const SEO = ({ description, lang, meta, title }) => {
         lang,
       }}
       title={title}
-      titleTemplate={`%s | ${site.siteMetadata.title}`}
+      titleTemplate={`%s | ${site.siteMetadata?.title || `No title defined`}`}
       meta={[
         {
           name: `description`,
@@ -59,7 +59,7 @@ const SEO = ({ description, lang, meta, title }) => {
         },
         {
           name: `twitter:creator`,
-          content: site.siteMetadata.social.twitter,
+          content: site.siteMetadata?.social?.twitter || ``,
         },
         {
           name: `twitter:title`,

--- a/starters/blog/src/pages/404.js
+++ b/starters/blog/src/pages/404.js
@@ -10,7 +10,7 @@ const NotFoundPage = ({ data, location }) => {
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title="404: Not Found" />
-      <h1>Not Found</h1>
+      <h1>404: Not Found</h1>
       <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
     </Layout>
   )

--- a/starters/blog/src/pages/index.js
+++ b/starters/blog/src/pages/index.js
@@ -7,18 +7,18 @@ import SEO from "../components/seo"
 import { rhythm } from "../utils/typography"
 
 const BlogIndex = ({ data, location }) => {
-  const siteTitle = data.site.siteMetadata.title
-  const posts = data.allMarkdownRemark.edges
+  const siteTitle = data.site.siteMetadata?.title || `Title`
+  const posts = data.allMarkdownRemark.nodes
 
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title="All posts" />
       <Bio />
-      {posts.map(({ node }) => {
-        const title = node.frontmatter.title || node.fields.slug
+      {posts.map((post) => {
+        const title = post.frontmatter.title || post.fields.slug
         return (
           <article
-            key={node.fields.slug}
+            key={post.fields.slug}
             itemScope
             itemType="http://schema.org/Article"
           >
@@ -30,18 +30,18 @@ const BlogIndex = ({ data, location }) => {
               >
                 <Link
                   style={{ boxShadow: `none` }}
-                  to={node.fields.slug}
+                  to={post.fields.slug}
                   itemProp="url"
                 >
                   <span itemProp="headline">{title}</span>
                 </Link>
               </h3>
-              <small>{node.frontmatter.date}</small>
+              <small>{post.frontmatter.date}</small>
             </header>
             <section>
               <p
                 dangerouslySetInnerHTML={{
-                  __html: node.frontmatter.description || node.excerpt,
+                  __html: post.frontmatter.description || post.excerpt,
                 }}
                 itemProp="description"
               />
@@ -63,17 +63,15 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
-      edges {
-        node {
-          excerpt
-          fields {
-            slug
-          }
-          frontmatter {
-            date(formatString: "MMMM DD, YYYY")
-            title
-            description
-          }
+      nodes {
+        excerpt
+        fields {
+          slug
+        }
+        frontmatter {
+          date(formatString: "MMMM DD, YYYY")
+          title
+          description
         }
       }
     }

--- a/starters/blog/src/pages/using-typescript.tsx
+++ b/starters/blog/src/pages/using-typescript.tsx
@@ -18,7 +18,7 @@ const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path, location 
     <p>This means that you can create and write <em>.ts/.tsx</em> files for your pages, components etc. Please note that the <em>gatsby-*.js</em> files (like gatsby-node.js) currently don't support TypeScript yet.</p>
     <p>For type checking you'll want to install <em>typescript</em> via npm and run <em>tsc --init</em> to create a <em>.tsconfig</em> file.</p>
     <p>You're currently on the page "{path}" which was built on {data.site.buildTime}.</p>
-    <p>To learn more, head over to our <a href="https://www.gatsbyjs.org/docs/typescript/">documentation about TypeScript</a>.</p>
+    <p>To learn more, head over to our <a href="https://www.gatsbyjs.com/docs/typescript/">documentation about TypeScript</a>.</p>
     <Link to="/">Go back to the homepage</Link>
   </Layout>
 )

--- a/starters/blog/src/templates/blog-post.js
+++ b/starters/blog/src/templates/blog-post.js
@@ -8,7 +8,7 @@ import { rhythm, scale } from "../utils/typography"
 
 const BlogPostTemplate = ({ data, pageContext, location }) => {
   const post = data.markdownRemark
-  const siteTitle = data.site.siteMetadata.title
+  const siteTitle = data.site.siteMetadata?.title || `Title`
   const { previous, next } = pageContext
 
   return (

--- a/starters/default/src/components/image.js
+++ b/starters/default/src/components/image.js
@@ -26,6 +26,10 @@ const Image = () => {
     }
   `)
 
+  if (!data?.placeholderImage?.childImageSharp?.fluid) {
+    return <div>Picture not found</div>
+  }
+
   return <Img fluid={data.placeholderImage.childImageSharp.fluid} />
 }
 

--- a/starters/default/src/components/layout.js
+++ b/starters/default/src/components/layout.js
@@ -25,7 +25,7 @@ const Layout = ({ children }) => {
 
   return (
     <>
-      <Header siteTitle={data.site.siteMetadata.title} />
+      <Header siteTitle={data.site.siteMetadata?.title || `No title defined`} />
       <div
         style={{
           margin: `0 auto`,
@@ -34,7 +34,9 @@ const Layout = ({ children }) => {
         }}
       >
         <main>{children}</main>
-        <footer>
+        <footer style={{
+          marginTop: `2rem`
+        }}>
           © {new Date().getFullYear()}, Built with
           {` `}
           <a href="https://www.gatsbyjs.com">Gatsby</a>

--- a/starters/default/src/components/layout.js
+++ b/starters/default/src/components/layout.js
@@ -37,7 +37,7 @@ const Layout = ({ children }) => {
         <footer>
           © {new Date().getFullYear()}, Built with
           {` `}
-          <a href="https://www.gatsbyjs.org">Gatsby</a>
+          <a href="https://www.gatsbyjs.com">Gatsby</a>
         </footer>
       </div>
     </>

--- a/starters/default/src/components/seo.js
+++ b/starters/default/src/components/seo.js
@@ -33,7 +33,7 @@ function SEO({ description, lang, meta, title }) {
         lang,
       }}
       title={title}
-      titleTemplate={`%s | ${site.siteMetadata.title}`}
+      titleTemplate={`%s | ${site.siteMetadata?.title || `No title defined`}`}
       meta={[
         {
           name: `description`,
@@ -57,7 +57,7 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           name: `twitter:creator`,
-          content: site.siteMetadata.author,
+          content: site.siteMetadata?.author || ``,
         },
         {
           name: `twitter:title`,

--- a/starters/default/src/pages/404.js
+++ b/starters/default/src/pages/404.js
@@ -6,7 +6,7 @@ import SEO from "../components/seo"
 const NotFoundPage = () => (
   <Layout>
     <SEO title="404: Not found" />
-    <h1>NOT FOUND</h1>
+    <h1>404: Not Found</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
   </Layout>
 )

--- a/starters/default/src/pages/using-typescript.tsx
+++ b/starters/default/src/pages/using-typescript.tsx
@@ -18,7 +18,7 @@ const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path }) => (
     <p>This means that you can create and write <em>.ts/.tsx</em> files for your pages, components etc. Please note that the <em>gatsby-*.js</em> files (like gatsby-node.js) currently don't support TypeScript yet.</p>
     <p>For type checking you'll want to install <em>typescript</em> via npm and run <em>tsc --init</em> to create a <em>.tsconfig</em> file.</p>
     <p>You're currently on the page "{path}" which was built on {data.site.buildTime}.</p>
-    <p>To learn more, head over to our <a href="https://www.gatsbyjs.org/docs/typescript/">documentation about TypeScript</a>.</p>
+    <p>To learn more, head over to our <a href="https://www.gatsbyjs.com/docs/typescript/">documentation about TypeScript</a>.</p>
     <Link to="/">Go back to the homepage</Link>
   </Layout>
 )


### PR DESCRIPTION
## Description

In order to reduce friction when people modify the `default` and `blog` starters I improved those two a bit. Both with newer best practices but also safe-guarding against `null` by using optional chaining. Furthermore a bit of schema customization for `blog` was added.

- Changed .org to .com links
- Changes `edges { node }` to `nodes`
- Checked for existence of images, titles, siteMetadata items and set default values
- Changed all caps `NOT FOUND` to something better for screen readers

### Notes

In theory we could also define the default values for e.g. `siteMetadata` items in the schema customization but I think JS code is more discover-able and easier to understand.
