### PR TITLE
Add relativeDirectory to destinationDir callback

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -39,6 +39,7 @@ const getDestination = (linkNode, dir) => {
       ? `${dir({
           name: linkNode.name,
           hash: linkNode.internal.contentDigest,
+          relativeDirectory: linkNode.relativeDirectory,
         })}.${linkNode.extension}`
       : `${dir()}/${defaultDestination(linkNode)}`
   } else if (_.isString(dir)) {


### PR DESCRIPTION
## Description

Draft of a fix for #27097, to pass the `linkNode.relativeDirectory` to the `destinationDir` callback.

### Documentation

If this is an ok solution, then I can add documentation!

## Related Issues

Closes #27097