### PR TITLE
chore(docs): Add children to styled-components doc

### DIFF
--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -129,7 +129,7 @@ const GlobalStyle = createGlobalStyle`
     color: ${props => (props.theme === "purple" ? "purple" : "white")};
   }
 `
-export default function Layout({ children }) {
+export default function Layout() {
   return (
     <React.Fragment>
       <GlobalStyle theme="purple" />

--- a/docs/docs/styled-components.md
+++ b/docs/docs/styled-components.md
@@ -129,10 +129,11 @@ const GlobalStyle = createGlobalStyle`
     color: ${props => (props.theme === "purple" ? "purple" : "white")};
   }
 `
-export default function Layout() {
+export default function Layout({ children }) {
   return (
     <React.Fragment>
       <GlobalStyle theme="purple" />
+      {children}
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Including this could create confusion 😕 for noobs, who might think that like other 'Layout' HOCs we have to try to _render_ `children`.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
