### PR TITLE
fix: csv transformer rethrows library errors

### DIFF
--- a/packages/gatsby-transformer-csv/src/gatsby-node.js
+++ b/packages/gatsby-transformer-csv/src/gatsby-node.js
@@ -6,7 +6,12 @@ const { typeNameFromFile } = require(`./index`)
 const convertToJson = (data, options) =>
   csv(options)
     .fromString(data)
-    .then(jsonData => jsonData, new Error(`CSV to JSON conversion failed!`))
+    .then(
+      jsonData => jsonData,
+      reason => {
+        throw new Error(`CSV to JSON conversion failed! : ${reason}`)
+      }
+    )
 
 async function onCreateNode(
   { node, actions, loadNodeContent, createNodeId, createContentDigest },


### PR DESCRIPTION
## Description

Since the transformer options are passed through directly to csvtojson, the recent major version bump meant that plugin configuration had to change as well. When an incorrect config value was passed in, the library invokes its error handling procedures, but what was being passed from the transformer to csvtojson was incorrect.

By throwing an error, the build process is halted entirely and you will get the error message through from csvtojson.

## Related Issues

Related to #27037

## Fixes 

Fixes #27509 

