### PR TITLE
fix: Update version in tests

### DIFF
--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -5,7 +5,7 @@
   "author": "Dustin Schau <dustin@gatsbyjs.com>",
   "dependencies": {
     "gatsby": "^2.4.4",
-    "gatsby-plugin-image": "^0.0.1",
+    "gatsby-plugin-image": "^0.0.2",
     "gatsby-image": "^2.0.41",
     "gatsby-plugin-manifest": "^2.0.17",
     "gatsby-plugin-offline": "^2.1.0",

--- a/e2e-tests/gatsby-static-image/package.json
+++ b/e2e-tests/gatsby-static-image/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "cypress": "^3.1.0",
     "gatsby": "^2.0.118",
-    "gatsby-plugin-image": "^0.0.1",
+    "gatsby-plugin-image": "^0.0.2",
     "gatsby-plugin-sharp": "^2.0.20",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "cypress": "3.4.1",
     "gatsby": "^2.22.9",
-    "gatsby-plugin-image": "^0.0.1",
+    "gatsby-plugin-image": "^0.0.2",
     "gatsby-plugin-manifest": "^2.0.17",
     "gatsby-plugin-offline": "^3.0.0",
     "gatsby-plugin-react-helmet": "^3.0.6",


### PR DESCRIPTION
The e2e tests have a non-existent version of gatsby-plugin-image