### PR TITLE
fix(gatsby): include graphql type definition in published files

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -198,6 +198,7 @@
     "dist/",
     "gatsby-admin-public/",
     "graphql.js",
+    "graphql.d.ts",
     "index.d.ts",
     "scripts/postinstall.js",
     "utils.js",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The `package.json` file in the `gatsby` module lists individual files to include, but that list does not include `graphql.d.ts`. This means that if you import from `gatsby/graphql` in a typescript project, it does not find the typings.

This PR simply adds that file to the list of files to be published.
