### PR TITLE
chore(gatsby-image): Add more DatoCMS fragments

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -246,6 +246,8 @@ Their fragments are:
 - `GatsbyDatoCmsFixed_noBase64`
 - `GatsbyDatoCmsFluid`
 - `GatsbyDatoCmsFluid_noBase64`
+- `GatsbyDatoCmsFluid_tracedSVG`
+- `GatsbyDatoCmsFixed_tracedSVG`
 
 ### gatsby-source-sanity
 

--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -244,10 +244,10 @@ Their fragments are:
 
 - `GatsbyDatoCmsFixed`
 - `GatsbyDatoCmsFixed_noBase64`
+- `GatsbyDatoCmsFixed_tracedSVG`
 - `GatsbyDatoCmsFluid`
 - `GatsbyDatoCmsFluid_noBase64`
 - `GatsbyDatoCmsFluid_tracedSVG`
-- `GatsbyDatoCmsFixed_tracedSVG`
 
 ### gatsby-source-sanity
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
DatoCMS nowadays support GatsbyDatoCmsFluid_tracedSVG and GatsbyDatoCmsFixed_tracedSVG fragments so I have added it to the doc.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes #27288 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
