### PR TITLE
Add support for plugin dependencies

### DIFF
--- a/packages/create-gatsby/src/features.json
+++ b/packages/create-gatsby/src/features.json
@@ -1,9 +1,47 @@
 {
-  "gatsby-plugin-google-analytics": {"message": "Add the Google Analytics tracking script"},
-  "gatsby-plugin-react-helmet": {"message": "Add page metadata", "dependencies": ["react-helmet"]},
-  "gatsby-plugin-sitemap": {"message": "Add an automatic sitemap"},
-  "gatsby-plugin-offline": {"message": "Enable offline functionality"},
-  "gatsby-plugin-manifest": {"message": "Generate a manifest file"},
-  "gatsby-plugin-mdx": {"message": "Add MDX support", "dependencies": ["@mdx-js/react", "@mdx-js/mdx"]}
-
+  "gatsby-plugin-google-analytics": {
+    "message": "Add the Google Analytics tracking script"
+  },
+  "gatsby-plugin-image": {
+    "message": "Add responsive images",
+    "plugins": [
+      "gatsby-plugin-sharp",
+      "gatsby-transformer-sharp",
+      "gatsby-source-filesystem:images"
+    ],
+    "options": {
+      "gatsby-source-filesystem:images": {
+        "name": "images",
+        "path": "./src/images/"
+      }
+    }
+  },
+  "gatsby-plugin-react-helmet": {
+    "message": "Add page meta tags with React Helmet",
+    "dependencies": ["react-helmet"]
+  },
+  "gatsby-plugin-sitemap": { "message": "Add an automatic sitemap" },
+  "gatsby-plugin-offline": { "message": "Enable offline functionality" },
+  "gatsby-plugin-manifest": { "message": "Generate a manifest file" },
+  "gatsby-transformer-remark": {
+    "message": "Add Markdown support (without MDX)",
+    "plugins": ["gatsby-source-filesystem:pages"],
+    "options": {
+      "gatsby-source-filesystem:pages": {
+        "name": "pages",
+        "path": "./src/pages/"
+      }
+    }
+  },
+  "gatsby-plugin-mdx": {
+    "message": "Add Markdown and MDX support",
+    "plugins": ["gatsby-source-filesystem:pages"],
+    "dependencies": ["@mdx-js/react", "@mdx-js/mdx"],
+    "options": {
+      "gatsby-source-filesystem:pages": {
+        "name": "pages",
+        "path": "./src/pages/"
+      }
+    }
+  }
 }

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -209,7 +209,7 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
       return [
         // Spread in extra dependencies
         ...(features[featureKey].dependencies || []),
-        // Spread in plugins, stripping the optional key
+        // Spread in plugins
         ...extraPlugins,
       ]
     })

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -169,11 +169,12 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
         cmses[data.cms].message
       )}`
     )
-    plugins.push(data.cms)
+    const extraPlugins = cmses[data.cms].plugins || []
+    plugins.push(data.cms, ...extraPlugins)
     packages.push(
       data.cms,
       ...(cmses[data.cms].dependencies || []),
-      ...(cmses[data.cms].plugins || [])
+      ...extraPlugins
     )
     pluginConfig = { ...pluginConfig, ...cmses[data.cms].options }
   }
@@ -184,11 +185,13 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
         styles[data.styling].message
       )} for styling your site`
     )
-    plugins.push(data.styling)
+    const extraPlugins = styles[data.styling].plugins || []
+
+    plugins.push(data.styling, ...extraPlugins)
     packages.push(
       data.styling,
       ...(styles[data.styling].dependencies || []),
-      ...(styles[data.styling].plugins || [])
+      ...extraPlugins
     )
     pluginConfig = { ...pluginConfig, ...styles[data.styling].options }
   }
@@ -200,12 +203,16 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
         .join(`, `)}`
     )
     plugins.push(...data.features)
-    const featureDependencies = data.features?.map(featureKey => [
-      // Spread in extra dependencies
-      ...(features[featureKey].dependencies || []),
-      // Spread in plugins, stripping the optional key
-      ...(features[featureKey].plugins || []),
-    ])
+    const featureDependencies = data.features?.map(featureKey => {
+      const extraPlugins = features[featureKey].plugins || []
+      plugins.push(...extraPlugins)
+      return [
+        // Spread in extra dependencies
+        ...(features[featureKey].dependencies || []),
+        // Spread in plugins, stripping the optional key
+        ...extraPlugins,
+      ]
+    })
     const flattenedDependencies = ([] as Array<string>).concat.apply(
       [],
       featureDependencies
@@ -249,10 +256,10 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
     return
   }
 
-  await initStarter(DEFAULT_STARTER, data.project, packages)
+  await initStarter(DEFAULT_STARTER, data.project, packages.map(removeKey))
 
   console.log(c.green(`✔ `) + `Created site in ` + c.green(data.project))
-
+  console.log({ plugins, pluginConfig })
   if (plugins.length) {
     console.log(c.bold(`🔌 Installing plugins...`))
     await installPlugins(plugins, pluginConfig, path.resolve(data.project), [])

--- a/packages/create-gatsby/src/install-plugins.ts
+++ b/packages/create-gatsby/src/install-plugins.ts
@@ -1,8 +1,9 @@
 import { reporter } from "./reporter"
 import path from "path"
+import { PluginConfigMap } from "."
 export async function installPlugins(
   plugins: Array<string>,
-  pluginOptions: Record<string, Record<string, any> | undefined> = {},
+  pluginOptions: PluginConfigMap = {},
   rootPath: string,
   packages: Array<string>
 ): Promise<void> {

--- a/packages/create-gatsby/src/plugin-options-form.ts
+++ b/packages/create-gatsby/src/plugin-options-form.ts
@@ -56,7 +56,7 @@ export const makePluginConfigQuestions = (
 
   selectedPlugins.forEach((pluginName: string): void => {
     const schema = pluginSchemas[pluginName as PluginName]
-    if (typeof schema === `string` || !(`keys` in schema)) {
+    if (!schema || typeof schema === `string` || !(`keys` in schema)) {
       return
     }
     const options: Record<string, Schema> | undefined = schema?.keys

--- a/packages/gatsby-cli/src/plugin-add.ts
+++ b/packages/gatsby-cli/src/plugin-add.ts
@@ -41,12 +41,15 @@ async function installPluginConfig(
     `Adding ${plugin} to gatsby-config`
   )
 
+  // Plugins can optionally include a key, to allow duplicates
+  const [pluginName, pluginKey] = plugin.split(`:`)
+
   installTimer.start()
-  reporter.info(`Adding ${plugin}`)
+  reporter.info(`Adding ${pluginName}`)
   try {
     const result = await GatsbyPlugin.create(
       { root },
-      { name: plugin, options }
+      { name: plugin, options, key: pluginKey }
     )
     reporter.info(result._message)
   } catch (err) {

--- a/packages/gatsby-cli/src/plugin-add.ts
+++ b/packages/gatsby-cli/src/plugin-add.ts
@@ -37,19 +37,19 @@ async function installPluginConfig(
   options: Record<string, unknown> | undefined,
   root: string
 ): Promise<void> {
+  // Plugins can optionally include a key, to allow duplicates
+  const [pluginName, pluginKey] = plugin.split(`:`)
+
   const installTimer = reporter.activityTimer(
     `Adding ${plugin} to gatsby-config`
   )
-
-  // Plugins can optionally include a key, to allow duplicates
-  const [pluginName, pluginKey] = plugin.split(`:`)
 
   installTimer.start()
   reporter.info(`Adding ${pluginName}`)
   try {
     const result = await GatsbyPlugin.create(
       { root },
-      { name: plugin, options, key: pluginKey }
+      { name: pluginName, options, key: pluginKey }
     )
     reporter.info(result._message)
   } catch (err) {


### PR DESCRIPTION
For discussion, this is a possible approach to allow plugin dependencies and plugin options. It handles possible duplicate plugin entries for e.g. source filesystem by allowing entries with the form `"name:key"`, e.g. `"gatsby-source-filesystem:pages"`