### PR TITLE
fix(gatsby-plugin-page-creator): Use correct queryAll name

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -1,3 +1,4 @@
+import _ from "lodash"
 import glob from "globby"
 import systemPath from "path"
 import { sync as existsSync } from "fs-exists-cached"
@@ -136,7 +137,7 @@ export function setFieldsOnGraphQLNodeType({
 }: SetFieldsOnGraphQLNodeTypeArgs): object {
   try {
     const extensions = store.getState().program.extensions
-    const collectionQuery = `all${type.name}`
+    const collectionQuery = _.camelCase(`all ${type.name}`)
     if (knownCollections.has(collectionQuery)) {
       return {
         gatsbyPath: {


### PR DESCRIPTION
## Description

Fixes a bug reported here: https://github.com/gatsbyjs/gatsby/issues/26375#issuecomment-708940572
We [camelcase the type](https://github.com/gatsbyjs/gatsby/blob/c76ab29a8c28ce8449fbca4a6b4566164d8ed469/packages/gatsby/src/schema/schema.js#L242) for our queryAll, so for checking against it we'll also need to do this here :)
