### PR TITLE
fix(gatsby-plugin-google-analytics): remove required on trackingId

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
@@ -1,10 +1,9 @@
 exports.pluginOptionsSchema = ({ Joi }) =>
+  // TODO: make sure that trackingId gets required() when releasing a major version
   Joi.object({
-    trackingId: Joi.string()
-      .required()
-      .description(
-        `The property ID; the tracking code won't be generated without it`
-      ),
+    trackingId: Joi.string().description(
+      `The property ID; the tracking code won't be generated without it`
+    ),
     head: Joi.boolean()
       .default(false)
       .description(

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -270,17 +270,6 @@ describe(`Load plugins`, () => {
               "validationErrors": Array [
                 Object {
                   "context": Object {
-                    "key": "trackingId",
-                    "label": "trackingId",
-                  },
-                  "message": "\\"trackingId\\" is required",
-                  "path": Array [
-                    "trackingId",
-                  ],
-                  "type": "any.required",
-                },
-                Object {
-                  "context": Object {
                     "key": "anonymize",
                     "label": "anonymize",
                     "value": "still not a boolean",


### PR DESCRIPTION
## Description

`trackingId` wasn't a mandatory option before schema validation. We need to keep this behaviour until a major release goes out.

Credits to @wardpeet.

Relates to https://github.com/gatsbyjs/gatsby/pull/27242