### PR TITLE
fix: add gatsby-admin public folders to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,6 +22,8 @@ packages/**/*.js
 !packages/gatsby-plugin-mdx/**/*.js
 packages/gatsby-plugin-mdx/node_modules/**/*.js
 packages/gatsby/cache-dir/commonjs/**/*.js
+packages/gatsby-admin/public/styles.*
+packages/gatsby/gatsby-admin-public/styles.*
 
 # fixtures
 **/__testfixtures__/**


### PR DESCRIPTION
## Description

This solves an issue where tests couldn't be run locally because the linter failed. This change adds the following two directories to `.prettierignore`:

* `packages/gatsby-admin/public`
* `packages/gatsby/gatsby-admin-public`

## Related Issues

N/A

For additional context: Without this change, when I clone the repo and run `yarn bootstrap` and then `yarn test` locally from the root directory, I see the following error:

```
packages/gatsby-admin/public/styles.24bf1742e3764eb5de3c.css
packages/gatsby/gatsby-admin-public/styles.24bf1742e3764eb5de3c.css
Code style issues found in the above file(s). Forgot to run Prettier?
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ prettier: `prettier "**/*.{md,css,scss,yaml,yml}" "--check"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ prettier script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/megansullivan/.npm/_logs/2020-10-07T20_27_16_767Z-debug.log
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "lint:other" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "lint" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```