### PR TITLE
chore(create-gatsby): Microbundle package

### DIFF
--- a/packages/create-gatsby/README.md
+++ b/packages/create-gatsby/README.md
@@ -18,4 +18,4 @@ yarn create gatsby
 
 It will ask you questions about what you're building, and set up a Gatsby project for you.
 
-_Note: this package is different from the Gatsby CLI, it is intended solely to create new sites.._
+_Note: this package is different from the Gatsby CLI, it is intended solely to create new sites._

--- a/packages/create-gatsby/cli.js
+++ b/packages/create-gatsby/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { run } from "."
+const { run } = require("./lib")
 
 run().catch(e => {
   console.warn(e)

--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -29,7 +29,7 @@
     "eslint": "^7.12.1",
     "execa": "^4.0.3",
     "fs-extra": "^9.0.1",
-    "gatsby-plugin-utils": "^0.3.0-next.0",
+    "gatsby-plugin-utils": "^0.4.0-next.0",
     "joi": "^17.2.1",
     "microbundle": "^0.12.4",
     "prettier": "^2.1.2",

--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -1,39 +1,41 @@
 {
   "name": "create-gatsby",
-  "version": "0.0.0-6",
+  "version": "0.0.0-8",
   "main": "lib/index.js",
-  "bin": "lib/cli.js",
+  "bin": "cli.js",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
-    "watch": "tsc --watch",
+    "build": "microbundle -i src/index.ts --no-pkg-main --target=node -f=cjs --sourcemap=false --compress --external=readable-stream",
+    "watch": "microbundle -i src/index.ts --no-pkg-main --target=node -f=cjs --external=readable-stream --watch ",
     "prepare": "yarn build",
     "import-plugin-options": "node ./scripts/import-options-schema.js"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/create-gatsby#readme",
-  "dependencies": {
-    "@babel/runtime": "^7.12.1",
-    "ansi-colors": "^4.1.1",
-    "ansi-wordwrap": "^1.0.2",
-    "common-tags": "^1.8.0",
-    "enquirer": "^2.3.6",
-    "execa": "^4.0.3",
-    "fs-extra": "^9.0.1",
-    "gatsby-core-utils": "^1.5.0-next.0",
-    "stream-filter": "^2.1.0",
-    "string-length": "^4.0.1",
-    "terminal-link": "^2.1.1"
-  },
   "files": [
-    "lib"
+    "lib/index.js",
+    "cli.js"
   ],
+  "dependencies": {
+    "readable-stream": "^2.3.6"
+  },
   "devDependencies": {
+    "@babel/runtime": "^7.12.1",
     "@types/configstore": "^4.0.0",
     "@types/fs-extra": "^9.0.2",
     "@types/node": "^14.14.5",
+    "ansi-wordwrap": "^1.0.2",
+    "common-tags": "^1.8.0",
+    "enquirer": "^2.3.6",
     "eslint": "^7.12.1",
+    "execa": "^4.0.3",
+    "fs-extra": "^9.0.1",
+    "gatsby-plugin-utils": "^0.3.0-next.0",
     "joi": "^17.2.1",
+    "microbundle": "^0.12.4",
     "prettier": "^2.1.2",
+    "stream-filter": "^2.1.0",
+    "string-length": "^4.0.1",
+    "terminal-link": "^2.1.1",
     "typescript": "^4.0.5"
   },
   "repository": {

--- a/packages/create-gatsby/src/components/placeholder.js
+++ b/packages/create-gatsby/src/components/placeholder.js
@@ -18,7 +18,7 @@ const isPrimitive = val =>
  * @api public
  */
 
-module.exports = (prompt, options = {}) => {
+export default (prompt, options = {}) => {
   prompt.cursorHide()
 
   let { input = ``, initial = ``, pos, showCursor = true, color } = options

--- a/packages/create-gatsby/src/get-config-store.ts
+++ b/packages/create-gatsby/src/get-config-store.ts
@@ -1,0 +1,22 @@
+import Configstore from "configstore"
+
+let config: Configstore
+/**
+ * Copied from gatsby-core-utils to avoid depending on it
+ * Gets the configstore instance related to gatsby
+ * @return the ConfigStore instance for gatsby
+ */
+
+export const getConfigStore = (): Configstore => {
+  if (!config) {
+    config = new Configstore(
+      `gatsby`,
+      {},
+      {
+        globalConfigPath: true,
+      }
+    )
+  }
+
+  return config
+}

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -93,6 +93,9 @@ interface IAnswers {
   features?: Array<keyof typeof features>
 }
 
+/**
+ * Interface for plugin JSON files
+ */
 interface IPluginEntry {
   /**
    * Message displayed in the menu when selecting the plugin
@@ -259,7 +262,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
   await initStarter(DEFAULT_STARTER, data.project, packages.map(removeKey))
 
   console.log(c.green(`✔ `) + `Created site in ` + c.green(data.project))
-  console.log({ plugins, pluginConfig })
+
   if (plugins.length) {
     console.log(c.bold(`🔌 Installing plugins...`))
     await installPlugins(plugins, pluginConfig, path.resolve(data.project), [])

--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -2,11 +2,10 @@ import { execSync } from "child_process"
 import execa from "execa"
 import fs from "fs-extra"
 import path from "path"
-import { updateSiteMetadata } from "gatsby-core-utils"
 import { reporter } from "./reporter"
-import { getConfigStore } from "gatsby-core-utils"
 import filterStream from "stream-filter"
 import { spin } from "./components/spin"
+import { getConfigStore } from "./get-config-store"
 type PackageManager = "yarn" | "npm"
 
 const packageMangerConfigKey = `cli.packageManager`
@@ -209,22 +208,6 @@ export async function initStarter(
 
   await install(rootPath, packages)
 
-  const sitePackageJson = await fs
-    .readJSON(path.join(sitePath, `package.json`))
-    .catch(() => {
-      reporter.verbose(
-        `Could not read "${path.join(sitePath, `package.json`)}"`
-      )
-    })
-
-  await updateSiteMetadata(
-    {
-      name: sitePackageJson?.name || rootPath,
-      sitePath,
-      lastRun: Date.now(),
-    },
-    false
-  )
   await gitSetup(rootPath)
   // trackCli(`NEW_PROJECT_END`);
 }

--- a/packages/create-gatsby/tsconfig.json
+++ b/packages/create-gatsby/tsconfig.json
@@ -4,10 +4,10 @@
     "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation:  */
-    "allowJs": true, /* Allow javascript files to be compiled. */
+    "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": false /* Generates corresponding '.d.ts' file. */,
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./lib" /* Redirect output structure to the directory. */,
@@ -48,12 +48,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.json",
-    "src/**/*.js"
-  ],
-  "exclude": [
-    "**/__tests__/**/*"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.json", "src/**/*.js"],
+  "exclude": ["**/__tests__/**/*"]
 }

--- a/packages/gatsby-cli/src/plugin-add.ts
+++ b/packages/gatsby-cli/src/plugin-add.ts
@@ -41,7 +41,7 @@ async function installPluginConfig(
   const [pluginName, pluginKey] = plugin.split(`:`)
 
   const installTimer = reporter.activityTimer(
-    `Adding ${plugin} to gatsby-config`
+    `Adding ${pluginName} ${pluginKey ? `(${pluginKey}) ` : ``}to gatsby-config`
   )
 
   installTimer.start()


### PR DESCRIPTION
The create-gatsby bundle was getting too large, so I've switched to using microbundle to compile it. I'm bundling almost all dependencies too, so we don't need to wait to install those. Unfortunately readable-stream doesn;t work with rollup, so we can't bundle that. I may switch to a different way of handling the streams, as I'm only using it via stream-filter to filter out npm install warnings.

In order to allow the bundling this makes a few other changes, such as including the configstore file from core-utils.