### PR TITLE
fix(gatsby-recipes): Added isLocal prop to wordpress recipe

### DIFF
--- a/packages/gatsby-recipes/recipes/wordpress.mdx
+++ b/packages/gatsby-recipes/recipes/wordpress.mdx
@@ -47,7 +47,7 @@ Creates a local Gatsby plugin that create pages for the WordPress data.
 
 Installs the local plugin.
 
-<GatsbyPlugin name="gatsby-plugin-wordpress" />
+<GatsbyPlugin name="gatsby-plugin-wordpress" isLocal={true} />
 
 ---
 


### PR DESCRIPTION
Implemented the fix that Kyle requested at https://github.com/gatsbyjs/gatsby/issues/22991#issuecomment-710151717

Just add the `isLocal={true}` prop to the <GatsbyPlugin /> call in the wordpress recipe.

