### PR TITLE
fix(gatsby-telemetry): use windowsHide to not show windows command prompt windows

### DIFF
--- a/packages/gatsby-telemetry/src/repository-id.ts
+++ b/packages/gatsby-telemetry/src/repository-id.ts
@@ -54,7 +54,7 @@ const getGitRemoteWithGit = (): IRepositoryId | null => {
     // we may live multiple levels in git repo
     const originBuffer = execSync(
       `git config --local --get remote.origin.url`,
-      { timeout: 1000, stdio: `pipe` }
+      { timeout: 1000, stdio: `pipe`, windowsHide: true }
     )
     const repo = String(originBuffer).trim()
     if (repo) {


### PR DESCRIPTION
## Description

This is quite weird issue - sometimes on Windows when using default "Command prompt" there would be cmd.exe windows popping up and immediately hiding (see videos in #28233 both from issue author and from me).

I used https://docs.microsoft.com/en-us/sysinternals/downloads/procmon to track down what those actually try to execute and found that it's our repository id getter function:
![Screenshot 2020-11-24 at 13 40 45](https://user-images.githubusercontent.com/419821/100095616-11c5a800-2e5b-11eb-9fb4-da4913d50fda.png)

`childProcess.execSync` (and all the other similar too) have `windowsHide` option that is disabled by default, which I flip here to handle the issue.

Seperate issue is that we call it multiple times - just from different processes, so memoization we have in https://github.com/gatsbyjs/gatsby/blob/e7976580111c4baa15db8170abf2ae792f94bb9c/packages/gatsby-telemetry/src/telemetry.ts#L176-L181 doesn't address cross process ( which might be fine not to handle, just good to be at least aware of it )

And cherry on cake here is that at least for me - without this `windowsHide` toggle - I only see those command prompts windows popping up in some cases - in here it seems like after main `gatsby develop` process dies / get killed

## Related Issues

Fixes #28233