### PR TITLE
fix(gatsby-source-filesystem): fix race condition when using `publicURL` field (#28176)

### DIFF
--- a/packages/gatsby-source-filesystem/src/extend-file-node.js
+++ b/packages/gatsby-source-filesystem/src/extend-file-node.js
@@ -30,7 +30,7 @@ module.exports = ({
         )
 
         if (!fs.existsSync(publicPath)) {
-          fs.copy(
+          fs.copySync(
             details.absolutePath,
             publicPath,
             { dereference: true },


### PR DESCRIPTION
Backporting #28176 to the release branch

(cherry picked from commit 1abf65c335f397e9f891d25c4113ceee0e3fc138)