### PR TITLE
Fix: corrected few grammatical errors in the file

### DIFF
--- a/starters/blog/content/blog/new-beginnings/index.md
+++ b/starters/blog/content/blog/new-beginnings/index.md
@@ -23,7 +23,7 @@ made herself on the way.
 
 When she reached the first hills of the **Italic Mountains**, she had a last
 view back on the skyline of her hometown _Bookmarksgrove_, the headline of
-[Alphabet Village](http://google.com) and the subline of her own road, the Line
+[Alphabet Village](http://google.com) and the subline of her road, the Line
 Lane. Pityful a rhetoric question ran over her cheek, then she continued her
 way. On her way she met a copy.
 
@@ -44,7 +44,7 @@ mouth. Even the all-powerful Pointing has no control about the blind texts it is
 an almost unorthographic life One day however a small line of blind text by the
 name of Lorem Ipsum decided to leave for the far World of Grammar.
 
-### According a funnily until pre-set or arrogant well cheerful
+### According to a funnily until pre-set or arrogant well cheerful
 
 The Big Oxmox advised her not to do so, because there were thousands of bad
 Commas, wild Question Marks and devious Semikoli, but the Little Blind Text
@@ -53,13 +53,13 @@ made herself on the way.
 
 1.  So baboon this
 2.  Mounted militant weasel gregariously admonishingly straightly hey
-3.  Dear foresaw hungry and much some overhung
+3.  Dear foresaw hungrily and much some overhung
 4.  Rash opossum less because less some amid besides yikes jeepers frenetic
     impassive fruitlessly shut
 
 When she reached the first hills of the Italic Mountains, she had a last view
 back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet
-Village and the subline of her own road, the Line Lane. Pityful a rhetoric
+Village and the subline of her road, the Line Lane. Pityful a rhetoric
 question ran over her cheek, then she continued her way. On her way she met a
 copy.
 
@@ -93,7 +93,7 @@ Question Marks and devious Semikoli, but the Little Blind Text didn’t listen.
 She packed her seven versalia, put her initial into the belt and made herself on
 the way. When she reached the first hills of the Italic Mountains, she had a
 last view back on the skyline of her hometown Bookmarksgrove, the headline of
-Alphabet Village and the subline of her own road, the Line Lane. Pityful a
+Alphabet Village and the subline of her road, the Line Lane. Pityful a
 rhetoric question ran over her cheek, then she continued her way. On her way she
 met a copy.
 


### PR DESCRIPTION
Removed few repeated redundant words and corrected few grammatical errors in the file.

## Description

Corrected few grammatical errors which is seen in the file and also removed some redundant words in the file.

### Documentation

Removed redundant words like "own" from the file as well as corrected few grammatical errors in the file.

