### PR TITLE
Try a different postinstall hook in attempt to make it more robust and fix telemetry postinstall

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -96,7 +96,7 @@
     "watch:babel": "npm run build:babel -- --watch",
     "watch:rollup": "npm run build:rollup -- -w",
     "watch": "npm-run-all -p watch:babel watch:rollup",
-    "postinstall": "node scripts/postinstall.js"
+    "postinstall": "node -e \"try{require('./scripts/postinstall')}catch(e){}\" || true"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -36,8 +36,7 @@
     "typescript": "^3.9.7"
   },
   "files": [
-    "lib/",
-    "src/"
+    "lib/"
   ],
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry#readme",
   "keywords": [
@@ -54,7 +53,7 @@
     "build": "babel src --out-dir lib --ignore \"**/__tests__\",\"**/__mocks__\" --extensions \".ts,.js\"",
     "prepare": "cross-env NODE_ENV=production npm run build && npm run typegen",
     "jest": "jest",
-    "postinstall": "node src/postinstall.js || true",
+    "postinstall": "node -e \"try{require('./lib/postinstall')}catch(e){}\" || true",
     "typegen": "rimraf \"lib/**/*.d.ts\" && tsc --emitDeclarationOnly --declaration --declarationDir lib/",
     "watch": "babel -w src --out-dir lib --ignore \"**/__tests__\",\"**/__mocks__\" --extensions \".ts,.js\""
   },

--- a/packages/gatsby-telemetry/src/postinstall.ts
+++ b/packages/gatsby-telemetry/src/postinstall.ts
@@ -1,5 +1,5 @@
 try {
-  const showAnalyticsNotification = require(`./showAnalyticsNotification`)
+  const { showAnalyticsNotification } = require(`./show-analytics-notification`)
   const { isCI } = require(`gatsby-core-utils`)
   const { EventStorage } = require(`./event-storage`)
 


### PR DESCRIPTION
Convert one remaining file in telemetry to typescript and fix import. Also tries to make the postinstall more robust https://github.com/gatsbyjs/gatsby/issues/22651
