### PR TITLE
chore: Update ignore files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,8 +8,7 @@ packages/*/scripts/**
 **/dist/*
 **/__testfixtures__/**
 **/__tests__/fixtures/**
-www/public
-www/src/components/search-form/docsearch.min.js
+www
 peril
 docs
 plop-templates

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,7 +10,7 @@ benchmarks/**/public
 e2e-tests/**/public
 examples/**/public
 integration-tests/**/public
-www/public
+www
 
 # cache-dirs
 **/.cache


### PR DESCRIPTION
## Description

Until we remove the `www` folder (or do something with it) it's not necessary to run ESLint/Prettier on it and fix things. Will help with https://github.com/gatsbyjs/gatsby/pull/27159 as unnecessary errors go away.
