### PR TITLE
fix(gatsby-plugin-offline): add workboxConfig.maximumFileSizeToCacheInBytes to options schema (#27913)

### DIFF
--- a/packages/gatsby-plugin-offline/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/__tests__/gatsby-node.js
@@ -176,6 +176,7 @@ describe(`pluginOptionsSchema`, () => {
         },
         cacheId: `gatsby-plugin-offline`,
         dontCacheBustURLsMatching: /(\.js$|\.css$|static\/)/,
+        maximumFileSizeToCacheInBytes: 4800,
         runtimeCaching: [
           {
             urlPattern: /(\.js$|\.css$|static\/)/,

--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -234,6 +234,7 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       modifyURLPrefix: Joi.object().pattern(MATCH_ALL_KEYS, Joi.string()),
       cacheId: Joi.string(),
       dontCacheBustURLsMatching: Joi.object().instance(RegExp),
+      maximumFileSizeToCacheInBytes: Joi.number(),
       runtimeCaching: Joi.array().items(
         Joi.object({
           urlPattern: Joi.object().instance(RegExp),


### PR DESCRIPTION
Backporting #27913 to the release branch

(cherry picked from commit e4fd0ad8cda56996f42e0a2b9fd6b580823289c9)
