### PR TITLE
feat(google-plugin-google-tag): add preconnect tags

### DIFF
--- a/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
@@ -1,3 +1,5 @@
+import React from "react"
+
 exports.onRouteUpdate = ({ location }) => {
   if (process.env.NODE_ENV !== `production` || typeof gtag !== `function`) {
     return null
@@ -28,4 +30,14 @@ exports.onRouteUpdate = ({ location }) => {
   }
 
   return null
+}
+
+exports.onRenderBody = ({ setHeadComponents }) => {
+  setHeadComponents([
+    <link
+      rel="dns-prefetch"
+      key="dns-prefetch-google-analytics"
+      href="https://www.google-analytics.com"
+    />,
+  ])
 }


### PR DESCRIPTION
adding dns-prefetch link tag for google analytics (helps with lighthouse reports)

fixes https://github.com/gatsbyjs/gatsby/discussions/27507
