### PR TITLE
fix(gatsby-plugin-sitemap): fixed missing sitemapSize config entry

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -109,6 +109,9 @@ exports.pluginOptionsSchema = ({ Joi }) =>
       Due to how this plugin was built it is currently expected/required to fetch the page paths from allSitePage, 
       but you may use the allSitePage.edges.node or allSitePage.nodes query structure.`
       ),
+      sitemapSize: Joi.number().description(
+        `The number of entries per sitemap file.`
+      ),
     })
     .external(({ query }) => {
       if (query) {


### PR DESCRIPTION
## Description

The Joi configuration validation setup for the sitemap plugin was missing the sitemapSize option, causing builds using the option to fail now that configuration is strictly validated. This adds the Joi entry for this option.