### PR TITLE
perf(gatsby): pull in cache lib and change lock from fs to mem

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -42,7 +42,6 @@
     "body-parser": "^1.19.0",
     "browserslist": "^4.12.2",
     "cache-manager": "^2.11.1",
-    "cache-manager-fs-hash": "^0.0.9",
     "chalk": "^4.1.0",
     "chokidar": "^3.4.2",
     "common-tags": "^1.8.0",

--- a/packages/gatsby/src/cache/__tests__/cache-fs.js
+++ b/packages/gatsby/src/cache/__tests__/cache-fs.js
@@ -1,0 +1,292 @@
+const assert = require(`assert`)
+const fs = require(`fs`)
+const removeDir = require(`rimraf`)
+const store = require(`../cache-fs.ts`)
+const cacheDirectory = __dirname + `/cache`
+
+function countFilesInCacheDir() {
+  return fs.readdirSync(cacheDirectory).length
+}
+
+describe(`DiskStore`, function () {
+  let cache
+  // remove test directory before each test
+  beforeEach(async function () {
+    return new Promise(resolve => {
+      removeDir(cacheDirectory, () => {
+        cache = store.create({ path: cacheDirectory })
+        resolve()
+      })
+    })
+  })
+  // remove test directory after last test
+  afterEach(async function () {
+    return new Promise(resolve => removeDir(cacheDirectory, resolve))
+  })
+
+  describe(`construction`, function () {
+    it(`should create cache dir`, function () {
+      assert(fs.existsSync(cache.options.path))
+    })
+  })
+
+  describe(`get()`, function () {
+    it(`should return undefined on non existing key callback`, async function () {
+      return new Promise(resolve => {
+        cache.get(`not existing key`, function (err, data) {
+          expect(err).toEqual(null)
+          expect(data).toEqual(undefined)
+          resolve()
+        })
+      })
+    })
+
+    it(`should return undefined on non existing key promise`, async function () {
+      const data = await cache.get(`not existing key`)
+      expect(data).toEqual(undefined)
+    })
+
+    it(`should not be that slow reading the same non existing cache key sequentially`, async function () {
+      for (let i = 0; i < 30; i++) {
+        const data = await cache.get(`not existing key`)
+        expect(data).toEqual(undefined)
+      }
+    })
+
+    it(`should not be that slow reading the same non existing cache key parallel`, async function () {
+      // this.slow(100)
+
+      for (let i = 0; i < 20; i++) {
+        await Promise.all(
+          [1, 2, 3, 4, 5].map(async function () {
+            const data = await cache.get(`not existing key`)
+            expect(data).toEqual(undefined)
+          })
+        )
+      }
+    })
+
+    it(`should not be that slow reading different non existing cache keys parallel`, async function () {
+      // this.slow(30)
+
+      await Promise.all(
+        Array.apply(null, Array(30)).map(async function (v, i) {
+          const data = await cache.get(`not existing key` + i)
+          expect(data).toEqual(undefined)
+        })
+      )
+    })
+  })
+
+  describe(`set()`, function () {
+    it(`should create a file for each saved value`, async function () {
+      await cache.set(`key`, `value`)
+      expect(countFilesInCacheDir()).toEqual(1)
+      await cache.set(`key2`, `value`)
+      expect(countFilesInCacheDir()).toEqual(2)
+    })
+
+    it(`should save buffers in seperate files promise`, async function () {
+      await cache.set(`key`, Buffer.alloc(100000))
+      expect(countFilesInCacheDir()).toEqual(2)
+    })
+
+    it(`should not modify the value while saving`, async function () {
+      const value = {
+        int: 5,
+        bool: true,
+        float: 0.1,
+        buffer: Buffer.from(`Hello World!`),
+        string: `#äö=)@€²(/&%$§"`,
+        largeBuffer: Buffer.alloc(100000),
+      }
+      await cache.set(`key`, value)
+      expect(value).toEqual({
+        int: 5,
+        bool: true,
+        float: 0.1,
+        buffer: Buffer.from(`Hello World!`),
+        string: `#äö=)@€²(/&%$§"`,
+        largeBuffer: Buffer.alloc(100000),
+      })
+    })
+  })
+
+  describe(`del()`, function () {
+    it(`should not throw for deleting nonexisting key`, async function () {
+      // this.slow(20)
+      const cache = store.create({ path: cacheDirectory })
+      await cache.del(`nonexisting key`)
+      expect(true).toEqual(true)
+    })
+
+    it(`should not throw for deleting nonexisting key (subdirs)`, async function () {
+      // this.slow(20)
+      const cache = store.create({ path: cacheDirectory, subdirs: true })
+      await cache.del(`nonexisting key`)
+      expect(true).toEqual(true)
+    })
+  })
+
+  describe(`set() and get()`, function () {
+    it(`should load the same value that was saved (simple object)`, async function () {
+      const originalValue = {
+        int: 5,
+        bool: true,
+        float: 0.1,
+        string: `#äö=)@€²(/&%$§"`,
+      }
+      await cache.set(`(simple object)`, originalValue)
+      const loadedValue = await cache.get(`(simple object)`)
+      expect(loadedValue).toEqual(originalValue)
+    })
+
+    it(`should load the same value that was saved (large buffers)`, async function () {
+      // this.slow(500)
+      // this.timeout(30000)
+
+      const originalValue = {
+        smallbuffer: Buffer.from(`Hello World!`),
+        largeBuffer: Buffer.alloc(1000 * 1000 * 10 /* 10MB */, 5),
+        largeBuffer2: Buffer.alloc(1000 * 1000 * 5 /* 5MB */, 100),
+      }
+      await cache.set(`(large buffers)`, originalValue)
+      const loadedValue = await cache.get(`(large buffers)`)
+      assert.deepEqual(originalValue, loadedValue)
+    })
+
+    it(`should not load expired data (global options)`, async function () {
+      const cache = store.create({ path: cacheDirectory, ttl: 0 })
+      await cache.set(`key`, `value`)
+      const loadedValue = await cache.get(`key`)
+      expect(loadedValue).toEqual(undefined)
+    })
+
+    it(`should not load expired data (set options)`, async function () {
+      await cache.set(`key`, `value`, { ttl: 0 })
+      const loadedValue = await cache.get(`key`)
+      expect(loadedValue).toEqual(undefined)
+    })
+
+    it(`should work with numeric keys`, async function () {
+      const originalValue = `value`
+      await cache.set(5, originalValue)
+      const loadedValue = await cache.get(5)
+      expect(loadedValue).toEqual(originalValue)
+    })
+
+    it(`should work with numeric and string keys mixed`, async function () {
+      const originalValue = `value`
+      await cache.set(5, originalValue)
+      const loadedValue = await cache.get(`5`)
+      expect(loadedValue).toEqual(originalValue)
+    })
+
+    it(`should be able to get a value written by an other cache instance using the same directory`, async function () {
+      const originalValue = `value`
+      const cache1 = store.create({ path: cacheDirectory })
+      const cache2 = store.create({ path: cacheDirectory })
+
+      await cache1.set(`key`, originalValue)
+      const loadedValue = await cache2.get(`key`)
+      expect(loadedValue).toEqual(originalValue)
+    })
+
+    it(`should work with subdirs`, async function () {
+      const cache = store.create({ path: cacheDirectory, subdirs: true })
+      const originalValue = {
+        int: 8,
+        bool: true,
+        float: 0.9,
+        string: `dsfsdöv`,
+      }
+      await cache.set(`(simple object)`, originalValue)
+      const loadedValue = await cache.get(`(simple object)`)
+      expect(loadedValue).toEqual(originalValue)
+    })
+
+    it(`should be able to set & get a value on different instances simultaneously`, async function () {
+      // this.slow(600)
+      // this.timeout(5000)
+
+      const cache1 = store.create({ path: cacheDirectory })
+      const cache2 = store.create({ path: cacheDirectory })
+      const cache3 = store.create({ path: cacheDirectory })
+
+      const value1 = {
+        int: 5,
+        bool: true,
+        float: Math.random(),
+        buffer: Buffer.from(`Hello World1!`),
+        string: `#äö=)@€²(/&%$§"1`,
+        largeBuffer: Buffer.alloc(1),
+      }
+      const value2 = {
+        int: 6,
+        bool: true,
+        float: Math.random(),
+        buffer: Buffer.from(`Hello World2!`),
+        string: `#äö=)@€²(/&%$§"2`,
+        largeBuffer: Buffer.alloc(2),
+      }
+      const value3 = {
+        int: 7,
+        bool: true,
+        float: Math.random(),
+        buffer: Buffer.from(`Hello World3!`),
+        string: `#äö=)@€²(/&%$§"3`,
+        largeBuffer: Buffer.alloc(3),
+      }
+
+      await Promise.all([
+        cache1.set(`key`, value1),
+        cache2.set(`key`, value2),
+        cache3.set(`key`, value3),
+      ])
+      const values = await Promise.all([
+        cache1.get(`key`),
+        cache2.get(`key`),
+        cache3.get(`key`),
+      ])
+      //all caches should be the same
+      expect(values[0]).toEqual(values[1])
+      expect(values[0]).toEqual(values[2])
+
+      //the cache should be one of the values that was stored to it
+      try {
+        expect(values[0]).toEqual(values[1])
+      } catch (e) {
+        try {
+          expect(values[0]).toEqual(value2)
+        } catch (e) {
+          expect(values[0]).toEqual(value3)
+        }
+      }
+    })
+
+    it(`should work with zip option`, async function () {
+      const cache = store.create({ path: cacheDirectory, zip: true })
+      const originalValue = {
+        int: 5,
+        bool: true,
+        float: Math.random(),
+        buffer: Buffer.from(`Hello World1!`),
+        string: `#äö=)@€²(/&%$§"1`,
+        largeBuffer: Buffer.alloc(1),
+      }
+
+      await cache.set(`key`, originalValue)
+      const loadedValue = await cache.get(`key`)
+      expect(loadedValue).toEqual(originalValue)
+    })
+
+    it(`should be able to store the number Infinity`, async function () {
+      const cache = store.create({ path: cacheDirectory })
+      const originalValue = Infinity
+
+      await cache.set(`key`, originalValue)
+      const loadedValue = await cache.get(`key`)
+      expect(loadedValue).toEqual(originalValue)
+    })
+  })
+})

--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -16,11 +16,11 @@ const wrapCallback = require(`./wrap-callback`)
  * @param {boolean} [args.subdirs] create subdirectories
  * @returns {DiskStore}
  */
-exports.create = function (args) {
+exports.create = function (args): typeof DiskStore {
   return new DiskStore(args && args.options ? args.options : args)
 }
 
-function DiskStore(options) {
+function DiskStore(options): void {
   options = options || {}
 
   this.options = {
@@ -162,14 +162,14 @@ DiskStore.prototype.del = wrapCallback(async function (key) {
 /**
  * cleanup cache on disk -> delete all files from the cache
  */
-DiskStore.prototype.reset = wrapCallback(async function () {
+DiskStore.prototype.reset = wrapCallback(async function (): Promise<void> {
   const readdir = promisify(fs.readdir)
   const stat = promisify(fs.stat)
   const unlink = promisify(fs.unlink)
 
   return await deletePath(this.options.path, 2)
 
-  async function deletePath(fileOrDir, maxDeep) {
+  async function deletePath(fileOrDir, maxDeep): Promise<void> {
     if (maxDeep < 0) {
       return
     }
@@ -195,7 +195,7 @@ DiskStore.prototype.reset = wrapCallback(async function () {
  * @returns {Promise}
  * @private
  */
-DiskStore.prototype._lock = function (filePath) {
+DiskStore.prototype._lock = function (filePath): Promise<void> {
   return promisify(lockFile.lock)(
     filePath + `.lock`,
     JSON.parse(JSON.stringify(this.options.lockFile)) //the options are modified -> create a copy to prevent that
@@ -209,7 +209,7 @@ DiskStore.prototype._lock = function (filePath) {
  * @returns {Promise}
  * @private
  */
-DiskStore.prototype._unlock = function (filePath) {
+DiskStore.prototype._unlock = function (filePath): Promise<void> {
   return promisify(lockFile.unlock)(filePath + `.lock`)
 }
 
@@ -219,7 +219,7 @@ DiskStore.prototype._unlock = function (filePath) {
  * @returns {string}
  * @private
  */
-DiskStore.prototype._getFilePathByKey = function (key) {
+DiskStore.prototype._getFilePathByKey = function (key): string {
   const hash = crypto
     .createHash(`md5`)
     .update(key + ``)

--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -1,0 +1,237 @@
+const fs = require(`fs`)
+const crypto = require(`crypto`)
+const path = require(`path`)
+const promisify = require(`util`).promisify
+const lockFile = require(`lockfile`)
+const jsonFileStore = require(`./json-file-store`)
+const wrapCallback = require(`./wrap-callback`)
+
+/**
+ * construction of the disk storage
+ * @param {object} [args] options of disk store
+ * @param {string} [args.path] path for cached files
+ * @param {number} [args.ttl] time to life in seconds
+ * @param {boolean} [args.zip] zip content to save diskspace
+ * @todo {number} [args.maxsize] max size in bytes on disk
+ * @param {boolean} [args.subdirs] create subdirectories
+ * @returns {DiskStore}
+ */
+exports.create = function (args) {
+  return new DiskStore(args && args.options ? args.options : args)
+}
+
+function DiskStore(options) {
+  options = options || {}
+
+  this.options = {
+    path: options.path || `./cache` /* path for cached files  */,
+    ttl:
+      options.ttl >= 0
+        ? +options.ttl
+        : 60 * 60 /* time before expiring in seconds */,
+    maxsize: options.maxsize || Infinity /* max size in bytes on disk */,
+    subdirs: options.subdirs || false,
+    zip: options.zip || false,
+    lockFile: {
+      //check lock at 0ms 50ms 100ms ... 400ms 1400ms 1450ms... up to 10 seconds, after that just asume the lock is staled
+      wait: 400,
+      pollPeriod: 50,
+      stale: 10 * 1000,
+      retries: 10,
+      retryWait: 600,
+    },
+  }
+
+  // check storage directory for existence (or create it)
+  if (!fs.existsSync(this.options.path)) {
+    fs.mkdirSync(this.options.path)
+  }
+}
+
+/**
+ * save an entry in store
+ * @param {string} key
+ * @param {*} val
+ * @param {object} [options]
+ * @param {number} options.ttl time to life in seconds
+ * @param {function} [cb]
+ * @returns {Promise}
+ */
+DiskStore.prototype.set = wrapCallback(async function (key, val, options) {
+  key = key + ``
+  const filePath = this._getFilePathByKey(key)
+
+  const ttl = options && options.ttl >= 0 ? +options.ttl : this.options.ttl
+  const data = {
+    expireTime: Date.now() + ttl * 1000,
+    key: key,
+    val: val,
+  }
+
+  if (this.options.subdirs) {
+    //check if subdir exists or create it
+    const dir = path.dirname(filePath)
+    await promisify(fs.access)(dir, fs.constants.W_OK).catch(function () {
+      return promisify(fs.mkdir)(dir).catch(err => {
+        if (err.code !== `EEXIST`) throw err
+      })
+    })
+  }
+
+  try {
+    await this._lock(filePath)
+    await jsonFileStore.write(filePath, data, this.options)
+  } catch (err) {
+    throw err
+  } finally {
+    await this._unlock(filePath)
+  }
+})
+
+/**
+ * get an entry from store
+ * @param {string} key
+ * @param {function} [cb]
+ * @returns {Promise}
+ */
+DiskStore.prototype.get = wrapCallback(async function (key) {
+  key = key + ``
+  const filePath = this._getFilePathByKey(key)
+
+  try {
+    const data = await jsonFileStore
+      .read(filePath, this.options)
+      .catch(async err => {
+        if (err.code === `ENOENT`) {
+          throw err
+        }
+        //maybe the file is currently written to, lets lock it and read again
+        try {
+          await this._lock(filePath)
+          return await jsonFileStore.read(filePath, this.options)
+        } catch (err2) {
+          throw err2
+        } finally {
+          await this._unlock(filePath)
+        }
+      })
+    if (data.expireTime <= Date.now()) {
+      //cache expired
+      this.del(key).catch(() => 0 /* ignore */)
+      return undefined
+    }
+    if (data.key !== key) {
+      //hash collision
+      return undefined
+    }
+    return data.val
+  } catch (err) {
+    //file does not exist lets return a cache miss
+    if (err.code === `ENOENT`) {
+      return undefined
+    } else {
+      throw err
+    }
+  }
+})
+
+/**
+ * delete entry from cache
+ */
+DiskStore.prototype.del = wrapCallback(async function (key) {
+  const filePath = this._getFilePathByKey(key)
+  try {
+    if (this.options.subdirs) {
+      //check if the folder exists to fail faster
+      const dir = path.dirname(filePath)
+      await promisify(fs.access)(dir, fs.constants.W_OK)
+    }
+
+    await this._lock(filePath)
+    await jsonFileStore.delete(filePath, this.options)
+  } catch (err) {
+    //ignore deleting non existing keys
+    if (err.code !== `ENOENT`) {
+      throw err
+    }
+  } finally {
+    await this._unlock(filePath)
+  }
+})
+
+/**
+ * cleanup cache on disk -> delete all files from the cache
+ */
+DiskStore.prototype.reset = wrapCallback(async function () {
+  const readdir = promisify(fs.readdir)
+  const stat = promisify(fs.stat)
+  const unlink = promisify(fs.unlink)
+
+  return await deletePath(this.options.path, 2)
+
+  async function deletePath(fileOrDir, maxDeep) {
+    if (maxDeep < 0) {
+      return
+    }
+    const stats = await stat(fileOrDir)
+    if (stats.isDirectory()) {
+      const files = await readdir(fileOrDir)
+      for (let i = 0; i < files.length; i++) {
+        await deletePath(path.join(fileOrDir, files[i]), maxDeep - 1)
+      }
+    } else if (
+      stats.isFile() &&
+      /[/\\]diskstore-[0-9a-fA-F/\\]+(\.json|-\d\.bin)/.test(fileOrDir)
+    ) {
+      //delete the file if it is a diskstore file
+      await unlink(fileOrDir)
+    }
+  }
+})
+
+/**
+ * locks a file so other forks that want to use the same file have to wait
+ * @param {string} filePath
+ * @returns {Promise}
+ * @private
+ */
+DiskStore.prototype._lock = function (filePath) {
+  return promisify(lockFile.lock)(
+    filePath + `.lock`,
+    JSON.parse(JSON.stringify(this.options.lockFile)) //the options are modified -> create a copy to prevent that
+  )
+}
+
+/**
+ * unlocks a file path
+ * @type {Function}
+ * @param {string} filePath
+ * @returns {Promise}
+ * @private
+ */
+DiskStore.prototype._unlock = function (filePath) {
+  return promisify(lockFile.unlock)(filePath + `.lock`)
+}
+
+/**
+ * returns the location where the value should be stored
+ * @param {string} key
+ * @returns {string}
+ * @private
+ */
+DiskStore.prototype._getFilePathByKey = function (key) {
+  const hash = crypto
+    .createHash(`md5`)
+    .update(key + ``)
+    .digest(`hex`)
+  if (this.options.subdirs) {
+    //create subdirs with the first 3 chars of the hash
+    return path.join(
+      this.options.path,
+      `diskstore-` + hash.substr(0, 3),
+      hash.substr(3)
+    )
+  } else {
+    return path.join(this.options.path, `diskstore-` + hash)
+  }
+}

--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -213,7 +213,7 @@ DiskStore.prototype._lock = function _lock(filePath): Promise<void> {
 function innerLock(resolve, reject, filePath): void {
   try {
     let lockTime = globalGatsbyCacheLock.get(filePath) ?? 0
-    if (lockTime > 0 && Date.now() - lockTime > 10 * 60 * 1000) {
+    if (lockTime > 0 && Date.now() - lockTime > 10 * 1000) {
       reporter.verbose(
         `Warning: lock file older than 10s, ignoring it... There is a possibility this leads to caching problems later.`
       )
@@ -224,7 +224,7 @@ function innerLock(resolve, reject, filePath): void {
     if (lockTime > 0) {
       setTimeout(() => {
         innerLock(resolve, reject, filePath)
-      }, 400)
+      }, 50)
     } else {
       resolve()
     }

--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -1,3 +1,28 @@
+// Initial file from https://github.com/rolandstarke/node-cache-manager-fs-hash @ af52d2d
+/*!
+The MIT License (MIT)
+
+Copyright (c) 2017 Roland Starke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 const fs = require(`fs`)
 const crypto = require(`crypto`)
 const path = require(`path`)

--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -203,7 +203,11 @@ DiskStore.prototype.reset = wrapCallback(async function (): Promise<void> {
  * @private
  */
 DiskStore.prototype._lock = function _lock(filePath): Promise<void> {
-  return new Promise((resolve, reject) => innerLock(resolve, reject, filePath))
+  return new Promise((resolve, reject) =>
+    innerLock(resolve, reject, filePath)
+  ).then(() => {
+    globalGatsbyCacheLock.set(filePath, Date.now())
+  })
 }
 
 function innerLock(resolve, reject, filePath): void {

--- a/packages/gatsby/src/cache/json-file-store.ts
+++ b/packages/gatsby/src/cache/json-file-store.ts
@@ -1,0 +1,157 @@
+const promisify = require(`util`).promisify
+const fs = require(`fs`)
+const zlib = require(`zlib`)
+
+exports.write = async function (path, data, options) {
+  const externalBuffers = []
+  let dataString = JSON.stringify(data, function replacerFunction(k, value) {
+    //Buffers searilize to {data: [...], type: "Buffer"}
+    if (
+      value &&
+      value.type === `Buffer` &&
+      value.data &&
+      value.data.length >=
+        1024 /* only save bigger Buffers external, small ones can be inlined */
+    ) {
+      const buffer = Buffer.from(value.data)
+      externalBuffers.push({
+        index: externalBuffers.length,
+        buffer: buffer,
+      })
+      return {
+        type: `ExternalBuffer`,
+        index: externalBuffers.length - 1,
+        size: buffer.length,
+      }
+    } else if (value === Infinity || value === -Infinity) {
+      return { type: `Infinity`, sign: Math.sign(value) }
+    } else {
+      return value
+    }
+  })
+
+  let zipExtension = ``
+  if (options.zip) {
+    zipExtension = `.gz`
+    dataString = await promisify(zlib.deflate)(dataString)
+  }
+  //save main json file
+  await promisify(fs.writeFile)(
+    path + `.json` + zipExtension,
+    dataString,
+    `utf8`
+  )
+
+  //save external buffers
+  await Promise.all(
+    externalBuffers.map(async function (externalBuffer) {
+      let buffer = externalBuffer.buffer
+      if (options.zip) {
+        buffer = await promisify(zlib.deflate)(buffer)
+      }
+      await promisify(fs.writeFile)(
+        path + `-` + externalBuffer.index + `.bin` + zipExtension,
+        buffer,
+        `utf8`
+      )
+    })
+  )
+}
+
+exports.read = async function (path, options) {
+  let zipExtension = ``
+  if (options.zip) {
+    zipExtension = `.gz`
+  }
+
+  //read main json file
+  let dataString
+  if (options.zip) {
+    const compressedData = await promisify(fs.readFile)(
+      path + `.json` + zipExtension
+    )
+    dataString = (await promisify(zlib.unzip)(compressedData)).toString()
+  } else {
+    dataString = await promisify(fs.readFile)(
+      path + `.json` + zipExtension,
+      `utf8`
+    )
+  }
+
+  const externalBuffers = []
+  const data = JSON.parse(dataString, function bufferReceiver(k, value) {
+    if (value && value.type === `Buffer` && value.data) {
+      return Buffer.from(value.data)
+    } else if (
+      value &&
+      value.type === `ExternalBuffer` &&
+      typeof value.index === `number` &&
+      typeof value.size === `number`
+    ) {
+      //JSON.parse is sync so we need to return a buffer sync, we will fill the buffer later
+      const buffer = Buffer.alloc(value.size)
+      externalBuffers.push({
+        index: +value.index,
+        buffer: buffer,
+      })
+      return buffer
+    } else if (
+      value &&
+      value.type === `Infinity` &&
+      typeof value.sign === `number`
+    ) {
+      return Infinity * value.sign
+    } else {
+      return value
+    }
+  })
+
+  //read external buffers
+  await Promise.all(
+    externalBuffers.map(async function (externalBuffer) {
+      if (options.zip) {
+        const bufferCompressed = await promisify(fs.readFile)(
+          path + `-` + +externalBuffer.index + `.bin` + zipExtension
+        )
+        const buffer = await promisify(zlib.unzip)(bufferCompressed)
+        buffer.copy(externalBuffer.buffer)
+      } else {
+        const fd = await promisify(fs.open)(
+          path + `-` + +externalBuffer.index + `.bin` + zipExtension,
+          `r`
+        )
+        await promisify(fs.read)(
+          fd,
+          externalBuffer.buffer,
+          0,
+          externalBuffer.buffer.length,
+          0
+        )
+        await promisify(fs.close)(fd)
+      }
+    })
+  )
+  return data
+}
+
+exports.delete = async function (path, options) {
+  let zipExtension = ``
+  if (options.zip) {
+    zipExtension = `.gz`
+  }
+
+  await promisify(fs.unlink)(path + `.json` + zipExtension)
+
+  //delete binary files
+  try {
+    for (let i = 0; i < Infinity; i++) {
+      await promisify(fs.unlink)(path + `-` + i + `.bin` + zipExtension)
+    }
+  } catch (err) {
+    if (err.code === `ENOENT`) {
+      // every binary is deleted, we are done
+    } else {
+      throw err
+    }
+  }
+}

--- a/packages/gatsby/src/cache/json-file-store.ts
+++ b/packages/gatsby/src/cache/json-file-store.ts
@@ -2,7 +2,7 @@ const promisify = require(`util`).promisify
 const fs = require(`fs`)
 const zlib = require(`zlib`)
 
-exports.write = async function (path, data, options) {
+exports.write = async function (path, data, options): Promise<void> {
   const externalBuffers = []
   let dataString = JSON.stringify(data, function replacerFunction(k, value) {
     //Buffers searilize to {data: [...], type: "Buffer"}
@@ -58,7 +58,7 @@ exports.write = async function (path, data, options) {
   )
 }
 
-exports.read = async function (path, options) {
+exports.read = async function (path, options): Promise<string> {
   let zipExtension = ``
   if (options.zip) {
     zipExtension = `.gz`
@@ -134,7 +134,7 @@ exports.read = async function (path, options) {
   return data
 }
 
-exports.delete = async function (path, options) {
+exports.delete = async function (path, options): Promise<void> {
   let zipExtension = ``
   if (options.zip) {
     zipExtension = `.gz`

--- a/packages/gatsby/src/cache/json-file-store.ts
+++ b/packages/gatsby/src/cache/json-file-store.ts
@@ -1,3 +1,28 @@
+// Initial file from https://github.com/rolandstarke/node-cache-manager-fs-hash @ af52d2d
+/*!
+The MIT License (MIT)
+
+Copyright (c) 2017 Roland Starke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 const promisify = require(`util`).promisify
 const fs = require(`fs`)
 const zlib = require(`zlib`)

--- a/packages/gatsby/src/cache/wrap-callback.ts
+++ b/packages/gatsby/src/cache/wrap-callback.ts
@@ -3,8 +3,10 @@
  * @param {function} fn
  * @returns {function}
  */
-module.exports = function wrapCallback(fn) {
-  return function (...args) {
+module.exports = function wrapCallback<T>(
+  fn: () => Promise<T>
+): () => Promise<T> {
+  return function (...args): Promise<T> {
     let cb
     if (typeof args[args.length - 1] === `function`) {
       cb = args.pop()

--- a/packages/gatsby/src/cache/wrap-callback.ts
+++ b/packages/gatsby/src/cache/wrap-callback.ts
@@ -1,0 +1,24 @@
+/**
+ * adds an callback param to the original function
+ * @param {function} fn
+ * @returns {function}
+ */
+module.exports = function wrapCallback(fn) {
+  return function (...args) {
+    let cb
+    if (typeof args[args.length - 1] === `function`) {
+      cb = args.pop()
+    }
+
+    const promise = fn.apply(this, args)
+
+    if (typeof cb === `function`) {
+      promise.then(
+        value => setImmediate(cb, null, value),
+        err => setImmediate(cb, err)
+      )
+    }
+
+    return promise
+  }
+}

--- a/packages/gatsby/src/cache/wrap-callback.ts
+++ b/packages/gatsby/src/cache/wrap-callback.ts
@@ -1,3 +1,28 @@
+// Initial file from https://github.com/rolandstarke/node-cache-manager-fs-hash @ af52d2d
+/*!
+The MIT License (MIT)
+
+Copyright (c) 2017 Roland Starke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /**
  * adds an callback param to the original function
  * @param {function} fn

--- a/packages/gatsby/src/utils/cache.ts
+++ b/packages/gatsby/src/utils/cache.ts
@@ -5,7 +5,7 @@ import manager, {
   MultiCache,
 } from "cache-manager"
 import fs from "fs-extra"
-import fsStore from "cache-manager-fs-hash"
+import fsStore from "../cache/cache-fs"
 import path from "path"
 
 const MAX_CACHE_SIZE = 250

--- a/yarn.lock
+++ b/yarn.lock
@@ -974,8 +974,6 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz#8f2682bcdcef9ed327e1b0861585d7013f8a54dd"
   integrity sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-runtime@^7.11.5":
   version "7.11.5"
@@ -6467,13 +6465,6 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
-
-cache-manager-fs-hash@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/cache-manager-fs-hash/-/cache-manager-fs-hash-0.0.9.tgz#a65bb7ca2c9f9f9cf7035945bbfab536c5aab340"
-  integrity sha512-G0RUUSMZADiMx/0tHjPa+uzJyjtVB/Xt9yuFm6g/rBpm0p/IMr4atUWX2G2f1yGCPmDnyUcFz4RlSpgNRgvldg==
-  dependencies:
-    lockfile "^1.0.4"
 
 cache-manager@^2.11.1:
   version "2.11.1"
@@ -15424,7 +15415,7 @@ lock@^1.0.0:
   resolved "https://registry.yarnpkg.com/lock/-/lock-1.1.0.tgz#53157499d1653b136ca66451071fca615703fa55"
   integrity sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU=
 
-lockfile@1.0.4, lockfile@^1.0.4:
+lockfile@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
   dependencies:


### PR DESCRIPTION
The cache object that we send to plugins relies on a fs-based locking mechanism to prevent race conditions from clobbering cache files. However this is causing a lot of io pressure, to the point where a baseline markdown benchmark drops 10%-15% just for this change.

Markdown is significantly affected because it aggressively caches the parsing steps. Other plugins might too, I've seen improvements in MDX for example. But really anything that heavily calls `cache.get` and `cache.set` should see a boost from this change.

This PR pulls in the plugin that we use for this cache: https://github.com/rolandstarke/node-cache-manager-fs-hash
The first commit copies it and only applies prettier/lint style fixes.
The second commit makes TS happy
The third commit replaces the `lockfile` library with a global map with the same purpose.

The in-memory lock includes a 400ms debounce and 10s timeout, just in case.

From my brief testing, I'm not sure we need the lock at all but for now it's probably better to keep it. There appears to be no significant difference in keeping the in-memory version anyways so that's fine.

Some numbers on markdown and mdx. I didn't run the full mdx benchmark because it literally takes over an hour. I think the impact should be similar to markdown in absolute terms (not relative) because mdx has a lot of other pain points that slow it down. Stats will tell in due time.

```
(bs=bootstrap, rq=run queries)
gabe-fs-markdown
    fs mem lock:
        - 10k:   40s (10s bs,  21s rq)
        - 100k: 372s (77s bs, 254s rq)
    mem lock:
        - 10k:   37s (10s bs,  18s rq)
        - 100k: 336s (78s bs, 217s rq)
    no lock:
        - 10k:   37s (10s bs,  18s rq)
        - 100k: 334s (78s bs, 215s rq)
gabe-fs-mdx
    fs lock:
        - 10k:  304s (117s bs, 177s rq)
    mem lock:
        - 10k:  297s (115s bs, 171s rq)
    no lock:
        - 10k:  295s (114s bs, 171s rq)
```