### PR TITLE
fix(gatsby): pull out a few bug fixes from https://github.com/gatsbyjs/gatsby/pull/28149/

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -568,5 +568,9 @@ export const publicLoader = {
 export default publicLoader
 
 export function getStaticQueryResults() {
-  return instance.staticQueryDb
+  if (instance) {
+    return instance.staticQueryDb
+  } else {
+    return {}
+  }
 }

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -71,7 +71,7 @@ This will help the dev environment more closely mimic builds so you'll catch bui
 
 Try out develop SSR *today* by running your site with it enabled:
 
-GATSBY_EXPERIMENT_DEV_SSR=true gatsby develop
+GATSBY_EXPERIMENTAL_DEV_SSR=true gatsby develop
 
 Please let us know how it goes good, bad, or otherwise at gatsby.dev/dev-ssr-feedback
       `,

--- a/packages/gatsby/src/utils/dev-ssr/render-dev-html.ts
+++ b/packages/gatsby/src/utils/dev-ssr/render-dev-html.ts
@@ -3,6 +3,7 @@ import _ from "lodash"
 
 import { startListener } from "../../bootstrap/requires-writer"
 import { findPageByPath } from "../find-page-by-path"
+import { getPageData as getPageDataExperimental } from "../get-page-data"
 
 const startWorker = (): any => {
   const newWorker = new JestWorker(require.resolve(`./render-dev-html-child`), {
@@ -62,6 +63,9 @@ export const renderDevHTML = ({
     if (pageObj.matchPath) {
       isClientOnlyPage = true
     }
+
+    // Ensure the query has been run and written out.
+    await getPageDataExperimental(pageObj.path)
 
     try {
       const htmlString = await worker.renderHTML({


### PR DESCRIPTION
- typo on env var
- make sure page-data.json is created before SSRing