### PR TITLE
chore(docs): remove extra "you" (typo)

### DIFF
--- a/docs/docs/recipes/working-with-plugins.md
+++ b/docs/docs/recipes/working-with-plugins.md
@@ -46,7 +46,7 @@ module.exports = {
 }
 ```
 
-_The instructions found in the README of the plugin you're using can you help you determine specifics about what configurations (if any) it requires. For this example to have an effect in your own site, you would need to create the `src/images` folder and place files inside of it._
+_The instructions found in the README of the plugin you're using can help you determine specifics about what configurations (if any) it requires. For this example to have an effect in your own site, you would need to create the `src/images` folder and place files inside of it._
 
 3. Run `gatsby develop`, your plugin should run as your site builds.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Hello!

I noticed an extra "you" in a sentence from the [Recipes: Working with Plugins](https://www.gatsbyjs.com/docs/recipes/working-with-plugins/) page.

After checking Gatsby's contributing documentation (and the comments in this PR), I think that the PR is fine as it is for such a small change, but I'd be more than happy to modify if it is not!

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
- https://www.gatsbyjs.com/docs/recipes/working-with-plugins/
- @gatsbyjs/documentation

## Related Issues

N/A

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
