### PR TITLE
Add reference about supporting CSS modules in storybook documentation

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -100,6 +100,7 @@ module.exports = {
   // highlight-end
 }
 ```
+Supporting CSS modules in storybook requires a few more changes to your webpack config - see [this issue](https://github.com/gatsbyjs/gatsby/issues/26714) for details. 
 
 Next create a new file under `.storybook` called `preview.js`. This configuration file preview.js is not responsible for loading any stories. Its main purpose is to add global parameters and [decorators](https://storybook.js.org/docs/addons/introduction/#1-decorators).
 

--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -100,7 +100,8 @@ module.exports = {
   // highlight-end
 }
 ```
-Supporting CSS modules in storybook requires a few more changes to your webpack config - see [this issue](https://github.com/gatsbyjs/gatsby/issues/26714) for details. 
+
+Supporting CSS modules in storybook requires a few more changes to your webpack config - see [this issue](https://github.com/gatsbyjs/gatsby/issues/26714) for details.
 
 Next create a new file under `.storybook` called `preview.js`. This configuration file preview.js is not responsible for loading any stories. Its main purpose is to add global parameters and [decorators](https://storybook.js.org/docs/addons/introduction/#1-decorators).
 


### PR DESCRIPTION
Supporting css modules in storybooks require more changes. We haven't found a recommended way to fix it, but it's worth giving any readers of this doc a heads up - and linking to the issue where it's being discussed.

## Description
Change to storybook docs, giving a heads up about supporting CSS modules

### Documentation

Will be seen at https://www.gatsbyjs.com/docs/visual-testing-with-storybook/

## Related Issues

Addresses #26714 
