### PR TITLE
fix(gatsby-plugin-postcss): Delete invalid plugins property from outer options object.

### DIFF
--- a/packages/gatsby-plugin-postcss/src/gatsby-node.js
+++ b/packages/gatsby-plugin-postcss/src/gatsby-node.js
@@ -22,10 +22,11 @@ exports.onCreateWebpackConfig = (
   const config = getConfig()
   const cssRules = findCssRules(config)
 
+  delete postcssLoaderOptions.plugins
+
   if (!postcssLoaderOptions.postcssOptions) {
     postcssLoaderOptions.postcssOptions = {}
   }
-  delete postcssLoaderOptions.postcssOptions.plugins
 
   if (postCssPlugins) {
     postcssLoaderOptions.postcssOptions.plugins = postCssPlugins


### PR DESCRIPTION
## Description

This is a followup to https://github.com/gatsbyjs/gatsby/pull/27418, where I realized that my fix didn't completely fix the problem. See [this comment of mine](https://github.com/gatsbyjs/gatsby/pull/27418#issuecomment-707936348) that describes the issue in a bit more detail.

The steps for reproducing are still the same as https://github.com/gatsbyjs/gatsby/issues/27417, and the error message is still the same, but the internal data structures in the code are a little bit different than before.

In this PR, I have restored the `delete` statement back to what it was previously, since I think it was intentionally trying to delete the property at the outer level and not the inner level. I don't feel that I understand why this is happening, so I'd appreciate some input on whether this is the right change to make.

This time I tested it by running through my steps for reproducing again, and then once again hot-editing my `node_modules/` directory with the exact same changes in this PR, so this time I at least feel like I've done a better job of doing a full integration test, but I'd appreciate input on anything else I should test.

### Documentation

No documentation changes, as this should hopefully make it work properly.

## Related Issues

Addresses https://github.com/gatsbyjs/gatsby/issues/27417 (for real, this time, hopefully).