### PR TITLE
fix(gatsby-recipes): fix GatsbyShadowFile resource — don't error if package isn't installed (#27790)

### DIFF
--- a/packages/gatsby-recipes/rollup.config.js
+++ b/packages/gatsby-recipes/rollup.config.js
@@ -2,7 +2,7 @@ import resolve from "@rollup/plugin-node-resolve"
 import babel from "@rollup/plugin-babel"
 import commonjs from "@rollup/plugin-commonjs"
 import json from "@rollup/plugin-json"
-import replace from "@rollup/plugin-replace";
+import replace from "@rollup/plugin-replace"
 import autoExternal from "rollup-plugin-auto-external"
 import internal from "rollup-plugin-internal"
 import path from "path"
@@ -28,7 +28,7 @@ export default [
   {
     input: {
       index: `src/index.js`,
-      "graphql-server/server": `src/graphql-server/server.js`
+      "graphql-server/server": `src/graphql-server/server.js`,
     },
     output: {
       dir: `dist`,
@@ -39,8 +39,8 @@ export default [
     plugins: [
       replace({
         values: {
-          "process.env.NODE_ENV": JSON.stringify(`production`)
-        }
+          "process.env.NODE_ENV": JSON.stringify(`production`),
+        },
       }),
       excludeDevTools(),
       json(),
@@ -50,7 +50,7 @@ export default [
         exclude: `node_modules/**`,
       }),
       commonjs({
-        transformMixedEsModules: true
+        transformMixedEsModules: true,
       }),
       resolve({
         dedupe: [
@@ -63,10 +63,10 @@ export default [
           `@mdx-js/mdx`,
           `@mdx-js/react`,
           `@mdx-js/runtime`,
-          `urql`, 
+          `urql`,
           `@urql/core`,
           `subscriptions-transport-ws`,
-        ]
+        ],
       }),
       autoExternal(),
       internal([
@@ -108,20 +108,14 @@ export default [
         exclude: `node_modules/**`,
       }),
       commonjs({
-        transformMixedEsModules: true
+        transformMixedEsModules: true,
       }),
       resolve({
-        dedupe: [
-          `@mdx-js/react`,
-        ]
+        dedupe: [`@mdx-js/react`],
       }),
       autoExternal(),
-      internal([
-        `@mdx-js/react`
-      ])
+      internal([`@mdx-js/react`]),
     ],
-    external: [
-      `react`
-    ]
-  }
+    external: [`react`],
+  },
 ]

--- a/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/shadow-file.test.js.snap
+++ b/packages/gatsby-recipes/src/providers/gatsby/__snapshots__/shadow-file.test.js.snap
@@ -16,6 +16,12 @@ export default () => <h1>F. Scott Fitzgerald</h1>
 exports[`Shadow File resource e2e shadow file resource test: GatsbyShadowFile create plan 1`] = `
 Object {
   "currentState": Object {},
+  "dependsOn": Array [
+    Object {
+      "name": "gatsby-theme-blog",
+      "resourceName": "NPMPackage",
+    },
+  ],
   "describe": "Shadow src/components/author.js from the theme gatsby-theme-blog",
   "diff": "- Original  - 0
 + Modified  + 4
@@ -77,6 +83,12 @@ export default () => <h1>F. Scott Fitzgerald</h1>
     "path": "src/gatsby-theme-blog/components/author.js",
     "theme": "gatsby-theme-blog",
   },
+  "dependsOn": Array [
+    Object {
+      "name": "gatsby-theme-blog",
+      "resourceName": "NPMPackage",
+    },
+  ],
   "describe": "Shadow src/components/author.js from the theme gatsby-theme-blog",
   "diff": "Compared values have no visual difference.",
   "id": "src/gatsby-theme-blog/components/author.js",


### PR DESCRIPTION
Backporting #27790 to the current release

* fix(gatsby-recipes): fix GatsbyShadowFile resource — don't error if package isn't installed

* Update snapshots

* Turn comment into verbose log

* Somehow utila started causing errors w/ rollup 🤷‍♂️

* remove reporter

* revert addiing utila to rollup externals

(cherry picked from commit 3817174822c61aeafd3efac5fb670604d895d89d)
