### PR TITLE
File System Route API: Improve example & fix couple of bugs

### DIFF
--- a/benchmarks/gabe-fs-markdown-route-api/package.json
+++ b/benchmarks/gabe-fs-markdown-route-api/package.json
@@ -7,10 +7,10 @@
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {
-    "bench": "rm -rf generated_articles; gatsby clean; N=${N:-512} node gen.js; CI=1 GATSBY_EXPERIMENTAL_ROUTING_APIS=1 node --max_old_space_size=${M:-2}000 node_modules/.bin/gatsby build",
-    "build": "GATSBY_EXPERIMENTAL_ROUTING_APIS=1 gatsby build",
+    "bench": "rm -rf generated_articles; gatsby clean; N=${N:-512} node gen.js; CI=1 node --max_old_space_size=${M:-2}000 node_modules/.bin/gatsby build",
+    "build": "gatsby build",
     "clean": "gatsby clean",
-    "develop": "GATSBY_EXPERIMENTAL_ROUTING_APIS=1 gatsby develop",
+    "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\""
   },
   "devDependencies": {

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "cross-env GATSBY_EXPERIMENTAL_ROUTING_APIS=1 CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=true gatsby develop",
+    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=true gatsby develop",
     "serve": "gatsby serve",
     "start": "npm run develop",
     "format": "prettier --write \"src/**/*.js\"",

--- a/e2e-tests/development-runtime/src/pages/collection-routing/{ImageSharp.parent__(File)__name}.js
+++ b/e2e-tests/development-runtime/src/pages/collection-routing/{ImageSharp.parent__(File)__name}.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link, graphql, unstable_collectionGraphql } from "gatsby"
+import { Link, graphql, collectionGraphql } from "gatsby"
 import Image from "gatsby-image"
 
 import Layout from "../../components/layout"
@@ -33,7 +33,7 @@ export const blogPostQuery = graphql`
 `
 
 // This should filter it down to just a single instance
-export const collectionQuery = unstable_collectionGraphql`
+export const collectionQuery = collectionGraphql`
   {
     allImageSharp(limit: 1, skip: 1) {
       ...CollectionPagesQueryFragment

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -22,8 +22,8 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "cross-env GATSBY_EXPERIMENTAL_ROUTING_APIS=1 CYPRESS_SUPPORT=y gatsby build",
-    "build:offline": "cross-env GATSBY_EXPERIMENTAL_ROUTING_APIS=1 TEST_PLUGIN_OFFLINE=y CYPRESS_SUPPORT=y gatsby build",
+    "build": "cross-env CYPRESS_SUPPORT=y gatsby build",
+    "build:offline": "cross-env TEST_PLUGIN_OFFLINE=y CYPRESS_SUPPORT=y gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write '**/*.js'",
     "serve": "gatsby serve",

--- a/e2e-tests/production-runtime/src/pages/collection-routing/{Product.name}.js
+++ b/e2e-tests/production-runtime/src/pages/collection-routing/{Product.name}.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link, graphql, unstable_collectionGraphql } from "gatsby"
+import { Link, graphql, collectionGraphql } from "gatsby"
 
 import Layout from "../../components/layout"
 
@@ -22,9 +22,9 @@ export const blogPostQuery = graphql`
   }
 `
 
-export const collection = unstable_collectionGraphql`
+export const collection = collectionGraphql`
   {
-    allProduct { 
+    allProduct {
       ...CollectionPagesQueryFragment
     }
   }

--- a/examples/route-api/gatsby-config.js
+++ b/examples/route-api/gatsby-config.js
@@ -24,22 +24,22 @@ module.exports = {
       resolve: `gatsby-source-filesystem`,
       options: {
         path: `${__dirname}/blog`,
-        name: `blog`
-      }
+        name: `blog`,
+      },
     },
     {
       resolve: `gatsby-source-filesystem`,
       options: {
         path: `${__dirname}/products`,
-        name: `products`
-      }
+        name: `products`,
+      },
     },
     {
       resolve: `gatsby-source-filesystem`,
       options: {
         path: `${__dirname}/parks`,
-        name: `parks`
-      }
+        name: `parks`,
+      },
     },
   ],
 }

--- a/examples/route-api/gatsby-config.js
+++ b/examples/route-api/gatsby-config.js
@@ -7,7 +7,17 @@ module.exports = {
     {
       resolve: `gatsby-transformer-yaml`,
       options: {
-        typeName: `Product`,
+        // Conditionally set the typeName so that we both use a lowercased and capitalized type name
+        typeName: ({ node }) => {
+          const name = node.sourceInstanceName
+          if (name === `products`) {
+            return `Product`
+          }
+          if (name === `parks`) {
+            return `park`
+          }
+          return name
+        },
       },
     },
     {
@@ -22,6 +32,13 @@ module.exports = {
       options: {
         path: `${__dirname}/products`,
         name: `products`
+      }
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `${__dirname}/parks`,
+        name: `parks`
       }
     },
   ],

--- a/examples/route-api/package.json
+++ b/examples/route-api/package.json
@@ -5,10 +5,10 @@
   "version": "1.0.0",
   "author": "LekoArts <lekoarts@gmail.com>",
   "dependencies": {
-    "gatsby": "^2.24.67",
-    "gatsby-source-filesystem": "^2.3.32",
-    "gatsby-transformer-remark": "^2.8.37",
-    "gatsby-transformer-yaml": "^2.4.13",
+    "gatsby": "^2.24.87",
+    "gatsby-source-filesystem": "^2.3.36",
+    "gatsby-transformer-remark": "^2.8.46",
+    "gatsby-transformer-yaml": "^2.4.15",
     "react": "^16.3.1",
     "react-dom": "^16.3.1"
   },

--- a/examples/route-api/package.json
+++ b/examples/route-api/package.json
@@ -18,11 +18,8 @@
   "license": "MIT",
   "main": "n/a",
   "scripts": {
-    "develop": "cross-env GATSBY_EXPERIMENTAL_ROUTING_APIS=1 gatsby develop",
-    "build": "cross-env GATSBY_EXPERIMENTAL_ROUTING_APIS=1 gatsby build",
+    "develop": "gatsby develop",
+    "build": "gatsby build",
     "start": "npm run develop"
-  },
-  "devDependencies": {
-    "cross-env": "^7.0.2"
   }
 }

--- a/examples/route-api/parks/park.yaml
+++ b/examples/route-api/parks/park.yaml
@@ -1,0 +1,49 @@
+- name: Fantasyworld
+  description: Fantasyworld is Park Four at Delos Destinations. It appears to be based around a fantasy version of Medieval Europe, with at least one host that looks like a dragon.
+  meta:
+    id: 1
+    location:
+      type: Theme Park
+      place: Park Four
+- name: Medievalworld
+  description: This is Medievalworld, where we have reconstructed 13th-century Europe. A world of chivalry and combat, romance and excitement. Our teams of engineers have spared no expense in this re-creation, precise to the smallest detail.
+  meta:
+    id: 2
+    location:
+      type: Resort
+      place: Resort One
+- name: Park Five
+  description: Park Five seems to be the place where Dolores first encountered Caleb Nichols, when he and his unit were training there. Caleb stopped the other men in his unit from mistreating the female hosts during a break in training.
+  meta:
+    id: 3
+    location:
+      type: Theme Park
+      place: Park Five
+- name: The Raj
+  description: The Raj is park six at Delos Destinations and the first park revealed that doesn't use the "-world" suffix in its name. The park is named after and inspired by the "British Raj", the period between 1858 and 1947 in which the British Crown ruled over the Indian subcontinent.
+  meta:
+    id: 4
+    location:
+      type: Theme Park
+      place: Park Six
+- name: Romanworld
+  description: abc
+  meta:
+    id: 5
+    location:
+      type: Resort
+      place: Resort Two
+- name: Shōgunworld
+  description: Shōgunworld is a Delos destination modeled and influenced by the Edo period in Japan. The world features a strong military presence, reflecting the military rule and political uncertainty of the Japanese period.
+  meta:
+    id: 6
+    location:
+      type: Theme Park
+      place: Park Two
+- name: Westworld
+  description: Westworld is a park owned by Delos Incorporated and was the first park to be built. Guests pay to immerse themselves in a carefully crafted simulation of the American Wild West.
+  meta:
+    id: 7
+    location:
+      type: Theme Park
+      place: Park One

--- a/examples/route-api/src/pages/index.js
+++ b/examples/route-api/src/pages/index.js
@@ -8,7 +8,7 @@ function Index({ data }) {
         <h1>File System Route API</h1>
         <p>
           Please see the{` `}
-          <a href="https://www.gatsbyjs.com/docs/file-system-page-creation">
+          <a href="https://www.gatsbyjs.com/docs/file-system-route-api">
             documentation
           </a>
           {` `}
@@ -62,6 +62,28 @@ function Index({ data }) {
             </li>
           ))}
         </ul>
+        <h3>Nested collections</h3>
+        <p>
+          The example below does a <em>group</em> query on all parks and links to them. The paths are created as nested collections, e.g. to construct a route at <em>/parks/theme-park/park-one/</em>.
+        </p>
+        <div>
+          {data.parks.group.map(field => {
+            const groupName = field.fieldValue
+
+            return (
+              <React.Fragment>
+                <h4>{groupName}</h4>
+                <ul>
+                  {field.nodes.map(park => (
+                    <li key={park.gatsbyPath}>
+                      <Link to={park.gatsbyPath}>{park.name}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </React.Fragment>
+            )
+          })}
+        </div>
         <h2>Client-Only routes</h2>
         <p>
           As shortly mentioned for the "Collection routes" the{` `}
@@ -109,6 +131,15 @@ export const query = graphql`
           ... on File {
             name
           }
+        }
+      }
+    }
+    parks: allPark {
+      group(field: meta___location___type) {
+        fieldValue
+        nodes {
+          name
+          gatsbyPath(filePath: "/parks/{park.meta__location__type}/{park.name}")
         }
       }
     }

--- a/examples/route-api/src/pages/index.js
+++ b/examples/route-api/src/pages/index.js
@@ -64,7 +64,9 @@ function Index({ data }) {
         </ul>
         <h3>collectionGraphql</h3>
         <p>
-          The example below is a list of parks that are all <em>not</em> the type of <em>Resort</em>. By using <em>collectionGraphql</em> the GraphQL query for creating the routes was adapted.
+          The example below is a list of parks that are all <em>not</em> the
+          type of <em>Resort</em>. By using <em>collectionGraphql</em> the
+          GraphQL query for creating the routes was adapted.
         </p>
         <ul>
           {data.parksFragment.nodes.map(park => (
@@ -75,18 +77,25 @@ function Index({ data }) {
         </ul>
         <h3>Nested collections</h3>
         <p>
-          The example below does a <em>group</em> query on all parks and links to them. The paths are created as nested collections, e.g. to construct a route at <em>/parks/theme-park/park-one/</em>.
+          The example below does a <em>group</em> query on all parks and links
+          to them. The paths are created as nested collections, e.g. to
+          construct a route at <em>/parks/theme-park/park-one/</em>.
         </p>
         <div>
           {data.parks.group.map(field => {
             const groupName = field.fieldValue
-            const inValidLinkPrefix = groupName === `Resort` ? `/parks/resort/` : `/parks/theme-park/`
+            const inValidLinkPrefix =
+              groupName === `Resort` ? `/parks/resort/` : `/parks/theme-park/`
 
             return (
               <React.Fragment>
                 <h4>{groupName}</h4>
                 <ul>
-                  <li><Link to={`${inValidLinkPrefix}hogwarts`}>Non-existing {groupName}</Link></li>
+                  <li>
+                    <Link to={`${inValidLinkPrefix}hogwarts`}>
+                      Non-existing {groupName}
+                    </Link>
+                  </li>
                   {field.nodes.map(park => (
                     <li key={park.gatsbyPath}>
                       <Link to={park.gatsbyPath}>{park.name}</Link>
@@ -156,7 +165,9 @@ export const query = graphql`
         }
       }
     }
-    parksFragment: allPark(filter: {meta: {location: {type: {ne: "Resort"}}}}) {
+    parksFragment: allPark(
+      filter: { meta: { location: { type: { ne: "Resort" } } } }
+    ) {
       nodes {
         name
         gatsbyPath(filePath: "/parks/{park.name}")

--- a/examples/route-api/src/pages/index.js
+++ b/examples/route-api/src/pages/index.js
@@ -62,6 +62,17 @@ function Index({ data }) {
             </li>
           ))}
         </ul>
+        <h3>collectionGraphql</h3>
+        <p>
+          The example below is a list of parks that are all <em>not</em> the type of <em>Resort</em>. By using <em>collectionGraphql</em> the GraphQL query for creating the routes was adapted.
+        </p>
+        <ul>
+          {data.parksFragment.nodes.map(park => (
+            <li key={park.name}>
+              <Link to={park.gatsbyPath}>{park.name}</Link>
+            </li>
+          ))}
+        </ul>
         <h3>Nested collections</h3>
         <p>
           The example below does a <em>group</em> query on all parks and links to them. The paths are created as nested collections, e.g. to construct a route at <em>/parks/theme-park/park-one/</em>.
@@ -69,11 +80,13 @@ function Index({ data }) {
         <div>
           {data.parks.group.map(field => {
             const groupName = field.fieldValue
+            const inValidLinkPrefix = groupName === `Resort` ? `/parks/resort/` : `/parks/theme-park/`
 
             return (
               <React.Fragment>
                 <h4>{groupName}</h4>
                 <ul>
+                  <li><Link to={`${inValidLinkPrefix}hogwarts`}>Non-existing {groupName}</Link></li>
                   {field.nodes.map(park => (
                     <li key={park.gatsbyPath}>
                       <Link to={park.gatsbyPath}>{park.name}</Link>
@@ -141,6 +154,12 @@ export const query = graphql`
           name
           gatsbyPath(filePath: "/parks/{park.meta__location__type}/{park.name}")
         }
+      }
+    }
+    parksFragment: allPark(filter: {meta: {location: {type: {ne: "Resort"}}}}) {
+      nodes {
+        name
+        gatsbyPath(filePath: "/parks/{park.name}")
       }
     }
   }

--- a/examples/route-api/src/pages/parks/{park.meta__location__type}/[name].js
+++ b/examples/route-api/src/pages/parks/{park.meta__location__type}/[name].js
@@ -1,0 +1,18 @@
+import * as React from "react"
+import { Link } from "gatsby"
+
+function NonExistingPark({ params, pageContext }) {
+  return (
+    <div className="wrapper">
+      <header>
+        <Link to="/">Go back to "Home"</Link>
+      </header>
+      <main>
+        <h1>Couldn't find the {pageContext.meta__location__type}</h1>
+        <p>We couldn't locate "{params.name}"</p>
+      </main>
+    </div>
+  )
+}
+
+export default NonExistingPark

--- a/examples/route-api/src/pages/parks/{park.meta__location__type}/{park.name}.js
+++ b/examples/route-api/src/pages/parks/{park.meta__location__type}/{park.name}.js
@@ -1,0 +1,26 @@
+import * as React from "react"
+import { graphql } from "gatsby"
+import ParkView from "../../../views/park-view"
+
+function ParkLocationPlace(props) {
+  const { park } = props.data
+  return <ParkView park={park} />
+}
+
+export default ParkLocationPlace
+
+export const query = graphql`
+  query($id: String!) {
+    park(id: { eq: $id }) {
+      name
+      description
+      meta {
+        id
+        location {
+          type
+          place
+        }
+      }
+    }
+  }
+`

--- a/examples/route-api/src/pages/parks/{park.name}.js
+++ b/examples/route-api/src/pages/parks/{park.name}.js
@@ -1,0 +1,26 @@
+import * as React from "react"
+import { graphql } from "gatsby"
+import ParkView from "../../views/park-view"
+
+function ParkName(props) {
+  const { park } = props.data
+  return <ParkView park={park} />
+}
+
+export default ParkName
+
+export const query = graphql`
+  query($id: String!) {
+    park(id: { eq: $id }) {
+      name
+      description
+      meta {
+        id
+        location {
+          type
+          place
+        }
+      }
+    }
+  }
+`

--- a/examples/route-api/src/pages/parks/{park.name}.js
+++ b/examples/route-api/src/pages/parks/{park.name}.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { graphql } from "gatsby"
+import { graphql, collectionGraphql } from "gatsby"
 import ParkView from "../../views/park-view"
 
 function ParkName(props) {
@@ -8,6 +8,13 @@ function ParkName(props) {
 }
 
 export default ParkName
+
+export const collectionQuery = collectionGraphql`
+{
+  allPark(filter: {meta: {location: {type: {ne: "Resort"}}}}) {
+    ...CollectionPagesQueryFragment
+  }
+}`
 
 export const query = graphql`
   query($id: String!) {

--- a/examples/route-api/src/views/park-view.js
+++ b/examples/route-api/src/views/park-view.js
@@ -9,10 +9,10 @@ function ParkView({ park }) {
       </header>
       <main>
         <h1>{park.name}</h1>
+        <p>{park.description}</p>
         <p>
-          {park.description}
+          Location: {park.meta.location.place} ({park.meta.location.type})
         </p>
-        <p>Location: {park.meta.location.place} ({park.meta.location.type})</p>
       </main>
       <footer>Delos Corporation.</footer>
     </div>

--- a/examples/route-api/src/views/park-view.js
+++ b/examples/route-api/src/views/park-view.js
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { Link } from "gatsby"
+
+function ParkView({ park }) {
+  return (
+    <div className="wrapper">
+      <header>
+        <Link to="/">Go back to "Home"</Link>
+      </header>
+      <main>
+        <h1>{park.name}</h1>
+        <p>
+          {park.description}
+        </p>
+        <p>Location: {park.meta.location.place} ({park.meta.location.type})</p>
+      </main>
+      <footer>Delos Corporation.</footer>
+    </div>
+  )
+}
+
+export default ParkView

--- a/packages/gatsby-plugin-page-creator/src/__tests__/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/collection-extract-query-string.ts
@@ -22,7 +22,7 @@ describe(`collectionExtractQueryString`, () => {
     // @ts-ignore
     patchReadFileSync(`
       import { graphql } from "gatsby"
-      export const pageQuery = graphql\`  
+      export const pageQuery = graphql\`
         { allThings(filter: { name: { nin: ["stuff"] }}) { nodes, id } }
       \`
       `)
@@ -35,10 +35,10 @@ describe(`collectionExtractQueryString`, () => {
     expect(query).toMatchInlineSnapshot(`"{allProduct{nodes{name,id}}}"`)
   })
 
-  it(`uses unstable_collectionGraphql if exported`, async () => {
+  it(`uses collectionGraphql if exported`, async () => {
     patchReadFileSync(`
-      import { unstable_collectionGraphql } from "gatsby"
-      export const collectionQuery = unstable_collectionGraphql\`  
+      import { collectionGraphql } from "gatsby"
+      export const collectionQuery = collectionGraphql\`
         { allThings(filter: { name: { nin: ["stuff"] }}) { ...CollectionPagesQueryFragment } }
       \`
       `)
@@ -55,8 +55,8 @@ describe(`collectionExtractQueryString`, () => {
 
   it(`reports an error if you forget the fragment`, async () => {
     patchReadFileSync(`
-      import { unstable_collectionGraphql } from "gatsby"
-      export const collectionQuery = unstable_collectionGraphql\`  
+      import { collectionGraphql } from "gatsby"
+      export const collectionQuery = collectionGraphql\`
         { allThings(filter: { name: { nin: ["stuff"] }}) { nodes { id } } }
       \`
       `)

--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -25,6 +25,26 @@ describe(`derive-path`, () => {
     ).toEqual(`product/1`)
   })
 
+  it(`has support for nested collections`, () => {
+    expect(
+      derivePath(
+        `product/{Product.id}/{Product.field__name}.js`,
+        { id: 1, field: { name: `foo` } },
+        reporter
+      )
+    ).toEqual(`product/1/foo`)
+  })
+
+  it(`has support for nested collections with same field`, () => {
+    expect(
+      derivePath(
+        `product/{Product.field__name}/{Product.field__category}.js`,
+        { field: { name: `foo`, category: `bar` } },
+        reporter
+      )
+    ).toEqual(`product/foo/bar`)
+  })
+
   it(`has union support`, () => {
     expect(
       derivePath(

--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -7,6 +7,9 @@ describe(`derive-path`, () => {
     expect(
       derivePath(`product/{Product.id}.js`, { id: `1` }, reporter)
     ).toEqual(`product/1`)
+    expect(
+      derivePath(`product/{product.id}.js`, { id: `1` }, reporter)
+    ).toEqual(`product/1`)
   })
 
   it(`converts number to string in URL`, () => {

--- a/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
@@ -27,7 +27,25 @@ describe(`extract query`, () => {
       ).toBe(`{allContentfulType{nodes{id}}}`)
     })
 
-    it(`works with different file extsnions`, () => {
+    it(`handles model name with underscore`, () => {
+      expect(
+        generateQueryFromString(
+          `_customType`,
+          compatiblePath(`/foo/{_customType.id}.js`)
+        )
+      ).toBe(`{allCustomType{nodes{id}}}`)
+    })
+
+    it(`handles model name with number`, () => {
+      expect(
+        generateQueryFromString(
+          `Type123`,
+          compatiblePath(`/foo/{Type123.id}.js`)
+        )
+      ).toBe(`{allType123{nodes{id}}}`)
+    })
+
+    it(`works with different file extensions`, () => {
       expect(
         generateQueryFromString(
           `Thing`,
@@ -36,7 +54,7 @@ describe(`extract query`, () => {
       ).toBe(`{allThing{nodes{id}}}`)
     })
 
-    it(`works with arguments arguments`, () => {
+    it(`works with arguments`, () => {
       expect(
         generateQueryFromString(
           `{ allThing(filter: { main_url: { nin: [] }}) { ...CollectionPagesQueryFragment } }`,
@@ -107,6 +125,14 @@ describe(`extract query`, () => {
           compatiblePath(`/foo/bar/{Thing.id}/{Thing.fields__name__thing}.js`)
         )
       ).toBe(`{allThing{nodes{id,fields{name{thing}}}}}`)
+      expect(
+        generateQueryFromString(
+          `customType`,
+          compatiblePath(
+            `/foo/bar/{customType.id}/{customType.fields__name__thing}.js`
+          )
+        )
+      ).toBe(`{allCustomType{nodes{id,fields{name{thing}}}}}`)
     })
 
     it(`supports graphql unions`, () => {
@@ -145,6 +171,14 @@ describe(`reverseLookupParams`, () => {
     ).toEqual({
       id: `foo`,
     })
+    expect(
+      reverseLookupParams(
+        { id: `foo`, otherProp: `bar` },
+        compatiblePath(`/{model.id}.js`)
+      )
+    ).toEqual({
+      id: `foo`,
+    })
   })
 
   it(`handles multiple depth items`, () => {
@@ -152,6 +186,14 @@ describe(`reverseLookupParams`, () => {
       reverseLookupParams(
         { fields: { name: `foo` } },
         compatiblePath(`/{Model.fields__name}.js`)
+      )
+    ).toEqual({
+      fields__name: `foo`,
+    })
+    expect(
+      reverseLookupParams(
+        { fields: { name: `foo` } },
+        compatiblePath(`/{_model.fields__name}.js`)
       )
     ).toEqual({
       fields__name: `foo`,
@@ -164,6 +206,15 @@ describe(`reverseLookupParams`, () => {
         // Unions are not present in the resulting structure
         { parent: { relativePath: `foo` } },
         compatiblePath(`/{Model.parent__(File)__relativePath}.js`)
+      )
+    ).toEqual({
+      parent__relativePath: `foo`,
+    })
+    expect(
+      reverseLookupParams(
+        // Unions are not present in the resulting structure
+        { parent: { relativePath: `foo` } },
+        compatiblePath(`/{model123.parent__(File)__relativePath}.js`)
       )
     ).toEqual({
       parent__relativePath: `foo`,

--- a/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
@@ -118,6 +118,17 @@ describe(`extract query`, () => {
       ).toBe(`{allThing{nodes{id,fields{name}}}}`)
     })
 
+    it(`multiple nested nodes`, () => {
+      expect(
+        generateQueryFromString(
+          `thing`,
+          compatiblePath(
+            `/foo/bar/{thing.fields__name}/{thing.fields__description}.js`
+          )
+        )
+      ).toBe(`{allThing{nodes{fields{name},fields{description},id}}}`)
+    })
+
     it(`deeply nested nodes`, () => {
       expect(
         generateQueryFromString(

--- a/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
@@ -18,6 +18,15 @@ describe(`extract query`, () => {
       ).toBe(`{allThing{nodes{id}}}`)
     })
 
+    it(`handles lowercased model name`, () => {
+      expect(
+        generateQueryFromString(
+          `contentfulType`,
+          compatiblePath(`/foo/{contentfulType.id}.js`)
+        )
+      ).toBe(`{allContentfulType{nodes{id}}}`)
+    })
+
     it(`works with different file extsnions`, () => {
       expect(
         generateQueryFromString(

--- a/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
@@ -45,6 +45,21 @@ describe(`extract query`, () => {
       ).toBe(`{allType123{nodes{id}}}`)
     })
 
+    it(`handles fields with number or underscore`, () => {
+      expect(
+        generateQueryFromString(
+          `_type123`,
+          compatiblePath(`/foo/{_type123.field123}.js`)
+        )
+      ).toBe(`{allType123{nodes{field123,id}}}`)
+      expect(
+        generateQueryFromString(
+          `_type123`,
+          compatiblePath(`/foo/{_type123._field123}.js`)
+        )
+      ).toBe(`{allType123{nodes{_field123,id}}}`)
+    })
+
     it(`works with different file extensions`, () => {
       expect(
         generateQueryFromString(

--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -18,6 +18,10 @@ describe(`isValidCollectionPathImplementation`, () => {
     `{model.bar__field}.js`,
     `{model.bar__(Union)__field}.js`,
     `{_model123.bar}.js`,
+    `{model.bar123}.js`,
+    `{model.bar_123}.js`,
+    `{model.bar__field123}.js`,
+    `{model.bar__(Union)__field123}.js`,
   ])(`%o passes`, path => {
     expect(() =>
       isValidCollectionPathImplementation(compatiblePath(path), reporter)
@@ -30,6 +34,8 @@ describe(`isValidCollectionPathImplementation`, () => {
     `/products/{Model:bar}`,
     `/products/{Model.bar.js`,
     `/products/{Model_bar}.js`,
+    `/products/{123Model.bar}.js`,
+    `/products/{Model.123bar}.js`,
   ])(`%o throws as expected`, path => {
     const part = path.split(`/`)[2]
 

--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -11,21 +11,25 @@ const compatiblePath = (filepath: string): string =>
   filepath.replace(/\//g, syspath.sep)
 
 describe(`isValidCollectionPathImplementation`, () => {
-  it.each([`{Model.bar}/{Model.bar}.js`, `{Model.bar__(Union)__field}.js`])(
-    `%o passes`,
-    path => {
-      expect(() =>
-        isValidCollectionPathImplementation(compatiblePath(path), reporter)
-      ).not.toThrow()
-    }
-  )
+  it.each([
+    `{Model.bar}/{Model.bar}.js`,
+    `{Model.bar__(Union)__field}.js`,
+    `{model.bar}.js`,
+    `{model.bar__field}.js`,
+    `{model.bar__(Union)__field}.js`,
+    `{_model123.bar}.js`,
+  ])(`%o passes`, path => {
+    expect(() =>
+      isValidCollectionPathImplementation(compatiblePath(path), reporter)
+    ).not.toThrow()
+  })
 
   it.each([
     `/products/{bar}`,
-    `/products/{missingCapitalization.bar}`,
     `/products/{Model.}`,
     `/products/{Model:bar}`,
     `/products/{Model.bar.js`,
+    `/products/{Model_bar}.js`,
   ])(`%o throws as expected`, path => {
     const part = path.split(`/`)[2]
 

--- a/packages/gatsby-plugin-page-creator/src/babel-remove-collection-graphql.ts
+++ b/packages/gatsby-plugin-page-creator/src/babel-remove-collection-graphql.ts
@@ -1,0 +1,171 @@
+import { NodePath, PluginObj } from "@babel/core"
+import { Binding } from "@babel/traverse"
+import {
+  CallExpression,
+  Expression,
+  Identifier,
+  ImportDeclaration,
+  ObjectExpression,
+  Program,
+  StringLiteral,
+  TaggedTemplateExpression,
+} from "@babel/types"
+
+interface IGraphQLTag {
+  isGlobal: boolean
+}
+
+const isGlobalIdentifier = (
+  tag: NodePath,
+  tagName: string = `graphql`
+): boolean =>
+  tag.isIdentifier({ name: tagName }) && tag.scope.hasGlobal(tagName)
+
+export function followVariableDeclarations(binding: Binding): Binding {
+  const node = binding.path?.node
+  if (
+    node?.type === `VariableDeclarator` &&
+    node?.id.type === `Identifier` &&
+    node?.init?.type === `Identifier`
+  ) {
+    return followVariableDeclarations(
+      binding.path.scope.getBinding(node.init.name) as Binding
+    )
+  }
+  return binding
+}
+
+function getTagImport(tag: NodePath<Identifier>): NodePath | null {
+  const name = tag.node.name
+  const binding = tag.scope.getBinding(name)
+
+  if (!binding) return null
+
+  const path = binding.path
+  const parent = path.parentPath
+
+  if (
+    binding.kind === `module` &&
+    parent.isImportDeclaration() &&
+    parent.node.source.value === `gatsby`
+  )
+    return path
+
+  if (
+    path.isVariableDeclarator() &&
+    (path.get(`init`) as NodePath).isCallExpression() &&
+    (path.get(`init.callee`) as NodePath).isIdentifier({ name: `require` }) &&
+    ((path.get(`init`) as NodePath<CallExpression>).node
+      .arguments[0] as StringLiteral).value === `gatsby`
+  ) {
+    const id = path.get(`id`) as NodePath
+    if (id.isObjectPattern()) {
+      return id
+        .get(`properties`)
+        .find(
+          path => (path.get(`value`) as NodePath<Identifier>).node.name === name
+        ) as NodePath
+    }
+    return id
+  }
+  return null
+}
+
+function isGraphqlTag(tag: NodePath, tagName: string = `graphql`): boolean {
+  const isExpression = tag.isMemberExpression()
+  const identifier = isExpression ? tag.get(`object`) : tag
+
+  const importPath = getTagImport(identifier as NodePath<Identifier>)
+  if (!importPath) return isGlobalIdentifier(tag, tagName)
+
+  if (
+    isExpression &&
+    (importPath.isImportNamespaceSpecifier() || importPath.isIdentifier())
+  ) {
+    return (tag.get(`property`) as NodePath<Identifier>).node.name === tagName
+  }
+
+  if (importPath.isImportSpecifier())
+    return importPath.node.imported.name === tagName
+
+  if (importPath.isObjectProperty())
+    return (importPath.get(`key`) as NodePath<Identifier>).node.name === tagName
+
+  return false
+}
+
+function getGraphQLTag(
+  path: NodePath<TaggedTemplateExpression>,
+  tagName: string = `graphql`
+): IGraphQLTag {
+  const tag: NodePath = path.get(`tag`) as NodePath
+  const isGlobal: boolean = isGlobalIdentifier(tag, tagName)
+
+  if (!isGlobal && !isGraphqlTag(tag, tagName)) return {} as IGraphQLTag
+
+  return {
+    isGlobal,
+  }
+}
+
+function removeImport(tag: NodePath<Expression>): void {
+  const isExpression = tag.isMemberExpression()
+  const identifier = isExpression ? tag.get(`object`) : tag
+  const importPath = getTagImport(identifier as NodePath<Identifier>)
+
+  const removeVariableDeclaration = (statement: NodePath): void => {
+    const declaration = statement.findParent((p: NodePath) =>
+      p.isVariableDeclaration()
+    )
+    if (declaration) {
+      declaration.remove()
+    }
+  }
+
+  if (!importPath) return
+
+  const parent = importPath.parentPath
+
+  if (importPath.isImportSpecifier()) {
+    if ((parent as NodePath<ImportDeclaration>).node.specifiers.length === 1) {
+      parent.remove()
+    } else importPath.remove()
+  }
+  if (importPath.isObjectProperty()) {
+    if ((parent as NodePath<ObjectExpression>).node.properties.length === 1) {
+      removeVariableDeclaration(importPath)
+    } else importPath.remove()
+  }
+  if (importPath.isIdentifier()) {
+    removeVariableDeclaration(importPath)
+  }
+}
+
+export default function ({ types: t }): PluginObj {
+  return {
+    visitor: {
+      Program(path: NodePath<Program>): void {
+        const tagsToRemoveImportsFrom = new Set<NodePath<Expression>>()
+
+        path.traverse({
+          TaggedTemplateExpression(path2: NodePath<TaggedTemplateExpression>) {
+            const { isGlobal } = getGraphQLTag(path2, `collectionGraphql`)
+
+            const tag = path2.get(`tag`)
+            if (!isGlobal) {
+              // Enqueue import removal. If we would remove it here, subsequent named exports
+              // wouldn't be handled properly
+              tagsToRemoveImportsFrom.add(tag)
+            }
+
+            // Replace the query with an empty string
+            path2.replaceWith(t.StringLiteral(``))
+            return null
+          },
+        })
+
+        tagsToRemoveImportsFrom.forEach(removeImport)
+      },
+    },
+  }
+}

--- a/packages/gatsby-plugin-page-creator/src/babel-remove-collection-graphql.ts
+++ b/packages/gatsby-plugin-page-creator/src/babel-remove-collection-graphql.ts
@@ -1,3 +1,6 @@
+// Taken from `babel-plugin-remove-graphql-queries`
+// In the future import from there
+
 import { NodePath, PluginObj } from "@babel/core"
 import { Binding } from "@babel/traverse"
 import {

--- a/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
@@ -21,12 +21,12 @@ export function collectionExtractQueryString(
   // so it can hit this case.
   if (!modelType) return null
 
-  // 1.  Read the file and scan for a use of unstable_collectionGraphql
+  // 1.  Read the file and scan for a use of collectionGraphql
   const fileContents = fs.readFileSync(absolutePath).toString()
 
   // 2.  If the user is using the collectionGraphql function, we have to
   //     parse the file and extract it's contents
-  if (fileContents.includes(`unstable_collectionGraphql`)) {
+  if (fileContents.includes(`collectionGraphql`)) {
     const ast = babelParseToAst(fileContents, absolutePath)
 
     traverse(ast, {
@@ -36,7 +36,7 @@ export function collectionExtractQueryString(
         }
         path.traverse({
           TaggedTemplateExpression(path) {
-            const { text } = getGraphQLTag(path, `unstable_collectionGraphql`)
+            const { text } = getGraphQLTag(path, `collectionGraphql`)
             if (!text) return
 
             if (text.includes(`...CollectionPagesQueryFragment`) === false) {

--- a/packages/gatsby-plugin-page-creator/src/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/extract-query.ts
@@ -20,7 +20,11 @@ export function generateQueryFromString(
     return fragmentInterpolator(queryOrModel, fields)
   }
 
-  return `{all${queryOrModel}{nodes{${fields}}}}`
+  // In case queryOrModel is not capitalized
+  const connectionQuery = _.camelCase(`all ${queryOrModel}`)
+  console.log(fields)
+
+  return `{${connectionQuery}{nodes{${fields}}}}`
 }
 
 // Takes a query result of something like `{ fields: { value: 'foo' }}` with a filepath of `/fields__value` and

--- a/packages/gatsby-plugin-page-creator/src/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/extract-query.ts
@@ -15,6 +15,7 @@ export function generateQueryFromString(
   queryOrModel: string,
   fileAbsolutePath: string
 ): string {
+  // TODO: 'fields' possibly contains duplicate fields, e.g. field{name},field{description} that should be merged to field{name,description}
   const fields = extractUrlParamsForQuery(fileAbsolutePath)
   if (queryOrModel.includes(`...CollectionPagesQueryFragment`)) {
     return fragmentInterpolator(queryOrModel, fields)

--- a/packages/gatsby-plugin-page-creator/src/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/extract-query.ts
@@ -22,7 +22,6 @@ export function generateQueryFromString(
 
   // In case queryOrModel is not capitalized
   const connectionQuery = _.camelCase(`all ${queryOrModel}`)
-  console.log(fields)
 
   return `{${connectionQuery}{nodes{${fields}}}}`
 }

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -197,6 +197,16 @@ export function setFieldsOnGraphQLNodeType({
   }
 }
 
+export function onCreateBabelConfig({ stage, actions }): void {
+  if (stage === `develop` || stage === `develop-html`) {
+    return
+  }
+
+  actions.setBabelPlugin({
+    name: require.resolve(`./babel-remove-collection-graphql`),
+  })
+}
+
 export async function onPreInit(
   { reporter }: ParentSpanPluginArgs,
   { path: pagesPath }: IOptions

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -25,7 +25,7 @@ export function isValidCollectionPathImplementation(
 
     try {
       assert(opener, `{`, ``) // This is a noop because of the opening check, but here for posterity
-      assert(model, /^[A-Z][a-zA-Z]+$/, errorMessage(part))
+      assert(model, /^[a-zA-Z_][a-zA-Z0-9_]+$/, errorMessage(part))
       assert(field, /^[a-zA-Z_()]+$/, errorMessage(part))
       assert(closer, `}`, errorMessage(part))
     } catch (e) {

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -19,14 +19,14 @@ export function isValidCollectionPathImplementation(
     if (!part.startsWith(`{`)) return
 
     const opener = part.slice(0)
-    const model = part.match(/{([a-zA-Z]+)./)?.[1]!
-    const field = part.match(/\.([a-zA-Z_()]+)}/)?.[1]!
+    const model = part.match(/{([a-zA-Z_][\w]+)./)?.[1]!
+    const field = part.match(/\.([a-zA-Z_][\w_()]+)}/)?.[1]!
     const closer = part.match(/\}/)?.[0]!
 
     try {
       assert(opener, `{`, ``) // This is a noop because of the opening check, but here for posterity
-      assert(model, /^[\w_][\w\d_]+$/, errorMessage(part))
-      assert(field, /^[a-zA-Z_()]+$/, errorMessage(part))
+      assert(model, /^[a-zA-Z_][\w]+$/, errorMessage(part))
+      assert(field, /^[a-zA-Z_][\w_()]+$/, errorMessage(part))
       assert(closer, `}`, errorMessage(part))
     } catch (e) {
       reporter.panicOnBuild({

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -25,7 +25,7 @@ export function isValidCollectionPathImplementation(
 
     try {
       assert(opener, `{`, ``) // This is a noop because of the opening check, but here for posterity
-      assert(model, /^[a-zA-Z_][a-zA-Z0-9_]+$/, errorMessage(part))
+      assert(model, /^[\w_][\w\d_]+$/, errorMessage(part))
       assert(field, /^[a-zA-Z_()]+$/, errorMessage(part))
       assert(closer, `}`, errorMessage(part))
     } catch (e) {

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -53,7 +53,7 @@ export function extractFieldWithoutUnion(filePart: string): string {
 }
 
 const extractFieldRegexCurlyBraces = /[{}]/g
-const extractFieldGraphQLModel = /[a-zA-Z_][a-zA-Z0-9_]+\./
+const extractFieldGraphQLModel = /[\w_][\w\d_]+\./
 
 // Given a filePath part that is a collection marker it do this transformation:
 // {Model.field__(Union)__bar} => field__(Union)__bar

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -48,12 +48,16 @@ export function extractFieldWithoutUnion(filePart: string): string {
 
 // Given a filePath part that is a collection marker it do this transformation:
 // {Model.field__(Union)__bar} => field__(Union)__bar
+// Also works with lowercased model
+// {model.field} => field
 export function extractField(filePart: string): string {
   return (
     filePart
+      // Remove curly braces
       .replace(/(\{|\})/g, ``)
       // Remove Model
-      .replace(/[A-Z][a-zA-Z]+\./, ``)
+      // Regex created with: https://spec.graphql.org/draft/#sec-Names
+      .replace(/[a-zA-Z_][a-zA-Z0-9_]+\./, ``)
   )
 }
 

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -1,4 +1,6 @@
-const extractModelRegex = /\{([\w\d_]+)\./
+// Regex created with: https://spec.graphql.org/draft/#sec-Names
+// First char only letter, underscore; rest letter, underscore, digit
+const extractModelRegex = /\{([a-zA-Z_][\w]+)\./
 
 // Given a absolutePath that has a collection marker it will extract the Model.
 // /foo/bar/{Model.bar} => Model
@@ -53,7 +55,9 @@ export function extractFieldWithoutUnion(filePart: string): string {
 }
 
 const extractFieldRegexCurlyBraces = /[{}]/g
-const extractFieldGraphQLModel = /[\w_][\w\d_]+\./
+// Regex created with: https://spec.graphql.org/draft/#sec-Names
+// First char only letter, underscore; rest letter, underscore, digit
+const extractFieldGraphQLModel = /[a-zA-Z_][\w]+\./
 
 // Given a filePath part that is a collection marker it do this transformation:
 // {Model.field__(Union)__bar} => field__(Union)__bar
@@ -65,7 +69,6 @@ export function extractField(filePart: string): string {
       // Remove curly braces
       .replace(extractFieldRegexCurlyBraces, ``)
       // Remove Model
-      // Regex created with: https://spec.graphql.org/draft/#sec-Names
       .replace(extractFieldGraphQLModel, ``)
   )
 }

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -1,4 +1,4 @@
-const extractModelRegex = /\{([a-zA-Z]+)\./
+const extractModelRegex = /\{([\w\d_]+)\./
 
 // Given a absolutePath that has a collection marker it will extract the Model.
 // /foo/bar/{Model.bar} => Model
@@ -52,7 +52,7 @@ export function extractFieldWithoutUnion(filePart: string): string {
   )
 }
 
-const extractFieldRegexCurlyBraces = /(\{|\})/g
+const extractFieldRegexCurlyBraces = /[{}]/g
 const extractFieldGraphQLModel = /[a-zA-Z_][a-zA-Z0-9_]+\./
 
 // Given a filePath part that is a collection marker it do this transformation:

--- a/packages/gatsby/cache-dir/gatsby-browser-entry.js
+++ b/packages/gatsby/cache-dir/gatsby-browser-entry.js
@@ -98,7 +98,7 @@ function graphql() {
   )
 }
 
-function unstable_collectionGraphql() {
+function collectionGraphql() {
   // TODO: Strip this out of the component and throw error if it gets called
   return null
 }
@@ -119,6 +119,5 @@ export {
   PageRenderer,
   useStaticQuery,
   prefetchPathname,
-  // Experimental API
-  unstable_collectionGraphql,
+  collectionGraphql,
 }

--- a/packages/gatsby/cache-dir/gatsby-browser-entry.js
+++ b/packages/gatsby/cache-dir/gatsby-browser-entry.js
@@ -99,8 +99,12 @@ function graphql() {
 }
 
 function collectionGraphql() {
-  // TODO: Strip this out of the component and throw error if it gets called
-  return null
+  throw new Error(
+    `It appears like Gatsby is misconfigured. Gatsby related \`collectionGraphql\` calls ` +
+      `are supposed to only be evaluated at compile time, and then compiled away. ` +
+      `Unfortunately, something went wrong and the query was left in the compiled code.\n\n` +
+      `Unless your site has a complex or custom babel/Gatsby configuration this is likely a bug in Gatsby.`
+  )
 }
 
 export {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -176,13 +176,13 @@ export class StaticQuery<T = any> extends React.Component<
 export const graphql: (query: TemplateStringsArray) => void
 
 /**
- * graphql is a tag function. Behind the scenes Gatsby handles these tags in a particular way
+ * collectionGraphql is a tag function. Behind the scenes Gatsby handles these tags in a particular way
  *
  * During the Gatsby build process, GraphQL queries are pulled out of the original source for parsing.
  *
  * @see https://www.gatsbyjs.org/docs/page-query#how-does-the-graphql-tag-work
  */
-export const unstable_collectionGraphql: (query: TemplateStringsArray) => void
+export const collectionGraphql: (query: TemplateStringsArray) => void
 
 /**
  * Gatsby configuration API.

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
@@ -96,6 +96,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -114,6 +115,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -132,6 +134,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -150,6 +153,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -168,6 +172,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -186,6 +191,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -236,6 +242,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -358,6 +365,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -376,6 +384,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -394,6 +403,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -412,6 +422,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -430,6 +441,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -448,6 +460,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -466,6 +479,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -516,6 +530,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -626,6 +641,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -646,6 +662,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -664,6 +681,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -682,6 +700,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -700,6 +719,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -718,6 +738,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -736,6 +757,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -754,6 +776,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {
@@ -804,6 +827,7 @@ Array [
     "nodeAPIs": Array [
       "createPagesStatefully",
       "setFieldsOnGraphQLNodeType",
+      "onCreateBabelConfig",
       "onPreInit",
     ],
     "pluginOptions": Object {


### PR DESCRIPTION
## Description

Part of https://github.com/gatsbyjs/gatsby/pull/27424

In the process of updating the example I've also fixed some bugs and did some necessary changes for GA. List of changes:

- Removed the `GATSBY_EXPERIMENTAL_ROUTING_APIS` flag from any scripts (benchmarks and example)
- Renamed `unstable_collectionGraphql` to `collectionGraphql`
- Updated the example:
	- Latest dependencies
	- Added a new type called "park" to demonstrate lowercased types
	- Added examples for `/{Model.id__field}/{Model.name}`, `/{Model.id__field}/[name]`, `collectionGraphql`
- Changed `generateQueryFromString` in `extract-query.ts` to account for lowercased type names by using lodash camelCase
	- Changed `isValidCollectionPathImplementation` to also account for that
- Changes in `path-utils`
	- Moved the regex out to variables
	- Changed the regex of `extractAllCollectionSegments` to make the function actually do what it was supposed to do (previously buggy)
- Add tests for fixes to bugs

---

[ch17903]
[ch17949]
[ch16064]
[ch17951]