### PR TITLE
chore(docs): Set correct path to the image

### DIFF
--- a/docs/tutorial/part-five/index.md
+++ b/docs/tutorial/part-five/index.md
@@ -94,7 +94,7 @@ Alternatively, you can add fields by using the autocomplete shortcut (<kbd>Ctrl 
 
 Try adding a number of fields to your query, press <kbd>Ctrl + Enter</kbd> each time to re-run the query. You'll see the updated query results:
 
-![The GraphiQL IDE showing the results of the query](./images/allfile-query.png)
+![The GraphiQL IDE showing the results of the query](allfile-query.png)
 
 The result is an array of `File` "nodes" (node is a fancy name for an object in a "graph"). Each `File` node object has the fields you queried for.
 


### PR DESCRIPTION
## Description

This PR fixes a path to the image on one of tutorial's pages.
