### PR TITLE
fix(gatsby-plugin-sass): fix default output style & allow unknown options

### DIFF
--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -152,4 +152,12 @@ describe(`pluginOptionsSchema`, () => {
 
     expect(isValid).toBe(true)
   })
+
+  it(`should allow unknown options`, async () => {
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+      webpackImporter: `unknown option`,
+    })
+
+    expect(isValid).toBe(true)
+  })
 })

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -166,7 +166,6 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       ),
     outputStyle: Joi.string()
       .valid(`nested`, `expanded`, `compact`, `compressed`)
-      .default(`nested`)
       .description(`Determines the output format of the final CSS style.`),
     precision: Joi.number()
       .default(5)
@@ -193,5 +192,5 @@ When typeof sourceMap === "string", the value of sourceMap will be used as the w
     sourceMapRoot: Joi.string().description(
       `the value will be emitted as sourceRoot in the source map information`
     ),
-  })
+  }).unknown(true)
 }


### PR DESCRIPTION
## Description

Cherry-picked #27822 for the release branch