### PR TITLE
fix(gatsby-plugin-typescript): Add peer dependencies

### DIFF
--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -24,6 +24,9 @@
     "babel-preset-gatsby-package": "^0.5.3",
     "cross-env": "^7.0.2"
   },
+  "peerDependencies": {
+    "gatsby": "^2.0.0"
+  },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript#readme",
   "keywords": [
     "gatsby",


### PR DESCRIPTION
## Description

The `babel-plugin-remove-graphql-queries` package declares a `gatsby` a peer dependency, and the `gatsby-plugin-typescript` package depends on `babel-plugin-remove-graphql-queries` without also declaring the `gatsby` peer dependency. Declaring the peer dependency resolves a Yarn v2 PNP resolution issue:

```
➤ YN0002: │ gatsby-plugin-typescript@npm:2.4.21 doesn't provide gatsby@^2.0.0 requested by babel-plugin-remove-graphql-queries@npm:2.9.20
```

## Related Issues

This addresses just one of the remaining Yarn v2 compatibility issues identified by #20949.