### PR TITLE
:fire: Remove unnecessary braces

### DIFF
--- a/docs/docs/static-folder.md
+++ b/docs/docs/static-folder.md
@@ -24,7 +24,7 @@ render() {
   // Note: this is an escape hatch and should be used sparingly!
   // Normally we recommend using `import` for getting asset URLs
   // as described in the “Importing Assets Directly Into Files” page.
-  return <img src={'/logo.png'} alt="Logo" />;
+  return <img src='/logo.png' alt="Logo" />;
 }
 ```
 


### PR DESCRIPTION
## Description

As I was following along, my linter pointed out the braces were not needed. 

### Documentation

It's documented [here.](https://www.gatsbyjs.com/docs/static-folder/#referencing-your-static-asset)

