### PR TITLE
Update setting-up-gatsby-without-gatsby-new.md

### DIFF
--- a/docs/docs/setting-up-gatsby-without-gatsby-new.md
+++ b/docs/docs/setting-up-gatsby-without-gatsby-new.md
@@ -34,6 +34,13 @@ Now, you'll need to install the necessary packages that Gatsby relies on to work
 npm install gatsby react react-dom
 ```
 
+After installing `gatsby` `react` and `react-dom`, you need to add:
+
+`"dev": "GATSBY_GRAPHQL_IDE=playground gatsby develop",`
+
+Adding this command will allow you run your gatsby app with the command `gatsby run dev`
+
+
 Next, you'll add a `src` directory and a `pages` directory inside your project.
 
 ```shell


### PR DESCRIPTION
## Description

Included a step to remind users they need to add a `run` command
I personally use `"dev": "GATSBY_GRAPHQL_IDE=playground gatsby develop",`

And then added that to run the gatsby app they can do `npm run dev`

### Documentation

I found these directions, because I remember following a Gatsby tutorial taught by Gatsby own Jason Lengstorf, but I forgot the command to use to run my app!

https://www.gatsbyjs.com/docs/setting-up-gatsby-without-gatsby-new/

