### PR TITLE
feat: Add "gatsby plugin" command

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -393,6 +393,23 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
       }
     ),
   })
+
+  cli.command({
+    command: `plugin <cmd> [plugins...]`,
+    describe: `Useful commands relating to Gatsby plugins`,
+    builder: yargs =>
+      yargs
+        .positional(`cmd`, {
+          choices: [`docs`, `add`, `configure`],
+          describe: "Valid commands include `docs`, `add`, `configure`.",
+          type: `string`,
+        })
+        .positional(`plugins`, {
+          describe: `The plugin names`,
+          type: `string`,
+        }),
+    handler: getCommandHandler(`plugin`),
+  })
 }
 
 function isLocalGatsbySite(): boolean {
@@ -506,42 +523,6 @@ export const createCli = (argv: Array<string>): yargs.Arguments => {
         const enabled = Boolean(enable) || !disable
         setTelemetryEnabled(enabled)
         report.log(`Telemetry collection ${enabled ? `enabled` : `disabled`}`)
-      }),
-    })
-    .command({
-      command: `plugin [cmd]`,
-      describe: `Useful commands relating to Gatsby plugins`,
-      builder: yargs =>
-        yargs.positional(`cmd`, {
-          choices: [`docs`],
-          describe: "Valid commands include `docs`.",
-          type: `string`,
-        }),
-      handler: handlerP(({ cmd }) => {
-        if (cmd === `docs`) {
-          console.log(`
-      Using a plugin:
-      - What is a Plugin? (https://www.gatsbyjs.com/docs/what-is-a-plugin/)
-      - Using a Plugin in Your Site (https://www.gatsbyjs.com/docs/using-a-plugin-in-your-site/)
-      - What You Don't Need Plugins For (https://www.gatsbyjs.com/docs/what-you-dont-need-plugins-for/)
-      - Loading Plugins from Your Local Plugins Folder (https://www.gatsbyjs.com/docs/loading-plugins-from-your-local-plugins-folder/)
-      - Plugin Library (https://www.gatsbyjs.com/plugins/)
-
-      Creating a plugin:
-      - Naming a Plugin (https://www.gatsbyjs.com/docs/naming-a-plugin/)
-      - Files Gatsby Looks for in a Plugin (https://www.gatsbyjs.com/docs/files-gatsby-looks-for-in-a-plugin/)
-      - Creating a Generic Plugin (https://www.gatsbyjs.com/docs/creating-a-generic-plugin/)
-      - Creating a Local Plugin (https://www.gatsbyjs.com/docs/creating-a-local-plugin/)
-      - Creating a Source Plugin (https://www.gatsbyjs.com/docs/creating-a-source-plugin/)
-      - Creating a Transformer Plugin (https://www.gatsbyjs.com/docs/creating-a-transformer-plugin/)
-      - Submit to Plugin Library (https://www.gatsbyjs.com/contributing/submit-to-plugin-library/)
-      - Source Plugin Tutorial (https://www.gatsbyjs.com/tutorial/source-plugin-tutorial/)
-      - Maintaining a Plugin (https://www.gatsbyjs.com/docs/maintaining-a-plugin/)
-      - Join Discord #plugin-authoring channel to ask questions! (https://gatsby.dev/discord/)
-                 `)
-        } else {
-          console.log(`Current valid subcommands are: 'docs'`) // right now this is hardcoded because we only have a single command
-        }
       }),
     })
     .command({

--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -400,8 +400,10 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
     builder: yargs =>
       yargs
         .positional(`cmd`, {
-          choices: [`docs`, `add`, `configure`],
-          describe: "Valid commands include `docs`, `add`, `configure`.",
+          choices: process.env.GATSBY_EXPERIMENTAL_PLUGIN_COMMANDS
+            ? [`docs`, `add`, `configure`]
+            : [`docs`],
+          describe: "Valid commands include `docs`.",
           type: `string`,
         })
         .positional(`plugins`, {

--- a/packages/gatsby/src/commands/plugin-add.ts
+++ b/packages/gatsby/src/commands/plugin-add.ts
@@ -1,0 +1,6 @@
+export default async function run({ plugins }: IProgram): Promise<void> {
+  if (!plugins?.length) {
+    console.log(`Please specify a plugin to install`)
+  }
+  console.log(plugins)
+}

--- a/packages/gatsby/src/commands/plugin.ts
+++ b/packages/gatsby/src/commands/plugin.ts
@@ -1,0 +1,35 @@
+import add from "./plugin-add"
+
+module.exports = async (args: IProgram): Promise<void> => {
+  const { report, cmd } = args
+  switch (cmd) {
+    case `docs`:
+      console.log(`
+        Using a plugin:
+        - What is a Plugin? (https://www.gatsbyjs.com/docs/what-is-a-plugin/)
+        - Using a Plugin in Your Site (https://www.gatsbyjs.com/docs/using-a-plugin-in-your-site/)
+        - What You Don't Need Plugins For (https://www.gatsbyjs.com/docs/what-you-dont-need-plugins-for/)
+        - Loading Plugins from Your Local Plugins Folder (https://www.gatsbyjs.com/docs/loading-plugins-from-your-local-plugins-folder/)
+        - Plugin Library (https://www.gatsbyjs.com/plugins/)
+  
+        Creating a plugin:
+        - Naming a Plugin (https://www.gatsbyjs.com/docs/naming-a-plugin/)
+        - Files Gatsby Looks for in a Plugin (https://www.gatsbyjs.com/docs/files-gatsby-looks-for-in-a-plugin/)
+        - Creating a Generic Plugin (https://www.gatsbyjs.com/docs/creating-a-generic-plugin/)
+        - Creating a Local Plugin (https://www.gatsbyjs.com/docs/creating-a-local-plugin/)
+        - Creating a Source Plugin (https://www.gatsbyjs.com/docs/creating-a-source-plugin/)
+        - Creating a Transformer Plugin (https://www.gatsbyjs.com/docs/creating-a-transformer-plugin/)
+        - Submit to Plugin Library (https://www.gatsbyjs.com/contributing/submit-to-plugin-library/)
+        - Source Plugin Tutorial (https://www.gatsbyjs.com/tutorial/source-plugin-tutorial/)
+        - Maintaining a Plugin (https://www.gatsbyjs.com/docs/maintaining-a-plugin/)
+        - Join Discord #plugin-authoring channel to ask questions! (https://gatsby.dev/discord/)
+                   `)
+      return void 0
+
+    case `add`:
+      return add(args)
+
+    default:
+      report.error(`Unknown command ${cmd}`)
+  }
+}

--- a/packages/gatsby/src/commands/plugin.ts
+++ b/packages/gatsby/src/commands/plugin.ts
@@ -32,4 +32,5 @@ module.exports = async (args: IProgram): Promise<void> => {
     default:
       report.error(`Unknown command ${cmd}`)
   }
+  return void 0
 }


### PR DESCRIPTION
This creates a stub `gatsby plugin <cmd> [plugins...]` command, ready for the add and configure subcommands. It moves across the `docs` command that already existed, though we'll probably want to change it.