### PR TITLE
fix(gatsby-plugin-page-creator): use graphql from gatsby

### DIFF
--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -30,7 +30,6 @@
     "fs-exists-cached": "^1.0.0",
     "gatsby-page-utils": "^0.5.0-next.0",
     "globby": "^11.0.1",
-    "graphql": "^14.7.0",
     "lodash": "^4.17.20"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -10,7 +10,7 @@ import {
   PluginCallback,
 } from "gatsby"
 import { trackFeatureIsUsed } from "gatsby-telemetry"
-import { parse, GraphQLString } from "graphql"
+import { parse, GraphQLString } from "gatsby/graphql"
 import { createPath, watchDirectory } from "gatsby-page-utils"
 import { createPage } from "./create-page-wrapper"
 import { collectionExtractQueryString } from "./collection-extract-query-string"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12212,7 +12212,7 @@ graphql-type-json@^0.3.2:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
 
-graphql@^14.6.0, graphql@^14.7.0:
+graphql@^14.6.0:
   version "14.7.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
   integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==


### PR DESCRIPTION
## Description

`gatsby-plugin-page-creator` has a different version of `graphql` than the rest of gatsby. This causes multiple versions of GraphQL to be installed and produces various related errors.

This PR removes `graphql` from dependencies of `gatsby-plugin-page-creator`. Instead, we import directly from `gatsby/graphql` to use the exact same version of graphql.