### PR TITLE
WIP fix(gatsby): don't load all static query results upfront.

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/redirect.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/redirect.js
@@ -21,7 +21,7 @@ const runTests = () => {
     })
   })
 
-  it(`should redirect page to index page even there is a such page`, () => {
+  it(`should redirect page to index page even if there is a such page`, () => {
     cy.visit(`/redirect`).waitForRouteChange()
 
     cy.location(`pathname`).should(`equal`, `/`)

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -106,11 +106,16 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     ReactDOM.render
   )[0]
 
+  console.log(`loading pages`)
+  const loadPagePromise = loader.loadPage(`/dev-404-page/`)
+  console.log(`dev-404-page`, { loadPagePromise })
+  loadPagePromise.then(() => console.log(`====loaded dev-404-page`))
   Promise.all([
     loader.loadPage(`/dev-404-page/`),
     loader.loadPage(`/404.html`),
     loader.loadPage(window.location.pathname),
   ]).then(() => {
+    console.log(`pages loaded!`)
     const preferDefault = m => (m && m.default) || m
     let Root = preferDefault(require(`./root`))
     domReady(() => {

--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -49,7 +49,6 @@ class DevLoader extends BaseLoader {
 
   loadPageDataJson(rawPath, refresh) {
     return super.loadPageDataJson(rawPath, refresh).then(data => {
-      ___emitter.emit(`onLoadPageDataJson`, null)
       // when we can't find a proper 404.html we fallback to dev-404-page
       // we need to make sure to mark it as not found.
       if (

--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -42,17 +42,14 @@ class DevLoader extends BaseLoader {
     super(loadComponent, matchPaths)
   }
 
-  loadPage(pagePath) {
+  loadPage(pagePath, refresh) {
     const realPath = findPath(pagePath)
-    return super.loadPage(realPath).then(result =>
-      require(`./socketIo`)
-        .getPageData(realPath)
-        .then(() => result)
-    )
+    return super.loadPage(realPath, refresh)
   }
 
-  loadPageDataJson(rawPath) {
-    return super.loadPageDataJson(rawPath).then(data => {
+  loadPageDataJson(rawPath, refresh) {
+    return super.loadPageDataJson(rawPath, refresh).then(data => {
+      ___emitter.emit(`onLoadPageDataJson`, null)
       // when we can't find a proper 404.html we fallback to dev-404-page
       // we need to make sure to mark it as not found.
       if (
@@ -72,7 +69,7 @@ class DevLoader extends BaseLoader {
   }
 
   doPrefetch(pagePath) {
-    return Promise.resolve(require(`./socketIo`).getPageData(pagePath))
+    return super.loadPage(pagePath)
   }
 }
 

--- a/packages/gatsby/cache-dir/ensure-resources.js
+++ b/packages/gatsby/cache-dir/ensure-resources.js
@@ -74,6 +74,7 @@ class EnsureResources extends React.Component {
   }
 
   render() {
+    console.log(`ensure-resources render`)
     if (process.env.NODE_ENV !== `production` && !this.state.pageResources) {
       throw new Error(
         `EnsureResources was not able to find resources for path: "${this.props.location.pathname}"

--- a/packages/gatsby/cache-dir/gatsby-browser-entry.js
+++ b/packages/gatsby/cache-dir/gatsby-browser-entry.js
@@ -19,8 +19,8 @@ const StaticQueryContext = React.createContext({})
 
 function StaticQueryDataRenderer({ staticQueryData, data, query, render }) {
   const combinedStaticQueryData = {
-    ...staticQueryData,
     ...loader.getStaticQueryResults(),
+    ...staticQueryData,
   }
   const finalData = data
     ? data.data
@@ -76,9 +76,7 @@ useStaticQuery(graphql\`${query}\`);
   }
 
   // Merge data loaded via socket.io & xhr
-  //
-  // TODO just load data over xhr & socket.io just triggers
-  // re-fetches
+  // We favor socket.io data as it'll be the freshest.
   const staticQueryData = {
     ...loader.getStaticQueryResults(),
     ...context,

--- a/packages/gatsby/cache-dir/gatsby-browser-entry.js
+++ b/packages/gatsby/cache-dir/gatsby-browser-entry.js
@@ -84,9 +84,11 @@ useStaticQuery(graphql\`${query}\`);
     ...loader.getStaticQueryResults(),
   }
 
+  console.log({ staticQueryData, query })
   if (staticQueryData?.[query]?.data) {
     return staticQueryData[query].data
   } else {
+    // window.location.reload()
     throw new Error(
       `The result of this StaticQuery could not be fetched.\n\n` +
         `This is likely a bug in Gatsby and if refreshing the page does not fix it, ` +

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -406,7 +406,10 @@ export class BaseLoader {
   }
 
   hovering(rawPath) {
-    this.loadPage(rawPath)
+    this.loadPage(
+      rawPath,
+      process.env.NODE_ENV === `development` ? true : false
+    )
   }
 
   getResourceURLsForPathname(rawPath) {

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -286,7 +286,7 @@ export class BaseLoader {
       const staticQueryBatchPromise = Promise.all(
         staticQueryHashes.map(staticQueryHash => {
           // Check for cache in case this static query result has already been loaded
-          if (this.staticQueryDb[staticQueryHash]) {
+          if (!refresh && this.staticQueryDb[staticQueryHash]) {
             const jsonPayload = this.staticQueryDb[staticQueryHash]
             return { staticQueryHash, jsonPayload }
           }

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -212,7 +212,6 @@ export class BaseLoader {
 
   loadPageDataJson(rawPath, refresh = false) {
     const pagePath = findPath(rawPath)
-    console.trace()
     console.log({ pagePath, refresh })
     if (!refresh && this.pageDataDb.has(pagePath)) {
       return Promise.resolve(this.pageDataDb.get(pagePath))

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -81,46 +81,44 @@ const navigate = (to, options = {}) => {
     })
   }, 1000)
 
-  loader
-    .loadPage(pathname, process.env.NODE_ENV === `development` ? true : false)
-    .then(pageResources => {
-      // If no page resources, then refresh the page
-      // Do this, rather than simply `window.location.reload()`, so that
-      // pressing the back/forward buttons work - otherwise when pressing
-      // back, the browser will just change the URL and expect JS to handle
-      // the change, which won't always work since it might not be a Gatsby
-      // page.
-      if (!pageResources || pageResources.status === PageResourceStatus.Error) {
-        window.history.replaceState({}, ``, location.href)
-        window.location = pathname
-        clearTimeout(timeoutId)
-        return
-      }
-
-      // If the loaded page has a different compilation hash to the
-      // window, then a rebuild has occurred on the server. Reload.
-      if (process.env.NODE_ENV === `production` && pageResources) {
-        if (
-          pageResources.page.webpackCompilationHash !==
-          window.___webpackCompilationHash
-        ) {
-          // Purge plugin-offline cache
-          if (
-            `serviceWorker` in navigator &&
-            navigator.serviceWorker.controller !== null &&
-            navigator.serviceWorker.controller.state === `activated`
-          ) {
-            navigator.serviceWorker.controller.postMessage({
-              gatsbyApi: `clearPathResources`,
-            })
-          }
-
-          window.location = pathname
-        }
-      }
-      reachNavigate(to, options)
+  loader.loadPage(pathname).then(pageResources => {
+    // If no page resources, then refresh the page
+    // Do this, rather than simply `window.location.reload()`, so that
+    // pressing the back/forward buttons work - otherwise when pressing
+    // back, the browser will just change the URL and expect JS to handle
+    // the change, which won't always work since it might not be a Gatsby
+    // page.
+    if (!pageResources || pageResources.status === PageResourceStatus.Error) {
+      window.history.replaceState({}, ``, location.href)
+      window.location = pathname
       clearTimeout(timeoutId)
-    })
+      return
+    }
+
+    // If the loaded page has a different compilation hash to the
+    // window, then a rebuild has occurred on the server. Reload.
+    if (process.env.NODE_ENV === `production` && pageResources) {
+      if (
+        pageResources.page.webpackCompilationHash !==
+        window.___webpackCompilationHash
+      ) {
+        // Purge plugin-offline cache
+        if (
+          `serviceWorker` in navigator &&
+          navigator.serviceWorker.controller !== null &&
+          navigator.serviceWorker.controller.state === `activated`
+        ) {
+          navigator.serviceWorker.controller.postMessage({
+            gatsbyApi: `clearPathResources`,
+          })
+        }
+
+        window.location = pathname
+      }
+    }
+    reachNavigate(to, options)
+    clearTimeout(timeoutId)
+  })
 }
 
 function shouldUpdateScroll(prevRouterProps, { location }) {

--- a/packages/gatsby/cache-dir/query-result-store.js
+++ b/packages/gatsby/cache-dir/query-result-store.js
@@ -12,8 +12,10 @@ import normalizePagePath from "./normalize-page-path"
 // Pulled from react-compat
 // https://github.com/developit/preact-compat/blob/7c5de00e7c85e2ffd011bf3af02899b63f699d3a/src/index.js#L349
 function shallowDiffers(a, b) {
-  for (let i in a) if (!(i in b)) return true
-  for (let i in b) if (a[i] !== b[i]) return true
+  if (a && b) {
+    for (let i in a) if (!(i in b)) return true
+    for (let i in b) if (a[i] !== b[i]) return true
+  }
   return false
 }
 
@@ -85,11 +87,12 @@ export class PageQueryStore extends React.Component {
     const nextRealProps = nextState.pageQueryData.get(nextState.path)?.payload
       ?.result
 
+    console.log({ curProps, nextRealProps })
+
     return (
       this.props.location !== nextProps.location ||
       this.state.path !== nextState.path ||
-      shallowDiffers(curProps.pageContext, nextRealProps.pageContext) ||
-      shallowDiffers(curProps.data, curProps.pageContext)
+      curProps !== nextRealProps
     )
   }
 
@@ -111,17 +114,18 @@ export class StaticQueryStore extends React.Component {
     super(props)
     this.state = {
       staticQueryData: {
-        ...socketGetStaticQueryData(),
         ...loader.getStaticQueryResults(),
+        ...socketGetStaticQueryData(),
       },
     }
   }
 
-  handleMittEvent = () => {
+  handleMittEvent = msg => {
+    console.log(msg)
     this.setState({
       staticQueryData: {
-        ...socketGetStaticQueryData(),
         ...loader.getStaticQueryResults(),
+        ...socketGetStaticQueryData(),
       },
     })
   }
@@ -138,10 +142,11 @@ export class StaticQueryStore extends React.Component {
     // We want to update this component when:
     // - static query results changed
 
-    return this.state.staticQueryData !== nextState.staticQueryData
+    return shallowDiffers(this.state.staticQueryData, nextState.staticQueryData)
   }
 
   render() {
+    console.log(this.state.staticQueryData)
     return (
       <StaticQueryContext.Provider value={this.state.staticQueryData}>
         {this.props.children}

--- a/packages/gatsby/cache-dir/socketIo.js
+++ b/packages/gatsby/cache-dir/socketIo.js
@@ -2,9 +2,16 @@ import io from "socket.io-client"
 import { reportError, clearError } from "./error-overlay-handler"
 import loader from "./loader"
 import normalizePagePath from "./normalize-page-path"
+import { debounce } from "lodash"
 
 let socket = null
 let staticQueryData = {}
+
+const debouncedLoadPage = debounce(
+  () => loader.loadPage(window.location.pathname, true),
+  100,
+  { leading: true }
+)
 
 export const getStaticQueryData = () => staticQueryData
 
@@ -53,8 +60,7 @@ export default function socketIo() {
           }
 
           if (msg.type === `pageQueryResult`) {
-            const normalizedPath = normalizePagePath(msg.payload)
-            loader.loadPage(normalizedPath, true)
+            debouncedLoadPage()
           }
 
           if (msg.type && msg.payload) {

--- a/packages/gatsby/cache-dir/socketIo.js
+++ b/packages/gatsby/cache-dir/socketIo.js
@@ -1,15 +1,23 @@
 import io from "socket.io-client"
 import { reportError, clearError } from "./error-overlay-handler"
+import loader from "./loader"
 import normalizePagePath from "./normalize-page-path"
 
 let socket = null
-
-const inFlightGetPageDataPromiseCache = {}
 let staticQueryData = {}
-let pageQueryData = {}
 
 export const getStaticQueryData = () => staticQueryData
-export const getPageQueryData = () => pageQueryData
+
+const didDataChange = (msg, queryData) => {
+  const id =
+    msg.type === `staticQueryResult`
+      ? msg.payload.id
+      : normalizePagePath(msg.payload.id)
+  return (
+    !(id in queryData) ||
+    JSON.stringify(msg.payload.result) !== JSON.stringify(queryData[id])
+  )
+}
 
 export default function socketIo() {
   if (process.env.NODE_ENV !== `production`) {
@@ -26,26 +34,15 @@ export default function socketIo() {
           socket.io.opts.transports = [`polling`, `websocket`]
         })
 
-        const didDataChange = (msg, queryData) => {
-          const id =
-            msg.type === `staticQueryResult`
-              ? msg.payload.id
-              : normalizePagePath(msg.payload.id)
-          return (
-            !(id in queryData) ||
-            JSON.stringify(msg.payload.result) !== JSON.stringify(queryData[id])
-          )
-        }
-
-        socket.on(`connect`, () => {
-          // we might have disconnected so we loop over the page-data requests in flight
-          // so we can get the data again
-          Object.keys(inFlightGetPageDataPromiseCache).forEach(pathname => {
-            socket.emit(`getDataForPath`, pathname)
-          })
-        })
-
         socket.on(`message`, msg => {
+          console.log(msg)
+          if (msg.type === `overlayError`) {
+            if (msg.payload.message) {
+              reportError(msg.payload.id, msg.payload.message)
+            } else {
+              clearError(msg.payload.id)
+            }
+          }
           if (msg.type === `staticQueryResult`) {
             if (didDataChange(msg, staticQueryData)) {
               staticQueryData = {
@@ -53,19 +50,11 @@ export default function socketIo() {
                 [msg.payload.id]: msg.payload.result,
               }
             }
-          } else if (msg.type === `pageQueryResult`) {
-            if (didDataChange(msg, pageQueryData)) {
-              pageQueryData = {
-                ...pageQueryData,
-                [normalizePagePath(msg.payload.id)]: msg.payload.result,
-              }
-            }
-          } else if (msg.type === `overlayError`) {
-            if (msg.payload.message) {
-              reportError(msg.payload.id, msg.payload.message)
-            } else {
-              clearError(msg.payload.id)
-            }
+          }
+
+          if (msg.type === `pageQueryResult`) {
+            const normalizedPath = normalizePagePath(msg.payload)
+            loader.loadPage(normalizedPath, true)
           }
 
           if (msg.type && msg.payload) {
@@ -88,35 +77,6 @@ export default function socketIo() {
   }
 }
 
-function getPageData(pathname) {
-  pathname = normalizePagePath(pathname)
-  if (inFlightGetPageDataPromiseCache[pathname]) {
-    return inFlightGetPageDataPromiseCache[pathname]
-  } else {
-    inFlightGetPageDataPromiseCache[pathname] = new Promise(resolve => {
-      if (pageQueryData[pathname]) {
-        delete inFlightGetPageDataPromiseCache[pathname]
-        resolve(pageQueryData[pathname])
-      } else {
-        const onPageDataCallback = msg => {
-          if (
-            msg.type === `pageQueryResult` &&
-            normalizePagePath(msg.payload.id) === pathname
-          ) {
-            socket.off(`message`, onPageDataCallback)
-            delete inFlightGetPageDataPromiseCache[pathname]
-            resolve(pageQueryData[pathname])
-          }
-        }
-        socket.on(`message`, onPageDataCallback)
-
-        socket.emit(`getDataForPath`, pathname)
-      }
-    })
-  }
-  return inFlightGetPageDataPromiseCache[pathname]
-}
-
 // Tell websocket-manager.js the new path we're on.
 // This will help the backend prioritize queries for this
 // path.
@@ -129,4 +89,4 @@ function unregisterPath(path) {
   socket.emit(`unregisterPath`, path)
 }
 
-export { getPageData, registerPath, unregisterPath }
+export { registerPath, unregisterPath }

--- a/packages/gatsby/src/utils/__tests__/websocket-manager.ts
+++ b/packages/gatsby/src/utils/__tests__/websocket-manager.ts
@@ -460,34 +460,19 @@ describe(`websocket-manager`, () => {
           const clientSocket = await getClientSocket()
 
           const pageQueryId = `/blog/`
-          const result = {
-            path: pageQueryId,
-            result: {
-              data: { foo: `bar` },
-            },
-
-            componentChunkName: `not-important`,
-            staticQueryHashes: [],
-          }
 
           const receivedDataOnClientPromise = new Promise(resolve => {
             function handler(msg): void {
-              if (
-                msg.type === `pageQueryResult` &&
-                msg.payload.id === pageQueryId
-              ) {
-                expect(msg.payload.result).toEqual(result)
+              expect(msg.payload).toEqual(pageQueryId)
 
-                clientSocket.off(`message`, handler)
-                resolve()
-              }
+              clientSocket.off(`message`, handler)
+              resolve()
             }
             clientSocket.on(`message`, handler)
           })
 
           websocketManager.emitPageData({
             id: pageQueryId,
-            result,
           })
 
           await receivedDataOnClientPromise
@@ -532,96 +517,6 @@ describe(`websocket-manager`, () => {
           })
 
           await receivedDataOnClientPromise
-
-          // disconnect remaining session (mostly to make sure other tests are not affected)
-          await disconnectClientSocket(clientSocket)
-        },
-        TEST_TIMEOUT
-      )
-    })
-
-    describe(`getPageData`, () => {
-      it(
-        `Client can request resources for a page and receive them`,
-        async () => {
-          expect.assertions(2)
-          const clientSocket = await getClientSocket()
-
-          const staticQueryId = `12345`
-          const staticQueryResult = {
-            data: { foo: `static-query` },
-          }
-
-          const pageQueryId = `/blog/`
-          const pageQueryResult = {
-            path: pageQueryId,
-            result: {
-              data: { foo: `page-query` },
-            },
-
-            componentChunkName: `not-important`,
-            staticQueryHashes: [staticQueryId],
-          }
-
-          MOCK_FILE_INFO[
-            path.join(
-              __dirname,
-              `public`,
-              `page-data`,
-              `blog`,
-              `page-data.json`
-            )
-          ] = pageQueryResult
-          MOCK_FILE_INFO[
-            path.join(
-              __dirname,
-              `public`,
-              `page-data`,
-              `sq`,
-              `d`,
-              `${staticQueryId}.json`
-            )
-          ] = staticQueryResult
-          console.log({ MOCK_FILE_INFO })
-
-          const receivedPageQueryDataOnClientPromise = new Promise(resolve => {
-            function handler(msg): void {
-              if (
-                msg.type === `pageQueryResult` &&
-                msg.payload.id === pageQueryId
-              ) {
-                expect(msg.payload.result).toEqual(pageQueryResult)
-
-                clientSocket.off(`message`, handler)
-                resolve()
-              }
-            }
-            clientSocket.on(`message`, handler)
-          })
-
-          const receivedStaticQueryDataOnClientPromise = new Promise(
-            resolve => {
-              function handler(msg): void {
-                if (
-                  msg.type === `staticQueryResult` &&
-                  msg.payload.id === staticQueryId
-                ) {
-                  expect(msg.payload.result).toEqual(staticQueryResult)
-
-                  clientSocket.off(`message`, handler)
-                  resolve()
-                }
-              }
-              clientSocket.on(`message`, handler)
-            }
-          )
-
-          clientSocket.emit(`getDataForPath`, pageQueryId)
-
-          await Promise.all([
-            receivedPageQueryDataOnClientPromise,
-            receivedStaticQueryDataOnClientPromise,
-          ])
 
           // disconnect remaining session (mostly to make sure other tests are not affected)
           await disconnectClientSocket(clientSocket)

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -265,7 +265,7 @@ export async function startServer(
   // This can lead to serving stale html files during development.
   //
   // We serve by default an empty index.html that sets up the dev environment.
-  app.use(developStatic(`public`, { index: false }))
+  app.use(developStatic(`public`, { index: false, redirect: false }))
 
   const webpackDevMiddlewareInstance = (webpackDevMiddleware(compiler, {
     logLevel: `silent`,

--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -279,6 +279,7 @@ export class WebsocketManager {
   }
 
   emitPageData = (data: IPageQueryResult): void => {
+    console.log(`emitPageData`, data.id)
     this.pageResults.set(data.id, data)
 
     if (this.websocket) {

--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -175,14 +175,14 @@ export class WebsocketManager {
       const getDataForPath = async (path: string): Promise<void> => {
         const page = findPageByPath(store.getState(), path)
         if (!page) {
-          socket.send({
-            type: `pageQueryResult`,
-            why: `getDataForPath-notfound`,
-            payload: {
-              id: path,
-              result: undefined,
-            },
-          })
+          // socket.send({
+          // type: `pageQueryResult`,
+          // why: `getDataForPath-notfound`,
+          // payload: {
+          // id: path,
+          // result: undefined,
+          // },
+          // })
           return
         }
         path = page.path
@@ -209,18 +209,18 @@ export class WebsocketManager {
               this.staticQueryResults.set(queryId, staticQueryResult)
             }
 
-            socket.send({
-              type: `staticQueryResult`,
-              payload: staticQueryResult,
-            })
+            // socket.send({
+            // type: `staticQueryResult`,
+            // payload: staticQueryResult,
+            // })
           })
         )
 
-        socket.send({
-          type: `pageQueryResult`,
-          why: `getDataForPath`,
-          payload: pageData,
-        })
+        // socket.send({
+        // type: `pageQueryResult`,
+        // why: `getDataForPath`,
+        // payload: pageData,
+        // })
 
         if (this.clients.size > 0) {
           telemetry.trackCli(
@@ -282,7 +282,7 @@ export class WebsocketManager {
     this.pageResults.set(data.id, data)
 
     if (this.websocket) {
-      this.websocket.send({ type: `pageQueryResult`, payload: data })
+      this.websocket.send({ type: `pageQueryResult`, payload: data.id })
 
       if (this.clients.size > 0) {
         telemetry.trackCli(


### PR DESCRIPTION
## Problem
- Many sites' dev runtime loads very slowly. The primary variable here seems to be the number & size of static queries in the site. When investigating, I found that on connection, we don't do a client-side render until all static queries are pushed.
- This slows down loading the runtime as the total number/size of static queries can grow quite large on larger sites — MBs of data. Also it's not needed as we already are loading static queries over XHR so we don't need to push them over [socket.io](http://socket.io) as well.

## Solution
This PR changes the runtime to rely on xhr loaded page/static query data and never try to load all page/static query data. We also only push the page path when a page is written out & then just do a simple debounced refetch of page data.

We still need pushed static queries as we synchronously render changes to static queries so we need to push static query results to the runtime before the hot reloaded code changes arrive.

This is a followup PR to https://github.com/gatsbyjs/gatsby/pull/27884/ so once that's merged in, this PR's base branch can switch to master.