### PR TITLE
fix(gatsby): Make pluginOptionsSchema optional

### DIFF
--- a/packages/gatsby-plugin-utils/src/test-plugin-options-schema.ts
+++ b/packages/gatsby-plugin-utils/src/test-plugin-options-schema.ts
@@ -7,7 +7,7 @@ interface ITestPluginOptionsSchemaReturnType {
 }
 
 export function testPluginOptionsSchema<PluginOptions = object>(
-  pluginSchemaFunction: GatsbyNode["pluginOptionsSchema"],
+  pluginSchemaFunction: Exclude<GatsbyNode["pluginOptionsSchema"], undefined>,
   pluginOptions: PluginOptions
 ): ITestPluginOptionsSchemaReturnType {
   const pluginOptionsNames = Object.keys(pluginOptions)

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -518,7 +518,7 @@ export interface GatsbyNode {
    * Add a Joi schema for the possible options of your plugin.
    * Currently experimental and not enabled by default.
    */
-  pluginOptionsSchema(args: PluginOptionsSchemaArgs): ObjectSchema
+  pluginOptionsSchema?(args: PluginOptionsSchemaArgs): ObjectSchema
 }
 
 /**

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -182,11 +182,12 @@ export async function validatePluginOptions({
           const gatsbyNode = require(`${plugin.resolve}/gatsby-node`)
           if (!gatsbyNode.pluginOptionsSchema) return null
 
-          let optionsSchema = (gatsbyNode.pluginOptionsSchema as GatsbyNode["pluginOptionsSchema"])(
-            {
-              Joi,
-            }
-          )
+          let optionsSchema = (gatsbyNode.pluginOptionsSchema as Exclude<
+            GatsbyNode["pluginOptionsSchema"],
+            undefined
+          >)({
+            Joi,
+          })
 
           // Validate correct usage of pluginOptionsSchema
           if (!Joi.isSchema(optionsSchema) || optionsSchema.type !== `object`) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

As discussed in #27242, the type for `pluginOptionsSchema` in the `GatsbyNode` interface should be optional, so not everybody who configures their Gatsby nodes needs to define it.

Maybe there should be a separate interface, so every plugins eventually defines their schema, but this is up to another PR after the discussion.

### Documentation
See #27242

## Related Issues
See #27242
