### PR TITLE
fix(gatsby): do not ignore source file changes during recompilation (#28237)

### DIFF
--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -187,10 +187,13 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
     },
     // Recompile the JS bundle
     recompiling: {
+      // Important: mark source files as clean when recompiling starts
+      // Doing this `onDone` will wipe all file change events that occur **during** recompilation
+      // See https://github.com/gatsbyjs/gatsby/issues/27609
+      entry: `markSourceFilesClean`,
       invoke: {
         src: `recompile`,
         onDone: {
-          actions: `markSourceFilesClean`,
           target: `waiting`,
         },
         onError: {
@@ -247,8 +250,14 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         data: ({
           store,
           nodeMutationBatch = [],
+          sourceFilesDirty,
         }: IBuildContext): IWaitingContext => {
-          return { store, nodeMutationBatch, runningBatch: [] }
+          return {
+            store,
+            nodeMutationBatch,
+            sourceFilesDirty,
+            runningBatch: [],
+          }
         },
         // "done" means we need to rebuild
         onDone: {

--- a/packages/gatsby/src/state-machines/waiting/index.ts
+++ b/packages/gatsby/src/state-machines/waiting/index.ts
@@ -22,12 +22,21 @@ export const waitingStates: MachineConfig<IWaitingContext, any, any> = {
   },
   states: {
     idle: {
-      always: {
-        // If we already have queued node mutations, move
-        // immediately to batching
-        cond: (ctx): boolean => !!ctx.nodeMutationBatch.length,
-        target: `batchingNodeMutations`,
-      },
+      always: [
+        {
+          // If we already have queued node mutations, move
+          // immediately to batching
+          cond: (ctx): boolean => !!ctx.nodeMutationBatch.length,
+          target: `batchingNodeMutations`,
+        },
+        {
+          // If source files are dirty upon entering this state,
+          // move immediately to aggregatingFileChanges to force re-compilation
+          // See https://github.com/gatsbyjs/gatsby/issues/27609
+          target: `aggregatingFileChanges`,
+          cond: ({ sourceFilesDirty }): boolean => Boolean(sourceFilesDirty),
+        },
+      ],
       on: {
         ADD_NODE_MUTATION: {
           actions: `addNodeMutation`,

--- a/packages/gatsby/src/state-machines/waiting/types.ts
+++ b/packages/gatsby/src/state-machines/waiting/types.ts
@@ -9,6 +9,5 @@ export interface IWaitingContext {
   nodeMutationBatch: Array<IMutationAction>
   store?: Store<IGatsbyState, AnyAction>
   runningBatch: Array<IMutationAction>
-  filesDirty?: boolean
-  webhookBody?: Record<string, unknown>
+  sourceFilesDirty?: boolean
 }


### PR DESCRIPTION
Backporting #28237 to the release branch

(cherry picked from commit 41488778ddcb102a5147b7acfb9631565ede958e)