### PR TITLE
chore(babel-preset-gatsby): fix broken link to optimize-hook-destructuring

### DIFF
--- a/packages/babel-preset-gatsby/README.md
+++ b/packages/babel-preset-gatsby/README.md
@@ -15,7 +15,7 @@ For more information on how to customize the Babel configuration of your Gatsby 
 - [`babel-plugin-transform-react-remove-prop-types`](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types)
 - [`@babel/plugin-proposal-nullish-coalescing-operator`](https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator)
 - [`@babel/plugin-proposal-optional-chaining`](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining)
-- [`babel-plugin-optimize-hook-destructuring`](https://www.github.com/gatsbyjs/gatsby/packages/babel-plugin-optimize-hook-destructring)
+- [`babel-plugin-optimize-hook-destructuring`](src/optimize-hook-destructuring.ts)
 
 ## Usage
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

- previously it pointed to an actual package, however, there is no such
  package and so this link 404'd
  - looking through the blames, this seems to be a plugin implemented
    within preset-gatsby itself, not as a separate package
    - point to correct location there instead
    - would probably be good to have a separate package for it though!

I stumbled upon `babel-preset-gatsby` a few weeks ago while looking for how other large projects handle Babel configs to get some ideas for TSDX (particularly https://github.com/formium/tsdx/issues/383#issuecomment-705965398 / https://github.com/formium/tsdx/issues/634) and found this plugin that I had never heard of, but then hit a 404. Took the time to fix that 404 today!

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

It's a docs PR itself!

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

#19943 is the original proposal.
https://github.com/gatsbyjs/gatsby/pull/22619#pullrequestreview-384678615 mentions separating it out as a separate package, which I guess was rejected/changed, but the docs were accidentally left as is.

Maybe @developit would consider maintaining this as an independent plugin since it's been implemented in both Next and Gatsby?