### PR TITLE
chore(e2e-pnp): don't pin berry version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,9 +318,6 @@ jobs:
       - run: # Quick upgrade to the v2 (any version, we just need the real set version)
           command: yarn policies set-version berry
           working_directory: ~/project/e2e-tests/gatsby-pnp
-      - run: # Pins the Yarn version
-          command: yarn set version 2.0.0-rc.32
-          working_directory: ~/project/e2e-tests/gatsby-pnp
       - run: # Forces to use the local packages
           command: yarn link --all --private ../..
           working_directory: ~/project/e2e-tests/gatsby-pnp


### PR DESCRIPTION
Currently our e2e pnp tests pin yarn 2 versions to quite outdated rc version and recently started failing constantly. This is due to some patches that needs to be applied to typescript to work with PnP. I'm very light on details here, check comments I linked below. At the time comments were made patch was already updated, but wasn't released yet (it might have been already released, it might not - TBD, will see how tests run on this PR I guess and we will be able to rerun them periodically if it wasn't released yet).

Removing pinning was suggested by Yarn 2 maintainers (in one of linked comments)

## Related Issues

This was PR unrelated to PnP, but comments there are actually relevant

https://github.com/gatsbyjs/gatsby/pull/28218#issuecomment-732422940
https://github.com/gatsbyjs/gatsby/pull/28218#issuecomment-732440291
https://github.com/gatsbyjs/gatsby/pull/28218#issuecomment-732448483