### PR TITLE
fix(gatsby): Increase timeout for fetching component to 30 seconds

### DIFF
--- a/packages/gatsby/cache-dir/ensure-page-component-in-bundle.js
+++ b/packages/gatsby/cache-dir/ensure-page-component-in-bundle.js
@@ -14,13 +14,13 @@ const ensureComponentInBundle = chunkName =>
     // Tell the server the user wants to visit this page
     // to trigger it compiling the page component's code.
     //
-    // Try for 10 seconds and then error.
+    // Try for 30 seconds and then error.
     let checkCount = 0
     const checkForBundle = () => {
       checkCount += 1
-      if (checkCount > 99) {
+      if (checkCount > 299) {
         reject(
-          `Loading the page component ${chunkName} timed out after 5 seconds`
+          `Loading the page component ${chunkName} timed out after 30 seconds`
         )
       }
       // Check if the bundle is included and return.


### PR DESCRIPTION
Increase timeout for loading a component from 5 seconds to 30 seconds. The only reason for this is to avoid having ever churning XHR requests from bad requests but many pages will take 5-20s to compile so the lower timeout hurt UX