### PR TITLE
Add Deploy on Platform.sh option

### DIFF
--- a/starters/blog/README.md
+++ b/starters/blog/README.md
@@ -99,4 +99,8 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-blog)
 
+<a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
+    <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
+</a>
+
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/starters/blog/README.md
+++ b/starters/blog/README.md
@@ -99,9 +99,6 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-blog)
 
-[![Deploy to Platform.sh](https://platform.sh/images/deploy/sml-blue.svg)](https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform)
-
-
 <a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
     <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
 </a>

--- a/starters/blog/README.md
+++ b/starters/blog/README.md
@@ -99,6 +99,9 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-blog)
 
+[![Deploy to Platform.sh](https://platform.sh/images/deploy/lg-blue.svg)](https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform)
+
+
 <a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
     <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
 </a>

--- a/starters/blog/README.md
+++ b/starters/blog/README.md
@@ -99,7 +99,7 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-blog)
 
-[![Deploy to Platform.sh](https://platform.sh/images/deploy/lg-blue.svg)](https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform)
+[![Deploy to Platform.sh](https://platform.sh/images/deploy/sml-blue.svg)](https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform)
 
 
 <a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/gatsby/.platform.template.yaml&utm_content=gatsby&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">


### PR DESCRIPTION
## Description

We maintain a Gatsby template for Platform.sh based on the `gatsby-starter-blog` project that can be found here [https://github.com/platformsh-templates/gatsby](https://github.com/platformsh-templates/gatsby). We pull regularly from the `gatsby-starter-blog` repo, with the only modifications being the addition of our three configuration files. 

This PR just adds the button already present in our README to this one. 

Many thanks!