### PR TITLE
fix(docs): fix lazy-images install instructions

### DIFF
--- a/docs/reference/release-notes/v2.26/index.md
+++ b/docs/reference/release-notes/v2.26/index.md
@@ -168,17 +168,7 @@ Try early alpha (and [let us know](https://github.com/gatsbyjs/gatsby/discussion
 npm install gatsby-plugin-sharp@lazy-images
 ```
 
-Enable in your `gatsby-config.js`:
-
-```js
-// in gatsby-config.js
-{
-  resolve: 'gatsby-plugin-sharp',
-  options: {
-    experimentalDisableLazyProcessing: true,
-  }
-}
-```
+Lazy images are enabled by-default in this version.
 
 [Details and discussion](https://github.com/gatsbyjs/gatsby/discussions/27603).
 


### PR DESCRIPTION
## Description

Instructions for lazy images setup were misleading: the feature is enabled by default in the `lazy-images` canary. But instructions implied it had to be enabled separately.