### PR TITLE
feat: log Contentful API responses when --verbose flag is set

### DIFF
--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -16,6 +16,18 @@ module.exports = async function contentfulFetch({
     host: pluginConfig.get(`host`),
     environment: pluginConfig.get(`environment`),
     proxy: pluginConfig.get(`proxy`),
+    responseLogger: response => {
+      const meta = [
+        `size: ${response.headers[`content-length`]}B`,
+        `response id: ${response.headers[`x-contentful-request-id`]}`,
+        `cache: ${response.headers[`x-cache`]}`,
+      ]
+      reporter.verbose(
+        `${response.config.method} /${response.config.url}: ${
+          response.status
+        } ${response.statusText} (${meta.join(` `)})`
+      )
+    },
   }
 
   const client = contentful.createClient(contentfulClientOptions)


### PR DESCRIPTION
When building with `--verbose`, gatsby-source-contentful will now log enough information to identify of API issues.

This will simplify debugging, especially for out friends at Gatsby & Contentful support.

This might get pretty verbose on big spaces, but will help a lot to identify problems :)


```
verbose get /: 200 OK (size: 325B, response id: 75ea2c57-635f-4941-a17e-35e1a9e4df05, cache: HIT)
verbose get /locales: 200 OK (size: 538B, response id: 3e8ace80-73b6-484b-a1b6-e1b981e98b42, cache: HIT)
verbose get /sync: 200 OK (size: 67857B, response id: 5d30f4ec-6538-4740-b2b5-fecfcc62171c, cache: HIT)
verbose get /sync: 200 OK (size: 58682B, response id: 51b4e75a-d648-41f7-9759-c48f316aef66, cache: HIT)
verbose get /sync: 200 OK (size: 51482B, response id: 9bc340b8-52e6-4863-a1b8-a8d67fa324f9, cache: HIT)
verbose get /sync: 200 OK (size: 63779B, response id: aee654df-ce66-46e9-a6de-0e968a4f7fca, cache: HIT)
verbose get /sync: 200 OK (size: 13674B, response id: 198ce675-e844-4147-9f9e-3a0231ee1095, cache: HIT)
verbose get /sync: 200 OK (size: 32060B, response id: 5d339663-385d-4a33-9147-46202c544ba4, cache: HIT)
verbose get /sync: 200 OK (size: 29904B, response id: bb2bb3b6-565a-4a4f-b905-454afcd2dee1, cache: HIT)
verbose get /sync: 200 OK (size: 20306B, response id: 0d4cd461-f453-4d34-ac87-d3dccdd358e6, cache: HIT)
verbose get /sync: 200 OK (size: 11812B, response id: 5a38c537-f006-402a-909f-731434077566, cache: HIT)
verbose get /sync: 200 OK (size: 11675B, response id: ed9b5712-383e-4d5b-98d3-15e69068000f, cache: HIT)
verbose get /sync: 200 OK (size: 12230B, response id: 04e8d2e4-f530-4b9d-92a4-0e8501422ab9, cache: HIT)
verbose get /sync: 200 OK (size: 13137B, response id: b207ecd2-39b9-4d6d-ab12-a792238e2476, cache: HIT)
verbose get /sync: 200 OK (size: 12648B, response id: 1cb037d3-7f0e-4f3a-abb6-73be38f706a1, cache: HIT)
verbose get /sync: 200 OK (size: 1331B, response id: ab05fa27-585a-45d5-8b6c-09ff9cb05e3b, cache: HIT)
verbose get /content_types: 200 OK (size: 1890B, response id: 51c3282b-3d98-4e4c-9b78-1f3315b04500, cache: HIT)
```