### PR TITLE
chore(gatsby-plugin-manifest): sync version of gatsby-plugin-utils dependency

### DIFF
--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "gatsby-core-utils": "^1.3.23",
-    "gatsby-plugin-utils": "0.2.35",
+    "gatsby-plugin-utils": "0.2.39",
     "semver": "^7.3.2",
     "sharp": "^0.25.4"
   },

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
@@ -527,8 +527,8 @@ describe(`Test plugin manifest options`, () => {
 })
 
 describe(`pluginOptionsSchema`, () => {
-  it(`validates options correctly`, () => {
-    expect(testPluginOptionsSchema(pluginOptionsSchema, manifestOptions))
+  it(`validates options correctly`, async () => {
+    expect(await testPluginOptionsSchema(pluginOptionsSchema, manifestOptions))
       .toMatchInlineSnapshot(`
       Object {
         "errors": Array [],


### PR DESCRIPTION
After https://github.com/gatsbyjs/gatsby/pull/27565 was merged our `scripts/check-versions` script (it runs on `yarn bootstrap`) that makes sure we rely on latest deps from monorepo started failing:

```sh
➜  gatsby git:(master) yarn check-versions   
yarn run v1.21.0
$ babel-node scripts/check-versions.js
gatsby-plugin-manifest: 
  Depends on "gatsby-plugin-utils@0.2.35" 
  instead of "gatsby-plugin-utils@0.2.39". 

error Command failed with exit code 1.
```

This just bumps the dep version to "latest"