### PR TITLE
chore(gatsby): Migrate query-watcher to ts

### DIFF
--- a/packages/gatsby/src/query/query-watcher.ts
+++ b/packages/gatsby/src/query/query-watcher.ts
@@ -19,7 +19,7 @@ import { boundActionCreators } from "../redux/actions"
 import { IGatsbyStaticQueryComponents } from "../redux/types"
 import queryCompiler from "./query-compiler"
 import report from "gatsby-cli/lib/reporter"
-import queryUtil from "./index"
+import queryUtil from "./"
 import { getGatsbyDependents } from "../utils/gatsby-dependents"
 
 const debug = require(`debug`)(`gatsby:query-watcher`)

--- a/packages/gatsby/src/query/query-watcher.ts
+++ b/packages/gatsby/src/query/query-watcher.ts
@@ -96,8 +96,8 @@ const handleQuery = (
     // format query text, but it doesn't mean that compiled text will change.
     if (
       isNewQuery ||
-      (oldQuery &&
-        (oldQuery.hash !== query.hash || oldQuery.query !== query.text))
+      oldQuery?.hash !== query.hash ||
+      oldQuery?.query !== query.text
     ) {
       boundActionCreators.replaceStaticQuery({
         name: query.name,


### PR DESCRIPTION
## Description

Migration of `gatsby/src/query/query-watcher.js` to TypeScript

## Related Issues
Related to https://github.com/gatsbyjs/gatsby/issues/21995#issuecomment-704254164

