### PR TITLE
chore(gatsby-transformer-sharp): Replace alpha warning for gatsbyImageData

### DIFF
--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -317,7 +317,7 @@ Because this no longer uses fragments to specify which fields to return, it inst
   - `BLURRED`: (default) a blurred, low resolution image, encoded as a base64 data URI
   - `TRACED_SVG`: a low-resolution traced SVG of the image.
   - `NONE`: no placeholder. Set "background" to use a fixed background color.
-  - `DOMINANT_COLOR`: a solid color, calculated from the dominant color of the image. _Currently disabled until sharp is updated_
+  - `DOMINANT_COLOR`: a solid color, calculated from the dominant color of the image.
 - `layout`: The layout for the image.
   - `FIXED:` A static image sized, that does not resize according to the screen width
   - `FLUID`: The image resizes to fit its container. Pass a "sizes" option if it isn't going to be the full width of the screen.

--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -385,7 +385,7 @@ const fluidNodeType = ({
   }
 }
 
-let warnedForAlpha = false
+let warnedForBeta = false
 
 const imageNodeType = ({
   pathPrefix,
@@ -511,13 +511,12 @@ const imageNodeType = ({
         reporter.warn(`Please upgrade gatsby-plugin-sharp`)
         return null
       }
-      if (!warnedForAlpha) {
+      if (!warnedForBeta) {
         reporter.warn(
           stripIndent`
-        You are using the alpha version of the \`gatsbyImageData\` sharp API, which is unstable and will change without notice. 
-        Please do not use it in production.`
+        Thank you for trying the beta version of the \`gatsbyImageData\` API. Please provide feedback and report any issues at: https://github.com/gatsbyjs/gatsby/discussions/27950`
         )
-        warnedForAlpha = true
+        warnedForBeta = true
       }
       const imageData = await generateImageData({
         file,


### PR DESCRIPTION
This replaces the scary alpha warning when using `gatsbyImageData` with a more reassuring beta warning, directing users to the RFC to give feedback. It also removes a comment about dominant color being disabled, because we have now upgraded sharp