### PR TITLE
perf(gatsby): test sync before calling onCreateNode

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/on-node-create.js
@@ -1,6 +1,6 @@
 const Promise = require(`bluebird`)
 const _ = require(`lodash`)
-const onCreateNode = require(`../on-node-create`)
+const { onCreateNode } = require(`../on-node-create`)
 const { graphql } = require(`gatsby/graphql`)
 
 const { createContentDigest } = require(`gatsby-core-utils`)

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -1,5 +1,7 @@
+const { onCreateNode, onCreateNodeSyncTest } = require(`./on-node-create`)
+exports.onCreateNode = onCreateNode
+exports.onCreateNodeSyncTest = onCreateNodeSyncTest
 exports.createSchemaCustomization = require(`./create-schema-customization`)
-exports.onCreateNode = require(`./on-node-create`)
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)
 
 if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -1,6 +1,6 @@
-const { onCreateNode, onCreateNodeSyncTest } = require(`./on-node-create`)
+const { onCreateNode, shouldOnCreateNode } = require(`./on-node-create`)
 exports.onCreateNode = onCreateNode
-exports.onCreateNodeSyncTest = onCreateNodeSyncTest
+exports.shouldOnCreateNode = shouldOnCreateNode
 exports.createSchemaCustomization = require(`./create-schema-customization`)
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)
 

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -1,6 +1,9 @@
-const { onCreateNode, shouldOnCreateNode } = require(`./on-node-create`)
+const {
+  onCreateNode,
+  unstable_shouldOnCreateNode,
+} = require(`./on-node-create`)
 exports.onCreateNode = onCreateNode
-exports.shouldOnCreateNode = shouldOnCreateNode
+exports.unstable_shouldOnCreateNode = unstable_shouldOnCreateNode
 exports.createSchemaCustomization = require(`./create-schema-customization`)
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)
 

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -1,7 +1,7 @@
 const grayMatter = require(`gray-matter`)
 const _ = require(`lodash`)
 
-function onCreateNodeSyncTest(node) {
+function shouldOnCreateNode(node) {
   return (
     node.internal.mediaType === `text/markdown` ||
     node.internal.mediaType === `text/x-markdown`
@@ -22,7 +22,7 @@ module.exports.onCreateNode = async function onCreateNode(
   const { createNode, createParentChildLink } = actions
 
   // We only care about markdown content.
-  if (!onCreateNodeSyncTest(node)) {
+  if (!shouldOnCreateNode(node)) {
     return {}
   }
 
@@ -81,4 +81,4 @@ module.exports.onCreateNode = async function onCreateNode(
   }
 }
 
-module.exports.onCreateNodeSyncTest = onCreateNodeSyncTest
+module.exports.shouldOnCreateNode = shouldOnCreateNode

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -1,7 +1,7 @@
 const grayMatter = require(`gray-matter`)
 const _ = require(`lodash`)
 
-function onCreateNodeSyncTest({ node }) {
+function onCreateNodeSyncTest(node) {
   return (
     node.internal.mediaType === `text/markdown` ||
     node.internal.mediaType === `text/x-markdown`
@@ -22,7 +22,7 @@ module.exports.onCreateNode = async function onCreateNode(
   const { createNode, createParentChildLink } = actions
 
   // We only care about markdown content.
-  if (!onCreateNodeSyncTest({ node })) {
+  if (!onCreateNodeSyncTest(node)) {
     return {}
   }
 

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -1,7 +1,14 @@
 const grayMatter = require(`gray-matter`)
 const _ = require(`lodash`)
 
-module.exports = async function onCreateNode(
+function onCreateNodeSyncTest({ node }) {
+  return (
+    node.internal.mediaType === `text/markdown` ||
+    node.internal.mediaType === `text/x-markdown`
+  )
+}
+
+module.exports.onCreateNode = async function onCreateNode(
   {
     node,
     loadNodeContent,
@@ -15,10 +22,7 @@ module.exports = async function onCreateNode(
   const { createNode, createParentChildLink } = actions
 
   // We only care about markdown content.
-  if (
-    node.internal.mediaType !== `text/markdown` &&
-    node.internal.mediaType !== `text/x-markdown`
-  ) {
+  if (!onCreateNodeSyncTest({ node })) {
     return {}
   }
 
@@ -76,3 +80,5 @@ module.exports = async function onCreateNode(
     return {} // eslint
   }
 }
+
+module.exports.onCreateNodeSyncTest = onCreateNodeSyncTest

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -1,7 +1,7 @@
 const grayMatter = require(`gray-matter`)
 const _ = require(`lodash`)
 
-function shouldOnCreateNode(node) {
+function unstable_shouldOnCreateNode(node) {
   return (
     node.internal.mediaType === `text/markdown` ||
     node.internal.mediaType === `text/x-markdown`
@@ -22,7 +22,7 @@ module.exports.onCreateNode = async function onCreateNode(
   const { createNode, createParentChildLink } = actions
 
   // We only care about markdown content.
-  if (!shouldOnCreateNode(node)) {
+  if (!unstable_shouldOnCreateNode(node)) {
     return {}
   }
 
@@ -81,4 +81,4 @@ module.exports.onCreateNode = async function onCreateNode(
   }
 }
 
-module.exports.shouldOnCreateNode = shouldOnCreateNode
+module.exports.unstable_shouldOnCreateNode = unstable_shouldOnCreateNode

--- a/packages/gatsby-transformer-remark/src/on-node-create.js
+++ b/packages/gatsby-transformer-remark/src/on-node-create.js
@@ -1,7 +1,7 @@
 const grayMatter = require(`gray-matter`)
 const _ = require(`lodash`)
 
-function unstable_shouldOnCreateNode(node) {
+function unstable_shouldOnCreateNode({ node }) {
   return (
     node.internal.mediaType === `text/markdown` ||
     node.internal.mediaType === `text/x-markdown`
@@ -22,7 +22,7 @@ module.exports.onCreateNode = async function onCreateNode(
   const { createNode, createParentChildLink } = actions
 
   // We only care about markdown content.
-  if (!unstable_shouldOnCreateNode(node)) {
+  if (!unstable_shouldOnCreateNode({ node })) {
     return {}
   }
 

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -1,5 +1,5 @@
-const { onCreateNode, onCreateNodeSyncTest } = require(`./on-node-create`)
+const { onCreateNode, shouldOnCreateNode } = require(`./on-node-create`)
 exports.onCreateNode = onCreateNode
-exports.onCreateNodeSyncTest = onCreateNodeSyncTest
+exports.shouldOnCreateNode = shouldOnCreateNode
 exports.createSchemaCustomization = require(`./customize-schema`)
 exports.createResolvers = require(`./create-resolvers`)

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -1,3 +1,5 @@
-exports.onCreateNode = require(`./on-node-create`)
+const { onCreateNode, onCreateNodeSyncTest } = require(`./on-node-create`)
+exports.onCreateNode = onCreateNode
+exports.onCreateNodeSyncTest = onCreateNodeSyncTest
 exports.createSchemaCustomization = require(`./customize-schema`)
 exports.createResolvers = require(`./create-resolvers`)

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -1,5 +1,8 @@
-const { onCreateNode, shouldOnCreateNode } = require(`./on-node-create`)
+const {
+  onCreateNode,
+  unstable_shouldOnCreateNode,
+} = require(`./on-node-create`)
 exports.onCreateNode = onCreateNode
-exports.shouldOnCreateNode = shouldOnCreateNode
+exports.unstable_shouldOnCreateNode = unstable_shouldOnCreateNode
 exports.createSchemaCustomization = require(`./customize-schema`)
 exports.createResolvers = require(`./create-resolvers`)

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,6 +1,6 @@
 const { supportedExtensions } = require(`./supported-extensions`)
 
-function onCreateNodeSyncTest({ node }) {
+function onCreateNodeSyncTest(node) {
   return !!supportedExtensions[node.extension]
 }
 
@@ -11,7 +11,7 @@ module.exports.onCreateNode = async function onCreateNode({
 }) {
   const { createNode, createParentChildLink } = actions
 
-  if (!onCreateNodeSyncTest({ node })) {
+  if (!onCreateNodeSyncTest(node)) {
     return
   }
 

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,9 +1,17 @@
 const { supportedExtensions } = require(`./supported-extensions`)
 
-module.exports = async function onCreateNode({ node, actions, createNodeId }) {
+function onCreateNodeSyncTest({ node }) {
+  return !!supportedExtensions[node.extension]
+}
+
+module.exports.onCreateNode = async function onCreateNode({
+  node,
+  actions,
+  createNodeId,
+}) {
   const { createNode, createParentChildLink } = actions
 
-  if (!supportedExtensions[node.extension]) {
+  if (!onCreateNodeSyncTest({ node })) {
     return
   }
 
@@ -22,3 +30,5 @@ module.exports = async function onCreateNode({ node, actions, createNodeId }) {
 
   return
 }
+
+module.exports.onCreateNodeSyncTest = onCreateNodeSyncTest

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,6 +1,6 @@
 const { supportedExtensions } = require(`./supported-extensions`)
 
-function onCreateNodeSyncTest(node) {
+function shouldOnCreateNode(node) {
   return !!supportedExtensions[node.extension]
 }
 
@@ -11,7 +11,7 @@ module.exports.onCreateNode = async function onCreateNode({
 }) {
   const { createNode, createParentChildLink } = actions
 
-  if (!onCreateNodeSyncTest(node)) {
+  if (!shouldOnCreateNode(node)) {
     return
   }
 
@@ -31,4 +31,4 @@ module.exports.onCreateNode = async function onCreateNode({
   return
 }
 
-module.exports.onCreateNodeSyncTest = onCreateNodeSyncTest
+module.exports.shouldOnCreateNode = shouldOnCreateNode

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,6 +1,6 @@
 const { supportedExtensions } = require(`./supported-extensions`)
 
-function unstable_shouldOnCreateNode(node) {
+function unstable_shouldOnCreateNode({ node }) {
   return !!supportedExtensions[node.extension]
 }
 
@@ -11,7 +11,7 @@ module.exports.onCreateNode = async function onCreateNode({
 }) {
   const { createNode, createParentChildLink } = actions
 
-  if (!unstable_shouldOnCreateNode(node)) {
+  if (!unstable_shouldOnCreateNode({ node })) {
     return
   }
 

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,6 +1,6 @@
 const { supportedExtensions } = require(`./supported-extensions`)
 
-function shouldOnCreateNode(node) {
+function unstable_shouldOnCreateNode(node) {
   return !!supportedExtensions[node.extension]
 }
 
@@ -11,7 +11,7 @@ module.exports.onCreateNode = async function onCreateNode({
 }) {
   const { createNode, createParentChildLink } = actions
 
-  if (!shouldOnCreateNode(node)) {
+  if (!unstable_shouldOnCreateNode(node)) {
     return
   }
 
@@ -31,4 +31,4 @@ module.exports.onCreateNode = async function onCreateNode({
   return
 }
 
-module.exports.shouldOnCreateNode = shouldOnCreateNode
+module.exports.unstable_shouldOnCreateNode = unstable_shouldOnCreateNode

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -311,9 +311,9 @@ export interface GatsbyNode {
    * then Gatsby will not schedule the `onCreateNode` callback for this node for this plugin.
    *
    * @example
-   * exports.onCreateNodeSyncTest = node => node.internal.type === 'SharpNode'
+   * exports.shouldOnCreateNode = node => node.internal.type === 'SharpNode'
    */
-  onCreateNodeSyncTest?<TNode extends object = {}>(
+  shouldOnCreateNode?<TNode extends object = {}>(
     node: TNode,
   ): boolean
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -309,9 +309,11 @@ export interface GatsbyNode {
   /**
    * Called before scheduling a `onCreateNode` callback for a plugin. If it returns falsy
    * then Gatsby will not schedule the `onCreateNode` callback for this node for this plugin.
+   * Note: this API does not receive the regular `api` that other callbacks get as first arg.
    *
+   * @gatsbyVersion 2.24.79
    * @example
-   * exports.shouldOnCreateNode = node => node.internal.type === 'SharpNode'
+   * exports.shouldOnCreateNode = (node, pluginOptions) => node.internal.type === 'Image'
    */
   shouldOnCreateNode?<TNode extends object = {}>(
     node: TNode,

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -307,6 +307,17 @@ export interface GatsbyNode {
   ): void
 
   /**
+   * Called before scheduling a `onCreateNode` callback for a plugin. If it returns falsy
+   * then Gatsby will not schedule the `onCreateNode` callback for this node for this plugin.
+   *
+   * @example
+   * exports.onCreateNodeSyncTest = node => node.internal.type === 'SharpNode'
+   */
+  onCreateNodeSyncTest?<TNode extends object = {}>(
+    node: TNode,
+  ): boolean
+
+  /**
    * Called when a new page is created. This extension API is useful
    * for programmatically manipulating pages created by other plugins e.g.
    * if you want paths without trailing slashes.

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -313,10 +313,11 @@ export interface GatsbyNode {
    *
    * @gatsbyVersion 2.24.80
    * @example
-   * exports.unstable_shouldOnCreateNode = (node, pluginOptions) => node.internal.type === 'Image'
+   * exports.unstable_shouldOnCreateNode = ({node}, pluginOptions) => node.internal.type === 'Image'
    */
   unstable_shouldOnCreateNode?<TNode extends object = {}>(
-    node: TNode,
+    args: { node: TNode },
+    options?: PluginOptions
   ): boolean
 
   /**

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -311,11 +311,11 @@ export interface GatsbyNode {
    * then Gatsby will not schedule the `onCreateNode` callback for this node for this plugin.
    * Note: this API does not receive the regular `api` that other callbacks get as first arg.
    *
-   * @gatsbyVersion 2.24.79
+   * @gatsbyVersion 2.24.80
    * @example
-   * exports.shouldOnCreateNode = (node, pluginOptions) => node.internal.type === 'Image'
+   * exports.unstable_shouldOnCreateNode = (node, pluginOptions) => node.internal.type === 'Image'
    */
-  shouldOnCreateNode?<TNode extends object = {}>(
+  unstable_shouldOnCreateNode?<TNode extends object = {}>(
     node: TNode,
   ): boolean
 

--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -46,7 +46,6 @@ it("generates the expected api output", done => {
           "onCreateBabelConfig": Object {},
           "onCreateDevServer": Object {},
           "onCreateNode": Object {},
-          "shouldOnCreateNode": Object {},
           "onCreatePage": Object {},
           "onCreateWebpackConfig": Object {},
           "onPostBootstrap": Object {},
@@ -59,6 +58,9 @@ it("generates the expected api output", done => {
           "preprocessSource": Object {},
           "resolvableExtensions": Object {},
           "setFieldsOnGraphQLNodeType": Object {},
+          "shouldOnCreateNode": Object {
+            "version": "2.24.79",
+          },
           "sourceNodes": Object {},
         },
         "ssr": Object {

--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -46,6 +46,7 @@ it("generates the expected api output", done => {
           "onCreateBabelConfig": Object {},
           "onCreateDevServer": Object {},
           "onCreateNode": Object {},
+          "onCreateNodeSyncTest": Object {},
           "onCreatePage": Object {},
           "onCreateWebpackConfig": Object {},
           "onPostBootstrap": Object {},

--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -46,7 +46,7 @@ it("generates the expected api output", done => {
           "onCreateBabelConfig": Object {},
           "onCreateDevServer": Object {},
           "onCreateNode": Object {},
-          "onCreateNodeSyncTest": Object {},
+          "shouldOnCreateNode": Object {},
           "onCreatePage": Object {},
           "onCreateWebpackConfig": Object {},
           "onPostBootstrap": Object {},

--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -58,8 +58,8 @@ it("generates the expected api output", done => {
           "preprocessSource": Object {},
           "resolvableExtensions": Object {},
           "setFieldsOnGraphQLNodeType": Object {},
-          "shouldOnCreateNode": Object {
-            "version": "2.24.79",
+          "unstable_shouldOnCreateNode": Object {
+            "version": "2.24.80",
           },
           "sourceNodes": Object {},
         },

--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -58,10 +58,10 @@ it("generates the expected api output", done => {
           "preprocessSource": Object {},
           "resolvableExtensions": Object {},
           "setFieldsOnGraphQLNodeType": Object {},
+          "sourceNodes": Object {},
           "unstable_shouldOnCreateNode": Object {
             "version": "2.24.80",
           },
-          "sourceNodes": Object {},
         },
         "ssr": Object {
           "onPreRenderHTML": Object {},

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -134,13 +134,13 @@ export const sourceNodes = true
 export const onCreateNode = true
 
 /**
- * Called when a new node is created before the `onCreateNode` handler is called.
- * This is an optimization that can prevent the `onCreateNode` handler to be scheduled
- * if the plugin already knows it's not interested in processing this node.
+ * Called before scheduling a `onCreateNode` callback for a plugin. If it returns falsy
+ * then Gatsby will not schedule the `onCreateNode` callback for this node for this plugin.
+ * Note: this API does not receive the regular `api` that other callbacks get as first arg.
  *
  * @gatsbyVersion 2.24.79
  * @example
- * exports.shouldOnCreateNode = (node) => node.internal.type === 'Image'
+ * exports.shouldOnCreateNode = (node, pluginOptions) => node.internal.type === 'Image'
  */
 export const shouldOnCreateNode = true
 

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -138,7 +138,7 @@ export const onCreateNode = true
  * This is an optimization that can prevent the `onCreateNode` handler to be scheduled
  * if the plugin already knows it's not interested in processing this node.
  *
- * @gatsbyVersion 2.24.78
+ * @gatsbyVersion 2.24.79
  * @example
  * exports.shouldOnCreateNode = (node) => node.internal.type === 'Image'
  */

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -138,10 +138,11 @@ export const onCreateNode = true
  * This is an optimization that can prevent the `onCreateNode` handler to be scheduled
  * if the plugin already knows it's not interested in processing this node.
  *
+ * @gatsbyVersion 2.24.78
  * @example
- * exports.onCreateNodeSyncTest = (node) => node.internal.type === 'Image'
+ * exports.shouldOnCreateNode = (node) => node.internal.type === 'Image'
  */
-export const onCreateNodeSyncTest = true
+export const shouldOnCreateNode = true
 
 /**
  * Called when a new page is created. This extension API is useful

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -134,6 +134,16 @@ export const sourceNodes = true
 export const onCreateNode = true
 
 /**
+ * Called when a new node is created before the `onCreateNode` handler is called.
+ * This is an optimization that can prevent the `onCreateNode` handler to be scheduled
+ * if the plugin already knows it's not interested in processing this node.
+ *
+ * @example
+ * exports.onCreateNodeSyncTest = (node) => node.internal.type === 'Image'
+ */
+export const onCreateNodeSyncTest = true
+
+/**
  * Called when a new page is created. This extension API is useful
  * for programmatically manipulating pages created by other plugins e.g.
  * if you want paths without trailing slashes.

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -138,11 +138,11 @@ export const onCreateNode = true
  * then Gatsby will not schedule the `onCreateNode` callback for this node for this plugin.
  * Note: this API does not receive the regular `api` that other callbacks get as first arg.
  *
- * @gatsbyVersion 2.24.79
+ * @gatsbyVersion 2.24.80
  * @example
- * exports.shouldOnCreateNode = (node, pluginOptions) => node.internal.type === 'Image'
+ * exports.unstable_shouldOnCreateNode = (node, pluginOptions) => node.internal.type === 'Image'
  */
-export const shouldOnCreateNode = true
+export const unstable_shouldOnCreateNode = true
 
 /**
  * Called when a new page is created. This extension API is useful

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -140,7 +140,7 @@ export const onCreateNode = true
  *
  * @gatsbyVersion 2.24.80
  * @example
- * exports.unstable_shouldOnCreateNode = (node, pluginOptions) => node.internal.type === 'Image'
+ * exports.unstable_shouldOnCreateNode = ({node}, pluginOptions) => node.internal.type === 'Image'
  */
 export const unstable_shouldOnCreateNode = true
 

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -530,6 +530,13 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
       const pluginName =
         plugin.name === `default-site-plugin` ? `gatsby-node.js` : plugin.name
 
+      // if (api === 'onCreateNode') {
+      //   if (plugin.nodeAPIs.includes('onCreateNodeSyncTest') && !require(plugin.resolve + '/gatsby-node.js')?.onCreateNodeSyncTest(args)) {
+      //     // Do not try to schedule an async event for this node for this plugin
+      //     return null;
+      //   }
+      // }
+
       return new Promise(resolve => {
         resolve(runAPI(plugin, api, { ...args, parentSpan: apiSpan }, activity))
       }).catch(err => {

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -540,7 +540,7 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
       if (
         api === `onCreateNode` &&
         gatsbyNode?.shouldOnCreateNode && // Don't bail if this api is not exported
-        !gatsbyNode.shouldOnCreateNode(args.node)
+        !gatsbyNode.shouldOnCreateNode(args.node, plugin.pluginOptions)
       ) {
         // Do not try to schedule an async event for this node for this plugin
         return null

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -536,10 +536,11 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
       const pluginName =
         plugin.name === `default-site-plugin` ? `gatsby-node.js` : plugin.name
 
+      // TODO: rethink createNode API to handle this better
       if (
         api === `onCreateNode` &&
-        gatsbyNode?.onCreateNodeSyncTest && // Don't bail if this api is not exported
-        !gatsbyNode.onCreateNodeSyncTest(args.node)
+        gatsbyNode?.shouldOnCreateNode && // Don't bail if this api is not exported
+        !gatsbyNode.shouldOnCreateNode(args.node)
       ) {
         // Do not try to schedule an async event for this node for this plugin
         return null

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -538,7 +538,7 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
 
       if (
         api === `onCreateNode` &&
-        gatsbyNode?.onCreateNodeSyncTest(args.node)
+        gatsbyNode?.onCreateNodeSyncTest?.(args.node)
       ) {
         // Do not try to schedule an async event for this node for this plugin
         return null

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -538,7 +538,8 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
 
       if (
         api === `onCreateNode` &&
-        gatsbyNode?.onCreateNodeSyncTest?.(args.node)
+        gatsbyNode?.onCreateNodeSyncTest && // Don't bail if this api is not exported
+        !gatsbyNode.onCreateNodeSyncTest(args.node)
       ) {
         // Do not try to schedule an async event for this node for this plugin
         return null

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -539,8 +539,8 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
       // TODO: rethink createNode API to handle this better
       if (
         api === `onCreateNode` &&
-        gatsbyNode?.shouldOnCreateNode && // Don't bail if this api is not exported
-        !gatsbyNode.shouldOnCreateNode(args.node, plugin.pluginOptions)
+        gatsbyNode?.unstable_shouldOnCreateNode && // Don't bail if this api is not exported
+        !gatsbyNode.unstable_shouldOnCreateNode(args.node, plugin.pluginOptions)
       ) {
         // Do not try to schedule an async event for this node for this plugin
         return null

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -540,7 +540,10 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
       if (
         api === `onCreateNode` &&
         gatsbyNode?.unstable_shouldOnCreateNode && // Don't bail if this api is not exported
-        !gatsbyNode.unstable_shouldOnCreateNode(args.node, plugin.pluginOptions)
+        !gatsbyNode.unstable_shouldOnCreateNode(
+          { node: args.node },
+          plugin.pluginOptions
+        )
       ) {
         // Do not try to schedule an async event for this node for this plugin
         return null


### PR DESCRIPTION
This change allows a plugin to register a `shouldOnCreateNode` callback which is called when Gatsby is about to schedule a callback for the (async) `onCreateNode` callback. The scheduling is relatively expensive at scale and the test is often cheap. As a result, this saves roughly 20% of a certain step during bootstrap for some cases (lot's of conditions, but this will apply to most sites to a certain degree). In the site I was benchmarking it drops a minute from a five minute step.

The problem is particular to `onCreateNode` because it will call the callback for each plugin for every node generated, even though in many cases the plugin may not care about that particular node (sharp does not care about markdown nodes, callback is still scheduled and invoked async).

Turns out that these promises do add quite some back pressure at scale. Who woulda thought.