### PR TITLE
fix(gatsby-source-filesystem): fix race condition when using `publicURL` field

### DIFF
--- a/packages/gatsby-source-filesystem/src/extend-file-node.js
+++ b/packages/gatsby-source-filesystem/src/extend-file-node.js
@@ -30,7 +30,7 @@ module.exports = ({
         )
 
         if (!fs.existsSync(publicPath)) {
-          fs.copy(
+          fs.copySync(
             details.absolutePath,
             publicPath,
             { dereference: true },


### PR DESCRIPTION
## Description

Fixes the race condition as discussed in #27984. @pieh: Please review.