### PR TITLE
fix(gatsby): support protocol relative link when using `--https` in develop

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -36,7 +36,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       if (services.developstatusserver) {
         let isRestarting = false
         const parentSocket = io(
-          `http://${window.location.hostname}:${services.developstatusserver.port}`
+          `${window.location.protocol}//${window.location.hostname}:${services.developstatusserver.port}`
         )
 
         parentSocket.on(`structured-log`, msg => {


### PR DESCRIPTION
Fixes #27294
Should only affect `gatsby develop` when using `--https`
