### PR TITLE
fix(gatsby-plugin-mdx): allow plugins: [...] in options schema

### DIFF
--- a/packages/gatsby-plugin-mdx/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/__tests__/gatsby-node.js
@@ -12,6 +12,7 @@ describe(`pluginOptionsSchema`, () => {
       `"gatsbyRemarkPlugins[1]" does not match any of the allowed types`,
       `"remarkPlugins" must be an array`,
       `"rehypePlugins" must be an array`,
+      `"plugins[0]" does not match any of the allowed types`,
       `"mediaTypes[0]" must be a string`,
       `"mediaTypes[1]" must be a string`,
       `"shouldBlockNodeFromTransformation" must have an arity lesser or equal to 1`,
@@ -23,6 +24,7 @@ describe(`pluginOptionsSchema`, () => {
       gatsbyRemarkPlugins: [1, { not: `existing prop` }, `valid one`],
       remarkPlugins: `this should be an array of object`,
       rehypePlugins: `this should be an array of object`,
+      plugins: [2],
       mediaTypes: [1, 2],
       shouldBlockNodeFromTransformation: (wrong, number) => null,
     })
@@ -50,6 +52,7 @@ describe(`pluginOptionsSchema`, () => {
         require(`../gatsby-node.js`),
         [require(`../gatsby-node.js`), { target: false }],
       ],
+      plugins: [{ resolve: `remark-autolink-plugin` }],
       rehypePlugins: [
         require(`../gatsby-node.js`),
         [require(`../gatsby-node.js`), { behavior: `wrap` }],

--- a/packages/gatsby-plugin-mdx/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby-node.js
@@ -93,36 +93,21 @@ if (process.env.GATSBY_EXPERIMENTAL_PLUGIN_OPTION_VALIDATION) {
         .description(`Use Gatsby-specific remark plugins`),
       remarkPlugins: Joi.array()
         .items(
-          Joi.alternatives().try(
-            Joi.alternatives().try(
-              Joi.function(),
-              Joi.object({}).unknown(true),
-              Joi.array().items(
-                Joi.alternatives().try(
-                  Joi.object({}).unknown(true),
-                  Joi.function()
-                )
-              )
-            )
-          )
+          Joi.function(),
+          Joi.object({}).unknown(true),
+          Joi.array().items(Joi.object({}).unknown(true), Joi.function())
         )
         .default([])
         .description(`Specify remark plugins`),
       rehypePlugins: Joi.array()
         .items(
-          Joi.alternatives().try(
-            Joi.function(),
-            Joi.object({}).unknown(true),
-            Joi.array().items(
-              Joi.alternatives().try(
-                Joi.object({}).unknown(true),
-                Joi.function()
-              )
-            )
-          )
+          Joi.function(),
+          Joi.object({}).unknown(true),
+          Joi.array().items(Joi.object({}).unknown(true), Joi.function())
         )
         .default([])
         .description(`Specify rehype plugins`),
+      plugins: Joi.array().items(Joi.string(), Joi.object({}).unknown(true)),
       mediaTypes: Joi.array()
         .items(Joi.string())
         .default(["text/markdown", "text/x-markdown"])


### PR DESCRIPTION
Turns out, there is a use-case for specifying `plugins: [...]` in `gatsby-plugin-mdx` as explained in this comment as a workaround for gatsby-browser/node/... support in `rehype/markPlugins`: https://github.com/gatsbyjs/gatsby/issues/15486#issuecomment-510153237

This adds plugins to the plugin options schema for gatsby-plugin-mdx! :+1:
