### PR TITLE
Fix gatsby-cli: Yarn check always passes

### DIFF
--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -33,8 +33,8 @@ const spawn = (
 // Refer to https://github.com/yarnpkg/yarn/issues/673
 const checkForYarn = async (): Promise<boolean> => {
   try {
-    execSync(`yarnpkg --version`, { stdio: `ignore` })
-    return true
+    const version = execSync(`yarnpkg --version`, { stdio: `ignore` })
+    return !!version
   } catch (e) {
     return false
   }

--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -33,7 +33,7 @@ const spawn = (
 // Refer to https://github.com/yarnpkg/yarn/issues/673
 const checkForYarn = async (): Promise<boolean> => {
   try {
-    const version = execSync(`yarnpkg --version`, { stdio: `ignore` })
+    const version = execSync(`yarnpkg --version`)
     return !!version
   } catch (e) {
     return false

--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -110,7 +110,7 @@ const install = async (rootPath: string): Promise<void> => {
         setPackageManager(`npm`)
       }
     }
-    if (getPackageManager() === `yarn` && checkForYarn()) {
+    if (getPackageManager() === `yarn` && (await checkForYarn())) {
       if (await fs.pathExists(`package-lock.json`)) {
         if (!(await fs.pathExists(`yarn.lock`))) {
           await spawn(`yarnpkg import`)

--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -31,7 +31,7 @@ const spawn = (
 // Checks the existence of yarn package
 // We use yarnpkg instead of yarn to avoid conflict with Hadoop yarn
 // Refer to https://github.com/yarnpkg/yarn/issues/673
-const checkForYarn = async (): Promise<boolean> => {
+const checkForYarn = (): boolean => {
   try {
     const version = execSync(`yarnpkg --version`)
     return !!version
@@ -110,7 +110,7 @@ const install = async (rootPath: string): Promise<void> => {
         setPackageManager(`npm`)
       }
     }
-    if (getPackageManager() === `yarn` && (await checkForYarn())) {
+    if (getPackageManager() === `yarn` && checkForYarn()) {
       if (await fs.pathExists(`package-lock.json`)) {
         if (!(await fs.pathExists(`yarn.lock`))) {
           await spawn(`yarnpkg import`)


### PR DESCRIPTION
This fixes #27338

When we changed the CLI code, we removed a yarn command inside the try catch block and kept the version check. However, when `yarnpkg` does not exist, the exit code of the command is still 0 and therefore doesn't throw an error.

Instead, we need to check the output and return the existence of a version. This is a bit of an edge case because it will only happen if a user has a stale file with yarn set as package manager and yarn is not installed. However, the previous check was a false positive.