### PR TITLE
benchmarks(contentful): use the new max pageLimit

### DIFF
--- a/benchmarks/source-contentful/gatsby-config.js
+++ b/benchmarks/source-contentful/gatsby-config.js
@@ -27,6 +27,7 @@ module.exports = {
     {
       resolve: "gatsby-source-contentful",
       options: contentfulConfig,
+      pageLimit: 1000,
     },
   ],
 }


### PR DESCRIPTION
The limit was raised and it should be raised for the wib benchmark as well.