### PR TITLE
add typescript definitions for google analytics config

### DIFF
--- a/packages/gatsby-plugin-google-analytics/index.d.ts
+++ b/packages/gatsby-plugin-google-analytics/index.d.ts
@@ -7,6 +7,9 @@ interface OutboundLinkProps {
   eventLabel?: string
 }
 
+/**
+ * @see https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/#outboundlink-component
+ */
 export class OutboundLink extends React.Component<
   OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>,
   any
@@ -23,4 +26,62 @@ export interface CustomEventArgs {
   callbackTimeout?: Number
 }
 
+/**
+ * @see https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/#trackcustomevent-function
+ */
 export function trackCustomEvent(args: CustomEventArgs): void
+
+export interface GoogleAnalyticsConfig {
+  resolve: "gatsby-plugin-google-analytics"
+  options: GoogleAnalyticsOptions
+}
+
+/**
+ * @see https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#options
+ */
+interface GoogleAnalyticsOptions {
+  /** The property ID; the tracking code won't be generated without it */
+  trackingId: string
+  /** Defines where to place the tracking script - `true` in the head and `false` in the body */
+  head?: boolean
+  anonymize?: boolean
+  respectDNT?: boolean
+  /** Avoids sending pageview hits from custom paths */
+  exclude?: string[]
+  /** Delays sending pageview hits on route update (in milliseconds) */
+  pageTransitionDelay?: number
+  /** Enables Google Optimize using your container Id */
+  optimizeId?: string
+  /** Enables Google Optimize Experiment ID */
+  experimentId?: string
+  /** Set Variation ID. 0 for original 1,2,3.... */
+  variationId?: string
+  /** Defers execution of google analytics script after page load */
+  defer?: boolean
+
+  // Create Only fields
+  /** tracker name */
+  name?: string
+  clientId?: string
+  sampleRate?: number
+  siteSpeedSampleRate?: number
+  alwaysSendReferrer?: boolean
+  allowAnchor?: boolean
+  cookieName?: string
+  cookieFlags?: string
+  /** defaults to 'auto' if not given */
+  cookieDomain?: string
+  cookieExpires?: number
+  storeGac?: boolean
+  legacyCookieDomain?: string
+  legacyHistoryImport?: boolean
+  allowLinker?: boolean
+  storage?: string
+
+  // General Fields
+  allowAdFeatures?: boolean
+  dataSource?: string
+  queueTime?: number
+  forceSSL?: boolean
+  transport?: string
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add typescript definitions for the config for the google analytics plugin

### Documentation

Documentation already exists at https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics

## Related Issues

N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
