### PR TITLE
feat(gatsby-source-filesystem): env flag to placeholder remote assets

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -267,11 +267,11 @@ async function fetchRemoteNode({
     httpOpts.auth = `${auth.htaccess_user}:${auth.htaccess_pass}`
   }
 
+  // Create the temp and permanent file names for the url.
   const digest = createContentDigest(url)
   if (!name) {
     name = getRemoteFileName(url)
   }
-
   if (!ext) {
     ext = getRemoteFileExtension(url)
   }


### PR DESCRIPTION
This is an experimental env flag to help with debugging. It replaces any remote asset that is fetched through `createRemoteFileNode` with a local placeholder file. The path is used as is.

This helps with debugging and profiling sites where the remote assets are not necessary but still take minutes to download. Not meant to be used with regular sites so it's only exposed as an experimental flag.