### PR TITLE
feat: Update gatsby-plugin-manifest Readme.md

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -99,12 +99,12 @@ Add the following line to the plugin options
   icon: `src/images/icon.png`, // This path is relative to the root of the site.
   icons: [
     {
-      src: `/favicons/android-chrome-192x192.png`,
+      src: `/favicons/android-chrome-192x192.png`, // This path is relative to the static folder
       sizes: `192x192`,
       type: `image/png`,
     },
     {
-      src: `/favicons/android-chrome-512x512.png`,
+      src: `/favicons/android-chrome-512x512.png`, // This path is relative to the static folder
       sizes: `512x512`,
       type: `image/png`,
     },
@@ -122,12 +122,12 @@ Add the following line to the plugin options
 ```js
 icons: [
   {
-    src: `/favicons/android-chrome-192x192.png`,
+    src: `/favicons/android-chrome-192x192.png`, // This path is relative to the static folder
     sizes: `192x192`,
     type: `image/png`,
   },
   {
-    src: `/favicons/android-chrome-512x512.png`,
+    src: `/favicons/android-chrome-512x512.png`, // This path is relative to the static folder
     sizes: `512x512`,
     type: `image/png`,
   },

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -97,14 +97,15 @@ Add the following line to the plugin options
 
 ```js
   icon: `src/images/icon.png`, // This path is relative to the root of the site.
+  // All entries in src are relative to the static folder
   icons: [
     {
-      src: `/favicons/android-chrome-192x192.png`, // This path is relative to the static folder
+      src: `/favicons/android-chrome-192x192.png`,
       sizes: `192x192`,
       type: `image/png`,
     },
     {
-      src: `/favicons/android-chrome-512x512.png`, // This path is relative to the static folder
+      src: `/favicons/android-chrome-512x512.png`,
       sizes: `512x512`,
       type: `image/png`,
     },
@@ -120,14 +121,15 @@ The hybrid option allows the most flexibility while still not requiring you to c
 Add the following line to the plugin options
 
 ```js
+// All entries in src are relative to the static folder
 icons: [
   {
-    src: `/favicons/android-chrome-192x192.png`, // This path is relative to the static folder
+    src: `/favicons/android-chrome-192x192.png`,
     sizes: `192x192`,
     type: `image/png`,
   },
   {
-    src: `/favicons/android-chrome-512x512.png`, // This path is relative to the static folder
+    src: `/favicons/android-chrome-512x512.png`,
     sizes: `512x512`,
     type: `image/png`,
   },

--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -97,8 +97,7 @@ Add the following line to the plugin options
 
 ```js
   icon: `src/images/icon.png`, // This path is relative to the root of the site.
-  // All entries in src are relative to the static folder
-  icons: [
+  icons: [ // The paths defined in src are relative to the root of the site when hosted
     {
       src: `/favicons/android-chrome-192x192.png`,
       sizes: `192x192`,
@@ -121,8 +120,7 @@ The hybrid option allows the most flexibility while still not requiring you to c
 Add the following line to the plugin options
 
 ```js
-// All entries in src are relative to the static folder
-icons: [
+icons: [ // The paths defined in src are relative to the root of the site when hosted
   {
     src: `/favicons/android-chrome-192x192.png`,
     sizes: `192x192`,


### PR DESCRIPTION
Added new comments next to the icons.src value to distinguish the path with the icon option

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I have just included four comment lines same at icon property but in icons array instead. to make clear the difference between when to use the root/src or static/ paths. This is already described below the manual config but perhaps this helps when you want to only copy - paste the config and you didn't notice the note.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

https://github.com/gatsbyjs/gatsby/issues/27751
