### PR TITLE
docs(gatsby-source-contentful): clean up changelog

### DIFF
--- a/packages/gatsby-source-contentful/CHANGELOG.md
+++ b/packages/gatsby-source-contentful/CHANGELOG.md
@@ -13,39 +13,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### BREAKING CHANGES
 
-- - Entities references in Rich Text fields are no more automatically resolved
+- Entities references in Rich Text fields are no more automatically resolved
 - Use the `raw` subfield instead of `json`
 - Use GraphQL to define your referenced data with the new `references` field
 - Removes the `resolveFieldLocales` as the new `references` field automatically resolves locales
 - To render Rich Text fields unse the new `renderRichText()` function from `gatsby-source-contentful/rich-text`
-
-- perf(gatsby-source-contentful): use getNodesByType to locate Rich Text references
-
-- clean up from rebase
-
-- refactor to use a query for entry references
-
-- simplify and reduce complexity of rich text raw field value injection
-
-- performance: directly inject references into Rich Text field, skipping the extra node type
-
-- remove plugin config for no more existing rich text resolveFieldLocales
-
-- add hint to remove extra traversal of rich text as soon fixIds is gone
-
-- add first test for rich text
-
-- clean up code and use more Maps
-
-- align readme for new rich text changes
-
-- remove workarounds for fixIds
-
-- add typescript types for rich text render function
-
-- add tests for rich text rendering
-
-- Dirty lock file
 
 Co-authored-by: Peter van der Zee <github-public@qfox.nl>
 Co-authored-by: gatsbybot <mathews.kyle+gatsbybot@gmail.com>


### PR DESCRIPTION
We messed up the Contentful changelog a little bit. This should fix it for next. We might need to do this again after the `v4` release today.