### PR TITLE
Remove async statement around sync function

### DIFF
--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -31,7 +31,7 @@ const spawn = (
 // Checks the existence of yarn package
 // We use yarnpkg instead of yarn to avoid conflict with Hadoop yarn
 // Refer to https://github.com/yarnpkg/yarn/issues/673
-const checkForYarn = async (): Promise<boolean> => {
+const checkForYarn = (): boolean => {
   try {
     execSync(`yarnpkg --version`, { stdio: `ignore` })
     return true


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/27338

Steps to reproduce :

1. Uninstall yarn
2. Verify that PackageManager is setted to 'yarn' in config.json
3. Run gatsby-cli new

It failed with

```

 ERROR

Command failed with ENOENT: yarnpkg
spawn yarnpkg ENOENT

  Error: Command failed with ENOENT: yarnpkg
  spawn yarnpkg ENOENT

  - child_process.js:268 Process.ChildProcess._handle.onexit
    internal/child_process.js:268:19

  - child_process.js:464 onErrorNT
    internal/child_process.js:464:16

  - task_queues.js:80 processTicksAndRejections
    internal/process/task_queues.js:80:21
```
