### PR TITLE
fix(gatsby-plugin-image): Fix placeholder bg color

### DIFF
--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -362,7 +362,7 @@ icon.svg`,
           aria-hidden="true"
           data-placeholder-image=""
           sources=""
-          style="opacity: 1; transition: opacity 500ms linear; background-color: red; position: relative;"
+          style="opacity: 1; transition: opacity 500ms linear; background-color: red; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px;"
         />
       `)
     })
@@ -388,7 +388,7 @@ icon.svg`,
           aria-hidden="true"
           data-placeholder-image=""
           sources=""
-          style="opacity: 1; transition: opacity 500ms linear; width: 100px; height: 100px; background-color: red; position: relative;"
+          style="opacity: 1; transition: opacity 500ms linear; background-color: red; width: 100px; height: 100px; position: relative;"
         />
       `)
     })
@@ -414,7 +414,7 @@ icon.svg`,
           aria-hidden="true"
           data-placeholder-image=""
           sources=""
-          style="opacity: 1; transition: opacity 500ms linear; display: inline-block; background-color: red; position: relative;"
+          style="opacity: 1; transition: opacity 500ms linear; background-color: red; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px;"
         />
       `)
     })

--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -53,9 +53,7 @@ export function getWrapperProps(
   if (layout === `fixed`) {
     wrapperStyle.width = width
     wrapperStyle.height = height
-  }
-
-  if (layout === `constrained`) {
+  } else if (layout === `constrained`) {
     wrapperStyle.display = `inline-block`
   }
 
@@ -145,17 +143,26 @@ export function getPlaceholderProps(
   const wrapperStyle: CSSProperties = {}
 
   if (backgroundColor) {
+    wrapperStyle.backgroundColor = backgroundColor
+
     if (layout === `fixed`) {
       wrapperStyle.width = width
       wrapperStyle.height = height
+      wrapperStyle.backgroundColor = backgroundColor
+      wrapperStyle.position = `relative`
+    } else if (layout === `constrained`) {
+      wrapperStyle.position = `absolute`
+      wrapperStyle.top = 0
+      wrapperStyle.left = 0
+      wrapperStyle.bottom = 0
+      wrapperStyle.right = 0
+    } else if (layout === `fluid`) {
+      wrapperStyle.position = `absolute`
+      wrapperStyle.top = 0
+      wrapperStyle.left = 0
+      wrapperStyle.bottom = 0
+      wrapperStyle.right = 0
     }
-
-    if (layout === `constrained`) {
-      wrapperStyle.display = `inline-block`
-    }
-
-    wrapperStyle.backgroundColor = backgroundColor
-    wrapperStyle.position = `relative`
   }
 
   const result: PlaceholderImageAttrs = {

--- a/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
+++ b/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
@@ -65,7 +65,7 @@ export const LayoutWrapper: FunctionComponent<ILayoutWrapperProps> = function La
             }}
           />
         </div>
-        {/* extra div to help content fit. before that, the placeholder was playing a role in position the element
+        {/* extra div to help content fit. before that, the placeholder was playing a role in positionning the element.
        We should prevent placeholders from having an impact on the final visual representation of the UI */}
         <div style={{ display: `inline-block` }} />
       </>

--- a/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
+++ b/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
@@ -51,24 +51,19 @@ export const LayoutWrapper: FunctionComponent<ILayoutWrapperProps> = function La
   }
   if (layout === `constrained`) {
     sizer = (
-      <>
-        <div style={{ maxWidth: width, display: `block` }}>
-          <img
-            alt=""
-            role="presentation"
-            aria-hidden="true"
-            src={`data:image/svg+xml;charset=utf-8,%3Csvg height='${height}' width='${width}' xmlns='http://www.w3.org/2000/svg' version='1.1'%3E%3C/svg%3E`}
-            style={{
-              maxWidth: `100%`,
-              display: `block`,
-              position: `static`,
-            }}
-          />
-        </div>
-        {/* extra div to help content fit. before that, the placeholder was playing a role in positionning the element.
-       We should prevent placeholders from having an impact on the final visual representation of the UI */}
-        <div style={{ display: `inline-block` }} />
-      </>
+      <div style={{ maxWidth: width, display: `block` }}>
+        <img
+          alt=""
+          role="presentation"
+          aria-hidden="true"
+          src={`data:image/svg+xml;charset=utf-8,%3Csvg height='${height}' width='${width}' xmlns='http://www.w3.org/2000/svg' version='1.1'%3E%3C/svg%3E`}
+          style={{
+            maxWidth: `100%`,
+            display: `block`,
+            position: `static`,
+          }}
+        />
+      </div>
     )
   }
 

--- a/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
+++ b/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
@@ -51,19 +51,24 @@ export const LayoutWrapper: FunctionComponent<ILayoutWrapperProps> = function La
   }
   if (layout === `constrained`) {
     sizer = (
-      <div style={{ maxWidth: width, display: `block` }}>
-        <img
-          alt=""
-          role="presentation"
-          aria-hidden="true"
-          src={`data:image/svg+xml;charset=utf-8,%3Csvg height='${height}' width='${width}' xmlns='http://www.w3.org/2000/svg' version='1.1'%3E%3C/svg%3E`}
-          style={{
-            maxWidth: `100%`,
-            display: `block`,
-            position: `static`,
-          }}
-        />
-      </div>
+      <>
+        <div style={{ maxWidth: width, display: `block` }}>
+          <img
+            alt=""
+            role="presentation"
+            aria-hidden="true"
+            src={`data:image/svg+xml;charset=utf-8,%3Csvg height='${height}' width='${width}' xmlns='http://www.w3.org/2000/svg' version='1.1'%3E%3C/svg%3E`}
+            style={{
+              maxWidth: `100%`,
+              display: `block`,
+              position: `static`,
+            }}
+          />
+        </div>
+        {/* extra div to help content fit. before that, the placeholder was playing a role in position the element
+       We should prevent placeholders from having an impact on the final visual representation of the UI */}
+        <div style={{ display: `inline-block` }} />
+      </>
     )
   }
 


### PR DESCRIPTION

## Description

Fixing the missing placeholder background color for constrained and fluid in gatsby-plugin-image.

To test, modify the following query and change "CONSTRAINED" by "FLUID" or "FIXED"

```js
export const query = graphql`
  query {
    file(relativePath: { eq: "gatsby-icon.png" }) {
      childImageSharp {
        gatsbyImageData(
          layout: CONSTRAINED
          maxWidth: 256
          height: 125
          placeholder: DOMINANT_COLOR
        )
      }
    }
  }
`
```