### PR TITLE
Added how to preserve custom domains when publishing

### DIFF
--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -54,6 +54,15 @@ Then add a `deploy` script to `package.json` in your repository's codebase:
 }
 ```
 
+If you are using a custom domain, edit the deploy script to output a CNAME file to the public directory before publishing to preserve your custom domain:
+```json:title=package.json
+{
+  "scripts": {
+    "deploy": "gatsby build --prefix-paths && echo 'example.com' > public/CNAME && gh-pages -d public"
+  }
+}
+```
+
 When you run `npm run deploy` all contents of the `public` folder will be moved to your repository's `gh-pages` branch. Make sure that your repository's settings has the `gh-pages` branch set as the source to deploy from.
 
 **Note**: to select master or gh-pages as your publishing source, you must have the branch present in your repository. If you don't have a master or gh-pages branch, you can create them and then return to source settings to change your publishing source.

--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -55,6 +55,7 @@ Then add a `deploy` script to `package.json` in your repository's codebase:
 ```
 
 If you are using a custom domain, edit the deploy script to output a CNAME file to the public directory before publishing to preserve your custom domain:
+
 ```json:title=package.json
 {
   "scripts": {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
In my use of Gatsby, I struggled at first to remember to update my CNAME file for my repositories while using the gh-pages utility. This adds the information on how to do that automatically when running the deploy command.

