### PR TITLE
chore(gatsby): dont generate heavy verbose payload we wont use

### DIFF
--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -39,13 +39,15 @@ export async function createPages({
     } (use --verbose for breakdown)`
   )
 
-  reporter.verbose(
-    `Number of node types: ${
-      store.getState().nodesByType.size
-    }. Nodes per type: ${[...store.getState().nodesByType.entries()]
-      .map(([type, nodes]) => type + `: ` + nodes.size)
-      .join(`, `)}`
-  )
+  if (process.env.gatsby_log_level === `verbose`) {
+    reporter.verbose(
+      `Number of node types: ${
+        store.getState().nodesByType.size
+      }. Nodes per type: ${[...store.getState().nodesByType.entries()]
+        .map(([type, nodes]) => type + `: ` + nodes.size)
+        .join(`, `)}`
+    )
+  }
 
   activity.end()
 

--- a/packages/gatsby/src/utils/state-machine-logging.ts
+++ b/packages/gatsby/src/utils/state-machine-logging.ts
@@ -24,7 +24,9 @@ export function logTransitions<T = DefaultContext>(
       return
     }
     last = state
-    reporter.verbose(`Transition to ${JSON.stringify(state.value)}`)
+    if (process.env.gatsby_log_level === `verbose`) {
+      reporter.verbose(`Transition to ${JSON.stringify(state.value)}`)
+    }
     // eslint-disable-next-line no-unused-expressions
     service.children?.forEach(child => {
       // We want to ensure we don't attach a listener to the same
@@ -40,11 +42,13 @@ export function logTransitions<T = DefaultContext>(
             return
           }
           sublast = substate
-          reporter.verbose(
-            `Transition to ${JSON.stringify(state.value)} > ${JSON.stringify(
-              substate.value
-            )}`
-          )
+          if (process.env.gatsby_log_level === `verbose`) {
+            reporter.verbose(
+              `Transition to ${JSON.stringify(state.value)} > ${JSON.stringify(
+                substate.value
+              )}`
+            )
+          }
         })
         listeners.add(child)
       }


### PR DESCRIPTION
Small tweak. Even if `--verbose` is not used, gatsby would still generate the strings before they are discarded. That's negligible for simple string concats but these cases were not that trivial.