### PR TITLE
fix(gatsby): route lifecycle ordering

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -142,4 +142,42 @@ describe(`navigation`, () => {
       cy.get(`h1`).invoke(`text`).should(`eq`, `Gatsby.js development 404 page`)
     })
   })
+
+  describe(`Route lifecycle update order`, () => {
+    it(`calls onPreRouteUpdate, render and onRouteUpdate the correct amount of times on route change`, () => {
+      cy.lifecycleCallCount(`onPreRouteUpdate`).should(`eq`, 1)
+      cy.lifecycleCallCount(`render`).should(`eq`, 1)
+      cy.lifecycleCallCount(`onRouteUpdate`).should(`eq`, 1)
+      cy.getTestElement(`page-two`).click().waitForRouteChange()
+      cy.getTestElement(`page-2-message`).should(`exist`)
+      cy.lifecycleCallCount(`onPreRouteUpdate`).should(`eq`, 2)
+      cy.lifecycleCallCount(`render`).should(`eq`, 2)
+      cy.lifecycleCallCount(`onRouteUpdate`).should(`eq`, 2)
+    })
+
+    it(`renders the component after onPreRouteUpdate on route change`, () => {
+      cy.getTestElement(`page-component`).should(`exist`)
+      cy.lifecycleCallCount(`onPreRouteUpdate`).should(`eq`, 1)
+      cy.lifecycleCallCount(`render`).should(`eq`, 1)
+      cy.lifecycleCallCount(`onRouteUpdate`).should(`eq`, 1)
+      cy.lifecycleCallOrder([
+        `onPreRouteUpdate`,
+        `render`,
+        `onRouteUpdate`,
+      ]).should(`eq`, true)
+      cy.getTestElement(`page-two`).click().waitForRouteChange()
+      cy.getTestElement(`page-2-message`).should(`exist`)
+      cy.lifecycleCallOrder([
+        `onPreRouteUpdate`,
+        `render`,
+        `onRouteUpdate`,
+        `onPreRouteUpdate`,
+        `render`,
+        `onRouteUpdate`,
+      ]).should(`eq`, true)
+      cy.lifecycleCallCount(`onPreRouteUpdate`).should(`eq`, 2)
+      cy.lifecycleCallCount(`render`).should(`eq`, 2)
+      cy.lifecycleCallCount(`onRouteUpdate`).should(`eq`, 2)
+    })
+  })
 })

--- a/e2e-tests/development-runtime/cypress/support/commands.js
+++ b/e2e-tests/development-runtime/cypress/support/commands.js
@@ -11,6 +11,46 @@ Cypress.Commands.add(`lifecycleCallCount`, action =>
     )
 )
 
+// This command is to find out that the lifecycle methods have
+// been called in the expected order, not to check the exact order.
+// It checks an array and makes sure that each item in the array is called at some point after the last.
+// It will return a boolean value if the order has been called correctly according to what has been passed in.
+Cypress.Commands.add(`lifecycleCallOrder`, expectedActionCallOrder =>
+  cy.window().then(win => {
+    const actions = win.___PageComponentLifecycleCallsLog
+    const expectedActionCallOrderLength = expectedActionCallOrder.length
+    const actionsLength = actions.length
+
+    if (expectedActionCallOrderLength > actionsLength) {
+      return false
+    }
+
+    // get loop starting point from the first actions index
+    const firstOccurrence = actions.findIndex(
+      action => action.action === expectedActionCallOrder[0]
+    )
+    if (firstOccurrence === -1) return false
+    
+    let prevActionIndex = 0
+    for (let i = 1; i < actionsLength; i += 1) {
+      const currentIndex = i + firstOccurrence
+      const nextActionIndex = prevActionIndex + 1
+
+      // if the next action is found in the correct order
+      if (actions[currentIndex].action === expectedActionCallOrder[nextActionIndex]) {
+        prevActionIndex = nextActionIndex
+      }
+    }
+
+    // if not all actions have been found then it has failed
+    if (prevActionIndex !== expectedActionCallOrderLength - 1) {
+      return false
+    }
+
+    return true
+  })
+)
+
 Cypress.Commands.add(`assertRouterWrapperFocus`, (shouldBeFocused = true) =>
   cy
     .focused()

--- a/e2e-tests/development-runtime/cypress/support/commands.js
+++ b/e2e-tests/development-runtime/cypress/support/commands.js
@@ -24,20 +24,13 @@ Cypress.Commands.add(`lifecycleCallOrder`, expectedActionCallOrder =>
     if (expectedActionCallOrderLength > actionsLength) {
       return false
     }
-
-    // get loop starting point from the first actions index
-    const firstOccurrence = actions.findIndex(
-      action => action.action === expectedActionCallOrder[0]
-    )
-    if (firstOccurrence === -1) return false
     
-    let prevActionIndex = 0
-    for (let i = 1; i < actionsLength; i += 1) {
-      const currentIndex = i + firstOccurrence
+    let prevActionIndex = -1
+    for (let i = 0; i < actionsLength; i += 1) {
       const nextActionIndex = prevActionIndex + 1
 
       // if the next action is found in the correct order
-      if (actions[currentIndex].action === expectedActionCallOrder[nextActionIndex]) {
+      if (actions[i].action === expectedActionCallOrder[nextActionIndex]) {
         prevActionIndex = nextActionIndex
       }
     }

--- a/e2e-tests/development-runtime/src/pages/page-2.js
+++ b/e2e-tests/development-runtime/src/pages/page-2.js
@@ -1,9 +1,9 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, navigate } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import { navigate } from "gatsby"
+import InstrumentPage from "../utils/instrument-page"
 
 const SecondPage = () => (
   <Layout>
@@ -19,4 +19,4 @@ const SecondPage = () => (
   </Layout>
 )
 
-export default SecondPage
+export default InstrumentPage(SecondPage)

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -207,19 +207,19 @@ class RouteUpdates extends React.Component {
     onRouteUpdate(this.props.location, null)
   }
 
-  componentDidUpdate(prevProps, prevState, shouldFireRouteUpdate) {
-    if (shouldFireRouteUpdate) {
-      onRouteUpdate(this.props.location, prevProps.location)
-    }
-  }
-
-  getSnapshotBeforeUpdate(prevProps) {
+  shouldComponentUpdate(prevProps) {
     if (this.props.location.pathname !== prevProps.location.pathname) {
       onPreRouteUpdate(this.props.location, prevProps.location)
       return true
     }
 
     return false
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      onRouteUpdate(this.props.location, prevProps.location)
+    }
   }
 
   render() {


### PR DESCRIPTION
## Description

Rendering is occurring before `onPreRouteUpdate` when it should be after.

Please see Issue https://github.com/gatsbyjs/gatsby/issues/26608 for a full description.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/26608
