### PR TITLE
Add error codes to reporter.panic in Contentful source plugin

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/fetch.js
+++ b/packages/gatsby-source-contentful/src/__tests__/fetch.js
@@ -185,9 +185,11 @@ it(`panics when localeFilter reduces locale list to 0`, async () => {
   })
 
   expect(reporter.panic).toBeCalledWith(
-    expect.stringContaining(
-      `Please check if your localeFilter is configured properly. Locales 'en-us' were found but were filtered down to none.`
-    )
+    expect.objectContaining({
+      context: {
+        sourceMessage: `Please check if your localeFilter is configured properly. Locales 'en-us' were found but were filtered down to none.`,
+      },
+    })
   )
 })
 
@@ -200,11 +202,23 @@ describe(`Displays troubleshooting tips and detailed plugin options on contentfu
     await fetchData({ pluginConfig, reporter })
 
     expect(reporter.panic).toBeCalledWith(
-      expect.stringContaining(`Accessing your Contentful space failed`)
+      expect.objectContaining({
+        context: {
+          sourceMessage: expect.stringContaining(
+            `Accessing your Contentful space failed`
+          ),
+        },
+      })
     )
 
     expect(reporter.panic).toBeCalledWith(
-      expect.stringContaining(`formatPluginOptionsForCLIMock`)
+      expect.objectContaining({
+        context: {
+          sourceMessage: expect.stringContaining(
+            `formatPluginOptionsForCLIMock`
+          ),
+        },
+      })
     )
 
     expect(formatPluginOptionsForCLI).toBeCalledWith(
@@ -225,11 +239,21 @@ describe(`Displays troubleshooting tips and detailed plugin options on contentfu
     await fetchData({ pluginConfig, reporter })
 
     expect(reporter.panic).toBeCalledWith(
-      expect.stringContaining(`You seem to be offline`)
+      expect.objectContaining({
+        context: {
+          sourceMessage: expect.stringContaining(`You seem to be offline`),
+        },
+      })
     )
 
     expect(reporter.panic).toBeCalledWith(
-      expect.stringContaining(`formatPluginOptionsForCLIMock`)
+      expect.objectContaining({
+        context: {
+          sourceMessage: expect.stringContaining(
+            `formatPluginOptionsForCLIMock`
+          ),
+        },
+      })
     )
 
     expect(formatPluginOptionsForCLI).toBeCalledWith(
@@ -250,11 +274,23 @@ describe(`Displays troubleshooting tips and detailed plugin options on contentfu
     await fetchData({ pluginConfig, reporter })
 
     expect(reporter.panic).toBeCalledWith(
-      expect.stringContaining(`Check if host and spaceId settings are correct`)
+      expect.objectContaining({
+        context: {
+          sourceMessage: expect.stringContaining(
+            `Check if host and spaceId settings are correct`
+          ),
+        },
+      })
     )
 
     expect(reporter.panic).toBeCalledWith(
-      expect.stringContaining(`formatPluginOptionsForCLIMock`)
+      expect.objectContaining({
+        context: {
+          sourceMessage: expect.stringContaining(
+            `formatPluginOptionsForCLIMock`
+          ),
+        },
+      })
     )
 
     expect(formatPluginOptionsForCLI).toBeCalledWith(
@@ -278,13 +314,23 @@ describe(`Displays troubleshooting tips and detailed plugin options on contentfu
     await fetchData({ pluginConfig, reporter })
 
     expect(reporter.panic).toBeCalledWith(
-      expect.stringContaining(
-        `Check if accessToken and environment are correct`
-      )
+      expect.objectContaining({
+        context: {
+          sourceMessage: expect.stringContaining(
+            `Check if accessToken and environment are correct`
+          ),
+        },
+      })
     )
 
     expect(reporter.panic).toBeCalledWith(
-      expect.stringContaining(`formatPluginOptionsForCLIMock`)
+      expect.objectContaining({
+        context: {
+          sourceMessage: expect.stringContaining(
+            `formatPluginOptionsForCLIMock`
+          ),
+        },
+      })
     )
 
     expect(formatPluginOptionsForCLI).toBeCalledWith(

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -52,9 +52,9 @@ module.exports = async function contentfulFetch({
       reporter.panic({
         id: CODES.LocalesMissing,
         context: {
-          sourceMessage: `Please check if your localeFilter is configured properly. Locales '${
-            contentfulLocales.map(item => item.code).join(`,`)
-          }' were found but were filtered down to none.`,
+          sourceMessage: `Please check if your localeFilter is configured properly. Locales '${contentfulLocales
+            .map(item => item.code)
+            .join(`,`)}' were found but were filtered down to none.`,
         },
       })
     }

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -52,10 +52,9 @@ module.exports = async function contentfulFetch({
       reporter.panic({
         id: CODES.LocalesMissing,
         context: {
-          sourceMessage: `Please check if your localeFilter is configured properly. Locales '${_.join(
-            contentfulLocales.map(item => item.code),
-            `,`
-          )}' were found but were filtered down to none.`,
+          sourceMessage: `Please check if your localeFilter is configured properly. Locales '${
+            contentfulLocales.map(item => item.code).join(`,`)
+          }' were found but were filtered down to none.`,
         },
       })
     }

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -2,15 +2,13 @@ const contentful = require(`contentful`)
 const _ = require(`lodash`)
 const chalk = require(`chalk`)
 const { formatPluginOptionsForCLI } = require(`./plugin-options`)
-const { makeContentfulReporter, CODES } = require(`./report`)
+const { CODES } = require(`./report`)
 
 module.exports = async function contentfulFetch({
   syncToken,
   pluginConfig,
   reporter,
 }) {
-  const contentfulReporter = makeContentfulReporter(reporter)
-
   // Fetch articles.
   const pageLimit = pluginConfig.get(`pageLimit`)
   const contentfulClientOptions = {
@@ -43,7 +41,7 @@ module.exports = async function contentfulFetch({
   let locales
   let defaultLocale = `en-US`
   try {
-    contentfulReporter.verbose(`Fetching default locale`)
+    reporter.verbose(`Fetching default locale`)
     space = await client.getSpace()
     let contentfulLocales = await client
       .getLocales()
@@ -51,24 +49,31 @@ module.exports = async function contentfulFetch({
     defaultLocale = _.find(contentfulLocales, { default: true }).code
     locales = contentfulLocales.filter(pluginConfig.get(`localeFilter`))
     if (locales.length === 0) {
-      contentfulReporter.panic(
-        `Please check if your localeFilter is configured properly. Locales '${_.join(
-          contentfulLocales.map(item => item.code),
-          `,`
-        )}' were found but were filtered down to none.`,
-        { code: CODES.LocalesMissing }
-      )
+      reporter.panic({
+        id: CODES.LocalesMissing,
+        context: {
+          sourceMessage: `Please check if your localeFilter is configured properly. Locales '${_.join(
+            contentfulLocales.map(item => item.code),
+            `,`
+          )}' were found but were filtered down to none.`,
+        },
+      })
     }
-    contentfulReporter.verbose(`Default locale is: ${defaultLocale}`)
+    reporter.verbose(`Default locale is: ${defaultLocale}`)
   } catch (e) {
     let details
     let errors
     if (e.code === `ENOTFOUND`) {
       details = `You seem to be offline`
     } else if (e.code === `SELF_SIGNED_CERT_IN_CHAIN`) {
-      contentfulReporter.panic(
-        `We couldn't make a secure connection to your contentful space. Please check if you have any self-signed SSL certificates installed.`,
-        { code: CODES.SelfSignedCertificate, err: e }
+      reporter.panic(
+        {
+          id: CODES.SelfSignedCertificate,
+          context: {
+            sourceMessage: `We couldn't make a secure connection to your contentful space. Please check if you have any self-signed SSL certificates installed.`,
+          },
+        },
+        e
       )
     } else if (e.response) {
       if (e.response.status === 404) {
@@ -92,11 +97,15 @@ module.exports = async function contentfulFetch({
       }
     }
 
-    contentfulReporter.panic(`Accessing your Contentful space failed.
+    reporter.panic({
+      context: {
+        sourceMessage: `Accessing your Contentful space failed.
 Try setting GATSBY_CONTENTFUL_OFFLINE=true to see if we can serve from cache.
 ${details ? `\n${details}\n` : ``}
 Used options:
-${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`)
+${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`,
+      },
+    })
   }
 
   let currentSyncData
@@ -110,10 +119,15 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`)
       : { initial: true, ...basicSyncConfig }
     currentSyncData = await client.sync(query)
   } catch (e) {
-    contentfulReporter.panic(`Fetching contentful data failed`, {
-      err: e,
-      code: CODES.SyncError,
-    })
+    reporter.panic(
+      {
+        id: CODES.SyncError,
+        context: {
+          sourceMessage: `Fetching contentful data failed`,
+        },
+      },
+      e
+    )
   }
 
   // We need to fetch content types with the non-sync API as the sync API
@@ -122,14 +136,17 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`)
   try {
     contentTypes = await pagedGet(client, `getContentTypes`, pageLimit)
   } catch (e) {
-    contentfulReporter.panic(`error fetching content types`, {
-      error: e,
-      code: CODES.FetchContentTypes,
-    })
+    reporter.panic(
+      {
+        id: CODES.FetchContentTypes,
+        context: {
+          sourceMessage: `error fetching content types`,
+        },
+      },
+      e
+    )
   }
-  contentfulReporter.verbose(
-    `Content types fetched ${contentTypes.items.length}`
-  )
+  reporter.verbose(`Content types fetched ${contentTypes.items.length}`)
 
   let contentTypeItems = contentTypes.items
 

--- a/packages/gatsby-source-contentful/src/report.js
+++ b/packages/gatsby-source-contentful/src/report.js
@@ -1,0 +1,87 @@
+export const CODES = {
+  /* Fetch errors */
+
+  LocalesMissing: 111001,
+  SelfSignedCertificate: 111002,
+  SyncError: 111003,
+  FetchContentTypes: 111004,
+}
+
+export const ERROR_MAP = {
+  [CODES.LocalesMissing]: {
+    text: context => context.message,
+    level: `ERROR`,
+    category: `USER`,
+  },
+  [CODES.SelfSignedCertificate]: {
+    text: context => context.message,
+    level: `ERROR`,
+    category: `USER`,
+  },
+  [CODES.SyncError]: {
+    text: context => context.message,
+    level: `ERROR`,
+    category: `THIRD_PARTY`,
+  },
+  [CODES.FetchContentTypes]: {
+    text: context => context.message,
+    level: `ERROR`,
+    category: `THIRD_PARTY`,
+  },
+}
+/**
+ * An alternative approach to https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/c19d845727d6c07c5d84689376c2b6dd66df258b/src/utils/wp-reporter.js#L55-L82
+ *
+ * Cons: more complex, harder to follow
+ * Pros: does the job better
+ *
+ * *********************
+ * Better in what way?
+ * *********************
+ *
+ * The functional wrapper in wordpress-experimental requires us
+ * to manually cover every possible member of the reporter object,
+ * even though we only need special handling for two functions:
+ * `error` and `panic`.
+ *
+ * In contrast, the proxy allows us to cover only those two
+ * functions. Any other members that a caller tries to access will
+ * go straight through to the reporter without manually wiring them
+ * up.
+ *
+ * I invite the plugin authors to suggest which approach is more
+ * appropriate for this codebase.
+ */
+
+export function makeContentfulReporter(reporter) {
+  if (!reporter.setErrorMap) {
+    return reporter
+  }
+
+  return new Proxy(reporter, {
+    get(obj, prop) {
+      if (
+        typeof obj[prop] === `function` &&
+        [`error`, `panic`].includes(prop.toString())
+      ) {
+        return new Proxy(obj[prop], {
+          apply: function (target, thisArg, argList) {
+            const [message, options = {}] = argList
+            const { code, err } = options
+            return target.apply(thisArg, [
+              {
+                id: code,
+                context: {
+                  message,
+                },
+              },
+              err,
+            ])
+          },
+        })
+      }
+
+      return obj[prop]
+    },
+  })
+}

--- a/packages/gatsby-source-contentful/src/report.js
+++ b/packages/gatsby-source-contentful/src/report.js
@@ -1,10 +1,10 @@
 export const CODES = {
   /* Fetch errors */
 
-  LocalesMissing: 111001,
-  SelfSignedCertificate: 111002,
-  SyncError: 111003,
-  FetchContentTypes: 111004,
+  LocalesMissing: `111001`,
+  SelfSignedCertificate: `111002`,
+  SyncError: `111003`,
+  FetchContentTypes: `111004`,
 }
 
 export const ERROR_MAP = {

--- a/packages/gatsby-source-contentful/src/report.js
+++ b/packages/gatsby-source-contentful/src/report.js
@@ -9,79 +9,23 @@ export const CODES = {
 
 export const ERROR_MAP = {
   [CODES.LocalesMissing]: {
-    text: context => context.message,
+    text: context => context.sourceMessage,
     level: `ERROR`,
     category: `USER`,
   },
   [CODES.SelfSignedCertificate]: {
-    text: context => context.message,
+    text: context => context.sourceMessage,
     level: `ERROR`,
     category: `USER`,
   },
   [CODES.SyncError]: {
-    text: context => context.message,
+    text: context => context.sourceMessage,
     level: `ERROR`,
     category: `THIRD_PARTY`,
   },
   [CODES.FetchContentTypes]: {
-    text: context => context.message,
+    text: context => context.sourceMessage,
     level: `ERROR`,
     category: `THIRD_PARTY`,
   },
-}
-/**
- * An alternative approach to https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/c19d845727d6c07c5d84689376c2b6dd66df258b/src/utils/wp-reporter.js#L55-L82
- *
- * Cons: more complex, harder to follow
- * Pros: does the job better
- *
- * *********************
- * Better in what way?
- * *********************
- *
- * The functional wrapper in wordpress-experimental requires us
- * to manually cover every possible member of the reporter object,
- * even though we only need special handling for two functions:
- * `error` and `panic`.
- *
- * In contrast, the proxy allows us to cover only those two
- * functions. Any other members that a caller tries to access will
- * go straight through to the reporter without manually wiring them
- * up.
- *
- * I invite the plugin authors to suggest which approach is more
- * appropriate for this codebase.
- */
-
-export function makeContentfulReporter(reporter) {
-  if (!reporter.setErrorMap) {
-    return reporter
-  }
-
-  return new Proxy(reporter, {
-    get(obj, prop) {
-      if (
-        typeof obj[prop] === `function` &&
-        [`error`, `panic`].includes(prop.toString())
-      ) {
-        return new Proxy(obj[prop], {
-          apply: function (target, thisArg, argList) {
-            const [message, options = {}] = argList
-            const { code, err } = options
-            return target.apply(thisArg, [
-              {
-                id: code,
-                context: {
-                  message,
-                },
-              },
-              err,
-            ])
-          },
-        })
-      }
-
-      return obj[prop]
-    },
-  })
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This adds error codes to `reporter.panic` calls that occur in `fetch.js`. Adding these codes helps us to categorize our build and preview failures.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
