### PR TITLE
perf(gatsby-plugin-mdx): lazily fetch file nodes for remark plugins

### DIFF
--- a/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -3,8 +3,6 @@ const _ = require(`lodash`)
 const debug = require(`debug`)(`get-source-plugins-as-remark-plugins`)
 const { interopDefault } = require(`./interop-default`)
 
-let fileNodes
-
 // ensure only one `/` in new url
 const withPathPrefix = (url, pathPrefix) =>
   (pathPrefix + url).replace(/\/\//, `/`)
@@ -39,8 +37,6 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
       }
   }
 
-  fileNodes = getNodesByType(`File`)
-
   // return list of remarkPlugins
   const userPlugins = gatsbyRemarkPlugins
     .filter(plugin => {
@@ -62,7 +58,9 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
               markdownNode: mdxNode,
               getNode,
               getNodesByType,
-              files: fileNodes,
+              get files() {
+                return getNodesByType(`File`)
+              },
               pathPrefix,
               reporter,
               cache,


### PR DESCRIPTION
Lazily fetch the list of `File` nodes. Before it would always generate the list of file nodes (which does a shallow copy, which is expensive at scale). Afterwards it only does this when the files are actually read, by adding a "getter" property.

Benchmark numbers on gabe-fs-mdx (no plugins), for just 10k pages:

```
info bootstrap finished - 110.731s
success run page queries - 176.578s - 10002/10002 56.64/s
info Done building in 297.347 sec
```
to
```
info bootstrap finished - 96.578s
success run page queries - 159.652s - 10002/10002 62.65/s
info Done building in 266.202 sec
```

(This snippet is used at sourcing time and as part of resolvers so run queries is also affected, so it saved roughly 2x 15s)
