### PR TITLE
fix(gatsby-plugin-google-analytics): Fix gatsby-node so we still have a warning on older gatsby versions

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
@@ -1,38 +1,48 @@
-exports.pluginOptionsSchema = ({ Joi }) =>
-  // TODO: make sure that trackingId gets required() when releasing a major version
-  Joi.object({
-    trackingId: Joi.string().description(
-      `The property ID; the tracking code won't be generated without it`
-    ),
-    head: Joi.boolean()
-      .default(false)
-      .description(
-        `Defines where to place the tracking script - \`true\` in the head and \`false\` in the body`
+if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
+  exports.pluginOptionsSchema = ({ Joi }) =>
+    // TODO: make sure that trackingId gets required() when releasing a major version
+    Joi.object({
+      trackingId: Joi.string().description(
+        `The property ID; the tracking code won't be generated without it`
       ),
-    anonymize: Joi.boolean().default(false),
-    respectDNT: Joi.boolean().default(false),
-    exclude: Joi.array()
-      .items(Joi.string())
-      .default([])
-      .description(`Avoids sending pageview hits from custom paths`),
-    pageTransitionDelay: Joi.number()
-      .default(0)
-      .description(
-        `Delays sending pageview hits on route update (in milliseconds)`
+      head: Joi.boolean()
+        .default(false)
+        .description(
+          `Defines where to place the tracking script - \`true\` in the head and \`false\` in the body`
+        ),
+      anonymize: Joi.boolean().default(false),
+      respectDNT: Joi.boolean().default(false),
+      exclude: Joi.array()
+        .items(Joi.string())
+        .default([])
+        .description(`Avoids sending pageview hits from custom paths`),
+      pageTransitionDelay: Joi.number()
+        .default(0)
+        .description(
+          `Delays sending pageview hits on route update (in milliseconds)`
+        ),
+      optimizeId: Joi.string().description(
+        `Enables Google Optimize using your container Id`
       ),
-    optimizeId: Joi.string().description(
-      `Enables Google Optimize using your container Id`
-    ),
-    experimentId: Joi.string().description(
-      `Enables Google Optimize Experiment ID`
-    ),
-    variationId: Joi.string().description(
-      `Set Variation ID. 0 for original 1,2,3....`
-    ),
-    defer: Joi.boolean().description(
-      `Defers execution of google analytics script after page load`
-    ),
-    sampleRate: Joi.number(),
-    siteSpeedSampleRate: Joi.number(),
-    cookieDomain: Joi.string(),
-  })
+      experimentId: Joi.string().description(
+        `Enables Google Optimize Experiment ID`
+      ),
+      variationId: Joi.string().description(
+        `Set Variation ID. 0 for original 1,2,3....`
+      ),
+      defer: Joi.boolean().description(
+        `Defers execution of google analytics script after page load`
+      ),
+      sampleRate: Joi.number(),
+      siteSpeedSampleRate: Joi.number(),
+      cookieDomain: Joi.string(),
+    })
+} else {
+  exports.onPreInit = ({ reporter }, { trackingId } = {}) => {
+    if (!trackingId) {
+      reporter.warn(
+        `The Google Analytics plugin requires a tracking ID. Did you mean to add it?`
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Description
As discussed with @mxstbr in https://github.com/gatsbyjs/gatsby/pull/27242#discussion_r506326021, I added `onPreInit` again in case `GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION` isn't `true`