### PR TITLE
refactor(gatsby): track page-data writes per-page

### DIFF
--- a/packages/gatsby/src/commands/build-javascript.ts
+++ b/packages/gatsby/src/commands/build-javascript.ts
@@ -62,6 +62,7 @@ export const buildProductionBundle = async (
                 type: `ADD_PENDING_TEMPLATE_DATA_WRITE`,
                 payload: {
                   componentPath,
+                  pages: state.components.get(componentPath)?.pages ?? [],
                 },
               })
               store.dispatch({

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -52,7 +52,6 @@ Object {
   "pageDataStats": Map {},
   "pendingPageDataWrites": Object {
     "pagePaths": Set {},
-    "templatePaths": Set {},
   },
   "queries": Object {
     "byConnection": Map {},

--- a/packages/gatsby/src/redux/reducers/pending-page-data-writes.ts
+++ b/packages/gatsby/src/redux/reducers/pending-page-data-writes.ts
@@ -3,7 +3,6 @@ import { ActionsUnion, IGatsbyState } from "../types"
 export const pendingPageDataWritesReducer = (
   state: IGatsbyState["pendingPageDataWrites"] = {
     pagePaths: new Set(),
-    templatePaths: new Set(),
   },
   action: ActionsUnion
 ): IGatsbyState["pendingPageDataWrites"] => {
@@ -12,13 +11,15 @@ export const pendingPageDataWritesReducer = (
       state.pagePaths.add(action.payload.path)
       return state
 
-    case `ADD_PENDING_TEMPLATE_DATA_WRITE`:
-      state.templatePaths.add(action.payload.componentPath)
+    case `ADD_PENDING_TEMPLATE_DATA_WRITE`: {
+      for (const page of action.payload.pages) {
+        state.pagePaths.add(page)
+      }
       return state
+    }
 
-    case `CLEAR_PENDING_PAGE_DATA_WRITES`: {
-      state.pagePaths.clear()
-      state.templatePaths.clear()
+    case `CLEAR_PENDING_PAGE_DATA_WRITE`: {
+      state.pagePaths.delete(action.payload.page)
       return state
     }
 

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -230,7 +230,6 @@ export interface IGatsbyState {
   staticQueriesByTemplate: Map<SystemPath, Array<Identifier>>
   pendingPageDataWrites: {
     pagePaths: Set<string>
-    templatePaths: Set<SystemPath>
   }
   // @deprecated
   jobs: {
@@ -341,7 +340,7 @@ export type ActionsUnion =
   | ISetStaticQueriesByTemplateAction
   | IAddPendingPageDataWriteAction
   | IAddPendingTemplateDataWriteAction
-  | IClearPendingPageDataWritesAction
+  | IClearPendingPageDataWriteAction
   | ICreateResolverContext
   | IClearSchemaCustomizationAction
   | ISetSchemaComposerAction
@@ -652,11 +651,15 @@ export interface IAddPendingTemplateDataWriteAction {
   type: `ADD_PENDING_TEMPLATE_DATA_WRITE`
   payload: {
     componentPath: SystemPath
+    pages: Array<string>
   }
 }
 
-export interface IClearPendingPageDataWritesAction {
-  type: `CLEAR_PENDING_PAGE_DATA_WRITES`
+export interface IClearPendingPageDataWriteAction {
+  type: `CLEAR_PENDING_PAGE_DATA_WRITE`
+  payload: {
+    page: string
+  }
 }
 
 export interface IDeletePageAction {

--- a/packages/gatsby/src/services/start-webpack-server.ts
+++ b/packages/gatsby/src/services/start-webpack-server.ts
@@ -144,6 +144,7 @@ export async function startWebpackServer({
                 type: `ADD_PENDING_TEMPLATE_DATA_WRITE`,
                 payload: {
                   componentPath,
+                  pages: state.components.get(componentPath)?.pages ?? [],
                 },
               })
               store.dispatch({

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -117,24 +117,14 @@ export async function flush(): Promise<void> {
   isFlushing = true
   const {
     pendingPageDataWrites,
-    components,
     pages,
     program,
     staticQueriesByTemplate,
   } = store.getState()
 
-  const { pagePaths, templatePaths } = pendingPageDataWrites
+  const { pagePaths } = pendingPageDataWrites
 
-  const pagesToWrite = Array.from(templatePaths).reduce(
-    (set, componentPath) => {
-      const templateComponent = components.get(componentPath)
-      if (templateComponent) {
-        templateComponent.pages.forEach(set.add.bind(set))
-      }
-      return set
-    },
-    new Set(pagePaths.values())
-  )
+  const pagesToWrite = pagePaths.values()
 
   for (const pagePath of pagesToWrite) {
     const page = pages.get(pagePath)
@@ -164,11 +154,14 @@ export async function flush(): Promise<void> {
         })
       }
     }
+    store.dispatch({
+      type: `CLEAR_PENDING_PAGE_DATA_WRITE`,
+      payload: {
+        page: pagePath,
+      },
+    })
   }
 
-  store.dispatch({
-    type: `CLEAR_PENDING_PAGE_DATA_WRITES`,
-  })
   isFlushing = false
   return
 }


### PR DESCRIPTION
## Description

Before this PR a page-data `flush` utility assumed that all queries for a given template were executed before it was called. I am referring to this function: https://github.com/gatsbyjs/gatsby/blob/b1b56e434934d189ddf21ffb87868b53fd1a7c41/packages/gatsby/src/utils/page-data.ts#L111

With query on demand, this assumption will be wrong as some queries for a template may be executed but others can still be in a pending (or dirty) state.

So this PR switches from per-component to per-page tracking of page data writes.

Required for #27620 