### PR TITLE
chore(gatsby-plugin-sharp): Wrap pluginOptionsSchema in env conditional

### DIFF
--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -62,19 +62,21 @@ exports.onPreBootstrap = ({ actions, emitter, reporter }, pluginOptions) => {
   // normalizedOptions = setPluginOptions(pluginOptions)
 }
 
-exports.pluginOptionsSchema = ({ Joi }) =>
-  Joi.object({
-    base64Width: Joi.number()
-      .default(20)
-      .description(`The width of the generated base64 preview image`),
-    forceBase64Format: Joi.any()
-      .valid(`png`, `jpg`, `webp`)
-      .description(
-        `Force a different format for the generated base64 image. Defaults to the same format as the input image`
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = ({ Joi }) =>
+    Joi.object({
+      base64Width: Joi.number()
+        .default(20)
+        .description(`The width of the generated base64 preview image`),
+      forceBase64Format: Joi.any()
+        .valid(`png`, `jpg`, `webp`)
+        .description(
+          `Force a different format for the generated base64 image. Defaults to the same format as the input image`
+        ),
+      useMozJpeg: Joi.boolean().description(
+        `The the mozJpeg library for encoding. Defaults to false, unless \`process.env.GATSBY_JPEG_ENCODER\` === \`MOZJPEG\``
       ),
-    useMozJpeg: Joi.boolean().description(
-      `The the mozJpeg library for encoding. Defaults to false, unless \`process.env.GATSBY_JPEG_ENCODER\` === \`MOZJPEG\``
-    ),
-    stripMetadata: Joi.boolean().default(true),
-    defaultQuality: Joi.number().default(50),
-  })
+      stripMetadata: Joi.boolean().default(true),
+      defaultQuality: Joi.number().default(50),
+    })
+}


### PR DESCRIPTION
As per #27370, wrap the export in a conditional so old Gatsby versions don't complain