### PR TITLE
fix(blog-starter): don't pass data via context - pass identifiers

### DIFF
--- a/starters/blog/gatsby-node.js
+++ b/starters/blog/gatsby-node.js
@@ -12,15 +12,21 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     `
       {
         allMarkdownRemark(
-          sort: { fields: [frontmatter___date], order: DESC }
+          sort: { fields: [frontmatter___date], order: ASC }
           limit: 1000
         ) {
-          nodes {
-            fields {
-              slug
+          edges {
+            previous {
+              id
             }
-            frontmatter {
-              title
+            next {
+              id
+            }
+            node {
+              id
+              fields {
+                slug
+              }
             }
           }
         }
@@ -36,24 +42,21 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     return
   }
 
-  const posts = result.data.allMarkdownRemark.nodes
+  const posts = result.data.allMarkdownRemark.edges
 
   // Create blog posts pages
   // But only if there's at least one markdown file found at "content/blog" (defined in gatsby-config.js)
   // `context` is available in the template as a prop and as a variable in GraphQL
 
   if (posts.length > 0) {
-    posts.forEach((post, index) => {
-      const previous = index === posts.length - 1 ? null : posts[index + 1]
-      const next = index === 0 ? null : posts[index - 1]
-
+    posts.forEach(post => {
       createPage({
-        path: post.fields.slug,
+        path: post.node.fields.slug,
         component: blogPost,
         context: {
-          slug: post.fields.slug,
-          previous,
-          next,
+          id: post.node.id,
+          previous: post.previous ? post.previous.id : undefined,
+          next: post.next ? post.next.id : undefined,
         },
       })
     })

--- a/starters/blog/src/templates/blog-post.js
+++ b/starters/blog/src/templates/blog-post.js
@@ -5,10 +5,10 @@ import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
-const BlogPostTemplate = ({ data, pageContext, location }) => {
+const BlogPostTemplate = ({ data, location }) => {
   const post = data.markdownRemark
   const siteTitle = data.site.siteMetadata?.title || `Title`
-  const { previous, next } = pageContext
+  const { previous, next } = data
 
   return (
     <Layout location={location} title={siteTitle}>
@@ -67,13 +67,21 @@ const BlogPostTemplate = ({ data, pageContext, location }) => {
 export default BlogPostTemplate
 
 export const pageQuery = graphql`
-  query BlogPostBySlug($slug: String!) {
+  fragment PrevNextFields on MarkdownRemark {
+    fields {
+      slug
+    }
+    frontmatter {
+      title
+    }
+  }
+  query BlogPostBySlug($id: String!, $next: String, $previous: String) {
     site {
       siteMetadata {
         title
       }
     }
-    markdownRemark(fields: { slug: { eq: $slug } }) {
+    markdownRemark(id: { eq: $id }) {
       id
       excerpt(pruneLength: 160)
       html
@@ -82,6 +90,12 @@ export const pageQuery = graphql`
         date(formatString: "MMMM DD, YYYY")
         description
       }
+    }
+    previous: markdownRemark(id: { eq: $previous }) {
+      ...PrevNextFields
+    }
+    next: markdownRemark(id: { eq: $next }) {
+      ...PrevNextFields
     }
   }
 `


### PR DESCRIPTION
In our starters we should use what we consider best practices for Gatsby. Passing data via context (instead of just identifiers) is causing quite a bit of problems. In our blog starter itself it actually isn't huge issue because we grab already available `title` and `slug`, but this approach of passing data like that is then copied over in user projects and build upon (getting excerpt, triggering image processing etc) and this is where this starts to get problematic.