### PR TITLE
chore: allow `unstable_` for API prefix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,11 +105,18 @@ module.exports = {
           "error",
           { ignoreParameters: true },
         ],
-        // This rule tries to ensure we use camelCase for all variables, properties
-        // functions, etc. However, it is not always possible to ensure properties
-        // are camelCase. Specifically we have `node.__gatsby_resolve` which breaks
-        // this rule. This allows properties to be whatever they need to be.
-        "@typescript-eslint/camelcase": ["error", { properties: "never" }],
+        "@typescript-eslint/camelcase": [
+          "error",
+          {
+            // This rule tries to ensure we use camelCase for all variables, properties
+            // functions, etc. However, it is not always possible to ensure properties
+            // are camelCase. Specifically we have `node.__gatsby_resolve` which breaks
+            // this rule. This allows properties to be whatever they need to be.
+            properties: "never",
+            // Allow unstable api's to use `unstable_`, which is easier to grep
+            allow: ["^unstable_"],
+          },
+        ],
         // This rule tries to prevent using `require()`. However in node code,
         // there are times where this makes sense. And it specifically is causing
         // problems in our tests where we often want this functionality for module


### PR DESCRIPTION
To be used in https://github.com/gatsbyjs/gatsby/pull/27442