### PR TITLE
chore(circleci): Remove unit tests for www

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,17 +234,6 @@ jobs:
       image: "14"
     <<: *test_template
 
-  unit_tests_www:
-    executor: node
-    steps:
-      - checkout
-      - run:
-          command: yarn
-          working_directory: ~/project/www
-      - run:
-          command: yarn test
-          working_directory: ~/project/www
-
   integration_tests_long_term_caching:
     executor: node
     steps:
@@ -561,11 +550,6 @@ workflows:
             - bootstrap
       - unit_tests_node12:
           <<: *ignore_docs
-          requires:
-            - lint
-            - typecheck
-            - bootstrap
-      - unit_tests_www:
           requires:
             - lint
             - typecheck


### PR DESCRIPTION
Since we merged .org and .com and moved the code to a private repository there's no use in running the tests for `www`.