### PR TITLE
fix(gatsby-plugin-google-tagmanager): allow functions for defaultDataLayer option

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/package.json
+++ b/packages/gatsby-plugin-google-tagmanager/package.json
@@ -13,7 +13,8 @@
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",
     "babel-preset-gatsby-package": "^0.6.0-next.0",
-    "cross-env": "^7.0.2"
+    "cross-env": "^7.0.2",
+    "gatsby-plugin-utils": "^0.3.0-next.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager#readme",
   "keywords": [

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
@@ -1,0 +1,35 @@
+import { pluginOptionsSchema } from "../gatsby-node"
+import { testPluginOptionsSchema } from "gatsby-plugin-utils"
+
+describe(`pluginOptionsSchema`, () => {
+  it(`should validate valid options`, async () => {
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+      id: `YOUR_GOOGLE_TAGMANAGER_ID`,
+      includeInDevelopment: false,
+      defaultDataLayer: { platform: `gatsby` },
+      gtmAuth: `YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_AUTH_STRING`,
+      gtmPreview: `YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_PREVIEW_NAME`,
+      dataLayerName: `YOUR_DATA_LAYER_NAME`,
+      routeChangeEventName: `YOUR_ROUTE_CHANGE_EVENT_NAME`,
+    })
+
+    expect(isValid).toEqual(true)
+  })
+
+  it(`should support defaultDataLayer as a function`, async () => {
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+      defaultDataLayer: () => {
+        return {
+          originalLocation:
+            document.location.protocol +
+            `//` +
+            document.location.hostname +
+            document.location.pathname +
+            document.location.search,
+        }
+      },
+    })
+
+    expect(isValid).toEqual(true)
+  })
+})

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -22,7 +22,8 @@ exports.pluginOptionsSchema = ({ Joi }) =>
       .description(
         `Include Google Tag Manager when running in development mode.`
       ),
-    defaultDataLayer: Joi.object()
+    defaultDataLayer: Joi.alternatives()
+      .try(Joi.object(),Joi.function())
       .default(null)
       .description(
         `Data layer to be set before Google Tag Manager is loaded. Should be an object or a function.`

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -23,7 +23,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
         `Include Google Tag Manager when running in development mode.`
       ),
     defaultDataLayer: Joi.alternatives()
-       .try(Joi.object(),Joi.function())
+      .try(Joi.object(), Joi.function())
       .default(null)
       .description(
         `Data layer to be set before Google Tag Manager is loaded. Should be an object or a function.`

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -23,7 +23,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
         `Include Google Tag Manager when running in development mode.`
       ),
     defaultDataLayer: Joi.alternatives()
-      .try(Joi.object(),Joi.function())
+       .try(Joi.object(),Joi.function())
       .default(null)
       .description(
         `Data layer to be set before Google Tag Manager is loaded. Should be an object or a function.`


### PR DESCRIPTION
## Description

Added support for function type in the plugin gatsby-plugin-google-tagmanager. This should solve #27874 

### Documentation

This actually helps validate the docs for gatsby-plugin-google-tagmanager found at [https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-tagmanager](url)

The docs mention that defaultDataLayer prop can accept both object and function, but using a function throws an error.

## Related Issues

#27874 
