### PR TITLE
fix(gatsby): trigger location effects in navigation

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -143,6 +143,24 @@ describe(`navigation`, () => {
     })
   })
 
+  describe(`All location changes should trigger an effect`, () => {
+    beforeEach(() => {
+      cy.visit(`/navigation-effects`).waitForRouteChange()
+    })
+
+    it(`should trigger an effect after a search param has changed`, () => {
+      cy.getTestElement(`effect-message`).invoke(`text`).should(`eq`, `Waiting for effect`)
+      cy.getTestElement(`send-search-message`).click().waitForRouteChange()
+      cy.getTestElement(`effect-message`).invoke(`text`).should(`eq`, `?message=searchParam`)
+    })
+
+    it(`should trigger an effect after the hash has changed`, () => {
+      cy.getTestElement(`effect-message`).invoke(`text`).should(`eq`, `Waiting for effect`)
+      cy.getTestElement(`send-hash-message`).click().waitForRouteChange()
+      cy.getTestElement(`effect-message`).invoke(`text`).should(`eq`, `#message-hash`)
+    })
+  })
+
   describe(`Route lifecycle update order`, () => {
     it(`calls onPreRouteUpdate, render and onRouteUpdate the correct amount of times on route change`, () => {
       cy.lifecycleCallCount(`onPreRouteUpdate`).should(`eq`, 1)

--- a/e2e-tests/development-runtime/src/pages/navigation-effects.js
+++ b/e2e-tests/development-runtime/src/pages/navigation-effects.js
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from "react"
+import { navigate } from "gatsby"
+
+import Layout from "../components/layout"
+
+export default function NavigationEffects({ location }) {
+  const [message, setMessage] = useState("Waiting for effect")
+
+  const searchParam = location.search
+  const searchHash = location.hash
+
+  useEffect(() => {
+    setMessage(searchParam)
+  }, [searchParam])
+
+  useEffect(() => {
+    setMessage(searchHash)
+  }, [searchHash])
+
+  const handleClick = next => navigate(`${next}`, { replace: true })
+
+  return (
+    <Layout>
+      <h1 data-testid="effect-message">{message}</h1>
+
+      <button
+        data-testid="send-search-message"
+        onClick={() => handleClick("?message=searchParam")}
+      >
+        Send Search
+      </button>
+      <button
+        data-testid="send-hash-message"
+        onClick={() => handleClick("#message-hash")}
+      >
+        Send Hash
+      </button>
+    </Layout>
+  )
+}

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -208,7 +208,7 @@ class RouteUpdates extends React.Component {
   }
 
   shouldComponentUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    if (this.props.location.href !== prevProps.location.href) {
       onPreRouteUpdate(this.props.location, prevProps.location)
       return true
     }
@@ -217,7 +217,7 @@ class RouteUpdates extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    if (this.props.location.href !== prevProps.location.href) {
       onRouteUpdate(this.props.location, prevProps.location)
     }
   }


### PR DESCRIPTION
## Description

Fixes issue: https://github.com/gatsbyjs/gatsby/issues/27351

Currently, when you change a route/location search param or hash, no effect will occur.

The expected behaviour is that if the route/location changes at all then effects should be triggered.

Please see https://github.com/gatsbyjs/gatsby/issues/27351 for more details on this bug.

## Related Issues

Fixes issue:  https://github.com/gatsbyjs/gatsby/issues/27351
