### PR TITLE
chore(benchmarks): remove option because it is not yet published

### DIFF
--- a/benchmarks/gabe-fs-mdx/gatsby-config.js
+++ b/benchmarks/gabe-fs-mdx/gatsby-config.js
@@ -13,7 +13,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
-        lessBabel: true,
+        // lessBabel: true,
       },
     },
   ],


### PR DESCRIPTION
Just temporary.