### PR TITLE
fix(gatsby): show theme that has faulty config

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -468,7 +468,9 @@ const errors = {
     text: (context): string =>
       [
         stripIndent(`
-          Invalid plugin options for "${context.pluginName}":
+          Invalid plugin options for "${context.pluginName}"${
+          context.configDir ? `, configured by ${context.configDir}` : ``
+        }:
         `),
       ]
         .concat([``])

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -225,6 +225,7 @@ describe(`Load plugins`, () => {
         Array [
           Object {
             "context": Object {
+              "configDir": null,
               "pluginName": "gatsby-plugin-google-analytics",
               "validationErrors": Array [
                 Object {
@@ -262,6 +263,7 @@ describe(`Load plugins`, () => {
         Array [
           Object {
             "context": Object {
+              "configDir": null,
               "pluginName": "gatsby-plugin-google-analytics",
               "validationErrors": Array [
                 Object {
@@ -339,6 +341,7 @@ describe(`Load plugins`, () => {
         Array [
           Object {
             "context": Object {
+              "configDir": null,
               "pluginName": "gatsby-remark-autolink-headers",
               "validationErrors": Array [
                 Object {

--- a/packages/gatsby/src/bootstrap/load-plugins/index.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.ts
@@ -89,7 +89,7 @@ export async function loadPlugins(
 
   // Show errors for invalid plugin configuration
   if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
-    await validateConfigPluginsOptions(config)
+    await validateConfigPluginsOptions(config, rootDir)
   }
 
   const currentAPIs = getAPI({

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -244,7 +244,6 @@ async function validatePluginsOptions(
               rootDir &&
               path.relative(rootDir, plugin.parentDir)) ||
             null
-          console.log(``)
           reporter.error({
             id: `11331`,
             context: {
@@ -253,7 +252,6 @@ async function validatePluginsOptions(
               pluginName: plugin.resolve,
             },
           })
-          console.log(``)
 
           // Only process.exit if it's an error the user can fix
           if (!configDir) {

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -1,4 +1,5 @@
 import _ from "lodash"
+import path from "path"
 import * as semver from "semver"
 import * as stringSimilarity from "string-similarity"
 import { version as gatsbyVersion } from "gatsby/package.json"
@@ -174,7 +175,8 @@ export async function handleBadExports({
 }
 
 async function validatePluginsOptions(
-  plugins: Array<IPluginRefObject>
+  plugins: Array<IPluginRefObject>,
+  rootDir: string | null
 ): Promise<{
   errors: number
   plugins: Array<IPluginRefObject>
@@ -227,20 +229,28 @@ async function validatePluginsOptions(
             errors: subErrors,
             plugins: subPlugins,
           } = await validatePluginsOptions(
-            plugin.options.plugins as Array<IPluginRefObject>
+            plugin.options.plugins as Array<IPluginRefObject>,
+            rootDir
           )
           plugin.options.plugins = subPlugins
           errors += subErrors
         }
       } catch (error) {
         if (error instanceof Joi.ValidationError) {
+          console.log(``)
           reporter.error({
             id: `11331`,
             context: {
+              configDir:
+                (plugin.parentDir &&
+                  rootDir &&
+                  path.relative(rootDir, plugin.parentDir)) ||
+                null,
               validationErrors: error.details,
               pluginName: plugin.resolve,
             },
           })
+          console.log(``)
           errors++
 
           return plugin
@@ -256,11 +266,15 @@ async function validatePluginsOptions(
 }
 
 export async function validateConfigPluginsOptions(
-  config: ISiteConfig = {}
+  config: ISiteConfig = {},
+  rootDir: string | null
 ): Promise<void> {
   if (!config.plugins) return
 
-  const { errors, plugins } = await validatePluginsOptions(config.plugins)
+  const { errors, plugins } = await validatePluginsOptions(
+    config.plugins,
+    rootDir
+  )
 
   config.plugins = plugins
 

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -237,21 +237,28 @@ async function validatePluginsOptions(
         }
       } catch (error) {
         if (error instanceof Joi.ValidationError) {
+          // If rootDir and plugin.parentDir are the same, i.e. if this is a plugin a user configured in their gatsby-config.js (and not a sub-theme that added it), this will be ""
+          // Otherwise, this will contain (and show) the relative path and warn instead of error
+          const configDir =
+            (plugin.parentDir &&
+              rootDir &&
+              path.relative(rootDir, plugin.parentDir)) ||
+            null
           console.log(``)
           reporter.error({
             id: `11331`,
             context: {
-              configDir:
-                (plugin.parentDir &&
-                  rootDir &&
-                  path.relative(rootDir, plugin.parentDir)) ||
-                null,
+              configDir,
               validationErrors: error.details,
               pluginName: plugin.resolve,
             },
           })
           console.log(``)
-          errors++
+
+          // Only process.exit if it's an error the user can fix
+          if (!configDir) {
+            errors++
+          }
 
           return plugin
         }

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -238,7 +238,7 @@ async function validatePluginsOptions(
       } catch (error) {
         if (error instanceof Joi.ValidationError) {
           // If rootDir and plugin.parentDir are the same, i.e. if this is a plugin a user configured in their gatsby-config.js (and not a sub-theme that added it), this will be ""
-          // Otherwise, this will contain (and show) the relative path and warn instead of error
+          // Otherwise, this will contain (and show) the relative path
           const configDir =
             (plugin.parentDir &&
               rootDir &&
@@ -252,11 +252,7 @@ async function validatePluginsOptions(
               pluginName: plugin.resolve,
             },
           })
-
-          // Only process.exit if it's an error the user can fix
-          if (!configDir) {
-            errors++
-          }
+          errors++
 
           return plugin
         }


### PR DESCRIPTION
When a user uses a theme that has a invalid plugin configuration in its gatsby-config.js, the user will see a blocking error:

```
❯ GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION=true yarn start
yarn run v1.22.4
$ gatsby develop

success open and validate gatsby-configs - 0.064s

 ERROR #11331  PLUGIN

Invalid plugin options for "gatsby-plugin-mdx":

- "plugins" must contain 0 items

not finished load plugins - 3.026s
error Command failed with exit code 1.
```

However, the user doesn't even have `gatsby-plugin-mdx` in their gatsby-config and cannot fix this since they might not have control over the theme that incorrectly uses this plugin! :scream:

This patch fixes that case by instead 1) logging the directory of the faulty gatsby-config and 2) not blocking `yarn develop` if the error is from a gatsby-config outside the users root directory.

Now, it looks like this:

```
❯ GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION=true yarn start
yarn run v1.22.4
$ gatsby develop

Something is already running at port 8000
✔ Would you like to run the app at another port instead? … yes
success open and validate gatsby-configs - 0.073s
⠀
 ERROR #11331  PLUGIN

Invalid plugin options for "gatsby-plugin-mdx", configured by node_modules/@lekoarts/gatsby-theme-minimal-blog-core:

- "plugins" must contain 0 items

success load plugins - 0.892s
success onPreInit - 0.029s
success initialize cache - 0.026s
success copy gatsby files - 0.048s
success onPreBootstrap - 0.015s
success createSchemaCustomization - 0.010s
...etc...
```

This makes sure we don't block the user with errors they don't have control over.