### PR TITLE
chore(gatsby-remark-autolink-headers): add styling instructions

### DIFF
--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -88,20 +88,22 @@ module.exports = {
 }
 ```
 
-## How to style generated svg
+## How to style the anchor link
 
-Sometimes you would want to change the generated svg to better fit you website theme
+Sometimes you would like to style the generated anchor link because it does not fit the theme of your website.
 
-To style the generated SVG you can use the following css to add currentColor
+To style the generated anchor link you can use the following css to make it red
 
 ```
 a.anchor {
-  fill: currentColor
+  fill: 'red'
 }
 ```
 
-Or if you want to only target the svg (note that the first selector is faster than the one below but that's micro optimisations)
+If you want to only target the svg (note that the first selector is faster than the one below but that's micro optimisations)
 
 ```
-a.anchor > svg
+a.anchor > svg {
+    fill: 'red'
+}
 ```

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -96,7 +96,7 @@ In your CSS you can specify this element, in this instance the anchor tag will a
 
 ```css
 a.anchor {
-    fill: 'red'
+  fill: "red";
 }
 ```
 

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -90,9 +90,9 @@ module.exports = {
 
 ## How to style the anchor link
 
-Sometimes you would like to style the generated anchor link because it does not fit the theme of your website.
+By default, the anchor link has no additional styling. To make it fit your website, we'll have to write some extra CSS rules. 
 
-To style the generated anchor link you can use the following css to make it red
+If you want to make the anchor icon red, you can add the following CSS rule:
 
 ```
 a.anchor {
@@ -100,10 +100,4 @@ a.anchor {
 }
 ```
 
-If you want to only target the svg (note that the first selector is faster than the one below but that's micro optimisations)
-
-```
-a.anchor > svg {
-    fill: 'red'
-}
-```
+note: Not sure how to add custom css? You can visit our [tutorial][https://www.gatsbyjs.com/tutorial/part-two/).

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -88,7 +88,9 @@ module.exports = {
 }
 ```
 
-## Styling
+## How to style generated svg
+
+Sometimes you would want to change the generated svg to better fit you website theme
 
 To style the generated SVG you can use the following css to add currentColor
 

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -90,14 +90,14 @@ module.exports = {
 
 ## How to style the anchor link
 
-By default, the anchor link has no additional styling. To make it fit your website, we'll have to write some extra CSS rules. 
+By default, the anchor link has no additional styling. To make it fit your website, we'll have to write som extra CSS rules.
 
-If you want to make the anchor icon red, you can add the following CSS rule:
+If you want to make the anchor link red, you can add the following CSS rule:
 
 ```
 a.anchor {
-  fill: 'red'
+    fill: 'red'
 }
 ```
 
-note: Not sure how to add custom css? You can visit our [tutorial][https://www.gatsbyjs.com/tutorial/part-two/).
+note: Nor sure how to add custom css? You can visit out [tutorial][https://www.gatsbyjs.com/tutorial/part-two/].

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -90,9 +90,9 @@ module.exports = {
 
 ## How to style the anchor link
 
-By default, the anchor link has no additional styling. To make it fit your website, we'll have to write som extra CSS rules.
+By default, the anchor link has a class of `anchor` (see `className` option to change this name) on the element but has no additional styling. To make it fit your website, you'll have to write some CSS to change the appeareance.
 
-If you want to make the anchor link red, you can add the following CSS rule:
+In your CSS you can specify this element, in this instance the anchor tag will appear red:
 
 ```
 a.anchor {
@@ -100,4 +100,4 @@ a.anchor {
 }
 ```
 
-note: Not sure how to add custom css? You can visit our [tutorial](https://www.gatsbyjs.com/tutorial/part-two/).
+Note: There are a variety of approaches to styling your Gatsby site, see [styling documentation](https://www.gatsbyjs.com/docs/styling/) for more detail.

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -100,4 +100,4 @@ a.anchor {
 }
 ```
 
-note: Not sure how to add custom css? You can visit our [tutorial][https://www.gatsbyjs.com/tutorial/part-two/].
+note: Not sure how to add custom css? You can visit our [tutorial](https://www.gatsbyjs.com/tutorial/part-two/).

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -87,3 +87,19 @@ module.exports = {
   ],
 }
 ```
+
+## Styling
+
+To style the generated SVG you can use the following css to add currentColor
+
+```
+a.anchor {
+  fill: currentColor
+}
+```
+
+Or if you want to only target the svg (note that the first selector is faster than the one below but that's micro optimisations)
+
+```
+a.anchor > svg
+```

--- a/packages/gatsby-remark-autolink-headers/README.md
+++ b/packages/gatsby-remark-autolink-headers/README.md
@@ -94,7 +94,7 @@ By default, the anchor link has a class of `anchor` (see `className` option to c
 
 In your CSS you can specify this element, in this instance the anchor tag will appear red:
 
-```
+```css
 a.anchor {
     fill: 'red'
 }


### PR DESCRIPTION
## Description

Add instructions on how to style svg in gatsby-remark-autolink-headers

## Related Issues

Fixes #20982 
