### PR TITLE
fix(gatsby): use xhr on pageload for page load

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/dev-loader.js
+++ b/packages/gatsby/cache-dir/__tests__/dev-loader.js
@@ -8,6 +8,8 @@ jest.mock(`../socketIo`, () => {
   return {
     default: jest.fn(),
     getPageData: jest.fn().mockResolvedValue(),
+    savePageDataAndStaticQueries: jest.fn(),
+    hasReceivedSocketIoUpdate: jest.fn(() => false),
   }
 })
 


### PR DESCRIPTION
## Description

Sites with many static queries can overload socket.io which results in a slow develop experience, mostly on Gatsby cloud. By using the page-data logic and saving it inside socket.io cache we can bypass socket.io on first run. We'll still receive data-updates through the socket.
