### PR TITLE
fix(gatsby-transformer-remark): wait for cache promises before returning

### DIFF
--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -30,8 +30,9 @@ async function queryResult(
     {
       type: { name: `MarkdownRemark` },
       cache: {
-        get: () => null,
-        set: () => null,
+        // GatsbyCache
+        get: async () => null,
+        set: async () => null,
       },
       getNodesByType: type => [],
       ...additionalParameters,

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -105,23 +105,24 @@ const bootstrapTest = (
 
   it(label, async done => {
     node.content = content
-    const createNode = markdownNode => {
-      queryResult([markdownNode], query, {
+    async function createNode(markdownNode) {
+      const result = await queryResult([markdownNode], query, {
         additionalParameters,
         pluginOptions,
-      }).then(result => {
-        if (result.errors) {
-          done.fail(result.errors)
-        }
-
-        try {
-          test(result.data.listNode[0])
-          done()
-        } catch (err) {
-          done.fail(err)
-        }
       })
+
+      if (result.errors) {
+        done.fail(result.errors)
+      }
+
+      try {
+        test(result.data.listNode[0])
+        done()
+      } catch (err) {
+        done.fail(err)
+      }
     }
+
     const createParentChildLink = jest.fn()
     const actions = { createNode, createParentChildLink }
     const createNodeId = jest.fn()

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -560,11 +560,10 @@ module.exports = function remarkExtendNodeType(
       },
       htmlAst: {
         type: `JSON`,
-        resolve(markdownNode) {
-          return getHTMLAst(markdownNode).then(ast => {
-            const strippedAst = stripPosition(_.clone(ast), true)
-            return hastReparseRaw(strippedAst)
-          })
+        async resolve(markdownNode) {
+          const ast = await getHTMLAst(markdownNode)
+          const strippedAst = stripPosition(_.clone(ast), true)
+          return hastReparseRaw(strippedAst)
         },
       },
       excerpt: {
@@ -604,19 +603,15 @@ module.exports = function remarkExtendNodeType(
             defaultValue: false,
           },
         },
-        resolve(markdownNode, { pruneLength, truncate }) {
-          return getHTMLAst(markdownNode)
-            .then(fullAST =>
-              getExcerptAst(fullAST, markdownNode, {
-                pruneLength,
-                truncate,
-                excerptSeparator: pluginOptions.excerpt_separator,
-              })
-            )
-            .then(ast => {
-              const strippedAst = stripPosition(_.clone(ast), true)
-              return hastReparseRaw(strippedAst)
-            })
+        async resolve(markdownNode, { pruneLength, truncate }) {
+          const fullAST = await getHTMLAst(markdownNode)
+          const ast = await getExcerptAst(fullAST, markdownNode, {
+            pruneLength,
+            truncate,
+            excerptSeparator: pluginOptions.excerpt_separator,
+          })
+          const strippedAst = stripPosition(_.clone(ast), true)
+          return hastReparseRaw(strippedAst)
         },
       },
       headings: {
@@ -624,20 +619,20 @@ module.exports = function remarkExtendNodeType(
         args: {
           depth: `MarkdownHeadingLevels`,
         },
-        resolve(markdownNode, { depth }) {
-          return getHeadings(markdownNode).then(headings => {
-            const level = depth && headingLevels[depth]
-            if (typeof level === `number`) {
-              headings = headings.filter(heading => heading.depth === level)
-            }
-            return headings
-          })
+        async resolve(markdownNode, { depth }) {
+          let headings = await getHeadings(markdownNode)
+          const level = depth && headingLevels[depth]
+          if (typeof level === `number`) {
+            headings = headings.filter(heading => heading.depth === level)
+          }
+          return headings
         },
       },
       timeToRead: {
         type: `Int`,
-        resolve(markdownNode) {
-          return getHTML(markdownNode).then(timeToRead)
+        async resolve(markdownNode) {
+          const r = await getHTML(markdownNode)
+          return timeToRead(r)
         },
       },
       tableOfContents: {

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -80,7 +80,7 @@ const headingLevels = [...Array(6).keys()].reduce((acc, i) => {
   return acc
 }, {})
 
-module.exports = (
+module.exports = function remarkExtendNodeType(
   {
     type,
     basePath,
@@ -92,7 +92,7 @@ module.exports = (
     ...rest
   },
   pluginOptions
-) => {
+) {
   if (type.name !== `MarkdownRemark`) {
     return {}
   }

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -161,10 +161,15 @@ module.exports = function remarkExtendNodeType(
 
       // Return the promise that will cache the result if good, and deletes the promise from local cache either way
       // Note that if this cache hits for another parse, it won't have to wait for the cache
-      return ASTGenerationPromise.then(markdownAST =>
-        // Return a promise that waits for the cache to be set, but that does return the generated AST
-        cache.set(cacheKey, markdownAST).then(() => markdownAST)
-      ).finally(() => ASTPromiseMap.delete(cacheKey))
+      try {
+        const markdownAST = await ASTGenerationPromise
+
+        await cache.set(cacheKey, markdownAST)
+
+        return markdownAST
+      } finally {
+        ASTPromiseMap.delete(cacheKey)
+      }
     }
 
     // Parse a markdown string and its AST representation, applying the remark plugins if necessary

--- a/packages/gatsby/src/utils/__tests__/api-runner-node.js
+++ b/packages/gatsby/src/utils/__tests__/api-runner-node.js
@@ -190,8 +190,8 @@ it(`Doesn't initialize cache in onPreInit API`, async () => {
     `test-plugin-on-preinit-fails/gatsby-node`,
     () => {
       return {
-        onPreInit: ({ cache }) => {
-          cache.get(`foo`)
+        onPreInit: async ({ cache }) => {
+          await cache.get(`foo`)
         },
       }
     },

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -241,10 +241,11 @@ const getUninitializedCache = plugin => {
     (plugin && plugin !== `default-site-plugin` ? ` (called in ${plugin})` : ``)
 
   return {
-    get() {
+    // GatsbyCache
+    async get() {
       throw new Error(message)
     },
-    set() {
+    async set() {
       throw new Error(message)
     },
   }

--- a/packages/gatsby/src/utils/cache.ts
+++ b/packages/gatsby/src/utils/cache.ts
@@ -16,7 +16,7 @@ interface ICacheProperties {
   store?: Store
 }
 
-export default class Cache {
+export default class GatsbyCache {
   public name: string
   public store: Store
   public directory: string
@@ -28,7 +28,7 @@ export default class Cache {
     this.directory = path.join(process.cwd(), `.cache/caches/${name}`)
   }
 
-  init(): Cache {
+  init(): GatsbyCache {
     fs.ensureDirSync(this.directory)
 
     const configs: Array<StoreConfig> = [
@@ -58,7 +58,7 @@ export default class Cache {
     return new Promise(resolve => {
       if (!this.cache) {
         throw new Error(
-          `Cache wasn't initialised yet, please run the init method first`
+          `GatsbyCache wasn't initialised yet, please run the init method first`
         )
       }
       this.cache.get<T>(key, (err, res) => {
@@ -75,7 +75,7 @@ export default class Cache {
     return new Promise(resolve => {
       if (!this.cache) {
         throw new Error(
-          `Cache wasn't initialised yet, please run the init method first`
+          `GatsbyCache wasn't initialised yet, please run the init method first`
         )
       }
       this.cache.set(key, value, args, err => {

--- a/packages/gatsby/src/utils/get-cache.ts
+++ b/packages/gatsby/src/utils/get-cache.ts
@@ -1,11 +1,11 @@
-import Cache from "./cache"
+import GatsbyCache from "./cache"
 
-const caches = new Map<string, Cache>()
+const caches = new Map<string, GatsbyCache>()
 
-export const getCache = (name: string): Cache => {
+export const getCache = (name: string): GatsbyCache => {
   let cache = caches.get(name)
   if (!cache) {
-    cache = new Cache({ name }).init()
+    cache = new GatsbyCache({ name }).init()
     caches.set(name, cache)
   }
   return cache


### PR DESCRIPTION
The first commit allows us to run markdown in serial mode again (the remark plugin was not awaiting the cache plugins so it was not properly running in serial).

This may also fix a race condition where the same source is parsed twice at the same time, since the cache.set call of the first may not have been completed when the second starts. But that's a very unlike scenario as these caches are more likely to be hit for subsequent builds, not the same session.

The remaining commits refactor the code. I can be okay to drop most of them if people feel it's too much.