### PR TITLE
chore(docs): Add props to MyParagraph

### DIFF
--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -475,7 +475,7 @@ all of the MDX content.
 import { MDXProvider } from "@mdx-js/react"
 
 const MyH1 = props => <h1 style={{ color: "tomato" }} {...props} />
-const MyParagraph = props => <p style={{ fontSize: "18px", lineHeight: 1.6 }} />
+const MyParagraph = props => <p style={{ fontSize: "18px", lineHeight: 1.6 }} {...props} />
 
 const components = {
   h1: MyH1,

--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -475,7 +475,9 @@ all of the MDX content.
 import { MDXProvider } from "@mdx-js/react"
 
 const MyH1 = props => <h1 style={{ color: "tomato" }} {...props} />
-const MyParagraph = props => <p style={{ fontSize: "18px", lineHeight: 1.6 }} {...props} />
+const MyParagraph = props => (
+  <p style={{ fontSize: "18px", lineHeight: 1.6 }} {...props} />
+)
 
 const components = {
   h1: MyH1,


### PR DESCRIPTION
In the section for `MDXProvider`, the `{..props}` was there for the `MyH1` component, but not for the `MyParagraph` component, which would leave the paragraph empty.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
