### PR TITLE
fix(gatsby): allow unknown plugin options

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -302,8 +302,14 @@ describe(`Load plugins`, () => {
         plugins,
       })
 
-      console.log((reporter.error as jest.Mock).mock.calls)
       expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(0)
+      expect(reporter.warn as jest.Mock).toHaveBeenCalledTimes(1)
+      expect((reporter.warn as jest.Mock).mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          "Warning: there are unknown plugin options for \\"gatsby-plugin-google-analytics\\": doesThisExistInTheSchema
+        Please open an issue at ghub.io/gatsby-plugin-google-analytics if you believe this option is valid.",
+        ]
+      `)
       expect(mockProcessExit).not.toHaveBeenCalled()
     })
 

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -18,6 +18,7 @@ afterEach(() => {
   Object.keys(reporter).forEach(method => {
     reporter[method].mockClear()
   })
+  mockProcessExit.mockClear()
 })
 
 describe(`Load plugins`, () => {
@@ -285,6 +286,25 @@ describe(`Load plugins`, () => {
         ]
       `)
       expect(mockProcessExit).toHaveBeenCalledWith(1)
+    })
+
+    it(`allows unknown options`, async () => {
+      const plugins = [
+        {
+          resolve: `gatsby-plugin-google-analytics`,
+          options: {
+            trackingId: `yes`,
+            doesThisExistInTheSchema: `no`,
+          },
+        },
+      ]
+      await loadPlugins({
+        plugins,
+      })
+
+      console.log((reporter.error as jest.Mock).mock.calls)
+      expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(0)
+      expect(mockProcessExit).not.toHaveBeenCalled()
     })
 
     it(`defaults plugin options to the ones defined in the schema`, async () => {

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -15,6 +15,7 @@ import {
   ISiteConfig,
 } from "./types"
 import { IPluginRefObject } from "gatsby-plugin-utils/dist/types"
+import { stripIndent } from "common-tags"
 
 interface IApi {
   version?: string
@@ -219,9 +220,6 @@ async function validatePluginsOptions(
           })
         }
 
-        // Allow unknown keys to avoid users hitting blocking errors due to incomplete schemas
-        optionsSchema = optionsSchema.unknown(true)
-
         plugin.options = await validateOptionsSchema(
           optionsSchema,
           (plugin.options as IPluginInfoOptions) || {}
@@ -240,6 +238,14 @@ async function validatePluginsOptions(
         }
       } catch (error) {
         if (error instanceof Joi.ValidationError) {
+          // Show a small warning on unknown options rather than erroring
+          const validationWarnings = error.details.filter(
+            err => err.type === `object.unknown`
+          )
+          const validationErrors = error.details.filter(
+            err => err.type !== `object.unknown`
+          )
+
           // If rootDir and plugin.parentDir are the same, i.e. if this is a plugin a user configured in their gatsby-config.js (and not a sub-theme that added it), this will be ""
           // Otherwise, this will contain (and show) the relative path
           const configDir =
@@ -247,15 +253,35 @@ async function validatePluginsOptions(
               rootDir &&
               path.relative(rootDir, plugin.parentDir)) ||
             null
-          reporter.error({
-            id: `11331`,
-            context: {
-              configDir,
-              validationErrors: error.details,
-              pluginName: plugin.resolve,
-            },
-          })
-          errors++
+          if (validationErrors.length > 0) {
+            reporter.error({
+              id: `11331`,
+              context: {
+                configDir,
+                validationErrors: error.details,
+                pluginName: plugin.resolve,
+              },
+            })
+            errors++
+          }
+
+          if (validationWarnings.length > 0) {
+            reporter.warn(
+              stripIndent(`
+                Warning: there are unknown plugin options for "${
+                  plugin.resolve
+                }"${
+                configDir ? `, configured by ${configDir}` : ``
+              }: ${validationWarnings
+                .map(error => error.path.join(`.`))
+                .join(`, `)}
+                Please open an issue at ghub.io/${
+                  plugin.resolve
+                } if you believe this option is valid.
+              `)
+            )
+            // We do not increment errors++ here as we do not want to process.exit if there are only warnings
+          }
 
           return plugin
         }

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -219,6 +219,9 @@ async function validatePluginsOptions(
           })
         }
 
+        // Allow unknown keys to avoid users hitting blocking errors due to incomplete schemas
+        optionsSchema = optionsSchema.unknown(true)
+
         plugin.options = await validateOptionsSchema(
           optionsSchema,
           (plugin.options as IPluginInfoOptions) || {}

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -16,6 +16,7 @@ import {
 } from "./types"
 import { IPluginRefObject } from "gatsby-plugin-utils/dist/types"
 import { stripIndent } from "common-tags"
+import { trackCli } from "gatsby-telemetry"
 
 interface IApi {
   version?: string
@@ -280,6 +281,12 @@ async function validatePluginsOptions(
                 } if you believe this option is valid.
               `)
             )
+            trackCli(`UNKNOWN_PLUGIN_OPTION`, {
+              name: plugin.resolve,
+              valueString: validationWarnings
+                .map(error => error.path.join(`.`))
+                .join(`, `),
+            })
             // We do not increment errors++ here as we do not want to process.exit if there are only warnings
           }
 

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -259,7 +259,7 @@ async function validatePluginsOptions(
               id: `11331`,
               context: {
                 configDir,
-                validationErrors: error.details,
+                validationErrors,
                 pluginName: plugin.resolve,
               },
             })


### PR DESCRIPTION
- [x] Allow unknown options
- [x] Warn on unknown options
- [x] Track unknown options people use in telemetry so we can adjust the schemas

[ch18531]

Requires #27949 to land first, as that adds support for `valueString` to the `trackCli` flags!