### PR TITLE
fix(gatsby-source-contentful): set default for contentful asset workers

### DIFF
--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -12,10 +12,10 @@ const bar = new ProgressBar(
 /**
  * @name distributeWorkload
  * @param workers A list of async functions to complete
- * @param {number} count The number of task runners to use
+ * @param {number} count The number of task runners to use (see assetDownloadWorkers in config)
  */
 
-async function distributeWorkload(workers, count) {
+async function distributeWorkload(workers, count = 50) {
   const methods = workers.slice()
 
   async function task() {


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/27563 introduced a `assetDownloadWorkers` but the function that generated the workers could still receive `undefined`. This sets the default to make sure it's always getting some value.