### PR TITLE
fix(gatsby-telemetry): use windowsHide to not show windows command prompt windows (#28258)

### DIFF
--- a/packages/gatsby-telemetry/src/repository-id.ts
+++ b/packages/gatsby-telemetry/src/repository-id.ts
@@ -54,7 +54,7 @@ const getGitRemoteWithGit = (): IRepositoryId | null => {
     // we may live multiple levels in git repo
     const originBuffer = execSync(
       `git config --local --get remote.origin.url`,
-      { timeout: 1000, stdio: `pipe` }
+      { timeout: 1000, stdio: `pipe`, windowsHide: true }
     )
     const repo = String(originBuffer).trim()
     if (repo) {


### PR DESCRIPTION
Backporting #28258 to the release branch

(cherry picked from commit e416368c42971a77ae7059376d764f17032f62ff)