### PR TITLE
fix(benchmarks): dont access .node because its already a node

### DIFF
--- a/benchmarks/gabe-csv-markdown/gatsby-node.js
+++ b/benchmarks/gabe-csv-markdown/gatsby-node.js
@@ -26,8 +26,8 @@ exports.createPages = async ({ graphql, actions }) => {
   const posts = result.data.allMarkdownRemark.nodes
 
   posts.forEach(({ id, frontmatter: { slug } }, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const previous = index === posts.length - 1 ? null : posts[index + 1]
+    const next = index === 0 ? null : posts[index - 1]
 
     createPage({
       path: slug,

--- a/benchmarks/gabe-csv-text/gatsby-node.js
+++ b/benchmarks/gabe-csv-text/gatsby-node.js
@@ -24,8 +24,8 @@ exports.createPages = async ({ graphql, actions }) => {
   const posts = result.data.allGendataCsv.nodes
 
   posts.forEach(({ id, slug }, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const previous = index === posts.length - 1 ? null : posts[index + 1]
+    const next = index === 0 ? null : posts[index - 1]
 
     createPage({
       path: slug,

--- a/benchmarks/gabe-fs-markdown/gatsby-node.js
+++ b/benchmarks/gabe-fs-markdown/gatsby-node.js
@@ -26,8 +26,8 @@ exports.createPages = async ({ graphql, actions }) => {
   const posts = result.data.allMarkdownRemark.nodes
 
   posts.forEach(({ id, frontmatter: { slug } }, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const previous = index === posts.length - 1 ? null : posts[index + 1]
+    const next = index === 0 ? null : posts[index - 1]
 
     createPage({
       path: slug,

--- a/benchmarks/gabe-fs-mdx/gatsby-node.js
+++ b/benchmarks/gabe-fs-mdx/gatsby-node.js
@@ -26,8 +26,8 @@ exports.createPages = async ({ graphql, actions }) => {
   const posts = result.data.allMdx.nodes
 
   posts.forEach(({ id, slug }, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const previous = index === posts.length - 1 ? null : posts[index + 1]
+    const next = index === 0 ? null : posts[index - 1]
 
     createPage({
       path: slug,

--- a/benchmarks/gabe-fs-text/gatsby-node.js
+++ b/benchmarks/gabe-fs-text/gatsby-node.js
@@ -24,8 +24,8 @@ exports.createPages = async ({ graphql, actions }) => {
   const posts = result.data.allTexto.nodes
 
   posts.forEach(({ id, slug }, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const previous = index === posts.length - 1 ? null : posts[index + 1]
+    const next = index === 0 ? null : posts[index - 1]
 
     createPage({
       path: slug,

--- a/benchmarks/gabe-json-text/gatsby-node.js
+++ b/benchmarks/gabe-json-text/gatsby-node.js
@@ -24,8 +24,8 @@ exports.createPages = async ({ graphql, actions }) => {
   const posts = result.data.allGendataJson.nodes
 
   posts.forEach(({ id, slug }, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const previous = index === posts.length - 1 ? null : posts[index + 1]
+    const next = index === 0 ? null : posts[index - 1]
 
     createPage({
       path: slug,

--- a/benchmarks/gabe-yaml-text/gatsby-node.js
+++ b/benchmarks/gabe-yaml-text/gatsby-node.js
@@ -24,8 +24,8 @@ exports.createPages = async ({ graphql, actions }) => {
   const posts = result.data.allGendataYaml.nodes
 
   posts.forEach(({ id, slug }, index) => {
-    const previous = index === posts.length - 1 ? null : posts[index + 1].node
-    const next = index === 0 ? null : posts[index - 1].node
+    const previous = index === posts.length - 1 ? null : posts[index + 1]
+    const next = index === 0 ? null : posts[index - 1]
 
     createPage({
       path: slug,


### PR DESCRIPTION
This happened as I changed the `edges` to `node` and cloned the result to all these benchmarks.

ht @LekoArts for reporting