### PR TITLE
fix(gatsby-transformer-remark): add excerpt_separator to plugin options schema

### DIFF
--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -21,6 +21,9 @@ exports.pluginOptionsSchema = function ({ Joi }) {
     gfm: Joi.boolean().description(
       `Activates GitHub Flavored Markdown mode (default: true)`
     ),
+    excerpt_separator: Joi.string().description(
+      `If your Markdown file contains HTML, excerpt will not return a value. In that case, you can set an excerpt_separator to an HTML tag. Edit your Markdown files to include that HTML tag after the text you’d like to appear in the excerpt.`
+    ),
     plugins: Joi.array()
       .items(
         Joi.string(),


### PR DESCRIPTION
Closes #27784