### PR TITLE
fix(gatsby-remark-images): enable creating img tag with empty alt attribute

### DIFF
--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -59,6 +59,14 @@ by Gatsby image processing.
 ![my image](./my-awesome-image.png)
 ```
 
+By default, the text `my image` will be used as the alt attribute of the
+generated `img` tag. If an empty alt attribute like `alt=""` is wished,
+a reserved keyword `_SKIP_` can be used.
+
+```markdown
+![_SKIP_](./my-awesome-image.png)
+```
+
 ## Remark plugins
 
 You can use [remark plugins](https://github.com/remarkjs/remark/blob/master/doc/plugins.md)

--- a/docs/docs/mdx/plugins.md
+++ b/docs/docs/mdx/plugins.md
@@ -61,10 +61,10 @@ by Gatsby image processing.
 
 By default, the text `my image` will be used as the alt attribute of the
 generated `img` tag. If an empty alt attribute like `alt=""` is wished,
-a reserved keyword `_SKIP_` can be used.
+a reserved keyword `GATSBY_EMPTY_ALT` can be used.
 
 ```markdown
-![_SKIP_](./my-awesome-image.png)
+![GATSBY_EMPTY_ALT](./my-awesome-image.png)
 ```
 
 ## Remark plugins

--- a/packages/gatsby-remark-images/README.md
+++ b/packages/gatsby-remark-images/README.md
@@ -50,6 +50,13 @@ You can reference an image using the relative path, where that path is relative 
 ![Alt text here](./image.jpg)
 ```
 
+By default, the text `Alt text here` will be used as the alt attribute of the generated `img` tag. If an empty alt attribute like `alt=""` is wished,
+a reserved keyword `_SKIP_` can be used.
+
+```markdown
+![_SKIP_](./image.png)
+```
+
 ## Options
 
 | Name                    | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |

--- a/packages/gatsby-remark-images/README.md
+++ b/packages/gatsby-remark-images/README.md
@@ -51,10 +51,10 @@ You can reference an image using the relative path, where that path is relative 
 ```
 
 By default, the text `Alt text here` will be used as the alt attribute of the generated `img` tag. If an empty alt attribute like `alt=""` is wished,
-a reserved keyword `_SKIP_` can be used.
+a reserved keyword `GATSBY_EMPTY_ALT` can be used.
 
 ```markdown
-![_SKIP_](./image.png)
+![GATSBY_EMPTY_ALT](./image.png)
 ```
 
 ## Options

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -671,3 +671,29 @@ describe(`disableBgImage`, () => {
     expect(node.value).toMatchSnapshot()
   })
 })
+
+describe(`image alt attribute`, () => {
+  it(`should be generated correctly`, async () => {
+    const imagePath = `images/my-image.jpeg`
+    const content = `![testing-if-alt-is-correct](./${imagePath} "some title")`
+
+    const nodes = await plugin(createPluginOptions(content, imagePath))
+    expect(nodes.length).toBe(1)
+
+    const node = nodes.pop()
+    const $ = cheerio.load(node.value)
+    expect($(`img`).attr(`alt`)).toEqual(`testing-if-alt-is-correct`)
+  })
+
+  it(`should be able to consider EMPTY_ALT`, async () => {
+    const imagePath = `images/my-image.jpeg`
+    const content = `![GATSBY_EMPTY_ALT](./${imagePath} "some title")`
+
+    const nodes = await plugin(createPluginOptions(content, imagePath))
+    expect(nodes.length).toBe(1)
+
+    const node = nodes.pop()
+    const $ = cheerio.load(node.value)
+    expect($(`img`).attr(`alt`)).toEqual(``)
+  })
+})

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -685,7 +685,7 @@ describe(`image alt attribute`, () => {
     expect($(`img`).attr(`alt`)).toEqual(`testing-if-alt-is-correct`)
   })
 
-  it(`should use filename as fallback`, async () => {
+  it(`should use escaped filename as fallback`, async () => {
     const imagePath = `images/my-image.jpeg`
     const content = `![](./${imagePath} "some title")`
 
@@ -694,7 +694,7 @@ describe(`image alt attribute`, () => {
 
     const node = nodes.pop()
     const $ = cheerio.load(node.value)
-    expect($(`img`).attr(`alt`)).toEqual(`my-image`)
+    expect($(`img`).attr(`alt`)).toEqual(`my image`)
   })
 
   it(`should be able to consider EMPTY_ALT`, async () => {

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -685,6 +685,18 @@ describe(`image alt attribute`, () => {
     expect($(`img`).attr(`alt`)).toEqual(`testing-if-alt-is-correct`)
   })
 
+  it(`should use filename as fallback`, async () => {
+    const imagePath = `images/my-image.jpeg`
+    const content = `![](./${imagePath} "some title")`
+
+    const nodes = await plugin(createPluginOptions(content, imagePath))
+    expect(nodes.length).toBe(1)
+
+    const node = nodes.pop()
+    const $ = cheerio.load(node.value)
+    expect($(`img`).attr(`alt`)).toEqual(`my-image`)
+  })
+
   it(`should be able to consider EMPTY_ALT`, async () => {
     const imagePath = `images/my-image.jpeg`
     const content = `![GATSBY_EMPTY_ALT](./${imagePath} "some title")`

--- a/packages/gatsby-remark-images/src/constants.js
+++ b/packages/gatsby-remark-images/src/constants.js
@@ -12,7 +12,7 @@ exports.DEFAULT_OPTIONS = {
   disableBgImage: false,
 }
 
-exports.EMPTY_ALT = `_SKIP_`
+exports.EMPTY_ALT = `GATSBY_EMPTY_ALT`
 
 exports.imageClass = `gatsby-resp-image-image`
 exports.imageWrapperClass = `gatsby-resp-image-wrapper`

--- a/packages/gatsby-remark-images/src/constants.js
+++ b/packages/gatsby-remark-images/src/constants.js
@@ -12,6 +12,8 @@ exports.DEFAULT_OPTIONS = {
   disableBgImage: false,
 }
 
+exports.EMPTY_ALT = `_SKIP_`
+
 exports.imageClass = `gatsby-resp-image-image`
 exports.imageWrapperClass = `gatsby-resp-image-wrapper`
 exports.imageBackgroundClass = `gatsby-resp-image-background-image`

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -169,11 +169,13 @@ module.exports = (
     const fileName = srcSplit[srcSplit.length - 1]
     const fileNameNoExt = fileName.replace(/\.[^/.]+$/, ``)
     const defaultAlt = fileNameNoExt.replace(/[^A-Z0-9]/gi, ` `)
-    const isEmptyAlt = node.alt === EMPTY_ALT;
-      
-    const alt = isEmptyAlt ? `` : _.escape(
-      overWrites.alt ? overWrites.alt : node.alt ? node.alt : defaultAlt
-    )
+    const isEmptyAlt = node.alt === EMPTY_ALT
+
+    const alt = isEmptyAlt
+      ? ``
+      : _.escape(
+          overWrites.alt ? overWrites.alt : node.alt ? node.alt : defaultAlt
+        )
 
     const title = node.title ? _.escape(node.title) : alt
 

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -1,5 +1,6 @@
 const {
   DEFAULT_OPTIONS,
+  EMPTY_ALT,
   imageClass,
   imageBackgroundClass,
   imageWrapperClass,
@@ -168,8 +169,9 @@ module.exports = (
     const fileName = srcSplit[srcSplit.length - 1]
     const fileNameNoExt = fileName.replace(/\.[^/.]+$/, ``)
     const defaultAlt = fileNameNoExt.replace(/[^A-Z0-9]/gi, ` `)
-
-    const alt = _.escape(
+    const isEmptyAlt = node.alt === EMPTY_ALT;
+      
+    const alt = isEmptyAlt ? `` : _.escape(
       overWrites.alt ? overWrites.alt : node.alt ? node.alt : defaultAlt
     )
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
add a keyword `GATSBY_EMPTY_ALT` to enable that an img tag with an empty alt attribute can be created

### Documentation

add the keyword description @gatsbyjs/documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #20179 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
