### PR TITLE
fix:gatsby-remark-autolink-headers option to disable "position: relat…

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
@@ -12,7 +12,664 @@ Object {
             "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
           },
         ],
+        "hProperties": Object {// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gatsby-remark-autolink-headers adds id to a markdown header 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
+          },
+        ],
         "hProperties": Object {
+          "aria-label": "heading uno permalink",
+          "class": "anchor before",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#heading-uno",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "heading-uno",
+    },
+    "htmlAttributes": Object {
+      "id": "heading-uno",
+    },
+    "id": "heading-uno",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers adds id to a markdown header with custom class 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-label": "heading uno permalink",
+          "class": "custom-class before",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#heading-uno",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "heading-uno",
+    },
+    "htmlAttributes": Object {
+      "id": "heading-uno",
+    },
+    "id": "heading-uno",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers adds id to a markdown header with custom svg icon 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg width=\\"400\\" height=\\"110\\"><rect width=\\"300\\" height=\\"100\\" /></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-label": "heading uno permalink",
+          "class": "anchor before",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#heading-uno",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "heading-uno",
+      "style": "position:relative;",
+    },
+    "htmlAttributes": Object {
+      "id": "heading-uno",
+    },
+    "id": "heading-uno",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers adds id to a markdown header with no icon 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "heading-uno",
+    },
+    "htmlAttributes": Object {
+      "id": "heading-uno",
+    },
+    "id": "heading-uno",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers adds id to a markdown heading when elements prop is passed with matching heading type 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-label": "heading uno permalink",
+          "class": "anchor before",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#heading-uno",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "heading-uno",
+    },
+    "htmlAttributes": Object {
+      "id": "heading-uno",
+    },
+    "id": "heading-uno",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers adds places anchor after header when isIconAfterHeader prop is passed 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-label": "heading uno permalink",
+          "class": "anchor after",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#heading-uno",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "heading-uno",
+      "style": "position:relative;",
+    },
+    "htmlAttributes": Object {
+      "id": "heading-uno",
+    },
+    "id": "heading-uno",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers does not add data to a markdown heading when elements prop is passed with no matching heading type 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+          "offset": 13,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno",
+    },
+  ],
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+      "offset": 13,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers does not add data to a markdown heading with custom id when elements prop is passed with no matching heading type 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 27,
+          "line": 1,
+          "offset": 26,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 1,
+          "offset": 2,
+        },
+      },
+      "type": "text",
+      "value": "Heading Uno {#custom_h1}",
+    },
+  ],
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 27,
+      "line": 1,
+      "offset": 26,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers maintain case of markdown header for id 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-label": "Heading One permalink",
+          "class": "anchor before",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#Heading-One",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+          "offset": 14,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 3,
+          "line": 2,
+          "offset": 3,
+        },
+      },
+      "type": "text",
+      "value": "Heading One",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "Heading-One",
+    },
+    "htmlAttributes": Object {
+      "id": "Heading-One",
+    },
+    "id": "Heading-One",
+  },
+  "depth": 1,
+  "position": Position {
+    "end": Object {
+      "column": 14,
+      "line": 2,
+      "offset": 14,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 2,
+      "offset": 1,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers maintain case of markdown header for id 2`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-label": "Heading Two permalink",
+          "class": "anchor before",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#Heading-Two",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 15,
+          "line": 4,
+          "offset": 30,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 4,
+          "line": 4,
+          "offset": 19,
+        },
+      },
+      "type": "text",
+      "value": "Heading Two",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "Heading-Two",
+    },
+    "htmlAttributes": Object {
+      "id": "Heading-Two",
+    },
+    "id": "Heading-Two",
+  },
+  "depth": 2,
+  "position": Position {
+    "end": Object {
+      "column": 15,
+      "line": 4,
+      "offset": 30,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 4,
+      "offset": 16,
+    },
+  },
+  "type": "heading",
+}
+`;
+
+exports[`gatsby-remark-autolink-headers maintain case of markdown header for id 3`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [],
+      "data": Object {
+        "hChildren": Array [
+          Object {
+            "type": "raw",
+            "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
+          },
+        ],
+        "hProperties": Object {
+          "aria-label": "Heading Three permalink",
+          "class": "anchor before",
+        },
+      },
+      "title": null,
+      "type": "link",
+      "url": "#Heading-Three",
+    },
+    Object {
+      "position": Position {
+        "end": Object {
+          "column": 18,
+          "line": 6,
+          "offset": 49,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 5,
+          "line": 6,
+          "offset": 36,
+        },
+      },
+      "type": "text",
+      "value": "Heading Three",
+    },
+  ],
+  "data": Object {
+    "hProperties": Object {
+      "id": "Heading-Three",
+    },
+    "htmlAttributes": Object {
+      "id": "Heading-Three",
+    },
+    "id": "Heading-Three",
+  },
+  "depth": 3,
+  "position": Position {
+    "end": Object {
+      "column": 18,
+      "line": 6,
+      "offset": 49,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 6,
+      "offset": 32,
+    },
+  },
+  "type": "heading",
+}
+`;
+
           "aria-label": "heading uno permalink",
           "class": "anchor before",
         },

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
@@ -42,7 +42,6 @@ Object {
   "data": Object {
     "hProperties": Object {
       "id": "heading-uno",
-      "style": "position:relative;",
     },
     "htmlAttributes": Object {
       "id": "heading-uno",

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -60,9 +60,8 @@ module.exports = (
     patch(data, `hProperties`, {})
     patch(data.htmlAttributes, `id`, id)
     patch(data.hProperties, `id`, id)
-    patch(data.hProperties, `style`, `position:relative;`)
-
     if (icon !== false) {
+      patch(data.hProperties, `style`, `position:relative;`)
       const label = id.split(`-`).join(` `)
       const method = isIconAfterHeader ? `push` : `unshift`
       node.children[method]({


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->
https://github.com/gatsbyjs/gatsby/issues/26961#issuecomment-695989198
## Description

<!-- Write a brief description of the changes introduced by this PR -->
```gatsby-remark-autolink-headers``` has ```style:"position:relative"``` which doesn't always work as intended. The inline style is needed for the icon option to function as it positions said icon with style of absolute or inline-block.This fix applies relative positioning only when the icon is present.
### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes #26961 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
