### PR TITLE
fix(gatsby): fix race condition in cache lock

### DIFF
--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -238,7 +238,6 @@ DiskStore.prototype._lock = function _lock(filePath): Promise<void> {
     innerLock(resolve, reject, filePath, rid)
   ).then(() => {
     global.debugging.push(rid + ` lock(` + filePath + `) received`)
-    globalGatsbyCacheLock.set(filePath, Date.now())
   })
 }
 
@@ -271,6 +270,8 @@ function innerLock(resolve, reject, filePath, rid): void {
       }, 50)
     } else {
       global.debugging.push(rid + ` have lock for ` + filePath)
+      // set sync
+      globalGatsbyCacheLock.set(filePath, Date.now())
       resolve()
     }
   } catch (e) {

--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -235,7 +235,7 @@ DiskStore.prototype._lock = function _lock(filePath): Promise<void> {
   const rid = ++lockRid
   global.debugging.push(rid + ` lock(` + filePath + `) requested`)
   return new Promise((resolve, reject) =>
-    innerLock(resolve, reject, filePath)
+    innerLock(resolve, reject, filePath, rid)
   ).then(() => {
     global.debugging.push(rid + ` lock(` + filePath + `) received`)
     globalGatsbyCacheLock.set(filePath, Date.now())

--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -266,6 +266,7 @@ function innerLock(resolve, reject, filePath, rid): void {
     if (lockTime > 0) {
       global.debugging.push(rid + ` waiting 50ms for ` + filePath)
       setTimeout(() => {
+        global.debugging.push(rid + ` trying again for ` + filePath)
         innerLock(resolve, reject, filePath, rid)
       }, 50)
     } else {

--- a/packages/gatsby/src/cache/json-file-store.ts
+++ b/packages/gatsby/src/cache/json-file-store.ts
@@ -104,32 +104,42 @@ exports.read = async function (path, options): Promise<string> {
   }
 
   const externalBuffers = []
-  const data = JSON.parse(dataString, function bufferReceiver(k, value) {
-    if (value && value.type === `Buffer` && value.data) {
-      return Buffer.from(value.data)
-    } else if (
-      value &&
-      value.type === `ExternalBuffer` &&
-      typeof value.index === `number` &&
-      typeof value.size === `number`
-    ) {
-      //JSON.parse is sync so we need to return a buffer sync, we will fill the buffer later
-      const buffer = Buffer.alloc(value.size)
-      externalBuffers.push({
-        index: +value.index,
-        buffer: buffer,
-      })
-      return buffer
-    } else if (
-      value &&
-      value.type === `Infinity` &&
-      typeof value.sign === `number`
-    ) {
-      return Infinity * value.sign
-    } else {
-      return value
-    }
-  })
+  let data
+  try {
+    data = JSON.parse(dataString, function bufferReceiver(k, value) {
+      if (value && value.type === `Buffer` && value.data) {
+        return Buffer.from(value.data)
+      } else if (
+        value &&
+        value.type === `ExternalBuffer` &&
+        typeof value.index === `number` &&
+        typeof value.size === `number`
+      ) {
+        //JSON.parse is sync so we need to return a buffer sync, we will fill the buffer later
+        const buffer = Buffer.alloc(value.size)
+        externalBuffers.push({
+          index: +value.index,
+          buffer: buffer,
+        })
+        return buffer
+      } else if (
+        value &&
+        value.type === `Infinity` &&
+        typeof value.sign === `number`
+      ) {
+        return Infinity * value.sign
+      } else {
+        return value
+      }
+    })
+  } catch (e) {
+    throw new Error(
+      "json-file-store failed to JSON.parse this string: `" +
+        dataString.replace(/\n/g, `⏎`) +
+        "`\n" +
+        e.message
+    )
+  }
 
   //read external buffers
   await Promise.all(

--- a/packages/gatsby/src/cache/json-file-store.ts
+++ b/packages/gatsby/src/cache/json-file-store.ts
@@ -28,7 +28,6 @@ const fs = require(`fs`)
 const zlib = require(`zlib`)
 
 exports.write = async function (path, data, options): Promise<void> {
-  global.debugging.push(`writing to ` + path)
   const externalBuffers = []
   let dataString = JSON.stringify(data, function replacerFunction(k, value) {
     //Buffers searilize to {data: [...], type: "Buffer"}
@@ -85,8 +84,6 @@ exports.write = async function (path, data, options): Promise<void> {
 }
 
 exports.read = async function (path, options): Promise<string> {
-  global.debugging.push(`reading from ` + path)
-
   let zipExtension = ``
   if (options.zip) {
     zipExtension = `.gz`
@@ -138,11 +135,7 @@ exports.read = async function (path, options): Promise<string> {
   } catch (e) {
     throw new Error(
       "json-file-store failed to JSON.parse this string: `" +
-        dataString.replace(/\n/g, `⏎`) +
-        "`\n" +
-        e.message +
-        `\ndebugging:` +
-        global.debugging.map(s => `- ` + s).join(`\n`)
+        dataString.replace(/\n/g, `⏎`)
     )
   }
 

--- a/packages/gatsby/src/cache/json-file-store.ts
+++ b/packages/gatsby/src/cache/json-file-store.ts
@@ -28,6 +28,7 @@ const fs = require(`fs`)
 const zlib = require(`zlib`)
 
 exports.write = async function (path, data, options): Promise<void> {
+  global.debugging.push(`writing to ` + path)
   const externalBuffers = []
   let dataString = JSON.stringify(data, function replacerFunction(k, value) {
     //Buffers searilize to {data: [...], type: "Buffer"}
@@ -84,6 +85,8 @@ exports.write = async function (path, data, options): Promise<void> {
 }
 
 exports.read = async function (path, options): Promise<string> {
+  global.debugging.push(`reading from ` + path)
+
   let zipExtension = ``
   if (options.zip) {
     zipExtension = `.gz`
@@ -137,7 +140,9 @@ exports.read = async function (path, options): Promise<string> {
       "json-file-store failed to JSON.parse this string: `" +
         dataString.replace(/\n/g, `⏎`) +
         "`\n" +
-        e.message
+        e.message +
+        `\ndebugging:` +
+        global.debugging.map(s => `- ` + s).join(`\n`)
     )
   }
 


### PR DESCRIPTION
Fixes a race condition by reserving the lock sync, rather than doing it in the `.then()` callback. Doing it in the callback was causing a race condition because it allowed other lock requests to also be granted in the mean time. `*`raises fist`*`

Also adds a try/catch around a JSON.parse call to show the complete output of what is being parsed in case we need to debug this again next time.
