### PR TITLE
Remove richtext config option from Readme

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -174,9 +174,6 @@ If you are confident your Content Types will have natural-language IDs (e.g. `bl
 
 Number of entries to retrieve from Contentful at a time. Due to some technical limitations, the response payload should not be greater than 7MB when pulling content from Contentful. If you encounter this issue you can set this param to a lower number than 100, e.g `50`.
 
-**`richText.resolveFieldLocales`** [boolean][optional] [default: `false`]
-
-If you want to resolve the locales in fields of assets and entries that are referenced by rich text (e.g., via embedded entries or entry hyperlinks), set this to `true`. Otherwise, fields of referenced assets or entries will be objects keyed by locale.
 
 ## Notes on Contentful Content Models
 


### PR DESCRIPTION
plugin-options.js does not contain this option anymore on contentful-next branch.  @axe312ger am I correct to remove this from `contentful-next`? I get this error on contentful-next if I try to include this option.  Maybe we should have a comment about this for backwards compatibility?

```
Problems with gatsby-source-contentful plugin options:
[...]
richText: {"resolveFieldLocales":true} - "richText" is not allowed
```