### PR TITLE
fix(gatsby-plugin-google-analytics): add cookieFlags to options schema (#27923)

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-node.js
@@ -35,6 +35,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     sampleRate: Joi.number(),
     siteSpeedSampleRate: Joi.number(),
     cookieDomain: Joi.string(),
+    cookieFlags: Joi.string(),
     name: Joi.string(),
     clientId: Joi.string(),
     alwaysSendReferrer: Joi.boolean(),


### PR DESCRIPTION
Backporting #27923 to the release branch

(cherry picked from commit 557139ed20fb18db08686db42284511ab8f9bdfd)
