### PR TITLE
chore(gatsby-plugin-sitemap): Add options schema

### DIFF
--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
+    "common-tags": "^1.8.0",
     "minimatch": "^3.0.4",
     "pify": "^3.0.0",
     "sitemap": "^1.13.0"

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -81,45 +81,47 @@ exports.onPostBuild = async (
   })
 }
 
-exports.pluginOptionsSchema = ({ Joi }) =>
-  Joi.object()
-    .keys({
-      output: Joi.string()
-        .default(`/sitemap.xml`)
-        .description(`The filepath and name`),
-      exclude: Joi.array()
-        .items(Joi.string())
-        .description(`An array of paths to exclude from the sitemap`),
-      createLinkInHead: Joi.boolean()
-        .default(true)
-        .description(
-          `Whether to populate the \`<head>\` of your site with a link to the sitemap.`
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = ({ Joi }) =>
+    Joi.object()
+      .keys({
+        output: Joi.string()
+          .default(`/sitemap.xml`)
+          .description(`The filepath and name`),
+        exclude: Joi.array()
+          .items(Joi.string())
+          .description(`An array of paths to exclude from the sitemap`),
+        createLinkInHead: Joi.boolean()
+          .default(true)
+          .description(
+            `Whether to populate the \`<head>\` of your site with a link to the sitemap.`
+          ),
+        serialize: Joi.function().description(
+          `Takes the output of the data query and lets you return an array of sitemap entries.`
         ),
-      serialize: Joi.function().description(
-        `Takes the output of the data query and lets you return an array of sitemap entries.`
-      ),
-      resolveSiteUrl: Joi.function().description(
-        `Takes the output of the data query and lets you return the site URL.`
-      ),
-      query: Joi.string().description(
-        stripIndent`
+        resolveSiteUrl: Joi.function().description(
+          `Takes the output of the data query and lets you return the site URL.`
+        ),
+        query: Joi.string().description(
+          stripIndent`
       The query for the data you need to generate the sitemap. It’s required to get the site’s URL, 
       if you are not fetching it from site.siteMetadata.siteUrl, you will need to set a custom resolveSiteUrl function. 
       If you override the query, you probably will also need to set a serializer to return the correct data for the sitemap. 
       Due to how this plugin was built it is currently expected/required to fetch the page paths from allSitePage, 
       but you may use the allSitePage.edges.node or allSitePage.nodes query structure.`
-      ),
-    })
-    .external(({ query }) => {
-      if (query) {
-        try {
-          parse(query)
-        } catch (e) {
-          throw new Error(
-            stripIndent`
+        ),
+      })
+      .external(({ query }) => {
+        if (query) {
+          try {
+            parse(query)
+          } catch (e) {
+            throw new Error(
+              stripIndent`
             Invalid plugin options for "gatsby-plugin-sitemap":
             "query" must be a valid GraphQL query. Received the error "${e.message}"`
-          )
+            )
+          }
         }
-      }
-    })
+      })
+}

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -7,6 +7,8 @@ import {
   renameFile,
   withoutTrailingSlash,
 } from "./internals"
+import { stripIndent } from "common-tags"
+import { parse } from "gatsby/graphql"
 
 const publicPath = `./public`
 
@@ -78,3 +80,46 @@ exports.onPostBuild = async (
     sitemap.createSitemapIndex(sitemapIndexOptions)
   })
 }
+
+exports.pluginOptionsSchema = ({ Joi }) =>
+  Joi.object()
+    .keys({
+      output: Joi.string()
+        .default(`/sitemap.xml`)
+        .description(`The filepath and name`),
+      exclude: Joi.array()
+        .items(Joi.string())
+        .description(`An array of paths to exclude from the sitemap`),
+      createLinkInHead: Joi.boolean()
+        .default(true)
+        .description(
+          `Whether to populate the \`<head>\` of your site with a link to the sitemap.`
+        ),
+      serialize: Joi.function().description(
+        `Takes the output of the data query and lets you return an array of sitemap entries.`
+      ),
+      resolveSiteUrl: Joi.function().description(
+        `Takes the output of the data query and lets you return the site URL.`
+      ),
+      query: Joi.string().description(
+        stripIndent`
+      The query for the data you need to generate the sitemap. It’s required to get the site’s URL, 
+      if you are not fetching it from site.siteMetadata.siteUrl, you will need to set a custom resolveSiteUrl function. 
+      If you override the query, you probably will also need to set a serializer to return the correct data for the sitemap. 
+      Due to how this plugin was built it is currently expected/required to fetch the page paths from allSitePage, 
+      but you may use the allSitePage.edges.node or allSitePage.nodes query structure.`
+      ),
+    })
+    .external(({ query }) => {
+      if (query) {
+        try {
+          parse(query)
+        } catch (e) {
+          throw new Error(
+            stripIndent`
+            Invalid plugin options for "gatsby-plugin-sitemap":
+            "query" must be a valid GraphQL query. Received the error "${e.message}"`
+          )
+        }
+      }
+    })


### PR DESCRIPTION
Adds options schema for gatsby-plugin-sitemap. Includes external validator for the query syntax.