### PR TITLE
fix(gatsby-plugin-utils): skip libcheck during typegen

### DIFF
--- a/packages/gatsby-plugin-utils/tsconfig.json
+++ b/packages/gatsby-plugin-utils/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
 }


### PR DESCRIPTION
This adds `skipLibCheck` to the tsconfig for `gatsby-plugin-utils`, which means the typegen doesn't also typecheck all of the lib's dependencies. This avoids a race condition where types cannot be generated unless gatsby-cli has already been compiled. This doesn't affect compilation or type-checking, just typegen, and the types in question are already checked in the scripts for those packages.