### PR TITLE
fix(gatsby): notify when Gatsby cache is incomplete

### DIFF
--- a/integration-tests/long-term-caching/__tests__/long-term-caching.js
+++ b/integration-tests/long-term-caching/__tests__/long-term-caching.js
@@ -1,7 +1,6 @@
 const {
   copy,
   mkdirp,
-  move,
   readdir,
   readFile,
   remove,
@@ -41,7 +40,7 @@ describe(`long term caching`, () => {
 
   const createPublic0 = async () => {
     execFileSync(`yarn`, [`build`], { cwd: basePath })
-    return move(`${basePath}/public`, `${basePath}/public-0`)
+    return copy(`${basePath}/public`, `${basePath}/public-0`)
   }
 
   const createPublic1 = async () => {
@@ -53,7 +52,7 @@ describe(`long term caching`, () => {
     await writeFile(`${pagesPath}/index.js`, modifiedData)
 
     execFileSync(`yarn`, [`build`], { cwd: basePath })
-    return move(`${basePath}/public`, `${basePath}/public-1`)
+    return copy(`${basePath}/public`, `${basePath}/public-1`)
   }
 
   const createPublic2 = async () => {
@@ -66,7 +65,7 @@ describe(`long term caching`, () => {
     await writeFile(`${pagesPath}/index.js`, modifiedData)
 
     execFileSync(`yarn`, [`build`], { cwd: basePath })
-    return move(`${basePath}/public`, `${basePath}/public-2`)
+    return copy(`${basePath}/public`, `${basePath}/public-2`)
   }
 
   const createPublic3 = async () => {
@@ -79,7 +78,7 @@ describe(`long term caching`, () => {
     await writeFile(`${pagesPath}/index.js`, modifiedData)
 
     execFileSync(`yarn`, [`build`], { cwd: basePath })
-    return move(`${basePath}/public`, `${basePath}/public-3`)
+    return copy(`${basePath}/public`, `${basePath}/public-3`)
   }
 
   const createPublic4 = async () => {
@@ -93,7 +92,7 @@ describe(`long term caching`, () => {
     await writeFile(`${pagesPath}/index.js`, modifiedData)
 
     execFileSync(`yarn`, [`build`], { cwd: basePath })
-    return move(`${basePath}/public`, `${basePath}/public-4`)
+    return copy(`${basePath}/public`, `${basePath}/public-4`)
   }
 
   const createPublic5 = async () => {
@@ -105,7 +104,7 @@ describe(`long term caching`, () => {
     await writeFile(`${srcPath}/async-2.js`, modifiedData)
 
     execFileSync(`yarn`, [`build`], { cwd: basePath })
-    return move(`${basePath}/public`, `${basePath}/public-5`)
+    return copy(`${basePath}/public`, `${basePath}/public-5`)
   }
 
   beforeAll(async () => {

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -251,7 +251,19 @@ export async function initialize({
     `)
   }
   const cacheDirectory = `${program.directory}/.cache`
-  if (!oldPluginsHash || pluginsHash !== oldPluginsHash) {
+  const publicDirectory = `${program.directory}/public`
+  const cacheIsCorrupt =
+    fs.existsSync(cacheDirectory) && !fs.existsSync(publicDirectory)
+
+  if (cacheIsCorrupt) {
+    reporter.info(reporter.stripIndent`
+      We've detected that the Gatsby cache is incomplete (the .cache directory exists
+      but the public directory does not). As a precaution, we're deleting your site's
+      cache to ensure there's no stale data.
+    `)
+  }
+
+  if (!oldPluginsHash || pluginsHash !== oldPluginsHash || cacheIsCorrupt) {
     try {
       // Attempt to empty dir if remove fails,
       // like when directory is mount point
@@ -286,7 +298,7 @@ export async function initialize({
   await fs.ensureDir(cacheDirectory)
 
   // Ensure the public/static directory
-  await fs.ensureDir(`${program.directory}/public/static`)
+  await fs.ensureDir(`${publicDirectory}/static`)
 
   activity.end()
 


### PR DESCRIPTION
## Description

This PR adds a warning and wipes the `.cache` when the `public` folder is missing but the `.cache` folder exists.

### Why

Builds can break if someone deletes the `public` folder but not the `.cache` (with cryptic errors about missing `page-data` files).

There is one case when doing this still leads to accidentally working builds: when the project only has pages without any queries. This behavior actually relies on our "bug" - at the moment we always re-run page queries without dependencies (or in other words - pages without graphql queries in them).

This skipped test sums up the problem: 
https://github.com/gatsbyjs/gatsby/blob/ecc0ad37f3fb6d542964c95c2f853c25cc99d5b8/packages/gatsby/src/query/__tests__/data-tracking.js#L1241-L1243

That's exactly what happens in `gatsby-admin` and our `long-term-caching` integration tests (we don't have any build-time graphql queries in those and delete the `public` folder without deleting the `.cache`). At the moment this "works" but won't work anymore after #27504 lands (which actually fixes this bug).
