### PR TITLE
Detail a workaround for hot-reload

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -38,6 +38,7 @@ gatsby develop
 ```
 
 Gatsby will start a hot-reloading development environment accessible by default at `http://localhost:8000`.
+> Please notice that some antivirus may be blocking the webpack socket that takes care of the hot-reloading of changes
 
 Try editing the home page in `src/pages/index.js`. Saved changes will live reload in the browser.
 


### PR DESCRIPTION

## Description
I noticed that the hot-reload was not working. 
After trying many things, I just got IT dep to disable antivirus on my local computer and that made it

### Documentation
I noticed that the webpack socket `__webpack_hmr` network request never made it. Disabling the antivirus made it to work