### PR TITLE
fix: Path prefix does not work when page URL starts with path prefix …

### DIFF
--- a/packages/gatsby/cache-dir/strip-prefix.js
+++ b/packages/gatsby/cache-dir/strip-prefix.js
@@ -8,10 +8,6 @@ export default function stripPrefix(str, prefix = ``) {
     return str
   }
 
-  if (str === prefix) {
-    return `/`
-  }
-
   if (str.startsWith(`${prefix}/`)) {
     return str.slice(prefix.length)
   }


### PR DESCRIPTION
The issue was only if the page name is exactly the same as the prefix