### PR TITLE
feat(gatsby): more `gatsby plugin configure` additions

### DIFF
--- a/packages/gatsby/src/commands/plugin/configure.ts
+++ b/packages/gatsby/src/commands/plugin/configure.ts
@@ -38,9 +38,7 @@ export async function run(): Promise<void> {
       return {
         name,
         initial: supportedOptionTypes.includes(typeof option.flags?.default)
-          ? // TODO: Don't toString() this otherwise the answers will have e.g. "false" instead of `false`
-            // Might require an upstream fix in enquirer.
-            option.flags?.default.toString()
+          ? option.flags?.default.toString()
           : ``,
         message: name,
         disabled: !supported,

--- a/packages/gatsby/src/commands/plugin/configure.ts
+++ b/packages/gatsby/src/commands/plugin/configure.ts
@@ -22,6 +22,9 @@ export async function run(): Promise<void> {
     .map(name => {
       const option = options[name]
       const supported = supportedOptionTypes.includes(option.type)
+      // TODO: Don't hard code this.
+      // Maybe we just allowlist a bunch of options like accessToken, password, token?
+      const isSensitive = name === `accessToken`
 
       return {
         name,
@@ -32,6 +35,10 @@ export async function run(): Promise<void> {
           : ``,
         message: name,
         disabled: !supported,
+        // coerce inputs on sensitive fields into asterisks
+        ...(isSensitive && {
+          format: (input): string => `*`.repeat(input.length),
+        }),
         // hint: option.flags?.description,
       }
     })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

In an attempt to start addressing some of the TODOs from https://github.com/gatsbyjs/gatsby/pull/27727 I added a couple additions:

- [x] _Hide token/secret values in inputs_: using the `format` function from `enquirer` we can replace the input with asterisks on sensitive fields. Maybe we can denote something as sensitive in a schema, or just allow list the names of options we think will show up there like `accessToken`, `token`, etc 🤷‍♂️ 

I hardcoded options matching `accessToken` to sensitive in this example:

![CleanShot 2020-10-30 at 15 03 40](https://user-images.githubusercontent.com/21114044/97756849-34b1a600-1ac1-11eb-8868-41a67b095ef8.gif)

- [x] _Fix the initial (default) value only supporting strings_: I think the `result` function from `enquirer` is a good candidate for this. It can transform or modify the returned value, which allows us to coerce the values into the types they're supposed to be from the plugin schema. 

![CleanShot 2020-10-30 at 15 06 47](https://user-images.githubusercontent.com/21114044/97757125-bd304680-1ac1-11eb-805f-4888d4bb4ab2.gif)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

#27727