### PR TITLE
chore(benchmarks): cleanup the gabe benchmarks a bit

### DIFF
--- a/benchmarks/gabe-csv-markdown/.gitignore
+++ b/benchmarks/gabe-csv-markdown/.gitignore
@@ -69,3 +69,4 @@ yarn-error.log
 .yarn-integrity
 
 gendata.csv
+yarn.lock

--- a/benchmarks/gabe-csv-markdown/gen.js
+++ b/benchmarks/gabe-csv-markdown/gen.js
@@ -11,7 +11,7 @@ const FILE = path.resolve("gendata.csv")
 // We then hand that off to markdown
 
 console.log("Now generating " + N + " articles into", FILE)
-fs.writeFileSync(FILE, "articleContent,a,b,c\n")
+fs.writeFileSync(FILE, "articleContent\n")
 
 function createArticle(n) {
   const title = faker.lorem.sentence()
@@ -47,7 +47,7 @@ ${faker.lorem.paragraphs(2)}
     '"' + pageContent
       .trim()
       .replace(/"/g, '""')
-      + '",1,2,3' +
+      + '"' +
       "\n" // markdown does care about newlines
   )
 }

--- a/benchmarks/gabe-csv-text/.gitignore
+++ b/benchmarks/gabe-csv-text/.gitignore
@@ -69,3 +69,4 @@ yarn-error.log
 .yarn-integrity
 
 gendata.csv
+yarn.lock

--- a/benchmarks/gabe-csv-text/gen.js
+++ b/benchmarks/gabe-csv-text/gen.js
@@ -37,13 +37,10 @@ function createArticle(n) {
 <p>${faker.lorem.paragraphs(1)}</p>
       `,
     ]
-      .map(s =>
-        s
-          .trim()
-          // Need to escape newlines and commas
-          .replace(/,/g, "\\,")
-          .replace(/\n/g, "") // html don't care about newlines
-      )
+      // Can only escape double quotes, by doubling them
+      .map(s => s.trim().replace(/"/g, '""'))
+      // Can only use commas and newlines in text by double-quote wrapping them. Or by removing them
+      .map(s => `"${s}"`)
       .join(",") + "\n"
   )
 }

--- a/benchmarks/gabe-fs-markdown/.gitignore
+++ b/benchmarks/gabe-fs-markdown/.gitignore
@@ -69,3 +69,4 @@ yarn-error.log
 .yarn-integrity
 
 generated_articles
+yarn.lock

--- a/benchmarks/gabe-fs-mdx/.gitignore
+++ b/benchmarks/gabe-fs-mdx/.gitignore
@@ -4,3 +4,4 @@ public/
 .env
 generated_articles
 .DS_Store
+yarn.lock


### PR DESCRIPTION
Mostly ignores yarn.lock file
Also fixes how the csv-markdown site generates the csv