### PR TITLE
chore(gatsby-transformer-remark): add pluginOptionsSchema export

### DIFF
--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -33,7 +33,8 @@
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",
     "babel-preset-gatsby-package": "^0.5.3",
-    "cross-env": "^7.0.2"
+    "cross-env": "^7.0.2",
+    "gatsby-plugin-utils": "^0.2.29"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-remark#readme",
   "keywords": [

--- a/packages/gatsby-transformer-remark/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/gatsby-node.js
@@ -1,0 +1,44 @@
+import { testPluginOptionsSchema } from "gatsby-plugin-utils"
+import { pluginOptionsSchema } from "../gatsby-node"
+
+describe(`gatsby-node.js`, () => {
+  it(`should provide meaningful errors when fields are invalid`, () => {
+    const expectedErrors = [
+      `"commonmark" must be a boolean`,
+      `"footnotes" must be a boolean`,
+      `"pedantic" must be a boolean`,
+      `"gfm" must be a boolean`,
+      `"plugins" must be an array`,
+    ]
+
+    const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+      commonmark: `this should be a boolean`,
+      footnotes: `this should be a boolean`,
+      pedantic: `this should be a boolean`,
+      gfm: `this should be a boolean`,
+      plugins: `this should be an array`,
+    })
+
+    expect(errors).toEqual(expectedErrors)
+  })
+
+  it(`should validate the schema`, () => {
+    const { isValid, errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+      commonmark: false,
+      footnotes: false,
+      pedantic: false,
+      gfm: false,
+      plugins: [
+        `gatsby-remark-copy-linked-files`,
+        {
+          resolve: `gatsby-remark-images`,
+          options: {
+            maxWidth: 756,
+          },
+        },
+      ],
+    })
+
+    expect(isValid).toBe(true)
+  })
+})

--- a/packages/gatsby-transformer-remark/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/gatsby-node.js
@@ -23,7 +23,7 @@ describe(`gatsby-node.js`, () => {
   })
 
   it(`should validate the schema`, () => {
-    const { isValid, errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
       commonmark: false,
       footnotes: false,
       pedantic: false,

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -1,3 +1,33 @@
 exports.createSchemaCustomization = require(`./create-schema-customization`)
 exports.onCreateNode = require(`./on-node-create`)
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)
+
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = function ({ Joi }) {
+    return Joi.object({
+      commonmark: Joi.boolean().description(
+        `Activates CommonMark mode (default: true)`
+      ),
+      footnotes: Joi.boolean().description(
+        `Activates Footnotes mode (default: true)`
+      ),
+      pedantic: Joi.boolean().description(
+        `Activates Pandemic mode (default: true)`
+      ),
+      gfm: Joi.boolean().description(
+        `Activates GitHub Flavored Markdown mode (default: true)`
+      ),
+      plugins: Joi.array()
+        .items(
+          Joi.string(),
+          Joi.object({
+            resolve: Joi.string(),
+            options: Joi.object({}).unknown(true),
+          })
+        )
+        .description(
+          `A list of remark plugins. See also: https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark for examples`
+        ),
+    })
+  }
+}

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -12,7 +12,7 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
         `Activates Footnotes mode (default: true)`
       ),
       pedantic: Joi.boolean().description(
-        `Activates Pandemic mode (default: true)`
+        `Activates pedantic mode (default: true)`
       ),
       gfm: Joi.boolean().description(
         `Activates GitHub Flavored Markdown mode (default: true)`


### PR DESCRIPTION
## Description

Add plugin schema options in `gatsby-transformer-remark`

Relates to https://github.com/gatsbyjs/gatsby/pull/27242 and https://www.gatsbyjs.com/plugins/gatsby-transformer-remark/