### PR TITLE
fix(gatsby-plugin-canonical-urls): Drop data attributes & correct protocol

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -6,8 +6,6 @@ exports[`gatsby-plugin-canonical-urls creates a canonical link if siteUrl is set
     Array [
       Array [
         <link
-          data-basehost="someurl.com"
-          data-baseprotocol="http:"
           href="http://someurl.com/somepost"
           rel="canonical"
         />,
@@ -31,8 +29,6 @@ exports[`gatsby-plugin-canonical-urls strips a trailing slash on the siteUrl and
     Array [
       Array [
         <link
-          data-basehost="someurl.com"
-          data-baseprotocol="http:"
           href="http://someurl.com/somepost?tag=foobar"
           rel="canonical"
         />,
@@ -54,8 +50,6 @@ exports[`gatsby-plugin-canonical-urls strips search parameters if option stripQu
     Array [
       Array [
         <link
-          data-basehost="someurl.com"
-          data-baseprotocol="http:"
           href="http://someurl.com/somepost"
           rel="canonical"
         />,

--- a/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/__tests__/gatsby-browser.js
@@ -2,7 +2,7 @@ const { onRouteUpdate } = require(`../gatsby-browser`)
 
 describe(`gatsby-plugin-canonical-urls`, () => {
   beforeEach(() => {
-    global.document.head.innerHTML = `<link data-basehost="someurl.com" data-baseprotocol="http:" href="http://someurl.com/somepost" rel="canonical"
+    global.document.head.innerHTML = `<link href="http://someurl.com/somepost" rel="canonical"
         />`
   })
 
@@ -10,7 +10,7 @@ describe(`gatsby-plugin-canonical-urls`, () => {
     onRouteUpdate({ location: { pathname: `/hogwarts`, hash: ``, search: `` } })
 
     expect(global.document.head.innerHTML).toMatchInlineSnapshot(
-      `"<link data-basehost=\\"someurl.com\\" data-baseprotocol=\\"http:\\" href=\\"http://someurl.com/hogwarts\\" rel=\\"canonical\\">"`
+      `"<link href=\\"http://someurl.com/hogwarts\\" rel=\\"canonical\\">"`
     )
   })
   it(`should keep the hash`, () => {
@@ -19,7 +19,7 @@ describe(`gatsby-plugin-canonical-urls`, () => {
     })
 
     expect(global.document.head.innerHTML).toMatchInlineSnapshot(
-      `"<link data-basehost=\\"someurl.com\\" data-baseprotocol=\\"http:\\" href=\\"http://someurl.com/hogwarts#harry-potter\\" rel=\\"canonical\\">"`
+      `"<link href=\\"http://someurl.com/hogwarts#harry-potter\\" rel=\\"canonical\\">"`
     )
   })
   it(`shouldn't strip search parameter by default`, () => {
@@ -32,7 +32,7 @@ describe(`gatsby-plugin-canonical-urls`, () => {
     })
 
     expect(global.document.head.innerHTML).toMatchInlineSnapshot(
-      `"<link data-basehost=\\"someurl.com\\" data-baseprotocol=\\"http:\\" href=\\"http://someurl.com/hogwarts?house=gryffindor\\" rel=\\"canonical\\">"`
+      `"<link href=\\"http://someurl.com/hogwarts?house=gryffindor\\" rel=\\"canonical\\">"`
     )
   })
   it(`should strip search parameters if option stripQueryString is true`, () => {
@@ -52,7 +52,7 @@ describe(`gatsby-plugin-canonical-urls`, () => {
     )
 
     expect(global.document.head.innerHTML).toMatchInlineSnapshot(
-      `"<link data-basehost=\\"someurl.com\\" data-baseprotocol=\\"http:\\" href=\\"http://someurl.com/hogwarts\\" rel=\\"canonical\\">"`
+      `"<link href=\\"http://someurl.com/hogwarts\\" rel=\\"canonical\\">"`
     )
   })
 })

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -1,13 +1,14 @@
+import url from "url"
+
 exports.onRouteUpdate = (
   { location },
   pluginOptions = { stripQueryString: false }
 ) => {
   const domElem = document.querySelector(`link[rel='canonical']`)
   const existingValue = domElem.getAttribute(`href`)
-  const baseProtocol = domElem.getAttribute(`data-baseProtocol`)
-  const baseHost = domElem.getAttribute(`data-baseHost`)
-  if (existingValue && baseProtocol && baseHost) {
-    let value = `${baseProtocol}//${baseHost}${location.pathname}`
+  if (existingValue) {
+    const parsed = url.parse(existingValue)
+    let value = `${parsed.protocol}//${parsed.host}${location.pathname}`
 
     const { stripQueryString } = pluginOptions
 

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -1,4 +1,4 @@
-import url from "url"
+const url = require(`url`)
 
 exports.onRouteUpdate = (
   { location },

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
@@ -21,14 +21,6 @@ exports.onRenderBody = (
       pageUrl = parsed.href
     }
 
-    setHeadComponents([
-      <link
-        rel="canonical"
-        key={pageUrl}
-        href={pageUrl}
-        data-baseprotocol={parsed.protocol}
-        data-basehost={parsed.host}
-      />,
-    ])
+    setHeadComponents([<link rel="canonical" key={pageUrl} href={pageUrl} />])
   }
 }


### PR DESCRIPTION
## Description

Dropped the following attributes since they are no longer useful:
* `data-baseprotocol`
* `data-basehost`

These attributes were ambiguous and poorly documented.
Their values can be parsed from the URL's `href` attribute if need be.

This exactly what has been done in `gatsby-browser.js` now, the only file which previously used the dropped attributes.

### Documentation

The dropped attributes were not mentioned in the plugin's documentation. Lucky.

## Related Issues

Fixes #27298 