### PR TITLE
fix: Fix starter publish and scripts

### DIFF
--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -92,13 +92,7 @@ const install = async (
       }
     }
     if (getPackageManager() === `yarn` && checkForYarn()) {
-      if (await fs.pathExists(`package-lock.json`)) {
-        if (!(await fs.pathExists(`yarn.lock`))) {
-          await execa(`yarnpkg`, [`import`])
-        }
-        await fs.remove(`package-lock.json`)
-      }
-
+      await fs.remove(`package-lock.json`)
       const args = packages.length ? [`add`, silent, ...packages] : [silent]
       await execa(`yarnpkg`, args)
     } else {

--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -111,12 +111,7 @@ const install = async (rootPath: string): Promise<void> => {
       }
     }
     if (getPackageManager() === `yarn` && checkForYarn()) {
-      if (await fs.pathExists(`package-lock.json`)) {
-        if (!(await fs.pathExists(`yarn.lock`))) {
-          await spawn(`yarnpkg import`)
-        }
-        await fs.remove(`package-lock.json`)
-      }
+      await fs.remove(`package-lock.json`)
       await spawn(`yarnpkg`)
     } else {
       await fs.remove(`yarn.lock`)

--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -29,7 +29,7 @@ for folder in $GLOB; do
 
   if [ "$IS_WORKSPACE" = null ]; then
     rm -f yarn.lock
-    if ["$MINIMAL_STARTER" != "$NAME"]; then # ignore minimal starter because we don't want any lock files for create-gatsby
+    if [ "$MINIMAL_STARTER" != "$NAME" ]; then # ignore minimal starter because we don't want any lock files for create-gatsby
       yarn import # generate a new yarn.lock file based on package-lock.json, gatsby new does this is new CLI versions but will ignore if file exists
     fi
   fi


### PR DESCRIPTION
The current start publish script has a syntax error. This also revealed an issue where `yarn import` breaks in yarn 2, and is [considered a bad idea](https://github.com/gatsbyjs/gatsby/issues/28238#issuecomment-732506607) anyway. This PR fixes the publish script and removes the import step from gatsby-cli and create-gatsby
Fixes #28238