### PR TITLE
fix(docs): fix gatsby-image instructions

### DIFF
--- a/www/src/components/layer-model/image-model/index.js
+++ b/www/src/components/layer-model/image-model/index.js
@@ -56,7 +56,9 @@ const layers = [
     text: <QueryLayer />,
     example: (
       <CodeWrapper title="src/pages/index.js" language="graphql">
-        {`export const query = graphql\`
+        {`import { graphql } from "gatsby"
+
+export const query = graphql\`
   query {
     file(relativePath: { eq: "images/gatsby-logo.png" }) {
       childImageSharp {

--- a/www/src/components/layer-model/image-model/index.js
+++ b/www/src/components/layer-model/image-model/index.js
@@ -24,7 +24,7 @@ const layers = [
     text: <InstallLayer />,
     example: (
       <CodeWrapper title="shell" language="shell">
-        {`npm install gatsby-transformer-sharp gatsby-plugin-sharp gatsby-image`}
+        {`npm install gatsby-transformer-sharp gatsby-plugin-sharp gatsby-image gatsby-source-filesystem`}
       </CodeWrapper>
     ),
   },
@@ -56,7 +56,7 @@ const layers = [
     text: <QueryLayer />,
     example: (
       <CodeWrapper title="src/pages/index.js" language="graphql">
-        {`const query = graphql\`
+        {`export const query = graphql\`
   query {
     file(relativePath: { eq: "images/gatsby-logo.png" }) {
       childImageSharp {


### PR DESCRIPTION
1. Users need to install `gatsby-source-filesystem` as it's used in the configure step
1. Users need to `export` the query for the image for it to work
1. Users need to import { graphql } from 'gatsby'. While it will work without that, they'll get a warning in their terminal that says "warn Using the global `graphql` tag is deprecated, and will not be supported in v3. Import it instead like:  import { graphql } from 'gatsby' in file: /Users/mxstbr/projects/gatsby-site/src/pages/index.js"