### PR TITLE
fix(gatsby): Finish running queries if source files change

### DIFF
--- a/packages/gatsby/src/state-machines/query-running/actions.ts
+++ b/packages/gatsby/src/state-machines/query-running/actions.ts
@@ -16,10 +16,17 @@ export const assignDirtyQueries = assign<
   }
 })
 
-export const queryActions: ActionFunctionMap<
-  IQueryRunningContext,
-  DoneInvokeEvent<any>
-> = {
+export const markSourceFilesDirty = assign<IQueryRunningContext>({
+  filesDirty: true,
+})
+
+export const markSourceFilesClean = assign<IQueryRunningContext>({
+  filesDirty: false,
+})
+
+export const queryActions: ActionFunctionMap<IQueryRunningContext, any> = {
   assignDirtyQueries,
   flushPageData,
+  markSourceFilesDirty,
+  markSourceFilesClean,
 }

--- a/packages/gatsby/src/state-machines/query-running/index.ts
+++ b/packages/gatsby/src/state-machines/query-running/index.ts
@@ -12,7 +12,7 @@ export const queryStates: MachineConfig<IQueryRunningContext, any, any> = {
   id: `queryRunningMachine`,
   on: {
     SOURCE_FILE_CHANGED: {
-      target: `extractingQueries`,
+      actions: `markSourceFilesDirty`,
     },
   },
   context: {},
@@ -24,6 +24,7 @@ export const queryStates: MachineConfig<IQueryRunningContext, any, any> = {
         src: `extractQueries`,
         onDone: {
           target: `writingRequires`,
+          actions: `markSourceFilesClean`,
         },
       },
     },
@@ -67,6 +68,11 @@ export const queryStates: MachineConfig<IQueryRunningContext, any, any> = {
     },
     // This waits for the jobs API to finish
     waitingForJobs: {
+      // If files are dirty go and extract again
+      always: {
+        cond: (ctx): boolean => !!ctx.filesDirty,
+        target: `extractingQueries`,
+      },
       invoke: {
         src: `waitUntilAllJobsComplete`,
         id: `waiting-for-jobs`,


### PR DESCRIPTION
In the query running state machine, if a source file is changed while we're running queries we need to go back and extract queries again. In the existing implementation we jump back immediately. However this meant that dirty queries were not run, and then weren't showing as dirty anymore after they were next extracted. This PR changes the behaviour to instead flag the file as dirty, rather than jumping straight to extracting, ensuring that we finish running queries before jumping back to extract any new ones. 

Fixes #26287 