### PR TITLE
perf(gatsby-source-contentful): change O(n*m) loop to O(n+m)

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -114,12 +114,21 @@ const makeMakeId = ({ currentLocale, defaultLocale, createNodeId }) => (
   type
 ) => createNodeId(makeId({ spaceId, id, currentLocale, defaultLocale, type }))
 
-exports.buildEntryList = ({ contentTypeItems, mergedSyncData }) =>
-  contentTypeItems.map(contentType =>
-    mergedSyncData.entries.filter(
-      entry => entry.sys.contentType.sys.id === contentType.sys.id
-    )
+exports.buildEntryList = ({ contentTypeItems, mergedSyncData }) => {
+  // Create buckets for each type sys.id that we care about (we will always want an array for each, even if its empty)
+  const map = new Map(
+    contentTypeItems.map(contentType => [contentType.sys.id, []])
   )
+  // Now fill the buckets. Ignore entries for which there exists no bucket. (Not sure if that ever happens)
+  mergedSyncData.entries.map(entry => {
+    let arr = map.get(entry.sys.contentType.sys.id)
+    if (arr) {
+      arr.push(entry)
+    }
+  })
+  // Order is relevant, must map 1:1 to contentTypeItems array
+  return contentTypeItems.map(contentType => map.get(contentType.sys.id))
+}
 
 exports.buildResolvableSet = ({
   entryList,


### PR DESCRIPTION
Had a case where this function was called with n=96 m=73529 . The old code would 96x filter the list of 73k elements. The new code buckets it once.

Before it would take 650ms, after it takes 31ms. Not a major win in absolute time but massive win in relative perf.
