### PR TITLE
chore(gatsby-plugin-sass): add pluginOptionsSchema export

### DIFF
--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -15,7 +15,7 @@
     "@babel/core": "^7.11.6",
     "babel-preset-gatsby-package": "^0.5.3",
     "cross-env": "^7.0.2",
-    "gatsby-plugin-utils": "^0.2.31"
+    "gatsby-plugin-utils": "^0.2.33"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass#readme",
   "keywords": [

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -14,7 +14,8 @@
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",
     "babel-preset-gatsby-package": "^0.5.3",
-    "cross-env": "^7.0.2"
+    "cross-env": "^7.0.2",
+    "gatsby-plugin-utils": "^0.2.31"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sass#readme",
   "keywords": [

--- a/packages/gatsby-plugin-sass/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-sass/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -15,7 +15,7 @@ exports[`gatsby-plugin-sass Stage: build-html / No options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -59,7 +59,7 @@ exports[`gatsby-plugin-sass Stage: build-html / PostCss plugins 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -103,7 +103,7 @@ exports[`gatsby-plugin-sass Stage: build-html / Sass options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "includePaths": Array [
                           "absolute/path/a",
@@ -151,7 +151,7 @@ exports[`gatsby-plugin-sass Stage: build-html / css-loader options 1`] = `
                     "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -195,7 +195,7 @@ exports[`gatsby-plugin-sass Stage: build-html / sass rule modules test options 1
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -239,7 +239,7 @@ exports[`gatsby-plugin-sass Stage: build-html / sass rule test options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -284,7 +284,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / No options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -298,7 +298,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / No options 1`] = `
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -337,7 +337,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / PostCss plugins 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -351,7 +351,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / PostCss plugins 1`] = `
                     "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -390,7 +390,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / Sass options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "includePaths": Array [
                           "absolute/path/a",
@@ -408,7 +408,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / Sass options 1`] = `
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "includePaths": Array [
                           "absolute/path/a",
@@ -451,7 +451,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / css-loader options 1`] = `
                     "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -465,7 +465,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / css-loader options 1`] = `
                     "css({\\"camelCase\\":false,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -504,7 +504,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / sass rule modules test opt
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -518,7 +518,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / sass rule modules test opt
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -557,7 +557,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / sass rule test options 1`]
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -571,7 +571,7 @@ exports[`gatsby-plugin-sass Stage: build-javascript / sass rule test options 1`]
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -610,7 +610,7 @@ exports[`gatsby-plugin-sass Stage: develop / No options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -624,7 +624,7 @@ exports[`gatsby-plugin-sass Stage: develop / No options 1`] = `
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -663,7 +663,7 @@ exports[`gatsby-plugin-sass Stage: develop / PostCss plugins 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -677,7 +677,7 @@ exports[`gatsby-plugin-sass Stage: develop / PostCss plugins 1`] = `
                     "css({\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -716,7 +716,7 @@ exports[`gatsby-plugin-sass Stage: develop / Sass options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "includePaths": Array [
                           "absolute/path/a",
@@ -734,7 +734,7 @@ exports[`gatsby-plugin-sass Stage: develop / Sass options 1`] = `
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "includePaths": Array [
                           "absolute/path/a",
@@ -777,7 +777,7 @@ exports[`gatsby-plugin-sass Stage: develop / css-loader options 1`] = `
                     "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -791,7 +791,7 @@ exports[`gatsby-plugin-sass Stage: develop / css-loader options 1`] = `
                     "css({\\"camelCase\\":false,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -830,7 +830,7 @@ exports[`gatsby-plugin-sass Stage: develop / sass rule modules test options 1`] 
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -844,7 +844,7 @@ exports[`gatsby-plugin-sass Stage: develop / sass rule modules test options 1`] 
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -883,7 +883,7 @@ exports[`gatsby-plugin-sass Stage: develop / sass rule test options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -897,7 +897,7 @@ exports[`gatsby-plugin-sass Stage: develop / sass rule test options 1`] = `
                     "css({\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": true,
                       },
@@ -935,7 +935,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / No options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -979,7 +979,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / PostCss plugins 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({\\"plugins\\":[\\"test1\\"]})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -1023,7 +1023,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / Sass options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "includePaths": Array [
                           "absolute/path/a",
@@ -1071,7 +1071,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / css-loader options 1`] = `
                     "css({\\"camelCase\\":false,\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -1115,7 +1115,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / sass rule modules test options
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },
@@ -1159,7 +1159,7 @@ exports[`gatsby-plugin-sass Stage: develop-html / sass rule test options 1`] = `
                     "css({\\"modules\\":true,\\"importLoaders\\":2})",
                     "postcss({})",
                     Object {
-                      "loader": "/resolved/path/sass-loader",
+                      "loader": "<PROJECT_ROOT>/node_modules/sass-loader/dist/cjs.js",
                       "options": Object {
                         "sourceMap": false,
                       },

--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -1,3 +1,6 @@
+import { testPluginOptionsSchema } from "gatsby-plugin-utils"
+import { pluginOptionsSchema } from "../gatsby-node"
+
 describe(`gatsby-plugin-sass`, () => {
   jest.mock(`../resolve`, () => module => `/resolved/path/${module}`)
 
@@ -51,5 +54,21 @@ describe(`gatsby-plugin-sass`, () => {
         expect(actions.setWebpackConfig).toMatchSnapshot()
       })
     }
+  })
+})
+
+describe.only(`pluginOptionsSchema`, () => {
+  it(`should provide meaningful errors when fields are invalid`, () => {
+    const expectedErrors = []
+
+    const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {})
+
+    expect(errors).toEqual(expectedErrors)
+  })
+
+  it(`should validate the schema`, () => {
+    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {})
+
+    expect(isValid).toBe(true)
   })
 })

--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -59,16 +59,77 @@ describe(`gatsby-plugin-sass`, () => {
 
 describe.only(`pluginOptionsSchema`, () => {
   it(`should provide meaningful errors when fields are invalid`, () => {
-    const expectedErrors = []
+    const expectedErrors = [
+      `"file" must be a string`,
+      `"data" must be a string`,
+      `"importer" must be of type function`,
+      `"functions" must be of type object`,
+      `"includePaths" must be an array`,
+      `"indentedSyntax" must be a boolean`,
+      `"indentType" must be a string`,
+      `"indentWidth" must be less than or equal to 10`,
+      `"linefeed" must be one of [cr, crlf, lf, lfcr]`,
+      `"omitSourceMapUrl" must be a boolean`,
+      `"outFile" must be a string`,
+      `"outputStyle" must be one of [nested, expanded, compact, compressed]`,
+      `"precision" must be a number`,
+      `"sourceComments" must be a boolean`,
+      `"sourceMap" must be one of [boolean, string]`,
+      `"sourceMapContents" must be a boolean`,
+      `"sourceMapEmbed" must be a boolean`,
+      `"sourceMapRoot" must be a string`,
+    ]
 
-    const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {})
+    const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+      file: 123, // should be a string
+      data: 123, // should be a string
+      importer: `This should be a function`,
+      functions: `This should be an object of { string: function }`,
+      includePaths: 123, // should be an array of string
+      indentedSyntax: `This should be a boolean`,
+      indentType: 123, // this should be a string
+      indentWidth: 40,
+      linefeed: `This should be cr, crlf, lf or lfcr`,
+      omitSourceMapUrl: `This should be a boolean`,
+      outFile: 123, // This should be a string
+      outputStyle: `This should be nested, expanded, compact or compressed`,
+      precision: `This should be a number`,
+      sourceComments: `This should be a boolean`,
+      sourceMap: 123, // This should be a string or a boolean
+      sourceMapContents: `This should be a boolean`,
+      sourceMapEmbed: `This should be a boolean`,
+      sourceMapRoot: 123, // This should be a string
+    })
 
     expect(errors).toEqual(expectedErrors)
   })
 
   it(`should validate the schema`, () => {
     const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
-      sourceComments: undefined,
+      file: `../path-to-file`,
+      data: `{ some: data }`,
+      importer: function () {
+        return { file: `path-to-file`, contents: `data` }
+      },
+      functions: {
+        "headings($from: 0, $to: 6)": function () {
+          return []
+        },
+      },
+      includePaths: [`some`, `path`],
+      indentedSyntax: true,
+      indentType: `tabs`,
+      indentWidth: 7,
+      linefeed: `crlf`,
+      omitSourceMapUrl: true,
+      outFile: `somewhere-around.css`,
+      outputStyle: `expanded`,
+      precision: 12,
+      sourceComments: true,
+      sourceMap: true,
+      sourceMapContents: true,
+      sourceMapEmbed: true,
+      sourceMapRoot: `some-source-map-root`,
     })
 
     expect(isValid).toBe(true)

--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -67,7 +67,9 @@ describe.only(`pluginOptionsSchema`, () => {
   })
 
   it(`should validate the schema`, () => {
-    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {})
+    const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
+      sourceComments: undefined,
+    })
 
     expect(isValid).toBe(true)
   })

--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -57,9 +57,14 @@ describe(`gatsby-plugin-sass`, () => {
   })
 })
 
-describe.only(`pluginOptionsSchema`, () => {
+describe(`pluginOptionsSchema`, () => {
   it(`should provide meaningful errors when fields are invalid`, () => {
     const expectedErrors = [
+      `"implementation" must be of type object`,
+      `"postCssPlugins" must be an array`,
+      `"sassRuleTest" must be of type object`,
+      `"sassRuleModulesTest" must be of type object`,
+      `"useResolveUrlLoader" must be one of [boolean, object]`,
       `"file" must be a string`,
       `"data" must be a string`,
       `"importer" must be of type function`,
@@ -81,12 +86,17 @@ describe.only(`pluginOptionsSchema`, () => {
     ]
 
     const { errors } = testPluginOptionsSchema(pluginOptionsSchema, {
+      implementation: `This should be a require() thing`,
+      postCssPlugins: `This should be an array of postCss plugins`,
+      sassRuleTest: `This should be a regexp`,
+      sassRuleModulesTest: `This should be a regexp`,
+      useResolveUrlLoader: `This should be a boolean`,
       file: 123, // should be a string
       data: 123, // should be a string
       importer: `This should be a function`,
       functions: `This should be an object of { string: function }`,
       includePaths: 123, // should be an array of string
-      indentedSyntax: `This should be a boolean`,
+      indentedSyntax: `"useResolveUrlLoader" must be a boolean`,
       indentType: 123, // this should be a string
       indentWidth: 40,
       linefeed: `This should be cr, crlf, lf or lfcr`,
@@ -106,6 +116,11 @@ describe.only(`pluginOptionsSchema`, () => {
 
   it(`should validate the schema`, () => {
     const { isValid } = testPluginOptionsSchema(pluginOptionsSchema, {
+      implementation: require(`../gatsby-node.js`),
+      postCssPlugins: [{ post: `CSS plugin` }],
+      sassRuleTest: /\.global\.s(a|c)ss$/,
+      sassRuleModulesTest: /\.mod\.s(a|c)ss$/,
+      useResolveUrlLoader: false,
       file: `../path-to-file`,
       data: `{ some: data }`,
       importer: function () {

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -80,6 +80,27 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
   const MATH_ALL_KEYS = /^/
   exports.pluginOptionsSchema = function ({ Joi }) {
     return Joi.object({
+      implementation: Joi.object({})
+        .unknown(true)
+        .description(
+          `By default the node implementation of Sass (node-sass) is used. To use the implementation written in Dart (dart-sass), you can install sass instead of node-sass and pass it into the options as the implementation`
+        ),
+      postCssPlugins: Joi.array()
+        .items(Joi.object({}).unknown(true))
+        .description(`An array of postCss plugins`),
+      sassRuleTest: Joi.object()
+        .instance(RegExp)
+        .description(`Override the file regex for SASS`),
+      sassRuleModulesTest: Joi.object()
+        .instance(RegExp)
+        .description(`Override the file regex for SASS`),
+      useResolveUrlLoader: Joi.alternatives().try(
+        Joi.boolean(),
+        Joi.object({}).unknown(true)
+      )
+        .description(`This plugin resolves url() paths relative to the entry SCSS/Sass file not – as might be expected – the location relative to the declaration. Under the hood, it makes use of sass-loader and this is documented in the readme.
+
+        Using resolve-url-loader provides a workaround, if you want to use relative url just install the plugin and then add it to your sass plugin options configuration.`),
       file: Joi.string()
         .allow(null)
         .description(`Path to a file for LibSass to compile.`)

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -75,3 +75,9 @@ exports.onCreateWebpackConfig = (
     },
   })
 }
+
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = function ({ Joi }) {
+    return Joi.object({})
+  }
+}

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -77,7 +77,101 @@ exports.onCreateWebpackConfig = (
 }
 
 if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  const MATH_ALL_KEYS = /^/
   exports.pluginOptionsSchema = function ({ Joi }) {
-    return Joi.object({})
+    return Joi.object({
+      file: Joi.string()
+        .allow(null)
+        .description(`Path to a file for LibSass to compile.`)
+        .default(null),
+      data: Joi.string()
+        .allow(null)
+        .description(
+          `A string to pass to LibSass to compile. It is recommended that you use includePaths in conjunction with this so that LibSass can find files when using the @import directive.`
+        )
+        .default(null),
+      importer: Joi.function()
+        .maxArity(3)
+        .description(
+          `Handles when LibSass encounters the @import directive. A custom importer allows extension of the LibSass engine in both a synchronous and asynchronous manner. In both cases, the goal is to either return or call done() with an object literal. (https://github.com/sass/node-sass#importer--v200---experimental)`
+        ),
+      functions: Joi.object()
+        .pattern(MATH_ALL_KEYS, Joi.function().maxArity(2))
+        .description(
+          `functions is an Object that holds a collection of custom functions that may be invoked by the sass files being compiled.`
+        ),
+      includePaths: Joi.array()
+        .items(Joi.string)
+        .default([])
+        .description(
+          `An array of paths that LibSass can look in to attempt to resolve your @import declarations. When using data, it is recommended that you use this.`
+        ),
+      indentedSyntax: Joi.boolean()
+        .default(false)
+        .description(
+          `true values enable Sass Indented Syntax for parsing the data string or file.`
+        ),
+      indentType: Joi.string()
+        .default(`space`)
+        .description(
+          `Used to determine whether to use space or tab character for indentation.`
+        ),
+      indentWidth: Joi.number()
+        .default(2)
+        .max(10)
+        .description(
+          `Used to determine the number of spaces or tabs to be used for indentation.`
+        ),
+      linefeed: Joi.string()
+        .default(`lf`)
+        .valid(`cr`, `crlf`, `lf`, `lfcr`)
+        .description(
+          `Used to determine whether to use cr, crlf, lf or lfcr sequence for line break.`
+        ),
+      omitSourceMapUrl: Joi.boolean()
+        .default(false)
+        .description(
+          `true values disable the inclusion of source map information in the output file.`
+        ),
+      outFile: Joi.string()
+        .allow(null)
+        .default(null)
+        .description(
+          `Specify the intended location of the output file. Strongly recommended when outputting source maps so that they can properly refer back to their intended files.`
+        ),
+      outputStyle: Joi.string()
+        .valid(`nested`, `expanded`, `compact`, `compressed`)
+        .default(`nested`)
+        .description(`Determines the output format of the final CSS style.`),
+      precision: Joi.number()
+        .default(5)
+        .description(
+          `Used to determine how many digits after the decimal will be allowed. For instance, if you had a decimal number of 1.23456789 and a precision of 5, the result will be 1.23457 in the final CSS.`
+        ),
+      sourceComments: Joi.boolean()
+        .default(false)
+        .description(
+          `true Enables the line number and file where a selector is defined to be emitted into the compiled CSS as a comment. Useful for debugging, especially when using imports and mixins.`
+        ),
+      sourceMap: Joi.alternatives()
+        .try(Joi.boolean(), Joi.string())
+        .description(
+          `Enables source map generation during render and renderSync.
+
+When sourceMap === true, the value of outFile is used as the target output location for the source map with the suffix .map appended. If no outFile is set, sourceMap parameter is ignored.
+When typeof sourceMap === "string", the value of sourceMap will be used as the writing location for the file`
+        ),
+      sourceMapContents: Joi.boolean()
+        .default(false)
+        .description(
+          `true includes the contents in the source map information`
+        ),
+      sourceMapEmbed: Joi.boolean()
+        .default(false)
+        .description(`true embeds the source map as a data URI`),
+      sourceMapRoot: Joi.string().description(
+        `the value will be emitted as sourceRoot in the source map information`
+      ),
+    })
   }
 }

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -101,7 +101,7 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
           `functions is an Object that holds a collection of custom functions that may be invoked by the sass files being compiled.`
         ),
       includePaths: Joi.array()
-        .items(Joi.string)
+        .items(Joi.string())
         .default([])
         .description(
           `An array of paths that LibSass can look in to attempt to resolve your @import declarations. When using data, it is recommended that you use this.`


### PR DESCRIPTION
## Description

Add plugin schema options in `gatsby-plugin-sass`

Relates to #27242 and https://www.gatsbyjs.com/plugins/gatsby-plugin-sass/

Notes:

- Many options come from https://github.com/sass/node-sass
- I didn't manage to make some special cases using [`Joi.when()`](https://joi.dev/api/?v=17.2.1#anywhencondition-options) like the following: `file or data must be specified` (one or the other is strictly required)
- I'm not overly confident about this plugin options since it owns a lot of options and sub module options 😓 