### PR TITLE
fix(gatsby): Always compile the index page (if it exists)

### DIFF
--- a/packages/gatsby/src/redux/reducers/visited-page.ts
+++ b/packages/gatsby/src/redux/reducers/visited-page.ts
@@ -12,6 +12,7 @@ const createDefault = (): StateMap => {
   const defaults = new Set<string>()
   defaults.add(`component---cache-dev-404-page-js`)
   defaults.add(`component---src-pages-404-js`)
+  defaults.add(`component---src-pages-index-js`)
 
   const state: StateMap = new Map([
     [`client`, new Set(defaults)],


### PR DESCRIPTION
Always compile the home page (most people will visit it so it's a worse experience to immediately have to wait for it to finish)