### PR TITLE
fix(gatsby-transformer-remark): ensure `getNodesByType()` is passed through (#28218)

### DIFF
--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -219,6 +219,7 @@ module.exports = function remarkExtendNodeType(
               markdownAST,
               markdownNode,
               getNode,
+              getNodesByType,
               files: fileNodes,
               basePath,
               reporter,


### PR DESCRIPTION
Backporting #28218 to the release branch.

(cherry picked from commit 7867897c5cc4f627a4fb91c939b24d884497ee20)