### PR TITLE
fix(create-gatsby): Shim worker_threads

### DIFF
--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -5,8 +5,8 @@
   "bin": "cli.js",
   "license": "MIT",
   "scripts": {
-    "build": "microbundle -i src/index.ts --no-pkg-main --target=node -f=cjs --sourcemap=false --compress --external=readable-stream",
-    "watch": "microbundle -i src/index.ts --no-pkg-main --target=node -f=cjs --external=readable-stream --watch ",
+    "build": "microbundle -i src/index.ts --no-pkg-main --target=node -f=cjs --sourcemap=false --compress --alias worker_threads=@ascorbic/worker-threads-shim",
+    "watch": "microbundle -i src/index.ts --no-pkg-main --target=node -f=cjs --alias worker_threads=@ascorbic/worker-threads-shim --watch ",
     "prepare": "yarn build",
     "import-plugin-options": "node ./scripts/import-options-schema.js"
   },
@@ -16,6 +16,7 @@
     "cli.js"
   ],
   "devDependencies": {
+    "@ascorbic/worker-threads-shim": "^1.0.0",
     "@babel/runtime": "^7.12.1",
     "@types/configstore": "^4.0.0",
     "@types/fs-extra": "^9.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,11 @@
     asciidoctor-opal-runtime "0.3.0"
     unxhr "1.0.1"
 
+"@ascorbic/worker-threads-shim@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ascorbic/worker-threads-shim/-/worker-threads-shim-1.0.0.tgz#d003ac1f9aacc9d95d8a0e453bce256d7fa99923"
+  integrity sha512-CEvYpC2w2t7tDWgloPA8ETra79cZzi2IdeM0bluTTkvWcnEdLWYStM12ymq2VRE3OMR8OtmKD4l026dUel1d+w==
+
 "@babel/cli@^7.11.6", "@babel/cli@^7.8.7":
   version "7.11.6"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.11.6.tgz#1fcbe61c2a6900c3539c06ee58901141f3558482"


### PR DESCRIPTION
One of the transient dependencies of create-gatsby tries to import `worker_threads` inside a try/catch block to find the pid, and falls-back to 0 if it can't load it. Because rollup hoists this import outside the block it fails on Node 10 where the package is behind a flag. This PR aliases worker_threads to [a shim](https://github.com/ascorbic/worker-threads-shim) that just returns 0 for the pid.