### PR TITLE
Update add-404-page.md

### DIFF
--- a/docs/docs/add-404-page.md
+++ b/docs/docs/add-404-page.md
@@ -15,3 +15,16 @@ The screenshot below shows the default 404 page that Gatsby creates. It also lis
 
 The screenshot below shows the custom 404 page.
 ![Gatsby Custom 404 Page](./images/gatsby-custom-404.png)
+
+> 💡 Note: The 404 Page must have 404 HTTP status code in header not 200 or any other status code.
+
+To use custom 404 page with iis write following rules in web.config
+
+```
+<system.webServer>
+  <httpErrors>
+    <remove statusCode="404" subStatusCode="-1" />
+    <error statusCode="404" prefixLanguageFilePath="" path="error\404.html" responseMode="File" />
+  </httpErrors>
+</system.webServer>
+```


### PR DESCRIPTION
Gatsby custom 404 not work with 404 page if didn't have 404 HTTP status code in header of page. I know that it's default that  404 page that have 404 HTTP status code in header but some of host not do this and I'll be very helpful to notify developers.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
