### PR TITLE
fix(gatsby): Handle double prefix case for `extendErrorIdWithPluginName`

### DIFF
--- a/integration-tests/structured-logging/__tests__/plugin-errors.js
+++ b/integration-tests/structured-logging/__tests__/plugin-errors.js
@@ -59,7 +59,24 @@ describe(`Plugin Errors`, () => {
           action: expect.objectContaining({
             type: `LOG`,
             payload: expect.objectContaining({
-              level: "ERROR",
+              level: `ERROR`,
+              category: `SYSTEM`,
+              text: `Error text is MORE ERROR!`,
+              code: `structured-plugin-errors_12345`
+            })
+          })
+        })
+      ])
+    )
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: `LOG_ACTION`,
+          action: expect.objectContaining({
+            type: `LOG`,
+            payload: expect.objectContaining({
+              level: `ERROR`,
               category: `SYSTEM`,
               text: `Error text is PANIC!`,
               code: `structured-plugin-errors_1337`,

--- a/integration-tests/structured-logging/plugins/structured-plugin-errors/gatsby-node.js
+++ b/integration-tests/structured-logging/plugins/structured-plugin-errors/gatsby-node.js
@@ -4,13 +4,20 @@ exports.onPreInit = ({ reporter }) => {
       text: context => `Error text is ${context && context.someProp}`,
       level: "ERROR",
       category: "SYSTEM",
-      docsUrl: `https://www.gatsbyjs.org/docs/gatsby-cli/#new`,
+      docsUrl: `https://www.gatsbyjs.com/docs/gatsby-cli/#new`,
     },
+    "12345": {
+      text: context => `Error text is ${context && context.someProp}`,
+      level: "ERROR",
+      category: "SYSTEM",
+      docsUrl: `https://www.gatsbyjs.com/docs/cheat-sheet/`,
+    }
   })
 
   reporter.info("setErrorMap")
 
   if (process.env.PANIC_IN_PLUGIN) {
+    reporter.error({ id: "structured-plugin-errors_12345", context: { someProp: `MORE ERROR!` } })
     reporter.panic({ id: "1337", context: { someProp: `PANIC!` } })
   }
 }

--- a/integration-tests/structured-logging/plugins/structured-plugin-errors/gatsby-node.js
+++ b/integration-tests/structured-logging/plugins/structured-plugin-errors/gatsby-node.js
@@ -4,7 +4,7 @@ exports.onPreInit = ({ reporter }) => {
       text: context => `Error text is ${context && context.someProp}`,
       level: "ERROR",
       category: "SYSTEM",
-      docsUrl: `https://www.gatsbyjs.com/docs/gatsby-cli/#new`,
+      docsUrl: `https://www.gatsbyjs.org/docs/gatsby-cli/#new`,
     },
     "12345": {
       text: context => `Error text is ${context && context.someProp}`,

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -132,7 +132,8 @@ function getLocalReporter({ activity, reporter }) {
 function extendErrorIdWithPluginName(pluginName, errorMeta) {
   if (typeof errorMeta === `object`) {
     const id = errorMeta && errorMeta[`id`]
-    if (id) {
+    const isPrefixed = id.includes(`${pluginName}_`)
+    if (id && !isPrefixed) {
       return {
         ...errorMeta,
         id: `${pluginName}_${id}`,

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -130,10 +130,10 @@ function getLocalReporter({ activity, reporter }) {
 }
 
 function extendErrorIdWithPluginName(pluginName, errorMeta) {
-  if (typeof errorMeta === `object`) {
-    const id = errorMeta && errorMeta[`id`]
+  if (typeof errorMeta === `object` && errorMeta[`id`]) {
+    const id = errorMeta[`id`]
     const isPrefixed = id.includes(`${pluginName}_`)
-    if (id && !isPrefixed) {
+    if (!isPrefixed) {
       return {
         ...errorMeta,
         id: `${pluginName}_${id}`,

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -130,8 +130,8 @@ function getLocalReporter({ activity, reporter }) {
 }
 
 function extendErrorIdWithPluginName(pluginName, errorMeta) {
-  if (typeof errorMeta === `object` && errorMeta[`id`]) {
-    const id = errorMeta[`id`]
+  const id = errorMeta?.id
+  if (id) {
     const isPrefixed = id.includes(`${pluginName}_`)
     if (!isPrefixed) {
       return {


### PR DESCRIPTION
## Description

While working on https://github.com/gatsbyjs/gatsby/pull/27441 I discovered the 4 cases that `gatsby` and `gatsby-cli` could be in and how `setErrorMap` API behaves with it. To keep our internal/maintained plugins backwards compatible we'll be already prefixing `id` with the `pluginName` so that older versions already have this.

This change is necessary for https://github.com/gatsbyjs/gatsby/pull/27441 to be eventually be merged into `master` as the current behavior otherwise would be that `id` is double prefixed, e.g. `gatsby-plugin-page-creator_gatsby-plugin-page-creator_12345`.

The plugins will use a little helper like [this function](https://github.com/gatsbyjs/gatsby/blob/unified-routes/structured-errors/packages/gatsby-plugin-page-creator/src/error-utils.ts#L16-L18) to prefix the IDs.

[ch17458]
