### PR TITLE
Closes [#27237] - un-clear documentation on .env

### DIFF
--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -2,6 +2,8 @@
 title: Environment Variables
 ---
 
+> :warning: **Gatsby does not support .env files by default**: You can add support by following the [Server-side Node.js](https://www.gatsbyjs.com/docs/environment-variables/#server-side-nodejs) section below.
+
 You can provide environment variables to your site to customize its behavior in different environments.
 
 Environment variables can be distinguished between different types.


### PR DESCRIPTION
<!-- Write a brief description of the changes introduced by this PR -->

PR fixes unclear documentation surrounding `.env` files with Gatsby outlined in issue [#27237](https://github.com/gatsbyjs/gatsby/issues/27237).

### Documentation

Documentation affected: https://www.gatsbyjs.com/docs/environment-variables

When searching for how to make use of .env files with Gatsby, the current documentation is not clear enough and causes confusion.

When understanding how to use project-wide environment variables with .env files, the documentation frequently references using `.env.*`, `.env.development`, or `.env.production` and only references that it is not supported by default later on in the documentation which is currently hidden in the server-side node.js section and difficult to find.

Current documentation un-intentionally suggests `.env` is supported by default in early paragraphs by talking about using `.env` files.
The message that is is not supported is hidden away in the documentation and needs to be clearer.

## Related Issues

Relates to issue: [#27237](https://github.com/gatsbyjs/gatsby/issues/27237)

Here is an issue that could have been prevented with the doc fix in this PR: [#22880](https://github.com/gatsbyjs/gatsby/issues/22880)


