### PR TITLE
Feature/add types for load themes

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -210,6 +210,11 @@ export interface GatsbyConfig {
   }
   /** Sometimes you need more granular/flexible access to the development server. Gatsby exposes the Express.js development server to your site’s gatsby-config.js where you can add Express middleware as needed. */
   developMiddleware?(app: any): void
+  /**
+   * Same as plugins, but kept to allow time to migrate.
+   * @deprecated Please use `plugins` instead.
+   */
+  __experimentalThemes?: Array<PluginRef>,
 }
 
 /**

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/index.ts
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/index.ts
@@ -1,5 +1,5 @@
 import loadThemes from "../"
-import * as path from "path"
+import path from "path"
 
 describe(`loadThemes`, () => {
   test(`resolves themes and plugins from location of gatsby-config`, async () => {

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/index.ts
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/index.ts
@@ -1,5 +1,5 @@
-const loadThemes = require(`..`)
-const path = require(`path`)
+import loadThemes from "../"
+import * as path from "path"
 
 describe(`loadThemes`, () => {
   test(`resolves themes and plugins from location of gatsby-config`, async () => {

--- a/packages/gatsby/src/bootstrap/load-themes/index.ts
+++ b/packages/gatsby/src/bootstrap/load-themes/index.ts
@@ -147,21 +147,21 @@ const processTheme = (
   }
 }
 
-interface LoadThemesOptions {
+interface ILoadThemesOptions {
   useLegacyThemes?: boolean
   configFilePath: string
   rootDir: string
 }
 
-interface LoadedThemes {
+interface ILoadedThemes {
   config: GatsbyConfig
   themes: Array<IProcessedTheme>
 }
 
 export default async function loadThemes(
   config: GatsbyConfig,
-  { useLegacyThemes = false, configFilePath, rootDir }: LoadThemesOptions
-): globalThis.Promise<LoadedThemes> {
+  { useLegacyThemes = false, configFilePath, rootDir }: ILoadThemesOptions
+): globalThis.Promise<ILoadedThemes> {
   const themesA = await Promise.mapSeries(
     (useLegacyThemes ? config.__experimentalThemes : config.plugins) || [],
     async themeSpec => {

--- a/packages/gatsby/src/bootstrap/load-themes/index.ts
+++ b/packages/gatsby/src/bootstrap/load-themes/index.ts
@@ -8,7 +8,7 @@ import { getConfigFile } from "../get-config-file"
 import { resolvePlugin } from "../load-plugins/load"
 import reporter from "gatsby-cli/lib/reporter"
 import Debug from "debug"
-import { GatsbyConfig, PluginRef } from "../../../index"
+import { GatsbyConfig, PluginRef } from "../../../"
 
 const debug = Debug(`gatsby:load-themes`)
 

--- a/packages/gatsby/src/bootstrap/load-themes/index.ts
+++ b/packages/gatsby/src/bootstrap/load-themes/index.ts
@@ -12,7 +12,7 @@ import { GatsbyConfig, PluginRef } from "../../../index"
 
 const debug = Debug(`gatsby:load-themes`)
 
-type ResolvedTheme = {
+interface IResolvedTheme {
   themeName: string
   themeConfig: GatsbyConfig
   themeSpec: PluginRef
@@ -26,10 +26,10 @@ const resolveTheme = async (
   configFileThatDeclaredTheme: string,
   isMainConfig = false,
   rootDir: string
-): globalThis.Promise<ResolvedTheme> => {
+): globalThis.Promise<IResolvedTheme> => {
   const themeName =
-    typeof themeSpec === "string" ? themeSpec : themeSpec.resolve
-  let themeDir = ""
+    typeof themeSpec === `string` ? themeSpec : themeSpec.resolve
+  let themeDir = ``
   try {
     const scopedRequire = createRequireFromPath(
       `${rootDir}/:internal:`
@@ -37,7 +37,7 @@ const resolveTheme = async (
     // theme is an node-resolvable module
     themeDir = path.dirname(scopedRequire.resolve(themeName))
   } catch (e) {
-    let pathToLocalTheme = ""
+    let pathToLocalTheme = ``
 
     // only try to look for local theme in main site
     // local themes nested in other themes is potential source of problems:
@@ -78,7 +78,7 @@ const resolveTheme = async (
   // if theme is a function, call it with the themeConfig
   let themeConfig: GatsbyConfig = theme
   if (_.isFunction(theme)) {
-    themeConfig = theme(typeof themeSpec === "string" ? {} : themeSpec.options)
+    themeConfig = theme(typeof themeSpec === `string` ? {} : themeSpec.options)
   }
   return {
     themeName,
@@ -90,12 +90,12 @@ const resolveTheme = async (
   }
 }
 
-type ProcessThemeOptions = {
+interface IProcessThemeOptions {
   useLegacyThemes: boolean
   rootDir: string
 }
 
-type ProcessedTheme = {
+interface IProcessedTheme {
   themeName: string
   themeConfig: GatsbyConfig
   themeSpec: PluginRef
@@ -103,7 +103,7 @@ type ProcessedTheme = {
   parentDir: string
 }
 
-type ProcessedThemes = (ProcessedTheme | ProcessedThemes)[]
+type ProcessedThemes = Array<IProcessedTheme | ProcessedThemes>
 
 // single iteration of a recursive function that resolve parent themes
 // It's recursive because we support child themes declaring parents and
@@ -119,8 +119,8 @@ const processTheme = (
     themeSpec,
     themeDir,
     configFilePath,
-  }: ResolvedTheme,
-  { useLegacyThemes, rootDir }: ProcessThemeOptions
+  }: IResolvedTheme,
+  { useLegacyThemes, rootDir }: IProcessThemeOptions
 ): Promise<ProcessedThemes> => {
   const themesList = useLegacyThemes
     ? themeConfig && themeConfig.__experimentalThemes
@@ -147,15 +147,15 @@ const processTheme = (
   }
 }
 
-type LoadThemesOptions = {
+interface LoadThemesOptions {
   useLegacyThemes?: boolean
   configFilePath: string
   rootDir: string
 }
 
-type LoadedThemes = {
+interface LoadedThemes {
   config: GatsbyConfig
-  themes: ProcessedTheme[]
+  themes: Array<IProcessedTheme>
 }
 
 export default async function loadThemes(


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Add typescript types for the load-themes/index file & the test.

### Documentation
Self-documented

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Related to #21995
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
