### PR TITLE
fix(gatsby-recipes): Add peer dependencies

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -127,7 +127,10 @@
   "license": "MIT",
   "main": "dist/index.js",
   "peerDependencies": {
-    "react": "^16.12.0"
+    "gatsby": "^2.6.0",
+    "ink": ">=2.0.0",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

The `gatsby-interface` package declares `gatsby` and `react-dom` peer dependencies, and the `gatsby-recipes` package depends on `gatsby-interface` without also declaring `gatsby` and `react-dom` peer dependencies. The same goes for an `ink` peer dependency requested by `ink-box`. Declaring the peer dependencies resolves a Yarn v2 PNP resolution issue:

```
➤ YN0002: │ gatsby-recipes@npm:0.2.29 [70091] doesn't provide gatsby@^2.6.0 requested by gatsby-interface@npm:0.0.193
➤ YN0002: │ gatsby-recipes@npm:0.2.29 [70091] doesn't provide react-dom@^16.8.1 requested by gatsby-interface@npm:0.0.193
➤ YN0002: │ gatsby-recipes@npm:0.2.29 [70091] doesn't provide ink@>=2.0.0 requested by ink-box@npm:1.0.0
```

## Related Issues

This addresses just one of the remaining Yarn v2 compatibility issues identified by #20949.