### PR TITLE
Allow auto runtime for supported v15/v16 versions

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -727,7 +727,9 @@ function reactHasJsxRuntime(): boolean {
     const react = require(`react/package.json`)
     return (
       !!require.resolve(`react/jsx-runtime.js`) &&
-      semver.major(react.version) >= 17
+      (semver.major(react.version) >= 17 ||
+        semver.minor(react.version) >= 16.4 ||
+        semver.minor(react.version) >= 15.7)
     )
   } catch (e) {
     // If the require.resolve throws, that means this version of React


### PR DESCRIPTION
## Description

Add to initial runtime check PR [27468](https://github.com/gatsbyjs/gatsby/pull/27468) since React > v16.4 and v15.7 also support the `automatic` runtime option.

### Documentation

[React Blog Post](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)

## Related Issues

The initial fix above only checked for v17
[239d539](https://github.com/gatsbyjs/gatsby/commit/239d539b76421f210a0db901786021ac45a42ac7)
