### PR TITLE
fix(gatsby-transformer-asciidoc): fails when doc doesn't have title (#27865)

### DIFF
--- a/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
+++ b/packages/gatsby-transformer-asciidoc/src/gatsby-node.js
@@ -87,11 +87,17 @@ async function onCreateNode(
       },
       children: [],
       html,
-      document: {
-        title: title.getCombined(),
-        subtitle: title.hasSubtitle() ? title.getSubtitle() : ``,
-        main: title.getMain(),
-      },
+      document: title
+        ? {
+            title: title.getCombined(),
+            subtitle: title.hasSubtitle() ? title.getSubtitle() : ``,
+            main: title.getMain(),
+          }
+        : {
+            title: ``,
+            subtitle: ``,
+            main: ``,
+          },
       revision,
       author,
       pageAttributes,


### PR DESCRIPTION
Backporting #27865 to release branch

(cherry picked from commit ce43564edae4bf5e11b3e58fa59f4b48d564919f)
