### PR TITLE
fix(gatsby-remark-autolink-headers): remove incorrect default value for icon option

### DIFF
--- a/packages/gatsby-remark-autolink-headers/src/gatsby-node.js
+++ b/packages/gatsby-remark-autolink-headers/src/gatsby-node.js
@@ -8,8 +8,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
       .try(Joi.string(), Joi.boolean())
       .description(
         `SVG shape inside a template literal or boolean 'false'. Set your own svg or disable icon.`
-      )
-      .default(true),
+      ),
     className: Joi.string()
       .description(`Set your own class for the anchor.`)
       .default(`anchor`),


### PR DESCRIPTION
Closes #27813. This should be defaulted to `undefined`, as `true` isn't supported.
