### PR TITLE
fix(gatsby): account for edge case when payload of DELETE_NODE is undefined

### DIFF
--- a/packages/gatsby/src/redux/reducers/__tests__/queries.ts
+++ b/packages/gatsby/src/redux/reducers/__tests__/queries.ts
@@ -826,6 +826,13 @@ describe(`create node`, () => {
 })
 
 describe(`delete node`, () => {
+  it(`accounts for undefined payload`, () => {
+    const runDeleteNode = (): void => {
+      reducer(state, { type: `DELETE_NODE`, payload: undefined })
+    }
+    expect(runDeleteNode).not.toThrow(`Cannot read property 'id' of undefined`)
+  })
+
   it.todo(`marks page query as dirty when it has this node as a dependency`)
   it.todo(`marks static query as dirty when it has this node as a dependency`)
   it.todo(

--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -170,6 +170,9 @@ export function queriesReducer(
     case `CREATE_NODE`:
     case `DELETE_NODE`: {
       const node = action.payload
+      if (!node) {
+        return state
+      }
       const queriesByNode = state.byNode.get(node.id) ?? []
       const queriesByConnection =
         state.byConnection.get(node.internal.type) ?? []

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -737,7 +737,8 @@ export interface IAddChildNodeToParentNodeAction {
 
 export interface IDeleteNodeAction {
   type: `DELETE_NODE`
-  payload: IGatsbyNode
+  // FIXME: figure out why payload can be undefined here
+  payload: IGatsbyNode | void
 }
 
 export interface IDeleteNodesAction {


### PR DESCRIPTION
## Description

Turns out a payload of the `DELETE_NODE` action can be `undefined` in some edge cases (no idea when exactly). And refactor from #27504 didn't account for this. This causes `Cannot read property 'id' of undefined'` error (again, hard to say in which circumstances).

This PR fixes this problem by using the same strategy as other reducers (just treats this situation as a no-op). Example from other reducer:

https://github.com/gatsbyjs/gatsby/blob/557139ed20fb18db08686db42284511ab8f9bdfd/packages/gatsby/src/redux/reducers/nodes.ts#L21-L26
