### PR TITLE
fix(gatsby-remark-images): adding missing plugin options (#27944 and #27998)

### DIFF
--- a/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
@@ -12,7 +12,7 @@ describe(`pluginOptionsSchema`, () => {
       `"wrapperStyle" must be one of [object, string]`,
       `"backgroundColor" must be a string`,
       `"quality" must be a number`,
-      `"withWebp" must be a boolean`,
+      `"withWebp" must be one of [object, boolean]`,
       `"tracedSVG" must be a boolean`,
       `"loading" must be one of [lazy, eager, auto]`,
       `"disableBgImageOnAlpha" must be a boolean`,
@@ -29,7 +29,7 @@ describe(`pluginOptionsSchema`, () => {
       wrapperStyle: true,
       backgroundColor: 123,
       quality: `This should be a number`,
-      withWebp: `This should be a boolean`,
+      withWebp: `This should be a boolean or an object`,
       tracedSVG: `This should be a boolean`,
       loading: `This should be lazy, eager or auto`,
       disableBgImageOnAlpha: `This should be a boolean`,
@@ -56,6 +56,14 @@ describe(`pluginOptionsSchema`, () => {
       disableBgImageOnAlpha: true,
       disableBgImage: true,
       srcSetBreakpoints: [400, 600, 800],
+    })
+
+    expect(isValid).toBe(true)
+  })
+
+  it(`should validate the withWebp prop`, async () => {
+    const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+      withWebp: { quality: 100 },
     })
 
     expect(isValid).toBe(true)

--- a/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/__tests__/gatsby-node.js
@@ -6,7 +6,7 @@ describe(`pluginOptionsSchema`, () => {
     const expectedErrors = [
       `"maxWidth" must be a number`,
       `"linkImagesToOriginal" must be a boolean`,
-      `"showCaptions" must be a boolean`,
+      `"showCaptions" must be one of [boolean, array]`,
       `"markdownCaptions" must be a boolean`,
       `"sizeByPixelDensity" must be a boolean`,
       `"wrapperStyle" must be one of [object, string]`,
@@ -67,5 +67,39 @@ describe(`pluginOptionsSchema`, () => {
     })
 
     expect(isValid).toBe(true)
+  })
+
+  describe(`allow to use array of valid strings for "showCaptions"`, () => {
+    it(`["title", "alt"]`, async () => {
+      const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+        showCaptions: [`title`, `alt`],
+      })
+
+      expect(isValid).toBe(true)
+    })
+
+    it(`["title"]`, async () => {
+      const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+        showCaptions: [`title`],
+      })
+
+      expect(isValid).toBe(true)
+    })
+
+    it(`["alt"]`, async () => {
+      const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+        showCaptions: [`alt`],
+      })
+
+      expect(isValid).toBe(true)
+    })
+
+    it(`["not valid"] (should fail validation)`, async () => {
+      const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
+        showCaptions: [`not valid`],
+      })
+
+      expect(isValid).toBe(false)
+    })
   })
 })

--- a/packages/gatsby-remark-images/src/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/gatsby-node.js
@@ -39,7 +39,8 @@ exports.pluginOptionsSchema = function ({ Joi }) {
     quality: Joi.number()
       .default(50)
       .description(`The quality level of the generated files.`),
-    withWebp: Joi.boolean()
+    withWebp: Joi.alternatives()
+      .try(Joi.object({ quality: Joi.number() }), Joi.boolean())
       .default(false)
       .description(
         `Additionally generate WebP versions alongside your chosen file format. They are added as a srcset with the appropriate mimetype and will be loaded in browsers that support the format. Pass true for default support, or an object of options to specifically override those for the WebP files. For example, pass { quality: 80 } to have the WebP images be at quality level 80.`

--- a/packages/gatsby-remark-images/src/gatsby-node.js
+++ b/packages/gatsby-remark-images/src/gatsby-node.js
@@ -10,7 +10,14 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       .description(
         `Add a link to each image to the original image. Sometimes people want to see a full-sized version of an image e.g. to see extra detail on a part of the image and this is a convenient and common pattern for enabling this. Set this option to false to disable this behavior.`
       ),
-    showCaptions: Joi.boolean()
+    showCaptions: Joi.alternatives()
+      .try(
+        Joi.boolean(),
+        Joi.array().items(
+          Joi.string().valid(`title`),
+          Joi.string().valid(`alt`)
+        )
+      )
       .default(false)
       .description(
         `Add a caption to each image with the contents of the title attribute, when this is not empty. If the title attribute is empty but the alt attribute is not, it will be used instead. Set this option to true to enable this behavior. You can also pass an array instead to specify which value should be used for the caption — for example, passing ['alt', 'title'] would use the alt attribute first, and then the title. When this is set to true it is the same as passing ['title', 'alt']. If you just want to use the title (and omit captions for images that have alt attributes but no title), pass ['title'].`


### PR DESCRIPTION
## Description

Backporting **two** PRs into the release branch: #27944 and #27998 The latter one requires the former and can't be cherry-picked individually. The downside is that in the release branch they will be squashed into a single commit but they both just fix plugin options of the same plugin, so I don't see a big problem here as long as we mention original commits in the message.

The alternative is to cherry-pick serially and wait for the full test suite on #27944, merge and then cherry-pick #27998 separately.

(cherry picked from commit 3675467)
(cherry picked from commit 08447bd)
