### PR TITLE
fix(gatsby-plugin-page-creator): Update Route API tests & Fix slash replacement

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/unified-routing/client-side-routes.js
+++ b/e2e-tests/development-runtime/cypress/integration/unified-routing/client-side-routes.js
@@ -1,17 +1,31 @@
 describe(`client-side-routing`, () => {
-  beforeEach(() => {
-    cy.visit(`/`).waitForRouteChange()
-  })
-
   it(`supports dynamic url segments`, () => {
     cy.visit(`/client-dynamic-route/foo`).waitForRouteChange()
 
-    cy.getTestElement(`params`).invoke(`text`).should(`equal`, `foo`)
+    cy.findByTestId(`params`)
+    cy.should(`have.text`, `foo`)
+  })
+
+  it(`supports nested dynamic url segments`, () => {
+    cy.visit(`/client-dynamic-route/products/incite/holo-lens`).waitForRouteChange()
+
+    cy.findByTestId(`params-brand`)
+    cy.should(`have.text`, `incite`)
+    cy.findByTestId(`params-product`)
+    cy.should(`have.text`, `holo-lens`)
   })
 
   it(`supports splats`, () => {
     cy.visit(`/client-dynamic-route/splat/blah/blah/blah`).waitForRouteChange()
 
-    cy.getTestElement(`splat`).invoke(`text`).should(`equal`, `blah/blah/blah`)
+    cy.findByTestId(`splat`)
+    cy.should(`have.text`, `blah/blah/blah`)
+  })
+
+  it(`supports named splats`, () => {
+    cy.visit(`/client-dynamic-route/named-splat/dolores`).waitForRouteChange()
+
+    cy.findByTestId(`splat`)
+    cy.should(`have.text`, `dolores`)
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
+++ b/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
@@ -1,6 +1,6 @@
 describe(`collection-routing`, () => {
   beforeEach(() => {
-    cy.visit(`/collection-routing/root`).waitForRouteChange()
+    cy.visit(`/collection-routing`).waitForRouteChange()
   })
 
   it(`can create simplest collection route that also has a number as an identifier`, () => {
@@ -13,7 +13,7 @@ describe(`collection-routing`, () => {
   })
 
   it(`can navigate to a collection route and see its content rendered`, () => {
-    cy.findByTestId(`collection-routing-blog`)
+    cy.findByTestId(`collection-routing-blog-0`)
     cy.should(`have.attr`, `data-testslug`, `/2018-12-14-hello-world/`)
       .click()
     cy.waitForRouteChange()
@@ -36,8 +36,10 @@ describe(`collection-routing`, () => {
     cy.should(`have.text`, `gatsby-astronaut`)
   })
 
-  it(`should respect collectionGraphql and only show one image instance`, () => {
-    cy.findByTestId(`collection-routing-image-1`)
-      .should(`not.exist`)
+  it(`should respect collectionGraphql and create only one image instance`, () => {
+    cy.visit(`/collection-routing/gatsby-icon`)
+    cy.waitForRouteChange()
+    cy.findByTestId(`name`)
+    cy.should(`not.exist`)
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
+++ b/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
@@ -11,15 +11,24 @@ describe(`collection-routing`, () => {
       .assertRoute(`/collection-routing/2018-12-14-hello-world/`)
     cy.findByTestId(`slug`)
     cy.should(`have.text`, `/2018-12-14-hello-world/`)
+    cy.findByTestId(`pagecontext`)
+    cy.should(`have.text`, `/2018-12-14-hello-world/`)
   })
 
   it(`can navigate to a collection route that uses unions and collectionGraphql query and see its content rendered`, () => {
-    cy.findByTestId(`collection-routing-image`)
+    cy.findByTestId(`collection-routing-image-0`)
     cy.should(`have.attr`, `data-testimagename`, `gatsby-astronaut`)
       .click()
     cy.waitForRouteChange()
       .assertRoute(`/collection-routing/gatsby-astronaut`)
     cy.findByTestId(`name`)
     cy.should(`have.text`, `gatsby-astronaut`)
+    cy.findByTestId(`pagecontext`)
+    cy.should(`have.text`, `gatsby-astronaut`)
+  })
+
+  it(`should respect collectionGraphql and only show one image instance`, () => {
+    cy.findByTestId(`collection-routing-image-1`)
+      .should(`not.exist`)
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
+++ b/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
@@ -3,6 +3,15 @@ describe(`collection-routing`, () => {
     cy.visit(`/collection-routing/root`).waitForRouteChange()
   })
 
+  it(`can create simplest collection route that also has a number as an identifier`, () => {
+    cy.visit(`/collection-routing/1/`)
+      .waitForRouteChange()
+    cy.findByTestId(`slug`)
+      .should(`have.text`, `/preview/1`)
+    cy.findByTestId(`pagecontext`)
+      .should(`have.text`, `1`)
+  })
+
   it(`can navigate to a collection route and see its content rendered`, () => {
     cy.findByTestId(`collection-routing-blog`)
     cy.should(`have.attr`, `data-testslug`, `/2018-12-14-hello-world/`)

--- a/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
+++ b/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
@@ -1,39 +1,25 @@
 describe(`collection-routing`, () => {
   beforeEach(() => {
-    cy.visit(`/`).waitForRouteChange()
+    cy.visit(`/collection-routing/root`).waitForRouteChange()
   })
 
   it(`can navigate to a collection route and see its content rendered`, () => {
-    cy.visit(`/collection-routing/root`).waitForRouteChange()
-
-    cy.getTestElement(`collection-routing-blog`)
-      .invoke(`attr`, `data-testslug`)
-      .then(slug => {
-        // should navigate us to an actual collection builder route.
-        cy.getTestElement(`collection-routing-blog`)
-          .first()
-          .click()
-          .waitForRouteChange()
-          .getTestElement(`slug`)
-          .invoke(`text`)
-          .should(`equal`, slug)
-      })
+    cy.findByTestId(`collection-routing-blog`)
+    cy.should(`have.attr`, `data-testslug`, `/2018-12-14-hello-world/`)
+      .click()
+    cy.waitForRouteChange()
+      .assertRoute(`/collection-routing/2018-12-14-hello-world/`)
+    cy.findByTestId(`slug`)
+    cy.should(`have.text`, `/2018-12-14-hello-world/`)
   })
 
   it(`can navigate to a collection route that uses unions and collectionGraphql query and see its content rendered`, () => {
-    cy.visit(`/collection-routing/root`).waitForRouteChange()
-
-    cy.getTestElement(`collection-routing-image`)
-      .invoke(`attr`, `data-testimagename`)
-      .then(name => {
-        // should navigate us to an actual collection builder route.
-        cy.getTestElement(`collection-routing-image`)
-          .first()
-          .click()
-          .waitForRouteChange()
-          .getTestElement(`name`)
-          .invoke(`text`)
-          .should(`equal`, name)
-      })
+    cy.findByTestId(`collection-routing-image`)
+    cy.should(`have.attr`, `data-testimagename`, `gatsby-astronaut`)
+      .click()
+    cy.waitForRouteChange()
+      .assertRoute(`/collection-routing/gatsby-astronaut`)
+    cy.findByTestId(`name`)
+    cy.should(`have.text`, `gatsby-astronaut`)
   })
 })

--- a/e2e-tests/development-runtime/cypress/support/commands.js
+++ b/e2e-tests/development-runtime/cypress/support/commands.js
@@ -47,3 +47,7 @@ Cypress.Commands.add(
       .then(() => subject)
   }
 )
+
+Cypress.Commands.add(`assertRoute`, (route) => {
+  cy.url().should(`equal`, `${window.location.origin}${route}`)
+})

--- a/e2e-tests/development-runtime/gatsby-node.js
+++ b/e2e-tests/development-runtime/gatsby-node.js
@@ -15,7 +15,7 @@ exports.onCreateNode = function onCreateNode({
 
       createNodeField({
         name: `slug`,
-        value: slug.replace("/", ""),
+        value: slug,
         node,
       })
       break

--- a/e2e-tests/development-runtime/gatsby-node.js
+++ b/e2e-tests/development-runtime/gatsby-node.js
@@ -59,7 +59,7 @@ exports.createPages = async function createPages({
   data.posts.edges.forEach(({ node }) => {
     const { slug } = node.fields
     createPage({
-      path: `/${slug}`,
+      path: slug,
       component: blogPostTemplate,
       context: {
         slug: slug,

--- a/e2e-tests/development-runtime/src/pages/client-dynamic-route/named-splat/[...name].js
+++ b/e2e-tests/development-runtime/src/pages/client-dynamic-route/named-splat/[...name].js
@@ -1,0 +1,9 @@
+import React from "react"
+import Layout from "../../../components/layout"
+
+export default props => (
+  <Layout>
+    <h1 data-testid="title">Named SPLAT!</h1>
+    <h2 data-testid="splat">{props.params.name}</h2>
+  </Layout>
+)

--- a/e2e-tests/development-runtime/src/pages/client-dynamic-route/products/[brand]/[product].js
+++ b/e2e-tests/development-runtime/src/pages/client-dynamic-route/products/[brand]/[product].js
@@ -1,0 +1,10 @@
+import React from "react"
+import Layout from "../../../../components/layout"
+
+export default props => (
+  <Layout>
+    <h1 data-testid="title">Nested Dynamic Route</h1>
+    <h2 data-testid="params-brand">{props.params.brand}</h2>
+    <h2 data-testid="params-product">{props.params.product}</h2>
+  </Layout>
+)

--- a/e2e-tests/development-runtime/src/pages/collection-routing/index.js
+++ b/e2e-tests/development-runtime/src/pages/collection-routing/index.js
@@ -2,15 +2,15 @@ import React from "react"
 import { Link, graphql } from "gatsby"
 import Layout from "../../components/layout"
 
-export default function Root(props) {
+export default function Index(props) {
   return (
     <Layout>
-      {props.data.markdown.nodes.map(node => {
+      {props.data.markdown.nodes.map((node, index) => {
         return (
           <Link
             key={node.gatsbyPath}
             to={node.gatsbyPath}
-            data-testid="collection-routing-blog"
+            data-testid={`collection-routing-blog-${index}`}
             data-testslug={node.fields.slug}
           >
             {node.frontmatter.title}
@@ -34,7 +34,7 @@ export default function Root(props) {
 }
 
 export const query = graphql`
-  query AllMarkdown {
+  query {
     markdown: allMarkdownRemark {
       nodes {
         frontmatter {

--- a/e2e-tests/development-runtime/src/pages/collection-routing/root.js
+++ b/e2e-tests/development-runtime/src/pages/collection-routing/root.js
@@ -17,12 +17,12 @@ export default function Root(props) {
           </Link>
         )
       })}
-      {props.data.images.nodes.map(node => {
+      {props.data.images.nodes.map((node, index) => {
         return (
           <Link
             key={node.gatsbyPath}
             to={node.gatsbyPath}
-            data-testid="collection-routing-image"
+            data-testid={`collection-routing-image-${index}`}
             data-testimagename={node.parent.name}
           >
             {node.parent.name}

--- a/e2e-tests/development-runtime/src/pages/collection-routing/{FakeData.uuid}.js
+++ b/e2e-tests/development-runtime/src/pages/collection-routing/{FakeData.uuid}.js
@@ -1,0 +1,29 @@
+import React from "react"
+import { Link, graphql } from "gatsby"
+
+import Layout from "../../components/layout"
+
+export default function FakeData({ data: { fake }, pageContext: { uuid } }) {
+  return (
+    <Layout>
+      <h1>{fake.title}</h1>
+      <h2 data-testid="slug">{fake.fields.slug}</h2>
+      <p data-testid="pagecontext">{uuid}</p>
+      <Link to="/">Back to home</Link>
+    </Layout>
+  )
+}
+
+export const blogPostQuery = graphql`
+  query GetFakeDataByUUIDCollection($id: String!) {
+    fake: fakeData(id: { eq: $id }) {
+      fields {
+        slug
+      }
+      title
+      updates
+      uuid
+      message
+    }
+  }
+`

--- a/e2e-tests/development-runtime/src/pages/collection-routing/{ImageSharp.parent__(File)__name}.js
+++ b/e2e-tests/development-runtime/src/pages/collection-routing/{ImageSharp.parent__(File)__name}.js
@@ -5,11 +5,12 @@ import Image from "gatsby-image"
 import Layout from "../../components/layout"
 import SEO from "../../components/seo"
 
-export default function BlogPost({ data: { image } }) {
+export default function BlogPost({ data: { image }, pageContext: { parent__name } }) {
   return (
     <Layout>
       <SEO title={image.parent.name} />
       <h2 data-testid="name">{image.parent.name}</h2>
+      <p data-testid="pagecontext">{parent__name}</p>
       <Image fixed={image.fixed} />
       <Link to="/">Back to home</Link>
     </Layout>

--- a/e2e-tests/development-runtime/src/pages/collection-routing/{MarkdownRemark.fields__slug}.js
+++ b/e2e-tests/development-runtime/src/pages/collection-routing/{MarkdownRemark.fields__slug}.js
@@ -4,12 +4,13 @@ import { Link, graphql } from "gatsby"
 import Layout from "../../components/layout"
 import SEO from "../../components/seo"
 
-export default function BlogPost({ data: { post } }) {
+export default function BlogPost({ data: { post }, pageContext: { fields__slug } }) {
   return (
     <Layout>
       <SEO title={post.frontmatter.title} description={post.excerpt} />
       <h1>{post.frontmatter.title}</h1>
       <h2 data-testid="slug">{post.fields.slug}</h2>
+      <p data-testid="pagecontext">{fields__slug}</p>
       <div dangerouslySetInnerHTML={{ __html: post.html }} />
       <Link to="/">Back to home</Link>
     </Layout>

--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -9,6 +9,12 @@ describe(`derive-path`, () => {
     ).toEqual(`product/1`)
   })
 
+  it(`converts number to string in URL`, () => {
+    expect(derivePath(`product/{Product.id}.js`, { id: 1 }, reporter)).toEqual(
+      `product/1`
+    )
+  })
+
   it(`has nested value support`, () => {
     expect(
       derivePath(

--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -56,4 +56,18 @@ describe(`derive-path`, () => {
       )
     ).toEqual(`/film/mrs-doubtfire/`)
   })
+
+  it(`slugify's has working slash replacement for e.g. createFilePath`, () => {
+    expect(
+      derivePath(
+        `blog/{MarkdownRemark.fields__slug}.js`,
+        {
+          fields: {
+            slug: `/fire-and-powder/`,
+          },
+        },
+        reporter
+      )
+    ).toEqual(`blog/fire-and-powder/`)
+  })
 })

--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -63,7 +63,10 @@ describe(`derive-path`, () => {
     ).toEqual(`/film/mrs-doubtfire/`)
   })
 
-  it(`slugify's has working slash replacement for e.g. createFilePath`, () => {
+  it(`keeps existing slashes around and handles possible double forward slashes`, () => {
+    // This tests two things
+    // 1) The trailing slash should be transferred (normally "@sindresorhus/slugify" would remove that)
+    // 2) There shouldn't be a double forward slash in the final URL => blog//fire-and-powder/
     expect(
       derivePath(
         `blog/{MarkdownRemark.fields__slug}.js`,

--- a/packages/gatsby-plugin-page-creator/src/__tests__/get-match-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/get-match-path.ts
@@ -21,5 +21,8 @@ describe(`getMatchPath`, () => {
     expect(getMatchPath(`/products/[id]/[...page]`)).toEqual(
       `/products/:id/*page`
     )
+    expect(getMatchPath(`/products/[brand]/offer/[coupon]`)).toEqual(
+      `/products/:brand/offer/:coupon`
+    )
   })
 })

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -63,8 +63,11 @@ export function derivePath(
 // function will remove the slashes. This is a hack to make sure the slashes
 // stick around in the final url structuring
 function safeSlugify(nodeValue: string): string {
-  return nodeValue
-    .split(`/`)
-    .map(v => slugify(v))
-    .join(`/`)
+  return (
+    nodeValue +
+    ``
+      .split(`/`)
+      .map(v => slugify(v))
+      .join(`/`)
+  )
 }

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -1,5 +1,6 @@
 import _ from "lodash"
 import slugify from "@sindresorhus/slugify"
+import { Reporter } from "gatsby"
 import {
   compose,
   removeFileExtension,
@@ -7,7 +8,8 @@ import {
   extractAllCollectionSegments,
   switchToPeriodDelimiters,
 } from "./path-utils"
-import { Reporter } from "gatsby"
+
+const doubleForwardSlashes = /\/\/+/g
 
 // Generates the path for the page from the file path
 // product/{Product.id}.js => /product/:id, pulls from nodes.id
@@ -26,7 +28,7 @@ export function derivePath(
 
   // 3.  For each slug parts get the actual value from the node data
   slugParts.forEach(slugPart => {
-    // 3.a. this transforms foo__bar into foo.bar
+    // 3.a.  this transforms foo__bar into foo.bar
     const key = compose(
       extractFieldWithoutUnion,
       switchToPeriodDelimiters
@@ -51,24 +53,18 @@ export function derivePath(
     pathWithoutExtension = pathWithoutExtension.replace(slugPart, value)
   })
 
-  return pathWithoutExtension
+  // 4.  Remove double forward slashes that could occur in the final URL
+  const derivedPath = pathWithoutExtension.replace(doubleForwardSlashes, `/`)
+
+  return derivedPath
 }
 
+// If the node value is meant to be a slug, like `foo/bar`, the slugify
+// function will remove the slashes. This is a hack to make sure the slashes
+// stick around in the final url structuring
 function safeSlugify(nodeValue: string): string {
-  // If the node value is meant to be a slug, like `foo/bar`, the slugify
-  // function will remove the slashes. This is a hack to make sure the slashes
-  // stick around in the final url structuring
-  const SLASH_PRESERVING_STATIC_KEY = `-replaced-`
-
-  const replaceSlashesValue = (nodeValue + ``).replace(
-    /\//g,
-    SLASH_PRESERVING_STATIC_KEY
-  )
-
-  const slugifiedWithoutSlashesValue = slugify(replaceSlashesValue)
-
-  return slugifiedWithoutSlashesValue.replace(
-    new RegExp(SLASH_PRESERVING_STATIC_KEY, `g`),
-    `/`
-  )
+  return nodeValue
+    .split(`/`)
+    .map(v => slugify(v))
+    .join(`/`)
 }

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -63,11 +63,9 @@ export function derivePath(
 // function will remove the slashes. This is a hack to make sure the slashes
 // stick around in the final url structuring
 function safeSlugify(nodeValue: string): string {
-  return (
-    nodeValue +
-    ``
-      .split(`/`)
-      .map(v => slugify(v))
-      .join(`/`)
-  )
+  // The incoming GraphQL data can also be a number
+  const input = String(nodeValue)
+  const tempArr = input.split(`/`)
+
+  return tempArr.map(v => slugify(v)).join(`/`)
 }


### PR DESCRIPTION
## Description

The overall mission is to look through all tests and see if they work as intended and cover all use cases.

- Replaced the old logic of `getTestElement` with `findByTestId`
- Also assert the correct route (that helped with catching a bug)
- Bug found: The `/` replacement for slugs like `/my-slug/` didn't work and left the url in `replaced-my-slug-replaced` state
- Add some more E2E and unit test cases

[ch16062]