### PR TITLE
Update README.md of high-priority-prs

### DIFF
--- a/.github/actions/high-priority-prs/README.md
+++ b/.github/actions/high-priority-prs/README.md
@@ -6,8 +6,7 @@ Sends Slack messages [scheduled by GitHub actions](https://developer.github.com/
 
 This is an experimental effort to help with identifying the PRs that most need responses — initially breaking them up into three queues, those that have:
 
-— never seen a response from core maintainers
-
+- never seen a response from core maintainers
 - had commits since the last comment so need a new review
 - not been updated for at least 30 days
 
@@ -28,7 +27,7 @@ except for the Core team which receives a list from all open PRs.
 Run using [act](https://github.com/nektos/act): `act -a "high-priority-prs"`
 
 You'll be prompted to enter in the required tokens (GitHub will use the tokens saved from the UI), you can
-[generate your own Slack token](https://api.slack.com/custom-integrations/legacy-tokens) as well as [your own GitHub token](), for GitHub be sure to
+[generate your own Slack token](https://api.slack.com/custom-integrations/legacy-tokens) as well as [your own GitHub token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token), for GitHub be sure to
 add permissions when generating for `repo`, `read:org`, and `read:discussion`, you can enter the ID of your personal slack channel to send direct messages
 to yourself while testing.
 


### PR DESCRIPTION
Hello, I'm a relatively new user of Gatsby, and was browsing through the documentation and readme files.
I found a couple of things which I think could be fixed, in the readme for high-priority-prs' readme, [here](https://github.com/gatsbyjs/gatsby/tree/master/.github/actions/high-priority-prs).

These are very minor changes, but I decided to propose them regardless to improve the readme, just by a tad bit.

Firstly, I fixed what I believe was a formatting error, where there was supposed to be a list of three points, yet it was being displayed as one unformatted and two formatted points.

Secondly, the link to accessing personal Github tokens was left empty, and hence redirected the user to the same readme page that they were on. I've gone ahead and linked the official Github documentation for creating personal access tokens.

I hope these help even if a by tiny bit :)