### PR TITLE
fix(gatsby-remark-images): allow showCaptions to accept array of valid strings

### DIFF
--- a/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
@@ -6,7 +6,7 @@ describe(`pluginOptionsSchema`, () => {
     const expectedErrors = [
       `"maxWidth" must be a number`,
       `"linkImagesToOriginal" must be a boolean`,
-      `"showCaptions" must be a boolean`,
+      `"showCaptions" must be one of [boolean, array]`,
       `"markdownCaptions" must be a boolean`,
       `"sizeByPixelDensity" must be a boolean`,
       `"wrapperStyle" must be one of [object, string]`,
@@ -67,5 +67,39 @@ describe(`pluginOptionsSchema`, () => {
     })
 
     expect(isValid).toBe(true)
+  })
+
+  describe(`allow to use array of valid strings for "showCaptions"`, () => {
+    it(`["title", "alt"]`, async () => {
+      const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+        showCaptions: [`title`, `alt`],
+      })
+
+      expect(isValid).toBe(true)
+    })
+
+    it(`["title"]`, async () => {
+      const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+        showCaptions: [`title`],
+      })
+
+      expect(isValid).toBe(true)
+    })
+
+    it(`["alt"]`, async () => {
+      const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+        showCaptions: [`alt`],
+      })
+
+      expect(isValid).toBe(true)
+    })
+
+    it(`["not valid"] (should fail validation)`, async () => {
+      const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+        showCaptions: [`not valid`],
+      })
+
+      expect(isValid).toBe(false)
+    })
   })
 })

--- a/packages/gatsby-remark-images/src/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/gatsby-node.js
@@ -10,7 +10,14 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       .description(
         `Add a link to each image to the original image. Sometimes people want to see a full-sized version of an image e.g. to see extra detail on a part of the image and this is a convenient and common pattern for enabling this. Set this option to false to disable this behavior.`
       ),
-    showCaptions: Joi.boolean()
+    showCaptions: Joi.alternatives()
+      .try(
+        Joi.boolean(),
+        Joi.array().items(
+          Joi.string().valid(`title`),
+          Joi.string().valid(`alt`)
+        )
+      )
       .default(false)
       .description(
         `Add a caption to each image with the contents of the title attribute, when this is not empty. If the title attribute is empty but the alt attribute is not, it will be used instead. Set this option to true to enable this behavior. You can also pass an array instead to specify which value should be used for the caption — for example, passing ['alt', 'title'] would use the alt attribute first, and then the title. When this is set to true it is the same as passing ['title', 'alt']. If you just want to use the title (and omit captions for images that have alt attributes but no title), pass ['title'].`


### PR DESCRIPTION
## Description

`showCaptions` can receive either boolean (`true` which internally translates into array of `['title', 'alt']`) or array of valid strings - see https://github.com/gatsbyjs/gatsby/blob/001e045c92dfd37a7d573d75ee9d81ae44c8e7a5/packages/gatsby-remark-images/src/index.js#L84-L88

## Related Issues

Fixes #27983