### PR TITLE
chore(gatsby): Only warn for cache lock timeout once

### DIFF
--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -38,6 +38,8 @@ import reporter from "gatsby-cli/lib/reporter"
 // we currently don't support two concurrent builds at the same time anyways.
 const globalGatsbyCacheLock = new Map()
 
+let showLockTimeoutWarning = true // Only show this once
+
 /**
  * construction of the disk storage
  * @param {object} [args] options of disk store
@@ -235,9 +237,12 @@ function innerLock(resolve, reject, filePath): void {
   try {
     let lockTime = globalGatsbyCacheLock.get(filePath) ?? 0
     if (lockTime > 0 && Date.now() - lockTime > 10 * 1000) {
-      reporter.verbose(
-        `Warning: lock file older than 10s, ignoring it... There is a possibility this leads to caching problems later.`
-      )
+      if (showLockTimeoutWarning) {
+        showLockTimeoutWarning = false
+        reporter.verbose(
+          `Warning: lock file older than 10s, ignoring it... There is a possibility this leads to caching problems later. This warning will only be shown once.`
+        )
+      }
       lockTime = 0
       globalGatsbyCacheLock.delete(filePath)
     }


### PR DESCRIPTION
The warning was shown whenever a lock got older than 10s and ignored but this turned out to be quite noisy.