### PR TITLE
fix(gatsby): wait for extracted query enqueuing before running queries

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/page-queries.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/page-queries.js
@@ -1,0 +1,19 @@
+const author = `@gatsbyjs`
+
+beforeEach(() => {
+  cy.visit(`/page-query/`).waitForRouteChange()
+})
+
+describe(`hot-reloading page queries`, () => {
+  it(`displays placeholder content on launch`, () => {
+    cy.getTestElement(`hot`).invoke(`text`).should(`not.contain`, author)
+  })
+
+  it(`can edit a page query`, () => {
+    cy.exec(
+      `npm run update -- --file src/pages/page-query.js --replacements "# %AUTHOR%:author" --exact`
+    )
+
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, author)
+  })
+})

--- a/e2e-tests/development-runtime/src/pages/page-query.js
+++ b/e2e-tests/development-runtime/src/pages/page-query.js
@@ -1,0 +1,23 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+function PageQuery({ data }) {
+  return (
+    <p data-testid="hot">
+      {data.site.siteMetadata.title}: {data.site.siteMetadata.author}
+    </p>
+  )
+}
+
+export const query = graphql`
+  {
+    site {
+      siteMetadata {
+        # %AUTHOR%
+        title
+      }
+    }
+  }
+`
+
+export default PageQuery


### PR DESCRIPTION
## Description

This PR fixes a problem with hot-reloading of page query results. Before this PR updated queries were not executed after extraction and were only executed on a subsequent update of the page component.

The correct flow for query running is:

1. Extract queries from updated components
2. **Enqueue extracted queries for execution**
3. Execute dirty queries (including enqueued extracted queries)

But we had this instead:

1. Extract queries from updated components
2. Execute dirty queries (including enqueued extracted queries)
3. **Enqueue extracted queries for execution**

The culprit is `setTimeout` here which triggers enqueuing too late:

https://github.com/gatsbyjs/gatsby/blob/961f3d5fbf7103512a8b200ecbafde82a881f9a9/packages/gatsby/src/redux/machines/page-component.ts#L132-L139

So when we run `calculatingDirtyQueries` it doesn't yet include extracted queries.

## Related Issues

Fixes #26580
