### PR TITLE
chore: add cypress dashboard config to e2e tests that don't have it yet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,6 +363,9 @@ jobs:
 
   mdx_e2e_tests:
     <<: *e2e-executor
+    environment:
+      CYPRESS_PROJECT_ID: spbj28
+      CYPRESS_RECORD_KEY: af30ea46-121f-4fb7-97dd-f17ec224402e
     steps:
       - e2e-test:
           test_path: e2e-tests/mdx
@@ -370,6 +373,9 @@ jobs:
 
   e2e_tests_gatsby-static-image:
     <<: *e2e-executor
+    environment:
+      CYPRESS_PROJECT_ID: zstawi
+      CYPRESS_RECORD_KEY: 389326a6-c0d2-4215-bc5e-3be29483ed13
     steps:
       - e2e-test:
           test_path: e2e-tests/gatsby-static-image
@@ -377,6 +383,9 @@ jobs:
 
   e2e_tests_visual-regression:
     <<: *e2e-executor
+    environment:
+      CYPRESS_PROJECT_ID: nz99aw
+      CYPRESS_RECORD_KEY: ed4b1af1-bd97-47d4-bb09-3cab2435a147
     steps:
       - e2e-test:
           test_path: e2e-tests/visual-regression


### PR DESCRIPTION
we have few e2e cypress tests that don't upload results to cypress dashboard (which is really quite nice and it does often is useful - especially when alternative is to check terminal output in CircleCI)