### PR TITLE
fix(gatsby-source-filesystem,gatsby-transformer-sharp): Use custom errors

### DIFF
--- a/packages/gatsby-source-filesystem/src/error-utils.js
+++ b/packages/gatsby-source-filesystem/src/error-utils.js
@@ -1,0 +1,26 @@
+export const CODES = {
+  Generic: `10000`,
+  MissingResource: `10001`,
+}
+
+export const pluginPrefix = `gatsby-source-filesystem`
+
+export function prefixId(id) {
+  return `${pluginPrefix}_${id}`
+}
+
+// TODO: Refactor to use contextual data instead of only context.sourceMessage
+// once reporter.setErrorMap is guaranteed to be available
+export const ERROR_MAP = {
+  [CODES.Generic]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    type: `PLUGIN`,
+  },
+  [CODES.MissingResource]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+}

--- a/packages/gatsby-source-filesystem/src/extend-file-node.js
+++ b/packages/gatsby-source-filesystem/src/extend-file-node.js
@@ -1,8 +1,14 @@
 const { GraphQLString } = require(`gatsby/graphql`)
 const fs = require(`fs-extra`)
 const path = require(`path`)
+const { prefixId, CODES } = require(`./error-utils`)
 
-module.exports = ({ type, getNodeAndSavePathDependency, pathPrefix = `` }) => {
+module.exports = ({
+  type,
+  getNodeAndSavePathDependency,
+  pathPrefix = ``,
+  reporter,
+}) => {
   if (type.name !== `File`) {
     return {}
   }
@@ -30,8 +36,13 @@ module.exports = ({ type, getNodeAndSavePathDependency, pathPrefix = `` }) => {
             { dereference: true },
             err => {
               if (err) {
-                console.error(
-                  `error copying file from ${details.absolutePath} to ${publicPath}`,
+                reporter.panic(
+                  {
+                    id: prefixId(CODES.MissingResource),
+                    context: {
+                      sourceMessage: `error copying file from ${details.absolutePath} to ${publicPath}`,
+                    },
+                  },
                   err
                 )
               }

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -4,6 +4,13 @@ const path = require(`path`)
 const { Machine, interpret } = require(`xstate`)
 
 const { createFileNode } = require(`./create-file-node`)
+const { ERROR_MAP } = require(`./error-utils`)
+
+exports.onPreInit = ({ reporter }) => {
+  if (reporter.setErrorMap) {
+    reporter.setErrorMap(ERROR_MAP)
+  }
+}
 
 /**
  * Create a state machine to manage Chokidar's not-ready/ready states.

--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -31,6 +31,7 @@ const {
   PotraceType,
   ImageFitType,
 } = require(`./types`)
+const { prefixId, CODES } = require(`./error-utils`)
 
 function toArray(buf) {
   const arr = new Array(buf.length)
@@ -441,8 +442,13 @@ const createFields = ({
             // this is no longer in progress
             inProgressCopy.delete(publicPath)
             if (err) {
-              console.error(
-                `error copying file from ${details.absolutePath} to ${publicPath}`,
+              reporter.panic(
+                {
+                  id: prefixId(CODES.MissingResource),
+                  context: {
+                    sourceMessage: `error copying file from ${details.absolutePath} to ${publicPath}`,
+                  },
+                },
                 err
               )
             }

--- a/packages/gatsby-transformer-sharp/src/error-utils.js
+++ b/packages/gatsby-transformer-sharp/src/error-utils.js
@@ -1,0 +1,26 @@
+export const CODES = {
+  Generic: `20000`,
+  MissingResource: `20001`,
+}
+
+export const pluginPrefix = `gatsby-transformer-sharp`
+
+export function prefixId(id) {
+  return `${pluginPrefix}_${id}`
+}
+
+// TODO: Refactor to use contextual data instead of only context.sourceMessage
+// once reporter.setErrorMap is guaranteed to be available
+export const ERROR_MAP = {
+  [CODES.Generic]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    type: `PLUGIN`,
+  },
+  [CODES.MissingResource]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+}

--- a/packages/gatsby-transformer-sharp/src/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/gatsby-node.js
@@ -2,6 +2,13 @@ const {
   onCreateNode,
   unstable_shouldOnCreateNode,
 } = require(`./on-node-create`)
+const { ERROR_MAP } = require(`./error-utils`)
+
+exports.onPreInit = ({ reporter }) => {
+  if (reporter.setErrorMap) {
+    reporter.setErrorMap(ERROR_MAP)
+  }
+}
 exports.onCreateNode = onCreateNode
 exports.unstable_shouldOnCreateNode = unstable_shouldOnCreateNode
 exports.createSchemaCustomization = require(`./customize-schema`)


### PR DESCRIPTION
## Description

> Related to Cloud functionality

In effort to improve the Cloud user experience, we need to make sure "Error copying file from..." errors are appropriately captured/categorized for Builds and Previews.

This PR simply updates the locations where log this error so that it uses `reporter.panic` instead of `console.error`

### To do
1. [x] What `id` should be used for this error? - _Any 5-digit number; this is an arbitrary value and contained within the context of the plugin (e.g., there is no risk error code conflicts between modules)_
    - [x] Should the `id` be different between `gatsby-source-filesystem` and `gatsby-transformer-sharp` (the two places that log this error) - _Yes, the module name is included in the ID prefix for both error locations._
