### PR TITLE
fix(gatsby-plugin-google-gtag): Separate preconnect and dns-prefetch

### DIFF
--- a/packages/gatsby-plugin-google-gtag/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/__tests__/gatsby-ssr.js
@@ -15,7 +15,7 @@ it(`does not crash when no pluginConfig is provided`, () => {
 
 const DO_NOT_TRACK_STRING = `!(navigator.doNotTrack == "1" || window.doNotTrack == "1")`
 
-it(`adds a preconnect link for Google Analytics`, () => {
+it(`adds preconnect and dns-prefetch links for Google Analytics`, () => {
   const mocks = {
     setHeadComponents: jest.fn(),
     setPostBodyComponents: jest.fn(),
@@ -26,12 +26,22 @@ it(`adds a preconnect link for Google Analytics`, () => {
   }
 
   onRenderBody(mocks, pluginOptions)
-  const [link] = mocks.setHeadComponents.mock.calls[0][0]
+  const [
+    preconnectLink,
+    prefetchLink,
+  ] = mocks.setHeadComponents.mock.calls[0][0]
 
-  expect(link).toEqual(
+  expect(preconnectLink).toEqual(
     <link
-      rel="preconnect dns-prefetch"
+      rel="preconnect"
       key="preconnect-google-analytics"
+      href="https://www.google-analytics.com"
+    />
+  )
+  expect(prefetchLink).toEqual(
+    <link
+      rel="dns-prefetch"
+      key="dns-prefetch-google-analytics"
       href="https://www.google-analytics.com"
     />
   )

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -11,8 +11,13 @@ exports.onRenderBody = (
   // Lighthouse recommends pre-connecting to google analytics
   setHeadComponents([
     <link
-      rel="preconnect dns-prefetch"
+      rel="preconnect"
       key="preconnect-google-analytics"
+      href="https://www.google-analytics.com"
+    />,
+    <link
+      rel="dns-prefetch"
+      key="dns-prefetch-google-analytics"
       href="https://www.google-analytics.com"
     />,
   ])


### PR DESCRIPTION
## Description
As it was mentioned in https://github.com/gatsbyjs/gatsby/pull/25279 by @deminoth, implementing dns-prefetch fallback in the same tag causes a bug in Safari where preconnect gets cancelled. This was fixed in gatsby-plugin-google-analytics but not in gatsby-plugin-google-gtag so this PR address that

### Documentation
https://web.dev/preconnect-and-dns-prefetch/
https://bugs.webkit.org/show_bug.cgi?id=197010

## Related Issues
Related to #25279 
