### PR TITLE
fix(gatsby): purge jobsV2 results when cache is corrupt

### DIFF
--- a/packages/gatsby/src/redux/reducers/jobsv2.ts
+++ b/packages/gatsby/src/redux/reducers/jobsv2.ts
@@ -5,14 +5,21 @@ import {
   IGatsbyCompleteJobV2,
 } from "../types"
 
-export const jobsV2Reducer = (
-  state: IGatsbyState["jobsV2"] = {
+const initialState = (): IGatsbyState["jobsV2"] => {
+  return {
     incomplete: new Map(),
     complete: new Map(),
-  },
+  }
+}
+
+export const jobsV2Reducer = (
+  state = initialState(),
   action: ActionsUnion
 ): IGatsbyState["jobsV2"] => {
   switch (action.type) {
+    case `DELETE_CACHE`:
+      return action.cacheIsCorrupt ? initialState() : state
+
     case `CREATE_JOB_V2`: {
       const { job, plugin } = action.payload
 

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -574,6 +574,7 @@ export interface ISetResolvedThemesAction {
 
 export interface IDeleteCacheAction {
   type: `DELETE_CACHE`
+  cacheIsCorrupt?: boolean
 }
 
 export interface IRemovePageDataAction {

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -278,6 +278,7 @@ export async function initialize({
     // been loaded from the file system cache).
     store.dispatch({
       type: `DELETE_CACHE`,
+      cacheIsCorrupt,
     })
 
     // in future this should show which plugin's caches are purged


### PR DESCRIPTION
## Description

We consider Gatsby cache to be corrupt when a user deletes the `public` folder but not the `.cache` folder. In this case we purge the cache for him (via #27549) and also call `DELETE_CACHE` to purge the redux state that is already in memory by this point.

But `jobsV2` reducer doesn't clear job cache on `DELETE_CACHE` action. This makes sense because sharp jobs can survive `.cache` folder removal. But they can't survive the `public` folder removal (as that's where job results are physically stored).

This PR changes the behvaior of `jobsV2` reducer and makes it purge the job cache when the cache is corrupt (so only when the `public` folder is deleted).

## Related Issues

Fixes #27699
