### PR TITLE
chore(docs): Update 'Build Caching' example code

### DIFF
--- a/docs/docs/build-caching.md
+++ b/docs/docs/build-caching.md
@@ -40,15 +40,16 @@ The [Node API helpers](/docs/node-api-helpers/#cache) documentation offers more 
 In your plugin's `gatsby-node.js` file, you can access the `cache` argument like so:
 
 ```js:title=gatsby-node.js
-exports.onPostBuild = async function ({ cache, store, graphql }, { query }) {
+exports.onPostBuild = async function ({ cache, graphql }, { query }) {
   const cacheKey = "some-key-name"
+  const twentyFourHoursInMilliseconds = 24 * 60 * 60 * 1000; // 86400000
   let obj = await cache.get(cacheKey)
 
   if (!obj) {
     obj = { created: Date.now() }
     const data = await graphql(query)
     obj.data = data
-  } else if (Date.now() > obj.lastChecked + 3600000) {
+  } else if (Date.now() > obj.lastChecked + twentyFourHoursInMilliseconds) {
     /* Reload after a day */
     const data = await graphql(query)
     obj.data = data

--- a/docs/docs/build-caching.md
+++ b/docs/docs/build-caching.md
@@ -42,7 +42,7 @@ In your plugin's `gatsby-node.js` file, you can access the `cache` argument like
 ```js:title=gatsby-node.js
 exports.onPostBuild = async function ({ cache, graphql }, { query }) {
   const cacheKey = "some-key-name"
-  const twentyFourHoursInMilliseconds = 24 * 60 * 60 * 1000; // 86400000
+  const twentyFourHoursInMilliseconds = 24 * 60 * 60 * 1000 // 86400000
   let obj = await cache.get(cacheKey)
 
   if (!obj) {


### PR DESCRIPTION
## Description

Update 'Build Caching' [page](https://www.gatsbyjs.com/docs/build-caching/) example code

Changes:
- Remove unused `store` parameter
- Replace 3600000 milliseconds, which amounts to one hour, not one day, with twenty-four hours in milliseconds as a variable

### Documentation

N/A

## Related Issues

N/A