### PR TITLE
change @emotion/core module in tutorial

### DIFF
--- a/docs/tutorial/part-four/index.md
+++ b/docs/tutorial/part-four/index.md
@@ -76,14 +76,14 @@ cd tutorial-part-four
 Then install some other needed dependencies at the root of the project. You'll use the Typography theme "Kirkham", and you'll try out a CSS-in-JS library, ["Emotion"](https://emotion.sh/):
 
 ```shell
-npm install gatsby-plugin-typography typography react-typography typography-theme-kirkham gatsby-plugin-emotion @emotion/core
+npm install gatsby-plugin-typography typography react-typography typography-theme-kirkham gatsby-plugin-emotion @emotion/react
 ```
 
 Set up a site similar to what you ended with in [Part Three](/tutorial/part-three). This site will have a layout component and two page components:
 
 ```jsx:title=src/components/layout.js
 import React from "react"
-import { css } from "@emotion/core"
+import { css } from "@emotion/react"
 import { Link } from "gatsby"
 
 import { rhythm } from "../utils/typography"
@@ -285,7 +285,7 @@ Go ahead and make some changes to your `src/components/layout.js` file to use th
 
 ```jsx:title=src/components/layout.js
 import React from "react"
-import { css } from "@emotion/core"
+import { css } from "@emotion/react"
 // highlight-next-line
 import { useStaticQuery, Link, graphql } from "gatsby"
 

--- a/docs/tutorial/part-seven/index.md
+++ b/docs/tutorial/part-seven/index.md
@@ -306,7 +306,7 @@ Return to `src/pages/index.js`, query for your markdown slugs, and create links.
 
 ```jsx:title=src/pages/index.js
 import React from "react"
-import { css } from "@emotion/core"
+import { css } from "@emotion/react"
 import { Link, graphql } from "gatsby" // highlight-line
 import { rhythm } from "../utils/typography"
 import Layout from "../components/layout"

--- a/docs/tutorial/part-six/index.md
+++ b/docs/tutorial/part-six/index.md
@@ -87,7 +87,7 @@ Like with the `src/pages/my-files.js` page, replace `src/pages/index.js` with th
 ```jsx:title=src/pages/index.js
 import React from "react"
 import { graphql } from "gatsby"
-import { css } from "@emotion/core"
+import { css } from "@emotion/react"
 import { rhythm } from "../utils/typography"
 import Layout from "../components/layout"
 


### PR DESCRIPTION
- tutorial refers to module: @emotion/core, but this has been renamed
recently to @emotion/react

- see: https://github.com/emotion-js/emotion/releases/tag/%40emotion%2Freact%4011.0.0

- there are other references in the docs to @emotion/core

- so far I've only tested the main tutorial

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
