### PR TITLE
chore(docs): Update the link to global css example

### DIFF
--- a/docs/docs/global-css.md
+++ b/docs/docs/global-css.md
@@ -10,7 +10,7 @@ Globally-scoped CSS rules are declared in external `.css` stylesheets, and [CSS 
 
 The best way to add global styles is with a [shared layout component](/tutorial/part-three/#your-first-layout-component). This layout component is used for things that are shared throughout the site, including styles, header components, and other common items.
 
-> **NOTE:** This pattern is implemented by default in [the default starter](https://github.com/gatsbyjs/gatsby-starter-default/blob/02324e5b04ea0a66d91c7fe7408b46d0a7eac868/src/layouts/index.js#L6).
+> **NOTE:** This pattern is implemented by default in [the default starter](https://github.com/gatsbyjs/gatsby-starter-default/blob/e1e2a960f8a54e2a1234d1694d390b1cc26b7947/src/pages/index.js#L9).
 
 To create a shared layout with global styles, start by creating a new Gatsby site with the [hello world starter](https://github.com/gatsbyjs/gatsby-starter-hello-world).
 

--- a/docs/docs/global-css.md
+++ b/docs/docs/global-css.md
@@ -10,7 +10,7 @@ Globally-scoped CSS rules are declared in external `.css` stylesheets, and [CSS 
 
 The best way to add global styles is with a [shared layout component](/tutorial/part-three/#your-first-layout-component). This layout component is used for things that are shared throughout the site, including styles, header components, and other common items.
 
-> **NOTE:** This pattern is implemented by default in [the default starter](https://github.com/gatsbyjs/gatsby-starter-default/blob/e1e2a960f8a54e2a1234d1694d390b1cc26b7947/src/pages/index.js#L9).
+> **NOTE:** This pattern is implemented by default in [the default starter](https://github.com/gatsbyjs/gatsby-starter-default/blob/063978d59f74103da45d5880a61ebd2e77798e3c/src/components/layout.js#L13).
 
 To create a shared layout with global styles, start by creating a new Gatsby site with the [hello world starter](https://github.com/gatsbyjs/gatsby-starter-hello-world).
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
On line 13, the link to index.js points to a commit from 2018.  The link is there to demonstrate how a Layout component is implemented, and this implementation has changed from 2018 to 2020.  For me, the way it's done in the latest commit is much easier to understand.

Also, when I clicked on the link from documentation, at first I didn't realize that I wasn't looking at the latest commit and it caused a bit of confusion for me.

Not sure if you want to link to the [commit on May 28th, 2020:](https://github.com/gatsbyjs/gatsby-starter-default/blob/e1e2a960f8a54e2a1234d1694d390b1cc26b7947/src/pages/index.js#L9) 

Or just link to the [latest commit:](https://github.com/gatsbyjs/gatsby-starter-default/blob/master/src/pages/index.js#L9) 

In the proposed change, I updated the link to the May 28th commit to be safe.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
[https://www.gatsbyjs.com/docs/global-css/](https://www.gatsbyjs.com/docs/global-css/)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
