### PR TITLE
fix(gatsby): Error context for 11328

### DIFF
--- a/packages/gatsby/src/utils/validate-page-component.ts
+++ b/packages/gatsby/src/utils/validate-page-component.ts
@@ -89,7 +89,7 @@ export function validatePageComponent(
           error: {
             id: `11328`,
             context: {
-              component,
+              fileName: component,
             },
           },
           panicOnBuild: true,


### PR DESCRIPTION
## Description

The error 11328 expects a `context.fileName` but only `context.component` was passed until now. This was changed in https://github.com/gatsbyjs/gatsby/commit/64858b12b34a3fab45b1bb06a6b65803231569e2

With this the path is printed again:

![image](https://user-images.githubusercontent.com/16143594/95829060-0c425180-0d36-11eb-80ef-fb06f37f6c95.png)


## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/27410
