### PR TITLE
docs: release notes for v2.27

### DIFF
--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -56,8 +56,8 @@ What this means for you: faster local development experience, up to 2x faster in
 
 This feature is available under a flag.
 
-```sh
-cross-env GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND=1 gatsby develop
+```shell
+GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND=1 gatsby develop
 ```
 
 Please try it and [let us know](https://github.com/gatsbyjs/gatsby/discussions/27620) if you have any issues

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -27,7 +27,7 @@ Sneak peek to next releases:
 if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 
 [Previous release notes](../v2.26/index.md)<br>
-[Full changelog](<(https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0)>)
+[Full changelog](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0)>)
 
 ### Create-gatsby
 
@@ -42,6 +42,7 @@ This command will trigger a series of prompts, allowing you to select your CMS, 
 This is also the alias for the existing `gatsby new` command when no arguments are passed. However, `gatsby new <github repo>` retains its current functionality, allowing you to make use of the numerous fully functional starters.
 
 ### Making `gatsby develop` faster
+
 The Gatsby develop server can get slow to start on larger sites. We're working hard to speed it up. We're addressing different scaling problems one by one and have shipped several improvements behind flags as detailed below. If you'd like to enable all these dev speedups (along with all future ones!), we've created a single flag for you. Run your site like `GATSBY_EXPERIMENTAL_FAST_DEV=true gatsby develop` and zoom zoom!
 
 ### Experimental: Queries on Demand

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -41,6 +41,9 @@ This command will trigger a series of prompts, allowing you to select your CMS, 
 
 This is also the alias for the existing `gatsby new` command when no arguments are passed. However, `gatsby new <github repo>` retains its current functionality, allowing you to make use of the numerous fully functional starters.
 
+### Making `gatsby develop` faster
+The Gatsby develop server can get slow to start on larger sites. We're working hard to speed it up. We're addressing different scaling problems one by one and have shipped several improvements behind flags as detailed below. If you'd like to enable all these dev speedups (along with all future ones!), we've created a single flag for you. Run your site like `GATSBY_EXPERIMENTAL_FAST_DEV=true gatsby develop` and zoom zoom!
+
 ### Experimental: Queries on Demand
 
 When developing a Gatsby site there's no need to run all graphql queries before serving the site.

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -29,7 +29,7 @@ if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 [Previous release notes](../v2.26/index.md)<br>
 [Full changelog](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0)
 
-### create-gatsby
+## create-gatsby
 
 There is now a new, interactive way to create a Gatsby site. As long as you have Node.js installed you're ready to go.
 
@@ -41,7 +41,7 @@ This command will ask a series of questions, allowing you to select your CMS, pr
 
 This is also the alias for the existing `gatsby new` command when no arguments are passed. However, `gatsby new <github repo>` retains its current functionality, allowing you to make use of the numerous fully functional starters.
 
-### Making `gatsby develop` faster
+## Making `gatsby develop` faster
 
 The Gatsby develop server can get slow to start on larger sites. We're working hard to speed it up. We're addressing different scaling problems one by one and have shipped several improvements behind flags as detailed below. If you'd like to enable all these dev speedups (along with all future ones!), we've created a single flag for you. Run your site like `GATSBY_EXPERIMENTAL_FAST_DEV=true gatsby develop` and zoom zoom!
 
@@ -65,7 +65,7 @@ Please try it and [let us know](https://github.com/gatsbyjs/gatsby/discussions/2
 
 [Details and discussion](https://github.com/gatsbyjs/gatsby/discussions/27620).
 
-## Experimental: SSR in Development
+### Experimental: SSR in Development
 
 One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other browser globals that are not accessible in Node.js during SSR.
 
@@ -75,7 +75,7 @@ With this coming feature, we'll SSR pages during development when do a full refr
 
 Try it out immediately by running `GATSBY_EXPERIMENTAL_DEV_SSR=true gatsby develop`. Join in the discussion in its [umbrella issue](https://github.com/gatsbyjs/gatsby/issues/28138).
 
-## Experimental: Lazy page bundling in development
+### Experimental: Lazy page bundling in development
 
 An obstacle to Gatsby being a delightful experience for larger sites is JavaScript compilation can start to get annoyingly slow. For example, gatsbyjs.com takes over two minutes currently (with a cold cache) to compile and bundle the code for the many page components. Not acceptable!
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -67,7 +67,7 @@ Please try it and [let us know](https://github.com/gatsbyjs/gatsby/discussions/2
 
 ## Experimental: SSR in Development
 
-One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other browser globals that are not accessible in node.js during SSR.
+One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other browser globals that are not accessible in Node.js during SSR.
 
 Currently the only way to debug these is to change some code and rebuild and repeat until the problem is solved. This is a very slow way to debug. Worst, these sorts of bugs are often only encountered after a long development period. It's no fun to push code you're proud of to CI only to discover it's broken.
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -22,6 +22,7 @@ Sneak peek to next releases:
 
 - [Experimental: Lazy images in develop](#experimental-lazy-images-in-develop)
 - [Documentation Reorganization](#documentation-reorganization)
+- [Experimental: SSR in develop](#experimental-ssr-in-develop)
 
 **Bleeding Edge:** Want to try new features as soon as possible? Install `gatsby@next` and let us know
 if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
@@ -69,6 +70,15 @@ but it has a steep learning curve. We want to make it easier to get started with
 And that means having documentation that helps y’all find the information you need when you need it.
 
 [Announcement and discussion](https://github.com/gatsbyjs/gatsby/discussions/27856).
+
+## Experimental: SSR in Development
+One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other globals that are only accessible in the browser and not in node.js when doing SSR.
+
+Currently the only way to debug this is to change some code and rebuild and then repeat until the problem is solved. This is a very slow way to debug. Worst, these sorts of bugs are often only encountered after a long development period. It's no fun to push code you're proud of to CI only to discover it's broken.
+
+With this coming feature, we'll SSR pages during development when do a full refresh of a page (navigating between pages will still only do a client-side render). This will help you both discover build errors earlier _and_ fix them faster.
+
+Try it out immediately by running `GATSBY_EXPERIMENT_DEVJS_LAZY=true gatsby develop`. Join in the discussion in its umbrella issue at https://github.com/gatsbyjs/gatsby/issues/28138
 
 ## Contributors
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -23,6 +23,7 @@ Sneak peek to next releases:
 - [Experimental: Lazy images in develop](#experimental-lazy-images-in-develop)
 - [Documentation Reorganization](#documentation-reorganization)
 - [Experimental: SSR in develop](#experimental-ssr-in-develop)
+- [Experimental: Lazy page bundling in development](#experimental-lazy-page-bundling-in-development)
 
 **Bleeding Edge:** Want to try new features as soon as possible? Install `gatsby@next` and let us know
 if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
@@ -72,13 +73,22 @@ And that means having documentation that helps y’all find the information you 
 [Announcement and discussion](https://github.com/gatsbyjs/gatsby/discussions/27856).
 
 ## Experimental: SSR in Development
-One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other globals that are only accessible in the browser and not in node.js when doing SSR.
+One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other browser globals that are not accessible in node.js during SSR.
 
-Currently the only way to debug this is to change some code and rebuild and then repeat until the problem is solved. This is a very slow way to debug. Worst, these sorts of bugs are often only encountered after a long development period. It's no fun to push code you're proud of to CI only to discover it's broken.
+Currently the only way to debug these is to change some code and rebuild and repeat until the problem is solved. This is a very slow way to debug. Worst, these sorts of bugs are often only encountered after a long development period. It's no fun to push code you're proud of to CI only to discover it's broken.
 
 With this coming feature, we'll SSR pages during development when do a full refresh of a page (navigating between pages will still only do a client-side render). This will help you both discover build errors earlier _and_ fix them faster.
 
-Try it out immediately by running `GATSBY_EXPERIMENT_DEVJS_LAZY=true gatsby develop`. Join in the discussion in its umbrella issue at https://github.com/gatsbyjs/gatsby/issues/28138
+Try it out immediately by running `GATSBY_EXPERIMENTAL_DEV_SSR=true gatsby develop`. Join in the discussion in its umbrella issue at https://github.com/gatsbyjs/gatsby/issues/28138
+
+## Experimental: Lazy page bundling in development
+An obstacle to Gatsby being a delightful experience for larger sites is JavaScript compilation can start to get annoyingly slow. For example, gatsbyjs.com takes over two minutes currently (with a cold cache) to compile and bundle the code for the many page components. Not acceptable!
+
+We knew we needed to make this lazy and have shipped experimental support for this.
+
+Now when you run `GATSBY_EXPERIMENT_DEVJS_LAZY=true gatsby develop`, webpack won't look at any of your page components until you visit them. You'll notice a slight (generally under 0.5s) delay when you first visit a page while webpack compiles it but thereafter, it'll be instantaneous.
+
+All sites should see some speedups but it's especially noticible for larger sites like gatsbyjs.com which now starts webpack 81% faster than before! Please test it out and tell us how fast your dev server boots up over at the [umbrella issue](https://github.com/gatsbyjs/gatsby/issues/28138) along with any bugs you might run across.
 
 ## Contributors
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -33,7 +33,7 @@ if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 
 There is now a new, interactive way to create a Gatsby site. As long as you have Node.js installed you're ready to go.
 
-```
+```shell
 npm init gatsby
 ```
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -11,7 +11,7 @@ Welcome to `gatsby@2.27.0` release (November 2020 #2).
 
 Key highlights of this release:
 
-- [Create-gatsby](#create-gatsby) - new, interactive way to create a Gatsby site
+- [create-gatsby](#create-gatsby) - new, interactive way to create a Gatsby site
 - [Experimental: Queries on Demand](#experimental-queries-on-demand) - improves `gatsby develop` bootup time
 - [Experimental: Lazy page bundling](#experimental-lazy-page-bundling-in-development) - also improves `gatsby develop` bootup time
 - [Experimental: SSR in develop](#experimental-ssr-in-development) - catch SSR errors early

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -37,7 +37,7 @@ There is now a new, interactive way to create a Gatsby site. As long as you have
 npm init gatsby
 ```
 
-This command will trigger a series of prompts, allowing you to select your CMS, preferred styling tools and common Gatsby plugins. After you've made your selections let the installation complete and you'll have a working Gatsby site, all packages included and configured for use.
+This command will ask a series of questions, allowing you to select your CMS, preferred styling tools and common Gatsby plugins. After you've made your selections let the installation complete and you'll have a working Gatsby site, all packages included and configured for use.
 
 This is also the alias for the existing `gatsby new` command when no arguments are passed. However, `gatsby new <github repo>` retains its current functionality, allowing you to make use of the numerous fully functional starters.
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -29,7 +29,7 @@ if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 [Previous release notes](../v2.26/index.md)<br>
 [Full changelog](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0)
 
-### Create-gatsby
+### create-gatsby
 
 There is now a new, interactive way to create a Gatsby site. As long as you have Node.js installed you're ready to go.
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -27,7 +27,7 @@ Sneak peek to next releases:
 if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 
 [Previous release notes](../v2.26/index.md)<br>
-[Full changelog](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0)>)
+[Full changelog](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0)
 
 ### Create-gatsby
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -33,8 +33,11 @@ if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 ### Queries on Demand
 
 When developing a Gatsby site there's no need to run all graphql queries before serving the site.
-Instead, Gatsby could run queries for pages as they're requested by a browser.
-This would avoid having to wait for slower queries (like image processing) if you're editing an unrelated part of a site.
+Instead, Gatsby will run queries for pages as they're requested by a browser.
+Think of it like lazily loading the data your pages need, when they need it!
+
+This avoids having to wait for slower queries (like image processing) if you're editing an unrelated part of a site.
+What this means for you: faster local development experience, up to 2x faster in many cases!
 
 This feature is available under a flag.
 
@@ -51,7 +54,8 @@ Please try it and [let us know](https://github.com/gatsbyjs/gatsby/discussions/2
 
 ### Experimental: Lazy images in develop
 
-We've got some feedback that the more image-heavy your website gets, the slower `gatsby develop`.
+We've got some feedback that the more images your website contains, the slower your local development experience gets.
+You spend time waiting for images to process, instead of you know, developing! No longer!
 This experimental version of `gatsby-plugin-sharp` only does image processing when the page gets requested.
 
 Try early alpha (and [let us know](https://github.com/gatsbyjs/gatsby/discussions/27603) if you have any issues with it):
@@ -73,6 +77,7 @@ And that means having documentation that helps y’all find the information you 
 [Announcement and discussion](https://github.com/gatsbyjs/gatsby/discussions/27856).
 
 ## Experimental: SSR in Development
+
 One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other browser globals that are not accessible in node.js during SSR.
 
 Currently the only way to debug these is to change some code and rebuild and repeat until the problem is solved. This is a very slow way to debug. Worst, these sorts of bugs are often only encountered after a long development period. It's no fun to push code you're proud of to CI only to discover it's broken.
@@ -82,6 +87,7 @@ With this coming feature, we'll SSR pages during development when do a full refr
 Try it out immediately by running `GATSBY_EXPERIMENTAL_DEV_SSR=true gatsby develop`. Join in the discussion in its umbrella issue at https://github.com/gatsbyjs/gatsby/issues/28138
 
 ## Experimental: Lazy page bundling in development
+
 An obstacle to Gatsby being a delightful experience for larger sites is JavaScript compilation can start to get annoyingly slow. For example, gatsbyjs.com takes over two minutes currently (with a cold cache) to compile and bundle the code for the many page components. Not acceptable!
 
 We knew we needed to make this lazy and have shipped experimental support for this.

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -11,26 +11,37 @@ Welcome to `gatsby@2.27.0` release (November 2020 #2).
 
 Key highlights of this release:
 
-- [Queries on Demand](#queries-on-demand) - improves `gatsby develop` bootup time
-- [Add your item here](#link-to-header) - one-line summary
-
-Other notable changes and bugfixes:
-
-- [Add your item here](#link-to-header) - one-line summary
+- [Create-gatsby](#create-gatsby) - new, interactive way to create a Gatsby site
+- [Experimental: Queries on Demand](#experimental-queries-on-demand) - improves `gatsby develop` bootup time
+- [Experimental: Lazy page bundling](#experimental-lazy-page-bundling-in-development) - also improves `gatsby develop` bootup time
+- [Experimental: SSR in develop](#experimental-ssr-in-development) - catch SSR errors early
+- [gatsby-plugin-mdx@1.5.0](#gatsby-plugin-mdx150) - new option for better performance
+- [Notable bugfixes](#notable-bugfixes)
 
 Sneak peek to next releases:
 
 - [Experimental: Lazy images in develop](#experimental-lazy-images-in-develop)
 - [Documentation Reorganization](#documentation-reorganization)
-- [Experimental: SSR in develop](#experimental-ssr-in-development)
-- [Experimental: Lazy page bundling in development](#experimental-lazy-page-bundling-in-development)
 
 **Bleeding Edge:** Want to try new features as soon as possible? Install `gatsby@next` and let us know
 if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 
-[Previous release notes](../v2.26/index.md)
+[Previous release notes](../v2.26/index.md)<br>
+[Full changelog](<(https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0)>)
 
-### Queries on Demand
+### Create-gatsby
+
+There is now a new, interactive way to create a Gatsby site. As long as you have Node.js installed you're ready to go.
+
+```
+npm init gatsby
+```
+
+This command will trigger a series of prompts, allowing you to select your CMS, preferred styling tools and common Gatsby plugins. After you've made your selections let the installation complete and you'll have a working Gatsby site, all packages included and configured for use.
+
+This is also the alias for the existing `gatsby new` command when no arguments are passed. However, `gatsby new <github repo>` retains its current functionality, allowing you to make use of the numerous fully functional starters.
+
+### Experimental: Queries on Demand
 
 When developing a Gatsby site there's no need to run all graphql queries before serving the site.
 Instead, Gatsby will run queries for pages as they're requested by a browser.
@@ -49,6 +60,37 @@ Please try it and [let us know](https://github.com/gatsbyjs/gatsby/discussions/2
 (it may become a default for `develop` in the future)
 
 [Details and discussion](https://github.com/gatsbyjs/gatsby/discussions/27620).
+
+## Experimental: SSR in Development
+
+One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other browser globals that are not accessible in node.js during SSR.
+
+Currently the only way to debug these is to change some code and rebuild and repeat until the problem is solved. This is a very slow way to debug. Worst, these sorts of bugs are often only encountered after a long development period. It's no fun to push code you're proud of to CI only to discover it's broken.
+
+With this coming feature, we'll SSR pages during development when do a full refresh of a page (navigating between pages will still only do a client-side render). This will help you both discover build errors earlier _and_ fix them faster.
+
+Try it out immediately by running `GATSBY_EXPERIMENTAL_DEV_SSR=true gatsby develop`. Join in the discussion in its [umbrella issue](https://github.com/gatsbyjs/gatsby/issues/28138).
+
+## Experimental: Lazy page bundling in development
+
+An obstacle to Gatsby being a delightful experience for larger sites is JavaScript compilation can start to get annoyingly slow. For example, gatsbyjs.com takes over two minutes currently (with a cold cache) to compile and bundle the code for the many page components. Not acceptable!
+
+We knew we needed to make this lazy and have shipped experimental support for this.
+
+Now when you run `GATSBY_EXPERIMENT_DEVJS_LAZY=true gatsby develop`, webpack won't look at any of your page components until you visit them. You'll notice a slight (generally under 0.5s) delay when you first visit a page while webpack compiles it but thereafter, it'll be instantaneous.
+
+All sites should see some speedups but it's especially noticible for larger sites like gatsbyjs.com which now starts webpack 81% faster than before! Please test it out and tell us how fast your dev server boots up over at the [umbrella issue](https://github.com/gatsbyjs/gatsby/issues/28138) along with any bugs you might run across.
+
+## gatsby-plugin-mdx@1.5.0
+
+Adds a `lessBabel` option to the plugin which allows you to use a fast path for scanning exports during sourcing. The savings are significant, especially at scale, but as the new scanner does not use Babel, if your site depends on Babel then you can't use this. Please give the option a try and report any problems unrelated to not running Babel so we can improve the support.
+
+See PR [#27941](https://github.com/gatsby/gatsby/issues/27941)
+
+## Notable bugfixes
+
+- fix: endless page refresh in develop [#28034](https://github.com/gatsbyjs/gatsby/pull/28034)
+- fix: performance regression when running queries [#28032](https://github.com/gatsbyjs/gatsby/pull/28032)
 
 ## Work in progress
 
@@ -75,26 +117,6 @@ but it has a steep learning curve. We want to make it easier to get started with
 And that means having documentation that helps y’all find the information you need when you need it.
 
 [Announcement and discussion](https://github.com/gatsbyjs/gatsby/discussions/27856).
-
-## Experimental: SSR in Development
-
-One of the least enjoyable bugs to encounter in Gatsby is when your build fails due to code trying to reference `window` or `document` or other browser globals that are not accessible in node.js during SSR.
-
-Currently the only way to debug these is to change some code and rebuild and repeat until the problem is solved. This is a very slow way to debug. Worst, these sorts of bugs are often only encountered after a long development period. It's no fun to push code you're proud of to CI only to discover it's broken.
-
-With this coming feature, we'll SSR pages during development when do a full refresh of a page (navigating between pages will still only do a client-side render). This will help you both discover build errors earlier _and_ fix them faster.
-
-Try it out immediately by running `GATSBY_EXPERIMENTAL_DEV_SSR=true gatsby develop`. Join in the discussion in its umbrella issue at https://github.com/gatsbyjs/gatsby/issues/28138
-
-## Experimental: Lazy page bundling in development
-
-An obstacle to Gatsby being a delightful experience for larger sites is JavaScript compilation can start to get annoyingly slow. For example, gatsbyjs.com takes over two minutes currently (with a cold cache) to compile and bundle the code for the many page components. Not acceptable!
-
-We knew we needed to make this lazy and have shipped experimental support for this.
-
-Now when you run `GATSBY_EXPERIMENT_DEVJS_LAZY=true gatsby develop`, webpack won't look at any of your page components until you visit them. You'll notice a slight (generally under 0.5s) delay when you first visit a page while webpack compiles it but thereafter, it'll be instantaneous.
-
-All sites should see some speedups but it's especially noticible for larger sites like gatsbyjs.com which now starts webpack 81% faster than before! Please test it out and tell us how fast your dev server boots up over at the [umbrella issue](https://github.com/gatsbyjs/gatsby/issues/28138) along with any bugs you might run across.
 
 ## Contributors
 

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -1,0 +1,75 @@
+---
+date: "2020-11-19"
+version: "2.27.0"
+---
+
+# [v2.27](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0) (November 2020 #2)
+
+---
+
+Welcome to `gatsby@2.27.0` release (November 2020 #2).
+
+Key highlights of this release:
+
+- [Queries on Demand](#queries-on-demand) - improves `gatsby develop` bootup time
+- [Add your item here](#link-to-header) - one-line summary
+
+Other notable changes and bugfixes:
+
+- [Add your item here](#link-to-header) - one-line summary
+
+Sneak peek to next releases:
+
+- [Experimental: Lazy images in develop](#experimental-lazy-images-in-develop)
+- [Documentation Reorganization](#documentation-reorganization)
+
+**Bleeding Edge:** Want to try new features as soon as possible? Install `gatsby@next` and let us know
+if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
+
+[Previous release notes](../v2.26/index.md)
+
+### Queries on Demand
+
+When developing a Gatsby site there's no need to run all graphql queries before serving the site.
+Instead, Gatsby could run queries for pages as they're requested by a browser.
+This would avoid having to wait for slower queries (like image processing) if you're editing an unrelated part of a site.
+
+This feature is available under a flag.
+
+```sh
+cross-env GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND=1 gatsby develop
+```
+
+Please try it and [let us know](https://github.com/gatsbyjs/gatsby/discussions/27620) if you have any issues
+(it may become a default for `develop` in the future)
+
+[Details and discussion](https://github.com/gatsbyjs/gatsby/discussions/27620).
+
+## Work in progress
+
+### Experimental: Lazy images in develop
+
+We've got some feedback that the more image-heavy your website gets, the slower `gatsby develop`.
+This experimental version of `gatsby-plugin-sharp` only does image processing when the page gets requested.
+
+Try early alpha (and [let us know](https://github.com/gatsbyjs/gatsby/discussions/27603) if you have any issues with it):
+
+```
+npm install gatsby-plugin-sharp@lazy-images
+```
+
+Lazy images are enabled by-default in this version.
+
+[Details and discussion](https://github.com/gatsbyjs/gatsby/discussions/27603).
+
+### Documentation Reorganization
+
+We’ve heard repeatedly from the community that Gatsby is a powerful tool,
+but it has a steep learning curve. We want to make it easier to get started with Gatsby.
+And that means having documentation that helps y’all find the information you need when you need it.
+
+[Announcement and discussion](https://github.com/gatsbyjs/gatsby/discussions/27856).
+
+## Contributors
+
+A big **Thank You** to [everyone who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0) to this release 💜

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -22,7 +22,7 @@ Sneak peek to next releases:
 
 - [Experimental: Lazy images in develop](#experimental-lazy-images-in-develop)
 - [Documentation Reorganization](#documentation-reorganization)
-- [Experimental: SSR in develop](#experimental-ssr-in-develop)
+- [Experimental: SSR in develop](#experimental-ssr-in-development)
 - [Experimental: Lazy page bundling in development](#experimental-lazy-page-bundling-in-development)
 
 **Bleeding Edge:** Want to try new features as soon as possible? Install `gatsby@next` and let us know


### PR DESCRIPTION
## Description

Release notes for v2.27. Please add anything you would like to mention from this release.

[Rendered version](https://github.com/gatsbyjs/gatsby/blob/release-notes-2-27/docs/reference/release-notes/v2.27/index.md)
