### PR TITLE
fix(gatsby-plugin-manifest): Add missing webmanifest options

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -94,6 +94,41 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     icon_options: Joi.object({
       purpose: Joi.string(),
     }),
+    categories: Joi.array().items(Joi.string()),
+    dir: Joi.string().valid(`auto`, `ltr`, `rtl`),
+    iarc_rating_id: Joi.string(),
+    orientation: Joi.string().valid(
+      `any`,
+      `natural`,
+      `landscape`,
+      `landscape-primary`,
+      `landscape-secondary`,
+      `portrait`,
+      `portrait-primary`,
+      `portrait-secondary`
+    ),
+    related_applications: Joi.array.items(
+      Joi.object({
+        platform: Joi.string(),
+        url: Joi.string(),
+      })
+    ),
+    prefer_related_applications: Joi.boolean(),
+    scope: Joi.string(),
+    screenshots: Joi.array().items(
+      Joi.object({
+        src: Joi.string(),
+        sizes: Joi.string(),
+        type: Joi.string(),
+      })
+    ),
+    shortcuts: Joi.array().items(
+      Joi.object({
+        name: Joi.string(),
+        url: Joi.string(),
+        description: Joi.string(),
+      })
+    ),
   })
 
 /**


### PR DESCRIPTION
Used the following list as reference:
https://developer.mozilla.org/en-US/docs/Web/Manifest

Skipped those marked as obsolete

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
The documentation already mentions where to find more information. Since these options don't get any special treatment, but are just forwarded to the `manifest.webmanifest` file, I figured I could skip documenting them.
