### PR TITLE
fix(recipes): Resolve themes relative to root (#27836)

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -53,7 +53,6 @@
     "remark-mdxjs": "^2.0.0-next.4",
     "remark-parse": "^6.0.3",
     "remark-stringify": "^8.1.0",
-    "resolve-cwd": "^3.0.0",
     "resolve-from": "^5.0.0",
     "semver": "^7.3.2",
     "single-trailing-newline": "^1.0.0",

--- a/packages/gatsby-recipes/src/providers/gatsby/plugin.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/plugin.js
@@ -6,7 +6,6 @@ import { declare } from "@babel/helper-plugin-utils"
 import * as Joi from "@hapi/joi"
 import glob from "glob"
 import prettier from "prettier"
-import resolveCwd from "resolve-cwd"
 import { slash } from "gatsby-core-utils"
 import fetch from "node-fetch"
 
@@ -25,7 +24,11 @@ import { read as readPackageJSON } from "../npm/package"
 const fileExists = filePath => fs.existsSync(filePath)
 
 const listShadowableFilesForTheme = (directory, theme) => {
-  const themePath = path.dirname(resolveCwd(path.join(theme, `package.json`)))
+  const themePath = path.dirname(
+    require.resolve(slash(path.join(theme, `package.json`)), {
+      paths: [directory],
+    })
+  )
   const themeSrcPath = path.join(themePath, `src`)
   const shadowableThemeFiles = glob.sync(themeSrcPath + `/**/*.*`, {
     follow: true,


### PR DESCRIPTION
Backporting #27836 to the release branch

* Resolve themes relative to root

* fix(gatsby-plugin-cxs): Fix dependency version

* Slash

(cherry picked from commit 57b8023890a764d562cd8f667d03084e9a8a5560)
