### PR TITLE
fix(gatsby-telemetry): export Typescript types, add captureEvent method

### DIFF
--- a/packages/gatsby-telemetry/README.md
+++ b/packages/gatsby-telemetry/README.md
@@ -4,7 +4,13 @@ Check out: [gatsby.dev/telemetry](https://gatsby.dev/telemetry)
 
 ## API
 
+### captureEvent(type, tags)
+
+Capture an event of type `type` and decorate the generated event with these tags (note: allowed tags are filtered on server side)
+
 ### trackCli(type, tags)
+
+_This one does the same thing as the `captureEvent` function described above._
 
 Capture an event of type `type` and decorate the generated event with these tags (note: allowed tags are filtered on server side)
 

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -41,6 +41,14 @@ export function trackCli(
   instance.captureEvent(input, tags, opts)
 }
 
+export function captureEvent(
+  input: string | Array<string>,
+  tags?: ITelemetryTagsPayload,
+  opts?: ITelemetryOptsPayload
+): void {
+  instance.captureEvent(input, tags, opts)
+}
+
 export function trackError(input: string, tags?: ITelemetryTagsPayload): void {
   instance.captureError(input, tags)
 }
@@ -101,6 +109,14 @@ export function setDefaultComponentId(componentId: string): void {
 
 export function setGatsbyCliVersion(version: string): void {
   instance.gatsbyCliVersion = version
+}
+
+export {
+  AnalyticsTracker,
+  IAggregateStats,
+  ITelemetryTagsPayload,
+  ITelemetryOptsPayload,
+  IDefaultTelemetryTagsPayload,
 }
 
 module.exports = {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

- Exports some Typescript types
- `trackCli` is not a very good name for capturing an event. Adding a method called `captureEvent` doing the same thing as trackCli

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

In the readme (inside the file modified)