### PR TITLE
fix(gatsby-plugin-static-images): add missing static image fields

### DIFF
--- a/packages/gatsby-plugin-static-image/src/get-custom-sharp-fields.ts
+++ b/packages/gatsby-plugin-static-image/src/get-custom-sharp-fields.ts
@@ -2,7 +2,7 @@ import { Node, GatsbyCache, Reporter } from "gatsby"
 import { fluid, fixed, traceSVG } from "gatsby-plugin-sharp"
 
 export async function getCustomSharpFields({
-  isFixed, // make sure fluid is also handled
+  isFixed,
   file,
   args,
   reporter,
@@ -10,7 +10,7 @@ export async function getCustomSharpFields({
 }: {
   isFixed: boolean
   file: Node
-  args: any // TODO type this correctly
+  args: any // TODO: type this correctly
   reporter: Reporter
   cache: GatsbyCache
 }): Promise<{
@@ -29,14 +29,22 @@ export async function getCustomSharpFields({
     // If the file is already in webp format or should explicitly
     // be converted to webp, we do not create additional webp files
     if (file.extension !== `webp`) {
-      const fixedWebP = await fixed({
-        file,
-        args: { ...args, toFormat: `webp` },
-        reporter,
-        cache,
-      })
-      customSharpFields.srcWebP = fixedWebP.src
-      customSharpFields.srcSetWebP = fixedWebP.srcSet
+      const generatedWebP = await (isFixed
+        ? fixed({
+            file,
+            // TODO: need to get access to pathPrefix into these invocations
+            args: { ...args, toFormat: `webp` },
+            reporter,
+            cache,
+          })
+        : fluid({
+            file,
+            args: { ...args, toFormat: `webp` },
+            reporter,
+            cache,
+          }))
+      customSharpFields.srcWebP = generatedWebP.src
+      customSharpFields.srcSetWebP = generatedWebP.srcSet
     }
   }
 

--- a/packages/gatsby-plugin-static-image/src/get-custom-sharp-fields.ts
+++ b/packages/gatsby-plugin-static-image/src/get-custom-sharp-fields.ts
@@ -1,0 +1,55 @@
+import { Node, GatsbyCache, Reporter } from "gatsby"
+import { fluid, fixed, traceSVG } from "gatsby-plugin-sharp"
+
+export async function getCustomSharpFields({
+  isFixed, // make sure fluid is also handled
+  file,
+  args,
+  reporter,
+  cache,
+}: {
+  isFixed: boolean
+  file: Node
+  args: any // TODO type this correctly
+  reporter: Reporter
+  cache: GatsbyCache
+}): Promise<{
+  srcWebP: string | null
+  srcSetWebP: string | null
+  tracedSVG: string | null
+}> {
+  const { webP, tracedSVG } = args
+  const customSharpFields = {
+    srcWebP: null,
+    srcSetWebP: null,
+    tracedSVG: null,
+  }
+
+  if (webP) {
+    // If the file is already in webp format or should explicitly
+    // be converted to webp, we do not create additional webp files
+    if (file.extension !== `webp`) {
+      const fixedWebP = await fixed({
+        file,
+        args: { ...args, toFormat: `webp` },
+        reporter,
+        cache,
+      })
+      customSharpFields.srcWebP = fixedWebP.src
+      customSharpFields.srcSetWebP = fixedWebP.srcSet
+    }
+  }
+
+  if (tracedSVG) {
+    const tracedSVG = await traceSVG({
+      file,
+      args: { ...args, traceSVG: true },
+      fileArgs: args,
+      cache,
+      reporter,
+    })
+    customSharpFields.tracedSVG = tracedSVG
+  }
+
+  return customSharpFields
+}

--- a/packages/gatsby-plugin-static-image/src/image-processing.ts
+++ b/packages/gatsby-plugin-static-image/src/image-processing.ts
@@ -2,6 +2,7 @@ import { Node, GatsbyCache, Reporter } from "gatsby"
 import { fluid as fluidSharp, fixed as fixedSharp } from "gatsby-plugin-sharp"
 import fs from "fs-extra"
 import path from "path"
+import { getCustomSharpFields } from "./get-custom-sharp-fields"
 
 const fileCache = new Map<string, Node>()
 
@@ -19,7 +20,7 @@ export async function writeImages({
   cache: GatsbyCache
 }): Promise<void> {
   const promises = [...images.entries()].map(
-    async ([hash, { src, fluid, fixed, ...args }]) => {
+    async ([hash, { src, fluid, fixed, webP, tracedSVG, ...args }]) => {
       const isFixed = fixed ?? !fluid
 
       let file = fileCache.get(src as string)
@@ -34,9 +35,21 @@ export async function writeImages({
       const filename = path.join(cacheDir, `${hash}.json`)
       try {
         const options = { file, args, reporter, cache }
-        const data = await (isFixed ? fixedSharp(options) : fluidSharp(options))
+        // get standard set of fields from sharp
+        const sharpData = await (isFixed
+          ? fixedSharp(options)
+          : fluidSharp(options))
+        if (sharpData) {
+          // get the equivalent webP and tracedSVG fields gatsby-transformer-sharp handles normally
+          const customSharpFields = await getCustomSharpFields({
+            isFixed: isFixed ? true : false,
+            file,
+            args,
+            reporter,
+            cache,
+          })
+          const data = { ...sharpData, ...customSharpFields }
 
-        if (data) {
           await fs.writeJSON(filename, data)
         } else {
           console.log(`Could not process image`)

--- a/packages/gatsby-plugin-static-image/src/image-processing.ts
+++ b/packages/gatsby-plugin-static-image/src/image-processing.ts
@@ -20,7 +20,7 @@ export async function writeImages({
   cache: GatsbyCache
 }): Promise<void> {
   const promises = [...images.entries()].map(
-    async ([hash, { src, fluid, fixed, webP, tracedSVG, ...args }]) => {
+    async ([hash, { src, fluid, fixed, ...args }]) => {
       const isFixed = fixed ?? !fluid
 
       let file = fileCache.get(src as string)

--- a/packages/gatsby-plugin-static-image/src/utils.ts
+++ b/packages/gatsby-plugin-static-image/src/utils.ts
@@ -24,6 +24,8 @@ export const SHARP_ATTRIBUTES = new Set([
   `background`,
   `width`,
   `height`,
+  `tracedSVG`,
+  `webP`,
 ])
 
 export function evaluateImageAttributes(


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

`webP` and `tracedSVG` weren't handled since they were implemented in custom resolvers in `gatsby-transformer-sharp` which is bypassed by this static image plugin. 

This takes the implementation there and roughly copies it into this plugin.

_There are likely some issues with TypeScript and a few TODOs that I left commented but I was trying to get something up before my end of day since I'll be gone tomorrow, Oct 1st_ 🙂 



## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

https://github.com/gatsbyjs/gatsby/pull/26924#issuecomment-701435232
