### PR TITLE
Remove extraneous import

### DIFF
--- a/docs/docs/client-only-routes-and-user-authentication.md
+++ b/docs/docs/client-only-routes-and-user-authentication.md
@@ -87,7 +87,7 @@ The `<PrivateRoute />` component would look something like this one (taken from 
 
 ```jsx:title=src/components/PrivateRoute.js
 // import ...
-import React, { Component } from "react"
+import React from "react"
 import { navigate } from "gatsby"
 import { isLoggedIn } from "../services/auth"
 


### PR DESCRIPTION
## Description

In "[Client-only Routes & User Authentication](https://www.gatsbyjs.com/docs/client-only-routes-and-user-authentication/#adjusting-routes-to-account-for-authenticated-users)" doc page, a code example include this import directive:
`import React, { Component } from "react"`

I think that `Component` should not have been imported here.

A `Component` variable name is next used in the example, but it is as renamed destructured prop.
Not as an imported component.

