### PR TITLE
feat(gatsby): track usage of GATSBY_EXPERIMENTAL_FAST_DEV (#28223)

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -52,6 +52,8 @@ Please give feedback on their respective umbrella issues!
 - https://gatsby.dev/query-on-demand-feedback
 - https://gatsby.dev/dev-ssr-feedback
   `)
+
+  telemetry.trackFeatureIsUsed(`FastDev`)
 }
 
 if (


### PR DESCRIPTION
Backporting #28223 to the release branch

(cherry picked from commit 849b3bd4ec871ecb7596819940f8004ce9ec3793)