### PR TITLE
fix(gatsby-react-router-scroll): debounce function for scollListener

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/scroll-behavior.js
+++ b/e2e-tests/production-runtime/cypress/integration/scroll-behavior.js
@@ -44,6 +44,7 @@ describe(`Scroll behaviour`, () => {
       expect(win.scrollY).not.to.eq(0, 0)
 
       cy.scrollTo(`bottom`)
+      cy.wait(500) // allow ScrollContext to update scroll position store
       cy.go(`back`).waitForRouteChange()
       cy.go(`forward`).waitForRouteChange()
 

--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -25,12 +25,17 @@ export class ScrollHandler extends React.Component<
 
   _stateStorage: SessionStorage = new SessionStorage()
 
+  isScrolling = -1
   scrollListener = (): void => {
-    const { key } = this.props.location
+    window.clearTimeout(this.isScrolling)
 
-    if (key) {
-      this._stateStorage.save(this.props.location, key, window.scrollY)
-    }
+    this.isScrolling = window.setTimeout(() => {
+      const { key } = this.props.location
+
+      if (key) {
+        this._stateStorage.save(this.props.location, key, window.scrollY)
+      }
+    }, 150)
   }
 
   componentDidMount(): void {

--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -26,24 +26,28 @@ export class ScrollHandler extends React.Component<
   _stateStorage: SessionStorage = new SessionStorage()
 
   // @see https://www.html5rocks.com/en/tutorials/speed/animations/
-  _isTicking: boolean = false;
-  _latestKnownScrollY: Number = 0;
+  _isTicking = false
+  _latestKnownScrollY = 0
   scrollListener = (): void => {
-    this._latestKnownScrollY = window.scrollY;
+    this._latestKnownScrollY = window.scrollY
 
     if (!this._isTicking) {
-      this._isTicking = true;
-      requestAnimationFrame(this._saveScroll.bind(this));
+      this._isTicking = true
+      requestAnimationFrame(this._saveScroll.bind(this))
     }
   }
 
   _saveScroll(): void {
-    const key = this.props.location.key || null;
+    const key = this.props.location.key || null
 
     if (key) {
-      this._state Storage.save(this.props.location, key, this._latestKnownScrollY)
+      this._stateStorage.save(
+        this.props.location,
+        key,
+        this._latestKnownScrollY
+      )
     }
-    this._isTicking = false;
+    this._isTicking = false
   }
 
   componentDidMount(): void {

--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -25,17 +25,25 @@ export class ScrollHandler extends React.Component<
 
   _stateStorage: SessionStorage = new SessionStorage()
 
-  isScrolling = -1
+  // @see https://www.html5rocks.com/en/tutorials/speed/animations/
+  _isTicking: boolean = false;
+  _latestKnownScrollY: Number = 0;
   scrollListener = (): void => {
-    window.clearTimeout(this.isScrolling)
+    this._latestKnownScrollY = window.scrollY;
 
-    this.isScrolling = window.setTimeout(() => {
-      const { key } = this.props.location
+    if (!this._isTicking) {
+      this._isTicking = true;
+      requestAnimationFrame(this._saveScroll.bind(this));
+    }
+  }
 
-      if (key) {
-        this._stateStorage.save(this.props.location, key, window.scrollY)
-      }
-    }, 150)
+  _saveScroll(): void {
+    const key = this.props.location.key || null;
+
+    if (key) {
+      this._state Storage.save(this.props.location, key, this._latestKnownScrollY)
+    }
+    this._isTicking = false;
   }
 
   componentDidMount(): void {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Added debounce function to improve scrolling performance.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes #26878 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
