### PR TITLE
fix(gatsby): get-page-data should timeout gracefully

### DIFF
--- a/packages/gatsby/src/utils/__tests__/get-page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/get-page-data.ts
@@ -1,0 +1,131 @@
+import { store } from "../../redux"
+import { getPageData } from "../get-page-data"
+import {
+  IGatsbyPage,
+  IGatsbyPlugin,
+  IQueryStartAction,
+} from "../../redux/types"
+import { pageQueryRun, queryStart } from "../../redux/actions/internal"
+
+const MOCK_FILE_INFO = {}
+
+jest.mock(`fs-extra`, () => {
+  return {
+    readJson: jest.fn(path => {
+      if (MOCK_FILE_INFO[path]) {
+        return MOCK_FILE_INFO[path]
+      }
+      throw new Error(`Doesn't exist`)
+    }),
+    pathExists: jest.fn(path => !!MOCK_FILE_INFO[path]),
+    readFile: jest.fn(path => JSON.stringify(MOCK_FILE_INFO[path])),
+  }
+})
+
+describe(`get-page-data-util`, () => {
+  let Pages
+  beforeAll(() => {
+    Pages = {
+      foo: {
+        path: `/foo`,
+        componentPath: `/foo.js`,
+        component: `/foo.js`,
+      },
+      bar: {
+        path: `/bar`,
+        componentPath: `/bar.js`,
+        component: `/bar.js`,
+      },
+      bar2: {
+        path: `/bar2`,
+        componentPath: `/bar.js`,
+        component: `/bar.js`,
+      },
+    }
+
+    store.dispatch({
+      type: `SET_PROGRAM`,
+      payload: {
+        directory: __dirname,
+      },
+    })
+  })
+
+  it(`times out gracefully`, async () => {
+    jest.useFakeTimers()
+
+    createPage(Pages.foo)
+    const resultPromise = getPageData(Pages.foo.path)
+
+    expect(setTimeout).toHaveBeenCalledTimes(1)
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 10000)
+
+    jest.runAllTimers()
+
+    expect(resultPromise).rejects.toThrowError(
+      `Error loading a result for the page query in "/foo". Query was not run and no cached result was found.`
+    )
+  })
+
+  it.skip(`handles page deletion in the middle of execution gracefully`, async () => {
+    // TODO
+    createPage(Pages.foo)
+    const resultPromise = getPageData(Pages.foo.path)
+    startPageQuery(Pages.foo)
+    deletePage(Pages.foo)
+
+    const result = await resultPromise
+    expect(result).toEqual({})
+  })
+})
+
+function createPage(page: Partial<IGatsbyPage>): void {
+  store.dispatch({
+    type: `CREATE_PAGE`,
+    payload: { ...page, context: {} },
+    plugin: { name: `get-page-data-test` },
+  })
+}
+
+function deletePage(page: Partial<IGatsbyPage>): void {
+  store.dispatch({
+    type: `DELETE_PAGE`,
+    payload: page,
+    plugin: { name: `get-page-data-test` },
+  })
+}
+
+function startPageQuery(page: Partial<IGatsbyPage>): void {
+  const payload: IQueryStartAction["payload"] = {
+    path: page.path,
+    componentPath: page.componentPath,
+    isPage: true,
+  }
+  store.dispatch(
+    queryStart(payload, { name: `page-data-test` } as IGatsbyPlugin)
+  )
+}
+
+function finishQuery(page: Partial<IGatsbyPage>): void {
+  const payload: IQueryStartAction["payload"] = {
+    path: page.path,
+    componentPath: page.componentPath,
+    isPage: true,
+  }
+  store.dispatch(
+    pageQueryRun(payload, { name: `page-data-test` } as IGatsbyPlugin)
+  )
+  store.dispatch({
+    type: `ADD_PENDING_PAGE_DATA_WRITE`,
+    payload: {
+      path: page.path,
+    },
+  })
+}
+
+function clearDataWrite(page: Partial<IGatsbyPage>): void {
+  store.dispatch({
+    type: `CLEAR_PENDING_PAGE_DATA_WRITE`,
+    payload: { page: page.path },
+  })
+}

--- a/packages/gatsby/src/utils/__tests__/get-page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/get-page-data.ts
@@ -60,7 +60,7 @@ describe(`get-page-data-util`, () => {
     deletePageDataFilesFromFs()
   })
 
-  it(`Resolves immediately of query result is up to date`, async () => {
+  it(`Resolves immediately if query result is up to date`, async () => {
     // query did already run before
     createPage(Pages.foo)
     startPageQuery(Pages.foo)

--- a/packages/gatsby/src/utils/get-page-data.ts
+++ b/packages/gatsby/src/utils/get-page-data.ts
@@ -6,12 +6,28 @@ import {
   readPageData as readPageDataUtil,
 } from "./page-data"
 
-const WAIT_TIMEOUT = 10 * 1000
+const DEFAULT_WAIT_TIMEOUT = 15 * 1000
+export const RETRY_INTERVAL = 5 * 1000
 
 export async function getPageData(
-  pagePath: string
+  pagePath: string,
+  waitForMS: number = DEFAULT_WAIT_TIMEOUT
 ): Promise<IPageDataWithQueryResult> {
-  const { queries, pendingPageDataWrites } = store.getState()
+  return doGetPageData(pagePath, waitForMS, waitForMS)
+}
+
+async function doGetPageData(
+  pagePath: string,
+  waitForMS: number,
+  initialWaitForMs: number
+): Promise<IPageDataWithQueryResult> {
+  const { queries, pendingPageDataWrites, pages } = store.getState()
+
+  if (!pages.has(pagePath)) {
+    throw new Error(
+      `Page "${pagePath}" doesn't exist. It might have been deleted recently.`
+    )
+  }
 
   const query = queries.trackedQueries.get(pagePath)
 
@@ -19,38 +35,58 @@ export async function getPageData(
     throw new Error(`Could not find query ${pagePath}`)
   }
   if (query.running !== 0) {
-    return waitNextPageData(pagePath)
+    return waitNextPageData(pagePath, waitForMS, initialWaitForMs)
   }
   if (query.dirty !== 0) {
     emitter.emit(`QUERY_RUN_REQUESTED`, { pagePath })
-    return waitNextPageData(pagePath)
+    return waitNextPageData(pagePath, waitForMS, initialWaitForMs)
   }
   if (pendingPageDataWrites.pagePaths.has(pagePath)) {
-    return waitNextPageData(pagePath)
+    return waitNextPageData(pagePath, waitForMS, initialWaitForMs)
   }
   // Results are up-to-date
   return readPageData(pagePath)
 }
 
 async function waitNextPageData(
-  pagePath: string
+  pagePath: string,
+  remainingTime: number,
+  initialWaitForMs: number
 ): Promise<IPageDataWithQueryResult> {
-  return new Promise(resolve => {
-    emitter.on(`CLEAR_PENDING_PAGE_DATA_WRITE`, listener)
-    const timeout = setTimeout(finalize, WAIT_TIMEOUT)
+  if (remainingTime > 0) {
+    return new Promise(resolve => {
+      emitter.on(`CLEAR_PENDING_PAGE_DATA_WRITE`, listener)
 
-    function finalize(): void {
-      emitter.off(`CLEAR_PENDING_PAGE_DATA_WRITE`, listener)
-      clearTimeout(timeout)
-      resolve(readPageData(pagePath))
-    }
+      const timeout = setTimeout((): void => {
+        emitter.off(`CLEAR_PENDING_PAGE_DATA_WRITE`, listener)
+        resolve(
+          doGetPageData(
+            pagePath,
+            Math.max(remainingTime - RETRY_INTERVAL, 0),
+            initialWaitForMs
+          )
+        )
+      }, Math.min(RETRY_INTERVAL, remainingTime))
 
-    function listener(data: IClearPendingPageDataWriteAction): void {
-      if (data.payload.page === pagePath) {
-        finalize()
+      function listener(data: IClearPendingPageDataWriteAction): void {
+        if (data.payload.page === pagePath) {
+          clearTimeout(timeout)
+          emitter.off(`CLEAR_PENDING_PAGE_DATA_WRITE`, listener)
+          resolve(readPageData(pagePath))
+        }
       }
-    }
-  })
+    })
+  } else {
+    // not ideal ... but try to push results we might have (stale)
+    // or fail/reject
+    return readPageData(pagePath).catch(() => {
+      throw new Error(
+        `Couldn't get query results for "${pagePath}" in ${(
+          initialWaitForMs / 1000
+        ).toFixed(3)}s.`
+      )
+    })
+  }
 }
 
 async function readPageData(pagePath): Promise<IPageDataWithQueryResult> {


### PR DESCRIPTION
## Description

This PR adds a timeout and retries to `getPageData` utility introduced in #27939 
Also adds missing test coverage.

All credits for this PR go to @pieh 😄 