### PR TITLE
chore(gatsby-plugin-emotion): Remove invalid options syntax

### DIFF
--- a/packages/gatsby-plugin-emotion/README.md
+++ b/packages/gatsby-plugin-emotion/README.md
@@ -27,10 +27,10 @@ module.exports = {
       options: {
         // Accepts the following options, all of which are defined by `babel-plugin-emotion` plugin.
         // The values for each key in this example are the defaults the plugin uses.
-        `sourceMap`: true,
-        `autoLabel`: process.env.NODE_ENV !== 'production',
-        `labelFormat`: `[local]`,
-        `cssPropOptimization`: true
+        sourceMap: true,
+        autoLabel: process.env.NODE_ENV !== 'production',
+        labelFormat: `[local]`,
+        cssPropOptimization: true
       },
     },
   ],

--- a/packages/gatsby-plugin-emotion/README.md
+++ b/packages/gatsby-plugin-emotion/README.md
@@ -28,9 +28,9 @@ module.exports = {
         // Accepts the following options, all of which are defined by `babel-plugin-emotion` plugin.
         // The values for each key in this example are the defaults the plugin uses.
         sourceMap: true,
-        autoLabel: process.env.NODE_ENV !== 'production',
+        autoLabel: process.env.NODE_ENV !== "production",
         labelFormat: `[local]`,
-        cssPropOptimization: true
+        cssPropOptimization: true,
       },
     },
   ],


### PR DESCRIPTION
Previous syntax was incorrect/not working with gatsby-config.js