### PR TITLE
fix(gatsby): Recognise null pages as not found

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/redirect.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/redirect.js
@@ -40,6 +40,21 @@ const runTests = () => {
       )
     })
   })
+
+  it(`should redirect to a dynamically-created replacement page`, () => {
+    cy.visit(`/redirect-me/`).waitForRouteChange()
+
+    cy.location(`pathname`).should(`equal`, `/pt/redirect-me/`)
+    cy.then(() => {
+      expect(spy).not.to.be.calledWith(
+        `The route "/redirect" matches both a page and a redirect; this is probably not intentional.`
+      )
+
+      cy.findByText("This should be at /pt/redirect-me/", {
+        exact: false,
+      }).should(`exist`)
+    })
+  })
 }
 
 describe(`redirect`, () => {

--- a/e2e-tests/development-runtime/gatsby-node.js
+++ b/e2e-tests/development-runtime/gatsby-node.js
@@ -104,10 +104,34 @@ exports.createPages = async function createPages({
 }
 
 exports.onCreatePage = async ({ page, actions }) => {
-  const { createPage } = actions
+  const { createPage, createRedirect, deletePage } = actions
 
   if (page.path.match(/^\/client-only-paths/)) {
     page.matchPath = `/client-only-paths/*`
     createPage(page)
+  }
+
+  if (page.path === `/redirect-me/`) {
+    const toPath = `/pt${page.path}`
+
+    deletePage(page)
+
+    createRedirect({
+      fromPath: page.path,
+      toPath,
+      isPermanent: false,
+      redirectInBrowser: true,
+      Language: `pt`,
+      statusCode: 301,
+    })
+
+    createPage({
+      ...page,
+      path: toPath,
+      context: {
+        ...page.context,
+        lang: `pt`,
+      },
+    })
   }
 }

--- a/e2e-tests/development-runtime/src/pages/redirect-me.js
+++ b/e2e-tests/development-runtime/src/pages/redirect-me.js
@@ -1,0 +1,13 @@
+import React from "react"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const Redirect = () => (
+  <Layout>
+    <SEO title="Redirect" />
+    <p>This should be at /pt/redirect-me/</p>
+  </Layout>
+)
+
+export default Redirect

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -394,7 +394,7 @@ export class BaseLoader {
   isPageNotFound(rawPath) {
     const pagePath = findPath(rawPath)
     const page = this.pageDb.get(pagePath)
-    return page && page.notFound === true
+    return !page || page.notFound
   }
 
   loadAppData(retries = 0) {

--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -202,8 +202,10 @@ export class WebsocketManager {
 
       socket.on(`registerPath`, (path: string): void => {
         socket.join(getRoomNameFromPath(path))
-        activePath = path
-        this.activePaths.add(path)
+        if (path) {
+          activePath = path
+          this.activePaths.add(path)
+        }
       })
 
       socket.on(`disconnect`, (): void => {


### PR DESCRIPTION
In the client side loader, if a page in the db is null it is not shown as "not found". This causes an error in some situations with client-side redirects. See #26988 for an example. This returns true for `isPageNotFound` if the page is null. Additionally, it doesn't register a path in websocket manager if it is null, which would otherwise occur in this case with a client-side redirect.

Fixes #26988