### PR TITLE
fix(gatsby-remark-images): adding missing plugin options

### DIFF
--- a/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
@@ -12,7 +12,7 @@ describe(`pluginOptionsSchema`, () => {
       `"wrapperStyle" must be one of [object, string]`,
       `"backgroundColor" must be a string`,
       `"quality" must be a number`,
-      `"withWebp" must be a boolean`,
+      `"withWebp" must be one of [object, boolean]`,
       `"tracedSVG" must be a boolean`,
       `"loading" must be one of [lazy, eager, auto]`,
       `"disableBgImageOnAlpha" must be a boolean`,
@@ -29,7 +29,7 @@ describe(`pluginOptionsSchema`, () => {
       wrapperStyle: true,
       backgroundColor: 123,
       quality: `This should be a number`,
-      withWebp: `This should be a boolean`,
+      withWebp: `This should be a boolean or an object`,
       tracedSVG: `This should be a boolean`,
       loading: `This should be lazy, eager or auto`,
       disableBgImageOnAlpha: `This should be a boolean`,
@@ -56,6 +56,14 @@ describe(`pluginOptionsSchema`, () => {
       disableBgImageOnAlpha: true,
       disableBgImage: true,
       srcSetBreakpoints: [400, 600, 800],
+    })
+
+    expect(isValid).toBe(true)
+  })
+
+  it(`should validate the withWebp prop`, async () => {
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+      withWebp: { quality: 100 },
     })
 
     expect(isValid).toBe(true)

--- a/packages/gatsby-remark-images/src/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/gatsby-node.js
@@ -39,7 +39,8 @@ exports.pluginOptionsSchema = function ({ Joi }) {
     quality: Joi.number()
       .default(50)
       .description(`The quality level of the generated files.`),
-    withWebp: Joi.boolean()
+    withWebp: Joi.alternatives()
+      .try(Joi.object({ quality: Joi.number() }), Joi.boolean())
       .default(false)
       .description(
         `Additionally generate WebP versions alongside your chosen file format. They are added as a srcset with the appropriate mimetype and will be loaded in browsers that support the format. Pass true for default support, or an object of options to specifically override those for the WebP files. For example, pass { quality: 80 } to have the WebP images be at quality level 80.`


### PR DESCRIPTION

## Description

Fix the `withWebp` option in `gatsby-remark-images` option schema

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/27437#discussion_r520549965
