### PR TITLE
feat(gatsby): Add "gatsby plugin add" command

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -400,9 +400,7 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
     builder: yargs =>
       yargs
         .positional(`cmd`, {
-          choices: process.env.GATSBY_EXPERIMENTAL_PLUGIN_COMMANDS
-            ? [`docs`, `add`, `configure`]
-            : [`docs`],
+          choices: [`docs`],
           describe: "Valid commands include `docs`.",
           type: `string`,
         })

--- a/packages/gatsby-cli/src/plugin-add.ts
+++ b/packages/gatsby-cli/src/plugin-add.ts
@@ -1,6 +1,5 @@
 import { NPMPackage, GatsbyPlugin } from "gatsby-recipes"
-import { IProgram } from "./types"
-
+import reporter from "./reporter"
 const normalizePluginName = (plugin: string): string => {
   if (plugin.startsWith(`gatsby-`)) {
     return plugin
@@ -17,8 +16,7 @@ const normalizePluginName = (plugin: string): string => {
 
 async function installPluginPackage(
   plugin: string,
-  root: string,
-  reporter: IProgram["report"]
+  root: string
 ): Promise<void> {
   const installTimer = reporter.activityTimer(`Installing ${plugin}`)
 
@@ -36,8 +34,7 @@ async function installPluginPackage(
 
 async function installPluginConfig(
   plugin: string,
-  root: string,
-  reporter: IProgram["report"]
+  root: string
 ): Promise<void> {
   const installTimer = reporter.activityTimer(
     `Adding ${plugin} to gatsby-config`
@@ -55,22 +52,21 @@ async function installPluginConfig(
   installTimer.end()
 }
 
-export default async function run({
-  plugins,
-  report,
-  directory,
-}: IProgram & { plugins?: Array<string> }): Promise<void> {
+export async function addPlugins(
+  directory: string,
+  plugins?: Array<string>
+): Promise<void> {
   if (!plugins?.length) {
-    report.error(`Please specify a plugin to install`)
+    reporter.error(`Please specify a plugin to install`)
     return
   }
 
   const pluginList = plugins.map(normalizePluginName)
 
   await Promise.all(
-    pluginList.map(plugin => installPluginPackage(plugin, directory, report))
+    pluginList.map(plugin => installPluginPackage(plugin, directory))
   )
   await Promise.all(
-    pluginList.map(plugin => installPluginConfig(plugin, directory, report))
+    pluginList.map(plugin => installPluginConfig(plugin, directory))
   )
 }

--- a/packages/gatsby/src/commands/plugin-add.ts
+++ b/packages/gatsby/src/commands/plugin-add.ts
@@ -1,6 +1,76 @@
-export default async function run({ plugins }: IProgram): Promise<void> {
-  if (!plugins?.length) {
-    console.log(`Please specify a plugin to install`)
+import { NPMPackage, GatsbyPlugin } from "gatsby-recipes"
+import { IProgram } from "./types"
+
+const normalizePluginName = (plugin: string): string => {
+  if (plugin.startsWith(`gatsby-`)) {
+    return plugin
   }
-  console.log(plugins)
+  if (
+    plugin.startsWith(`source-`) ||
+    plugin.startsWith(`transformer-`) ||
+    plugin.startsWith(`plugin-`)
+  ) {
+    return `gatsby-${plugin}`
+  }
+  return `gatsby-plugin-${plugin}`
+}
+
+async function installPluginPackage(
+  plugin: string,
+  root: string,
+  reporter: IProgram["report"]
+): Promise<void> {
+  const installTimer = reporter.activityTimer(`Installing ${plugin}`)
+
+  installTimer.start()
+  reporter.info(`Installing ${plugin}`)
+  try {
+    const result = await NPMPackage.create({ root }, { name: plugin })
+    reporter.info(result._message)
+  } catch (err) {
+    reporter.error(JSON.parse(err)?.message)
+    installTimer.setStatus(`FAILED`)
+  }
+  installTimer.end()
+}
+
+async function installPluginConfig(
+  plugin: string,
+  root: string,
+  reporter: IProgram["report"]
+): Promise<void> {
+  const installTimer = reporter.activityTimer(
+    `Adding ${plugin} to gatsby-config`
+  )
+
+  installTimer.start()
+  reporter.info(`Adding ${plugin}`)
+  try {
+    const result = await GatsbyPlugin.create({ root }, { name: plugin })
+    reporter.info(result._message)
+  } catch (err) {
+    reporter.error(JSON.parse(err)?.message)
+    installTimer.setStatus(`FAILED`)
+  }
+  installTimer.end()
+}
+
+export default async function run({
+  plugins,
+  report,
+  directory,
+}: IProgram & { plugins?: Array<string> }): Promise<void> {
+  if (!plugins?.length) {
+    report.error(`Please specify a plugin to install`)
+    return
+  }
+
+  const pluginList = plugins.map(normalizePluginName)
+
+  await Promise.all(
+    pluginList.map(plugin => installPluginPackage(plugin, directory, report))
+  )
+  await Promise.all(
+    pluginList.map(plugin => installPluginConfig(plugin, directory, report))
+  )
 }

--- a/packages/gatsby/src/commands/plugin.ts
+++ b/packages/gatsby/src/commands/plugin.ts
@@ -1,5 +1,3 @@
-import add from "./plugin-add"
-
 module.exports = async (args: IProgram): Promise<void> => {
   const { report, cmd } = args
   switch (cmd) {
@@ -25,9 +23,6 @@ module.exports = async (args: IProgram): Promise<void> => {
         - Join Discord #plugin-authoring channel to ask questions! (https://gatsby.dev/discord/)
                    `)
       return void 0
-
-    case `add`:
-      return add(args)
 
     default:
       report.error(`Unknown command ${cmd}`)


### PR DESCRIPTION
Adds a WIP gatsby plugin add command, which uses the recipes providers to install the npm package and add the plugin to the config

[ch17925]
[ch17779]
