### PR TITLE
fix(gatsby): don't hide original error if stack-trace point to not existing file (#27953)

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -569,19 +569,25 @@ module.exports = async (api, args = {}, { pluginSource, activity } = {}) =>
         if (file) {
           const { fileName, lineNumber: line, columnNumber: column } = file
 
-          const code = fs.readFileSync(fileName, { encoding: `utf-8` })
-          codeFrame = codeFrameColumns(
-            code,
-            {
-              start: {
-                line,
-                column,
+          try {
+            const code = fs.readFileSync(fileName, { encoding: `utf-8` })
+            codeFrame = codeFrameColumns(
+              code,
+              {
+                start: {
+                  line,
+                  column,
+                },
               },
-            },
-            {
-              highlightCode: true,
-            }
-          )
+              {
+                highlightCode: true,
+              }
+            )
+          } catch (_e) {
+            // sometimes stack trace point to not existing file
+            // particularly when file is transpiled and path actually changes
+            // (like pointing to not existing `src` dir or original typescript file)
+          }
 
           structuredError.location = {
             start: { line: line, column: column },


### PR DESCRIPTION
Backporting #27953 to release branch

(cherry picked from commit 5e2b3eeb4af46a203de80fa8ce45774f9c6c3fa5)
