### PR TITLE
File System Route API: Support `/{Model.foo}-{Model.bar}`

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/__tests__/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/collection-extract-query-string.ts
@@ -35,6 +35,23 @@ describe(`collectionExtractQueryString`, () => {
     expect(query).toMatchInlineSnapshot(`"{allProduct{nodes{name,id}}}"`)
   })
 
+  it(`will create a basic query from the route with minimal length`, async () => {
+    // @ts-ignore
+    patchReadFileSync(`
+      import { graphql } from "gatsby"
+      export const pageQuery = graphql\`
+        { allThings(filter: { name: { nin: ["stuff"] }}) { nodes, id } }
+      \`
+      `)
+
+    const query = await collectionExtractQueryString(
+      createPath(`src/pages/{P.n}`),
+      reporter
+    )
+
+    expect(query).toMatchInlineSnapshot(`"{allP{nodes{n,id}}}"`)
+  })
+
   it(`will create a basic query from the route with a prefix variant 1`, async () => {
     // @ts-ignore
     patchReadFileSync(`
@@ -101,5 +118,73 @@ describe(`collectionExtractQueryString`, () => {
     )
 
     expect(query).toMatchInlineSnapshot(`"{allProduct{nodes{name,id}}}"`)
+  })
+
+  it(`will create a basic query with multiple entries`, async () => {
+    // @ts-ignore
+    patchReadFileSync(`
+      import { graphql } from "gatsby"
+      export const pageQuery = graphql\`
+        { allThings(filter: { name: { nin: ["stuff"] }}) { nodes, id } }
+      \`
+      `)
+
+    const query = await collectionExtractQueryString(
+      createPath(`src/pages/{Product.name}-{Product.color}`),
+      reporter
+    )
+
+    expect(query).toMatchInlineSnapshot(`"{allProduct{nodes{name,color,id}}}"`)
+  })
+
+  it(`will create a basic query with multiple entries and different delimiters variant 1`, async () => {
+    // @ts-ignore
+    patchReadFileSync(`
+      import { graphql } from "gatsby"
+      export const pageQuery = graphql\`
+        { allThings(filter: { name: { nin: ["stuff"] }}) { nodes, id } }
+      \`
+      `)
+
+    const query = await collectionExtractQueryString(
+      createPath(`src/pages/{Product.name}_{Product.color}`),
+      reporter
+    )
+
+    expect(query).toMatchInlineSnapshot(`"{allProduct{nodes{name,color,id}}}"`)
+  })
+
+  it(`will create a basic query with multiple entries and different delimiters variant 1`, async () => {
+    // @ts-ignore
+    patchReadFileSync(`
+      import { graphql } from "gatsby"
+      export const pageQuery = graphql\`
+        { allThings(filter: { name: { nin: ["stuff"] }}) { nodes, id } }
+      \`
+      `)
+
+    const query = await collectionExtractQueryString(
+      createPath(`src/pages/{Product.name}.{Product.color}`),
+      reporter
+    )
+
+    expect(query).toMatchInlineSnapshot(`"{allProduct{nodes{name,color,id}}}"`)
+  })
+
+  it(`will create a basic query with multiple entries and different delimiters variant 1`, async () => {
+    // @ts-ignore
+    patchReadFileSync(`
+      import { graphql } from "gatsby"
+      export const pageQuery = graphql\`
+        { allThings(filter: { name: { nin: ["stuff"] }}) { nodes, id } }
+      \`
+      `)
+
+    const query = await collectionExtractQueryString(
+      createPath(`src/pages/{Product.name}__{Product.color}`),
+      reporter
+    )
+
+    expect(query).toMatchInlineSnapshot(`"{allProduct{nodes{name,color,id}}}"`)
   })
 })

--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -9,6 +9,13 @@ describe(`derive-path`, () => {
     expect(
       derivePath(`product/{product.id}`, { id: `1` }, reporter).derivedPath
     ).toEqual(`product/1`)
+    expect(
+      derivePath(`product/{p.d}`, { d: `1` }, reporter).derivedPath
+    ).toEqual(`product/1`)
+    expect(
+      derivePath(`product/{p123_foo.d123_a}`, { d123_a: `1` }, reporter)
+        .derivedPath
+    ).toEqual(`product/1`)
   })
 
   it(`converts number to string in URL`, () => {
@@ -35,6 +42,13 @@ describe(`derive-path`, () => {
         reporter
       ).derivedPath
     ).toEqual(`product/1/foo`)
+    expect(
+      derivePath(
+        `product/{Product.id}-{Product.field__name}`,
+        { id: 1, field: { name: `foo` } },
+        reporter
+      ).derivedPath
+    ).toEqual(`product/1-foo`)
   })
 
   it(`has support for nested collections with same field`, () => {
@@ -45,6 +59,13 @@ describe(`derive-path`, () => {
         reporter
       ).derivedPath
     ).toEqual(`product/foo/bar`)
+    expect(
+      derivePath(
+        `product/{Product.field__name}-{Product.field__category}`,
+        { field: { name: `foo`, category: `bar` } },
+        reporter
+      ).derivedPath
+    ).toEqual(`product/foo-bar`)
   })
 
   it(`has union support`, () => {
@@ -57,6 +78,16 @@ describe(`derive-path`, () => {
         reporter
       ).derivedPath
     ).toEqual(`product/1`)
+
+    expect(
+      derivePath(
+        `product/{Product.field__(File)__id}-{Product.field__(File)__foo}`,
+        {
+          field: { id: `1`, foo: `123` },
+        },
+        reporter
+      ).derivedPath
+    ).toEqual(`product/1-123`)
   })
 
   it(`doesnt remove '/' from slug`, () => {
@@ -81,6 +112,16 @@ describe(`derive-path`, () => {
         reporter
       ).derivedPath
     ).toEqual(`film/mrs-doubtfire`)
+    expect(
+      derivePath(
+        `film/{Movie.title}-{Movie.actor}`,
+        {
+          title: `Mrs. Doubtfire`,
+          actor: `Mr. Gatsby`,
+        },
+        reporter
+      ).derivedPath
+    ).toEqual(`film/mrs-doubtfire-mr-gatsby`)
   })
 
   it(`supports prefixes`, () => {
@@ -131,6 +172,23 @@ describe(`derive-path`, () => {
         reporter
       ).derivedPath
     ).toEqual(`foo/dolorespostfix/awesome_another-postfix`)
+  })
+
+  it(`supports nesting, characters in between, weird slugs, unions all in one`, () => {
+    expect(
+      derivePath(
+        `blog/prefix-{M.name}.middle.{M.field__(Union)__color}_postfix/{M.director}--{M.s}`,
+        {
+          name: `Mr. Gatsby`,
+          director: `doug_judy`,
+          field: { color: `purple` },
+          s: `/magic/wonderful`,
+        },
+        reporter
+      ).derivedPath
+    ).toEqual(
+      `blog/prefix-mr-gatsby.middle.purple_postfix/doug-judy--/magic/wonderful`
+    )
   })
 
   it(`keeps existing slashes around and handles possible double forward slashes`, () => {

--- a/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
@@ -77,23 +77,6 @@ describe(`extract query`, () => {
         )
       ).toBe(`{ allThing(filter: { main_url: { nin: [] }}) { nodes{id} } }`)
     })
-
-    it(`supports a special fragment`, () => {
-      expect(
-        generateQueryFromString(
-          `{ allMarkdownRemark {
-        group(field: frontmatter___topic) {
-            ...CollectionPagesQueryFragment
-        }}
-    }`,
-          compatiblePath(`/foo/bar/{MarkdownRemark.frontmatter__topic}.js`)
-        )
-      ).toEqual(`{ allMarkdownRemark {
-        group(field: frontmatter___topic) {
-            nodes{frontmatter{topic},id}
-        }}
-    }`)
-    })
   })
 
   describe(`filepath resolution`, () => {
@@ -120,6 +103,12 @@ describe(`extract query`, () => {
         generateQueryFromString(
           `Thing`,
           compatiblePath(`/foo/bar/{Thing.id}/{Thing.name}.js`)
+        )
+      ).toBe(`{allThing{nodes{id,name}}}`)
+      expect(
+        generateQueryFromString(
+          `Thing`,
+          compatiblePath(`/foo/bar/{Thing.id}-{Thing.name}.js`)
         )
       ).toBe(`{allThing{nodes{id,name}}}`)
     })

--- a/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/extract-query.ts
@@ -68,15 +68,6 @@ describe(`extract query`, () => {
         )
       ).toBe(`{allThing{nodes{id}}}`)
     })
-
-    it(`works with arguments`, () => {
-      expect(
-        generateQueryFromString(
-          `{ allThing(filter: { main_url: { nin: [] }}) { ...CollectionPagesQueryFragment } }`,
-          compatiblePath(`/foo/bar/{Thing.id}.js`)
-        )
-      ).toBe(`{ allThing(filter: { main_url: { nin: [] }}) { nodes{id} } }`)
-    })
   })
 
   describe(`filepath resolution`, () => {

--- a/packages/gatsby-plugin-page-creator/src/__tests__/get-collection-route-params.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/get-collection-route-params.ts
@@ -49,4 +49,13 @@ describe(`getCollectionRouteParams`, () => {
     expect(params.id).toEqual(`1234`)
     expect(params.name).toEqual(`burger`)
   })
+
+  it(`outputs empty object for no matches`, () => {
+    const filePath = `/products/{Product.id}-test.js`
+    const urlPath = `/products/1234`
+
+    const params = getCollectionRouteParams(filePath, urlPath)
+
+    expect(params).toEqual({})
+  })
 })

--- a/packages/gatsby-plugin-page-creator/src/__tests__/get-collection-route-params.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/get-collection-route-params.ts
@@ -18,6 +18,18 @@ describe(`getCollectionRouteParams`, () => {
     expect(params.name).toEqual(`burger`)
   })
 
+  it(`gets multiple params out of url in same part`, () => {
+    const filePath = `/{Product.name}-{Product.id}_{Product.desc}.{Product.number}.js`
+    const urlPath = `/burger-1234_foo.bar`
+
+    const params = getCollectionRouteParams(filePath, urlPath)
+
+    expect(params.id).toEqual(`1234`)
+    expect(params.name).toEqual(`burger`)
+    expect(params.desc).toEqual(`foo`)
+    expect(params.number).toEqual(`bar`)
+  })
+
   it(`gets multiple params out of url with prefixes`, () => {
     const filePath = `/products/prefix-{Product.id}/another-prefix_{Product.name}/product.js`
     const urlPath = `/products/prefix-1234/another-prefix_burger/product`

--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -68,6 +68,14 @@ describe(`isValidCollectionPathImplementation`, () => {
     `/{Model.test}/Model.id}.js`,
     `/products/{Model.id}-{Model.}.js`,
     `/products/{Model.id}-{Model_foo}.js`,
+    `/products/{Model.id}-Model.id}.js`,
+    `/products/Model.id}-{Model.id}.js`,
+    `/products/Model.id}-Model.id}.js`,
+    `/products/{Model.id-{Model.id.js`,
+    `/products/{Model.id-Model.id.js`,
+    `/products/Model.id}-Model.id.js`,
+    `/products/Model.id-{Model.id.js`,
+    `/products/Model.id-Model.id}.js`,
   ])(`%o throws as expected`, path => {
     const part = path.split(`/`)[2]
 

--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -33,6 +33,11 @@ describe(`isValidCollectionPathImplementation`, () => {
     `/products/{Model.bar}/[...name].js`,
     `/products/{M.id}.js`,
     `/products/{M.i}.js`,
+    `/products/{Model.id}-{Model.foo}.js`,
+    `/products/prefix-{Model.id}-{Model.foo}.js`,
+    `/products/{Model.id}-{Model.foo}-postfix.js`,
+    `/products/{Model.id}_{Model.foo}.js`,
+    `/products/{Model.id}.{Model.foo}.js`,
   ])(`%o passes`, path => {
     expect(() =>
       isValidCollectionPathImplementation(compatiblePath(path), reporter)
@@ -61,6 +66,8 @@ describe(`isValidCollectionPathImplementation`, () => {
     `/products/prefix-{Model.foo.bar.baz}.js`,
     `/{Model.test}/{Model.id.js`,
     `/{Model.test}/Model.id}.js`,
+    `/products/{Model.id}-{Model.}.js`,
+    `/products/{Model.id}-{Model_foo}.js`,
   ])(`%o throws as expected`, path => {
     const part = path.split(`/`)[2]
 

--- a/packages/gatsby-plugin-page-creator/src/__tests__/validate-path-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/validate-path-query.ts
@@ -49,7 +49,7 @@ Unable to find a file at: \\"<PROJECT_ROOT>/src/pages/foo/{bar}\\""
   })
 
   it(`works if all the above predicates pass`, async () => {
-    const filePath = `/foo/{bar}-{baz}_{a}.{b}`
+    const filePath = `/foo/{bar}`
     const absolutePath = systemPath.join(
       process.cwd(),
       `src/pages`,

--- a/packages/gatsby-plugin-page-creator/src/__tests__/validate-path-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/validate-path-query.ts
@@ -49,7 +49,7 @@ Unable to find a file at: \\"<PROJECT_ROOT>/src/pages/foo/{bar}\\""
   })
 
   it(`works if all the above predicates pass`, async () => {
-    const filePath = `/foo/{bar}`
+    const filePath = `/baz/{bar}`
     const absolutePath = systemPath.join(
       process.cwd(),
       `src/pages`,

--- a/packages/gatsby-plugin-page-creator/src/__tests__/validate-path-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/validate-path-query.ts
@@ -49,7 +49,7 @@ Unable to find a file at: \\"<PROJECT_ROOT>/src/pages/foo/{bar}\\""
   })
 
   it(`works if all the above predicates pass`, async () => {
-    const filePath = `/baz/{bar}`
+    const filePath = `/foo/{bar}-{baz}_{a}.{b}`
     const absolutePath = systemPath.join(
       process.cwd(),
       `src/pages`,
@@ -61,6 +61,6 @@ Unable to find a file at: \\"<PROJECT_ROOT>/src/pages/foo/{bar}\\""
       validatePathQuery(filePath, [`.js`, `.ts`, `.mjs`])
     }).not.toThrow()
 
-    await fs.remove(systemPath.join(process.cwd(), `src`))
+    await fs.remove(systemPath.join(process.cwd(), `src/pages`))
   })
 })

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -2,7 +2,6 @@ import _ from "lodash"
 import slugify from "@sindresorhus/slugify"
 import { Reporter } from "gatsby"
 import {
-  compose,
   extractFieldWithoutUnion,
   extractAllCollectionSegments,
   switchToPeriodDelimiters,
@@ -32,10 +31,8 @@ export function derivePath(
   // 3.  For each slug parts get the actual value from the node data
   slugParts.forEach(slugPart => {
     // 3.a.  this transforms foo__bar into foo.bar
-    const key = compose(
-      extractFieldWithoutUnion,
-      switchToPeriodDelimiters
-    )(slugPart)
+    const cleanedField = extractFieldWithoutUnion(slugPart)[0]
+    const key = switchToPeriodDelimiters(cleanedField)
 
     // 3.b  We do node or node.nodes here because we support the special group
     //      graphql field, which then moves nodes in another depth

--- a/packages/gatsby-plugin-page-creator/src/extract-query.ts
+++ b/packages/gatsby-plugin-page-creator/src/extract-query.ts
@@ -68,14 +68,7 @@ function extractUrlParamsForQuery(createdPath: string): string {
     > => {
       if (part.includes(`{`) && part.includes(`}`)) {
         const fields = extractField(part)
-
-        let derived: Array<string> | string
-
-        if (typeof fields === `string`) {
-          derived = deriveNesting(fields)
-        } else {
-          derived = fields.map(f => deriveNesting(f))
-        }
+        const derived = fields.map(f => deriveNesting(f))
 
         return queryParts.concat(derived)
       }

--- a/packages/gatsby-plugin-page-creator/src/get-collection-route-params.ts
+++ b/packages/gatsby-plugin-page-creator/src/get-collection-route-params.ts
@@ -24,16 +24,19 @@ export function getCollectionRouteParams(
     if (!part.includes(`{`) || !part.includes(`}`)) {
       return
     }
+    // Use the previously created regex to match prefix-123 to prefix-(.+)
+    const match = urlParts[i].match(templateRegex[i])
 
-    const key = extractFieldWithoutUnion(part)
+    if (!match) {
+      return
+    }
 
-    key.forEach((k, j) => {
-      // Use the previously created regex to match prefix-123 to prefix-(.+)
-      const match = urlParts[i].match(templateRegex[i])
+    const keys = extractFieldWithoutUnion(part)
 
-      if (match) {
-        params[k] = match[j + 1]
-      }
+    keys.some((k, j) => {
+      params[k] = match[j + 1]
+
+      return !match
     })
   })
 

--- a/packages/gatsby-plugin-page-creator/src/get-collection-route-params.ts
+++ b/packages/gatsby-plugin-page-creator/src/get-collection-route-params.ts
@@ -15,6 +15,7 @@ export function getCollectionRouteParams(
   // Create a regex string for later use by creating groups for all { } finds
   // e.g. /foo/prefix-{Product.id} => /foo/prefix-(.+)
   const templateRegex = cleanedUrlTemplate
+    .replace(/\./g, `\\.`) // Escape dots
     .replace(/(\{.*?\})/g, `(.+)`)
     .split(`/`)
   const urlParts = urlPath.split(`/`)

--- a/packages/gatsby-plugin-page-creator/src/get-collection-route-params.ts
+++ b/packages/gatsby-plugin-page-creator/src/get-collection-route-params.ts
@@ -25,12 +25,15 @@ export function getCollectionRouteParams(
     }
 
     const key = extractFieldWithoutUnion(part)
-    // Use the previously created regex to match prefix-123 to prefix-(.+)
-    const match = urlParts[i].match(templateRegex[i])
 
-    if (match) {
-      params[key] = match[1]
-    }
+    key.forEach((k, j) => {
+      // Use the previously created regex to match prefix-123 to prefix-(.+)
+      const match = urlParts[i].match(templateRegex[i])
+
+      if (match) {
+        params[k] = match[j + 1]
+      }
+    })
   })
 
   return params

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -20,19 +20,20 @@ export function isValidCollectionPathImplementation(
     if (!part.includes(`{`) && !part.includes(`}`)) return
 
     const model = matchAllPolyfill(/\{([a-zA-Z_]\w*)./g, part) // Search for word before first dot, e.g. Model
-    const field = matchAllPolyfill(/{.*?((?<=\w\.)[^}]*)}/g, part) // Search for everything after the first dot, e.g. foo__bar (or in invalid case: foo.bar)
-
-    const models = Array.from(model, m => m[1])
-    const fields = Array.from(field, f => f[1])
+    const field = matchAllPolyfill(/.*?((?<=\w\.)[^}]*)}/g, part) // Search for everything after the first dot, e.g. foo__bar (or in invalid case: foo.bar)
 
     try {
       if (
-        models.length === 0 ||
-        fields.length === 0 ||
-        models.length !== fields.length
+        model.length === 0 ||
+        field.length === 0 ||
+        model.length !== field.length
       ) {
         throw new Error(errorMessage(part))
       }
+
+      const models = Array.from(model, m => m[1])
+      const fields = Array.from(field, f => f[1])
+
       for (const m of models) {
         assert(m, /^[a-zA-Z_]\w*$/, errorMessage(part)) // Check that Model is https://spec.graphql.org/draft/#sec-Names
       }

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -18,12 +18,26 @@ export function isValidCollectionPathImplementation(
   parts.forEach(part => {
     if (!part.includes(`{`) && !part.includes(`}`)) return
 
-    const model = part.match(/\{([a-zA-Z_]\w*)./)?.[1]! // Search for word before first dot, e.g. Model
-    const field = part.match(/((?<=\.).*)}/)?.[1]! // Search for everything after the first dot, e.g. foo__bar (or in invalid case: foo.bar)
+    const model = part.matchAll(/\{([a-zA-Z_]\w*)./g) // Search for word before first dot, e.g. Model
+    const field = part.matchAll(/{.*?((?<=\w\.)[^}]*)}/g) // Search for everything after the first dot, e.g. foo__bar (or in invalid case: foo.bar)
+
+    const models = Array.from(model, m => m[1])
+    const fields = Array.from(field, f => f[1])
 
     try {
-      assert(model, /^[a-zA-Z_]\w*$/, errorMessage(part)) // Check that Model is https://spec.graphql.org/draft/#sec-Names
-      assert(field, /^[a-zA-Z_][\w_()]*$/, errorMessage(part)) // Check that field is foo__bar__baz (and not foo.bar.baz) + https://spec.graphql.org/draft/#sec-Names
+      if (
+        models.length === 0 ||
+        fields.length === 0 ||
+        models.length !== fields.length
+      ) {
+        throw new Error(errorMessage(part))
+      }
+      for (const m of models) {
+        assert(m, /^[a-zA-Z_]\w*$/, errorMessage(part)) // Check that Model is https://spec.graphql.org/draft/#sec-Names
+      }
+      for (const f of fields) {
+        assert(f, /^[a-zA-Z_][\w_()]*$/, errorMessage(part)) // Check that field is foo__bar__baz (and not foo.bar.baz) + https://spec.graphql.org/draft/#sec-Names
+      }
     } catch (e) {
       reporter.panicOnBuild({
         id: prefixId(CODES.CollectionPath),

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -1,6 +1,7 @@
 import sysPath from "path"
 import { Reporter } from "gatsby"
 import { CODES, prefixId } from "./error-utils"
+import { matchAllPolyfill } from "./path-utils"
 
 // This file is a helper for consumers. It's going to log an error to them if they
 // in any way have an incorrect filepath setup for us to predictably use collection
@@ -18,8 +19,8 @@ export function isValidCollectionPathImplementation(
   parts.forEach(part => {
     if (!part.includes(`{`) && !part.includes(`}`)) return
 
-    const model = part.matchAll(/\{([a-zA-Z_]\w*)./g) // Search for word before first dot, e.g. Model
-    const field = part.matchAll(/{.*?((?<=\w\.)[^}]*)}/g) // Search for everything after the first dot, e.g. foo__bar (or in invalid case: foo.bar)
+    const model = matchAllPolyfill(/\{([a-zA-Z_]\w*)./g, part) // Search for word before first dot, e.g. Model
+    const field = matchAllPolyfill(/{.*?((?<=\w\.)[^}]*)}/g, part) // Search for everything after the first dot, e.g. foo__bar (or in invalid case: foo.bar)
 
     const models = Array.from(model, m => m[1])
     const fields = Array.from(field, f => f[1])

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -1,6 +1,6 @@
 // Regex created with: https://spec.graphql.org/draft/#sec-Names
 // First char only letter, underscore; rest letter, underscore, digit
-const extractModelRegex = /\{([a-zA-Z_][\w]+)\./
+const extractModelRegex = /\{([a-zA-Z_][\w]*)\./
 
 // Given a absolutePath that has a collection marker it will extract the Model.
 // /foo/bar/{Model.bar} => Model
@@ -51,18 +51,16 @@ const extractFieldWithoutUnionRegex = /\(.*\)__/g
 // {Model.bar} => bar
 // {Model.field__bar} => field__bar
 // {Model.field__(Union)__bar} => field__bar
-export function extractFieldWithoutUnion(filePart: string): string {
-  return (
-    extractField(filePart)
-      // Ignore union syntax
-      .replace(extractFieldWithoutUnionRegex, ``)
-  )
+export function extractFieldWithoutUnion(filePart: string): Array<string> {
+  const extracts = extractField(filePart)
+
+  return extracts.map(e => e.replace(extractFieldWithoutUnionRegex, ``))
 }
 
 const extractFieldRegexCurlyBraces = /[{}]/g
 // Regex created with: https://spec.graphql.org/draft/#sec-Names
 // First char only letter, underscore; rest letter, underscore, digit
-const extractFieldGraphQLModel = /[a-zA-Z_][\w]+\./
+const extractFieldGraphQLModel = /[a-zA-Z_][\w]*\./
 
 // Given a filePath part that is a collection marker it do this transformation:
 // {Model.field__(Union)__bar} => field__(Union)__bar
@@ -70,18 +68,16 @@ const extractFieldGraphQLModel = /[a-zA-Z_][\w]+\./
 // {model.field} => field
 // Also works with prefixes/postfixes (due to the regex match)
 // prefix-{model.field} => field
-export function extractField(filePart: string): string {
+export function extractField(filePart: string): Array<string> {
   const content = filePart.match(curlyBracesContentsRegex)
 
   if (!content) {
-    return ``
+    return [``]
   }
 
-  return (
-    content[0]
-      // Remove curly braces
+  return content.map(c =>
+    c
       .replace(extractFieldRegexCurlyBraces, ``)
-      // Remove Model
       .replace(extractFieldGraphQLModel, ``)
   )
 }

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -111,3 +111,18 @@ export function compose(
   return (filePart: string): string =>
     functions.reduce((value, fn) => fn(value), filePart)
 }
+
+export function matchAllPolyfill(
+  regexPattern,
+  sourceString
+): Array<RegExpExecArray> {
+  const output: Array<RegExpExecArray> = []
+  let match: RegExpExecArray | null
+  while ((match = regexPattern.exec(sourceString))) {
+    // get rid of the string copy
+    delete match.input
+    // store the match data
+    output.push(match)
+  }
+  return output
+}

--- a/packages/gatsby-plugin-page-creator/src/path-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/path-utils.ts
@@ -47,10 +47,15 @@ export function extractAllCollectionSegments(
 
 const extractFieldWithoutUnionRegex = /\(.*\)__/g
 
-// Given a filePath part that is a collection marker it do this transformation:
-// {Model.bar} => bar
-// {Model.field__bar} => field__bar
-// {Model.field__(Union)__bar} => field__bar
+/**
+ * Given a filePath part that is a collection marker it do this transformation:
+ * @param {string} filePart - The individual part of the URL
+ * @returns {Array<string>} - Returns an array of extracted fields (with converted "Unions")
+ * @example
+ * {Model.bar} => bar
+ * {Model.field__bar} => field__bar
+ * {Model.field__(Union)__bar} => field__bar
+ */
 export function extractFieldWithoutUnion(filePart: string): Array<string> {
   const extracts = extractField(filePart)
 
@@ -62,12 +67,17 @@ const extractFieldRegexCurlyBraces = /[{}]/g
 // First char only letter, underscore; rest letter, underscore, digit
 const extractFieldGraphQLModel = /[a-zA-Z_][\w]*\./
 
-// Given a filePath part that is a collection marker it do this transformation:
-// {Model.field__(Union)__bar} => field__(Union)__bar
-// Also works with lowercased model
-// {model.field} => field
-// Also works with prefixes/postfixes (due to the regex match)
-// prefix-{model.field} => field
+/**
+ * Given a filePath part that is a collection marker it do this transformation:
+ * @param {string} filePart - The individual part of the URL
+ * @returns {Array<string>} - Returns an array of extracted fields
+ * @example
+ * {Model.field__(Union)__bar} => field__(Union)__bar
+ * Also works with lowercased model
+ * {model.field} => field
+ * Also works with prefixes/postfixes (due to the regex match)
+ * prefix-{model.field} => field
+ */
 export function extractField(filePart: string): Array<string> {
   const content = filePart.match(curlyBracesContentsRegex)
 
@@ -112,6 +122,12 @@ export function compose(
     functions.reduce((value, fn) => fn(value), filePart)
 }
 
+/**
+ * Since String.prototype.matchAll() is only supported by Node v12+ and we still support Node 10, this is how we need to workaround this
+ * @param regexPattern - Should include the /g flag!
+ * @param sourceString - Input string to match against
+ * @returns An array of RegExpExecArray similar to the shape of .matchAll()
+ */
 export function matchAllPolyfill(
   regexPattern,
   sourceString


### PR DESCRIPTION
## Description

Part of https://github.com/gatsbyjs/gatsby/pull/27424

- I forgot to remove some bits about `collectionGraphql` in https://github.com/gatsbyjs/gatsby/pull/27824 so I did this here. Namely:
	- Removing outdated tests with name `supports a special fragment`
	- Removing `fragmentInterpolator` and check for `...CollectionPagesQueryFragment` in src/extract-query.ts
- Until now the assumption in the code was that for every part between `/` only one `{Model.foo__bar}` is allowed, so e.g. `/blog/{Model.foo}/{Model.bar}.js`
	- This fixes this assumption and thus also allowes a `/blog/{Model.foo}-{Model.bar}.js`
	- I changed the extractions to give back array of strings, not strings as now multiple matches are counted

[ch18291]