### PR TITLE
fix(gatsby): Actually handle timeout while waiting for page component to be bundled

### DIFF
--- a/packages/gatsby/src/utils/dev-ssr/render-dev-html.ts
+++ b/packages/gatsby/src/utils/dev-ssr/render-dev-html.ts
@@ -96,7 +96,7 @@ const ensurePathComponentInSSRBundle = async (
           page.componentChunkName,
           htmlComponentRendererPath
         )
-        if (found || readAttempts === 5) {
+        if (found || readAttempts > 9) {
           clearInterval(searchForStringInterval)
           resolve()
         }
@@ -145,10 +145,17 @@ export const renderDevHTML = ({
     await getPageDataExperimental(pageObj.path)
 
     // Wait for public/render-page.js to update w/ the page component.
-    await ensurePathComponentInSSRBundle(pageObj, directory)
+    const found = await ensurePathComponentInSSRBundle(pageObj, directory)
 
-    // Ensure the query has been run and written out.
-    await getPageDataExperimental(pageObj.path)
+    // If we can't find the page, just force set isClientOnlyPage
+    // which skips rendering the body (so we just serve a shell)
+    // and the page will render normally on the client.
+    //
+    // This only happens on the first time we try to render a page component
+    // and it's taking a while to bundle its page component.
+    if (!found) {
+      isClientOnlyPage = true
+    }
 
     try {
       const htmlString = await worker.renderHTML({

--- a/packages/gatsby/src/utils/dev-ssr/render-dev-html.ts
+++ b/packages/gatsby/src/utils/dev-ssr/render-dev-html.ts
@@ -96,7 +96,7 @@ const ensurePathComponentInSSRBundle = async (
           page.componentChunkName,
           htmlComponentRendererPath
         )
-        if (found || readAttempts > 9) {
+        if (found || readAttempts > 5) {
           clearInterval(searchForStringInterval)
           resolve()
         }


### PR DESCRIPTION
I was occasionally seeing SSR errors where the page component wasn't found but which
would be fixed when I refreshed. It turns out I'd setup a timeout for waiting
for the bundle but hadn't handled this.

5*300ms == 1.5s which is a relatively short-timeout but SSR isn't generally needed so the right tradeoff seems
to not make people wait. 