### PR TITLE
Update port to use the proxy

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -36,7 +36,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       if (services.developstatusserver) {
         let isRestarting = false
         const parentSocket = io(
-          `${window.location.protocol}//${window.location.hostname}:${services.developstatusserver.port}`
+          `${window.location.protocol}//${window.location.hostname}:${window.location.port}`
         )
 
         parentSocket.on(`structured-log`, msg => {


### PR DESCRIPTION
## Description

This prevents SSL_PROTOCOL_ERROR when using `gatsby develop` with the `--https` flag by no longer bypassing the http-proxy-middleware. At the same time, this change still guarantees the intention of #27302 (the fix for #27294) to prevent mixed origin warnings when using the `--https` flag.

## Related Issues

Fixes #27427
Related to #27302 and #27294
