### PR TITLE
[do-not-merge] just testing e2e-test.sh failing properly

### DIFF
--- a/integration-tests/gatsby-cli/__tests__/build.js
+++ b/integration-tests/gatsby-cli/__tests__/build.js
@@ -9,6 +9,10 @@ describe(`gatsby build`, () => {
   beforeAll(() => GatsbyCLI.from(cwd).invoke(`clean`))
   afterAll(() => GatsbyCLI.from(cwd).invoke(`clean`))
 
+  it(`will fail the test`, () => {
+    expect(false).toBe(true)
+  })
+
   it(`creates a built gatsby site`, () => {
     const [code, logs] = GatsbyCLI.from(cwd).invoke(`build`)
 


### PR DESCRIPTION
This is just making sure that changes in https://github.com/gatsbyjs/gatsby/pull/27056 will continue to properly fail tests when jest actually fails