### PR TITLE
fix(gatsby): print real plugin loading error in verbose

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/load.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.ts
@@ -118,6 +118,12 @@ export function resolvePlugin(
       version: packageJSON.version,
     }
   } catch (err) {
+    if (process.argv.includes(`--verbose`)) {
+      console.log(
+        `Verbose: This is the error thrown while trying to load "${pluginName}":`,
+        err
+      )
+    }
     throw new Error(
       `Unable to find plugin "${pluginName}". Perhaps you need to install its package?`
     )

--- a/packages/gatsby/src/bootstrap/load-plugins/load.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.ts
@@ -119,7 +119,7 @@ export function resolvePlugin(
       version: packageJSON.version,
     }
   } catch (err) {
-    if (process.argv.includes(`--verbose`)) {
+    if (process.env.gatsby_log_level === `verbose`) {
       reporter.panicOnBuild(
         `plugin "${pluginName} threw the following error:\n`,
         err

--- a/packages/gatsby/src/bootstrap/load-plugins/load.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.ts
@@ -17,6 +17,7 @@ import {
   ISiteConfig,
 } from "./types"
 import { PackageJson } from "../../.."
+import reporter from "gatsby-cli/lib/reporter"
 
 function createFileContentHash(root: string, globPattern: string): string {
   const hash = crypto.createHash(`md5`)
@@ -119,14 +120,16 @@ export function resolvePlugin(
     }
   } catch (err) {
     if (process.argv.includes(`--verbose`)) {
-      console.log(
-        `Verbose: This is the error thrown while trying to load "${pluginName}":`,
+      reporter.panicOnBuild(
+        `plugin "${pluginName} threw the following error:\n`,
         err
       )
+    } else {
+      reporter.panicOnBuild(
+        `There was a problem loading plugin "${pluginName}". Perhaps you need to install its package?\nUse --verbose to see actual error.`
+      )
     }
-    throw new Error(
-      `Unable to find plugin "${pluginName}". Perhaps you need to install its package?`
-    )
+    throw new Error(`unreachable`)
   }
 }
 


### PR DESCRIPTION
Currently we print a very generic "failed to find plugin, are you sure it exists" message when the plugin exists but threw an error. This PR attempts to allow you to at least show the real error in verbose mode.

Without the `--verbose` flag it will show you the current state, with a small tweak to indicate it may have also been a different problem apart from not existing. And a hint that you can get the real error by using verbose mode.

With the `--verbose` flag you get the actual error and its stack trace.