### PR TITLE
fix(gatsby-cli): Categorize plugin validation error

### DIFF
--- a/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
+++ b/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
@@ -31,7 +31,7 @@ import {
   getGlobalStatus,
 } from "./utils"
 import { IStructuredError } from "../../structured-errors/types"
-import { ErrorCategory } from "gatsby-cli/src/structured-errors/error-map"
+import { ErrorCategory } from "../../structured-errors/error-map"
 
 const ActivityStatusToLogLevel = {
   [ActivityStatuses.Interrupted]: ActivityLogLevels.Interrupted,

--- a/packages/gatsby-cli/src/reporter/redux/types.ts
+++ b/packages/gatsby-cli/src/reporter/redux/types.ts
@@ -1,6 +1,6 @@
 import { Actions, ActivityStatuses, ActivityTypes } from "../constants"
 import { IStructuredError } from "../../structured-errors/types"
-import { ErrorCategory } from "gatsby-cli/src/structured-errors/error-map"
+import { ErrorCategory } from "../../structured-errors/error-map"
 
 export interface IGatsbyCLIState {
   messages: Array<ILog>

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -8,6 +8,12 @@ const optionalGraphQLInfo = (context: IOptionalGraphQLInfoContext): string =>
     context.plugin ? `\nPlugin: ${context.plugin}` : ``
   }`
 
+export enum ErrorCategory {
+  USER = `USER`,
+  SYSTEM = `SYSTEM`,
+  THIRD_PARTY = `THIRD_PARTY`,
+}
+
 const errors = {
   "": {
     text: (context): string => {
@@ -435,6 +441,7 @@ const errors = {
         .join(`\n`),
     type: Type.PLUGIN,
     level: Level.ERROR,
+    category: ErrorCategory.USER,
   },
   // node object didn't pass validation
   "11467": {
@@ -495,12 +502,6 @@ export type ErrorId = string | keyof typeof errors
 export const errorMap: Record<ErrorId, IErrorMapEntry> = errors
 
 export const defaultError = errorMap[``]
-
-export enum ErrorCategory {
-  USER = `USER`,
-  SYSTEM = `SYSTEM`,
-  THIRD_PARTY = `THIRD_PARTY`,
-}
 
 export interface IErrorMapEntry {
   text: (context) => string


### PR DESCRIPTION
Add category for `USER` on plugin validation errors.

Also fixes the paths for imports, which fixes https://github.com/gatsbyjs/gatsby/issues/27339