### PR TITLE
fix(gatsby):Fixed path prefix issue #27604

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-plugin-sharp/src/__tests__/__snapshots__/index.js.snap
@@ -33,6 +33,19 @@ Object {
 }
 `;
 
+exports[`gatsby-plugin-sharp duotone fixed 2`] = `
+Object {
+  "aspectRatio": 1,
+  "base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAAH6ji2bAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABk0lEQVQ4y7VUy07DMBDsf9IDhcauaVM4IajUIuALOFRI/R24wB8AgkpInJKI9ME5zDi24rx5HjZKvOP17Hg2neh8nNjo8CGESGL7sbpwMvrlaepriF4J3dQLMlsXvzbVFCKHLJ3J8+5PRxqlF0OzleFLkSG7Xrp4faiyRaI/Lgs13QhNVB5uCUyUTDyUloidvkjezvyMEB8B4uZkqAHCiR44bYtCcecSirD5XQDmIGzVjOrEiJo4fhvY2jWTG3C6g/TLmZ+8VwEJekWy20+loUSzA5kDp15BKJmXhmD6Iqcjtep5eSArk0ZQPPpqPNAaWiBpbKt0pLgEU2xuIOewTh7rmFWFRH9/M78uaG8yNuox4oYbbrQEhaI4HKEh7mvfS2OE98WR0r6P26zj2ofW5rWowlzY2WduAQxZ14odmNZuMWA0h6wo5pplDxj+MrgnqDM3W32E/QYNxaxN2f7ztNx6qWUCOC3H+F/Y35EU2XCw3QkGhBrHX/WXLbwG4wewoAwMst84t/0jH4ZG36DFLv9m7E/1HjvIa/canAAAAABJRU5ErkJggg==",
+  "height": 100,
+  "originalName": "test.png",
+  "src": "/static/1234/df2e1/test.png",
+  "srcSet": "/static/1234/df2e1/test.png 1x",
+  "tracedSVG": undefined,
+  "width": 100,
+}
+`;
+
 exports[`gatsby-plugin-sharp duotone fluid 1`] = `
 Object {
   "aspectRatio": 1,

--- a/packages/gatsby-recipes/src/providers/npm/__snapshots__/package.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/npm/__snapshots__/package.test.js.snap
@@ -66,6 +66,24 @@ Object {
 }
 `;
 
+exports[`npm package resource installs 2 resources, one prod & one dev: NPMPackage create 1`] = `
+Object {
+  "_message": "Installed NPM package is-sorted@1.0.0",
+  "description": "A small module to check if an Array is sorted",
+  "id": "is-sorted",
+  "name": "is-sorted",
+  "version": "1.0.0",
+}
+`;
+
+exports[`npm package resource installs 2 resources, one prod & one dev: NPMPackage update plan 1`] = `
+Object {
+  "currentState": "is-sorted@1.0.0",
+  "describe": "Install is-sorted@1.0.2",
+  "newState": "is-sorted@1.0.2",
+}
+`;
+
 exports[`package manager client commands generates the correct commands for npm 1`] = `
 Array [
   "install",

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -218,7 +218,7 @@ export class BaseLoader {
 
     const inFlightPromise = Promise.all([
       this.loadAppData(),
-      this.loadPageDataJson(pagePath),
+      this.loadPageDataJson(rawPath),
     ]).then(allData => {
       const result = allData[1]
       if (result.status === PageResourceStatus.Error) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Previously, the Path prefix didn't work when the page URL started with the same path prefix. (Refer to issue mentioned below)
It was because of the loadPageDataJson function in loader.js
It already includes a findPath function that finds the actual location to get page data but here we used findPath function twice (before sending rawpath to loadPageDataJson) which luckily didn't affect the loaded data when a prefix is different but when it is the same it sliced the URL twice thinking it to be prefix because of the same name.

### Documentation

Not Applicable


## Related Issues


  Link to the issue that is fixed by this PR:
  https://github.com/gatsbyjs/gatsby/issues/27604
