### PR TITLE
perf(gatsby-plugin-image): Optimise image size functions

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -28,6 +28,7 @@ const {
   fixed,
   queueImageResizing,
   getImageSize,
+  getImageSizeAsync,
   stats,
   setBoundActionCreators,
 } = require(`../`)
@@ -613,6 +614,23 @@ describe(`gatsby-plugin-sharp`, () => {
       )
 
       expect(result).toMatchSnapshot()
+    })
+
+    it(`handles padding bytes correctly in async version`, async () => {
+      const result = await getImageSizeAsync(
+        getFileObject(path.join(__dirname, `images/padding-bytes.jpg`))
+      )
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "hUnits": "px",
+          "height": 1000,
+          "mime": "image/jpeg",
+          "type": "jpg",
+          "wUnits": "px",
+          "width": 746,
+        }
+      `)
     })
   })
 


### PR DESCRIPTION
The current way we get the sizes of input images is very inefficient, particularly with large source images. This PR adds a much faster async function, which can be used by `fixed()`, which is already async. It also optimises the sync version, which we can't currently remove because it's used in various sync functions.

The results of benchmarking the various options:

| Implementation | Time for 100x reads of 15MB image (ms) |
| -------------- | -------------------------------------- |
| Current sync   | 8600                                   |
| Optimised sync* | 470                                    |
| Async*          | 87                                     |


 \* This PR