### PR TITLE
add query pluginOption for mongodb plugin

### DIFF
--- a/packages/gatsby-source-mongodb/README.md
+++ b/packages/gatsby-source-mongodb/README.md
@@ -41,6 +41,7 @@ module.exports = {
 - **dbName**: indicates the database name that you want to use
 - **collection**: the collection name within Mongodb, this can also be an array
   for multiple collections
+- **query**: add a query when retriving a collection. This is a key value object where key's are collection names, and value is the query object. Defaults to {} (i.e. the whole collection)
 - **server**: contains the server info, with sub properties address and port ex.
   server: { address: `ds143532.mlab.com`, port: 43532 }. Defaults to a server
   running locally on the default port.

--- a/packages/gatsby-source-mongodb/README.md
+++ b/packages/gatsby-source-mongodb/README.md
@@ -16,6 +16,7 @@ module.exports = {
     {
       resolve: `gatsby-source-mongodb`,
       options: { dbName: `local`, collection: `documents` },
+      query: { documents: { as_of: { $gte: 1604397088013 } } },
     },
   ],
 }

--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -80,10 +80,12 @@ function createNodes(
   collectionName,
   createContentDigest
 ) {
-  const { preserveObjectIds = false } = pluginOptions
+  const { preserveObjectIds = false, query = {} } = pluginOptions
   return new Promise((resolve, reject) => {
     let collection = db.collection(collectionName)
-    let cursor = collection.find()
+    let cursor = collection.find(
+      query[collectionName] ? query[collectionName] : {}
+    )
 
     // Execute the each command, triggers for each document
     cursor.toArray((err, documents) => {


### PR DESCRIPTION
## Description
Currently there is now way to add a query when getting a collection data from mongo. There is a possibility that the collection is very large and we'd like to specify a query to limit the number of rows we retrieve from the database. This query pluginOption allows us to do that.

Example usage:-

```
{
    resolve: `gatsby-source-mongodb`,
    options: {
      connectionString: `mongodb+srv://test:test@mymongodbserver/?retryWrites=true`,
      dbName: `my-db`,
      collection: [`myCollection`],
      query: {
        myCollection: {
          as_of: {
            $gte: 1604397088013,
          },
        }
      }
    },
},
```