### PR TITLE
docs: Create a page in contribution guide that lists the files/folders for major parts of the Gatsby code base

### DIFF
--- a/docs/contributing/Gatsby Code Base.md
+++ b/docs/contributing/Gatsby Code Base.md
@@ -1,6 +1,7 @@
-## Start contributing here!
+---
+title: Start contributing here---
 
-Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
+## Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
 
 * [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks)
 * [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs)

--- a/docs/contributing/Gatsby Code Base.md
+++ b/docs/contributing/Gatsby Code Base.md
@@ -2,7 +2,6 @@
 
 Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
 
-
 * [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks)
 * [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs)
 * [e2e-tests](https://github.com/gatsbyjs/gatsby/tree/master/e2e-tests)

--- a/docs/contributing/Gatsby Code Base.md
+++ b/docs/contributing/Gatsby Code Base.md
@@ -3,6 +3,7 @@ title: Gatsby Code Base
 ---
 
 ## Start contributing here
+
 Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
 
 * [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks)
@@ -20,3 +21,5 @@ Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsb
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 
 If it's your first time contributing to Gatsby, take a look at the [Good First Issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) to find an issue suitable for your first contribution.
+
+<GuideList slug={props.slug} />

--- a/docs/contributing/Gatsby Code Base.md
+++ b/docs/contributing/Gatsby Code Base.md
@@ -6,17 +6,27 @@ title: Gatsby Code Base
 
 Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
 
-* [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks).
-* [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs).
-* [e2e-tests](https://github.com/gatsbyjs/gatsby/tree/master/e2e-tests).
-* [Examples](https://github.com/gatsbyjs/gatsby/tree/master/examples).
-* [Integration-tests](https://github.com/gatsbyjs/gatsby/tree/master/integration-tests).
-* [Packages](https://github.com/gatsbyjs/gatsby/tree/master/packages).
-* [Peril](https://github.com/gatsbyjs/gatsby/tree/master/peril).
-* [Plop-templates](https://github.com/gatsbyjs/gatsby/tree/master/plop-templates).
-* [RFCS](https://github.com/gatsbyjs/gatsby/tree/master/rfcs).
-* [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts).
-* [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters).
+   1. [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks).
+   
+   2. [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs).
+   
+   3. [e2e-tests](https://github.com/gatsbyjs/gatsby/tree/master/e2e-tests).
+   
+   4. [Examples](https://github.com/gatsbyjs/gatsby/tree/master/examples).
+   
+   5. [Integration-tests](https://github.com/gatsbyjs/gatsby/tree/master/integration-tests).
+   
+   6. [Packages](https://github.com/gatsbyjs/gatsby/tree/master/packages).
+   
+   7. [Peril](https://github.com/gatsbyjs/gatsby/tree/master/peril).
+   
+   8. [Plop-templates](https://github.com/gatsbyjs/gatsby/tree/master/plop-templates).
+   
+   9. [RFCS](https://github.com/gatsbyjs/gatsby/tree/master/rfcs).
+   
+   10. [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts).
+   
+   11. [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters).
 
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 

--- a/docs/contributing/Gatsby Code Base.md
+++ b/docs/contributing/Gatsby Code Base.md
@@ -21,5 +21,3 @@ Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsb
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 
 If it's your first time contributing to Gatsby, take a look at the [Good First Issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) to find an issue suitable for your first contribution.
-
-<GuideList slug={props.slug} />

--- a/docs/contributing/Gatsby Code Base.md
+++ b/docs/contributing/Gatsby Code Base.md
@@ -1,0 +1,20 @@
+## Start contributing here!
+
+Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
+
+
+* [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks)
+* [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs)
+* [e2e-tests](https://github.com/gatsbyjs/gatsby/tree/master/e2e-tests)
+* [Examples](https://github.com/gatsbyjs/gatsby/tree/master/examples)
+* [Integration-tests](https://github.com/gatsbyjs/gatsby/tree/master/integration-tests)
+* [Packages](https://github.com/gatsbyjs/gatsby/tree/master/packages)
+* [Peril](https://github.com/gatsbyjs/gatsby/tree/master/peril)
+* [Plop-templates](https://github.com/gatsbyjs/gatsby/tree/master/plop-templates)
+* [RFCS](https://github.com/gatsbyjs/gatsby/tree/master/rfcs)
+* [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts)
+* [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters)
+
+**Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
+
+If it's your first time contributing to Gatsby, take a look at the [Good First Issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) to find an issue suitable for your first contribution.

--- a/docs/contributing/Gatsby Code Base.md
+++ b/docs/contributing/Gatsby Code Base.md
@@ -1,7 +1,9 @@
 ---
-title: Start contributing here---
+title: Gatsby Code Base
+---
 
-## Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
+## Start contributing here
+Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
 
 * [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks)
 * [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs)

--- a/docs/contributing/Gatsby Code Base.md
+++ b/docs/contributing/Gatsby Code Base.md
@@ -6,17 +6,17 @@ title: Gatsby Code Base
 
 Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
 
-* [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks)
-* [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs)
-* [e2e-tests](https://github.com/gatsbyjs/gatsby/tree/master/e2e-tests)
-* [Examples](https://github.com/gatsbyjs/gatsby/tree/master/examples)
-* [Integration-tests](https://github.com/gatsbyjs/gatsby/tree/master/integration-tests)
-* [Packages](https://github.com/gatsbyjs/gatsby/tree/master/packages)
-* [Peril](https://github.com/gatsbyjs/gatsby/tree/master/peril)
-* [Plop-templates](https://github.com/gatsbyjs/gatsby/tree/master/plop-templates)
-* [RFCS](https://github.com/gatsbyjs/gatsby/tree/master/rfcs)
-* [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts)
-* [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters)
+* [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks).
+* [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs).
+* [e2e-tests](https://github.com/gatsbyjs/gatsby/tree/master/e2e-tests).
+* [Examples](https://github.com/gatsbyjs/gatsby/tree/master/examples).
+* [Integration-tests](https://github.com/gatsbyjs/gatsby/tree/master/integration-tests).
+* [Packages](https://github.com/gatsbyjs/gatsby/tree/master/packages).
+* [Peril](https://github.com/gatsbyjs/gatsby/tree/master/peril).
+* [Plop-templates](https://github.com/gatsbyjs/gatsby/tree/master/plop-templates).
+* [RFCS](https://github.com/gatsbyjs/gatsby/tree/master/rfcs).
+* [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts).
+* [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters).
 
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 

--- a/docs/contributing/gatsby-code-base.md
+++ b/docs/contributing/gatsby-code-base.md
@@ -5,31 +5,19 @@ title: Gatsby Code Base
 Start contributing here
 =======================
 
-Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
+#### Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
 
-   1. [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks).
-   
-   2. [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs).
-   
-   3. [e2e-tests](https://github.com/gatsbyjs/gatsby/tree/master/e2e-tests).
-   
-   4. [Examples](https://github.com/gatsbyjs/gatsby/tree/master/examples).
-   
-   5. [Integration-tests](https://github.com/gatsbyjs/gatsby/tree/master/integration-tests).
-   
-   6. [Packages](https://github.com/gatsbyjs/gatsby/tree/master/packages).
-   
-   7. [Peril](https://github.com/gatsbyjs/gatsby/tree/master/peril).
-   
-   8. [Plop-templates](https://github.com/gatsbyjs/gatsby/tree/master/plop-templates).
-   
-   9. [RFCS](https://github.com/gatsbyjs/gatsby/tree/master/rfcs).
-   
-   10. [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts).
-   
-   11. [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters).
-
----
+* [Benchmarks](https://github.com/gatsbyjs/gatsby/tree/master/benchmarks).
+* [Docs](https://github.com/gatsbyjs/gatsby/tree/master/docs).
+* [e2e-tests](https://github.com/gatsbyjs/gatsby/tree/master/e2e-tests).
+* [Examples](https://github.com/gatsbyjs/gatsby/tree/master/examples).
+* [Integration-tests](https://github.com/gatsbyjs/gatsby/tree/master/integration-tests).
+* [Packages](https://github.com/gatsbyjs/gatsby/tree/master/packages).
+* [Peril](https://github.com/gatsbyjs/gatsby/tree/master/peril).
+* [Plop-templates](https://github.com/gatsbyjs/gatsby/tree/master/plop-templates).
+* [RFCS](https://github.com/gatsbyjs/gatsby/tree/master/rfcs).
+* [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts).
+* [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters).
 
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 

--- a/docs/contributing/gatsby-code-base.md
+++ b/docs/contributing/gatsby-code-base.md
@@ -33,4 +33,4 @@ Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsb
 
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 
-If it's your first time contributing to Gatsby, take a look at the [Good First Issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) to find an issue suitable for your first contribution.
+If it is your first time contributing to Gatsby, take a look at the [Good First Issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) to find an issue suitable for your first contribution.

--- a/docs/contributing/gatsby-code-base.md
+++ b/docs/contributing/gatsby-code-base.md
@@ -19,6 +19,8 @@ Start contributing here
 * [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts).
 * [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters).
 
+<GuideList slug={props.slug} />
+
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 
 If it is your first time contributing to Gatsby, take a look at the [Good First Issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) to find an issue suitable for your first contribution.

--- a/docs/contributing/gatsby-code-base.md
+++ b/docs/contributing/gatsby-code-base.md
@@ -2,7 +2,8 @@
 title: Gatsby Code Base
 ---
 
-## Start contributing here
+Start contributing here
+=======================
 
 Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsbyjs/gatsby). Take a look at them and start contributing.
 
@@ -27,6 +28,8 @@ Following is a list of folder in the [Gatsby Code Base](https://github.com/gatsb
    10. [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts).
    
    11. [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters).
+
+---
 
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 

--- a/docs/contributing/gatsby-code-base.md
+++ b/docs/contributing/gatsby-code-base.md
@@ -2,6 +2,10 @@
 title: Gatsby Code Base
 ---
 
+This page gives you a quick access to the Gatsby code base. Go through the folders, check the issues page and start contributing. For more details on how to contribe, take a look at [How to Contribute](contributing/how-to-contribute/) page. 
+
+Take a look at [Pair Programming](/contributing/pair-programming/) to work together with other contributors.
+
 Start contributing here
 =======================
 

--- a/docs/contributing/gatsby-code-base.md
+++ b/docs/contributing/gatsby-code-base.md
@@ -23,8 +23,8 @@ Start contributing here
 * [Scripts](https://github.com/gatsbyjs/gatsby/tree/master/scripts).
 * [Starters](https://github.com/gatsbyjs/gatsby/tree/master/starters).
 
-<GuideList slug={props.slug} />
-
 **Also take a look at the [Issues](https://github.com/gatsbyjs/gatsby/issues) page to find an open issue.**
 
 If it is your first time contributing to Gatsby, take a look at the [Good First Issues](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) to find an issue suitable for your first contribution.
+
+<GuideList slug={props.slug} />


### PR DESCRIPTION
Create Gatsby Code Base.md

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This PR adds a new page in the Contribution guide to give users quick access to folders in the Gatsby Code Base.


## Related Issues

 Addresses #12158

