### PR TITLE
fix(gatsby): fix materialization edge case

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -383,11 +383,10 @@ class LocalNodeModel {
           queryFields,
           actualFieldsToResolve
         )
-        const mergedResolved = _.merge(
-          node.__gatsby_resolved || {},
-          resolvedFields
-        )
-        return mergedResolved
+        if (!node.__gatsby_resolved) {
+          node.__gatsby_resolved = {}
+        }
+        return _.merge(node.__gatsby_resolved, resolvedFields)
       })
       this._preparedNodesCache.set(
         typeName,


### PR DESCRIPTION
## Description

There is a pretty complex set of conditions that causes Gatsby sorting to be skipped. Those are:

1. Run one query with `regex` filter without sorting
2. This filter must be run against a field **without a custom resolver**
3. Run the second query with the same `regex` filter but now also with sorting
4. The sorting must run against a field **with custom resolver**

(this situation is demonstrated in the added test)

The first query adds nodes to the fast filters cache. The second query fetches results from this cache. But when we get results from the cache we bypass `__gatsby_resolved` assignment (assuming it was set when we originally added nodes to cache).

But it was not set because of this line:

https://github.com/gatsbyjs/gatsby/blob/70b81a6e825c583387728c02d83a70e0d4e16072/packages/gatsby/src/schema/node-model.js#L386-L390

On the first call of this code, the `node.__gatsby_resolved` is not set and so any new materialized fields are not added to the cache until the next `__gatsby_resolved` assignment that never happens when results are returned from the fast filters cache.

P.S. this piece of Gatsby is so complicated, that it's even hard to explain 😕 

## Related Issues

Fixes #28047