### PR TITLE
test(e2e-development-runtime): bump timeout for those flaky test that seems to timeout sometimes in CI

### DIFF
--- a/e2e-tests/development-runtime/cypress.json
+++ b/e2e-tests/development-runtime/cypress.json
@@ -2,5 +2,5 @@
   "baseUrl": "http://localhost:8000",
   "failOnStatusCode": false,
   "chromeWebSecurity": false,
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 30000
 }

--- a/packages/gatsby-cypress/src/commands.js
+++ b/packages/gatsby-cypress/src/commands.js
@@ -6,7 +6,7 @@ Cypress.Commands.add(`getTestElement`, (selector, options = {}) =>
   cy.get(`[data-testid="${selector}"]`, options)
 )
 
-const TIMEOUT = 10000
+const TIMEOUT = 30000
 
 Cypress.Commands.add(
   `waitForAPI`,


### PR DESCRIPTION
Recently added runtime cache tests ( https://github.com/gatsbyjs/gatsby/pull/28060 ) seems to be flaky, let's bump the timeout to see if the problem is just not enough time waiting for things in CircleCI