### PR TITLE
feat: add utility to show experiment invitation notices

### DIFF
--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -1,0 +1,37 @@
+import { getConfigStore } from "gatsby-core-utils"
+import reporter from "gatsby-cli/lib/reporter"
+
+type CancelExperimentNoticeCallback = () => void
+
+export type CancelExperimentNoticeCallbackOrUndefined =
+  | CancelExperimentNoticeCallback
+  | undefined
+
+const ONE_DAY = 24 * 60 * 60 * 1000
+
+export function showExperimentNoticeAfterTimeout(
+  experimentIdentifier: string,
+  noticeText: string,
+  showNoticeAfterMs: number,
+  minimumIntervalBetweenNoticesMs: number = ONE_DAY
+): CancelExperimentNoticeCallbackOrUndefined {
+  const configStoreKey = `lastExperimentNotice.${experimentIdentifier}`
+
+  const lastTimeWeShowedNotice = getConfigStore().get(configStoreKey)
+
+  if (lastTimeWeShowedNotice) {
+    if (Date.now() - lastTimeWeShowedNotice < minimumIntervalBetweenNoticesMs) {
+      return undefined
+    }
+  }
+
+  const noticeTimeout = setTimeout(() => {
+    reporter.info(noticeText)
+
+    getConfigStore().set(configStoreKey, Date.now())
+  }, showNoticeAfterMs)
+
+  return function clearNoticeTimeout(): void {
+    clearTimeout(noticeTimeout)
+  }
+}


### PR DESCRIPTION
This adds utility to help showing targeted experiment notices in CLI when some work takes more than predefined time threshold. To avoid potentially frustrating spam in CLI it tracks last time it showed that notice and will show it at most once a day (similar to how feedback survey doesn't show too often for same user).

For example usage see https://github.com/pieh/gatsby/commit/03168276459b09ce5fcb8a28b7cdb45ee10d977d which would invite user to check out query on demand experiment if their page queries run for at least 2 minutes 

