### PR TITLE
fix(gatsby-transformer-sharp): create child nodes only for Files (#27992)

### DIFF
--- a/packages/gatsby-transformer-sharp/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-sharp/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -35,13 +35,10 @@ Array [
         "id": "whatever",
         "internal": Object {
           "contentDigest": "whatever",
+          "type": "File",
         },
       },
     },
   ],
 ]
 `;
-
-exports[`Process image nodes correctly doesn't create an ImageSharp node for a .gif file 1`] = `Array []`;
-
-exports[`Process image nodes correctly doesn't create an ImageSharp node for a .gif file 2`] = `Array []`;

--- a/packages/gatsby-transformer-sharp/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-sharp/src/__tests__/gatsby-node.js
@@ -8,6 +8,7 @@ describe(`Process image nodes correctly`, () => {
       children: [],
       internal: {
         contentDigest: `whatever`,
+        type: `File`,
       },
     }
     const createNode = jest.fn()
@@ -34,6 +35,7 @@ describe(`Process image nodes correctly`, () => {
       children: [],
       internal: {
         contentDigest: `whatever`,
+        type: `File`,
       },
     }
     const createNode = jest.fn()
@@ -47,8 +49,32 @@ describe(`Process image nodes correctly`, () => {
       actions,
       createNodeId,
     }).then(() => {
-      expect(createNode.mock.calls).toMatchSnapshot()
-      expect(createParentChildLink.mock.calls).toMatchSnapshot()
+      expect(createNode).toHaveBeenCalledTimes(0)
+      expect(createParentChildLink).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  it(`doesn't create an ImageSharp node if parent is not a File`, async () => {
+    const node = {
+      extension: `png`,
+      id: `whatever`,
+      children: [],
+      internal: {
+        contentDigest: `whatever`,
+        type: `NotAFile`,
+      },
+    }
+    const createNode = jest.fn()
+    const createParentChildLink = jest.fn()
+    const actions = { createNode, createParentChildLink }
+    const createNodeId = jest.fn()
+    createNodeId.mockReturnValue(`uuid-from-gatsby`)
+
+    await onCreateNode({
+      node,
+      actions,
+      createNodeId,
+    }).then(() => {
       expect(createNode).toHaveBeenCalledTimes(0)
       expect(createParentChildLink).toHaveBeenCalledTimes(0)
     })

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -1,7 +1,7 @@
 const { supportedExtensions } = require(`./supported-extensions`)
 
 function unstable_shouldOnCreateNode({ node }) {
-  return !!supportedExtensions[node.extension]
+  return node.internal.type === `File` && !!supportedExtensions[node.extension]
 }
 
 module.exports.unstable_shouldOnCreateNode = unstable_shouldOnCreateNode


### PR DESCRIPTION
Backport #27992 to the release branch.

(cherry picked from commit 001e045c92dfd37a7d573d75ee9d81ae44c8e7a5)
