### PR TITLE
chore(gatsby): log out when experimental concurrency flag is used

### DIFF
--- a/packages/gatsby/src/query/queue.ts
+++ b/packages/gatsby/src/query/queue.ts
@@ -10,6 +10,12 @@ import { ProgressActivityTracker } from "../.."
 export type Task = any
 type TaskResult = any
 
+if (process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) {
+  console.info(
+    `GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY: Running with concurrency set to \`${process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY}\``
+  )
+}
+
 const createBaseOptions = (): Pick<
   BetterQueue.QueueOptions<Task, TaskResult>,
   "concurrent" | "store"


### PR DESCRIPTION
We should log something out when experimental flags are active.