### PR TITLE
fix(gatsby): better heuristic for automatic cache purging

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -252,8 +252,11 @@ export async function initialize({
   }
   const cacheDirectory = `${program.directory}/.cache`
   const publicDirectory = `${program.directory}/public`
+
+  // .cache directory exists in develop at this point
+  // so checking for .cache/json as a heuristic (could be any expected file)
   const cacheIsCorrupt =
-    fs.existsSync(cacheDirectory) && !fs.existsSync(publicDirectory)
+    fs.existsSync(`${cacheDirectory}/json`) && !fs.existsSync(publicDirectory)
 
   if (cacheIsCorrupt) {
     reporter.info(reporter.stripIndent`


### PR DESCRIPTION
## Description

A follow up for #27549. That PR didn't take into account that the `.cache` directory exists in `develop` by the moment we call `initialize`. In develop the `.cache` directory is actually created here:

https://github.com/gatsbyjs/gatsby/blob/ed31b3583f6f94797697f04b2c887e697c658507/packages/gatsby/src/commands/develop.ts#L99-L102

This PR uses a different heuristic to check for cache presence by just checking for `.cache/json` folder. We ensure this dir exists in the same `initialize` method, so it seems an appropriate target for this check:

https://github.com/gatsbyjs/gatsby/blob/ed31b3583f6f94797697f04b2c887e697c658507/packages/gatsby/src/services/initialize.ts#L315

## Related Issues

Fixes #27641