### PR TITLE
updating the install dependency documentation

### DIFF
--- a/docs/tutorial/part-three/index.md
+++ b/docs/tutorial/part-three/index.md
@@ -43,10 +43,10 @@ cd tutorial-part-three
 
 There are two main steps to using a plugin: Installing and configuring.
 
-1. Install the `gatsby-plugin-typography` npm package.
+1. Install the `gatsby-plugin-typography` package.
 
 ```shell
-npm install --save gatsby-plugin-typography react-typography typography typography-theme-fairy-gates
+yarn add gatsby-plugin-typography react-typography typography typography-theme-fairy-gates
 ```
 
 > Note: Typography.js requires a few additional packages, so those are included in the instructions. Additional requirements like this will be listed in the "install" instructions of each plugin.


### PR DESCRIPTION
npm install with yarn creates this issues: https://github.com/gatsbyjs/gatsby/issues/18048
using `yarn add` allows for an error free set up.

## Description

update the documentation for installing the plugins for the third tutorial

### Documentation

This is an update to the current documentation for installing the dependency

## Related Issues

issues which may have risen due to difference of package managers (npm and yarn): https://github.com/gatsbyjs/gatsby/issues/18048
