### PR TITLE
fix(gatsby-plugin-sharp): avoid joi validation error when using reporter.panic

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -145,7 +145,7 @@ function createJob(job, { reporter }) {
   }
 
   promise.catch(err => {
-    reporter.panic(err)
+    reporter.panic(`error converting image`, err)
   })
 
   return promise


### PR DESCRIPTION


## Description

fix joi error when image conversion fails

previously just passing the error object would produce the following joi error

```
Failed to validate error Error [ValidationError]: "name" is not allowed
    at Object.exports.process (/myproject/node_modules/@hapi/joi/lib/errors.js:202:19)
    at internals.Object._validateWithOptions (/myproject/node_modules/@hapi/joi/lib/types/any/index.js:763:31)
    at internals.Object.validate (/myproject/node_modules/@hapi/joi/lib/types/any/index.js:797:21)
    at constructError (/myproject/node_modules/gatsby-cli/lib/structured-errors/construct-error.js:52:32)
    at Reporter.error (/myproject/node_modules/gatsby-cli/lib/reporter/reporter.js:135:59)
    at Reporter.panic (/myproject/node_modules/gatsby-cli/lib/reporter/reporter.js:75:34)
    at Object.panic (/myproject/node_modules/gatsby/src/utils/api-runner-node.js:201:16)
    at /myproject/node_modules/gatsby-plugin-sharp/index.js:162:14 {
  isJoi: true,
```

## Related Issues

- N/A