### PR TITLE
perf(gatsby): change hashing of createNodeId to use XXH

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -157,6 +157,7 @@
     "webpack-stats-plugin": "^0.3.2",
     "webpack-virtual-modules": "^0.2.2",
     "xstate": "^4.11.0",
+    "xxhashjs": "0.2.2",
     "yaml-loader": "^0.6.0"
   },
   "devDependencies": {

--- a/packages/gatsby/src/utils/__tests__/create-node-id.ts
+++ b/packages/gatsby/src/utils/__tests__/create-node-id.ts
@@ -104,7 +104,7 @@ describe(`createNodeId`, (): void => {
       )
 
       // The id should be consistent and deterministic (input should affect output, not run instance or rng)
-      expect(id).toMatchInlineSnapshot(`"a4c1c7d4"`)
+      expect(id).toMatchInlineSnapshot(`"Ga4c1c7d4"`)
     })
 
     it(`should hash a value with a namespace`, () => {
@@ -142,9 +142,9 @@ describe(`createNodeId`, (): void => {
       expect(id1 !== id2).toBe(true)
 
       // For completion sake
-      expect(idSans).toMatchInlineSnapshot(`"2546f2f0"`)
-      expect(id1).toMatchInlineSnapshot(`"2f0665fc2546f2f0"`)
-      expect(id2).toMatchInlineSnapshot(`"9ff818ec2546f2f0"`)
+      expect(idSans).toMatchInlineSnapshot(`"G2546f2f0"`)
+      expect(id1).toMatchInlineSnapshot(`"G2f0665fc2546f2f0"`)
+      expect(id2).toMatchInlineSnapshot(`"G9ff818ec2546f2f0"`)
     })
 
     it(`return same id for same input`, () => {
@@ -155,8 +155,8 @@ describe(`createNodeId`, (): void => {
       const idWith = createNodeId(KEY, NS)
 
       // Only input should affect it so repetitive calls should not change the output
-      expect(idSans).toMatchInlineSnapshot(`"92954a39"`)
-      expect(idWith).toMatchInlineSnapshot(`"2f0665fc92954a39"`)
+      expect(idSans).toMatchInlineSnapshot(`"G92954a39"`)
+      expect(idWith).toMatchInlineSnapshot(`"G2f0665fc92954a39"`)
 
       for (let i = 0; i < 10; ++i) {
         const idSans2 = createNodeId(KEY)

--- a/packages/gatsby/src/utils/__tests__/create-node-id.ts
+++ b/packages/gatsby/src/utils/__tests__/create-node-id.ts
@@ -1,0 +1,170 @@
+import { createNodeId } from "../create-node-id"
+
+describe(`createNodeId`, (): void => {
+  describe(`uuid`, () => {
+    // Keep tests in this group in sync with the xxhash group below
+
+    it(`should hash a value without namespace`, () => {
+      // Key is just something random that's not only ascii
+      const id = createNodeId(
+        `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"`
+      )
+
+      // The id should be consistent and deterministic (input should affect output, not run instance or rng)
+      expect(id).toMatchInlineSnapshot(`"ff299ec2-7698-599e-89ef-02f9a9a424c7"`)
+    })
+
+    it(`should hash a value with a namespace`, () => {
+      // Key is just something random that's not only ascii
+      const idSans = createNodeId(
+        `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"`
+      )
+      const idWith = createNodeId(
+        `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"`,
+        `gatsby-special-plugin`
+      )
+
+      // The id should be consistent and deterministic (input should affect output, not run instance or rng)
+      expect(idSans !== idWith).toEqual(true)
+    })
+
+    it(`should return a string`, () => {
+      // Key is just something random that's not only ascii
+      const id = createNodeId(`myboea"`)
+
+      expect(typeof id).toBe(`string`)
+
+      const id2 = createNodeId(`myboea"`, `ghost ns`)
+
+      expect(typeof id2).toBe(`string`)
+    })
+
+    it(`should return a different hash for namespaces`, () => {
+      const idSans = createNodeId(`my things`)
+      const id1 = createNodeId(`my things`, `gatsby-special-plugin`)
+      const id2 = createNodeId(`my things`, `gatsby-other-plugin`)
+
+      expect(idSans !== id1).toBe(true)
+      expect(idSans !== id2).toBe(true)
+      expect(id1 !== id2).toBe(true)
+
+      // For completion sake
+      expect(idSans).toMatchInlineSnapshot(
+        `"abfbea78-3ad4-57b7-9db8-2f43e9efe786"`
+      )
+      expect(id1).toMatchInlineSnapshot(
+        `"03ca507d-c732-5412-95d2-eaf114f42f69"`
+      )
+      expect(id2).toMatchInlineSnapshot(
+        `"5db58b36-473b-5c3f-a676-db34af789baf"`
+      )
+    })
+
+    it(`return same id for same input`, () => {
+      const KEY = `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bc"`
+      const NS = `gatsby-special-plugin`
+      // Key is just something random that's not only ascii
+      const idSans = createNodeId(KEY)
+      const idWith = createNodeId(KEY, NS)
+
+      // Only input should affect it so repetitive calls should not change the output
+      expect(idSans).toMatchInlineSnapshot(
+        `"826331ae-3f00-5556-9563-187da41e1c1c"`
+      )
+      expect(idWith).toMatchInlineSnapshot(
+        `"6614d1bf-8c8c-5cfc-b782-2c019d7a7c95"`
+      )
+
+      for (let i = 0; i < 10; ++i) {
+        const idSans2 = createNodeId(KEY)
+        const idWith2 = createNodeId(KEY, NS)
+
+        expect(idSans2).toEqual(idSans)
+        expect(idWith2).toEqual(idWith)
+      }
+    })
+  })
+
+  describe(`xxhash`, () => {
+    // This set is duplicate to the one above except it sets the env flag before and removes it afterwards
+    // Keep in sync
+
+    beforeEach(() => {
+      process.env.GATSBY_EXPERIMENTAL_ID_XXHASH = `1`
+    })
+
+    afterEach(() => {
+      delete process.env.GATSBY_EXPERIMENTAL_ID_XXHASH
+    })
+
+    it(`should hash a value without namespace`, () => {
+      // Key is just something random that's not only ascii
+      const id = createNodeId(
+        `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"`
+      )
+
+      // The id should be consistent and deterministic (input should affect output, not run instance or rng)
+      expect(id).toMatchInlineSnapshot(`"a4c1c7d4"`)
+    })
+
+    it(`should hash a value with a namespace`, () => {
+      // Key is just something random that's not only ascii
+      const idSans = createNodeId(
+        `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"`
+      )
+      const idWith = createNodeId(
+        `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"`,
+        `gatsby-special-plugin`
+      )
+
+      // The id should be consistent and deterministic (input should affect output, not run instance or rng)
+      expect(idSans !== idWith).toEqual(true)
+    })
+
+    it(`should return a string`, () => {
+      // Key is just something random that's not only ascii
+      const id = createNodeId(`myboea"`)
+
+      expect(typeof id).toBe(`string`)
+
+      const id2 = createNodeId(`myboea"`, `ghost ns`)
+
+      expect(typeof id2).toBe(`string`)
+    })
+
+    it(`should return a different hash for namespaces`, () => {
+      const idSans = createNodeId(`my things`)
+      const id1 = createNodeId(`my things`, `gatsby-special-plugin`)
+      const id2 = createNodeId(`my things`, `gatsby-other-plugin`)
+
+      expect(idSans !== id1).toBe(true)
+      expect(idSans !== id2).toBe(true)
+      expect(id1 !== id2).toBe(true)
+
+      // For completion sake
+      expect(idSans).toMatchInlineSnapshot(`"2546f2f0"`)
+      expect(id1).toMatchInlineSnapshot(`"2f0665fc2546f2f0"`)
+      expect(id2).toMatchInlineSnapshot(`"9ff818ec2546f2f0"`)
+    })
+
+    it(`return same id for same input`, () => {
+      const KEY = `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bc"`
+      const NS = `gatsby-special-plugin`
+      // Key is just something random that's not only ascii
+      const idSans = createNodeId(KEY)
+      const idWith = createNodeId(KEY, NS)
+
+      // Only input should affect it so repetitive calls should not change the output
+      expect(idSans).toMatchInlineSnapshot(`"92954a39"`)
+      expect(idWith).toMatchInlineSnapshot(`"2f0665fc92954a39"`)
+
+      for (let i = 0; i < 10; ++i) {
+        const idSans2 = createNodeId(KEY)
+        const idWith2 = createNodeId(KEY, NS)
+
+        expect(idSans2).toEqual(idSans)
+        expect(idWith2).toEqual(idWith)
+      }
+    })
+  })
+})

--- a/packages/gatsby/src/utils/create-node-id.ts
+++ b/packages/gatsby/src/utils/create-node-id.ts
@@ -1,12 +1,12 @@
+import uuidv5 from "uuid/v5"
 import XXH from "xxhashjs"
 
 import report from "gatsby-cli/lib/reporter"
 
 const SEED = 61773236 // "gezellig" (arbitrary seed)
+const seedConstant = `638f7a53-c567-4eca-8fc1-b23efb1cfb2b`
 
 /**
- * createNodeId()
- *
  * Generate a unique id that is consistent, deterministic, and fast while resulting in predictably short hashes.
  *
  * Some characteristics for this id:
@@ -21,8 +21,10 @@ const SEED = 61773236 // "gezellig" (arbitrary seed)
  * High level this step is meant to prevent people from using our `id` to have meaning in their site and it's meant
  * to make sure the id ends up being short, whatever the input size was.
  *
- * The switch to XXH is fairly arbitrary. It just meets the above criteria. If another algo does better we should
- * probably switch to it instead.
+ * For a long time, v2 used a regular UUID for this purpose. But creating UUIDs is slow due to calling into the native
+ * crypto libraries. You can opt-in to using XXHash instead through an env flag (`GATSBY_EXPERIMENTAL_ID_XXHASH`) which
+ * will be faster. But it might affect your site if you happen to use your id for slugs, for example. Ideally you
+ * wouldn't and this change wouldn't be noticable to you.
  *
  * Relevant for XXH:
  * - https://github.com/pierrec/js-xxhash
@@ -31,11 +33,14 @@ const SEED = 61773236 // "gezellig" (arbitrary seed)
  * - https://github.com/Cyan4973/xxHash/wiki/Collision-ratio-comparison#testing-64-bit-hashes-on-small-inputs-
  *
  * @param {String | Number} id - A string of arbitrary length
- * @param {String} namespace - Namespace to use for UUID
+ * @param {String} [namespace] - Namespace to use for UUID
  *
  * @return {String}
  */
-export function createNodeId(id: string | number, namespace: string): string {
+export function createNodeId(
+  id: string | number,
+  namespace: string = ``
+): string {
   if (typeof id === `number`) {
     id = id.toString()
   } else if (typeof id !== `string`) {
@@ -44,8 +49,12 @@ export function createNodeId(id: string | number, namespace: string): string {
     )
   }
 
-  const ns = namespace ? XXH.h32(namespace, SEED).toString(16) : ``
-  const val = XXH.h32(id, SEED).toString(16)
+  if (process.env.GATSBY_EXPERIMENTAL_ID_XXHASH) {
+    const ns = namespace ? XXH.h32(namespace, SEED).toString(16) : ``
+    const val = XXH.h32(id, SEED).toString(16)
 
-  return `${ns}_${val}`
+    return `${ns}${val}`
+  }
+
+  return uuidv5(id, uuidv5(namespace, seedConstant))
 }

--- a/packages/gatsby/src/utils/create-node-id.ts
+++ b/packages/gatsby/src/utils/create-node-id.ts
@@ -53,7 +53,8 @@ export function createNodeId(
     const ns = namespace ? XXH.h32(namespace, SEED).toString(16) : ``
     const val = XXH.h32(id, SEED).toString(16)
 
-    return `${ns}${val}`
+    // Prefix a `G` to prevent the id to look like a serialized number. If we don't then type inference might fail.
+    return `G${ns}${val}`
   }
 
   return uuidv5(id, uuidv5(namespace, seedConstant))

--- a/packages/gatsby/src/utils/create-node-id.ts
+++ b/packages/gatsby/src/utils/create-node-id.ts
@@ -1,15 +1,39 @@
-import uuidv5 from "uuid/v5"
+import XXH from "xxhashjs"
+
 import report from "gatsby-cli/lib/reporter"
 
-const seedConstant = `638f7a53-c567-4eca-8fc1-b23efb1cfb2b`
+const SEED = 61773236 // "gezellig" (arbitrary seed)
 
 /**
- * createNodeId() Generate UUID
+ * createNodeId()
+ *
+ * Generate a unique id that is consistent, deterministic, and fast while resulting in predictably short hashes.
+ *
+ * Some characteristics for this id:
+ *
+ * - The value of the `id` should not mean anything (it is "ours")
+ * - The value does not need to be encrypted
+ * - The value must be unique within our system (as little collision risk as possible on small ascii inputs)
+ * - The value needs to be deterministic (same input always results in same output)
+ * - The conversion needs to be fast (we used to use uuid, which called into crytpo for sha1, but it was super slow)
+ * - The result should be predictably short as it may be used in urls
+ *
+ * High level this step is meant to prevent people from using our `id` to have meaning in their site and it's meant
+ * to make sure the id ends up being short, whatever the input size was.
+ *
+ * The switch to XXH is fairly arbitrary. It just meets the above criteria. If another algo does better we should
+ * probably switch to it instead.
+ *
+ * Relevant for XXH:
+ * - https://github.com/pierrec/js-xxhash
+ * - https://github.com/Cyan4973/xxHash
+ * - https://github.com/Cyan4973/xxHash/wiki/Collision-ratio-comparison#collision-study
+ * - https://github.com/Cyan4973/xxHash/wiki/Collision-ratio-comparison#testing-64-bit-hashes-on-small-inputs-
  *
  * @param {String | Number} id - A string of arbitrary length
  * @param {String} namespace - Namespace to use for UUID
  *
- * @return {String} - UUID
+ * @return {String}
  */
 export function createNodeId(id: string | number, namespace: string): string {
   if (typeof id === `number`) {
@@ -20,5 +44,8 @@ export function createNodeId(id: string | number, namespace: string): string {
     )
   }
 
-  return uuidv5(id, uuidv5(namespace, seedConstant))
+  const ns = namespace ? XXH.h32(namespace, SEED).toString(16) : ``
+  const val = XXH.h32(id, SEED).toString(16)
+
+  return `${ns}_${val}`
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,8 +978,6 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz#8f2682bcdcef9ed327e1b0861585d7013f8a54dd"
   integrity sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-runtime@^7.11.5":
   version "7.11.5"
@@ -8236,6 +8234,11 @@ csvtojson@^2.0.10:
     bluebird "^3.5.1"
     lodash "^4.17.3"
     strip-bom "^2.0.0"
+
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -26328,6 +26331,13 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xxhashjs@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
While profiling I noticed that roughly 40% of the time of node creation is spent creating the actual id of the new node. Turns out this was caused by the `uuid` library which was calling into the native `crypto` library for hashing with sha-1. This call is slow and it shows at scale.

I've replaced it with `xxhashjs` (ht @ascorbic) which exhibits good collision properties on small ascii strings while improving speed and maintaining other constraints.

Now creating node ids is still pretty expensive, but way less expensive than it was before.