### PR TITLE
Add Vercel Analytics to documentation.

### DIFF
--- a/docs/docs/adding-analytics.md
+++ b/docs/docs/adding-analytics.md
@@ -76,3 +76,4 @@ Once this is configured you can deploy your site to test! If you navigate to the
 - [GoatCounter](/packages/gatsby-plugin-goatcounter/)
 - [PostHog](/packages/gatsby-plugin-posthog-analytics/)
 - [Plausible](/packages/gatsby-plugin-plausible/)
+- [Vercel](/packages/gatsby-plugin-vercel/)


### PR DESCRIPTION
## Description

Hey, all! 👋   This PR adds [Vercel Analytics](https://vercel.com/blog/gatsby-analytics) to the analytics documentation as an option. This allows Gatsby users to track [Core Web Vitals](https://vercel.com/docs/analytics/overview#web-vitals) over time with zero configuration.

For more information, check out [this post](https://vercel.com/blog/gatsby-analytics).

### Documentation

Current documentation: https://www.gatsbyjs.com/docs/adding-analytics/#other-gatsby-analytics-plugins
