### PR TITLE
Fix: (gatsby-recipes) Disgregard comments in config

### DIFF
--- a/packages/gatsby-recipes/src/providers/gatsby/utils/get-object-from-node.js
+++ b/packages/gatsby-recipes/src/providers/gatsby/utils/get-object-from-node.js
@@ -12,6 +12,7 @@ const isLiteral = node =>
 const getValueFromNode = node => {
   if (t.isTemplateLiteral(node)) {
     delete node.leadingComments
+    delete node.trailingComments
     const literalContents = generate(node).code
     return unwrapTemplateLiteral(literalContents)
   }


### PR DESCRIPTION
Currently, the parsing of a gatsby-config file will include "names" of config items it shouldn't.

The blog starter has a good example: 
```
    `gatsby-plugin-react-helmet`,
    // this (optional) plugin enables Progressive Web App + Offline functionality
    // To learn more, visit: https://gatsby.dev/offline
    // `gatsby-plugin-offline`,
```

All commented lines were included as plugins in the config, causing the `all` function to fail to process those since their names could not be matched to legitimate plugins. 

Whether comments are real plugins or just comments, they should not be processed as part of the active site config.