### PR TITLE
Added animation for the astronaut on the default starter

### DIFF
--- a/starters/default/src/components/image.css
+++ b/starters/default/src/components/image.css
@@ -1,0 +1,9 @@
+.astronaut {
+    animation: astronaut 4s infinite ease;
+}
+
+@keyframes astronaut {
+    0% { transform: translateY(10px) }
+    50% { transform: translateY(-20px) }
+    100% { transform: translateY(10px) }
+}

--- a/starters/default/src/components/image.css
+++ b/starters/default/src/components/image.css
@@ -1,5 +1,5 @@
 .astronaut {
-    animation: astronaut 4s infinite ease;
+    animation: astronaut 6s infinite ease;
 }
 
 @keyframes astronaut {

--- a/starters/default/src/components/image.js
+++ b/starters/default/src/components/image.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import Img from "gatsby-image"
+import "./image.css"
 
 /*
  * This component is built using `gatsby-image` to automatically serve optimized
@@ -30,7 +31,7 @@ const Image = () => {
     return <div>Picture not found</div>
   }
 
-  return <Img fluid={data.placeholderImage.childImageSharp.fluid} />
+  return <Img className="astronaut" fluid={data.placeholderImage.childImageSharp.fluid} />
 }
 
 export default Image


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I added a simple floating animation for the astronaut image on the [default starter](https://gatsby-starter-default-demo.netlify.app/).

### Documentation

No documentation.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

No related issues.
