### PR TITLE
chore(gatsby-plugin-google-tagmanager): Add schema

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -11,3 +11,34 @@ exports.onPreInit = (args, options) => {
     }
   }
 }
+
+exports.pluginOptionsSchema = ({ Joi }) =>
+  Joi.object({
+    id: Joi.string()
+      .required()
+      .description(
+        `Google Tag Manager ID that can be found in your Tag Manager dashboard.`
+      ),
+    includeInDevelopment: Joi.boolean()
+      .default(false)
+      .description(
+        `Include Google Tag Manager when running in development mode.`
+      ),
+    defaultDataLayer: Joi.object()
+      .default(null)
+      .description(
+        `Data layer to be set before Google Tag Manager is loaded. Should be an object or a function.`
+      ),
+    gtmAuth: Joi.string().description(
+      `Google Tag Manager environment auth string.`
+    ),
+    gtmPreview: Joi.string().description(
+      `Google Tag Manager environment preview name.`
+    ),
+    dataLayerName: Joi.string().description(`Data layer name.`),
+    routeChangeEventName: Joi.string()
+      .default(`gatsby-route-change`)
+      .description(
+        `Name of the event that is triggered on every Gatsby route change.`
+      ),
+  })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -14,10 +14,9 @@ exports.onPreInit = (args, options) => {
 
 exports.pluginOptionsSchema = ({ Joi }) =>
   Joi.object({
-    id: Joi.string()
-      .description(
-        `Google Tag Manager ID that can be found in your Tag Manager dashboard.`
-      ),
+    id: Joi.string().description(
+      `Google Tag Manager ID that can be found in your Tag Manager dashboard.`
+    ),
     includeInDevelopment: Joi.boolean()
       .default(false)
       .description(

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -15,7 +15,6 @@ exports.onPreInit = (args, options) => {
 exports.pluginOptionsSchema = ({ Joi }) =>
   Joi.object({
     id: Joi.string()
-      .required()
       .description(
         `Google Tag Manager ID that can be found in your Tag Manager dashboard.`
       ),

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -12,31 +12,33 @@ exports.onPreInit = (args, options) => {
   }
 }
 
-exports.pluginOptionsSchema = ({ Joi }) =>
-  Joi.object({
-    id: Joi.string().description(
-      `Google Tag Manager ID that can be found in your Tag Manager dashboard.`
-    ),
-    includeInDevelopment: Joi.boolean()
-      .default(false)
-      .description(
-        `Include Google Tag Manager when running in development mode.`
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = ({ Joi }) =>
+    Joi.object({
+      id: Joi.string().description(
+        `Google Tag Manager ID that can be found in your Tag Manager dashboard.`
       ),
-    defaultDataLayer: Joi.object()
-      .default(null)
-      .description(
-        `Data layer to be set before Google Tag Manager is loaded. Should be an object or a function.`
+      includeInDevelopment: Joi.boolean()
+        .default(false)
+        .description(
+          `Include Google Tag Manager when running in development mode.`
+        ),
+      defaultDataLayer: Joi.object()
+        .default(null)
+        .description(
+          `Data layer to be set before Google Tag Manager is loaded. Should be an object or a function.`
+        ),
+      gtmAuth: Joi.string().description(
+        `Google Tag Manager environment auth string.`
       ),
-    gtmAuth: Joi.string().description(
-      `Google Tag Manager environment auth string.`
-    ),
-    gtmPreview: Joi.string().description(
-      `Google Tag Manager environment preview name.`
-    ),
-    dataLayerName: Joi.string().description(`Data layer name.`),
-    routeChangeEventName: Joi.string()
-      .default(`gatsby-route-change`)
-      .description(
-        `Name of the event that is triggered on every Gatsby route change.`
+      gtmPreview: Joi.string().description(
+        `Google Tag Manager environment preview name.`
       ),
-  })
+      dataLayerName: Joi.string().description(`Data layer name.`),
+      routeChangeEventName: Joi.string()
+        .default(`gatsby-route-change`)
+        .description(
+          `Name of the event that is triggered on every Gatsby route change.`
+        ),
+    })
+}


### PR DESCRIPTION
Adds a schema for `gatsby-plugin-google-tagmanager`