### PR TITLE
fix(gatsby-plugin-manifest): fix plugin option schema and add a test for it

### DIFF
--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "gatsby-core-utils": "^1.3.23",
+    "gatsby-plugin-utils": "^0.2.36",
     "semver": "^7.3.2",
     "sharp": "^0.25.4"
   },

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "gatsby-core-utils": "^1.3.23",
-    "gatsby-plugin-utils": "^0.2.36",
+    "gatsby-plugin-utils": "0.2.35",
     "semver": "^7.3.2",
     "sharp": "^0.25.4"
   },

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
@@ -526,7 +526,7 @@ describe(`Test plugin manifest options`, () => {
   })
 })
 
-describe.only(`pluginOptionsSchema`, () => {
+describe(`pluginOptionsSchema`, () => {
   it(`validates options correctly`, () => {
     expect(testPluginOptionsSchema(pluginOptionsSchema, manifestOptions))
       .toMatchInlineSnapshot(`

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
@@ -61,7 +61,8 @@ const reporter = {
     }
   }),
 }
-const { onPostBootstrap } = require(`../gatsby-node`)
+const { onPostBootstrap, pluginOptionsSchema } = require(`../gatsby-node`)
+const { testPluginOptionsSchema } = require(`gatsby-plugin-utils`)
 
 const apiArgs = {
   reporter,
@@ -522,5 +523,17 @@ describe(`Test plugin manifest options`, () => {
     await onPostBootstrap({ ...apiArgs }, specificOptions)
 
     expect(fs.copyFileSync).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe.only(`pluginOptionsSchema`, () => {
+  it(`validates options correctly`, () => {
+    expect(testPluginOptionsSchema(pluginOptionsSchema, manifestOptions))
+      .toMatchInlineSnapshot(`
+      Object {
+        "errors": Array [],
+        "isValid": true,
+      }
+    `)
   })
 })

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -59,7 +59,7 @@ async function checkCache(cache, icon, srcIcon, srcIconDigest, callback) {
 }
 
 if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
-  exports.pluginOptionsSchema = ({ Joi }) => {
+  exports.pluginOptionsSchema = ({ Joi }) =>
     Joi.object({
       name: Joi.string(),
       short_name: Joi.string(),
@@ -89,13 +89,13 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
           src: Joi.string(),
           sizes: Joi.string(),
           type: Joi.string(),
+          purpose: Joi.string(),
         })
       ),
       icon_options: Joi.object({
         purpose: Joi.string(),
       }),
     })
-  }
 }
 
 /**


### PR DESCRIPTION
Using the latest version with the experimental feature flag (e.g. in gatsby-starter-blog) results in this error:

> warn Plugin "gatsby-plugin-manifest" has an invalid options schema so we cannot verify your configuration for it.

[ch17522]
