### PR TITLE
fix(gatsby-dev-cli): Correctly catch 404s from NPM when a package hasn't been published yet

### DIFF
--- a/packages/gatsby-dev-cli/src/utils/check-deps-changes.js
+++ b/packages/gatsby-dev-cli/src/utils/check-deps-changes.js
@@ -61,15 +61,13 @@ exports.checkDepsChanges = async ({
     // and save some time/work
     try {
       localPKGjson = await new Promise((resolve, reject) => {
-        got(`https://unpkg.com/${packageName}/package.json`).then(
-          (error, response) => {
+        got(`https://unpkg.com/${packageName}/package.json`)
+          .then((error, response) => {
             if (response && response.statusCode === 200) {
-              return resolve(JSON.parse(response.body))
+              resolve(JSON.parse(response.body))
             }
-
-            return reject(error)
-          }
-        )
+          })
+          .catch(e => reject(e))
       })
     } catch {
       console.log(

--- a/packages/gatsby-dev-cli/src/utils/check-deps-changes.js
+++ b/packages/gatsby-dev-cli/src/utils/check-deps-changes.js
@@ -60,15 +60,13 @@ exports.checkDepsChanges = async ({
     // this allow us to not publish to local repository
     // and save some time/work
     try {
-      localPKGjson = await new Promise((resolve, reject) => {
-        got(`https://unpkg.com/${packageName}/package.json`)
-          .then((error, response) => {
-            if (response && response.statusCode === 200) {
-              resolve(JSON.parse(response.body))
-            }
-          })
-          .catch(e => reject(e))
-      })
+      const response = await got(
+        `https://unpkg.com/${packageName}/package.json`
+      )
+      if (response?.statusCode !== 200) {
+        throw new Error(`No response or non 200 code`)
+      }
+      localPKGjson = JSON.parse(response.body)
     } catch {
       console.log(
         `'${packageName}' doesn't seem to be installed and is not published on NPM.`


### PR DESCRIPTION
Can't use gatsby-dev-cli with new package otherwise