### PR TITLE
Fixed typo in freeCodeCamp brand name

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -172,7 +172,7 @@ Formik
 Formspree
 Formspree's
 FOUC
-FreeCodeCamp
+*freeCodeCamp
 frontend
 frontmatter
 Frontmatter


### PR DESCRIPTION
## Description
Changes: 

- FreeCodeCamp -> freeCodeCamp (always lowercase)

## Related Issues
#25290 `enhancement (docs): Improvements to retext-spell`
