### PR TITLE
[docs][guides] improvements to Why Gatsby Uses GraphQL #15235

### DIFF
--- a/docs/docs/why-gatsby-uses-graphql.md
+++ b/docs/docs/why-gatsby-uses-graphql.md
@@ -256,7 +256,7 @@ GATSBY_GRAPHQL_IDE=playground gatsby develop
 
 You can explore the available data schema using the “Docs” tab at the right.
 
-One of the available options is `allProductsJson`, which contains “edges”, and those contain “nodes”.
+One of the available options is `allProductsJson`, which contains “edges”, and those contain “nodes”. The `allProductsJson` option was created by the JSON transformer plugin ([`gatsby-transformer-json`](/packages/gatsby-transformer-json/)).
 
 The JSON transformer plugin has created one node for each product, and inside the node you can select the data you need for that product.
 


### PR DESCRIPTION
## Description

A brief explanation of what created `allProductsJson` has been added. It refers to the `gatsby-transformer-json` plugin.

### Documentation

The change is related to this doc: https://www.gatsbyjs.com/docs/why-gatsby-uses-graphql/
Please can @gatsbyjs/documentation review this PR?

## Related Issues
Fixes #15235
