### PR TITLE
chore(gatsby-cli): Change `setErrorMap` & `IErrorMapEntry` type

### DIFF
--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -42,6 +42,9 @@ class Reporter {
   /**
    * Set a custom error map to the reporter. This allows
    * the reporter to extend the internal error map
+   *
+   * Please note: The entered IDs ideally should be different from the ones we internally use:
+   * https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/src/structured-errors/error-map.ts
    */
 
   setErrorMap = (entry: Record<string, IErrorMapEntry>): void => {

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -7,7 +7,7 @@ import * as reporterActions from "./redux/actions"
 import { LogLevels, ActivityStatuses } from "./constants"
 import { getErrorFormatter } from "./errors"
 import constructError from "../structured-errors/construct-error"
-import { IErrorMapEntry, ErrorId } from "../structured-errors/error-map"
+import { IErrorMapEntry } from "../structured-errors/error-map"
 import { prematureEnd } from "./catch-exit-signals"
 import { IStructuredError } from "../structured-errors/types"
 import { createTimerReporter, ITimerReporter } from "./reporter-timer"
@@ -37,14 +37,14 @@ class Reporter {
   stripIndent = stripIndent
   format = chalk
 
-  errorMap: Record<ErrorId, IErrorMapEntry> = {}
+  errorMap: Record<string, IErrorMapEntry> = {}
 
   /**
    * Set a custom error map to the reporter. This allows
    * the reporter to extend the internal error map
    */
 
-  setErrorMap = (entry: Record<ErrorId, IErrorMapEntry>): void => {
+  setErrorMap = (entry: Record<string, IErrorMapEntry>): void => {
     this.errorMap = {
       ...this.errorMap,
       ...entry,

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -7,7 +7,7 @@ import * as reporterActions from "./redux/actions"
 import { LogLevels, ActivityStatuses } from "./constants"
 import { getErrorFormatter } from "./errors"
 import constructError from "../structured-errors/construct-error"
-import { IErrorMapEntry } from "../structured-errors/error-map"
+import { IErrorMapEntry, ErrorId } from "../structured-errors/error-map"
 import { prematureEnd } from "./catch-exit-signals"
 import { IStructuredError } from "../structured-errors/types"
 import { createTimerReporter, ITimerReporter } from "./reporter-timer"
@@ -37,7 +37,7 @@ class Reporter {
   stripIndent = stripIndent
   format = chalk
 
-  errorMap: Record<string, IErrorMapEntry> = {}
+  errorMap: Record<ErrorId, IErrorMapEntry> = {}
 
   /**
    * Set a custom error map to the reporter. This allows

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -505,8 +505,8 @@ export const defaultError = errorMap[``]
 
 export interface IErrorMapEntry {
   text: (context) => string
-  level: Level
-  type?: Type
+  level: keyof typeof Level
+  type?: keyof typeof Type
   category?: ErrorCategory
   docsUrl?: string
 }

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -505,6 +505,7 @@ export const defaultError = errorMap[``]
 
 export interface IErrorMapEntry {
   text: (context) => string
+  // keyof typeof is used for these enums so that the public facing API (e.g. used by setErrorMap) doesn't rely on enum but gives an union
   level: keyof typeof Level
   type?: keyof typeof Type
   category?: ErrorCategory


### PR DESCRIPTION
## Description

I cherry-picked this commit from a WIP branch in which I used `setErrorMap` in a gatsby-node.ts file (a plugin). TS complained about my usage of e.g. `type: "ERROR"` as it expected an enum. For the `id` it would also be wrong to propose our internal set of IDs as we don't want people to use the exact same ones, thus I simply changed it to a `string`.
