### PR TITLE
improve type definition for useScrollRestoration

### DIFF
--- a/packages/gatsby-react-router-scroll/src/use-scroll-restoration.ts
+++ b/packages/gatsby-react-router-scroll/src/use-scroll-restoration.ts
@@ -2,17 +2,17 @@ import { ScrollContext } from "./scroll-handler"
 import { useRef, useContext, useLayoutEffect } from "react"
 import { useLocation } from "@reach/router"
 
-interface IScrollRestorationProps {
-  ref: React.MutableRefObject<HTMLElement | undefined>
+interface IScrollRestorationProps<T> {
+  ref: React.MutableRefObject<T | null>
   onScroll(): void
 }
 
-export function useScrollRestoration(
+export function useScrollRestoration<T extends HTMLElement>(
   identifier: string
-): IScrollRestorationProps {
+): IScrollRestorationProps<T> {
   const location = useLocation()
   const state = useContext(ScrollContext)
-  const ref = useRef<HTMLElement>()
+  const ref = useRef<T | null>(null)
 
   useLayoutEffect((): void => {
     if (ref.current) {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -26,10 +26,10 @@ export {
   withAssetPrefix,
 } from "gatsby-link"
 
-export const useScrollRestoration: (
+export const useScrollRestoration: <T extends HTMLElement>(
   key: string
 ) => {
-  ref: React.MutableRefObject<HTMLElement | undefined>
+  ref: React.MutableRefObject<T | null>
   onScroll(): void
 }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

add typescript Generic for useScrollRestoration hook.

### before
```tsx
const ulScrollRestoration = useScrollRestoration('page-component-ul-list');

return (
  <ul ref={ulScrollRestoration.ref} onScroll={ulScrollRestoration.onScroll}> 
     ~~~
  </ul>
);

```
`Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'string | ((instance: HTMLUListElement | null) => void) | RefObject<HTMLUListElement> | null | undefined'. Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'RefObject<HTMLUListElement>'. Types of property 'current' are incompatible. Type 'HTMLElement | null' is not assignable to type 'HTMLUListElement | null'. Type 'HTMLElement' is missing the following properties from type 'HTMLUListElement': compact, type  `

### after

```tsx
// no Error!
const ulScrollRestoration = useScrollRestoration<HTMLUListElement>('page-component-ul-list');

return (
  <ul ref={ulScrollRestoration.ref} onScroll={ulScrollRestoration.onScroll}> 
     ~~~
  </ul>
);
```

### Documentation

https://www.gatsbyjs.com/docs/scroll-restoration/

I will add tsx example if this PR is OK.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

X (I will write it if necessary)