### PR TITLE
fix(gatsby-plugin-google-analytics): add cookieFlags to options schema

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
@@ -35,6 +35,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     sampleRate: Joi.number(),
     siteSpeedSampleRate: Joi.number(),
     cookieDomain: Joi.string(),
+    cookieFlags: Joi.string(),
     name: Joi.string(),
     clientId: Joi.string(),
     alwaysSendReferrer: Joi.boolean(),


### PR DESCRIPTION
Actually closes #27833! I added all other options but forgot this one in #27914 :facepalm:
