### PR TITLE
refactor(create-gatsby): in order to add unit tests

### DIFF
--- a/packages/create-gatsby/src/__tests__/index.ts
+++ b/packages/create-gatsby/src/__tests__/index.ts
@@ -17,14 +17,13 @@ describe(`create-gatsby-app`, () => {
 
   beforeEach(() => {
     cli = createCli()
-    jest.setTimeout(10000)
   })
 
   afterEach(() => {
     jest.resetAllMocks()
   })
 
-  it(`creates a project only using the project name`, async () => {
+  it.only(`creates a project only using the project name`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {

--- a/packages/create-gatsby/src/__tests__/index.ts
+++ b/packages/create-gatsby/src/__tests__/index.ts
@@ -137,7 +137,7 @@ describe(`create-gatsby-app`, () => {
     )
   })
 
-  it.only(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
+  it(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {

--- a/packages/create-gatsby/src/__tests__/index.ts
+++ b/packages/create-gatsby/src/__tests__/index.ts
@@ -51,7 +51,7 @@ describe(`create-gatsby-app`, () => {
     expect(installPlugins).not.toBeCalled()
   })
 
-  it(`creates a project with a project name and a CSS tool`, async () => {
+  it.only(`creates a project with a project name and a CSS tool`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {

--- a/packages/create-gatsby/src/__tests__/index.ts
+++ b/packages/create-gatsby/src/__tests__/index.ts
@@ -1,0 +1,211 @@
+import Enquirer from "enquirer"
+import { installPlugins } from "../install-plugins"
+import { initStarter } from "../init-starter"
+import { createCli, run, IAnswers } from "../"
+
+jest.mock(`path`, () => {
+  return {
+    ...jest.requireActual(`path`),
+    resolve: (): string => `/root/somewhere`,
+  }
+})
+jest.mock(`../init-starter`)
+jest.mock(`../install-plugins`)
+
+describe(`create-gatsby-app`, () => {
+  let cli: Enquirer<IAnswers>
+
+  beforeEach(() => {
+    cli = createCli()
+    jest.setTimeout(10000)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it(`creates a project only using the project name`, async () => {
+    cli.on(`prompt`, p => {
+      p.on(`run`, async () => {
+        switch (p.name) {
+          case `project`:
+            p.value = `my-super-project-name`
+            break
+
+          case `features`:
+            await p.keypress(null, { name: `tab` })
+
+            break
+        }
+
+        p.submit()
+      })
+    })
+
+    await run(cli)
+
+    expect(initStarter).toBeCalledWith(
+      `https://github.com/ascorbic/gatsby-starter-hello-world.git`,
+      `my-super-project-name`,
+      []
+    )
+    expect(installPlugins).not.toBeCalled()
+  })
+
+  it(`creates a project with a project name and a CSS tool`, async () => {
+    cli.on(`prompt`, p => {
+      p.on(`run`, async () => {
+        switch (p.name) {
+          case `project`:
+            p.value = `my-super-project-name`
+            break
+
+          case `features`:
+            await p.keypress(null, { name: `tab` })
+            break
+
+          case `styling`:
+            await p.keypress(null, { name: `down` })
+            break
+        }
+
+        p.submit()
+      })
+    })
+
+    await run(cli)
+
+    expect(
+      initStarter
+    ).toBeCalledWith(
+      `https://github.com/ascorbic/gatsby-starter-hello-world.git`,
+      `my-super-project-name`,
+      [`gatsby-plugin-postcss`, `postcss`]
+    )
+    expect(installPlugins).toBeCalledWith(
+      [`gatsby-plugin-postcss`],
+      {},
+      `/root/somewhere`,
+      []
+    )
+  })
+
+  it(`creates a project with a project name and a CMS`, async () => {
+    cli.on(`prompt`, p => {
+      p.on(`run`, async () => {
+        switch (p.name) {
+          case `project`:
+            p.value = `my-super-project-name`
+            break
+
+          case `features`:
+            await p.keypress(null, { name: `tab` })
+            break
+
+          case `cms`:
+            await p.keypress(null, { name: `down` })
+            break
+
+          case `gatsby-source-wordpress-experimental`:
+            await p.keypress(`a`)
+            await p.keypress(`b`)
+            await p.keypress(`c`)
+            break
+        }
+
+        p.submit()
+      })
+    })
+
+    await run(cli)
+
+    expect(
+      initStarter
+    ).toBeCalledWith(
+      `https://github.com/ascorbic/gatsby-starter-hello-world.git`,
+      `my-super-project-name`,
+      [`gatsby-source-wordpress-experimental`]
+    )
+    expect(installPlugins).toBeCalledWith(
+      [`gatsby-source-wordpress-experimental`],
+      {
+        "gatsby-source-wordpress-experimental": {
+          url: `abc`,
+        },
+      },
+      `/root/somewhere`,
+      []
+    )
+  })
+
+  it(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
+    cli.on(`prompt`, p => {
+      p.on(`run`, async () => {
+        switch (p.name) {
+          case `project`:
+            p.value = `my-super-project-name`
+            break
+
+          case `styling`:
+            await p.keypress(null, { name: `down` })
+            break
+
+          case `features`:
+            await p.keypress(null, { name: `enter` })
+            await p.keypress(null, { name: `tab` })
+            break
+
+          case `cms`:
+            await p.keypress(null, { name: `down` })
+            break
+
+          case `gatsby-source-wordpress-experimental`:
+            await p.keypress(`a`)
+            await p.keypress(`b`)
+            await p.keypress(`c`)
+            break
+
+          case `gatsby-plugin-google-analytics`:
+            await p.keypress(`c`)
+            await p.keypress(`d`)
+            await p.keypress(`e`)
+            break
+        }
+
+        p.submit()
+      })
+    })
+
+    await run(cli)
+
+    expect(
+      initStarter
+    ).toBeCalledWith(
+      `https://github.com/ascorbic/gatsby-starter-hello-world.git`,
+      `my-super-project-name`,
+      [
+        `gatsby-source-wordpress-experimental`,
+        `gatsby-plugin-postcss`,
+        `postcss`,
+        `gatsby-plugin-google-analytics`,
+      ]
+    )
+    expect(installPlugins).toBeCalledWith(
+      [
+        `gatsby-source-wordpress-experimental`,
+        `gatsby-plugin-postcss`,
+        `gatsby-plugin-google-analytics`,
+      ],
+      {
+        "gatsby-source-wordpress-experimental": {
+          url: `abc`,
+        },
+        "gatsby-plugin-google-analytics": {
+          trackingId: `cde`,
+        },
+      },
+      `/root/somewhere`,
+      []
+    )
+  })
+})

--- a/packages/create-gatsby/src/__tests__/index.ts
+++ b/packages/create-gatsby/src/__tests__/index.ts
@@ -89,7 +89,7 @@ describe(`create-gatsby-app`, () => {
     )
   })
 
-  it(`creates a project with a project name and a CMS`, async () => {
+  it.only(`creates a project with a project name and a CMS`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {

--- a/packages/create-gatsby/src/__tests__/index.ts
+++ b/packages/create-gatsby/src/__tests__/index.ts
@@ -89,7 +89,7 @@ describe(`create-gatsby-app`, () => {
     )
   })
 
-  it.only(`creates a project with a project name and a CMS`, async () => {
+  it(`creates a project with a project name and a CMS`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {
@@ -137,7 +137,7 @@ describe(`create-gatsby-app`, () => {
     )
   })
 
-  it(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
+  it.only(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {

--- a/packages/create-gatsby/src/__tests__/index.ts
+++ b/packages/create-gatsby/src/__tests__/index.ts
@@ -33,7 +33,7 @@ describe(`create-gatsby-app`, () => {
             break
 
           case `features`:
-            await p.keypress(null, { name: `tab` })
+            await p.keypress(null, { name: `up` })
 
             break
         }
@@ -61,7 +61,7 @@ describe(`create-gatsby-app`, () => {
             break
 
           case `features`:
-            await p.keypress(null, { name: `tab` })
+            await p.keypress(null, { name: `up` })
             break
 
           case `styling`:
@@ -90,7 +90,7 @@ describe(`create-gatsby-app`, () => {
     )
   })
 
-  it.skip(`creates a project with a project name and a CMS`, async () => {
+  it(`creates a project with a project name and a CMS`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {
@@ -99,7 +99,7 @@ describe(`create-gatsby-app`, () => {
             break
 
           case `features`:
-            await p.keypress(null, { name: `tab` })
+            await p.keypress(null, { name: `up` })
             break
 
           case `cms`:
@@ -138,7 +138,7 @@ describe(`create-gatsby-app`, () => {
     )
   })
 
-  it.skip(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
+  it(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {
@@ -152,7 +152,7 @@ describe(`create-gatsby-app`, () => {
 
           case `features`:
             await p.keypress(null, { name: `enter` })
-            await p.keypress(null, { name: `tab` })
+            await p.keypress(null, { name: `up` })
             break
 
           case `cms`:

--- a/packages/create-gatsby/src/__tests__/index.ts
+++ b/packages/create-gatsby/src/__tests__/index.ts
@@ -90,7 +90,7 @@ describe(`create-gatsby-app`, () => {
     )
   })
 
-  it(`creates a project with a project name and a CMS`, async () => {
+  it.skip(`creates a project with a project name and a CMS`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {
@@ -138,7 +138,7 @@ describe(`create-gatsby-app`, () => {
     )
   })
 
-  it(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
+  it.skip(`creates a project with a project name, a CMS, a styling system, and google analytics`, async () => {
     cli.on(`prompt`, p => {
       p.on(`run`, async () => {
         switch (p.name) {

--- a/packages/create-gatsby/src/components/select.js
+++ b/packages/create-gatsby/src/components/select.js
@@ -10,6 +10,12 @@ export class SelectInput extends Select {
         )
         .join(`\n`)
     }
+
+    // On first render, this is undefined
+    if (!this.selected) {
+      return ``
+    }
+
     return this.styles.primary(
       this.symbols.middot + ` ` + this.selected.message
     )
@@ -32,30 +38,33 @@ export class SelectInput extends Select {
       return undefined
     }
 
-    let styles = this.styles
-    let focused = this.index === i
-    let style = focused ? styles.primary : val => val
-    let ele = await this.resolve(val[focused ? `on` : `off`] || val, this.state)
+    const styles = this.styles
+    const focused = this.index === i
+    const style = focused ? styles.primary : val => val
+    const ele = await this.resolve(
+      val[focused ? `on` : `off`] || val,
+      this.state
+    )
     return focused ? style(ele) : ` `.repeat(ele.length)
   }
 
   async render() {
-    let { submitted, size } = this.state
+    const { submitted, size } = this.state
 
     let prompt = ``
-    let header = await this.header()
-    let prefix = await this.prefix()
-    let message = await this.message()
+    const header = await this.header()
+    const prefix = await this.prefix()
+    const message = await this.message()
 
     if (this.options.promptLine !== false) {
       prompt = [prefix, message].join(` `)
       this.state.prompt = prompt
     }
 
-    let output = await this.format()
-    let help = (await this.error()) || (await this.hint())
-    let body = await this.renderChoices()
-    let footer = await this.footer()
+    const output = await this.format()
+    const help = (await this.error()) || (await this.hint())
+    const body = await this.renderChoices()
+    const footer = await this.footer()
 
     if (output) prompt += `\n` + output
     if (help && !prompt.includes(help)) prompt += `\n` + help
@@ -83,6 +92,8 @@ export class MultiSelectInput extends SelectInput {
   }
 
   toggle(choice, enabled) {
+    if (!choice) return
+
     if (choice.name === `___done`) {
       super.submit()
     } else {

--- a/packages/create-gatsby/src/components/utils.ts
+++ b/packages/create-gatsby/src/components/utils.ts
@@ -16,6 +16,8 @@ export function center(
   padding = ` `,
   width = DEFAULT_WIDTH
 ): string {
-  const pad = padding.repeat(Math.round((width - stringLength(text)) / 2))
+  const count = Math.round((width - stringLength(text)) / 2)
+
+  const pad = padding.repeat(count > 0 ? count : 0)
   return pad + text
 }

--- a/packages/create-gatsby/src/plugin-options-form.ts
+++ b/packages/create-gatsby/src/plugin-options-form.ts
@@ -89,11 +89,11 @@ export const makePluginConfigQuestions = (
 
     if (choices.length) {
       formPrompts.push({
-        type: `forminput`,
+        type: `form`,
         name: pluginName,
         multiple: true,
         message: stripIndent`
-          Configure the ${getName(pluginName)} plugin. 
+          Configure the ${getName(pluginName)} plugin.
           See ${docsLink(pluginName)} for help.
           ${
             choices.length > 1


### PR DESCRIPTION
## Description

- Only use one enquirer prompt
- Write a tiny test allowing to create a site only using the site name

## Tradeoffs

I've worked around typescript and relied on destructuring on a dynamic dictionary. Not perfect, but it allows to use only one enquirer prompt and to make tests on that one