### PR TITLE
feat(gatsby): track usage of GATSBY_EXPERIMENTAL_FAST_DEV

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -52,6 +52,8 @@ Please give feedback on their respective umbrella issues!
 - https://gatsby.dev/query-on-demand-feedback
 - https://gatsby.dev/dev-ssr-feedback
   `)
+
+  telemetry.trackFeatureIsUsed(`FastDev`)
 }
 
 if (


### PR DESCRIPTION
We want to see when this is used vs. just the individual flags