### PR TITLE
chore(benchmarks): enable the lessBabel flag for fs-gabe-mdx

### DIFF
--- a/benchmarks/gabe-fs-mdx/gatsby-config.js
+++ b/benchmarks/gabe-fs-mdx/gatsby-config.js
@@ -13,7 +13,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-mdx`,
       options: {
-        // lessBabel: true,
+        lessBabel: true,
       },
     },
   ],


### PR DESCRIPTION
Enable the flag that was published in 2.7.0