### PR TITLE
chore(gatsby): track number of pages in develop sessions

### DIFF
--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -12,6 +12,7 @@ import {
   showFeedbackRequest,
 } from "../utils/feedback"
 import { markWebpackStatusAsPending } from "../utils/webpack-status"
+import { store } from "../redux"
 
 import { IProgram, IDebugInfo } from "./types"
 import { interpret } from "xstate"
@@ -45,7 +46,11 @@ if (process.send) {
 }
 
 onExit(() => {
-  telemetry.trackCli(`DEVELOP_STOP`)
+  telemetry.trackCli(`DEVELOP_STOP`, {
+    siteMeasurements: {
+      pagesCount: store.getState().pages.size,
+    },
+  })
 })
 
 process.on(`message`, msg => {


### PR DESCRIPTION
We track `pagesCount` for builds ( https://github.com/gatsbyjs/gatsby/blob/7bf2bdbf0de545db7c8a1b540cfffb0641a7137a/packages/gatsby/src/commands/build-html.ts#L118-L120 ), but we don't do it for `gatsby develop`.

This is needed to prepare potential calculations around real world savings that users could see from implementing https://github.com/gatsbyjs/gatsby/issues/7348 - because number of pages is huge factor currently that impact time to boot up dev server, doing any analisys without bucketing by site page size wouldn't be able to provide needed nuanced information of potential impact.