### PR TITLE
fix(gatsby): Remove version annotation in createPages

### DIFF
--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -12,7 +12,6 @@ export const resolvableExtensions = true
  *
  * See also [the documentation for the action `createPage`](/docs/actions/#createPage).
  *
- * @gatsbyVersion 2.2.0
  * @param {object} $0 See the [documentation for `Node API Helpers` for more details](/docs/node-api-helpers)
  * @param {Actions} $0.actions See the [list of documented actions](/docs/actions)
  * @param {function} $0.actions.createPages [Documentation for this action](/docs/actions/#createPage)


### PR DESCRIPTION
Remove an incorrect getsbyVersion annotation in the docs for `createPages`. This was introduced in #27735, and broke snapshots.