### PR TITLE
fix(docs): remove README.md not displaying on Gatsby plugin library

### DIFF
--- a/packages/gatsby-cypress/package.json
+++ b/packages/gatsby-cypress/package.json
@@ -33,7 +33,6 @@
     "cypress": "^3.1.0",
     "gatsby": "^2.0.0-rc.13"
   },
-  "readme": "README.md",
   "scripts": {
     "build": "babel src --out-dir . --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",

--- a/packages/gatsby-plugin-coffeescript/package.json
+++ b/packages/gatsby-plugin-coffeescript/package.json
@@ -32,7 +32,6 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "readme": "README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git",

--- a/packages/gatsby-plugin-postcss/package.json
+++ b/packages/gatsby-plugin-postcss/package.json
@@ -27,7 +27,6 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "readme": "README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git",

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -29,7 +29,6 @@
     "gatsby": "^2.0.0",
     "node-sass": "^4.9.0"
   },
-  "readme": "README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git",

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -28,7 +28,6 @@
   "peerDependencies": {
     "gatsby": "^2.0.0"
   },
-  "readme": "README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby.git",


### PR DESCRIPTION
## Description

Fix the README.md file contents not displaying on the Gatsby plugin library page https://www.gatsbyjs.com/plugins/gatsby-plugin-postcss/

