### PR TITLE
chore(gatsby-plugin-netlify): add pluginOptionsSchema export

### DIFF
--- a/packages/gatsby-plugin-netlify/package.json
+++ b/packages/gatsby-plugin-netlify/package.json
@@ -23,7 +23,8 @@
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",
     "babel-preset-gatsby-package": "^0.5.3",
-    "cross-env": "^7.0.2"
+    "cross-env": "^7.0.2",
+    "gatsby-plugin-utils": "^0.2.27"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-netlify#readme",
   "keywords": [

--- a/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
@@ -1,0 +1,48 @@
+import { testPluginOptionsSchema } from "gatsby-plugin-utils"
+import { pluginOptionsSchema } from "../gatsby-node"
+
+// options: {
+//   headers: {}, // option to add more headers. `Link` headers are transformed by the below criteria
+//   allPageHeaders: [], // option to add headers for all pages. `Link` headers are transformed by the below criteria
+//   mergeSecurityHeaders: true, // boolean to turn off the default security headers
+//   mergeLinkHeaders: true, // boolean to turn off the default gatsby js headers
+//   mergeCachingHeaders: true, // boolean to turn off the default caching headers
+//   transformHeaders: (headers, path) => headers, // optional transform for manipulating headers under each path (e.g.sorting), etc.
+//   generateMatchPathRewrites: true, // boolean to turn off automatic creation of redirect rules for client only paths
+// },
+
+describe(`gatsby-node.js`, () => {
+  it(`should provide meaningful errors when fields are invalid`, () => {
+    const expectedErrors = [
+      `"headers" must be of type object`,
+      `"allPageHeaders" must be an array`,
+      `"mergeSecurityHeaders" must be a boolean`,
+      `"mergeLinkHeaders" must be a boolean`,
+      `"mergeCachingHeaders" must be a boolean`,
+      `"transformHeaders" must be of type function`,
+      `"generateMatchPathRewrites" must be a boolean`,
+    ]
+
+    const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+      headers: `this should be an object`,
+      allPageHeaders: `this should be an array`,
+      mergeSecurityHeaders: `this should be a boolean`,
+      mergeLinkHeaders: `this should be a boolean`,
+      mergeCachingHeaders: `this should be a boolean`,
+      transformHeaders: `this should be a function`,
+      generateMatchPathRewrites: `this should be a boolean`,
+    })
+
+    expect(errors).toEqual(expectedErrors)
+  })
+
+  it(`should validate the schema`, () => {
+    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
+      headers: {
+        Authorization: `Bearer: Some-Magic-Token`,
+      },
+    })
+
+    expect(isValid).toBe(true)
+  })
+})

--- a/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
@@ -29,8 +29,8 @@ describe(`gatsby-node.js`, () => {
   it(`should validate the schema`, () => {
     const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
       headers: {
-        Authorization: [`Bearer: Some-Magic-Token`],
-        otherHeader: [`some`, `great`, `headers`],
+        "/some-page": [`Bearer: Some-Magic-Token`],
+        "/some-other-page": [`some`, `great`, `headers`],
       },
       allPageHeaders: [`First header`, `Second header`],
       mergeSecurityHeaders: true,

--- a/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
@@ -29,7 +29,7 @@ describe(`gatsby-node.js`, () => {
       mergeSecurityHeaders: `this should be a boolean`,
       mergeLinkHeaders: `this should be a boolean`,
       mergeCachingHeaders: `this should be a boolean`,
-      transformHeaders: (too, much, args) => ``,
+      transformHeaders: (too, many, args) => ``,
       generateMatchPathRewrites: `this should be a boolean`,
     })
 

--- a/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
@@ -1,16 +1,6 @@
 import { testPluginOptionsSchema } from "gatsby-plugin-utils"
 import { pluginOptionsSchema } from "../gatsby-node"
 
-// options: {
-//   headers: {}, // option to add more headers. `Link` headers are transformed by the below criteria
-//   allPageHeaders: [], // option to add headers for all pages. `Link` headers are transformed by the below criteria
-//   mergeSecurityHeaders: true, // boolean to turn off the default security headers
-//   mergeLinkHeaders: true, // boolean to turn off the default gatsby js headers
-//   mergeCachingHeaders: true, // boolean to turn off the default caching headers
-//   transformHeaders: (headers, path) => headers, // optional transform for manipulating headers under each path (e.g.sorting), etc.
-//   generateMatchPathRewrites: true, // boolean to turn off automatic creation of redirect rules for client only paths
-// },
-
 describe(`gatsby-node.js`, () => {
   it(`should provide meaningful errors when fields are invalid`, () => {
     const expectedErrors = [

--- a/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/__tests__/gatsby-node.js
@@ -19,7 +19,7 @@ describe(`gatsby-node.js`, () => {
       `"mergeSecurityHeaders" must be a boolean`,
       `"mergeLinkHeaders" must be a boolean`,
       `"mergeCachingHeaders" must be a boolean`,
-      `"transformHeaders" must be of type function`,
+      `"transformHeaders" must have an arity lesser or equal to 2`,
       `"generateMatchPathRewrites" must be a boolean`,
     ]
 
@@ -29,7 +29,7 @@ describe(`gatsby-node.js`, () => {
       mergeSecurityHeaders: `this should be a boolean`,
       mergeLinkHeaders: `this should be a boolean`,
       mergeCachingHeaders: `this should be a boolean`,
-      transformHeaders: `this should be a function`,
+      transformHeaders: (too, much, args) => ``,
       generateMatchPathRewrites: `this should be a boolean`,
     })
 
@@ -39,8 +39,15 @@ describe(`gatsby-node.js`, () => {
   it(`should validate the schema`, () => {
     const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
       headers: {
-        Authorization: `Bearer: Some-Magic-Token`,
+        Authorization: [`Bearer: Some-Magic-Token`],
+        otherHeader: [`some`, `great`, `headers`],
       },
+      allPageHeaders: [`First header`, `Second header`],
+      mergeSecurityHeaders: true,
+      mergeLinkHeaders: false,
+      mergeCachingHeaders: true,
+      transformHeaders: () => null,
+      generateMatchPathRewrites: false,
     })
 
     expect(isValid).toBe(true)

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -52,3 +52,15 @@ exports.onPostBuild = async (
     createRedirects(pluginData, redirects, rewrites),
   ])
 }
+
+exports.pluginOptionsSchema = function ({ Joi }) {
+  return Joi.object({
+    headers: Joi.object(),
+    allPageHeaders: Joi.array(),
+    mergeSecurityHeaders: Joi.boolean(),
+    mergeLinkHeaders: Joi.boolean(),
+    mergeCachingHeaders: Joi.boolean(),
+    transformHeaders: Joi.function(),
+    generateMatchPathRewrites: Joi.boolean(),
+  })
+}

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -53,7 +53,7 @@ exports.onPostBuild = async (
   ])
 }
 
-exports.pluginOptionsSchema = function ({ Joi }) {
+const pluginOptionsSchema = function ({ Joi }) {
   // headers is a specific type used by Netlify: https://www.gatsbyjs.com/plugins/gatsby-plugin-netlify/#headers
   const headersSchema = Joi.object().pattern(
     /^/,
@@ -69,4 +69,8 @@ exports.pluginOptionsSchema = function ({ Joi }) {
     transformHeaders: Joi.function().maxArity(2), // This should return a "headersSchema" type defined at line 58
     generateMatchPathRewrites: Joi.boolean(),
   })
+}
+
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = pluginOptionsSchema
 }

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -54,13 +54,19 @@ exports.onPostBuild = async (
 }
 
 exports.pluginOptionsSchema = function ({ Joi }) {
+  // headers is a specific type used by Netlify: https://www.gatsbyjs.com/plugins/gatsby-plugin-netlify/#headers
+  const headersSchema = Joi.object().pattern(
+    /^/,
+    Joi.array().items(Joi.string())
+  )
+
   return Joi.object({
-    headers: Joi.object(),
-    allPageHeaders: Joi.array(),
+    headers: headersSchema,
+    allPageHeaders: Joi.array().items(Joi.string()),
     mergeSecurityHeaders: Joi.boolean(),
     mergeLinkHeaders: Joi.boolean(),
     mergeCachingHeaders: Joi.boolean(),
-    transformHeaders: Joi.function(),
+    transformHeaders: Joi.function().maxArity(2), // This should return a "headersSchema" type defined at line 58
     generateMatchPathRewrites: Joi.boolean(),
   })
 }

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -53,10 +53,11 @@ exports.onPostBuild = async (
   ])
 }
 
+const MATH_ALL_KEYS = /^/
 const pluginOptionsSchema = function ({ Joi }) {
   // headers is a specific type used by Netlify: https://www.gatsbyjs.com/plugins/gatsby-plugin-netlify/#headers
   const headersSchema = Joi.object()
-    .pattern(/^/, Joi.array().items(Joi.string()))
+    .pattern(MATH_ALL_KEYS, Joi.array().items(Joi.string()))
     .description(`Add more Netlify headers to specific pages`)
 
   return Joi.object({

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -65,13 +65,13 @@ const pluginOptionsSchema = function ({ Joi }) {
       .items(Joi.string())
       .description(`Add more headers to all the pages`),
     mergeSecurityHeaders: Joi.boolean().description(
-      `When true, turn off the default security headers`
+      `When set to true, turns off the default security headers`
     ),
     mergeLinkHeaders: Joi.boolean().description(
-      `When true, turn off the default gatsby js headers`
+      `When set to true, turns off the default gatsby js headers`
     ),
     mergeCachingHeaders: Joi.boolean().description(
-      `When true, turn off the default caching headers`
+      `When set to true, turns off the default caching headers`
     ),
     transformHeaders: Joi.function()
       .maxArity(2)
@@ -79,7 +79,7 @@ const pluginOptionsSchema = function ({ Joi }) {
         `Transform function for manipulating headers under each path (e.g.sorting), etc. This should return an object of type: { key: Array<string> }`
       ),
     generateMatchPathRewrites: Joi.boolean().description(
-      `When true, turn off automatic creation of redirect rules for client only paths`
+      `When set to true, turns off automatic creation of redirect rules for client only paths`
     ),
   })
 }

--- a/packages/gatsby-plugin-netlify/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify/src/gatsby-node.js
@@ -55,19 +55,32 @@ exports.onPostBuild = async (
 
 const pluginOptionsSchema = function ({ Joi }) {
   // headers is a specific type used by Netlify: https://www.gatsbyjs.com/plugins/gatsby-plugin-netlify/#headers
-  const headersSchema = Joi.object().pattern(
-    /^/,
-    Joi.array().items(Joi.string())
-  )
+  const headersSchema = Joi.object()
+    .pattern(/^/, Joi.array().items(Joi.string()))
+    .description(`Add more Netlify headers to specific pages`)
 
   return Joi.object({
     headers: headersSchema,
-    allPageHeaders: Joi.array().items(Joi.string()),
-    mergeSecurityHeaders: Joi.boolean(),
-    mergeLinkHeaders: Joi.boolean(),
-    mergeCachingHeaders: Joi.boolean(),
-    transformHeaders: Joi.function().maxArity(2), // This should return a "headersSchema" type defined at line 58
-    generateMatchPathRewrites: Joi.boolean(),
+    allPageHeaders: Joi.array()
+      .items(Joi.string())
+      .description(`Add more headers to all the pages`),
+    mergeSecurityHeaders: Joi.boolean().description(
+      `When true, turn off the default security headers`
+    ),
+    mergeLinkHeaders: Joi.boolean().description(
+      `When true, turn off the default gatsby js headers`
+    ),
+    mergeCachingHeaders: Joi.boolean().description(
+      `When true, turn off the default caching headers`
+    ),
+    transformHeaders: Joi.function()
+      .maxArity(2)
+      .description(
+        `Transform function for manipulating headers under each path (e.g.sorting), etc. This should return an object of type: { key: Array<string> }`
+      ),
+    generateMatchPathRewrites: Joi.boolean().description(
+      `When true, turn off automatic creation of redirect rules for client only paths`
+    ),
   })
 }
 


### PR DESCRIPTION

## Description

Add plugin options schema to gatsby-plugin-netlify.

- [The plugin documentation](https://www.gatsbyjs.com/plugins/gatsby-plugin-netlify)
- Relates to https://github.com/gatsbyjs/gatsby/pull/27242

Here are the potential options to pass to the plugin:

```javascript
plugins: [
  {
    resolve: `gatsby-plugin-netlify`,
    options: {
      headers: {}, // option to add more headers. `Link` headers are transformed by the below criteria
      allPageHeaders: [], // option to add headers for all pages. `Link` headers are transformed by the below criteria
      mergeSecurityHeaders: true, // boolean to turn off the default security headers
      mergeLinkHeaders: true, // boolean to turn off the default gatsby js headers
      mergeCachingHeaders: true, // boolean to turn off the default caching headers
      transformHeaders: (headers, path) => headers, // optional transform for manipulating headers under each path (e.g.sorting), etc.
      generateMatchPathRewrites: true, // boolean to turn off automatic creation of redirect rules for client only paths
    },
  },
]
```

**Notes:**

- `headers` is a specific netlify type corresponding to `{ [key: string]: Array<string> }` ([See details](https://www.gatsbyjs.com/plugins/gatsby-plugin-netlify/#headers))
-  `transformHeaders` is a function, but I didn't find a way to tell Joi about the return type of that function. In that scenario, the return type should be of type `Netlify Headers` (see previous bullet)
