### PR TITLE
Use NetworkFirst with networkTimeoutSeconds option configured

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -245,7 +245,7 @@ exports.pluginOptionsSchema = function ({ Joi }) {
             `CacheOnly`
           ),
           options: Joi.object({
-            networkTimeoutSeconds: Joi.number()
+            networkTimeoutSeconds: Joi.number(),
           }),
         })
       ),

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -244,6 +244,9 @@ exports.pluginOptionsSchema = function ({ Joi }) {
             `NetworkOnly`,
             `CacheOnly`
           ),
+          options: Joi.object({
+            networkTimeoutSeconds: Joi.number()
+          }),
         })
       ),
       skipWaiting: Joi.boolean(),


### PR DESCRIPTION
## Description
This PR enables the networkTimeoutSeconds option when using the NetworkFirst strategy.

### Documentation
https://developers.google.com/web/tools/workbox/guides/common-recipes#force_a_timeout_on_network_requests