### PR TITLE
fix(gatsby-plugin-mdx): babel.transform requires filename field now

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-page.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-page.js
@@ -20,7 +20,7 @@ module.exports = async ({ page, actions }, pluginOptions) => {
     })
 
     // grab the exported frontmatter
-    const { frontmatter } = extractExports(code)
+    const { frontmatter } = extractExports(code, page.component)
 
     deletePage(page)
     createPage(

--- a/packages/gatsby-plugin-mdx/utils/create-mdx-node.js
+++ b/packages/gatsby-plugin-mdx/utils/create-mdx-node.js
@@ -14,7 +14,10 @@ module.exports = async ({ id, node, content }) => {
   }
 
   // extract all the exports
-  const { frontmatter, ...nodeExports } = extractExports(code)
+  const { frontmatter, ...nodeExports } = extractExports(
+    code,
+    node.absolutePath
+  )
 
   const mdxNode = {
     id,

--- a/packages/gatsby-plugin-mdx/utils/extract-exports.js
+++ b/packages/gatsby-plugin-mdx/utils/extract-exports.js
@@ -4,9 +4,11 @@ const objRestSpread = require(`@babel/plugin-proposal-object-rest-spread`)
 const BabelPluginGatherExports = require(`./babel-plugin-gather-exports`)
 
 // grab all the export values
-module.exports = code => {
+module.exports = (code, filename) => {
   const instance = new BabelPluginGatherExports()
   babel.transform(code, {
+    // Note: filename is a mandatory field
+    filename,
     presets: [babelReact],
     plugins: [instance.plugin, objRestSpread],
   })


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/26446

Apparently Babel had a breaking requirement for directly calling `babel.transform` and this dependency bump causes our MDX plugin to now trigger this fatal in Babel.