### PR TITLE
Categorize GraphQL Errors

### DIFF
--- a/packages/gatsby/src/query/error-parser.ts
+++ b/packages/gatsby/src/query/error-parser.ts
@@ -65,6 +65,7 @@ const errorParser = ({
       cb: (match): IMatch => {
         return {
           id: `85923`,
+          category: `USER`,
           context: {
             sourceMessage: match[0],
             field: match[1],


### PR DESCRIPTION
## Description

We are getting several uncategorized GraphQL errors in ElasticSearch for things like `"unable to create posts Cannot query field "childrenFile" on type "BfzArticle". Did you mean "children"?`

From what I could tell, these seem to be errors that the user is responsible for (as well as the other GraphQL errors in the same `errorParser` method). I could be wrong, but wasn't sure :shrug: Figured I would let the core team help me out from here :heart: 

