### PR TITLE
Fix gatsby-plugin-canonical-urls Protocol Bug (#27298)

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
@@ -26,7 +26,7 @@ exports.onRenderBody = (
         rel="canonical"
         key={pageUrl}
         href={pageUrl}
-        data-baseprotocol={parsed.protocol}
+        data-baseprotocol={parsed.protocol.slice(0, -1)}
         data-basehost={parsed.host}
       />,
     ])


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
This PR is fixing base protocol bug from `https:` to `https`

prev result: `<link rel="canonical" href="https://www.abc.com" data-baseprotocol="https:" data-basehost="www.abc.com">`
current result: `<link rel="canonical" href="https://www.abc.com" data-baseprotocol="https" data-basehost="www.abc.com">`
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #27298
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
