### PR TITLE
fix(gatsby): don't hide original error if stack-trace point to not existing file

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -604,19 +604,25 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
         if (file) {
           const { fileName, lineNumber: line, columnNumber: column } = file
 
-          const code = fs.readFileSync(fileName, { encoding: `utf-8` })
-          codeFrame = codeFrameColumns(
-            code,
-            {
-              start: {
-                line,
-                column,
+          try {
+            const code = fs.readFileSync(fileName, { encoding: `utf-8` })
+            codeFrame = codeFrameColumns(
+              code,
+              {
+                start: {
+                  line,
+                  column,
+                },
               },
-            },
-            {
-              highlightCode: true,
-            }
-          )
+              {
+                highlightCode: true,
+              }
+            )
+          } catch (_e) {
+            // sometimes stack trace point to not existing file
+            // particularly when file is transpiled and path actually changes
+            // (like pointing to not existing `src` dir or original typescript file)
+          }
 
           structuredError.location = {
             start: { line: line, column: column },


### PR DESCRIPTION
## Description

I'm not exactly sure why but stack trace for transpiled files have original/source file immediately when constructing error: 
![Screenshot 2020-11-10 at 20 24 15](https://user-images.githubusercontent.com/419821/98724981-d0ca8f80-2394-11eb-969a-e4ccbcfd2ebb.png)

Not sure if there is weird side effect that something overwrites `Error` prototype?

This currently can result in hiding real errors when we try to print codeframe pointing to origin of it, because we try to read file content without error handling and in case file doesn't exist we print file reading error and not the original one.

This PR adds error handling ... by try-catching part that reads the file and just doing nothing if it errors out (best check diff with hiding white-space setting enabled - https://github.com/gatsbyjs/gatsby/pull/27953/files?diff=unified&w=1)
