### PR TITLE
feat(gatsby): allow configuration of default socket type

### DIFF
--- a/packages/gatsby/cache-dir/socketIo.js
+++ b/packages/gatsby/cache-dir/socketIo.js
@@ -18,7 +18,7 @@ export default function socketIo() {
       try {
         // force websocket as transport
         socket = io({
-          transports: [process.env.SOCKET_IO_DEFAULT_TRANSPORT],
+          transports: [process.env.GATSBY_SOCKET_IO_DEFAULT_TRANSPORT],
         })
 
         // when websocket fails, we'll try polling

--- a/packages/gatsby/cache-dir/socketIo.js
+++ b/packages/gatsby/cache-dir/socketIo.js
@@ -18,7 +18,7 @@ export default function socketIo() {
       try {
         // force websocket as transport
         socket = io({
-          transports: [`websocket`],
+          transports: [process.env.SOCKET_IO_DEFAULT_TRANSPORT],
         })
 
         // when websocket fails, we'll try polling

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -87,8 +87,8 @@ module.exports = async (
     envObject.CYPRESS_SUPPORT = JSON.stringify(process.env.CYPRESS_SUPPORT)
 
     if (stage === `develop`) {
-      envObject.SOCKET_IO_DEFAULT_TRANSPORT = JSON.stringify(
-        process.env.SOCKET_IO_DEFAULT_TRANSPORT || `websocket`
+      envObject.GATSBY_SOCKET_IO_DEFAULT_TRANSPORT = JSON.stringify(
+        process.env.GATSBY_SOCKET_IO_DEFAULT_TRANSPORT || `websocket`
       )
     }
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -86,6 +86,12 @@ module.exports = async (
     envObject.BUILD_STAGE = JSON.stringify(stage)
     envObject.CYPRESS_SUPPORT = JSON.stringify(process.env.CYPRESS_SUPPORT)
 
+    if (stage === `develop`) {
+      envObject.SOCKET_IO_DEFAULT_TRANSPORT = JSON.stringify(
+        process.env.SOCKET_IO_DEFAULT_TRANSPORT || `websocket`
+      )
+    }
+
     const mergedEnvVars = Object.assign(envObject, gatsbyVarObject)
 
     return Object.keys(mergedEnvVars).reduce(


### PR DESCRIPTION
## Description

Add an env var so we can set the default websocket type. It should fix long running websocket issues. When a faulty transport is given than socket.io will fallback to polling anyway.