### PR TITLE
fix(gatsby): handle async in stacktrack filenames

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -454,8 +454,9 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
 
         if (file) {
           const { fileName, lineNumber: line, columnNumber: column } = file
+          const strippedFileName = fileName.match(/^(async )?(.*)/)[2]
 
-          const code = fs.readFileSync(fileName, { encoding: `utf-8` })
+          const code = fs.readFileSync(strippedFileName, { encoding: `utf-8` })
           codeFrame = codeFrameColumns(
             code,
             {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The `stacktrace` parsing library doesn't recognize the [`async` keyword](https://v8.dev/docs/stack-trace-api#async-stack-traces) in V8 stack traces. Therefore, when an async error is thrown, the parsed `fileName` will contain the async keyword prefix.

This causes problem when `reporter` tries to read in the file where the error is thrown using the wrongly parsed file name.

Here, I handle this edge case explicitly with a regex. I understand that looks like a hack: a better solution will be to replace the `stacktrace` library entirely. However, I cannot find any library that supports the `async` keyword. Writing an in-lined replacement of the library will cause more problem, if we replace the library in the future; and it's hard to handle all types of stack trace CallSites properly.

PR tested with the bug reproduction (https://github.com/mathewTH/gatsby-bug-24863-repro), and works as expected. 

<img width="914" alt="Screenshot 2020-10-04 at 12 16 19 AM" src="https://user-images.githubusercontent.com/42670338/94996711-d3d5a180-05d8-11eb-9631-4d15bdd337be.png">

I tried adding tests, but can't get the `async` keyword to appear in the stack traces in the tests. I suppose it because Babel transforms the Jest tests. [A WIP of the test is here](https://github.com/tysng/gatsby/commit/25d709bdc85bd192ab614f1909c5fdbc77f6e5a3). Any help is appreciated.

## Related Issues

Fixes #24863