### PR TITLE
fix(gatsby): feedback test did not reset 7day check

### DIFF
--- a/packages/gatsby/src/utils/__tests__/feedback.ts
+++ b/packages/gatsby/src/utils/__tests__/feedback.ts
@@ -38,6 +38,7 @@ const clearStateToAllowHeuristicsToPass = (): void => {
   delete process.env.GATSBY_FEEDBACK_DISABLED
   // Heuristic 4
   getConfigStore().set(`feedback.lastRequestDate`, dateFromSixMonthsAgo)
+  getConfigStore().set(`feedback.sevenDayFeedbackDate`, dateFromSixMonthsAgo)
   // Heuristic 5
   ;(getGatsbyVersion as jest.Mock).mockReturnValue(`2.1.1`)
 }

--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -97,6 +97,7 @@ export async function userPassesFeedbackRequestHeuristic(): Promise<boolean> {
     }
   }
 
+  // 4.b
   // we don't want to give them this survey right after the seven day feedback survey
   const sevenDayFeedback = getConfigStore().get(sevenDayKey)
   if (sevenDayFeedback) {


### PR DESCRIPTION
The tests for the analytics did not reset the 7 day feedback date in config so it failed for me locally. This fixes it.