### PR TITLE
chore(gatsby-plugin-graphql-config): README typos

### DIFF
--- a/packages/gatsby-plugin-graphql-config/README.md
+++ b/packages/gatsby-plugin-graphql-config/README.md
@@ -25,7 +25,7 @@ plugins: [`gatsby-plugin-graphql-config`]
 
 ### Simplest setup
 
-if you are able to configure your tools to seek a different `basePath` for loading GraphQL Config, point them to `.cache` directory.
+If you are able to configure your tools to seek a different `basePath` for loading GraphQL Config, point them to `.cache` directory.
 
 ### Manual setup for repositories with no other GraphQL projects
 

--- a/packages/gatsby-plugin-graphql-config/README.md
+++ b/packages/gatsby-plugin-graphql-config/README.md
@@ -1,15 +1,17 @@
 # gatsby-plugin-graphql-config
 
-Persists gatsby graphql schema and fragments to the .cache directory, as well as a [graphql config](https://graphql-config.com) file to enable full-featured tooling for:
+Persists Gatsby GraphQL schema and fragments to the `.cache` directory, as well as a [GraphQL Config](https://graphql-config.com) file to enable full-featured tooling for:
 
 - [`vscode-graphql`](https://marketplace.visualstudio.com/items?itemName=Prisma.vscode-graphql), and other IDE extensions that use the official GraphQL LSP
 - [`eslint-plugin-graphql`](https://github.com/apollographql/eslint-plugin-graphql)
-- [`graphql code generator`](https://graphql-code-generator.com/) for gatsby projects using typescript
+- [`graphql code generator`](https://graphql-code-generator.com/) for Gatsby projects using TypeScript
 - eventually [`graphiql`](https://github.com/graphql/graphiql) will use it, even!
 
 ## Install
 
-`npm install --save gatsby-plugin-graphql-config`
+```shell
+npm install gatsby-plugin-graphql-config
+```
 
 ## How to use
 
@@ -17,38 +19,39 @@ First, add it to your plugin configuration:
 
 ```javascript
 // In your gatsby-config.js
+
 plugins: [`gatsby-plugin-graphql-config`]
 ```
 
-**simplest setup**:
-if you are able to configure your tools to seek a different `basePath` for loading graphql config, point them to `.cache` directory.
+### Simplest setup
 
-**manual setup for repos with no other graphql projects**:
+if you are able to configure your tools to seek a different `basePath` for loading `graphql.config.js`, point them to `.cache` directory.
 
-If your project is _only_ a gatsby project, you can place a `graphql.config.js` file at the root of your gatsby project like this:
+### Manual setup for repositories with no other GraphQL projects
 
-`<my project>/graphql.config.js`:
+If your project is _only_ a Gatsby project, you can place a `graphql.config.js` file at the root of your Gatsby project like this:
 
-```js
+```javascript
 // <my project>/graphql.config.js
+
 module.exports = require("./.cache/graphql.config.json")
 ```
 
-if it's in a subdirectory such as a `site/` folder, you would use this:
+If it's in a subdirectory such as a `site/` folder, you would use this:
 
-`<my project>/graphql.config.js`:
+```javascript
+// <my project>/graphql.config.js
 
-```js
 module.exports = require("./site/.cache/graphql.config.json")
 ```
 
-**for repositories with multiple graphql projects**
+### Manual setup for repositories with multiple GraphQL projects
 
-if your repository has multiple graphql projects including gatsby, you will want a config similar to this at the root:
+If your repository has multiple GraphQL projects including Gatsby, you will want a config similar to this at the root:
 
-`<my project>/graphql.config.js`:
+```javascript
+// <my project>/graphql.config.js
 
-```js
 module.exports = {
   projects: {
     site: require("packages/site/.cache/graphql.config.json"),
@@ -62,7 +65,7 @@ module.exports = {
 
 ### How it works
 
-It writes out these files to the gatsby `.cache` directory:
+It writes out these files to the Gatsby `.cache` directory:
 
 - `schema.graphql` - a complete representation of the schema, including plugins
 - `fragments.graphql` - all user, plugin and gatsby-core provided fragments in one file

--- a/packages/gatsby-plugin-graphql-config/README.md
+++ b/packages/gatsby-plugin-graphql-config/README.md
@@ -25,7 +25,7 @@ plugins: [`gatsby-plugin-graphql-config`]
 
 ### Simplest setup
 
-if you are able to configure your tools to seek a different `basePath` for loading `graphql.config.js`, point them to `.cache` directory.
+if you are able to configure your tools to seek a different `basePath` for loading GraphQL Config, point them to `.cache` directory.
 
 ### Manual setup for repositories with no other GraphQL projects
 


### PR DESCRIPTION
## Description

changes:
- brand name: 
  - `gatsby` -> `Gatsby`
  - `typescript` -> `TypeScript`
  - `graphql` -> `GraphQL`
  - `graphql config` -> `GraphQL Config`
- remove `--save` from `npm install`
- unify code snippets: put filename as comment, all same `javascript` tag



<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

- #26829 `chore: write graphql schema, fragments and config file to cache` 