### PR TITLE
feat(gatsby): add test for timeout for lazily loading components

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/__snapshots__/dev-loader-lazy.js.snap
+++ b/packages/gatsby/cache-dir/__tests__/__snapshots__/dev-loader-lazy.js.snap
@@ -18,3 +18,5 @@ Object {
   "staticQueryResults": Object {},
 }
 `;
+
+exports[`Dev loader loadPage should return an error when component cannot be loaded 1`] = `"Loading the page component chunky timed out after 10 seconds"`;

--- a/packages/gatsby/cache-dir/__tests__/dev-loader-lazy.js
+++ b/packages/gatsby/cache-dir/__tests__/dev-loader-lazy.js
@@ -390,6 +390,31 @@ describe(`Dev loader`, () => {
       })
     })
 
+    it(`should return an error when component cannot be loaded`, async () => {
+      jest.setTimeout(10000)
+      try {
+        const syncRequires = createSyncRequires({
+          chunk: `does-not-exist`,
+        })
+        const devLoader = new DevLoader(syncRequires, [])
+        const pageData = {
+          path: `/mypage/`,
+          componentChunkName: `chunky`,
+          staticQueryHashes: [],
+        }
+        devLoader.loadPageDataJson = jest.fn(() =>
+          Promise.resolve({
+            payload: pageData,
+            status: `success`,
+          })
+        )
+
+        await devLoader.loadPage(`/mypage/`)
+      } catch (e) {
+        expect(e).toMatchSnapshot()
+      }
+    })
+
     it(`should return an error pageData contains an error`, async () => {
       const syncRequires = createSyncRequires({
         chunk: `instance`,

--- a/packages/gatsby/cache-dir/ensure-page-component-in-bundle.js
+++ b/packages/gatsby/cache-dir/ensure-page-component-in-bundle.js
@@ -16,11 +16,12 @@ const ensureComponentInBundle = chunkName =>
     //
     // Try for 10 seconds and then error.
     let checkCount = 0
+    const checkCountLimit = 99
     const checkForBundle = () => {
       checkCount += 1
-      if (checkCount > 99) {
+      if (checkCount > checkCountLimit) {
         reject(
-          `Loading the page component ${chunkName} timed out after 5 seconds`
+          `Loading the page component ${chunkName} timed out after 10 seconds`
         )
       }
       // Check if the bundle is included and return.


### PR DESCRIPTION
Need to reevaluate this but wanted to capture the change