### PR TITLE
fix(gatsby-plugin-mdx): remark/hypePlugins options schema

### DIFF
--- a/packages/gatsby-plugin-mdx/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/__tests__/gatsby-node.js
@@ -7,7 +7,7 @@ describe(`pluginOptionsSchema`, () => {
       `"extensions[0]" must be a string`,
       `"extensions[1]" must be a string`,
       `"extensions[2]" must be a string`,
-      `"defaultLayout" must be of type object`,
+      `"defaultLayouts" must be of type object`,
       `"gatsbyRemarkPlugins[0]" does not match any of the allowed types`,
       `"gatsbyRemarkPlugins[1]" does not match any of the allowed types`,
       `"remarkPlugins" must be an array`,
@@ -19,7 +19,7 @@ describe(`pluginOptionsSchema`, () => {
 
     const { errors } = await testPluginOptionsSchema(pluginOptionsSchema, {
       extensions: [1, 2, 3],
-      defaultLayout: `this should be an object`,
+      defaultLayouts: `this should be an object`,
       gatsbyRemarkPlugins: [1, { not: `existing prop` }, `valid one`],
       remarkPlugins: `this should be an array of object`,
       rehypePlugins: `this should be an array of object`,
@@ -33,7 +33,7 @@ describe(`pluginOptionsSchema`, () => {
   it(`should validate the schema`, async () => {
     const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
       extensions: [`.mdx`, `.mdxx`],
-      defaultLayout: {
+      defaultLayouts: {
         posts: `../post-layout.js`,
         default: `../default-layout.js`,
       },

--- a/packages/gatsby-plugin-mdx/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby-node.js
@@ -77,7 +77,7 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
         .description(
           `Configure the file extensions that gatsby-plugin-mdx will process`
         ),
-      defaultLayout: Joi.object({})
+      defaultLayouts: Joi.object({})
         .unknown(true)
         .default({})
         .description(`Set the layout components for MDX source types`),

--- a/packages/gatsby-plugin-mdx/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby-node.js
@@ -6,7 +6,7 @@ const fs = require(`fs`)
 
 const {
   onCreateNode,
-  unstable_shouldOnCreateNode
+  unstable_shouldOnCreateNode,
 } = require(`./gatsby/on-create-node`)
 
 /**
@@ -94,8 +94,16 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
       remarkPlugins: Joi.array()
         .items(
           Joi.alternatives().try(
-            Joi.object({}).unknown(true),
-            Joi.array().items(Joi.object({}).unknown(true))
+            Joi.alternatives().try(
+              Joi.function(),
+              Joi.object({}).unknown(true),
+              Joi.array().items(
+                Joi.alternatives().try(
+                  Joi.object({}).unknown(true),
+                  Joi.function()
+                )
+              )
+            )
           )
         )
         .default([])
@@ -103,8 +111,14 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
       rehypePlugins: Joi.array()
         .items(
           Joi.alternatives().try(
+            Joi.function(),
             Joi.object({}).unknown(true),
-            Joi.array().items(Joi.object({}).unknown(true))
+            Joi.array().items(
+              Joi.alternatives().try(
+                Joi.object({}).unknown(true),
+                Joi.function()
+              )
+            )
           )
         )
         .default([])


### PR DESCRIPTION
The documented form to configure `gatsby-plugin-mdx` with `remark/hypePlugins` is to require them:

```JS
{
  resolve: `gatsby-plugin-mdx`,
  options: {
    remarkPlugins: [require(`remark-slug`)]
  }
}
```

The current `pluginOptionsSchema` for `gatsby-plugin-mdx` throws an error with this (valid!) configuration, stating that "remarkPlugins[0] should be object or array", which is inaccurate.

This fixes it by adding the correct type (function) to the possibilities for this array. Verified it works as expected by running the fix against the theme-ui docs website, which fails before this fix but works as expected afterwards.
