### PR TITLE
feat(create-gatsby): add wip plugin configuration forms

### DIFF
--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^14.14.5",
     "eslint": "^7.12.1",
     "mock-stdin": "^1.0.0",
+    "joi": "^17.2.1",
     "prettier": "^2.1.2",
     "stdout-stderr": "^0.1.13",
     "typescript": "^4.0.5"

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -108,18 +108,6 @@ export async function run(): Promise<void> {
   console.log(`Let's answer some questions:\n`)
   const data = await prompt<IAnswers>(questions)
 
-  const selectedPlugins = [data.cms, data.styling, ...data.features].filter(
-    pluginName => pluginName !== `none`
-  )
-
-  console.log(
-    `\nGreat! A few of the selections you made need to be configured, fill in the options for each plugin now:\n`
-  )
-  const pluginConfig = await prompt<IAnswers>(
-    makePluginConfigQuestions(selectedPlugins)
-  )
-  console.log(pluginConfig)
-
   const messages: Array<string> = [
     `🛠  Create a new Gatsby site in the folder ${c.blueBright(data.project)}`,
   ]
@@ -150,6 +138,14 @@ export async function run(): Promise<void> {
     )
     plugins.push(...data.features)
   }
+
+  console.log(
+    `\nGreat! A few of the selections you made need to be configured, fill in the options for each plugin now:\n`
+  )
+  const pluginConfig = await prompt<IAnswers>(
+    makePluginConfigQuestions(plugins)
+  )
+  console.log(pluginConfig)
 
   console.log(`
 

--- a/packages/create-gatsby/src/plugin-schemas.json
+++ b/packages/create-gatsby/src/plugin-schemas.json
@@ -1,0 +1,238 @@
+{
+  "gatsby-source-wordpress": "TODO: no schema in https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/plugin/gatsby-node.js",
+  "gatsby-source-contentful": {
+    "type": "object",
+    "externals": [{}],
+    "keys": {
+      "accessToken": {
+        "type": "string",
+        "flags": {
+          "description": "Contentful delivery api key, when using the Preview API use your Preview API key",
+          "presence": "required"
+        }
+      },
+      "spaceId": {
+        "type": "string",
+        "flags": { "description": "Contentful spaceId", "presence": "required" }
+      },
+      "host": {
+        "type": "string",
+        "flags": {
+          "description": "The base host for all the API requests, by default it's 'cdn.contentful.com', if you want to use the Preview API set it to 'preview.contentful.com'. You can use your own host for debugging/testing purposes as long as you respect the same Contentful JSON structure.",
+          "default": "cdn.contentful.com"
+        }
+      },
+      "environment": {
+        "type": "string",
+        "flags": {
+          "description": "The environment to pull the content from, for more info on environments check out this [Guide](https://www.contentful.com/developers/docs/concepts/multiple-environments/).",
+          "default": "master"
+        }
+      },
+      "downloadLocal": {
+        "type": "boolean",
+        "flags": {
+          "description": "Downloads and caches ContentfulAsset's to the local filesystem. Allows you to query a ContentfulAsset's localFile field, which is not linked to Contentful's CDN. Useful for reducing data usage.\nYou can pass in any other options available in the [contentful.js SDK](https://github.com/contentful/contentful.js#configuration).",
+          "default": false
+        }
+      },
+      "localeFilter": {
+        "type": "function",
+        "flags": {
+          "description": "Possibility to limit how many locales/nodes are created in GraphQL. This can limit the memory usage by reducing the amount of nodes created. Useful if you have a large space in contentful and only want to get the data from one selected locale.\nFor example, to filter locales on only germany `localeFilter: locale => locale.code === 'de-DE'`\n\nList of locales and their codes can be found in Contentful app -> Settings -> Locales"
+        }
+      },
+      "forceFullSync": {
+        "type": "boolean",
+        "flags": {
+          "description": "Prevents the use of sync tokens when accessing the Contentful API.",
+          "default": false
+        }
+      },
+      "pageLimit": {
+        "type": "number",
+        "flags": {
+          "description": "Number of entries to retrieve from Contentful at a time. Due to some technical limitations, the response payload should not be greater than 7MB when pulling content from Contentful. If you encounter this issue you can set this param to a lower number than 100, e.g 50.",
+          "default": 100
+        },
+        "rules": [{ "name": "integer" }]
+      },
+      "assetDownloadWorkers": {
+        "type": "number",
+        "flags": {
+          "description": "Number of workers to use when downloading contentful assets. Due to technical limitations, opening too many concurrent requests can cause stalled downloads. If you encounter this issue you can set this param to a lower number than 50, e.g 25.",
+          "default": 50
+        },
+        "rules": [{ "name": "integer" }]
+      },
+      "proxy": {
+        "type": "object",
+        "flags": {
+          "description": "Axios proxy configuration. See the [axios request config documentation](https://github.com/mzabriskie/axios#request-config) for further information about the supported values."
+        },
+        "keys": {
+          "host": { "type": "string", "flags": { "presence": "required" } },
+          "port": { "type": "number", "flags": { "presence": "required" } },
+          "auth": {
+            "type": "object",
+            "keys": {
+              "username": { "type": "string" },
+              "password": { "type": "string" }
+            }
+          }
+        }
+      },
+      "useNameForId": {
+        "type": "boolean",
+        "flags": {
+          "description": "Use the content's `name` when generating the GraphQL schema e.g. a Content Type called `[Component] Navigation bar` will be named `contentfulComponentNavigationBar`.\n    When set to `false`, the content's internal ID will be used instead e.g. a Content Type with the ID `navigationBar` will be called `contentfulNavigationBar`.\n\n    Using the ID is a much more stable property to work with as it will change less often. However, in some scenarios, Content Types' IDs will be auto-generated (e.g. when creating a new Content Type without specifying an ID) which means the name in the GraphQL schema will be something like `contentfulC6XwpTaSiiI2Ak2Ww0oi6qa`. This won't change and will still function perfectly as a valid field name but it is obviously pretty ugly to work with.\n\n    If you are confident your Content Types will have natural-language IDs (e.g. `blogPost`), then you should set this option to `false`. If you are unable to ensure this, then you should leave this option set to `true` (the default).",
+          "default": true
+        }
+      },
+      "plugins": { "type": "array" },
+      "richText": {
+        "type": "object",
+        "flags": { "default": {} },
+        "keys": {
+          "resolveFieldLocales": {
+            "type": "boolean",
+            "flags": {
+              "description": "If you want to resolve the locales in fields of assets and entries that are referenced by rich text (e.g., via embedded entries or entry hyperlinks), set this to `true`. Otherwise, fields of referenced assets or entries will be objects keyed by locale.",
+              "default": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "gatsby-source-datocms": "TODO: no schema in https://github.com/datocms/gatsby-source-datocms/blob/master/src/gatsby-node.js",
+  "gatsby-source-sanity": "TODO: no schema in https://github.com/sanity-io/gatsby-source-sanity/blob/main/src/gatsby-node.ts",
+  "gatsby-source-agility": "TODO: no schema in https://github.com/agility/gatsby-source-agilitycms/blob/master/gatsby-node.js",
+  "gatsby-plugin-postcss": {},
+  "gatsby-plugin-styled-components": {},
+  "gatsby-plugin-emotion": {},
+  "gatsby-plugin-sass": {},
+  "gatsby-plugin-themeui": {},
+  "gatsby-plugin-google-analytics": {
+    "type": "object",
+    "keys": {
+      "trackingId": {
+        "type": "string",
+        "flags": {
+          "description": "The property ID; the tracking code won't be generated without it",
+          "presence": "required"
+        }
+      },
+      "head": {
+        "type": "boolean",
+        "flags": {
+          "default": false,
+          "description": "Defines where to place the tracking script - `true` in the head and `false` in the body"
+        }
+      },
+      "anonymize": { "type": "boolean", "flags": { "default": false } },
+      "respectDNT": { "type": "boolean", "flags": { "default": false } },
+      "exclude": {
+        "type": "array",
+        "flags": {
+          "default": [],
+          "description": "Avoids sending pageview hits from custom paths"
+        },
+        "items": [{ "type": "string" }]
+      },
+      "pageTransitionDelay": {
+        "type": "number",
+        "flags": {
+          "default": 0,
+          "description": "Delays sending pageview hits on route update (in milliseconds)"
+        }
+      },
+      "optimizeId": {
+        "type": "string",
+        "flags": {
+          "description": "Enables Google Optimize using your container Id"
+        }
+      },
+      "experimentId": {
+        "type": "string",
+        "flags": { "description": "Enables Google Optimize Experiment ID" }
+      },
+      "variationId": {
+        "type": "string",
+        "flags": { "description": "Set Variation ID. 0 for original 1,2,3...." }
+      },
+      "defer": {
+        "type": "boolean",
+        "flags": {
+          "description": "Defers execution of google analytics script after page load"
+        }
+      },
+      "sampleRate": { "type": "number" },
+      "siteSpeedSampleRate": { "type": "number" },
+      "cookieDomain": { "type": "string" }
+    }
+  },
+  "gatsby-plugin-sitemap": {},
+  "gatsby-plugin-mdx": {},
+  "gatsby-plugin-offline": {},
+  "gatsby-plugin-manifest": {
+    "type": "object",
+    "keys": {
+      "name": { "type": "string" },
+      "short_name": { "type": "string" },
+      "description": { "type": "string" },
+      "lang": { "type": "string" },
+      "localize": {
+        "type": "array",
+        "items": [
+          {
+            "type": "object",
+            "keys": {
+              "start_url": { "type": "string" },
+              "name": { "type": "string" },
+              "short_name": { "type": "string" },
+              "description": { "type": "string" },
+              "lang": { "type": "string" }
+            }
+          }
+        ]
+      },
+      "start_url": { "type": "string" },
+      "background_color": { "type": "string" },
+      "theme_color": { "type": "string" },
+      "display": { "type": "string" },
+      "legacy": { "type": "boolean" },
+      "include_favicon": { "type": "boolean" },
+      "icon": { "type": "string" },
+      "theme_color_in_head": { "type": "boolean" },
+      "crossOrigin": {
+        "type": "string",
+        "flags": { "only": true },
+        "allow": ["use-credentials", "anonymous"]
+      },
+      "cache_busting_mode": {
+        "type": "string",
+        "flags": { "only": true },
+        "allow": ["query", "name", "none"]
+      },
+      "icons": {
+        "type": "array",
+        "items": [
+          {
+            "type": "object",
+            "keys": {
+              "src": { "type": "string" },
+              "sizes": { "type": "string" },
+              "type": { "type": "string" },
+              "purpose": { "type": "string" }
+            }
+          }
+        ]
+      },
+      "icon_options": {
+        "type": "object",
+        "keys": { "purpose": { "type": "string" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This is a mess of poorly typed code that introduces a WIP form of prompting users for required plugin options when they select plugins in the create gatsby flow.

