### PR TITLE
chore(gatsby): small refactor in cache

### DIFF
--- a/packages/gatsby/src/utils/cache.ts
+++ b/packages/gatsby/src/utils/cache.ts
@@ -19,15 +19,13 @@ interface ICacheProperties {
 export default class Cache {
   public name: string
   public store: Store
+  public directory: string
   public cache?: MultiCache
 
   constructor({ name = `db`, store = fsStore }: ICacheProperties = {}) {
     this.name = name
     this.store = store
-  }
-
-  get directory(): string {
-    return path.join(process.cwd(), `.cache/caches/${this.name}`)
+    this.directory = path.join(process.cwd(), `.cache/caches/${name}`)
   }
 
   init(): Cache {
@@ -56,7 +54,7 @@ export default class Cache {
     return this
   }
 
-  get<T = unknown>(key): Promise<T | undefined> {
+  async get<T = unknown>(key): Promise<T | undefined> {
     return new Promise(resolve => {
       if (!this.cache) {
         throw new Error(
@@ -69,7 +67,7 @@ export default class Cache {
     })
   }
 
-  set<T>(
+  async set<T>(
     key: string,
     value: T,
     args: CachingConfig = { ttl: TTL }


### PR DESCRIPTION
- The `directory` getter should really be a regular property that gets instantiated in the constructor
- The `get` and `set` methods return a Promise, so let's add the keyword for clarity. They still need to create their own promise because they pass down the `resolve` function, but it's way out of scope of this PR to improve that.