### PR TITLE
fix(gatsby-transformer-asciidoc): fails when doc doesn't have title

### DIFF
--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -88,7 +88,7 @@ async function onCreateNode(
       children: [],
       html,
       document: {
-        title: title.getCombined(),
+        title: title.getCombined() ? title.getCombined() : ``,
         subtitle: title.hasSubtitle() ? title.getSubtitle() : ``,
         main: title.getMain(),
       },

--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -87,11 +87,17 @@ async function onCreateNode(
       },
       children: [],
       html,
-      document: {
-        title: title.getCombined() ? title.getCombined() : ``,
-        subtitle: title.hasSubtitle() ? title.getSubtitle() : ``,
-        main: title.getMain(),
-      },
+      document: title
+        ? {
+            title: title.getCombined(),
+            subtitle: title.hasSubtitle() ? title.getSubtitle() : ``,
+            main: title.getMain(),
+          }
+        : {
+            title: ``,
+            subtitle: ``,
+            main: ``,
+          },
       revision,
       author,
       pageAttributes,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Check if title field exists. If not, use empty string. 

### Documentation

As mentioned in issue, according to https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#document-header title field is optional. This PR does the existence check for title. 

## Related Issues
  https://github.com/gatsbyjs/gatsby/issues/27714
  Fixes #27714 



