### PR TITLE
Fix #28003: Expose option to not follow redirections with the proxy

### DIFF
--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -240,7 +240,7 @@ export async function startServer(
   // Set up API proxy.
   const { proxy } = store.getState().config
   if (proxy) {
-    proxy.forEach(({ prefix, url }) => {
+    proxy.forEach(({ prefix, url, followRedirect }) => {
       app.use(`${prefix}/*`, (req, res) => {
         const proxiedUrl = url + req.originalUrl
         const {
@@ -252,7 +252,12 @@ export async function startServer(
         req
           .pipe(
             got
-              .stream(proxiedUrl, { headers, method, decompress: false })
+              .stream(proxiedUrl, {
+                headers,
+                method,
+                decompress: false,
+                followRedirect: followRedirect !== false,
+              })
               .on(`response`, response =>
                 res.writeHead(response.statusCode || 200, response.headers)
               )


### PR DESCRIPTION
Fixes #28003 by exposing a new option to disable redirection following in proxy (it is one of the mentioned solutions in the issue).

I would like to avoid to duplicate all the issue, all the details are in it.

If that PR is chosen I can improve the documentation as well.