### PR TITLE
perf(redirect): minified redirect file size

### DIFF
--- a/packages/gatsby/src/bootstrap/redirects-writer.ts
+++ b/packages/gatsby/src/bootstrap/redirects-writer.ts
@@ -13,7 +13,10 @@ export const writeRedirects = async (): Promise<void> => {
   const { program, redirects } = store.getState()
 
   // Filter for redirects that are meant for the browser.
-  const browserRedirects = redirects.filter(r => r.redirectInBrowser)
+  const browserRedirects = redirects
+    .filter(r => r.redirectInBrowser)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    .map(({ redirectInBrowser, isPermanent, ...rest }) => rest)
 
   const newHash = crypto
     .createHash(`md5`)

--- a/packages/gatsby/src/query/redirects-writer.ts
+++ b/packages/gatsby/src/query/redirects-writer.ts
@@ -13,7 +13,10 @@ export const writeRedirects = async (): Promise<void> => {
   const { program, redirects } = store.getState()
 
   // Filter for redirects that are meant for the browser.
-  const browserRedirects = redirects.filter(r => r.redirectInBrowser)
+  const browserRedirects = redirects
+    .filter(r => r.redirectInBrowser)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    .map(({ redirectInBrowser, isPermanent, ...rest }) => rest)
 
   const newHash = crypto
     .createHash(`md5`)


### PR DESCRIPTION
## Description

We found that the redirect section of our app bundle was 1MB parsed size, this was somewhat non-ideal. This PR removes some data that is unnecessary for the browser to be aware of, to slim down the size of the bundle. The browser doesn't need to know if a redirect should work on the browser, as *all* of the ones in the file should work in the browser. As for permanent redirects, there is no such thing as a permanent or temporary redirect to the browser.

This change took our redirect file from 1MB to 400kB. This is a 60% improvement for realistically no problem.