### PR TITLE
chore(renovate): allow updates to Gatsby packages immediately after publish

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -52,6 +52,12 @@
     },
     // these rules define dependencies that we have special handling for
     {
+      packageNames: ["gatsby-interface"],
+      sourceUrlPrefixes: ["https://github.com/gatsbyjs/gatsby"],
+      // update internal packages immediately after publish instead of waiting 3 days
+      stabilityDays: 0,
+    },
+    {
       updateTypes: ["minor"],
       excludePackageNames: [
         // below is list of packages that use 0.X version range, any minor bump there can contain breaking changes, so we just ignore minor bumps for those packages and will need to bump them manually


### PR DESCRIPTION
Currently Renovate must wait 3 days to check stability of every package. This is a great thing for the most part but causes updates to gatsby-interface and packages within this monorepo (e.g. gatsby-core-utils) to delay all other updates within each Renovate PR. Since Gatsby updates are pushed so frequently, this effectively prohibits the stabilityDays check from ever passing. This PR introduces a rule that removes internal Gatsby packages from the stabilityDays check, allowing Renovate to update gatsby-interface and packages that are sourced from this repo as soon as they are published, while still checking stability for all externally sourced packages.