### PR TITLE
fix(gatsby): materialization should always use resolver when defined

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -729,7 +729,7 @@ function resolveField(
   gqlField,
   fieldName
 ) {
-  if (!gqlField || !gqlField.resolve) {
+  if (!gqlField?.resolve) {
     return node[fieldName]
   }
   const withResolverContext = require(`./context`)

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -654,19 +654,14 @@ async function resolveRecursive(
     const gqlField = gqlFields[fieldName]
     const gqlNonNullType = getNullableType(gqlField.type)
     const gqlFieldType = getNamedType(gqlField.type)
-    let innerValue
-    if (gqlField.resolve) {
-      innerValue = await resolveField(
-        nodeModel,
-        schemaComposer,
-        schema,
-        node,
-        gqlField,
-        fieldName
-      )
-    } else {
-      innerValue = node[fieldName]
-    }
+    let innerValue = await resolveField(
+      nodeModel,
+      schemaComposer,
+      schema,
+      node,
+      gqlField,
+      fieldName
+    )
     if (gqlField && innerValue != null) {
       if (
         isCompositeType(gqlFieldType) &&
@@ -708,11 +703,20 @@ async function resolveRecursive(
     }
   }
 
-  Object.keys(queryFields).forEach(key => {
-    if (!fieldsToResolve[key] && node[key]) {
-      resolvedFields[key] = node[key]
+  for (const fieldName of Object.keys(queryFields)) {
+    if (!fieldsToResolve[fieldName] && node[fieldName]) {
+      // It is possible that this field still has a custom resolver
+      // See https://github.com/gatsbyjs/gatsby/issues/27368
+      resolvedFields[fieldName] = await resolveField(
+        nodeModel,
+        schemaComposer,
+        schema,
+        node,
+        gqlFields[fieldName],
+        fieldName
+      )
     }
-  })
+  }
 
   return _.pickBy(resolvedFields, (value, key) => queryFields[key])
 }
@@ -725,6 +729,9 @@ function resolveField(
   gqlField,
   fieldName
 ) {
+  if (!gqlField || !gqlField.resolve) {
+    return node[fieldName]
+  }
   const withResolverContext = require(`./context`)
   return gqlField.resolve(
     node,


### PR DESCRIPTION
## Description

This PR ensures that if a field has a custom resolver we always use it in materialization (and only read a field value directly when there is no resolver)

It fixes another edge case with materialization. See #27368 for a detailed explaination.

## Related Issues

Fixes #27368