### PR TITLE
fix(recipe): add brackets to directory names

### DIFF
--- a/packages/gatsby-recipes/recipes/gatsby-image.mdx
+++ b/packages/gatsby-recipes/recipes/gatsby-image.mdx
@@ -20,7 +20,7 @@ Installs NPM Packages.
 
 ---
 
-Adds Gatsby plugin `gatsby-source-filesystem` to read images from the src/images
+Adds Gatsby plugin `gatsby-source-filesystem` to read images from the `src/images`
 directory.
 
 <GatsbyPlugin


### PR DESCRIPTION
## Description

changes:
- place directory name in brackets


## Related Issues

- #27012 feat(gatsby-recipes): Add a built in recipe for Gatsby Image 
