### PR TITLE
fix(gatsby-plugin-sass): add missing options

### DIFF
--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -61,6 +61,7 @@ describe(`pluginOptionsSchema`, () => {
   it(`should provide meaningful errors when fields are invalid`, async () => {
     const expectedErrors = [
       `"implementation" must be of type object`,
+      `"cssLoaderOptions" must be of type object`,
       `"postCssPlugins" must be an array`,
       `"sassRuleTest" must be of type object`,
       `"sassRuleModulesTest" must be of type object`,
@@ -88,6 +89,7 @@ describe(`pluginOptionsSchema`, () => {
     const { errors } = await testPluginOptionsSchema(pluginOptionsSchema, {
       implementation: `This should be a require() thing`,
       postCssPlugins: `This should be an array of postCss plugins`,
+      cssLoaderOptions: `This should be an object of css-loader options`,
       sassRuleTest: `This should be a regexp`,
       sassRuleModulesTest: `This should be a regexp`,
       useResolveUrlLoader: `This should be a boolean`,
@@ -117,6 +119,7 @@ describe(`pluginOptionsSchema`, () => {
   it(`should validate the schema`, async () => {
     const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
       implementation: require(`../gatsby-node.js`),
+      cssLoaderOptions: { camelCase: false },
       postCssPlugins: [{ post: `CSS plugin` }],
       sassRuleTest: /\.global\.s(a|c)ss$/,
       sassRuleModulesTest: /\.mod\.s(a|c)ss$/,

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -86,7 +86,9 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       ),
     cssLoaderOptions: Joi.object({})
       .unknown(true)
-      .description(`Pass in options for css-loader: https://github.com/webpack-contrib/css-loader/tree/version-1#options`),
+      .description(
+        `Pass in options for css-loader: https://github.com/webpack-contrib/css-loader/tree/version-1#options`
+      ),
     postCssPlugins: Joi.array()
       .items(Joi.object({}).unknown(true))
       .description(`An array of postCss plugins`),

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -84,6 +84,9 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       .description(
         `By default the node implementation of Sass (node-sass) is used. To use the implementation written in Dart (dart-sass), you can install sass instead of node-sass and pass it into the options as the implementation`
       ),
+    cssLoaderOptions: Joi.object({})
+      .unknown(true)
+      .description(`Pass in options for css-loader: https://github.com/webpack-contrib/css-loader/tree/version-1#options`),
     postCssPlugins: Joi.array()
       .items(Joi.object({}).unknown(true))
       .description(`An array of postCss plugins`),


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

`cssLoaderOptions` is not defined in the schema, so it will return an error when passing in these options.
See readme: 
```
If you need to override the default options passed into css-loader: Note: Gatsby is using css-loader@1.0.1.

plugins: [
  {
    resolve: `gatsby-plugin-sass`,
    options: {
      cssLoaderOptions: {
        camelCase: false,
      },
    },
  },
]
```