### PR TITLE
feat(gatsby): add opt out flag SKIP_PLUGIN_OPTION_VALIDATION to bypass validation

### DIFF
--- a/docs/docs/configuring-usage-with-plugin-options.md
+++ b/docs/docs/configuring-usage-with-plugin-options.md
@@ -276,6 +276,14 @@ describe(`pluginOptionsSchema`, () => {
 })
 ```
 
+### Opting out of plugin option validation
+
+If you are running your site and run into an error trying to develop or build your site due to plugin options failing that are undocumented or seem erroneous, you can add the `SKIP_PLUGIN_OPTION_VALIDATION` flag set to `true`. It can be prepended to your develop and build scripts, included as an [environment variable](/docs/environment-variables/) in a .env file, or included before your `gatsby develop` command like this:
+
+```shell
+SKIP_PLUGIN_OPTION_VALIDATION=true gatsby develop
+```
+
 ## Additional resources
 
 - [Example Gatsby site using plugin options with a local plugin](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-plugin-options)

--- a/docs/docs/configuring-usage-with-plugin-options.md
+++ b/docs/docs/configuring-usage-with-plugin-options.md
@@ -283,7 +283,9 @@ If you are running your site and run into an error trying to develop or build yo
 ```shell
 SKIP_PLUGIN_OPTION_VALIDATION=true gatsby develop
 ```
+
 Please also [submit an issue](https://github.com/gatsbyjs/gatsby/issues) if you believe the options are failing incorrectly.
+
 ## Additional resources
 
 - [Example Gatsby site using plugin options with a local plugin](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-plugin-options)

--- a/docs/docs/configuring-usage-with-plugin-options.md
+++ b/docs/docs/configuring-usage-with-plugin-options.md
@@ -283,7 +283,7 @@ If you are running your site and run into an error trying to develop or build yo
 ```shell
 SKIP_PLUGIN_OPTION_VALIDATION=true gatsby develop
 ```
-
+Please also [submit an issue](https://github.com/gatsbyjs/gatsby/issues) if you believe the options are failing incorrectly.
 ## Additional resources
 
 - [Example Gatsby site using plugin options with a local plugin](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-plugin-options)

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -284,7 +284,7 @@ describe(`Load plugins`, () => {
           },
         ]
       `)
-      expect(mockProcessExit).toHaveBeenCalledWith(1)
+      expect(reporter.panic).toHaveBeenCalled()
     })
 
     it(`defaults plugin options to the ones defined in the schema`, async () => {
@@ -362,7 +362,7 @@ describe(`Load plugins`, () => {
           },
         ]
       `)
-      expect(mockProcessExit).toHaveBeenCalledWith(1)
+      expect(reporter.panic).toHaveBeenCalled()
     })
   })
 })

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -274,7 +274,7 @@ export async function validateConfigPluginsOptions(
   if (process.env.SKIP_PLUGIN_OPTION_VALIDATION) {
     reporter.warn(`you have enabled the SKIP_PLUGIN_OPTION_VALIDATION flag,`)
     reporter.warn(
-      `meaning Gatsby will not enforce types based on plugin's option schemas.`
+      `so Gatsby will not verify your plugin configurations.`
     )
     return
   }

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -271,6 +271,13 @@ export async function validateConfigPluginsOptions(
   rootDir: string | null
 ): Promise<void> {
   if (!config.plugins) return
+  if (process.env.SKIP_PLUGIN_OPTION_VALIDATION) {
+    reporter.warn(`you have enabled the SKIP_PLUGIN_OPTION_VALIDATION flag,`)
+    reporter.warn(
+      `meaning Gatsby will not enforce types based on plugin's option schemas.`
+    )
+    return
+  }
 
   const { errors, plugins } = await validatePluginsOptions(
     config.plugins,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Some users of the latest versions of Gatsby have run into problems with undocumented plugin options we didn't catch when adding schemas. When schema validation fails, the `build` and `develop` process errors out (`process.exit(1)`). To give an unblocking workaround for users frustrated by this behavior, this change allows the `SKIP_PLUGIN_OPTION_VALIDATION` to be set, a la:

```
SKIP_PLUGIN_OPTION_VALIDATION=true gatsby develop
```

To skip the validation and instead issue a warning that looks like this:

![image](https://user-images.githubusercontent.com/21114044/98416082-afd40880-203b-11eb-97ca-34924b2fd249.png)

An alternative approach to implementing this would be warning that options not included in the schema have separate warnings issued for them, rather than erroring. It looks like [this should be possible with Joi](https://joi.dev/api/?v=17.3.0#anyvalidateasyncvalue-options) (see the `warnings` option) but I couldn't get it to work and figured this would be a relatively quick way to get around this without digging into Joi and have a similar effect.


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

I added a note to the [plugin options guide](https://www.gatsbyjs.com/docs/configuring-usage-with-plugin-options/#how-to-validate-plugin-options)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to https://github.com/gatsbyjs/gatsby/issues/27839
