### PR TITLE
feat(gatsby): enable compression in the dev server

### DIFF
--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -7,6 +7,7 @@ import webpackDevMiddleware, {
 import got from "got"
 import webpack from "webpack"
 import express from "express"
+import compression from "compression"
 import graphqlHTTP from "express-graphql"
 import graphqlPlayground from "graphql-playground-middleware-express"
 import graphiqlExplorer from "gatsby-graphiql-explorer"
@@ -117,6 +118,7 @@ export async function startServer(
   /**
    * Set up the express app.
    **/
+  app.use(compression())
   app.use(telemetry.expressMiddleware(`DEVELOP`))
   app.use(
     webpackHotMiddleware(compiler, {


### PR DESCRIPTION
This lowers the amount of data transfered for one site from 5.8mb -> 1.3mb which speeds up
loading the preview especially in remote situations.

Most of that drop was from the commons.js bundle which dropped from 5.2mb -> 0.6mb.