### PR TITLE
fix(gatsby-source-filesystem): Improve the description

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-filesystem",
-  "description": "Gatsby plugin which parses files within a directory for further parsing by other plugins",
+  "description": "Gatsby source plugin for building websites from local data. Markdown, JSON, images, YAML, CSV, and dozens of other data types supported.",
   "version": "2.7.0-next.2",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": {


### PR DESCRIPTION
Currently it's "Gatsby plugin which parses files within a directory for further parsing by other plugins" which is rather opaque and CS-y.

This PR changes it to better describe how someone would actually use it — "build websites with data from your local filesystem"