### PR TITLE
fix(gatsby): add empty TS declaration file for gatsby-graphiql-explorer

### DIFF
--- a/packages/gatsby/gatsby-graphiql-explorer.d.ts
+++ b/packages/gatsby/gatsby-graphiql-explorer.d.ts
@@ -1,0 +1,4 @@
+declare module "gatsby-graphiql-explorer" {
+  const graphiqlExplorer: any
+  export default graphiqlExplorer
+}

--- a/packages/gatsby/tsconfig.json
+++ b/packages/gatsby/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   // This is for typegen purposes only. For now index.d.ts is manually-created, but gatsby/internal is auto-generated
-  "include": ["./src/internal.ts"]
+  "include": ["./src/internal.ts", "./gatsby-graphiql-explorer.d.ts"]
 }


### PR DESCRIPTION
Publishing on master is currently broken due to this error:

```
> gatsby@2.24.68 build:types /Users/mxstbr/projects/gatsbyjs/gatsby/packages/gatsby
> tsc --emitDeclarationOnly --declaration --declarationDir dist
src/utils/start-server.ts:12:30 - error TS2307: Cannot find module 'gatsby-graphiql-explorer' or its corresponding type declarations.
12 import graphiqlExplorer from "gatsby-graphiql-explorer"
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error.
```

I tried to publish and the publishing commit was pushed to master (84fa4be59108d02c40acbd2fb07c96a0c85aa85c), however the publish to npm failed afterwards with this error.

This resolves the error, although I have no clue how this hasn't happened to anyone else until now.