### PR TITLE
fix: make documents path relative as workaround

### DIFF
--- a/packages/gatsby-plugin-graphql-config/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-graphql-config/src/gatsby-node.ts
@@ -12,7 +12,7 @@ async function cacheGraphQLConfig(program: IStateProgram): Promise<void> {
         schema: resolve(base, `.cache/schema.graphql`),
         documents: [
           resolve(base, `src/**/**.{ts,js,tsx,jsx,esm}`),
-          resolve(base, `.cache/fragments.graphql`),
+          `./.cache/fragments.graphql`,
         ],
         extensions: {
           endpoints: {


### PR DESCRIPTION
works around a bug in vscode-graphql where absolute paths for documents don't work, but relative paths do

we will need to update tests if this ready PR gets merged first:

https://github.com/gatsbyjs/gatsby/pull/27019

