### PR TITLE
removing react import because react 17 doesn't need import

### DIFF
--- a/docs/docs/data-fetching.md
+++ b/docs/docs/data-fetching.md
@@ -104,7 +104,6 @@ query {
 With the source plugin installed and added to your config, you can write a [static query](/docs/use-static-query/) that will retrieve the necessary data from Gatsby's data layer while building the site.
 
 ```jsx:title=src/pages/index.js
-import React from "react"
 import { graphql, useStaticQuery } from "gatsby" // highlight-line
 
 const IndexPage = () => {
@@ -156,7 +155,7 @@ The `fetch` API is a modern implementation of the older, well-supported `XMLHttp
 With the `useState` and `useEffect` hooks from React, you can query for the data once when the page loads, and save the data returned to a variable called `starsCount`. Every time the page is refreshed, `fetch` will go to the GitHub API to retrieve the most up-to-date version of the data.
 
 ```jsx:title=src/pages/index.js
-import React, { useState, useEffect } from "react" // highlight-line
+import { useState, useEffect } from "react" // highlight-line
 import { graphql, useStaticQuery } from "gatsby"
 
 const IndexPage = () => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
