### PR TITLE
Added internal links for Node.js install instructions

### DIFF
--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -66,10 +66,10 @@ brew install node
 
 - Download and install the latest Node.js version from [the official Node.js website](https://nodejs.org/en/)
 
-#### Verify Nodejs on your windows computer:
+#### Verify Node.js on your windows computer:
 
 1. Restart your computer.
-2. Open your Command Prompt or Powershell.
+2. Open your Command Prompt or powershell.
 3. Run below command, to test Node and npm is successfully installed or not.
 
 ```shell
@@ -79,7 +79,6 @@ npm -v
 >> 6.14.6
 
 ```
-
 
 ### Linux Instructions
 

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -79,6 +79,8 @@ npm -v
 >> 6.14.6
 
 ```
+> 💡 If an error occurs, uninstall Node.js and reinstall the Node.js.
+
 
 ### Linux Instructions
 

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -66,6 +66,19 @@ brew install node
 
 - Download and install the latest Node.js version from [the official Node.js website](https://nodejs.org/en/)
 
+#### Verify Nodejs on your windows computer:
+
+1. Open your Command Prompt or Powershell.
+2. Run below command, to test Node and npm is successfully installed or not.
+
+```Command Prompt
+node -v
+>> v12.18.4
+npm -v
+>> 6.14.6
+
+```
+
 ### Linux Instructions
 
 Install nvm (Node Version Manager) and needed dependencies. nvm is used to manage Node.js and all its associated versions.

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -18,11 +18,9 @@ _**Note:** If you’re new to the command line, "running" a command, means "writ
 
 Node.js is an environment that can run JavaScript code outside of a web browser. Gatsby is built with Node.js. To get up and running with Gatsby, you’ll need to have a recent version installed on your computer. npm comes bundled with Node.js so if you don't have npm, chances are that you don't have Node.js either.
 
-[**1) Node.js on Mac**](#mac-instructions) 
-
-[**2) Node.js on Windows**](#windows-instructions)
-
-[**3) Node.js on Linux**](#linux-instructions)
+- [**Node.js on Mac**](#mac-instructions) 
+- [**Node.js on Windows**](#windows-instructions)
+- [**Node.js on Linux**](#linux-instructions)
 
 ### Mac instructions
 

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -68,16 +68,18 @@ brew install node
 
 #### Verify Nodejs on your windows computer:
 
-1. Open your Command Prompt or Powershell.
-2. Run below command, to test Node and npm is successfully installed or not.
+1. Restart your computer.
+2. Open your Command Prompt or Powershell.
+3. Run below command, to test Node and npm is successfully installed or not.
 
-```Command Prompt
+```shell
 node -v
 >> v12.18.4
 npm -v
 >> 6.14.6
 
 ```
+
 
 ### Linux Instructions
 

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -17,9 +17,12 @@ _**Note:** If you’re new to the command line, "running" a command, means "writ
 ## Install Node.js for your appropriate operating system
 
 Node.js is an environment that can run JavaScript code outside of a web browser. Gatsby is built with Node.js. To get up and running with Gatsby, you’ll need to have a recent version installed on your computer. npm comes bundled with Node.js so if you don't have npm, chances are that you don't have Node.js either.
-[Node.js on Mac](#mac-instructions)
-[Node.js on Windows](#windows-instructions)
-[Node.js on Linux](#linux-instructions)
+
+[**1) Node.js on Mac**](#mac-instructions) 
+
+[**2) Node.js on Windows**](#windows-instructions)
+
+[**3) Node.js on Linux**](#linux-instructions)
 
 ### Mac instructions
 

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -69,7 +69,7 @@ brew install node
 #### Verify Node.js on your windows computer:
 
 1. Restart your computer.
-2. Open your Command Prompt or powershell.
+2. Open your Command Prompt.
 3. Run below command, to test Node and npm is successfully installed or not.
 
 ```shell

--- a/docs/tutorial/part-zero/index.md
+++ b/docs/tutorial/part-zero/index.md
@@ -17,6 +17,9 @@ _**Note:** If you’re new to the command line, "running" a command, means "writ
 ## Install Node.js for your appropriate operating system
 
 Node.js is an environment that can run JavaScript code outside of a web browser. Gatsby is built with Node.js. To get up and running with Gatsby, you’ll need to have a recent version installed on your computer. npm comes bundled with Node.js so if you don't have npm, chances are that you don't have Node.js either.
+[Node.js on Mac](#mac-instructions)
+[Node.js on Windows](#windows-instructions)
+[Node.js on Linux](#linux-instructions)
 
 ### Mac instructions
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
1. Added Internal link easily to navigate through instruction to install Node.js on different operating system.
2. Add Node.js installation steps and test/check for windows operating system.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
Updated "Install Node.js for your appropriate operating system" under "Set Up Your Development Environment" in gatsby tutorials.  @gatsbybot 
link to site: [https://www.gatsbyjs.com/tutorial/part-zero/#install-nodejs-for-your-appropriate-operating-system](https://www.gatsbyjs.com/tutorial/part-zero/#install-nodejs-for-your-appropriate-operating-system)
<!--
  Where is this feature or API documented?
  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
