### PR TITLE
perf(gatsby-source-contentful): dont linear search on a maybe large set

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -196,25 +196,23 @@ exports.sourceNodes = async (
   // Create a map of up to date entries and assets
   function mergeSyncData(previous, current, deleted) {
     const entryMap = new Map()
-    previous.forEach(
-      e => !deleted.includes(e.sys.id) && entryMap.set(e.sys.id, e)
-    )
-    current.forEach(
-      e => !deleted.includes(e.sys.id) && entryMap.set(e.sys.id, e)
-    )
+    previous.forEach(e => !deleted.has(e.sys.id) && entryMap.set(e.sys.id, e))
+    current.forEach(e => !deleted.has(e.sys.id) && entryMap.set(e.sys.id, e))
     return [...entryMap.values()]
   }
+
+  const deletedSet = new Set(currentSyncData.deletedEntries.map(e => e.sys.id))
 
   const mergedSyncData = {
     entries: mergeSyncData(
       previousSyncData.entries,
       currentSyncData.entries,
-      currentSyncData.deletedEntries.map(e => e.sys.id)
+      deletedSet
     ),
     assets: mergeSyncData(
       previousSyncData.assets,
       currentSyncData.assets,
-      currentSyncData.deletedAssets.map(e => e.sys.id)
+      deletedSet
     ),
   }
 


### PR DESCRIPTION
Before it was doing a `.includes` on an array, searching for a particular sys.id. But that list could potentially have thousands of elements.

By this changes it creates a single `Set` of deleted ids, which has a much better lookup time, and can be used by both loops.