### PR TITLE
Add Macro Extensions to gatsby-transformer-asciidoc

### DIFF
--- a/packages/gatsby-transformer-asciidoc/README.md
+++ b/packages/gatsby-transformer-asciidoc/README.md
@@ -194,3 +194,36 @@ class CustomConverter {
 
 gatsby-transformer-asciidoc takes then this class, **not** a instance of `CustomConverter`, as the `converterFactory` option.
 You can also reuse the internal converter of gatsby-transformer-asciidoc, since the constructor of a given `CustomConverter` will be call with it as parameter.
+
+## Define a Macro Extension
+
+You can define custom extensions by adding the `macroExtension` option.
+
+```javascript
+// In your gatsby-config.js, make sure to import or declare MacroExtensions
+plugins: [
+  {
+    resolve: `gatsby-transformer-asciidoc`,
+    options: {
+      macroExtensions: MacroExtensions,
+    },
+  },
+]
+```
+
+`MacroExtensions` is an array of `MacroExtension`. A `MacroExtension` is a custom javascript class you'll need to create. Information on how to write a `MacroExtension` for [Block Elements](https://asciidoctor-docs.netlify.app/asciidoctor.js/extend/extensions/block-macro-processor/) and [Inline Elements](https://asciidoctor-docs.netlify.app/asciidoctor.js/extend/extensions/inline-macro-processor/i) can be found at the [asciidoctor docs].
+
+In the example below, we will use a macro to generate hello world paragraphs:
+
+```javascript
+function myAwesomeBlockMacro(registry) {
+  registry.blockMacro(function () {
+    var self = this
+    self.named("helloWorld")
+    self.process(function (parent, target, attrs) {
+      var size = parseInt(attrs.size)
+      return self.createBlock(parent, "paragraph", "hello world")
+    })
+  })
+}
+```

--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -38,6 +38,13 @@ async function onCreateNode(
   // changes the incoming imagesdir option to take the
   const asciidocOptions = processPluginOptions(pluginOptions, pathPrefix)
 
+  // register custom macros/extensions if given
+  if (pluginOptions.macroExtensions) {
+    const registry = asciidoc.Extensions.create()
+    pluginOptions.macroExtensions.forEach(extension => extension(registry))
+    asciidocOptions[`extension_registry`] = registry
+  }
+
   const { createNode, createParentChildLink } = actions
   // Load Asciidoc contents
   const content = await loadNodeContent(node)


### PR DESCRIPTION
## Description

This patch implements the Macro Extensions option for gatsby-transformer-asciidoc. It also adds a missing testcase regarding Custom Converters.

### Documentation

Documentation for this feature is included. The Feature is based on [AsciiDoctor API](https://asciidoctor-docs.netlify.app/asciidoctor.js/extend/extensions/block-macro-processor/).

## Related Issues

It closes https://github.com/gatsbyjs/gatsby/discussions/27510
