### PR TITLE
fix(gatsby-plugin-sitemap): fixed missing sitemapSize config entry (#27866)

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -109,6 +109,9 @@ exports.pluginOptionsSchema = ({ Joi }) =>
       Due to how this plugin was built it is currently expected/required to fetch the page paths from allSitePage, 
       but you may use the allSitePage.edges.node or allSitePage.nodes query structure.`
       ),
+      sitemapSize: Joi.number().description(
+        `The number of entries per sitemap file.`
+      ),
     })
     .external(({ query }) => {
       if (query) {


### PR DESCRIPTION
Backporting #27866 to the release branch

(cherry picked from commit f0689ffce82e8b59a02df5c338470bd31a5154f2)
