### PR TITLE
fix(gatsby): fixed navigation of search params not triggering render

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -208,7 +208,7 @@ class RouteUpdates extends React.Component {
   }
 
   shouldComponentUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    if (this.props.location.href !== prevProps.location.href) {
       onPreRouteUpdate(this.props.location, prevProps.location)
       return true
     }
@@ -217,7 +217,7 @@ class RouteUpdates extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    if (this.props.location.href !== prevProps.location.href) {
       onRouteUpdate(this.props.location, prevProps.location)
     }
   }


### PR DESCRIPTION
## Description

As of Gatsby 2.24.70, updating search params has not actually re-rendered the page. This resolves the issue.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/27020