### PR TITLE
feat(gatsby-plugin-sitemap): allow `serialize` plugin option to be async function

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -46,7 +46,7 @@ exports.onPostBuild = async (
     basePath,
     resolveSiteUrl
   )
-  const urls = serialize(filteredRecords)
+  const urls = await serialize(filteredRecords)
 
   if (!rest.sitemapSize || urls.length <= rest.sitemapSize) {
     const map = sitemap.createSitemap(rest)


### PR DESCRIPTION
Simple change to allow async operations in the serialize function. its already in an async block and runs on postbuild