### PR TITLE
feat(state-machine): add query on demand transitions

### DIFF
--- a/packages/gatsby/src/services/calculate-dirty-queries.ts
+++ b/packages/gatsby/src/services/calculate-dirty-queries.ts
@@ -5,54 +5,11 @@ import { assertStore } from "../utils/assert-store"
 
 export async function calculateDirtyQueries({
   store,
-  websocketManager,
-  currentlyHandledPendingQueryRuns,
 }: Partial<IQueryRunningContext>): Promise<{
   queryIds: IGroupedQueryIds
 }> {
   assertStore(store)
   const state = store.getState()
   const queryIds = calcDirtyQueryIds(state)
-
-  let queriesToRun: Array<string> = queryIds
-
-  if (
-    // eslint-disable-next-line
-    false &&
-    // disable this code path for now as it needs additional runtime changes
-    // this is just to illustrate how `currentlyHandledPendingQueryRuns` would be handled
-    process.env.gatsby_executing_command === `develop` &&
-    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
-  ) {
-    // 404 are special cases in our runtime that ideally use
-    // generic things to work, but for now they have special handling
-    const pagePathFilter = new Set([`/404.html`, `/dev-404-page/`])
-
-    // we want to make sure we run queries for pages that user currently
-    // view in the browser
-    if (websocketManager?.activePaths) {
-      // @ts-ignore (this is just because this code is unreachable for now, but TS complains that `websocketManager` is possibly 'undefined')
-      websocketManager.activePaths.forEach(
-        pagePathFilter.add.bind(pagePathFilter)
-      )
-    }
-
-    // we also want to make sure we include pages that were requested from
-    // via `page-data` fetches or websocket requests
-    if (currentlyHandledPendingQueryRuns) {
-      // @ts-ignore (this is just because this code is unreachable for now, but TS complains that `currentlyHandledPendingQueryRuns` is possibly 'undefined')
-      currentlyHandledPendingQueryRuns.forEach(
-        pagePathFilter.add.bind(pagePathFilter)
-      )
-    }
-
-    // static queries are also not on demand
-    queriesToRun = queryIds.filter(
-      queryId => queryId.startsWith(`sq--`) || pagePathFilter.has(queryId)
-    )
-  }
-
-  return {
-    queryIds: groupQueryIds(queriesToRun),
-  }
+  return { queryIds: groupQueryIds(queryIds) }
 }

--- a/packages/gatsby/src/services/calculate-dirty-queries.ts
+++ b/packages/gatsby/src/services/calculate-dirty-queries.ts
@@ -5,11 +5,54 @@ import { assertStore } from "../utils/assert-store"
 
 export async function calculateDirtyQueries({
   store,
+  websocketManager,
+  currentlyHandledPendingQueryRuns,
 }: Partial<IQueryRunningContext>): Promise<{
   queryIds: IGroupedQueryIds
 }> {
   assertStore(store)
   const state = store.getState()
   const queryIds = calcDirtyQueryIds(state)
-  return { queryIds: groupQueryIds(queryIds) }
+
+  let queriesToRun: Array<string> = queryIds
+
+  if (
+    // eslint-disable-next-line
+    false &&
+    // disable this code path for now as it needs additional runtime changes
+    // this is just to illustrate how `currentlyHandledPendingQueryRuns` would be handled
+    process.env.gatsby_executing_command === `develop` &&
+    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
+  ) {
+    // 404 are special cases in our runtime that ideally use
+    // generic things to work, but for now they have special handling
+    const pagePathFilter = new Set([`/404.html`, `/dev-404-page/`])
+
+    // we want to make sure we run queries for pages that user currently
+    // view in the browser
+    if (websocketManager?.activePaths) {
+      // @ts-ignore (this is just because this code is unreachable for now, but TS complains that `websocketManager` is possibly 'undefined')
+      websocketManager.activePaths.forEach(
+        pagePathFilter.add.bind(pagePathFilter)
+      )
+    }
+
+    // we also want to make sure we include pages that were requested from
+    // via `page-data` fetches or websocket requests
+    if (currentlyHandledPendingQueryRuns) {
+      // @ts-ignore (this is just because this code is unreachable for now, but TS complains that `currentlyHandledPendingQueryRuns` is possibly 'undefined')
+      currentlyHandledPendingQueryRuns.forEach(
+        pagePathFilter.add.bind(pagePathFilter)
+      )
+    }
+
+    // static queries are also not on demand
+    queriesToRun = queryIds.filter(
+      queryId => queryId.startsWith(`sq--`) || pagePathFilter.has(queryId)
+    )
+  }
+
+  return {
+    queryIds: groupQueryIds(queriesToRun),
+  }
 }

--- a/packages/gatsby/src/services/listen-for-mutations.ts
+++ b/packages/gatsby/src/services/listen-for-mutations.ts
@@ -14,13 +14,19 @@ export const listenForMutations: InvokeCallback = (callback: Sender<any>) => {
     callback({ type: `WEBHOOK_RECEIVED`, payload: event })
   }
 
+  const emitQueryRunRequest = (event: unknown): void => {
+    callback({ type: `QUERY_RUN_REQUESTED`, payload: event })
+  }
+
   emitter.on(`ENQUEUE_NODE_MUTATION`, emitMutation)
   emitter.on(`WEBHOOK_RECEIVED`, emitWebhook)
   emitter.on(`SOURCE_FILE_CHANGED`, emitSourceChange)
+  emitter.on(`QUERY_RUN_REQUESTED`, emitQueryRunRequest)
 
   return function unsubscribeFromMutationListening(): void {
     emitter.off(`ENQUEUE_NODE_MUTATION`, emitMutation)
     emitter.off(`WEBHOOK_RECEIVED`, emitWebhook)
     emitter.off(`SOURCE_FILE_CHANGED`, emitSourceChange)
+    emitter.off(`QUERY_RUN_REQUESTED`, emitQueryRunRequest)
   }
 }

--- a/packages/gatsby/src/services/types.ts
+++ b/packages/gatsby/src/services/types.ts
@@ -41,4 +41,5 @@ export interface IBuildContext {
   webpackListener?: Actor<unknown, AnyEventObject>
   queryFilesDirty?: boolean
   sourceFilesDirty?: boolean
+  pendingQueryRuns?: Set<string>
 }

--- a/packages/gatsby/src/state-machines/develop/actions.ts
+++ b/packages/gatsby/src/state-machines/develop/actions.ts
@@ -157,6 +157,22 @@ export const panicBecauseOfInfiniteLoop: ActionFunction<
   )
 }
 
+export const trackRequestedQueryRun = assign<IBuildContext, AnyEventObject>({
+  pendingQueryRuns: (context, { payload }) => {
+    const pendingQueryRuns = context.pendingQueryRuns || new Set<string>()
+    if (payload?.pagePath) {
+      pendingQueryRuns.add(payload.pagePath)
+    }
+    return pendingQueryRuns
+  },
+})
+
+export const clearPendingQueryRuns = assign<IBuildContext>(() => {
+  return {
+    pendingQueryRuns: new Set<string>(),
+  }
+})
+
 export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
   callApi,
   markNodesDirty,
@@ -180,4 +196,6 @@ export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
   setQueryRunningFinished,
   panic,
   logError,
+  trackRequestedQueryRun,
+  clearPendingQueryRuns,
 }

--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -110,7 +110,7 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
           actions: [`markNodesDirty`, `callApi`],
         },
         QUERY_RUN_REQUESTED: {
-          actions: [forwardTo(`run-queries`)],
+          actions: forwardTo(`run-queries`),
         },
       },
       invoke: {

--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -31,6 +31,9 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
       target: `reloadingData`,
       actions: `assignWebhookBody`,
     },
+    QUERY_RUN_REQUESTED: {
+      actions: `trackRequestedQueryRun`,
+    },
   },
   states: {
     // Here we handle the initial bootstrap
@@ -106,6 +109,9 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         ADD_NODE_MUTATION: {
           actions: [`markNodesDirty`, `callApi`],
         },
+        QUERY_RUN_REQUESTED: {
+          actions: [forwardTo(`run-queries`)],
+        },
       },
       invoke: {
         id: `run-queries`,
@@ -118,6 +124,7 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
           gatsbyNodeGraphQLFunction,
           graphqlRunner,
           websocketManager,
+          pendingQueryRuns,
         }: IBuildContext): IQueryRunningContext => {
           return {
             program,
@@ -126,6 +133,7 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
             gatsbyNodeGraphQLFunction,
             graphqlRunner,
             websocketManager,
+            pendingQueryRuns,
           }
         },
         onDone: [
@@ -145,13 +153,17 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
             target: `recreatingPages`,
             cond: ({ nodesMutatedDuringQueryRun }: IBuildContext): boolean =>
               !!nodesMutatedDuringQueryRun,
-            actions: [`markNodesClean`, `incrementRecompileCount`],
+            actions: [
+              `markNodesClean`,
+              `incrementRecompileCount`,
+              `clearPendingQueryRuns`,
+            ],
           },
           {
             // If we have no compiler (i.e. it's first run), then spin up the
             // webpack and socket.io servers
             target: `startingDevServers`,
-            actions: `setQueryRunningFinished`,
+            actions: [`setQueryRunningFinished`, `clearPendingQueryRuns`],
             cond: ({ compiler }: IBuildContext): boolean => !compiler,
           },
           {
@@ -159,14 +171,16 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
             target: `recompiling`,
             cond: ({ sourceFilesDirty }: IBuildContext): boolean =>
               !!sourceFilesDirty,
+            actions: [`clearPendingQueryRuns`],
           },
           {
             // ...otherwise just wait.
             target: `waiting`,
+            actions: [`clearPendingQueryRuns`],
           },
         ],
         onError: {
-          actions: `logError`,
+          actions: [`logError`, `clearPendingQueryRuns`],
           target: `waiting`,
         },
       },
@@ -205,6 +219,13 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
     },
     // Idle, waiting for events that make us rebuild
     waiting: {
+      always: [
+        {
+          target: `runningQueries`,
+          cond: ({ pendingQueryRuns }: IBuildContext): boolean =>
+            !!pendingQueryRuns && pendingQueryRuns.size > 0,
+        },
+      ],
       entry: [`saveDbState`, `resetRecompileCount`],
       on: {
         // Forward these events to the child machine, so it can handle batching

--- a/packages/gatsby/src/state-machines/query-running/actions.ts
+++ b/packages/gatsby/src/state-machines/query-running/actions.ts
@@ -1,5 +1,10 @@
 import { IQueryRunningContext } from "./types"
-import { DoneInvokeEvent, assign, ActionFunctionMap } from "xstate"
+import {
+  DoneInvokeEvent,
+  assign,
+  ActionFunctionMap,
+  AnyEventObject,
+} from "xstate"
 import { enqueueFlush } from "../../utils/page-data"
 
 export const flushPageData = (): void => {
@@ -24,9 +29,30 @@ export const markSourceFilesClean = assign<IQueryRunningContext>({
   filesDirty: false,
 })
 
+export const trackRequestedQueryRun = assign<
+  IQueryRunningContext,
+  AnyEventObject
+>({
+  pendingQueryRuns: (context, { payload }) => {
+    const pendingQueryRuns = context.pendingQueryRuns || new Set<string>()
+    if (payload?.pagePath) {
+      pendingQueryRuns.add(payload.pagePath)
+    }
+    return pendingQueryRuns
+  },
+})
+
+export const clearCurrentlyHandledPendingQueryRuns = assign<
+  IQueryRunningContext
+>({
+  currentlyHandledPendingQueryRuns: undefined,
+})
+
 export const queryActions: ActionFunctionMap<IQueryRunningContext, any> = {
   assignDirtyQueries,
   flushPageData,
   markSourceFilesDirty,
   markSourceFilesClean,
+  trackRequestedQueryRun,
+  clearCurrentlyHandledPendingQueryRuns,
 }

--- a/packages/gatsby/src/state-machines/query-running/types.ts
+++ b/packages/gatsby/src/state-machines/query-running/types.ts
@@ -19,4 +19,6 @@ export interface IQueryRunningContext {
   queryIds?: IGroupedQueryIds
   websocketManager?: WebsocketManager
   filesDirty?: boolean
+  pendingQueryRuns?: Set<string>
+  currentlyHandledPendingQueryRuns?: Set<string>
 }


### PR DESCRIPTION
The changes in this PR are meant to be part of https://github.com/gatsbyjs/gatsby/pull/27939 (hence it targets that branch), but because the other PR is quite large already - this is separate PR to check it as "standalone"

Query on demand will emit `QUERY_RUN_REQUESTED` event with path to query that we need to run (only when we don't have results cached yet, or the results are not up to date)

The idea of this PR is to just keep appending requested path to `pendingQueryRuns` Set stored in context (we have same field in main `develop` machine and in `query-running` machine).

When we are idle (`waiting` state) we do conditional transient transition to `query-running` if the `pendingQueryRuns` is not empty. We also forward `QUERY_RUN_REQUESTED` events to `query-running` machine if we are in that state.
