### PR TITLE
docs(guide): Remove beta notes from GraphCMS sourcing guide

### DIFF
--- a/docs/docs/sourcing-from-graphcms.md
+++ b/docs/docs/sourcing-from-graphcms.md
@@ -36,7 +36,7 @@ In order to fetch data from your GraphCMS project, you will need to install [`ga
 You can install this package with:
 
 ```shell
-  yarn add gatsby-source-graphcms
+npm install gatsby-source-graphcms
 ```
 
 ### Configure the plugin

--- a/docs/docs/sourcing-from-graphcms.md
+++ b/docs/docs/sourcing-from-graphcms.md
@@ -31,14 +31,12 @@ Once finished, navigate inside of the project with `cd gatsby-site`.
 
 ### Add the `gatsby-source-graphcms` plugin
 
-> This plugin is in **beta**. Please use at your own risk!
-
 In order to fetch data from your GraphCMS project, you will need to install [`gatsby-source-graphcms`](https://github.com/GraphCMS/gatsby-source-graphcms).
 
 You can install this package with:
 
 ```shell
-  yarn add gatsby-source-graphcms@next
+  yarn add gatsby-source-graphcms
 ```
 
 ### Configure the plugin


### PR DESCRIPTION
## Description

Removal of beta notes from the GraphCMS [data sourcing guide](https://www.gatsbyjs.com/docs/sourcing-from-graphcms/#reach-skip-nav), now that [`gatsby-source-graphcms`](https://github.com/GraphCMS/gatsby-source-graphcms) is available on `latest` tag.

### Documentation

* N/A

## Related Issues

* N/A
