### PR TITLE
Fix #28003: Proxy should not follow redirections

### DIFF
--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -252,7 +252,12 @@ export async function startServer(
         req
           .pipe(
             got
-              .stream(proxiedUrl, { headers, method, decompress: false })
+              .stream(proxiedUrl, {
+                headers,
+                method,
+                decompress: false,
+                followRedirect: false,
+              })
               .on(`response`, response =>
                 res.writeHead(response.statusCode || 200, response.headers)
               )


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/28003 by disabling redirection following (it is one of the mentioned solutions in the issue). It is a bug fix but is it a possible breaking change for people relying on it ⚠️ 

I would like to avoid to duplicate all the issue, all the details are in it.