### PR TITLE
fix(renovate): move express-graphql and react-reconciler from minor to major update groups

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2105,6 +2105,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby-recipes",
       excludePackageNames: ["cross-env"],
+      packageNames: ["express-graphql"],
     },
     {
       groupName: "minor and patch for gatsby-source-contentful",
@@ -2245,6 +2246,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby",
       excludePackageNames: ["cross-env"],
+      packageNames: ["express-graphql"],
     },
     {
       groupName: "minor and patch for gatsby-admin",

--- a/renovate.json5
+++ b/renovate.json5
@@ -2094,7 +2094,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-recipes",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "express-graphql", "lodash", "lodash-es"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2234,7 +2234,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "express-graphql", "lodash", "lodash-es"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -2094,7 +2094,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-recipes",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "express-graphql", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "express-graphql", "lodash", "lodash-es", "react-reconciler"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2105,7 +2105,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby-recipes",
       excludePackageNames: ["cross-env"],
-      packageNames: ["express-graphql"],
+      packageNames: ["express-graphql", "react-reconciler"],
     },
     {
       groupName: "minor and patch for gatsby-source-contentful",


### PR DESCRIPTION
[express-graphql](/graphql/express-graphql) includes breaking changes in its minor releases. This is semver-compatible since the package is still below v1, but it breaks Renovate PRs that include this package. I'll investigate manually adapting to the changes, specifically [express-graphql#608](/graphql/express-graphql/pull/608) which seems to be the root of the errors generated after updating.