### PR TITLE
Fix typo in schema-inference.md

### DIFF
--- a/docs/docs/schema-inference.md
+++ b/docs/docs/schema-inference.md
@@ -185,7 +185,7 @@ It creates a new GraphQL Field Config whose type is the just created `File` GqlT
 Say we have a `data/posts.json` file that has been sourced (of type `File`), and then the [gatsby-transformer-json](/packages/gatsby-transformer-json) transformer creates a child node (of type `PostsJson`)
 
 ```json:title=data/posts.json
-;[
+[
   {
     id: "1685001452849004065",
     text: "Venice is 👌",


### PR DESCRIPTION
I found a semicolon at the beginning of a JSON snippet. I believe it to be a typo.