### PR TITLE
test(integration/gatsby-cli): use sandboxed directory to "globally" install gatsby-cli

### DIFF
--- a/integration-tests/gatsby-cli/__tests__/new.js
+++ b/integration-tests/gatsby-cli/__tests__/new.js
@@ -14,7 +14,8 @@ const clean = dir => execa(`yarn`, ["del-cli", dir])
 describe(`gatsby new`, () => {
   // make folder for us to create sites into
   const dir = join(__dirname, "../execution-folder")
-  const originalPackageManager = getConfigStore().get("cli.packageManager")
+  const originalPackageManager =
+    getConfigStore().get("cli.packageManager") || `npm`
 
   beforeAll(async () => {
     await clean(dir)
@@ -23,7 +24,7 @@ describe(`gatsby new`, () => {
   })
 
   afterAll(async () => {
-    GatsbyCLI.from(cwd).invoke([`options`, `set`,`pm`, originalPackageManager])
+    GatsbyCLI.from(cwd).invoke([`options`, `set`, `pm`, originalPackageManager])
     await clean(dir)
   })
 

--- a/integration-tests/gatsby-cli/jest.boot.js
+++ b/integration-tests/gatsby-cli/jest.boot.js
@@ -1,0 +1,42 @@
+const path = require(`path`)
+const execa = require(`execa`)
+const fs = require(`fs-extra`)
+
+module.exports = async () => {
+  console.log(
+    `Installing "gatsby-cli" in sandbox directory: "${process.env.GLOBAL_GATSBY_CLI_LOCATION}"`
+  )
+  console.log(
+    `Tests will use "${process.env.GLOBAL_GATSBY_CLI_LOCATION}/node_modules/.bin/gatsby" CLI to invoke commands`
+  )
+
+  await fs.ensureDir(process.env.GLOBAL_GATSBY_CLI_LOCATION)
+
+  await fs.outputJson(
+    path.join(process.env.GLOBAL_GATSBY_CLI_LOCATION, `package.json`),
+    {
+      dependencies: {
+        "gatsby-cli": "latest",
+      },
+    }
+  )
+
+  const gatsbyDevLocation = path.join(
+    __dirname,
+    `..`,
+    `..`,
+    `packages`,
+    `gatsby-dev-cli`,
+    `dist`,
+    `index.js`
+  )
+
+  await execa.node(gatsbyDevLocation, [`--force-install`, `--scan-once`], {
+    cwd: process.env.GLOBAL_GATSBY_CLI_LOCATION,
+    stdio: `inherit`,
+    env: {
+      // we don't want to run gatsby-dev in with NODE_ENV=test
+      NODE_ENV: `production`,
+    },
+  })
+}

--- a/integration-tests/gatsby-cli/jest.config.js
+++ b/integration-tests/gatsby-cli/jest.config.js
@@ -1,0 +1,18 @@
+const fs = require(`fs`)
+const path = require(`path`)
+const os = require(`os`)
+const baseConfig = require(`../jest.config.js`)
+
+// install global gatsby-cli to tmp dir to simulate sandbox
+const GLOBAL_GATSBY_CLI_LOCATION = (process.env.GLOBAL_GATSBY_CLI_LOCATION = fs.mkdtempSync(
+  path.join(os.tmpdir(), `gatsby-cli-`)
+))
+
+module.exports = {
+  ...baseConfig,
+  globalSetup: "<rootDir>/integration-tests/gatsby-cli/jest.boot.js",
+  rootDir: `../../`,
+  globals: {
+    GLOBAL_GATSBY_CLI_LOCATION,
+  },
+}

--- a/integration-tests/gatsby-cli/package.json
+++ b/integration-tests/gatsby-cli/package.json
@@ -2,12 +2,11 @@
   "name": "gatsby-cli-tests",
   "version": "1.0.0",
   "dependencies": {
-    "gatsby-cli": "^2.12.29",
     "strip-ansi": "^6.0.0"
   },
   "license": "MIT",
   "scripts": {
-    "test": "jest --config=../jest.config.js gatsby-cli/"
+    "test": "jest --config=./jest.config.js gatsby-cli/"
   },
   "devDependencies": {
     "del-cli": "^3.0.1",

--- a/integration-tests/gatsby-cli/test-helpers/invoke-cli.js
+++ b/integration-tests/gatsby-cli/test-helpers/invoke-cli.js
@@ -1,6 +1,13 @@
 import execa, { sync } from "execa"
-import { join, resolve } from "path"
+import { join } from "path"
 import { createLogsMatcher } from "./matcher"
+
+const gatsbyBinLocation = join(
+  GLOBAL_GATSBY_CLI_LOCATION,
+  `node_modules`,
+  `.bin`,
+  `gatsby`
+)
 
 // Use as `GatsbyCLI.cwd('execution-folder').invoke('new', 'foo')`
 export const GatsbyCLI = {
@@ -9,14 +16,10 @@ export const GatsbyCLI = {
       invoke(args) {
         const NODE_ENV = args[0] === `develop` ? `development` : `production`
         try {
-          const results = sync(
-            resolve(`./node_modules/.bin/gatsby`),
-            [].concat(args),
-            {
-              cwd: join(__dirname, `../`, `./${relativeCwd}`),
-              env: { NODE_ENV, CI: 1, GATSBY_LOGGER: `ink` },
-            }
-          )
+          const results = sync(gatsbyBinLocation, [].concat(args), {
+            cwd: join(__dirname, `../`, `./${relativeCwd}`),
+            env: { NODE_ENV, CI: 1, GATSBY_LOGGER: `ink` },
+          })
 
           return [
             results.exitCode,
@@ -32,14 +35,10 @@ export const GatsbyCLI = {
 
       invokeAsync: (args, onExit) => {
         const NODE_ENV = args[0] === `develop` ? `development` : `production`
-        const res = execa(
-          resolve(`./node_modules/.bin/gatsby`),
-          [].concat(args),
-          {
-            cwd: join(__dirname, `../`, `./${relativeCwd}`),
-            env: { NODE_ENV, CI: 1, GATSBY_LOGGER: `ink` },
-          }
-        )
+        const res = execa(gatsbyBinLocation, [].concat(args), {
+          cwd: join(__dirname, `../`, `./${relativeCwd}`),
+          env: { NODE_ENV, CI: 1, GATSBY_LOGGER: `ink` },
+        })
 
         const logs = []
         res.stdout.on("data", data => {

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
+set -e # bail on errors
+
 SRC_PATH=$1
 CUSTOM_COMMAND="${2:-yarn test}"
 GATSBY_PATH="${CIRCLE_WORKING_DIRECTORY:-../../}"
 
 # cypress docker does not support sudo and does not need it, but the default node executor does
-command -v gatsby-dev || command -v sudo && sudo npm install -g gatsby-dev-cli || npm install -g gatsby-dev-cli &&
+command -v gatsby-dev || command -v sudo && sudo npm install -g gatsby-dev-cli || npm install -g gatsby-dev-cli
 
 # setting up child integration test link to gatsby packages
-cd "$SRC_PATH" &&
-gatsby-dev --set-path-to-repo "$GATSBY_PATH" &&
-gatsby-dev --force-install --scan-once  && # install _all_ files in gatsby/packages
-chmod +x ./node_modules/.bin/gatsby && # this is sometimes necessary to ensure executable
-sh -c "$CUSTOM_COMMAND" &&
+cd "$SRC_PATH"
+gatsby-dev --set-path-to-repo "$GATSBY_PATH"
+gatsby-dev --force-install --scan-once  # install _all_ files in gatsby/packages
+if test -f "./node_modules/.bin/gatsby"; then
+  chmod +x ./node_modules/.bin/gatsby # this is sometimes necessary to ensure executable
+  echo "Gatsby bin chmoded"
+else
+  echo "Gatsby bin doesn't exist. Skipping chmod."
+fi
+sh -c "$CUSTOM_COMMAND"
 echo "e2e test run succeeded"


### PR DESCRIPTION
Relies on https://github.com/gatsbyjs/gatsby/pull/27055

This installs gatsby-cli in some `/tmp` directory and let tests use that installation to invoke global gatsby-cli commands.

Those changes are looking to catch problems like https://github.com/gatsbyjs/gatsby/issues/26919 which was not caught by any automatic testing (it worked on CI because executed gatsby-cli was in nested monorepo directory so it had access to all `node_modules` which did hide some problems)

---

This is part of PR series:

1. [`feat(gatsby-dev-cli): install deps if there are no gatsby deps but --forceInstall was used`](https://github.com/gatsbyjs/gatsby/pull/27055)
2. [`test(integration/gatsby-cli): use sandboxed directory to "globally" install gatsby-cli`](https://github.com/gatsbyjs/gatsby/pull/27056) __(THIS PR)__
3. [`chore(gatsby-recipes): bundle dependencies`](https://github.com/gatsbyjs/gatsby/pull/27057)
4. [`chore(gatsby-cli): bundle dependencies`](https://github.com/gatsbyjs/gatsby/pull/27058)