### PR TITLE
tests: run CircleCI tests when only yarn.lock changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
     executor: node
     steps:
       - checkout
-      - run: ./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*|.circleci/*"
+      - run: ./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*|.circleci/*|yarn.lock"
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *persist_cache
@@ -213,7 +213,7 @@ jobs:
     steps:
       - checkout
       # We should always assert on master
-      - run: ./scripts/assert-changed-files.sh "packages/*|.circleci/*"
+      - run: ./scripts/assert-changed-files.sh "packages/*|.circleci/*|yarn.lock"
       - <<: *attach_to_bootstrap
       - run: yarn typecheck
       - run: yarn check-repo-fields


### PR DESCRIPTION
Currently bootstrap and typecheck tests aren't run unless there are changes in the `packages` directory. This means changes to the top-level yarn.lock are ignored. This causes errors like those in #27077 to be missed.