### PR TITLE
Report URL with expected protocol and port

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -217,9 +217,9 @@ exports.onCreateWebpackConfig = (
           clearConsole: false,
           compilationSuccessInfo: {
             messages: [
-              `Netlify CMS is running at ${program.ssl ? `https` : `http`}://${
-                program.host
-              }:${program.port}/${publicPathClean}/`,
+              `Netlify CMS is running at ${
+                program.https ? `https://` : `http://`
+              }${program.host}:${program.proxyPort}/${publicPathClean}/`,
             ],
           },
         }),


### PR DESCRIPTION
## Description

Updated the custom Netlify CMS compilation message to display the expected URL Netlify CMS is running at based on the `--port` and `--https` flags the user provided when running `gatsby develop`.

I first tried to use the same format as used in `gatsby-plugin-graphql-config`:
`${program.https ? `https://`:`http://`}${program.host}:${program.port}`

This worked for the protocol, but not for `program.port`, as it seems the `program` const is initialized at a different moment between those two plugins. For this reason, I opted to use `program.proxyPort` instead.

## Related Issues

Fixes #27429 
