### PR TITLE
feat(gatsby-dev-cli): install deps if there are no gatsby deps but --forceInstall was used

### DIFF
--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -105,7 +105,13 @@ If you prefer to place them in your package.json dependencies instead,
 gatsby-dev will pick them up.
 `
   )
-  process.exit()
+  if (!argv.forceInstall) {
+    process.exit()
+  } else {
+    console.log(
+      `Continuing other dependencies installation due to "--forceInstall" flag`
+    )
+  }
 }
 
 watch(gatsbyLocation, argv.packages, {

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -140,13 +140,22 @@ async function watch(
 
   if (forceInstall) {
     try {
-      await publishPackagesLocallyAndInstall({
-        packagesToPublish: allPackagesToWatch,
-        root,
-        localPackages,
-        ignorePackageJSONChanges,
-        yarnWorkspaceRoot,
-      })
+      if (allPackagesToWatch.length > 0) {
+        await publishPackagesLocallyAndInstall({
+          packagesToPublish: allPackagesToWatch,
+          root,
+          localPackages,
+          ignorePackageJSONChanges,
+          yarnWorkspaceRoot,
+        })
+      } else {
+        // run `yarn`
+        const yarnInstallCmd = [`yarn`]
+
+        console.log(`Installing packages from public NPM registry`)
+        await promisifiedSpawn(yarnInstallCmd)
+        console.log(`Installation complete`)
+      }
     } catch (e) {
       console.log(e)
     }


### PR DESCRIPTION
This is just QoL:

Right now our test script for e2e and integration tests all use `gatsby-dev-cli` to install deps. Next PR in the series will remove `gatsby-cli` dep from https://github.com/gatsbyjs/gatsby/blob/master/integration-tests/gatsby-cli/package.json which would make our test setup just not install anything currently (even `jest`).

---

This is part of PR series:

1. [`feat(gatsby-dev-cli): install deps if there are no gatsby deps but --forceInstall was used`](https://github.com/gatsbyjs/gatsby/pull/27055) __(THIS PR)__
2. [`test(integration/gatsby-cli): use sandboxed directory to "globally" install gatsby-cli`](https://github.com/gatsbyjs/gatsby/pull/27056) 
3. [`chore(gatsby-recipes): bundle dependencies`](https://github.com/gatsbyjs/gatsby/pull/27057)
4. [`chore(gatsby-cli): bundle dependencies`](https://github.com/gatsbyjs/gatsby/pull/27058)