### PR TITLE
chore(peril): disable merge-on-green

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -32,18 +32,6 @@
       ],
       "check_run": [
         "gatsbyjs/gatsby@peril/rules/validate-yaml.ts"
-      ],
-      "pull_request.labeled": [
-        "gatsbyjs/gatsby@peril/rules/merge-on-green.ts"
-      ],
-      "pull_request_review.submitted": [
-        "gatsbyjs/gatsby@peril/rules/merge-on-green.ts"
-      ],
-      "check_suite.completed": [
-        "gatsbyjs/gatsby@peril/rules/merge-on-green.ts"
-      ],
-      "status.success": [
-        "gatsbyjs/gatsby@peril/rules/merge-on-green.ts"
       ]
     },
     "gatsbyjs/gatsby-starter-default": {


### PR DESCRIPTION
After `peril` upgrade we noticed problems with merge-on-green that consistently fails because required environment variables are not passed to it. Until the problem is fixed, let's disable this automation because it just doesn't work right now and can cause confusing CI check failures. 

Issue (and potential upstream fix) in peril (for tracking purposes) - https://github.com/danger/peril/issues/474