### PR TITLE
perf(gatsby): cache `createNodeId` locally

### DIFF
--- a/packages/gatsby/src/utils/__tests__/create-node-id.ts
+++ b/packages/gatsby/src/utils/__tests__/create-node-id.ts
@@ -1,0 +1,60 @@
+import { createNodeId } from "../create-node-id"
+
+describe(`createNodeId`, (): void => {
+  describe(`uuid`, () => {
+    // Keep tests in this group in sync with the xxhash group below
+
+    it(`should return a string`, () => {
+      // Key is just something random that's not only ascii
+      const id2 = createNodeId(`myboea"`, `ghost ns`)
+
+      expect(typeof id2).toBe(`string`)
+    })
+
+    it(`should return a different hash for different keys`, () => {
+      const id1 = createNodeId(`my things`, `gatsby-some-plugin`)
+      const id2 = createNodeId(`your things`, `gatsby-some-plugin`)
+
+      expect(id1 !== id2).toBe(true)
+
+      // For completion sake
+      expect(id1).toMatchInlineSnapshot(
+        `"1ddac06a-6a4d-5921-a898-e9473e7ff0b1"`
+      )
+      expect(id2).toMatchInlineSnapshot(
+        `"b5a21b9c-ff21-5d05-9c7d-8d86c69d5399"`
+      )
+    })
+
+    it(`should return a different hash for different namespaces`, () => {
+      const id1 = createNodeId(`my things`, `gatsby-special-plugin`)
+      const id2 = createNodeId(`my things`, `gatsby-other-plugin`)
+
+      expect(id1 !== id2).toBe(true)
+
+      // For completion sake
+      expect(id1).toMatchInlineSnapshot(
+        `"03ca507d-c732-5412-95d2-eaf114f42f69"`
+      )
+      expect(id2).toMatchInlineSnapshot(
+        `"5db58b36-473b-5c3f-a676-db34af789baf"`
+      )
+    })
+
+    it(`return same id for same input`, () => {
+      const KEY = `resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bc"`
+      const NS = `gatsby-special-plugin`
+      // Key is just something random that's not only ascii
+      const id = createNodeId(KEY, NS)
+
+      // Only input should affect it so repetitive calls should not change the output
+      expect(id).toMatchInlineSnapshot(`"6614d1bf-8c8c-5cfc-b782-2c019d7a7c95"`)
+
+      for (let i = 0; i < 10; ++i) {
+        const id2 = createNodeId(KEY, NS)
+
+        expect(id2).toEqual(id)
+      }
+    })
+  })
+})

--- a/packages/gatsby/src/utils/__tests__/create-node-id.ts
+++ b/packages/gatsby/src/utils/__tests__/create-node-id.ts
@@ -2,8 +2,6 @@ import { createNodeId } from "../create-node-id"
 
 describe(`createNodeId`, (): void => {
   describe(`uuid`, () => {
-    // Keep tests in this group in sync with the xxhash group below
-
     it(`should return a string`, () => {
       // Key is just something random that's not only ascii
       const id2 = createNodeId(`myboea"`, `ghost ns`)

--- a/packages/gatsby/src/utils/create-node-id.ts
+++ b/packages/gatsby/src/utils/create-node-id.ts
@@ -5,9 +5,10 @@ const seedConstant = `638f7a53-c567-4eca-8fc1-b23efb1cfb2b`
 
 // This cache prevents duplicate calls to uuid which is relevant for certain cases
 const unprefixedCache: Map<string, string> = new Map()
+// ns -> name -> uuid
 const namespacedCache: Map<string, Map<string, string>> = new Map([
   [``, unprefixedCache],
-]) // ns -> name -> id
+])
 
 /**
  * Generate a unique id that is consistent, deterministic, and fast while resulting in predictably short hashes.
@@ -18,7 +19,7 @@ const namespacedCache: Map<string, Map<string, string>> = new Map([
  * - The value does not need to be encrypted
  * - The value must be unique within our system (as little collision risk as possible on small ascii inputs)
  * - The value needs to be deterministic (same input always results in same output)
- * - The conversion needs to be fast (we used to use uuid, which called into crytpo for sha1, but it was super slow)
+ * - The conversion needs to be fast
  * - The result should be predictably short as it may be used in urls
  *
  * High level this step is meant to prevent people from using our `id` to have meaning in their site and it's meant
@@ -45,7 +46,6 @@ export function createNodeId(id: string | number, namespace: string): string {
     )
   }
 
-  // Note: we can use the idCache for namespace as well since the key for ids will include the namespace
   let nsHash = unprefixedCache.get(namespace)
   if (!nsHash) {
     nsHash = uuidv5(namespace, seedConstant) as string

--- a/packages/gatsby/src/utils/create-node-id.ts
+++ b/packages/gatsby/src/utils/create-node-id.ts
@@ -3,8 +3,26 @@ import report from "gatsby-cli/lib/reporter"
 
 const seedConstant = `638f7a53-c567-4eca-8fc1-b23efb1cfb2b`
 
+// This cache prevents duplicate calls to uuid which is relevant for certain cases
+const idCache = new Map() // `${namespace}_${id}` -> hash
+
 /**
- * createNodeId() Generate UUID
+ * Generate a unique id that is consistent, deterministic, and fast while resulting in predictably short hashes.
+ *
+ * Some characteristics for this id:
+ *
+ * - The value of the `id` should not mean anything (it is "ours")
+ * - The value does not need to be encrypted
+ * - The value must be unique within our system (as little collision risk as possible on small ascii inputs)
+ * - The value needs to be deterministic (same input always results in same output)
+ * - The conversion needs to be fast (we used to use uuid, which called into crytpo for sha1, but it was super slow)
+ * - The result should be predictably short as it may be used in urls
+ *
+ * High level this step is meant to prevent people from using our `id` to have meaning in their site and it's meant
+ * to make sure the id ends up being short, whatever the input size was.
+ *
+ * Note: UUID is relatively slow because it calls into the native crypto library to generate SHA-1 hashes.
+ *       We do need the low collision rate of SHA-1 so we use a local (global) cache to speed up repetitive calls
  *
  * @param {String | Number} id - A string of arbitrary length
  * @param {String} namespace - Namespace to use for UUID
@@ -16,9 +34,40 @@ export function createNodeId(id: string | number, namespace: string): string {
     id = id.toString()
   } else if (typeof id !== `string`) {
     report.panic(
-      `Parameter passed to createNodeId must be a String or Number (got ${typeof id})`
+      `The \`id\` parameter passed to createNodeId must be a String or Number (got ${typeof id})`
+    )
+  } else if (typeof namespace !== `string`) {
+    report.panic(
+      `The \`namespace\` parameter passed to createNodeId must be a String (got ${typeof namespace})`
     )
   }
 
-  return uuidv5(id, uuidv5(namespace, seedConstant))
+  // Note: we can use the idCache for namespace as well since the key for ids will include the namespace
+  let nsHash = idCache.get(namespace)
+  if (!nsHash) {
+    nsHash = uuidv5(namespace, seedConstant)
+    idCache.set(namespace, nsHash)
+  }
+
+  // Calling uuid is relatively expensive because it calls into crypto for sha1.
+  // We use a local map to cache calls with the same ns+id pair, which helps a lot.
+  const key = `${namespace}_${id}`
+  let hash = idCache.get(key)
+  if (hash) {
+    return hash
+  }
+
+  if (
+    ![
+      `Plugin`,
+      `gatsby-source-contentful`,
+      `gatsby-transformer-remark`,
+    ].includes(namespace)
+  ) {
+    console.log(`namespace:`, namespace)
+  }
+
+  hash = uuidv5(id, nsHash)
+  idCache.set(key, hash)
+  return hash
 }

--- a/packages/gatsby/src/utils/create-node-id.ts
+++ b/packages/gatsby/src/utils/create-node-id.ts
@@ -57,16 +57,6 @@ export function createNodeId(id: string | number, namespace: string): string {
     return hash
   }
 
-  if (
-    ![
-      `Plugin`,
-      `gatsby-source-contentful`,
-      `gatsby-transformer-remark`,
-    ].includes(namespace)
-  ) {
-    console.log(`namespace:`, namespace)
-  }
-
   hash = uuidv5(id, nsHash)
   idCache.set(key, hash)
   return hash


### PR DESCRIPTION
This PR will cache the `uuid` calls when you call `createNodeId` repetitively with the same id/namespace.

This saves a large chunk at scale, especially for plugins like Contentful which call this API many times with the same key. Contentful tends to have a lot of nodes and a site that generates 1.6M nodes saves about 60 seconds just for doing this. Most sites won't see much difference.

It also caches the `uuid.v5` call for the namespace, which is often the same.

This is a fork of https://github.com/gatsbyjs/gatsby/pull/27661

> gabe-fs-text (128k pages)
```
success source and transform nodes - 56.154s
success createPages - 28.945s
info bootstrap finished - 89.735s
info Done building in 267.619 sec
```
```
success source and transform nodes - 52.153s
success createPages - 28.687s
info bootstrap finished - 85.447s
info Done building in 262.359 sec
```

> gabe-fs-markdown (128k pages)
```
success source and transform nodes - 65.534s
success createPages - 30.129s
info bootstrap finished - 100.817s
info Done building in 474.506 sec
```
```
success source and transform nodes - 61.841s
success createPages - 29.876s
info bootstrap finished - 96.869s
info Done building in 481.904 sec
```

1.6M node, 30k page Contentful site (Contentful plugin calls createNodeId very often with same args):
```
success Contentful: Create nodes - 206.140s
success source and transform nodes - 215.330s
success createPages - 57.998s
info bootstrap finished - 314.033s
```
```
success source and transform nodes - 151.334s
success Contentful: Create nodes - 142.157s
success createPages - 53.569s
info bootstrap finished - 244.923s
```

