### PR TITLE
fix(gatsby-recipes): Only remove the ".mdx" ending if running local recipe

### DIFF
--- a/packages/gatsby-recipes/src/cli/index.js
+++ b/packages/gatsby-recipes/src/cli/index.js
@@ -435,7 +435,11 @@ export default async ({
             </Text>
             <RecipesList
               setRecipe={async recipeItem => {
-                setRecipe(recipeItem.value.slice(0, -4))
+                if (recipeItem.value.endsWith(`.mdx`)) {
+                  setRecipe(recipeItem.value.slice(0, -4))
+                } else {
+                  setRecipe(recipeItem.value)
+                }
                 trackCli(`RECIPE_RUN`, { name: recipeItem.value })
                 showRecipesList = false
                 try {


### PR DESCRIPTION
This fixes showing the correct install command when running recipes from the recipes list shown when running `gatsby recipes`

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
