### PR TITLE
fixing by remove/change the word simply and easily in many documentation

### DIFF
--- a/benchmarks/markdown_id/README.md
+++ b/benchmarks/markdown_id/README.md
@@ -31,4 +31,4 @@ gatsby clean
 node --max_old_space_size=2000 node_modules/.bin/gatsby build
 ```
 
-The last step could also just be `gatsby build` if the number of pages is small enough. The example will increase the maximum reserved "old object space" which you'll need for a larger number of pages.
+The last step you could also use `gatsby build` if the number of pages is small enough. The example will increase the maximum reserved "old object space" which you'll need for a larger number of pages.

--- a/benchmarks/markdown_slug/README.md
+++ b/benchmarks/markdown_slug/README.md
@@ -31,4 +31,4 @@ gatsby clean
 node --max_old_space_size=2000 node_modules/.bin/gatsby build
 ```
 
-The last step could also just be `gatsby build` if the number of pages is small enough. The example will increase the maximum reserved "old object space" which you'll need for a larger number of pages.
+The last step you could also use `gatsby build` if the number of pages is small enough. The example will increase the maximum reserved "old object space" which you'll need for a larger number of pages.

--- a/benchmarks/source-contentful/README.md
+++ b/benchmarks/source-contentful/README.md
@@ -23,7 +23,7 @@ Use following approach to fix those:
 
 1. Run `yarn site find-broken-images`
 2. Change image URLs in will-it-build dataset for this site to some other images
-   (or just use one of the larger sites and set `BENCHMARK_SITE_ID` appropriately)
+   (or use one of the larger sites and set `BENCHMARK_SITE_ID` appropriately)
 3. Run `yarn site fix-broken-images imageid1 imageid2 imageid3`
    This command updates broken images with images from the `BENCHMARK_SITE_ID` dataset
 

--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -3,7 +3,7 @@ title: Gatsby Style Guide
 ---
 
 The Gatsby community is building out a more comprehensive Docs section. It
-will be full of relevant articles written to be easily understood by the many people who love building with Gatsby.
+will be full of relevant articles written to be more understood by the many people who love building with Gatsby.
 
 The community plans, writes, and maintains these Docs on GitHub.
 

--- a/docs/contributing/how-to-write-a-reference-guide.md
+++ b/docs/contributing/how-to-write-a-reference-guide.md
@@ -61,7 +61,7 @@ Guide topics should be chosen based on these priorities:
 
 ### Length of a reference guide
 
-Ideally, a guide's table of contents would fit above the fold on a desktop computer screen. This means the outline is easily consumable, so the person can quickly determine if that section of the docs contains the information they need to complete a task.
+Ideally, a guide's table of contents would fit above the fold on a desktop computer screen. This means the outline is more consumable, so the person can quickly determine if that section of the docs contains the information they need to complete a task.
 
 The content of a reference guide should provide just enough information to be actionable. Linking out to other materials and guides outside of Gatsby's core concepts is recommended to limit the scope to critical and unique parts of Gatsby development.
 

--- a/docs/contributing/how-to-write-a-reference-guide.md
+++ b/docs/contributing/how-to-write-a-reference-guide.md
@@ -133,7 +133,7 @@ Each overview should give a short introduction of its section of the guides and 
 
 ### Length of a reference guide overview
 
-Ideally, a guide overview fits above the fold on a desktop computer screen. This means the outline is easily consumable, so the person can quickly determine if that section of the docs contains the information they need to complete a task.
+Ideally, a guide overview fits above the fold on a desktop computer screen. This means the outline is more consumable, so the person can quickly determine if that section of the docs contains the information they need to complete a task.
 
 ### When should I create a new reference guide overview?
 

--- a/docs/docs/css-in-js.md
+++ b/docs/docs/css-in-js.md
@@ -2,7 +2,7 @@
 title: Enhancing Styles with CSS-in-JS
 ---
 
-CSS-in-JS refers to an approach where styles are written in JavaScript instead of in external CSS files to easily scope styles in components, eliminate dead code, encourage faster performance and dynamic styling, and more.
+CSS-in-JS refers to an approach where styles are written in JavaScript instead of in external CSS files to make it scope styles in components, eliminate dead code, encourage faster performance and dynamic styling, and more.
 
 CSS-in-JS bridges the gap between CSS and JavaScript:
 

--- a/docs/docs/debugging.md
+++ b/docs/docs/debugging.md
@@ -2,6 +2,6 @@
 title: Debugging
 ---
 
-While building your site, you’ll sometimes encounter bugs. These guides help you set up debugging in Gatsby so you can spot and squash bugs more easily.
+While building your site, you’ll sometimes encounter bugs. These guides help you set up debugging in Gatsby so you can spot and squash bugs easier.
 
 <GuideList slug={props.slug} />

--- a/docs/docs/gatsby-image.md
+++ b/docs/docs/gatsby-image.md
@@ -282,7 +282,7 @@ Read more about shared image query parameters in the [`gatsby-plugin-sharp`](/pa
 
 ## Image query fragments
 
-GraphQL includes a concept called "query fragments", which are a part of a query that can be reused. To ease building with `gatsby-image`, Gatsby image processing plugins which support `gatsby-image` ship with fragments which you can easily include in your queries.
+GraphQL includes a concept called "query fragments", which are a part of a query that can be reused. To ease building with `gatsby-image`, Gatsby image processing plugins which support `gatsby-image` ship with fragments which you can include in your queries.
 
 > Note: using fragments in your queries depends on which data source(s) you have configured. Read more about image query fragments in the [gatsby-image](/packages/gatsby-image/#fragments) README.
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -330,7 +330,7 @@ A pre-configured Gatsby project that can be used as a starting point for your pr
 
 ### Static
 
-Gatsby [builds](#build) static versions of your page that can be easily [hosted](#hosting). This is in contrast to dynamic systems in which each page is generated on-the-fly. Being static affords major performance gains because the work only needs to be done once per content or code change.
+Gatsby [builds](#build) static versions of your page that can be [hosted](#hosting). This is in contrast to dynamic systems in which each page is generated on-the-fly. Being static affords major performance gains because the work only needs to be done once per content or code change.
 
 It also refers to the `/static` folder which is automatically copied into `/public` on each [build](#build) for files that don't need to be processed by Gatsby but do need to exist in [public](#public).
 

--- a/docs/docs/how-code-splitting-works.md
+++ b/docs/docs/how-code-splitting-works.md
@@ -36,7 +36,7 @@ Content hash is a hash of the contents of the chunk that was code split. But wha
 
 ## Primer on chunkGroups and chunks
 
-Before we go on to show how Gatsby maps components to the generated bundle names, you should understand how webpack chunks work. A chunk group represents a logical code split, e.g. a Gatsby page, or the Gatsby core app. The chunk groups might share a bunch of code or libraries. webpack detects these and creates shared pieces of code. These are chunks, e.g. there might be a chunk for React and other libraries. Then there would be the leftover chunks of core Gatsby JS code for the particular chunk group. This is most easily explained by the below graph.
+Before we go on to show how Gatsby maps components to the generated bundle names, you should understand how webpack chunks work. A chunk group represents a logical code split, e.g. a Gatsby page, or the Gatsby core app. The chunk groups might share a bunch of code or libraries. webpack detects these and creates shared pieces of code. These are chunks, e.g. there might be a chunk for React and other libraries. Then there would be the leftover chunks of core Gatsby JS code for the particular chunk group. This is explained by the below graph.
 
 ```dot
 digraph {

--- a/docs/docs/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-gatsby-works-with-github-pages.md
@@ -2,7 +2,7 @@
 title: How Gatsby Works with GitHub Pages
 ---
 
-GitHub Pages is a service offered by GitHub that allows hosting for websites configured straight from the repository. A Gatsby site can be hosted on GitHub Pages with just a few configurations to the codebase and the repository's settings.
+GitHub Pages is a service offered by GitHub that allows hosting for websites configured straight from the repository. A Gatsby site can be hosted on GitHub Pages with a few configurations to the codebase and the repository's settings.
 
 You can publish your site on GitHub Pages several different ways:
 

--- a/docs/docs/node-apis.md
+++ b/docs/docs/node-apis.md
@@ -32,7 +32,7 @@ exports.createPages = (_, pluginOptions, cb) => {
 }
 ```
 
-If your plugin does not do async work, you can just return directly.
+If your plugin does not do async work, you can return it directly.
 
 ## Usage
 

--- a/docs/docs/schema-inference.md
+++ b/docs/docs/schema-inference.md
@@ -142,7 +142,7 @@ Gatsby stores these children in redux as IDs in the parent's `children` field. A
 }
 ```
 
-An important note here is that we do not store a distinct collection of each type of child. Rather we store a single collection that they're all packed into. The benefit of this is that we can easily create a `File.children` field that returns all children, regardless of type. The downside is that the creation of fields such as `File.childMarkdownRemark` and `File.childrenPostsJson` is more complicated. This is what [createNodeFields](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/build-node-types.js#L48) does.
+An important note here is that we do not store a distinct collection of each type of child. Rather we store a single collection that they're all packed into. The benefit of this is that we can create a `File.children` field that returns all children, regardless of type. The downside is that the creation of fields such as `File.childMarkdownRemark` and `File.childrenPostsJson` is more complicated. This is what [createNodeFields](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/build-node-types.js#L48) does.
 
 Another convenience Gatsby provides is the ability to query a node's `child` or `children`, depending on whether a parent node has 1 or more children of that type.
 

--- a/docs/docs/sourcing-from-agilitycms.md
+++ b/docs/docs/sourcing-from-agilitycms.md
@@ -52,11 +52,7 @@ Once you've the infrastructure set up, run the site in development mode:
 gatsby develop
 ```
 
-<<<<<<< HEAD
 The site is not only a starter, but it has a bunch of interesting features that you can use to build from. The next step is to hook this code up to your new Agility CMS instance that you just created.
-=======
-The site is a starter, but it has a bunch of interesting features that you can use to build from. The next step is to hook this code up to your new Agility CMS instance that you have created.
->>>>>>> 7309868e5609126751edc5b14c2b0c115ed1d0ed
 
 ## Hook it up to your Agility CMS instance
 

--- a/docs/docs/sourcing-from-agilitycms.md
+++ b/docs/docs/sourcing-from-agilitycms.md
@@ -52,7 +52,11 @@ Once you've the infrastructure set up, run the site in development mode:
 gatsby develop
 ```
 
+<<<<<<< HEAD
 The site is not only a starter, but it has a bunch of interesting features that you can use to build from. The next step is to hook this code up to your new Agility CMS instance that you just created.
+=======
+The site is a starter, but it has a bunch of interesting features that you can use to build from. The next step is to hook this code up to your new Agility CMS instance that you have created.
+>>>>>>> 7309868e5609126751edc5b14c2b0c115ed1d0ed
 
 ## Hook it up to your Agility CMS instance
 

--- a/docs/docs/sourcing-from-agilitycms.md
+++ b/docs/docs/sourcing-from-agilitycms.md
@@ -52,7 +52,7 @@ Once you've the infrastructure set up, run the site in development mode:
 gatsby develop
 ```
 
-The site is just a starter, but it has a bunch of interesting features that you can use to build from. The next step is to hook this code up to your new Agility CMS instance that you just created.
+The site is not only a starter, but it has a bunch of interesting features that you can use to build from. The next step is to hook this code up to your new Agility CMS instance that you just created.
 
 ## Hook it up to your Agility CMS instance
 

--- a/docs/docs/sourcing-from-kentico-kontent.md
+++ b/docs/docs/sourcing-from-kentico-kontent.md
@@ -96,7 +96,7 @@ const Layout = ({ children }) => {
 // ...
 ```
 
-If you look at `http://localhost:8000/`, you'll notice the title is now "Dancing Goat–Freshest coffee on the block!". You can easily change this title in Kentico Kontent to whatever you want and rerun `gatsby develop` to rebuild the site ([see below about automatic builds](#continuous-deployment)).
+If you look at `http://localhost:8000/`, you'll notice the title is now "Dancing Goat–Freshest coffee on the block!". You can change this title in Kentico Kontent to whatever you want and rerun `gatsby develop` to rebuild the site ([see below about automatic builds](#continuous-deployment)).
 
 So you've seen how to add content to existing pages in Gatsby using Kentico Kontent. Next, you will start creating new pages of your own.
 

--- a/docs/docs/sourcing-from-sanity.md
+++ b/docs/docs/sourcing-from-sanity.md
@@ -228,7 +228,7 @@ You can install [block-content-to-react](https://www.npmjs.com/package/@sanity/b
 
 ## Using .env variables
 
-If you don't want to attach your Sanity project's ID to the repo, you can easily store it in .env files by doing the following:
+If you don't want to attach your Sanity project's ID to the repo, you can store it in .env files by doing the following:
 
 ```text:title=.env
 SANITY_PROJECT_ID = abc123

--- a/docs/tutorial/gatsby-image-tutorial/index.md
+++ b/docs/tutorial/gatsby-image-tutorial/index.md
@@ -282,7 +282,7 @@ When you do that, you’ve changed the reference to the query object available i
 }
 ```
 
-Giving it an alias does not add a level of complexity to the response object, it just replaces it. So you end up with the same structure, referenced like this (note the alias `talks` in place of the longer `allSpeakingYaml`):
+Giving it an alias does not add a level of complexity to the response object, it just replaced it. So you end up with the same structure, referenced like this (note the alias `talks` in place of the longer `allSpeakingYaml`):
 
 ```jsx
 {

--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -179,7 +179,7 @@ export default function About() {
 
 ![New about page](05-about-page.png)
 
-Just by putting a React component in the `src/pages/about.js` file, you now have a page accessible at `/about`.
+By putting a React component in the `src/pages/about.js` file, you now have a page accessible at `/about`.
 
 ### ✋ Using sub-components
 

--- a/docs/tutorial/remark-plugin-tutorial.md
+++ b/docs/tutorial/remark-plugin-tutorial.md
@@ -121,7 +121,7 @@ module.exports = ({ markdownAST }, pluginOptions) => {
 }
 ```
 
-The first parameter is all of the default properties that can be used in plugins (actions, store, getNodes, schema, etc.) plus a couple just for gatsby-transformer-remark plugins. The most relevant field for our purposes is the `markdownAST` field which is destructured in the code snippet above.
+The first parameter is all of the default properties that can be used in plugins (actions, store, getNodes, schema, etc.) plus a couple for gatsby-transformer-remark plugins. The most relevant field for our purposes is the `markdownAST` field which is destructured in the code snippet above.
 
 As with other Gatsby plugins, the 2nd parameter is the `pluginOptions` which is obtained from the definition in `gatsby-config.js` file.
 

--- a/docs/tutorial/wordpress-source-plugin-tutorial.md
+++ b/docs/tutorial/wordpress-source-plugin-tutorial.md
@@ -16,7 +16,7 @@ In this tutorial, you will install the `gatsby-source-wordpress` plugin in order
 
 #### But do you prefer GraphQL?
 
-If you prefer using GraphQL, there's a [wp-graphql](https://github.com/wp-graphql/wp-graphql) plugin to easily expose both default and custom data in WordPress.
+If you prefer using GraphQL, there's a [wp-graphql](https://github.com/wp-graphql/wp-graphql) plugin to expose both default and custom data in WordPress.
 
 The same authentication schemes supported by the WP-API are supported in wp-graphql, which can be used with the [gatsby-source-graphql](/packages/gatsby-source-graphql/) plugin.
 

--- a/integration-tests/long-term-caching/README.md
+++ b/integration-tests/long-term-caching/README.md
@@ -6,7 +6,7 @@ changes between builds, to test that the bundle names change correctly.
 
 After each run, move the public folder to `public-${runNumber}`.
 
-You can easily compare run outputs with the tool Meld. `meld public-1 public-2`.
+You can compare run outputs with the tool Meld. `meld public-1 public-2`.
 
 It'd be nice to automate this but a manual check works for now.
 

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -199,7 +199,7 @@ object called `fluid`.
 GraphQL includes a concept called "query fragments". Which, as the name
 suggests, are a part of a query that can be used in multiple queries. To ease
 building with `gatsby-image`, Gatsby image processing plugins which support
-`gatsby-image` ship with fragments which you can easily include in your queries.
+`gatsby-image` ship with fragments which you can include in your queries.
 
 Note,
 [due to a limitation of GraphiQL](https://github.com/graphql/graphiql/issues/612),

--- a/packages/gatsby-plugin-facebook-analytics/README.md
+++ b/packages/gatsby-plugin-facebook-analytics/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-facebook-analytics
 
-Easily add Facebook Analytics to your Gatsby site.
+Add Facebook Analytics to your Gatsby site.
 
 You must have a [Facebook App](https://developers.facebook.com/apps) ID to use this plugin.
 

--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-google-analytics
 
-Easily add Google Analytics to your Gatsby site.
+Add Google Analytics to your Gatsby site.
 
 ## Install
 

--- a/packages/gatsby-plugin-google-gtag/README.md
+++ b/packages/gatsby-plugin-google-gtag/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-google-gtag
 
-Easily add Google Global Site Tag to your Gatsby site.
+Add Google Global Site Tag to your Gatsby site.
 
 > The global site tag (gtag.js) is a JavaScript tagging framework and API that allows you to send event data to Google Analytics, Google Ads, Campaign Manager, Display & Video 360, and Search Ads 360.
 

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -1,6 +1,10 @@
 # gatsby-plugin-google-tagmanager
 
+<<<<<<< HEAD
 Add Google Tag Manager to your Gatsby site.
+=======
+How to add Google Tag Manager to your Gatsby site.
+>>>>>>> 7309868e5609126751edc5b14c2b0c115ed1d0ed
 
 ## Install
 

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -1,6 +1,6 @@
 # gatsby-plugin-google-tagmanager
 
-Easily add Google Tagmanager to your Gatsby site.
+Add Google Tag Manager to your Gatsby site.
 
 ## Install
 

--- a/packages/gatsby-plugin-netlify/README.md
+++ b/packages/gatsby-plugin-netlify/README.md
@@ -3,7 +3,7 @@
 Automatically generates a `_headers` file and a `_redirects` file at the root of the public folder to configure
 [HTTP headers](https://www.netlify.com/docs/headers-and-basic-auth/) and [redirects](https://www.netlify.com/docs/redirects/) on Netlify.
 
-By default, the plugin will add some basic security headers. You can easily add or replace headers through the plugin config.
+By default, the plugin will add some basic security headers. You can add or replace headers through the plugin config.
 
 ## Install
 

--- a/packages/gatsby-plugin-react-helmet/README.md
+++ b/packages/gatsby-plugin-react-helmet/README.md
@@ -17,7 +17,7 @@ This is important not just for site viewers, but also for SEO -- title and descr
 
 ## How to use
 
-Just add the plugin to the plugins array in your `gatsby-config.js`
+Add the plugin to the plugins array in your `gatsby-config.js`
 
 ```javascript
 plugins: [`gatsby-plugin-react-helmet`]

--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -92,7 +92,7 @@ plugins: [
 #### Required: Pick a PrismJS theme or create your own
 
 PrismJS ships with a number of [themes][5] (previewable on the [PrismJS
-website][6]) that you can easily include in your Gatsby site, or you can build
+website][6]) that you can include in your Gatsby site, or you can build
 your own by copying and modifying an example (which is what we've done for
 [gatsbyjs.org](https://gatsbyjs.org)).
 

--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -96,7 +96,7 @@ website][6]) that you can easily include in your Gatsby site, or you can build
 your own by copying and modifying an example (which is what we've done for
 [gatsbyjs.org](https://gatsbyjs.org)).
 
-To load a theme, just require its CSS file in your `gatsby-browser.js` file, e.g.
+To load a theme, you require its CSS file in your `gatsby-browser.js` file, e.g.
 
 ```javascript
 // gatsby-browser.js
@@ -129,7 +129,7 @@ highlighted line runs wider than the surrounding code block container (causing a
 horizontal scrollbar), its background won't be drawn for the initially hidden,
 overflowing part. :(
 
-We saw others fix that problem and decided to do so, too. Just add the following
+We saw others fix that problem and decided to do so, too. Add the following
 CSS along your PrismJS theme and the styles for `.gatsby-highlight-code-line`:
 
 ```css

--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -26,7 +26,7 @@ An example site for this plugin is available.
 - Pulls data from self-hosted WordPress sites, or sites hosted on [WordPress.com](https://wordpress.com)
 - Should work with any number of posts (tested on a site with 900 posts)
 - Can authenticate to wordpress.com's API using OAuth 2 so media can be queried
-- Easily create responsive images in Gatsby from WordPress images. See [image
+- Create responsive images in Gatsby from WordPress images. See [image
   processing](#image-processing) section.
 
 ## WordPress and custom entities

--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -75,7 +75,7 @@ plugins: [
 ]
 ```
 
-In the asciidoc file you can insert your image just by using:
+In the asciidoc file you can insert your image by using:
 `image::myimage.png[]`
 
 **NOTE**


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I Removed or change the word "just" and "simply" from the sentence following for issue #18702 to appear more interactive and formal.


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Addresses  #18702
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
