### PR TITLE
Fix #26359: Support HTTPS for the develop status server

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -1,6 +1,7 @@
 // NOTE(@mxstbr): Do not use the reporter in this file, as that has side-effects on import which break structured logging
 import path from "path"
 import http from "http"
+import https from "https"
 import tmp from "tmp"
 import { ChildProcess } from "child_process"
 import execa from "execa"
@@ -332,7 +333,11 @@ module.exports = async (program: IProgram): Promise<void> => {
     unlocks = unlocks.concat([statusUnlock, developUnlock, telemetryUnlock])
   }
 
-  const statusServer = http.createServer().listen(statusServerPort)
+  const statusServer = program.ssl
+    ? https.createServer(program.ssl)
+    : http.createServer()
+  statusServer.listen(statusServerPort)
+
   const io = socket(statusServer)
 
   const handleChildProcessIPC = (msg): void => {


### PR DESCRIPTION
### Description

Fix #26359: Support HTTPS for the develop status server

### Documentation

It introduces a breaking change as now the `--https` CLI flag also uses a HTTPS server for the develop status server. But, from my understanding, it was a bug as this server was not usable without this fix. The error in Google Chrome is:
```
GET https://myDomain.com:8001/socket.io/?EIO=3&transport=polling&t=NMq6XUt net::ERR_SSL_PROTOCOL_ERROR
```

Inspired by https://github.com/gatsbyjs/gatsby/blob/76cddc7ff2e4d7d2db6d5bc2d1e2dc765af62c1d/packages/gatsby/src/utils/develop-proxy.ts#L81-L83

Since it is my first contribution to Gatsby I may have missed something, so feel free to discard this PR. 

### Motivations

We would like to reduce the amount of differences between development & production environments.

Having a nginx running in front of `gatsby develop` (with Gatsby launched on HTTP) does not seem to be an option: the JS application will target the develop status server using HTTPS but this one will be running using HTTP. It could be achieved by having control on both the develop status server port and the targeted port from the JS application & by proxying the targeted port to the listening port while performing SSL termination in nginx 🤷🏻‍♂️

### Related Issues

Closes https://github.com/gatsbyjs/gatsby/issues/26359
Fixes #27427
Related to #27302 and #27294

### Notes

Last but not least, thank you for this project & the time spent to review my PR.