### PR TITLE
fix(gatsby-plugin-preact): add babel-plugin properly

### DIFF
--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
-    "@prefresh/webpack": "^1.1.0"
+    "@prefresh/babel-plugin": "^0.2.0",
+    "@prefresh/webpack": "^1.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",

--- a/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
@@ -1,4 +1,4 @@
-const { onCreateWebpackConfig } = require(`../gatsby-node`)
+const { onCreateWebpackConfig, onCreateBabelConfig } = require(`../gatsby-node`)
 const PreactRefreshPlugin = require(`@prefresh/webpack`)
 const ReactRefreshWebpackPlugin = require(`@pmmmwh/react-refresh-webpack-plugin`)
 
@@ -15,9 +15,12 @@ describe(`gatsby-plugin-preact`, () => {
       replaceWebpackConfig: jest.fn(),
     }
 
+    onCreateBabelConfig({ stage: `develop`, actions })
+    onCreateBabelConfig({ stage: `develop-html`, actions })
     onCreateWebpackConfig({ stage: `develop`, actions, getConfig })
+    onCreateWebpackConfig({ stage: `develop-html`, actions, getConfig })
 
-    expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1)
+    expect(actions.setWebpackConfig).toHaveBeenCalledTimes(2)
     expect(actions.setWebpackConfig).toHaveBeenCalledWith({
       plugins: [new PreactRefreshPlugin()],
       resolve: {
@@ -32,6 +35,7 @@ describe(`gatsby-plugin-preact`, () => {
     expect(actions.setBabelPlugin).toHaveBeenCalledTimes(1)
     expect(actions.setBabelPlugin).toHaveBeenCalledWith({
       name: `@prefresh/babel-plugin`,
+      stage: `develop`,
     })
     expect(actions.replaceWebpackConfig).toMatchInlineSnapshot(`
       [MockFunction] {
@@ -86,9 +90,12 @@ describe(`gatsby-plugin-preact`, () => {
       replaceWebpackConfig: jest.fn(),
     }
 
+    onCreateBabelConfig({ stage: `build-javascript`, actions })
+    onCreateBabelConfig({ stage: `build-html`, actions })
     onCreateWebpackConfig({ stage: `build-javascript`, actions, getConfig })
+    onCreateWebpackConfig({ stage: `build-html`, actions, getConfig })
 
-    expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1)
+    expect(actions.setWebpackConfig).toHaveBeenCalledTimes(2)
     expect(actions.setWebpackConfig).toHaveBeenCalledWith({
       plugins: [],
       resolve: {

--- a/packages/gatsby-plugin-preact/src/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-node.js
@@ -5,6 +5,17 @@ exports.onPreInit = () => {
   process.env.GATSBY_HOT_LOADER = `fast-refresh`
 }
 
+exports.onCreateBabelConfig = ({ actions, stage }) => {
+  if (stage === `develop`) {
+    // enable react-refresh babel plugin to enable hooks
+    // @see https://github.com/JoviDeCroock/prefresh/tree/master/packages/webpack#using-hooks
+    actions.setBabelPlugin({
+      name: `@prefresh/babel-plugin`,
+      stage,
+    })
+  }
+}
+
 exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
   const webpackPlugins = []
   if (stage === `develop`) {
@@ -16,12 +27,6 @@ exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
       plugin => plugin.constructor.name !== `ReactRefreshPlugin`
     )
     actions.replaceWebpackConfig(webpackConfig)
-
-    // enable react-refresh babel plugin to enable hooks
-    // @see https://github.com/JoviDeCroock/prefresh/tree/master/packages/webpack#using-hooks
-    actions.setBabelPlugin({
-      name: `@prefresh/babel-plugin`,
-    })
   }
 
   // add preact to the framework bundle

--- a/yarn.lock
+++ b/yarn.lock
@@ -2874,6 +2874,11 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@prefresh/babel-plugin@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@prefresh/babel-plugin/-/babel-plugin-0.2.0.tgz#b6223b1b14cc1b6c18c2bc3f7c613e2230ebca47"
+  integrity sha512-Qd6SpS1IKBsW8dDF7hA58TrWSahOirXRvhlYepXXqLzpQJKUpDSVfzVfZJpKuxSlgK8opYvR4Zr07c9oN5+uzg==
+
 "@prefresh/core@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@prefresh/core/-/core-0.8.1.tgz#d4f15d9e3ee9c16bf420405e2b422774e807a594"
@@ -2884,7 +2889,7 @@
   resolved "https://registry.yarnpkg.com/@prefresh/utils/-/utils-0.3.1.tgz#f9e1a5e1fa4bc02989980733950e60520f0f9869"
   integrity sha512-9kLzPWN4teeiKuc+Rle3SF/hyx5lzo35X4rHr+kQXnJT+BaEb1ymDWIHGkv85xjnw8+l6I1r1H7JB4BHOMJfmg==
 
-"@prefresh/webpack@^1.1.0":
+"@prefresh/webpack@^1.0.2":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@prefresh/webpack/-/webpack-1.1.0.tgz#a36fd072ef1d5cd88ced8df89d7ae62bdbddf71b"
   integrity sha512-a3JG2maH3bacDobb4WywVTuqvAyBxJ7dRNSG2Ywv1AytAdgpgNZKJpR4xUTzPTwPGpRkfNOOf4mODqoOZ7W0Sw==


### PR DESCRIPTION
## Description

Seems like we didn't have the correct deps in package.json and we didn't use the correct lifecycle to add a babel plugin.


## Related Issues

Fixes #27151
