### PR TITLE
Bump file-loader dependency to latest (6.1.0)

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -72,7 +72,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
     "fast-levenshtein": "^2.0.6",
-    "file-loader": "^1.1.11",
+    "file-loader": "^6.1.0",
     "find-cache-dir": "^3.3.1",
     "fs-exists-cached": "1.0.0",
     "fs-extra": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10306,12 +10306,13 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-loader@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.11.tgz#6fe886449b0f2a936e43cabaac0cdbfb369506f8"
+file-loader@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.1.0.tgz#65b9fcfb0ea7f65a234a1f10cdd7f1ab9a33f253"
+  integrity sha512-26qPdHyTsArQ6gU4P1HJbAbnFTyT2r0pG7czh1GFAd9TZbj0n94wWbupgixZH/ET/meqi2/5+F7DhW4OAXD+Lg==
   dependencies:
-    loader-utils "^1.0.2"
-    schema-utils "^0.4.5"
+    loader-utils "^2.0.0"
+    schema-utils "^2.7.1"
 
 file-match@^1.0.1:
   version "1.0.2"
@@ -21923,13 +21924,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-schema-utils@^0.4.5:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
 
 schema-utils@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I'm having issues with a yarn workspaces environment that hosts both a gatsby-based site, and a https://github.com/facebook/docusaurus site. Gatsby and Docusaurus install different versions of a dependency, `file-loader`. Gatsby installs 1.1.11 from 3 years ago, and Docusaurus installs 6.0.0.

For some yarn-workspaces related reason that I don't fully understand, Docusaurus then winds up importing the older dependency that Gatsby specifies (https://github.com/facebook/docusaurus/issues/3515) rather than the one that it specifies. This results in my Docusaurus site not being able to build, but if I remove the Gatsby project, the Docusaurus site builds fine.

I was curious if we could please bump the Gatsby dependency on file-loader? This PR does just that, and `yarn test` tests all pass after the version bump. Presumably this wouldn't cause regressions, then.

I fully recognize this isn't a Gatsby-specific issue... it's probably a webpack issue from what I can tell, but I'm new enough to node that I don't have a solid grasp on yarn workspaces and dependency resolution.

Anyways, thanks for your consideration!

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
