### PR TITLE
fix(gatsby): leak less in chokidar listeners

### DIFF
--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -43,9 +43,7 @@ const createPageId = path => `SitePage ${path}`
 
 exports.sourceNodes = ({ createContentDigest, actions, store }) => {
   const { createNode } = actions
-  const state = store.getState()
-  const { program } = state
-  const { flattenedPlugins } = state
+  const { program, flattenedPlugins, config } = store.getState()
 
   // Add our default development page since we know it's going to
   // exist and we need a node to exist so its query works :-)
@@ -87,8 +85,8 @@ exports.sourceNodes = ({ createContentDigest, actions, store }) => {
       siteMetadata: {
         ...configCopy.siteMetadata,
       },
-      port: state.program.proxyPort,
-      host: state.program.host,
+      port: program.proxyPort,
+      host: program.host,
       ...configCopy,
     }
     createNode({
@@ -103,7 +101,7 @@ exports.sourceNodes = ({ createContentDigest, actions, store }) => {
     })
   }
 
-  createGatsbyConfigNode(state.config)
+  createGatsbyConfigNode(config)
 
   const buildTime = moment()
     .subtract(process.uptime(), `seconds`)
@@ -127,6 +125,10 @@ exports.sourceNodes = ({ createContentDigest, actions, store }) => {
     program.directory,
     `gatsby-config.js`
   )
+  watchConfig(pathToGatsbyConfig, createGatsbyConfigNode)
+}
+
+function watchConfig(pathToGatsbyConfig, createGatsbyConfigNode) {
   chokidar.watch(pathToGatsbyConfig).on(`change`, () => {
     const oldCache = require.cache[require.resolve(pathToGatsbyConfig)]
     try {


### PR DESCRIPTION
## Description

This PR addresses one of our memory leaks in `develop` with refresh endpoint (in this case in internal plugin `internal-data-bridge`).

Refresh endpoint always re-runs `sourceNodes` and we keep re-creating chokidar listeners that retain current redux state at the moment of the `sourceNodes` call. So we basically retain as many state "snapshots" as there were `sourceNode` API calls (i.e. refreshes).

To confirm I've run the https://github.com/reactjs/reactjs.org website with a 200MB node memory limit and kept hitting the `__refresh` endpoint. Before this PR it was OOMing on the 14-16th refresh, after this PR somewhere after 30th (so other memory leaks in play)

To clarify: this is not the only leak 😢 We have others. It is possible that chokidar listeners in `gatsby-source-filesystem` are also leaking. But this warrants a separate investigation.

Also, originally we were hoping that sourceNodesStatefully (#19663) would be a proper fix for those kinds of leaks but it has it's own issues and breaking changes, so need to fix those individually.

## Related Issues
Partially addresses #25868
