### PR TITLE
chore(gatsby-plugin-offline): add pluginOptionsSchema export 

### DIFF
--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -21,6 +21,7 @@
     "babel-preset-gatsby-package": "^0.5.3",
     "cpx": "^1.5.0",
     "cross-env": "^7.0.2",
+    "gatsby-plugin-utils": "^0.2.31",
     "rewire": "^4.0.1"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-offline#readme",

--- a/packages/gatsby-plugin-offline/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/__tests__/gatsby-node.js
@@ -110,7 +110,7 @@ describe(`onPostBuild`, () => {
   })
 })
 
-describe.only(`pluginOptionsSchema`, () => {
+describe(`pluginOptionsSchema`, () => {
   it(`should provide meaningful errors when fields are invalid`, () => {
     const expectedErrors = [
       `"precachePages" "[0]" must be a string. "[1]" must be a string. "[2]" must be a string`,

--- a/packages/gatsby-plugin-offline/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/__tests__/gatsby-node.js
@@ -1,3 +1,5 @@
+import { testPluginOptionsSchema } from "gatsby-plugin-utils"
+import { pluginOptionsSchema } from "../gatsby-node"
 const rewire = require(`rewire`)
 const fs = require(`fs`)
 const path = require(`path`)
@@ -105,5 +107,29 @@ describe(`onPostBuild`, () => {
     )
 
     expect(swText).toContain(`debug: true`)
+  })
+})
+
+describe.only(`pluginOptionsSchema`, () => {
+  it(`should provide meaningful errors when fields are invalid`, () => {
+    const expectedErrors = [
+      `"precachePages" "[0]" must be a string. "[1]" must be a string. "[2]" must be a string`,
+      `"appendScript" must be a string`,
+      `"debug" must be a boolean`,
+    ]
+
+    const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+      precachePages: [1, 2, 3],
+      appendScript: 1223,
+      debug: `This should be a boolean`,
+    })
+
+    expect(errors).toEqual(expectedErrors)
+  })
+
+  it(`should validate the schema`, () => {
+    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {})
+
+    expect(isValid).toBe(true)
   })
 })

--- a/packages/gatsby-plugin-offline/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/__tests__/gatsby-node.js
@@ -116,19 +116,74 @@ describe.only(`pluginOptionsSchema`, () => {
       `"precachePages" "[0]" must be a string. "[1]" must be a string. "[2]" must be a string`,
       `"appendScript" must be a string`,
       `"debug" must be a boolean`,
+      `"workboxConfig" "importWorkboxFrom" must be a string. "globDirectory" must be a string. "globPatterns[0]" must be a string. "globPatterns[1]" must be a string. "globPatterns[2]" must be a string. "modifyURLPrefix./" must be a string. "cacheId" must be a string. "dontCacheBustURLsMatching" must be of type object. "runtimeCaching[0].handler" must be one of [StaleWhileRevalidate, CacheFirst, NetworkFirst, NetworkOnly, CacheOnly]. "runtimeCaching[1]" must be of type object. "runtimeCaching[2]" must be of type object. "skipWaiting" must be a boolean. "clientsClaim" must be a boolean`,
     ]
 
     const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {
       precachePages: [1, 2, 3],
       appendScript: 1223,
       debug: `This should be a boolean`,
+      workboxConfig: {
+        importWorkboxFrom: 123,
+        globDirectory: 456,
+        globPatterns: [1, 2, 3],
+        modifyURLPrefix: {
+          "/": 123,
+        },
+        cacheId: 123,
+        dontCacheBustURLsMatching: `This should be a regexp`,
+        runtimeCaching: [
+          {
+            urlPattern: /(\.js$|\.css$|static\/)/,
+            handler: `Something Invalid`,
+          },
+          2,
+          3,
+        ],
+        skipWaiting: `This should be a boolean`,
+        clientsClaim: `This should be a boolean`,
+      },
     })
 
     expect(errors).toEqual(expectedErrors)
   })
 
   it(`should validate the schema`, () => {
-    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {})
+    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
+      precachePages: [`/about-us/`, `/projects/*`],
+      appendScript: `src/custom-sw-code.js`,
+      debug: true,
+      workboxConfig: {
+        importWorkboxFrom: `local`,
+        globDirectory: `rootDir`,
+        globPatterns: [`a`, `b`, `c`],
+        modifyURLPrefix: {
+          "/": `pathPrefix/`,
+        },
+        cacheId: `gatsby-plugin-offline`,
+        dontCacheBustURLsMatching: /(\.js$|\.css$|static\/)/,
+        runtimeCaching: [
+          {
+            urlPattern: /(\.js$|\.css$|static\/)/,
+            handler: `CacheFirst`,
+          },
+          {
+            urlPattern: /^https?:.*\/page-data\/.*\.json/,
+            handler: `StaleWhileRevalidate`,
+          },
+          {
+            urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
+            handler: `StaleWhileRevalidate`,
+          },
+          {
+            urlPattern: /^https?:\/\/fonts\.googleapis\.com\/css/,
+            handler: `StaleWhileRevalidate`,
+          },
+        ],
+        skipWaiting: true,
+        clientsClaim: true,
+      },
+    })
 
     expect(isValid).toBe(true)
   })

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -213,6 +213,7 @@ exports.onPostBuild = (
 }
 
 if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  const MATH_ALL_KEYS = /^/
   exports.pluginOptionsSchema = function ({ Joi }) {
     // These are the options of the v3: https://www.gatsbyjs.com/plugins/gatsby-plugin-offline/#available-options
     return Joi.object({
@@ -227,6 +228,22 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
       debug: Joi.boolean().description(
         `Specifies whether Workbox should show debugging output in the browser console at runtime. When undefined, defaults to showing debug messages on localhost only`
       ),
+      workboxConfig: Joi.object({
+        importWorkboxFrom: Joi.string(),
+        globDirectory: Joi.string(),
+        globPatterns: Joi.array().items(Joi.string()),
+        modifyURLPrefix: Joi.object().pattern(MATH_ALL_KEYS, Joi.string()),
+        cacheId: Joi.string(),
+        dontCacheBustURLsMatching: Joi.object().instance(RegExp),
+        runtimeCaching: Joi.array().items(
+          Joi.object({
+            urlPattern: Joi.object().instance(RegExp),
+            handler: Joi.string(),
+          })
+        ),
+        skipWaiting: Joi.boolean(),
+        clientsClaim: Joi.boolean(),
+      }),
     })
   }
 }

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -238,7 +238,13 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
         runtimeCaching: Joi.array().items(
           Joi.object({
             urlPattern: Joi.object().instance(RegExp),
-            handler: Joi.string(),
+            handler: Joi.string().valid(
+              `StaleWhileRevalidate`,
+              `CacheFirst`,
+              `NetworkFirst`,
+              `NetworkOnly`,
+              `CacheOnly`
+            ),
           })
         ),
         skipWaiting: Joi.boolean(),

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -211,3 +211,22 @@ exports.onPostBuild = (
       )
     })
 }
+
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = function ({ Joi }) {
+    // These are the options of the v3: https://www.gatsbyjs.com/plugins/gatsby-plugin-offline/#available-options
+    return Joi.object({
+      precachePages: Joi.array()
+        .items(Joi.string())
+        .description(
+          `An array of pages whose resources should be precached by the service worker, using an array of globs`
+        ),
+      appendScript: Joi.string().description(
+        `A file (path) to be appended at the end of the generated service worker`
+      ),
+      debug: Joi.boolean().description(
+        `Specifies whether Workbox should show debugging output in the browser console at runtime. When undefined, defaults to showing debug messages on localhost only`
+      ),
+    })
+  }
+}

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -249,7 +249,9 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
         ),
         skipWaiting: Joi.boolean(),
         clientsClaim: Joi.boolean(),
-      }),
+      })
+        .description(`Overrides workbox configuration. Helpful documentation: https://www.gatsbyjs.com/plugins/gatsby-plugin-offline/#overriding-workbox-configuration
+      `),
     })
   }
 }


### PR DESCRIPTION
## Description

Add plugin schema options in `gatsby-plugin-offline`

Relates to #27242 and https://www.gatsbyjs.com/plugins/gatsby-plugin-offline/
