### PR TITLE
fix(gatsby-plugin-sass): loosely check postCssPlugins (#27829)

### DIFF
--- a/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/__tests__/gatsby-node.js
@@ -120,7 +120,7 @@ describe(`pluginOptionsSchema`, () => {
     const { isValid } = await testPluginOptionsSchema(pluginOptionsSchema, {
       implementation: require(`../gatsby-node.js`),
       cssLoaderOptions: { camelCase: false },
-      postCssPlugins: [{ post: `CSS plugin` }],
+      postCssPlugins: [require(`autoprefixer`)],
       sassRuleTest: /\.global\.s(a|c)ss$/,
       sassRuleModulesTest: /\.mod\.s(a|c)ss$/,
       useResolveUrlLoader: false,

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -90,7 +90,7 @@ exports.pluginOptionsSchema = function ({ Joi }) {
         `Pass in options for css-loader: https://github.com/webpack-contrib/css-loader/tree/version-1#options`
       ),
     postCssPlugins: Joi.array()
-      .items(Joi.object({}).unknown(true))
+      .items(Joi.any())
       .description(`An array of postCss plugins`),
     sassRuleTest: Joi.object()
       .instance(RegExp)


### PR DESCRIPTION
Backporting #27829 to the release branch

(cherry picked from commit ac3759932c582663999aa4384e8e38f9935d7f29)
