### PR TITLE
updated shouldUpdateScroll example

### DIFF
--- a/packages/gatsby/src/utils/api-browser-docs.ts
+++ b/packages/gatsby/src/utils/api-browser-docs.ts
@@ -99,7 +99,7 @@ export const onRouteUpdate = true
  *
  *   window.scrollTo(...(currentPosition || [0, 0]))
  *
- *   return false
+ *   return true
  * }
  */
 export const shouldUpdateScroll = true


### PR DESCRIPTION
## Description

Return false will result in all the links in the site to keep the position and not scroll to the top.
