### PR TITLE
fix(gatsby-plugin-page-creator): Move to Structured Errors

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -31,9 +31,11 @@ describe(`isValidCollectionPathImplementation`, () => {
 
     isValidCollectionPathImplementation(compatiblePath(path), reporter)
     expect(reporter.panicOnBuild).toBeCalledWith({
-      context: { part: part },
+      context: {
+        sourceMessage: `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`,
+      },
       filePath: compatiblePath(path),
-      id: `5`,
+      id: `12105`,
     })
   })
 })

--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -30,8 +30,10 @@ describe(`isValidCollectionPathImplementation`, () => {
     const part = path.split(`/`)[2]
 
     isValidCollectionPathImplementation(compatiblePath(path), reporter)
-    expect(reporter.panicOnBuild)
-      .toBeCalledWith(`PageCreator: Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.
-filePath: ${compatiblePath(path)}`)
+    expect(reporter.panicOnBuild).toBeCalledWith({
+      context: { part: part },
+      filePath: compatiblePath(path),
+      id: `5`,
+    })
   })
 })

--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -35,7 +35,7 @@ describe(`isValidCollectionPathImplementation`, () => {
         sourceMessage: `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`,
       },
       filePath: compatiblePath(path),
-      id: `12105`,
+      id: `gatsby-plugin-page-creator_12105`,
     })
   })
 })

--- a/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
@@ -39,13 +39,15 @@ export function collectionExtractQueryString(
             if (!text) return
 
             if (text.includes(`...CollectionPagesQueryFragment`) === false) {
-              reporter.error(
-                `PageCreator: Your collection graphql query is incorrect. You must use the fragment "...CollectionPagesQueryFragment" to pull data nodes
+              reporter.error({
+                id: `3`,
+                context: {
+                  sourceMessage: `Your collection graphql query is incorrect. You must use the fragment "...CollectionPagesQueryFragment" to pull data nodes
 
-Please fix the query from ${absolutePath.split(`src/pages`)[1]}.
-
-Offending query: ${text}`
-              )
+Offending query: ${text}`,
+                },
+                filePath: absolutePath,
+              })
               queryString = ``
               modelType = ``
               return

--- a/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
@@ -40,11 +40,9 @@ export function collectionExtractQueryString(
 
             if (text.includes(`...CollectionPagesQueryFragment`) === false) {
               reporter.error({
-                id: `3`,
+                id: `2`,
                 context: {
-                  sourceMessage: `Your collection graphql query is incorrect. You must use the fragment "...CollectionPagesQueryFragment" to pull data nodes
-
-Offending query: ${text}`,
+                  queryString: text,
                 },
                 filePath: absolutePath,
               })

--- a/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
@@ -3,8 +3,9 @@ import { generateQueryFromString } from "./extract-query"
 import { getGraphQLTag } from "babel-plugin-remove-graphql-queries"
 import fs from "fs-extra"
 import traverse from "@babel/traverse"
-import { extractModel } from "./path-utils"
 import { Reporter } from "gatsby"
+import { extractModel } from "./path-utils"
+import { CODES } from "./error-utils"
 
 // This Function opens up the actual collection file and extracts the queryString used in the
 export function collectionExtractQueryString(
@@ -40,9 +41,11 @@ export function collectionExtractQueryString(
 
             if (text.includes(`...CollectionPagesQueryFragment`) === false) {
               reporter.error({
-                id: `2`,
+                id: CODES.CollectionGraphQL,
                 context: {
-                  queryString: text,
+                  sourceMessage: `Your collection graphql query is incorrect. You must use the fragment "...CollectionPagesQueryFragment" to pull data nodes
+
+Offending query: ${text}`,
                 },
                 filePath: absolutePath,
               })

--- a/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
@@ -41,7 +41,7 @@ export function collectionExtractQueryString(
 
             if (text.includes(`...CollectionPagesQueryFragment`) === false) {
               reporter.error({
-                id: prefixId(CODES.CollectionGraphQL, reporter),
+                id: prefixId(CODES.CollectionGraphQL),
                 context: {
                   sourceMessage: `Your collection graphql query is incorrect. You must use the fragment "...CollectionPagesQueryFragment" to pull data nodes
 

--- a/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
@@ -5,7 +5,7 @@ import fs from "fs-extra"
 import traverse from "@babel/traverse"
 import { Reporter } from "gatsby"
 import { extractModel } from "./path-utils"
-import { CODES } from "./error-utils"
+import { CODES, prefixId } from "./error-utils"
 
 // This Function opens up the actual collection file and extracts the queryString used in the
 export function collectionExtractQueryString(
@@ -41,7 +41,7 @@ export function collectionExtractQueryString(
 
             if (text.includes(`...CollectionPagesQueryFragment`) === false) {
               reporter.error({
-                id: CODES.CollectionGraphQL,
+                id: prefixId(CODES.CollectionGraphQL, reporter),
                 context: {
                   sourceMessage: `Your collection graphql query is incorrect. You must use the fragment "...CollectionPagesQueryFragment" to pull data nodes
 

--- a/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
@@ -38,11 +38,6 @@ export function createPage(
   // If the page includes a `{}` in it, then we create it as a collection builder
   if (pathIsCollectionBuilder(absolutePath)) {
     trackFeatureIsUsed(`UnifiedRoutes:collection-page-builder`)
-    if (!process.env.GATSBY_EXPERIMENTAL_ROUTING_APIS) {
-      reporter.panic(
-        `PageCreator: Found a collection route, but the proper env was not set to enable this experimental feature. Please run again with \`GATSBY_EXPERIMENTAL_ROUTING_APIS=1\` to enable.`
-      )
-    }
     createPagesFromCollectionBuilder(
       filePath,
       absolutePath,
@@ -56,10 +51,6 @@ export function createPage(
   // If the path includes a `[]` in it, then we create it as a client only route
   if (pathIsClientOnlyRoute(absolutePath)) {
     trackFeatureIsUsed(`UnifiedRoutes:client-page-builder`)
-    if (!process.env.GATSBY_EXPERIMENTAL_ROUTING_APIS) {
-      reporter.panic(`PageCreator: Found a client route, but the proper env was not set to enable this experimental feature. Please run again with \`GATSBY_EXPERIMENTAL_ROUTING_APIS=1\` to enable.
-Skipping creating pages for ${absolutePath}`)
-    }
     createClientOnlyPage(filePath, absolutePath, actions)
     return
   }

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -54,14 +54,16 @@ export async function createPagesFromCollectionBuilder(
 
   // 1.a If it fails, we need to inform the user and exit early
   if (!data || errors) {
-    reporter.error(
-      `Tried to create pages from the collection builder.
-Unfortunately, the query came back empty. There may be an error in your query.
+    reporter.error({
+      id: `4`,
+      context: {
+        sourceMessage: `Tried to create pages from the collection builder.
+Unfortunately, the query came back empty. There may be an error in your query:
 
-file: ${absolutePath}
-
-${errors.map(error => error.message).join(`\n`)}`.trim()
-    )
+${errors.map(error => error.message).join(`\n`)}`.trim(),
+      },
+      filePath: absolutePath,
+    })
 
     watchCollectionBuilder(
       absolutePath,

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -55,12 +55,9 @@ export async function createPagesFromCollectionBuilder(
   // 1.a If it fails, we need to inform the user and exit early
   if (!data || errors) {
     reporter.error({
-      id: `4`,
+      id: `3`,
       context: {
-        sourceMessage: `Tried to create pages from the collection builder.
-Unfortunately, the query came back empty. There may be an error in your query:
-
-${errors.map(error => error.message).join(`\n`)}`.trim(),
+        errors: errors,
       },
       filePath: absolutePath,
     })

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -1,14 +1,15 @@
 // Move this to gatsby-core-utils?
 import { Actions, CreatePagesArgs } from "gatsby"
+import { createPath } from "gatsby-page-utils"
+import { Reporter } from "gatsby"
 import { reverseLookupParams } from "./extract-query"
 import { getMatchPath } from "./get-match-path"
-import { createPath } from "gatsby-page-utils"
 import { getCollectionRouteParams } from "./get-collection-route-params"
 import { derivePath } from "./derive-path"
 import { watchCollectionBuilder } from "./watch-collection-builder"
 import { collectionExtractQueryString } from "./collection-extract-query-string"
 import { isValidCollectionPathImplementation } from "./is-valid-collection-path-implementation"
-import { Reporter } from "gatsby"
+import { CODES } from "./error-utils"
 
 // TODO: Do we need the ignore argument?
 export async function createPagesFromCollectionBuilder(
@@ -55,9 +56,12 @@ export async function createPagesFromCollectionBuilder(
   // 1.a If it fails, we need to inform the user and exit early
   if (!data || errors) {
     reporter.error({
-      id: `3`,
+      id: CODES.CollectionBuilder,
       context: {
-        errors: errors,
+        sourceMessage: `Tried to create pages from the collection builder.
+Unfortunately, the query came back empty. There may be an error in your query:
+
+${errors.map(error => error.message).join(`\n`)}`.trim(),
       },
       filePath: absolutePath,
     })

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -55,7 +55,7 @@ export async function createPagesFromCollectionBuilder(
   // 1.a If it fails, we need to inform the user and exit early
   if (!data || errors) {
     reporter.error(
-      `PageCreator: Tried to create pages from the collection builder.
+      `Tried to create pages from the collection builder.
 Unfortunately, the query came back empty. There may be an error in your query.
 
 file: ${absolutePath}
@@ -89,7 +89,7 @@ ${errors.map(error => error.message).join(`\n`)}`.trim()
   >
 
   if (nodes) {
-    reporter.info(
+    reporter.verbose(
       `   PageCreator: Creating ${nodes.length} page${
         nodes.length > 1 ? `s` : ``
       } from ${filePath}`

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -56,7 +56,7 @@ export async function createPagesFromCollectionBuilder(
   // 1.a If it fails, we need to inform the user and exit early
   if (!data || errors) {
     reporter.error({
-      id: prefixId(CODES.CollectionBuilder, reporter),
+      id: prefixId(CODES.CollectionBuilder),
       context: {
         sourceMessage: `Tried to create pages from the collection builder.
 Unfortunately, the query came back empty. There may be an error in your query:

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -9,7 +9,7 @@ import { derivePath } from "./derive-path"
 import { watchCollectionBuilder } from "./watch-collection-builder"
 import { collectionExtractQueryString } from "./collection-extract-query-string"
 import { isValidCollectionPathImplementation } from "./is-valid-collection-path-implementation"
-import { CODES } from "./error-utils"
+import { CODES, prefixId } from "./error-utils"
 
 // TODO: Do we need the ignore argument?
 export async function createPagesFromCollectionBuilder(
@@ -56,7 +56,7 @@ export async function createPagesFromCollectionBuilder(
   // 1.a If it fails, we need to inform the user and exit early
   if (!data || errors) {
     reporter.error({
-      id: CODES.CollectionBuilder,
+      id: prefixId(CODES.CollectionBuilder, reporter),
       context: {
         sourceMessage: `Tried to create pages from the collection builder.
 Unfortunately, the query came back empty. There may be an error in your query:

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -40,10 +40,12 @@ export function derivePath(
 
     // 3.c  log error if the key does not exist on node
     if (nodeValue === undefined) {
-      reporter.error(
-        `Could not find value in the following node for key ${slugPart} (transformed to ${key})`
-      )
-      reporter.log(JSON.stringify(node, null, 4))
+      reporter.error({
+        id: `5`,
+        context: {
+          sourceMessage: `Could not find value in the following node for key ${slugPart} (transformed to ${key})`,
+        },
+      })
       return
     }
 

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -41,9 +41,10 @@ export function derivePath(
     // 3.c  log error if the key does not exist on node
     if (nodeValue === undefined) {
       reporter.error({
-        id: `5`,
+        id: `4`,
         context: {
-          sourceMessage: `Could not find value in the following node for key ${slugPart} (transformed to ${key})`,
+          slugPart: slugPart,
+          key: key,
         },
       })
       return

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -41,7 +41,7 @@ export function derivePath(
     // 3.c  log error if the key does not exist on node
     if (nodeValue === undefined) {
       reporter.error(
-        `PageCreator: Could not find value in the following node for key ${slugPart} (transformed to ${key})`
+        `Could not find value in the following node for key ${slugPart} (transformed to ${key})`
       )
       reporter.log(JSON.stringify(node, null, 4))
       return

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -8,6 +8,7 @@ import {
   extractAllCollectionSegments,
   switchToPeriodDelimiters,
 } from "./path-utils"
+import { CODES } from "./error-utils"
 
 const doubleForwardSlashes = /\/\/+/g
 
@@ -41,10 +42,9 @@ export function derivePath(
     // 3.c  log error if the key does not exist on node
     if (nodeValue === undefined) {
       reporter.error({
-        id: `4`,
+        id: CODES.GeneratePath,
         context: {
-          slugPart: slugPart,
-          key: key,
+          sourceMessage: `Could not find value in the following node for key ${slugPart} (transformed to ${key})`,
         },
       })
       return

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -8,7 +8,7 @@ import {
   extractAllCollectionSegments,
   switchToPeriodDelimiters,
 } from "./path-utils"
-import { CODES } from "./error-utils"
+import { CODES, prefixId } from "./error-utils"
 
 const doubleForwardSlashes = /\/\/+/g
 
@@ -42,7 +42,7 @@ export function derivePath(
     // 3.c  log error if the key does not exist on node
     if (nodeValue === undefined) {
       reporter.error({
-        id: CODES.GeneratePath,
+        id: prefixId(CODES.GeneratePath, reporter),
         context: {
           sourceMessage: `Could not find value in the following node for key ${slugPart} (transformed to ${key})`,
         },

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -42,7 +42,7 @@ export function derivePath(
     // 3.c  log error if the key does not exist on node
     if (nodeValue === undefined) {
       reporter.error({
-        id: prefixId(CODES.GeneratePath, reporter),
+        id: prefixId(CODES.GeneratePath),
         context: {
           sourceMessage: `Could not find value in the following node for key ${slugPart} (transformed to ${key})`,
         },

--- a/packages/gatsby-plugin-page-creator/src/error-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/error-utils.ts
@@ -1,0 +1,63 @@
+import { Reporter } from "gatsby"
+
+export const CODES = {
+  Generic: `12101`,
+  CollectionGraphQL: `12102`,
+  CollectionBuilder: `12103`,
+  GeneratePath: `12104`,
+  CollectionPath: `12105`,
+  GraphQLResolver: `12106`,
+  RequiredPath: `12107`,
+  NonExistingPath: `12108`,
+}
+
+// TODO: Refactor to use contextual data instead of only context.sourceMessage
+// once reporter.setErrorMap is guaranteed to be available
+export const ERROR_MAP = {
+  [CODES.Generic]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+  },
+  [CODES.CollectionGraphQL]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+  [CODES.CollectionBuilder]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+  [CODES.GeneratePath]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+  [CODES.CollectionPath]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+  [CODES.GraphQLResolver]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+  },
+  [CODES.RequiredPath]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+  [CODES.NonExistingPath]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+} as Reporter["errorMap"]

--- a/packages/gatsby-plugin-page-creator/src/error-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/error-utils.ts
@@ -11,6 +11,12 @@ export const CODES = {
   NonExistingPath: `12108`,
 }
 
+export const pluginPrefix = `gatsby-plugin-page-creator`
+
+export function prefixId(id: string, reporter: Reporter): string {
+  return reporter.setErrorMap ? id : `${pluginPrefix}_${id}`
+}
+
 // TODO: Refactor to use contextual data instead of only context.sourceMessage
 // once reporter.setErrorMap is guaranteed to be available
 export const ERROR_MAP = {

--- a/packages/gatsby-plugin-page-creator/src/error-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/error-utils.ts
@@ -53,6 +53,7 @@ export const ERROR_MAP = {
     text: (context): string => `PageCreator: ${context.sourceMessage}`,
     level: `ERROR`,
     type: `PLUGIN`,
+    category: `SYSTEM`,
   },
   [CODES.RequiredPath]: {
     text: (context): string => `PageCreator: ${context.sourceMessage}`,

--- a/packages/gatsby-plugin-page-creator/src/error-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/error-utils.ts
@@ -13,8 +13,8 @@ export const CODES = {
 
 export const pluginPrefix = `gatsby-plugin-page-creator`
 
-export function prefixId(id: string, reporter: Reporter): string {
-  return reporter.setErrorMap ? id : `${pluginPrefix}_${id}`
+export function prefixId(id: string): string {
+  return `${pluginPrefix}_${id}`
 }
 
 // TODO: Refactor to use contextual data instead of only context.sourceMessage

--- a/packages/gatsby-plugin-page-creator/src/error-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/error-utils.ts
@@ -9,6 +9,8 @@ export const CODES = {
   GraphQLResolver: `12106`,
   RequiredPath: `12107`,
   NonExistingPath: `12108`,
+  FileSystemAdd: `12109`,
+  FileSystemRemove: `12110`,
 }
 
 export const pluginPrefix = `gatsby-plugin-page-creator`
@@ -66,5 +68,17 @@ export const ERROR_MAP = {
     level: `ERROR`,
     type: `PLUGIN`,
     category: `USER`,
+  },
+  [CODES.FileSystemAdd]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `SYSTEM`,
+  },
+  [CODES.FileSystemRemove]: {
+    text: (context): string => `PageCreator: ${context.sourceMessage}`,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `SYSTEM`,
   },
 } as Reporter["errorMap"]

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -187,7 +187,7 @@ export function setFieldsOnGraphQLNodeType({
     return {}
   } catch (e) {
     reporter.panic({
-      id: `1`,
+      id: `7`,
       context: {
         sourceMessage: e.message,
       },
@@ -208,6 +208,31 @@ export async function onPreInit(
       level: `ERROR`,
     },
     "2": {
+      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      type: `PLUGIN`,
+      level: `ERROR`,
+    },
+    "3": {
+      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      type: `PLUGIN`,
+      level: `ERROR`,
+    },
+    "4": {
+      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      type: `PLUGIN`,
+      level: `ERROR`,
+    },
+    "5": {
+      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      type: `PLUGIN`,
+      level: `ERROR`,
+    },
+    "6": {
+      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      type: `PLUGIN`,
+      level: `ERROR`,
+    },
+    "7": {
       text: (context): string => `PageCreator: ${context.sourceMessage}`,
       type: `PLUGIN`,
       level: `ERROR`,

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -16,7 +16,7 @@ import { createPage } from "./create-page-wrapper"
 import { collectionExtractQueryString } from "./collection-extract-query-string"
 import { derivePath } from "./derive-path"
 import { validatePathQuery } from "./validate-path-query"
-import { CODES, ERROR_MAP } from "./error-utils"
+import { CODES, ERROR_MAP, prefixId } from "./error-utils"
 
 interface IOptions extends PluginOptions {
   path: string
@@ -51,7 +51,7 @@ export async function createPagesStatefully(
 
     if (!pagesPath) {
       reporter.panic({
-        id: CODES.RequiredPath,
+        id: prefixId(CODES.RequiredPath, reporter),
         context: {
           sourceMessage: `"path" is a required option for gatsby-plugin-page-creator
 
@@ -63,7 +63,7 @@ See docs here - https://www.gatsbyjs.org/plugins/gatsby-plugin-page-creator/`,
     // Validate that the path exists.
     if (pathCheck && !existsSync(pagesPath)) {
       reporter.panic({
-        id: CODES.NonExistingPath,
+        id: prefixId(CODES.NonExistingPath, reporter),
         context: {
           sourceMessage: `The path passed to gatsby-plugin-page-creator does not exist on your file system:
 
@@ -103,7 +103,7 @@ Please pick a path to an existing directory.`,
           }
         } catch (e) {
           reporter.panic({
-            id: CODES.Generic,
+            id: prefixId(CODES.Generic, reporter),
             context: {
               sourceMessage: e.message,
             },
@@ -125,7 +125,7 @@ Please pick a path to an existing directory.`,
           knownFiles.delete(removedPath)
         } catch (e) {
           reporter.panic({
-            id: CODES.Generic,
+            id: prefixId(CODES.Generic, reporter),
             context: {
               sourceMessage: e.message,
             },
@@ -135,7 +135,7 @@ Please pick a path to an existing directory.`,
     ).then(() => doneCb(null, null))
   } catch (e) {
     reporter.panic({
-      id: CODES.Generic,
+      id: prefixId(CODES.Generic, reporter),
       context: {
         sourceMessage: e.message,
       },
@@ -188,7 +188,7 @@ export function setFieldsOnGraphQLNodeType({
     return {}
   } catch (e) {
     reporter.panic({
-      id: CODES.GraphQLResolver,
+      id: prefixId(CODES.GraphQLResolver, reporter),
       context: {
         sourceMessage: e.message,
       },
@@ -234,7 +234,7 @@ export async function onPreInit(
     )
   } catch (e) {
     reporter.panic({
-      id: CODES.Generic,
+      id: prefixId(CODES.Generic, reporter),
       context: {
         sourceMessage: e.message,
       },

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -51,7 +51,7 @@ export async function createPagesStatefully(
 
     if (!pagesPath) {
       reporter.panic({
-        id: prefixId(CODES.RequiredPath, reporter),
+        id: prefixId(CODES.RequiredPath),
         context: {
           sourceMessage: `"path" is a required option for gatsby-plugin-page-creator
 
@@ -63,7 +63,7 @@ See docs here - https://www.gatsbyjs.org/plugins/gatsby-plugin-page-creator/`,
     // Validate that the path exists.
     if (pathCheck && !existsSync(pagesPath)) {
       reporter.panic({
-        id: prefixId(CODES.NonExistingPath, reporter),
+        id: prefixId(CODES.NonExistingPath),
         context: {
           sourceMessage: `The path passed to gatsby-plugin-page-creator does not exist on your file system:
 
@@ -103,7 +103,7 @@ Please pick a path to an existing directory.`,
           }
         } catch (e) {
           reporter.panic({
-            id: prefixId(CODES.Generic, reporter),
+            id: prefixId(CODES.Generic),
             context: {
               sourceMessage: e.message,
             },
@@ -125,7 +125,7 @@ Please pick a path to an existing directory.`,
           knownFiles.delete(removedPath)
         } catch (e) {
           reporter.panic({
-            id: prefixId(CODES.Generic, reporter),
+            id: prefixId(CODES.Generic),
             context: {
               sourceMessage: e.message,
             },
@@ -135,7 +135,7 @@ Please pick a path to an existing directory.`,
     ).then(() => doneCb(null, null))
   } catch (e) {
     reporter.panic({
-      id: prefixId(CODES.Generic, reporter),
+      id: prefixId(CODES.Generic),
       context: {
         sourceMessage: e.message,
       },
@@ -188,7 +188,7 @@ export function setFieldsOnGraphQLNodeType({
     return {}
   } catch (e) {
     reporter.panic({
-      id: prefixId(CODES.GraphQLResolver, reporter),
+      id: prefixId(CODES.GraphQLResolver),
       context: {
         sourceMessage: e.message,
       },
@@ -234,7 +234,7 @@ export async function onPreInit(
     )
   } catch (e) {
     reporter.panic({
-      id: prefixId(CODES.Generic, reporter),
+      id: prefixId(CODES.Generic),
       context: {
         sourceMessage: e.message,
       },

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -103,7 +103,7 @@ Please pick a path to an existing directory.`,
           }
         } catch (e) {
           reporter.panic({
-            id: prefixId(CODES.Generic),
+            id: prefixId(CODES.FileSystemAdd),
             context: {
               sourceMessage: e.message,
             },
@@ -125,7 +125,7 @@ Please pick a path to an existing directory.`,
           knownFiles.delete(removedPath)
         } catch (e) {
           reporter.panic({
-            id: prefixId(CODES.Generic),
+            id: prefixId(CODES.FileSystemRemove),
             context: {
               sourceMessage: e.message,
             },

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -49,18 +49,28 @@ export async function createPagesStatefully(
     const exts = program.extensions.map(e => `${e.slice(1)}`).join(`,`)
 
     if (!pagesPath) {
-      reporter.panic(`"path" is a required option for gatsby-plugin-page-creator
+      reporter.panic({
+        id: `1`,
+        context: {
+          sourceMessage: `"path" is a required option for gatsby-plugin-page-creator
 
-See docs here - https://www.gatsbyjs.org/plugins/gatsby-plugin-page-creator/`)
+See docs here - https://www.gatsbyjs.org/plugins/gatsby-plugin-page-creator/`,
+        },
+      })
     }
 
     // Validate that the path exists.
     if (pathCheck && !existsSync(pagesPath)) {
-      reporter.panic(`The path passed to gatsby-plugin-page-creator does not exist on your file system:
+      reporter.panic({
+        id: `1`,
+        context: {
+          sourceMessage: `The path passed to gatsby-plugin-page-creator does not exist on your file system:
 
 ${pagesPath}
 
-Please pick a path to an existing directory.`)
+Please pick a path to an existing directory.`,
+        },
+      })
     }
 
     const pagesDirectory = systemPath.resolve(process.cwd(), pagesPath)
@@ -91,11 +101,12 @@ Please pick a path to an existing directory.`)
             knownFiles.add(addedPath)
           }
         } catch (e) {
-          reporter.panic(
-            e.message.startsWith(`PageCreator`)
-              ? e.message
-              : `PageCreator: ${e.message}`
-          )
+          reporter.panic({
+            id: `1`,
+            context: {
+              sourceMessage: e.message,
+            },
+          })
         }
       },
       removedPath => {
@@ -112,20 +123,22 @@ Please pick a path to an existing directory.`)
           })
           knownFiles.delete(removedPath)
         } catch (e) {
-          reporter.panic(
-            e.message.startsWith(`PageCreator`)
-              ? e.message
-              : `PageCreator: ${e.message}`
-          )
+          reporter.panic({
+            id: `1`,
+            context: {
+              sourceMessage: e.message,
+            },
+          })
         }
       }
     ).then(() => doneCb(null, null))
   } catch (e) {
-    reporter.panic(
-      e.message.startsWith(`PageCreator`)
-        ? e.message
-        : `PageCreator: ${e.message}`
-    )
+    reporter.panic({
+      id: `1`,
+      context: {
+        sourceMessage: e.message,
+      },
+    })
   }
 }
 
@@ -173,11 +186,12 @@ export function setFieldsOnGraphQLNodeType({
 
     return {}
   } catch (e) {
-    reporter.panic(
-      e.message.startsWith(`PageCreator`)
-        ? e.message
-        : `PageCreator: ${e.message}`
-    )
+    reporter.panic({
+      id: `1`,
+      context: {
+        sourceMessage: e.message,
+      },
+    })
     return {}
   }
 }
@@ -186,6 +200,20 @@ export async function onPreInit(
   { reporter }: ParentSpanPluginArgs,
   { path: pagesPath }: IOptions
 ): Promise<void> {
+  reporter.setErrorMap({
+    "1": {
+      // Generic/Catch-all error
+      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      type: `PLUGIN`,
+      level: `ERROR`,
+    },
+    "2": {
+      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      type: `PLUGIN`,
+      level: `ERROR`,
+    },
+  })
+
   try {
     const pagesGlob = `**/\\{*\\}**`
 
@@ -193,11 +221,6 @@ export async function onPreInit(
 
     if (files.length > 0) {
       trackFeatureIsUsed(`UnifiedRoutes:collection-page-builder`)
-      if (!process.env.GATSBY_EXPERIMENTAL_ROUTING_APIS) {
-        reporter.panic(
-          `PageCreator: Found a collection route, but the proper env was not set to enable this experimental feature. Please run again with \`GATSBY_EXPERIMENTAL_ROUTING_APIS=1\` to enable.`
-        )
-      }
     }
 
     await Promise.all(
@@ -219,10 +242,11 @@ export async function onPreInit(
       })
     )
   } catch (e) {
-    reporter.panic(
-      e.message.startsWith(`PageCreator`)
-        ? e.message
-        : `PageCreator: ${e.message}`
-    )
+    reporter.panic({
+      id: `1`,
+      context: {
+        sourceMessage: e.message,
+      },
+    })
   }
 }

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -187,7 +187,7 @@ export function setFieldsOnGraphQLNodeType({
     return {}
   } catch (e) {
     reporter.panic({
-      id: `7`,
+      id: `6`,
       context: {
         sourceMessage: e.message,
       },
@@ -208,31 +208,36 @@ export async function onPreInit(
       level: `ERROR`,
     },
     "2": {
-      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      text: (
+        context
+      ): string => `PageCreator: Your collection graphql query is incorrect. You must use the fragment "...CollectionPagesQueryFragment" to pull data nodes
+
+Offending query: ${context.queryString}`,
       type: `PLUGIN`,
       level: `ERROR`,
     },
     "3": {
-      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      text: (context): string =>
+        `PageCreator: Tried to create pages from the collection builder.
+Unfortunately, the query came back empty. There may be an error in your query:
+
+${context.errors.map(error => error.message).join(`\n`)}`.trim(),
       type: `PLUGIN`,
       level: `ERROR`,
     },
     "4": {
-      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      text: (context): string =>
+        `PageCreator: Could not find value in the following node for key ${context.slugPart} (transformed to ${context.key})`,
       type: `PLUGIN`,
       level: `ERROR`,
     },
     "5": {
-      text: (context): string => `PageCreator: ${context.sourceMessage}`,
+      text: (context): string =>
+        `PageCreator: Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${context.part}.`,
       type: `PLUGIN`,
       level: `ERROR`,
     },
     "6": {
-      text: (context): string => `PageCreator: ${context.sourceMessage}`,
-      type: `PLUGIN`,
-      level: `ERROR`,
-    },
-    "7": {
       text: (context): string => `PageCreator: ${context.sourceMessage}`,
       type: `PLUGIN`,
       level: `ERROR`,

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -23,15 +23,15 @@ export function isValidCollectionPathImplementation(
     const closer = part.match(/\}/)?.[0]!
 
     try {
-      assert(opener, `{`, ``) // This is a noop because of the opening check, but here for posterity
-      assert(model, /^[A-Z][a-zA-Z]+$/, errorMessage(part))
-      assert(field, /^[a-zA-Z_()]+$/, errorMessage(part))
-      assert(closer, `}`, errorMessage(part))
+      assert(opener, `{`) // This is a noop because of the opening check, but here for posterity
+      assert(model, /^[A-Z][a-zA-Z]+$/)
+      assert(field, /^[a-zA-Z_()]+$/)
+      assert(closer, `}`)
     } catch (e) {
       reporter.panicOnBuild({
-        id: `6`,
+        id: `5`,
         context: {
-          sourceMessage: e.message,
+          part: part,
         },
         filePath: filePath,
       })
@@ -41,14 +41,10 @@ export function isValidCollectionPathImplementation(
   return passing
 }
 
-function errorMessage(part: string): string {
-  return `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`
-}
-
-function assert(part: string, matches: string | RegExp, message: string): void {
+function assert(part: string, matches: string | RegExp): void {
   const regexp = matches instanceof RegExp ? matches : new RegExp(matches)
 
   if (!part || regexp.test(part) === false) {
-    throw new Error(message)
+    throw new Error()
   }
 }

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -36,7 +36,7 @@ export function isValidCollectionPathImplementation(
 }
 
 function errorMessage(filePath: string, part: string): string {
-  return `PageCreator: Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.
+  return `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.
 filePath: ${filePath}`
 }
 

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -24,20 +24,25 @@ export function isValidCollectionPathImplementation(
 
     try {
       assert(opener, `{`, ``) // This is a noop because of the opening check, but here for posterity
-      assert(model, /^[A-Z][a-zA-Z]+$/, errorMessage(filePath, part))
-      assert(field, /^[a-zA-Z_()]+$/, errorMessage(filePath, part))
-      assert(closer, `}`, errorMessage(filePath, part))
+      assert(model, /^[A-Z][a-zA-Z]+$/, errorMessage(part))
+      assert(field, /^[a-zA-Z_()]+$/, errorMessage(part))
+      assert(closer, `}`, errorMessage(part))
     } catch (e) {
-      reporter.panicOnBuild(e.message)
+      reporter.panicOnBuild({
+        id: `6`,
+        context: {
+          sourceMessage: e.message,
+        },
+        filePath: filePath,
+      })
       passing = false
     }
   })
   return passing
 }
 
-function errorMessage(filePath: string, part: string): string {
-  return `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.
-filePath: ${filePath}`
+function errorMessage(part: string): string {
+  return `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`
 }
 
 function assert(part: string, matches: string | RegExp, message: string): void {

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -1,5 +1,6 @@
 import sysPath from "path"
 import { Reporter } from "gatsby"
+import { CODES } from "./error-utils"
 
 // This file is a helper for consumers. It's going to log an error to them if they
 // in any way have an incorrect filepath setup for us to predictably use collection
@@ -29,9 +30,9 @@ export function isValidCollectionPathImplementation(
       assert(closer, `}`)
     } catch (e) {
       reporter.panicOnBuild({
-        id: `5`,
+        id: CODES.CollectionPath,
         context: {
-          part: part,
+          sourceMessage: `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`,
         },
         filePath: filePath,
       })

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -24,15 +24,15 @@ export function isValidCollectionPathImplementation(
     const closer = part.match(/\}/)?.[0]!
 
     try {
-      assert(opener, `{`) // This is a noop because of the opening check, but here for posterity
-      assert(model, /^[A-Z][a-zA-Z]+$/)
-      assert(field, /^[a-zA-Z_()]+$/)
-      assert(closer, `}`)
+      assert(opener, `{`, ``) // This is a noop because of the opening check, but here for posterity
+      assert(model, /^[A-Z][a-zA-Z]+$/, errorMessage(part))
+      assert(field, /^[a-zA-Z_()]+$/, errorMessage(part))
+      assert(closer, `}`, errorMessage(part))
     } catch (e) {
       reporter.panicOnBuild({
         id: prefixId(CODES.CollectionPath),
         context: {
-          sourceMessage: `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`,
+          sourceMessage: e.message,
         },
         filePath: filePath,
       })
@@ -42,10 +42,14 @@ export function isValidCollectionPathImplementation(
   return passing
 }
 
-function assert(part: string, matches: string | RegExp): void {
+function errorMessage(part: string): string {
+  return `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`
+}
+
+function assert(part: string, matches: string | RegExp, message: string): void {
   const regexp = matches instanceof RegExp ? matches : new RegExp(matches)
 
   if (!part || regexp.test(part) === false) {
-    throw new Error()
+    throw new Error(message)
   }
 }

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -30,7 +30,7 @@ export function isValidCollectionPathImplementation(
       assert(closer, `}`)
     } catch (e) {
       reporter.panicOnBuild({
-        id: prefixId(CODES.CollectionPath, reporter),
+        id: prefixId(CODES.CollectionPath),
         context: {
           sourceMessage: `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`,
         },

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -1,6 +1,6 @@
 import sysPath from "path"
 import { Reporter } from "gatsby"
-import { CODES } from "./error-utils"
+import { CODES, prefixId } from "./error-utils"
 
 // This file is a helper for consumers. It's going to log an error to them if they
 // in any way have an incorrect filepath setup for us to predictably use collection
@@ -30,7 +30,7 @@ export function isValidCollectionPathImplementation(
       assert(closer, `}`)
     } catch (e) {
       reporter.panicOnBuild({
-        id: CODES.CollectionPath,
+        id: prefixId(CODES.CollectionPath, reporter),
         context: {
           sourceMessage: `Collection page builder encountered an error parsing the filepath. To use collection paths the schema to follow is {Model.field}. The problematic part is: ${part}.`,
         },

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -3,11 +3,10 @@
 export function extractModel(absolutePath: string): string {
   const model = /\{([a-zA-Z]+)\./.exec(absolutePath)
 
-  //  This shouldn't happen - but TS requires us to validate
+  // This shouldn't happen - but TS requires us to validate
+  // Don't throw an error here as otherwise it would be captured in the onPreInit hook and not by isValidCollectionPathImplementation()
   if (!model) {
-    throw new Error(
-      `An error occured extracting the Model from the slug parts. This is likely a bug within Gatsby and not your code. Please report it to us if you run into this.`
-    )
+    return ``
   }
 
   return model[1]

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -6,7 +6,7 @@ export function extractModel(absolutePath: string): string {
   //  This shouldn't happen - but TS requires us to validate
   if (!model) {
     throw new Error(
-      `PageCreator: An error occured extracting the Model from the slug parts. This is likely a bug within Gatsby and not your code. Please report it to us if you run into this.`
+      `An error occured extracting the Model from the slug parts. This is likely a bug within Gatsby and not your code. Please report it to us if you run into this.`
     )
   }
 
@@ -28,7 +28,7 @@ export function extractAllCollectionSegments(
   // This shouldn't happen - but TS requires us to validate
   if (!slugParts) {
     throw new Error(
-      `PageCreator: An error occured building the slug parts. This is likely a bug within Gatsby and not your code. Please report it to us if you run into this.`
+      `An error occured building the slug parts. This is likely a bug within Gatsby and not your code. Please report it to us if you run into this.`
     )
   }
 

--- a/packages/gatsby-plugin-page-creator/src/validate-path-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/validate-path-query.ts
@@ -7,26 +7,26 @@ export function validatePathQuery(
 ): void {
   // Paths must start with /
   if (filePath.startsWith(`/`) !== true) {
-    throw new Error(`PageCreator: To query node "gatsbyPath" the "filePath" argument must be an absolute path, starting with a /
+    throw new Error(`To query node "gatsbyPath" the "filePath" argument must be an absolute path, starting with a /
 Please change this to: "/${filePath}"`)
   }
 
   // Paths must not include file extension
   if (/\.[a-z]+$/i.test(filePath)) {
-    throw new Error(`PageCreator: To query node "gatsbyPath" the "filePath" argument must omit the file extension
+    throw new Error(`To query node "gatsbyPath" the "filePath" argument must omit the file extension
 Please change ${filePath} to "${filePath.replace(/\.[a-z]+$/i, ``)}"`)
   }
 
   // Paths must not utilize src/pages
   if (filePath.includes(`src/pages`)) {
-    throw new Error(`PageCreator: To query node "gatsbyPath" the "filePath" argument must omit the src/pages prefix.
+    throw new Error(`To query node "gatsbyPath" the "filePath" argument must omit the src/pages prefix.
 Please change this to: "${filePath.replace(/\/?src\/pages\//, ``)}"`)
   }
 
   // Paths must not include index
   if (/index$/.test(filePath)) {
     throw new Error(
-      `PageCreator: To query node "gatsbyPath" the "filePath" argument must omit index.
+      `To query node "gatsbyPath" the "filePath" argument must omit index.
 Please change this to: "${filePath.replace(/index$/, ``)}"`
     )
   }
@@ -47,7 +47,7 @@ Please change this to: "${filePath.replace(/index$/, ``)}"`
 
   if (file.length === 0 || file[0].length === 0) {
     throw new Error(
-      `PageCreator: To query node "gatsbyPath" the "filePath" argument must represent a file that exists.
+      `To query node "gatsbyPath" the "filePath" argument must represent a file that exists.
 Unable to find a file at: "${absolutePath}"`
     )
   }

--- a/packages/gatsby-plugin-page-creator/src/validate-path-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/validate-path-query.ts
@@ -7,26 +7,26 @@ export function validatePathQuery(
 ): void {
   // Paths must start with /
   if (filePath.startsWith(`/`) !== true) {
-    throw new Error(`To query node "gatsbyPath" the "filePath" argument must be an absolute path, starting with a /
+    throw new Error(`PageCreator: To query node "gatsbyPath" the "filePath" argument must be an absolute path, starting with a /
 Please change this to: "/${filePath}"`)
   }
 
   // Paths must not include file extension
   if (/\.[a-z]+$/i.test(filePath)) {
-    throw new Error(`To query node "gatsbyPath" the "filePath" argument must omit the file extension
+    throw new Error(`PageCreator: To query node "gatsbyPath" the "filePath" argument must omit the file extension
 Please change ${filePath} to "${filePath.replace(/\.[a-z]+$/i, ``)}"`)
   }
 
   // Paths must not utilize src/pages
   if (filePath.includes(`src/pages`)) {
-    throw new Error(`To query node "gatsbyPath" the "filePath" argument must omit the src/pages prefix.
+    throw new Error(`PageCreator: To query node "gatsbyPath" the "filePath" argument must omit the src/pages prefix.
 Please change this to: "${filePath.replace(/\/?src\/pages\//, ``)}"`)
   }
 
   // Paths must not include index
   if (/index$/.test(filePath)) {
     throw new Error(
-      `To query node "gatsbyPath" the "filePath" argument must omit index.
+      `PageCreator: To query node "gatsbyPath" the "filePath" argument must omit index.
 Please change this to: "${filePath.replace(/index$/, ``)}"`
     )
   }
@@ -47,7 +47,7 @@ Please change this to: "${filePath.replace(/index$/, ``)}"`
 
   if (file.length === 0 || file[0].length === 0) {
     throw new Error(
-      `To query node "gatsbyPath" the "filePath" argument must represent a file that exists.
+      `PageCreator: To query node "gatsbyPath" the "filePath" argument must represent a file that exists.
 Unable to find a file at: "${absolutePath}"`
     )
   }


### PR DESCRIPTION
## Description

Part of https://github.com/gatsbyjs/gatsby/pull/27424

## Testing

I used yarn resolutions and the normal dependencies field to install those versions. After installation I checked with `yarn why` if they are really installed. Then I used `gatsby-dev` to copy over the new contents of `gatsby-plugin-page-creator`.

### 1 - No structured logging

```
"gatsby": "2.15.37",
"gatsby-cli": "2.8.30"
```
![image](https://user-images.githubusercontent.com/16143594/96241270-34ce8380-0fa2-11eb-8e83-266c26825178.png)

### 2 - Structured logging but not setErrorMap

```
"gatsby": "2.24.67",
"gatsby-cli": "2.12.102"
```

![image](https://user-images.githubusercontent.com/16143594/96241442-74956b00-0fa2-11eb-8d64-e36d11cd3fbb.png)

### 3 - setErrorMap in CLI but outdated Gatsby

```
"gatsby": "2.24.67",
"gatsby-cli": "2.12.107"
```

![image](https://user-images.githubusercontent.com/16143594/96431043-45316900-1203-11eb-9983-e81e33dce2cd.png)

### 4 - Latest versions

```
"gatsby": "latest",
"gatsby-cli": "latest"
```

With https://github.com/gatsbyjs/gatsby/pull/27547 merged

![image](https://user-images.githubusercontent.com/16143594/96439457-0ac9cb00-1207-11eb-8074-0bc250ba16f1.png)

---

[ch16760]
[ch16755]