### PR TITLE
fix(gatsby-image): Remove native browser cache detection feature

### DIFF
--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -355,9 +355,9 @@ class Image extends React.Component {
 
     this.state = {
       isVisible,
-      imgLoaded: false,
-      imgCached: false,
-      fadeIn: !this.seenBefore && props.fadeIn,
+      imgLoaded: this.seenBefore,
+      imgCached: this.seenBefore,
+      fadeIn: props.fadeIn,
       isHydrated: false,
     }
 
@@ -400,6 +400,8 @@ class Image extends React.Component {
     // render path than Intersection Observer ('useIOSupport').
     // 'isVisible' guard skips this for already loaded art directed images.
     if (this.useIOSupport && !this.state.isVisible) {
+      // Delayed method, called when image is in viewport range.
+      // Image may be already internally cached by this time.
       this.cleanUpListeners = listenToIntersections(ref, () => {
         const imageInCache = inImageCache(this.props)
 
@@ -411,9 +413,9 @@ class Image extends React.Component {
         // If internally cached, reveal image immediately, skipping transition.
         if (imageInCache) {
           this.setState({
-            isVisible: true, // render `<picture>`
-            imgLoaded: true, // skip placeholder visibility
-            imgCached: true, // skips fade-in
+            isVisible: true, // render real image
+            imgLoaded: true, // swap visibility (opacity) with placeholder
+            imgCached: true, // skip fade-in transition
           })
         } else {
           this.setState({ isVisible: true })

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -416,7 +416,7 @@ class Image extends React.Component {
             imgCached: true, // skips fade-in
           })
         } else {
-          this.setState({ isVisible: true, imgLoaded: true })
+          this.setState({ isVisible: true })
         }
       })
     }


### PR DESCRIPTION
## Description

`imgCached` is presently only implemented for IntersectionObserver fallback, this method will always be falsey in Firefox and always truthy in Safari, other browsers when using the IO render path work correctly. 

Safari is the primary browser that defaults to IO (native lazy load is available as an experimental feature toggle), and while `imgCached` can be implemented to support native lazy loading too, Safari is likely to remain buggy, so this feature is being removed. 

There has been no complaints regarding it's omission with Firefox and Chrome native lazy load support that has been available for a reasonable amount of time now.

---

The `handleRef()` method has also been slightly refactored. Better for any future handling without IO, and for Art Directed images using IO.

This PR uses a portion from my [Image cache improvements PR](https://github.com/gatsbyjs/gatsby/pull/26090), slightly modified to remove the `imgCached` handling that brought the feature to native image lazy load (at least for blink browsers). There has been various reports / confirmations of Safari mishandling this feature.

**Note:** This PR has not been thoroughly tested. It should only affect browsers that use IntersectionObserver, and since the majority for that is Safari, it should resolve the reported bug. The latest Safari 14 release from this month keeps img native lazy loading as an experimental toggle feature, this will continue to be an issue for a while longer without this PR.

**Warning:** `imgCached` was originally introduced by [this PR](https://github.com/gatsbyjs/gatsby/pull/12468) to address [this issue](https://github.com/gatsbyjs/gatsby/issues/12254), avoiding a placeholder flicker for an already cached image. I do not have access to Safari to reproduce, nor have I verified if that is an issue for Chrome/Firefox with current `gatsby-image`.

## TL;DR

Safari mishandles a feature that Chrome used to benefit from. It's been reverted to remove the rendering bug.

- `imgCached` is broken for Safari users. That feature was added before native lazy load, only Intersection Observer render path uses it.
- Safari is the dominant browser where `gatsby-image` fallsback to Intersection Observer for lazy load.

## Related Issues

Fixes: https://github.com/gatsbyjs/gatsby/issues/20126

Potential regression: https://github.com/gatsbyjs/gatsby/issues/12254