### PR TITLE
chore(docs): fix spelling from `yard` to `yarn`

### DIFF
--- a/docs/docs/using-web-fonts.md
+++ b/docs/docs/using-web-fonts.md
@@ -29,7 +29,7 @@ npm install --save typeface-open-sans
 Or with yarn:
 
 ```bash
-yard add typeface-open-sans
+yarn add typeface-open-sans
 ```
 
 In your `layout.js` file, import the typeface.
@@ -64,7 +64,7 @@ npm install --save gatsby-plugin-web-font-loader
 Or with yarn:
 
 ```bash
-yard add gatsby-plugin-web-font-loader
+yarn add gatsby-plugin-web-font-loader
 ```
 
 Then, create an [environment variable](/docs/environment-variables/) to store your Adobe Fonts project ID. (Make sure this file is in your `.gitignore` file so your ID doesn't get committed!) For example, if your Adobe Fonts project ID is `abcdefg`, your `.env` file will look like this:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Fix spelling from `yard` to `yarn` in gatsby [docs/using-web-fonts](https://www.gatsbyjs.com/docs/using-web-fonts/#reach-skip-nav)
<!-- Write a brief description of the changes introduced by this PR -->

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
