### PR TITLE
Fix gatsby-cli changes for yarn2

### DIFF
--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -104,7 +104,7 @@ const install = async (rootPath: string): Promise<void> => {
 
   try {
     if (!getPackageManager()) {
-      if (npmConfigUserAgent.includes(`yarn`)) {
+      if (npmConfigUserAgent?.includes(`yarn`)) {
         setPackageManager(`yarn`)
       } else {
         setPackageManager(`npm`)

--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -100,9 +100,15 @@ const install = async (rootPath: string): Promise<void> => {
   report.info(`Installing packages...`)
   process.chdir(rootPath)
 
+  const npmConfigUserAgent = process.env.npm_config_user_agent
+
   try {
     if (!getPackageManager()) {
-      setPackageManager(`npm`)
+      if (npmConfigUserAgent.includes(`yarn`)) {
+        setPackageManager(`yarn`)
+      } else {
+        setPackageManager(`npm`)
+      }
     }
     if (getPackageManager() === `yarn` && checkForYarn()) {
       if (await fs.pathExists(`package-lock.json`)) {


### PR DESCRIPTION
Addressing [this comment](https://github.com/gatsbyjs/gatsby/pull/26856#issuecomment-698230049) where the new CLI changes are not compatible with yarn 2. If yarn is used for the command, we'll set yarn as the package manager.