### PR TITLE
fix(gatsby-source-filesystem): allow regex and functions for ignore option (#27849)

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -157,7 +157,11 @@ exports.pluginOptionsSchema = ({ Joi }) =>
   Joi.object({
     name: Joi.string(),
     path: Joi.string(),
-    ignore: Joi.array().items(Joi.string()),
+    ignore: Joi.array().items(
+      Joi.string(),
+      Joi.object().regex(),
+      Joi.function()
+    ),
   })
 
 exports.sourceNodes = (api, pluginOptions) => {


### PR DESCRIPTION
Back-porting #27849 to the release branch.

(cherry picked from commit 253b1af728de1b007eb582d63286d0ce2476e41b)
