### PR TITLE
fix(gatsby): do not ignore source file changes during recompilation

### DIFF
--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -187,10 +187,13 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
     },
     // Recompile the JS bundle
     recompiling: {
+      // Important: mark source files as clean when recompiling starts
+      // Doing this `onDone` will wipe all file change events that occur **during** recompilation
+      // See https://github.com/gatsbyjs/gatsby/issues/27609
+      entry: `markSourceFilesClean`,
       invoke: {
         src: `recompile`,
         onDone: {
-          actions: `markSourceFilesClean`,
           target: `waiting`,
         },
         onError: {
@@ -247,8 +250,14 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         data: ({
           store,
           nodeMutationBatch = [],
+          sourceFilesDirty,
         }: IBuildContext): IWaitingContext => {
-          return { store, nodeMutationBatch, runningBatch: [] }
+          return {
+            store,
+            nodeMutationBatch,
+            sourceFilesDirty,
+            runningBatch: [],
+          }
         },
         // "done" means we need to rebuild
         onDone: {

--- a/packages/gatsby/src/state-machines/waiting/index.ts
+++ b/packages/gatsby/src/state-machines/waiting/index.ts
@@ -22,12 +22,21 @@ export const waitingStates: MachineConfig<IWaitingContext, any, any> = {
   },
   states: {
     idle: {
-      always: {
-        // If we already have queued node mutations, move
-        // immediately to batching
-        cond: (ctx): boolean => !!ctx.nodeMutationBatch.length,
-        target: `batchingNodeMutations`,
-      },
+      always: [
+        {
+          // If we already have queued node mutations, move
+          // immediately to batching
+          cond: (ctx): boolean => !!ctx.nodeMutationBatch.length,
+          target: `batchingNodeMutations`,
+        },
+        {
+          // If source files are dirty upon entering this state,
+          // move immediately to aggregatingFileChanges to force re-compilation
+          // See https://github.com/gatsbyjs/gatsby/issues/27609
+          target: `aggregatingFileChanges`,
+          cond: ({ sourceFilesDirty }): boolean => Boolean(sourceFilesDirty),
+        },
+      ],
       on: {
         ADD_NODE_MUTATION: {
           actions: `addNodeMutation`,

--- a/packages/gatsby/src/state-machines/waiting/types.ts
+++ b/packages/gatsby/src/state-machines/waiting/types.ts
@@ -9,6 +9,5 @@ export interface IWaitingContext {
   nodeMutationBatch: Array<IMutationAction>
   store?: Store<IGatsbyState, AnyAction>
   runningBatch: Array<IMutationAction>
-  filesDirty?: boolean
-  webhookBody?: Record<string, unknown>
+  sourceFilesDirty?: boolean
 }


### PR DESCRIPTION
## Description

Our state machine ignores some of the `SOURCE_FILE_CHANGED` events. Namely, when it is in the `recompiling` phase and an event occurs **during** recompilation.

In this case, after recompilation, we mark source files as clean although they are not. As a result, we transition to `waiting` state but never recompile the bundle. And `webpack` waits when do this to resume watching files ([see those lines](https://github.com/webpack/webpack/blob/2efeb4b5787e868e69233aa9dec469c200fa3b2c/lib/Watching.js#L98-L105)).

And so `webpack` stops emitting `invalid` hook events on source file changes and our HMR gets completely stuck.

This PR does two things:

1. Marks source files as clean on recompilation start (vs. on done previously). This way if `SOURCE_FILE_CHANGED` event occurs during `recompilation` - we mark source files as dirty again

2. Upon entering `waiting` state - it checks if source files are actually dirty - and if so - starts processing them immediately.

## Related Issues

Fixes #27609 

Potentially can also help with #27626 (although it is likely a different problem)