### PR TITLE
chore(gatsby-remark-images): add pluginOptionsSchema export

### DIFF
--- a/packages/gatsby-remark-images/.gitignore
+++ b/packages/gatsby-remark-images/.gitignore
@@ -1,6 +1,7 @@
 /constants.js
 /gatsby-browser.js
 /gatsby-ssr.js
+/gatsby-node.js
 /index.js
 /__tests__/*
 tests

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -24,6 +24,7 @@
     "@babel/core": "^7.11.6",
     "babel-preset-gatsby-package": "^0.5.3",
     "cross-env": "^7.0.2",
+    "gatsby-plugin-utils": "^0.2.31",
     "hast-util-to-html": "^6.1.0",
     "mdast-util-to-hast": "^6.0.2"
   },

--- a/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
@@ -41,7 +41,7 @@ describe(`pluginOptionsSchema`, () => {
   })
 
   it(`should validate the schema`, () => {
-    const { isValid, errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
       maxWidth: 700,
       linkImagesToOriginal: false,
       showCaptions: true,

--- a/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
@@ -9,7 +9,7 @@ describe(`pluginOptionsSchema`, () => {
       `"showCaptions" must be a boolean`,
       `"markdownCaptions" must be a boolean`,
       `"sizeByPixelDensity" must be a boolean`,
-      `"wrapperStyle" must be of type object`,
+      `"wrapperStyle" must be one of [object]`,
       `"backgroundColor" must be a string`,
       `"quality" must be a number`,
       `"withWebp" must be a boolean`,

--- a/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
@@ -41,7 +41,22 @@ describe(`pluginOptionsSchema`, () => {
   })
 
   it(`should validate the schema`, () => {
-    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {})
+    const { isValid, errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+      maxWidth: 700,
+      linkImagesToOriginal: false,
+      showCaptions: true,
+      markdownCaptions: true,
+      sizeByPixelDensity: true,
+      wrapperStyle: { marginTop: `1rem`, padding: `1.5rem`, color: `blue` },
+      backgroundColor: `red`,
+      quality: 77,
+      withWebp: true,
+      tracedSVG: true,
+      loading: `eager`,
+      disableBgImageOnAlpha: true,
+      disableBgImage: true,
+      srcSetBreakpoints: [400, 600, 800],
+    })
 
     expect(isValid).toBe(true)
   })

--- a/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
@@ -1,0 +1,48 @@
+import { testPluginOptionsSchema } from "gatsby-plugin-utils"
+import { pluginOptionsSchema } from "../gatsby-node"
+
+describe(`pluginOptionsSchema`, () => {
+  it(`should provide meaningful errors when fields are invalid`, () => {
+    const expectedErrors = [
+      `"maxWidth" must be a number`,
+      `"linkImagesToOriginal" must be a boolean`,
+      `"showCaptions" must be a boolean`,
+      `"markdownCaptions" must be a boolean`,
+      `"sizeByPixelDensity" must be a boolean`,
+      `"wrapperStyle" must be of type object`,
+      `"backgroundColor" must be a string`,
+      `"quality" must be a number`,
+      `"withWebp" must be a boolean`,
+      `"tracedSVG" must be a boolean`,
+      `"loading" must be one of [lazy, eager, auto]`,
+      `"disableBgImageOnAlpha" must be a boolean`,
+      `"disableBgImage" must be a boolean`,
+      `"srcSetBreakpoints" must be an array`,
+    ]
+
+    const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+      maxWidth: `This should be a number`,
+      linkImagesToOriginal: `This should be a boolean`,
+      showCaptions: `This should be a boolean`,
+      markdownCaptions: `This should be a boolean`,
+      sizeByPixelDensity: `This should be a boolean`,
+      wrapperStyle: `This should be an object`,
+      backgroundColor: 123,
+      quality: `This should be a number`,
+      withWebp: `This should be a boolean`,
+      tracedSVG: `This should be a boolean`,
+      loading: `This should be lazy, eager or auto`,
+      disableBgImageOnAlpha: `This should be a boolean`,
+      disableBgImage: `This should be a boolean`,
+      srcSetBreakpoints: `This should be an array`,
+    })
+
+    expect(errors).toEqual(expectedErrors)
+  })
+
+  it(`should validate the schema`, () => {
+    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {})
+
+    expect(isValid).toBe(true)
+  })
+})

--- a/packages/gatsby-remark-images/src/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/gatsby-node.js
@@ -1,0 +1,72 @@
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = function ({ Joi }) {
+    return Joi.object({
+      maxWidth: Joi.number()
+        .default(650)
+        .description(
+          `The maxWidth in pixels of the div where the markdown will be displayed. This value is used when deciding what the width of the various responsive thumbnails should be.`
+        ),
+      linkImagesToOriginal: Joi.boolean()
+        .default(true)
+        .description(
+          `Add a link to each image to the original image. Sometimes people want to see a full-sized version of an image e.g. to see extra detail on a part of the image and this is a convenient and common pattern for enabling this. Set this option to false to disable this behavior.`
+        ),
+      showCaptions: Joi.boolean()
+        .default(false)
+        .description(
+          `Add a caption to each image with the contents of the title attribute, when this is not empty. If the title attribute is empty but the alt attribute is not, it will be used instead. Set this option to true to enable this behavior. You can also pass an array instead to specify which value should be used for the caption — for example, passing ['alt', 'title'] would use the alt attribute first, and then the title. When this is set to true it is the same as passing ['title', 'alt']. If you just want to use the title (and omit captions for images that have alt attributes but no title), pass ['title'].`
+        ),
+      markdownCaptions: Joi.boolean()
+        .default(false)
+        .description(
+          `Parse the caption as markdown instead of raw text. Ignored if showCaptions is false.`
+        ),
+      sizeByPixelDensity: Joi.boolean()
+        .default(false)
+        .description(
+          `[deprecated] Pixel density is only used in vector images, which Gatsby’s implementation of Sharp doesn’t support. This option is currently a no-op and will be removed in the next major version of Gatsby.`
+        ),
+      wrapperStyle: Joi.object({}),
+      backgroundColor: Joi.string().default(`white`)
+        .description(`Set the background color of the image to match the background image of your design.
+
+      Note:
+      - set this option to transparent for a transparent image background.
+      - set this option to none to completely remove the image background.`),
+      quality: Joi.number()
+        .default(50)
+        .description(`The quality level of the generated files.`),
+      withWebp: Joi.boolean()
+        .default(false)
+        .description(
+          `Additionally generate WebP versions alongside your chosen file format. They are added as a srcset with the appropriate mimetype and will be loaded in browsers that support the format. Pass true for default support, or an object of options to specifically override those for the WebP files. For example, pass { quality: 80 } to have the WebP images be at quality level 80.`
+        ),
+      tracedSVG: Joi.boolean()
+        .default(false)
+        .description(
+          `Use traced SVGs for placeholder images instead of the “blur up” effect. Pass true for traced SVGs with the default settings (seen here), or an object of options to override the default. For example, pass { color: "#F00", turnPolicy: "TURNPOLICY_MAJORITY" } to change the color of the trace to red and the turn policy to TURNPOLICY_MAJORITY. See node-potrace parameter documentation for a full listing and explanation of the available options.`
+        ),
+      loading: Joi.string()
+        .valid(`lazy`, `eager`, `auto`)
+        .default(`lazy`)
+        .description(
+          `Set the browser’s native lazy loading attribute. One of lazy, eager or auto.`
+        ),
+      disableBgImageOnAlpha: Joi.boolean()
+        .default(false)
+        .description(
+          `Images containing transparent pixels around the edges results in images with blurry edges. As a result, these images do not work well with the “blur up” technique used in this plugin. As a workaround to disable background images with blurry edges on images containing transparent pixels, enable this setting.`
+        ),
+      disableBgImage: Joi.boolean()
+        .default(false)
+        .description(
+          `Remove background image and its’ inline style. Useful to prevent Stylesheet too long error on AMP.`
+        ),
+      srcSetBreakpoints: Joi.array()
+        .items(Joi.number())
+        .description(
+          `By default gatsby generates 0.25x, 0.5x, 1x, 1.5x, 2x, and 3x sizes of thumbnails. If you want more control over which sizes are output you can use the srcSetBreakpoints parameter. For example, if you want images that are 200, 340, 520, and 890 wide you can add srcSetBreakpoints: [ 200, 340, 520, 890 ] as a parameter. You will also get maxWidth as a breakpoint (which is 650 by default), so you will actually get [ 200, 340, 520, 650, 890 ] as breakpoints.`
+        ),
+    })
+  }
+}

--- a/packages/gatsby-remark-images/src/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/gatsby-node.js
@@ -26,7 +26,10 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
         .description(
           `[deprecated] Pixel density is only used in vector images, which Gatsby’s implementation of Sharp doesn’t support. This option is currently a no-op and will be removed in the next major version of Gatsby.`
         ),
-      wrapperStyle: Joi.object({}).unknown(true),
+      wrapperStyle: Joi.alternatives().try(
+        Joi.object({}).unknown(true),
+        Joi.function().maxArity(1)
+      ),
       backgroundColor: Joi.string().default(`white`)
         .description(`Set the background color of the image to match the background image of your design.
 

--- a/packages/gatsby-remark-images/src/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/gatsby-node.js
@@ -26,7 +26,7 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
         .description(
           `[deprecated] Pixel density is only used in vector images, which Gatsby’s implementation of Sharp doesn’t support. This option is currently a no-op and will be removed in the next major version of Gatsby.`
         ),
-      wrapperStyle: Joi.object({}),
+      wrapperStyle: Joi.object({}).unknown(true),
       backgroundColor: Joi.string().default(`white`)
         .description(`Set the background color of the image to match the background image of your design.
 


### PR DESCRIPTION

## Description

Add plugin schema options in `gatsby-remark-images`

Relates to #27242 and https://www.gatsbyjs.com/plugins/gatsby-remark-images/