### PR TITLE
Use passive event listener for scroll if it's supported

### DIFF
--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { LocationContext } from "@reach/router"
 import PropTypes from "prop-types"
 import { SessionStorage } from "./session-storage"
+import { supportsPassiveListener } from "./supports-passive-listener"
 
 export const ScrollContext = React.createContext<SessionStorage>(
   new SessionStorage()
@@ -34,7 +35,11 @@ export class ScrollHandler extends React.Component<
   }
 
   componentDidMount(): void {
-    window.addEventListener(`scroll`, this.scrollListener)
+    window.addEventListener(
+      `scroll`,
+      this.scrollListener,
+      supportsPassiveListener() ? { passive: true } : false
+    )
     let scrollPosition
     const { key, hash } = this.props.location
 

--- a/packages/gatsby-react-router-scroll/src/supports-passive-listener.ts
+++ b/packages/gatsby-react-router-scroll/src/supports-passive-listener.ts
@@ -1,0 +1,29 @@
+/**
+ * Detection code adapted from:
+ * https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
+ */
+
+let didCheck = false
+let isSupportedCached = false
+
+export function supportsPassiveListener(): boolean {
+  if (didCheck) {
+    return isSupportedCached
+  }
+  // Test via a getter in the options object to see if the passive property is accessed
+  try {
+    const opts = Object.defineProperty({}, `passive`, {
+      get: function (): void {
+        isSupportedCached = true
+        return undefined
+      },
+    })
+    const noop = (): void => {}
+    window.addEventListener(`scroll`, noop, opts)
+    window.removeEventListener(`scroll`, noop, opts)
+  } catch (e) {
+    isSupportedCached = false
+  }
+  didCheck = true
+  return isSupportedCached
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

This is a change to `gatsby-react-router-scroll` package

## Description

* Make scroll listener passive for better performance
* Check if passive events are supported by the browser
<!-- Write a brief description of the changes introduced by this PR -->

