### PR TITLE
removing react import because react 17 doesn't need import

### DIFF
--- a/docs/docs/why-gatsby-uses-graphql.md
+++ b/docs/docs/why-gatsby-uses-graphql.md
@@ -20,7 +20,6 @@ All that’s required to create a page is a `path` where it should be created an
 For example, if you had the following component:
 
 ```jsx:title=src/templates/no-data.js
-import React from "react"
 
 const NoData = () => (
   <section>
@@ -82,7 +81,6 @@ The `context` property accepts an object, and you can pass in any data you want 
 When Gatsby creates pages, it includes a prop called `pageContext` and sets its value to `context`, so you can access any of the values in your component:
 
 ```jsx:title=src/templates/with-context.js
-import React from "react"
 
 const WithContext = ({ pageContext }) => (
   <section>
@@ -162,7 +160,6 @@ exports.createPages = ({ actions: { createPage } }) => {
 The product template still uses `pageContext` to display the product data:
 
 ```jsx:title=src/templates/product.js
-import React from "react"
 
 const Product = ({ pageContext }) => (
   <div>
@@ -328,7 +325,6 @@ As you’ve already seen, the `context` argument is made available to the templa
 Here’s what that looks like in practice:
 
 ```jsx:title=src/templates/product-graphql.js
-import React from "react"
 import { graphql } from "gatsby"
 import Image from "gatsby-image"
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
