### PR TITLE
chore(gatsby-telemetry): add two more value placeholders. (#27949 and #28025)

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -106,6 +106,7 @@ export interface ITelemetryTagsPayload {
   }
   errorV2?: IStructuredErrorV2
   valueString?: string
+  valueStringArray?: Array<string>
   valueInteger?: number
 }
 

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -105,6 +105,8 @@ export interface ITelemetryTagsPayload {
     queryStats?: unknown
   }
   errorV2?: IStructuredErrorV2
+  valueString?: string
+  valueInteger?: number
 }
 
 export interface IDefaultTelemetryTagsPayload extends ITelemetryTagsPayload {


### PR DESCRIPTION
Backporting #27949 and #28025 to the release branch. Required for backporting #28010 

(cherry picked from commit c6d754a83683e505466e6d2b63e04395f4c67ea8)
(cherry picked from commit d5807ac1d1641b8f181fae6bc6a4b3fdc05ef898)