### PR TITLE
perf(gatsby-plugin-page-creator): use set for tracking existing files

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -1,5 +1,4 @@
 import glob from "globby"
-import _ from "lodash"
 import systemPath from "path"
 import { sync as existsSync } from "fs-exists-cached"
 import {

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -67,17 +67,19 @@ Please pick a path to an existing directory.`)
     const pagesGlob = `**/*.{${exts}}`
 
     // Get initial list of files.
-    let files = await glob(pagesGlob, { cwd: pagesPath })
+    const files = await glob(pagesGlob, { cwd: pagesPath })
     files.forEach(file => {
       createPage(file, pagesDirectory, actions, ignore, graphql, reporter)
     })
+
+    const knownFiles = new Set(files)
 
     watchDirectory(
       pagesPath,
       pagesGlob,
       addedPath => {
         try {
-          if (!_.includes(files, addedPath)) {
+          if (!knownFiles.has(addedPath)) {
             createPage(
               addedPath,
               pagesDirectory,
@@ -86,7 +88,7 @@ Please pick a path to an existing directory.`)
               graphql,
               reporter
             )
-            files.push(addedPath)
+            knownFiles.add(addedPath)
           }
         } catch (e) {
           reporter.panic(
@@ -108,7 +110,7 @@ Please pick a path to an existing directory.`)
               })
             }
           })
-          files = files.filter(f => f !== removedPath)
+          knownFiles.delete(removedPath)
         } catch (e) {
           reporter.panic(
             e.message.startsWith(`PageCreator`)


### PR DESCRIPTION
The changed code was doing `.has` and `.filter` on a purely informational data structure. This is a Set.

Should improve perf a little bit at scale for certain sites (linear search through 100k elements is not fun. Doing a `.filter` just to remove one element even worse.)

~Open question: in `develop`, how often is this lifecycle called? Because I don't think the `watchDirectory` is torn down. Does that mean we're creating more and more chokidars if a site uses this path at all?~ Yeah, should only be called once.