### PR TITLE
fix(documentationjs): fix example caption string

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -52,6 +52,34 @@ Object {
 }
 `;
 
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a captions from examples: description content 1`] = `
+"A js doc with multiple examples, some of them with caption
+"
+`;
+
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a captions from examples: examplesWithCaptions 1`] = `
+Array [
+  Object {
+    "caption": null,
+    "description": "const pear = require('pear')
+pear()",
+    "highlighted": "<span class=\\"token keyword\\">const</span> pear <span class=\\"token operator\\">=</span> <span class=\\"token function\\">require</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'pear'</span><span class=\\"token punctuation\\">)</span>
+<span class=\\"token function\\">pear</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span>",
+    "raw": "const pear = require('pear')
+pear()",
+  },
+  Object {
+    "caption": "How to async pear",
+    "description": "const pear = require('pear')
+await pear()",
+    "highlighted": "<span class=\\"token keyword\\">const</span> pear <span class=\\"token operator\\">=</span> <span class=\\"token function\\">require</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'pear'</span><span class=\\"token punctuation\\">)</span>
+<span class=\\"token keyword\\">await</span> <span class=\\"token function\\">pear</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span>",
+    "raw": "const pear = require('pear')
+await pear()",
+  },
+]
+`;
+
 exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: description content 1`] = `
 "A pretty cool jsdoc example
 "
@@ -59,6 +87,7 @@ exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should 
 
 exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: example 1`] = `
 Object {
+  "caption": null,
   "description": "const apple = require('apple')
 apple()",
   "highlighted": "<span class=\\"token keyword\\">const</span> apple <span class=\\"token operator\\">=</span> <span class=\\"token function\\">require</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'apple'</span><span class=\\"token punctuation\\">)</span>

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/code.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/code.js
@@ -8,3 +8,16 @@
 exports.apple = paramName => {
   console.log(`hi`)
 }
+
+/**
+ * A js doc with multiple examples, some of them with caption
+ * @example
+ * const pear = require('pear')
+ * pear()
+ * @example <caption>How to async pear</caption>
+ * const pear = require('pear')
+ * await pear()
+ */
+exports.pear = paramName => {
+  console.log(`bye`)
+}

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
@@ -88,6 +88,24 @@ describe(`gatsby-transformer-documentationjs: onCreateNode`, () => {
       )
     })
 
+    it(`should extract out a captions from examples`, () => {
+      const pearNode = createdNodes.find(node => node.name === `pear`)
+
+      expect(pearNode.examples.length).toBe(2)
+      expect(pearNode.examples).toMatchSnapshot(`examplesWithCaptions`)
+
+      expect(pearNode.examples[1].caption).toBeDefined()
+
+      const pearDescriptionNode = createdNodes.find(
+        node => node.id === pearNode.description___NODE
+      )
+
+      expect(pearDescriptionNode).toBeDefined()
+      expect(pearDescriptionNode.internal.content).toMatchSnapshot(
+        `description content`
+      )
+    })
+
     it(`should extract code and docs location`, () => {
       const appleNode = createdNodes.find(node => node.name === `apple`)
 

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -436,7 +436,8 @@ exports.onCreateNode = async ({ node, actions, ...helpers }) => {
       if (docsJson.examples) {
         picked.examples = docsJson.examples.map(example => {
           // Extract value from <caption/> element
-          const caption = example?.caption?.children[0]?.children[0].value
+          const caption =
+            example?.caption?.children[0]?.children[0].value || null
           return {
             ...example,
             caption,

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -435,8 +435,11 @@ exports.onCreateNode = async ({ node, actions, ...helpers }) => {
 
       if (docsJson.examples) {
         picked.examples = docsJson.examples.map(example => {
+          // Extract value from <caption/> element
+          const caption = example?.caption?.children[0]?.children[0].value
           return {
             ...example,
+            caption,
             raw: example.description,
             highlighted: Prism.highlight(
               example.description,


### PR DESCRIPTION
# The problem

I want to display the description and some examples on how to use components via `gatsby-transformer-documentationjs`

Here is how it would look like in one of my components:

```js
/**
 * Amazing description
 *
 * @example <caption>My custom example title</caption>
 * doSth()
 * ...
 */
export default function SomeComponent({
...
```

See: https://jsdoc.app/tags-example.html

If I now try to get the caption value of the example via GraphQL, I get the following:

```
String cannot represent value: { type: "root", children: [[Object]], position: { start: [Object], end: [Object] } }
```

Means: Captions support is at the moment broken, if your code contains captioned examples and you try to query them, it will fail.

# The reason

We expect a string for `examples.caption`: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-transformer-documentationjs/src/gatsby-node.js#L104

But documentationjs gives us an object, representing that `<caption/>` xml tag

# Solution

Extract the caption string from the `<caption />` xml tag and pass this value to GraphQL.
