### PR TITLE
fix: improve error handling, always show API response status and message

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/fetch.js
+++ b/packages/gatsby-source-contentful/src/__tests__/fetch.js
@@ -267,7 +267,7 @@ describe(`Displays troubleshooting tips and detailed plugin options on contentfu
   it(`API 404 response handling`, async () => {
     mockClient.getLocales.mockImplementation(() => {
       const err = new Error(`error`)
-      err.response = { status: 404 }
+      err.responseData = { status: 404 }
       throw err
     })
 
@@ -307,7 +307,7 @@ describe(`Displays troubleshooting tips and detailed plugin options on contentfu
   it(`API authorization error handling`, async () => {
     mockClient.getLocales.mockImplementation(() => {
       const err = new Error(`error`)
-      err.response = { status: 401 }
+      err.responseData = { status: 401 }
       throw err
     })
 

--- a/packages/gatsby-source-contentful/src/__tests__/fetch.js
+++ b/packages/gatsby-source-contentful/src/__tests__/fetch.js
@@ -83,13 +83,21 @@ beforeAll(() => {
   }
 })
 
+const start = jest.fn()
+const end = jest.fn()
+
+const mockActivity = {
+  start,
+  end,
+  done: end,
+}
+
 const reporter = {
   info: jest.fn(),
   verbose: jest.fn(),
   panic: jest.fn(),
-  activityTimer: () => {
-    return { start: jest.fn(), end: jest.fn() }
-  },
+  activityTimer: jest.fn(() => mockActivity),
+  createProgress: jest.fn(() => mockActivity),
 }
 
 beforeEach(() => {

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -89,7 +89,9 @@ module.exports = async function contentfulFetch({
         },
       })
     }
-    reporter.verbose(`Default locale is: ${defaultLocale}`)
+    reporter.verbose(
+      `Default locale is: ${defaultLocale}. There are ${contentfulLocales.length} locales in total.`
+    )
   } catch (e) {
     let details
     let errors

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -11,8 +11,8 @@ module.exports = async function contentfulFetch({
 }) {
   // Fetch articles.
   let syncProgress
-  const pageLimit = pluginConfig.get(`pageLimit`)
   let syncItemCount = 0
+  const pageLimit = pluginConfig.get(`pageLimit`)
   const contentfulClientOptions = {
     space: pluginConfig.get(`spaceId`),
     accessToken: pluginConfig.get(`accessToken`),
@@ -21,6 +21,9 @@ module.exports = async function contentfulFetch({
     proxy: pluginConfig.get(`proxy`),
     responseLogger: response => {
       function createMetadataLog(response) {
+        if (process.env.gatsby_log_level === `verbose`) {
+          return ``
+        }
         return [
           response?.headers[`content-length`] &&
             `size: ${response.headers[`content-length`]}B`,
@@ -166,7 +169,6 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`,
       ? { nextSyncToken: syncToken, ...basicSyncConfig }
       : { initial: true, ...basicSyncConfig }
     currentSyncData = await client.sync(query)
-    syncProgress.done()
   } catch (e) {
     reporter.panic(
       {
@@ -177,6 +179,8 @@ ${formatPluginOptionsForCLI(pluginConfig.getOriginalPluginOptions(), errors)}`,
       },
       e
     )
+  } finally {
+    syncProgress.done()
   }
 
   // We need to fetch content types with the non-sync API as the sync API

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -336,7 +336,7 @@ exports.sourceNodes = async (
   fetchActivity.end()
 
   const processingActivity = reporter.activityTimer(
-    `Contentful: Proccess data (${sourceId})`,
+    `Contentful: Process data (${sourceId})`,
     {
       parentSpan,
     }


### PR DESCRIPTION
Changes to the Contentful SDK and Axios slipped through and broke our graceful error catching.

This PR will do the following:
* [x] Show custom error messages again, especially when you have a invalid spaceid, access token or environment
* [x] Show the actual Contentful API status code and message if available
* [x] Improve output of verbose request logging
* [x] Add a progress indicator if fetching content entries takes more that one request to the Contentful API
* [x] Output the total number of locales. Very helpful for debugging via build log.

## improved logging when using `--verbose` flag:
<img width="884" alt="Screenshot 2020-10-30 at 13 39 35" src="https://user-images.githubusercontent.com/1737026/97706384-ddf29f00-1ab5-11eb-85f8-eb775446af1b.png">

## New more detailed error messages:
<img width="609" alt="Screenshot 2020-10-30 at 13 39 04" src="https://user-images.githubusercontent.com/1737026/97706387-dfbc6280-1ab5-11eb-8a92-49341de9144c.png">

## Reintroduced custom error messages:
<img width="651" alt="Screenshot 2020-10-30 at 13 37 06" src="https://user-images.githubusercontent.com/1737026/97706388-e054f900-1ab5-11eb-8b53-c308770c0683.png">
<img width="663" alt="Screenshot 2020-10-30 at 13 36 35" src="https://user-images.githubusercontent.com/1737026/97706390-e0ed8f80-1ab5-11eb-9fed-1cac965d1a43.png">
