### PR TITLE
Adding position releative to autolinks is now conditional

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -59,10 +59,10 @@ module.exports = (
     patch(data, `htmlAttributes`, {})
     patch(data, `hProperties`, {})
     patch(data.htmlAttributes, `id`, id)
-    patch(data.hProperties, `id`, id)
-    patch(data.hProperties, `style`, `position:relative;`)
+    patch(data.hProperties, `id`, id)    
 
     if (icon !== false) {
+      patch(data.hProperties, `style`, `position:relative;`)
       const label = id.split(`-`).join(` `)
       const method = isIconAfterHeader ? `push` : `unshift`
       node.children[method]({

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -59,7 +59,7 @@ module.exports = (
     patch(data, `htmlAttributes`, {})
     patch(data, `hProperties`, {})
     patch(data.htmlAttributes, `id`, id)
-    patch(data.hProperties, `id`, id)    
+    patch(data.hProperties, `id`, id)
 
     if (icon !== false) {
       patch(data.hProperties, `style`, `position:relative;`)


### PR DESCRIPTION
## Description

Changes made to autolink-headers plugin.

Moved the line `patch(data.hProperties, 'style', 'position:relative;')` to the conditional check for icons to avoid adding positioning to unwanted elements.

### Documentation

## Related Issues

Fixes: #26961