### PR TITLE
Ensure Cache-Control: no-store on page-data files

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -29,7 +29,7 @@ const createPageDataUrl = path => {
   return `${__PATH_PREFIX__}/page-data/${fixedPath}/page-data.json`
 }
 
-function doFetch(url, method = `GET`) {
+function doFetch(url, method = `GET`, noCache = false) {
   return new Promise((resolve, reject) => {
     const req = new XMLHttpRequest()
     req.open(method, url, true)
@@ -37,6 +37,10 @@ function doFetch(url, method = `GET`) {
       if (req.readyState == 4) {
         resolve(req)
       }
+    }
+    // Ensure responses are not cached. Usefull if page-data.json files are accidentally cached for example
+    if (noCache) {
+      req.setRequestHeader(`Cache-Control`, `no-store`)
     }
     req.send(null)
   })
@@ -106,7 +110,7 @@ export class BaseLoader {
     let inFlightPromise = this.inFlightNetworkRequests.get(url)
 
     if (!inFlightPromise) {
-      inFlightPromise = doFetch(url, `GET`)
+      inFlightPromise = doFetch(url, `GET`, true)
       this.inFlightNetworkRequests.set(url, inFlightPromise)
     }
 
@@ -476,7 +480,7 @@ export class ProdLoader extends BaseLoader {
       if (data.notFound) {
         // check if html file exist using HEAD request:
         // if it does we should navigate to it instead of showing 404
-        return doFetch(rawPath, `HEAD`).then(req => {
+        return doFetch(rawPath, `HEAD`, true).then(req => {
           if (req.status === 200) {
             // page (.html file) actually exist (or we asked for 404 )
             // returning page resources status as errored to trigger

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -40,7 +40,7 @@ function doFetch(url, method = `GET`, noCache = false) {
     }
     // Ensure responses are not cached. Usefull if page-data.json files are accidentally cached for example
     if (noCache) {
-      req.setRequestHeader(`Cache-Control`, `no-store`)
+      req.setRequestHeader(`Cache-Control`, `no-cache`)
     }
     req.send(null)
   })


### PR DESCRIPTION
## Description

This PR sets the Cache-Control request header of the cache-dir loader to no-control ensuring that the cache-dir files are not cached in the browser preventing hard to find bugs.

### Documentation

The [documentation](https://www.gatsbyjs.com/docs/caching/) already states that those files should be hosted with Cache-Control: public, max-age=0, must-revalidate.
This PR adds another level of resilience in case you forgot to set the correct headers on your server / CDN.

## Related Issues

I didn't find a specific issue, but I got bitten myself by a stale cache. I can open an issue if needed.
