### PR TITLE
test(gatsby-plugin-image): add E2E tests for native and intersection obs

### DIFF
--- a/e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
+++ b/e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
@@ -1,0 +1,37 @@
+describe(`gatsby-plugin-image / intersection observer`, () => {
+  beforeEach(() => {
+    cy.visit(`/lazy-loading`)
+    cy.window().then(win => {
+      // Removing the native lazy loading capabilities
+      delete win.HTMLImageElement.prototype.loading
+    })
+  })
+
+  it(`lazy loads an image when scrolling`, () => {
+    // We need to wait for a decent amount of time so that the image
+    // can resolve. This is necessary because the assertion
+    // is done outside the Cypress scheduler and so, Cypress is not able
+    // to ping for the specific assertion to be truthy.
+    cy.wait(500)
+    cy.get(`[data-cy=already-loaded]`)
+      .should(`be.visible`)
+      .then($img => {
+        expect($img[0].complete).to.equal(true)
+      })
+
+    cy.get(`[data-cy=lazy-loaded]`)
+      .should(`exist`)
+      .then($img => {
+        expect($img[0].naturalHeight).to.equal(0)
+      })
+
+    cy.scrollTo(`bottom`)
+
+    cy.wait(500)
+    cy.get(`[data-cy=lazy-loaded]`)
+      .should(`exist`)
+      .then($img => {
+        expect($img[0].naturalHeight).to.equal(59)
+      })
+  })
+})

--- a/e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
+++ b/e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
@@ -31,7 +31,7 @@ describe(`gatsby-plugin-image / intersection observer`, () => {
     cy.get(`[data-cy=lazy-loaded]`)
       .should(`exist`)
       .then($img => {
-        expect($img[0].naturalHeight).to.equal(59)
+        expect($img[0].naturalHeight).to.be.greaterThan(0)
       })
   })
 })

--- a/e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
+++ b/e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
@@ -9,13 +9,13 @@ describe(`gatsby-plugin-image / intersection observer`, () => {
 
   it(`lazy loads an image when scrolling`, () => {
     cy.window().then(win => {
-      expect(win.HTMLImageElement.prototype.loading).to.equal(undefined)
+      expect(`loading` in win.HTMLImageElement.prototype).toBeFalsy()
     })
 
     // We need to wait for a decent amount of time so that the image
     // can resolve. This is necessary because the assertion
     // is done outside the Cypress scheduler and so, Cypress is not able
-    // t o ping for the specific assertion to be truthy.
+    // to ping for the specific assertion to be truthy.
     cy.wait(500)
     cy.get(`[data-cy=already-loaded]`)
       .should(`be.visible`)

--- a/e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
+++ b/e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
@@ -8,10 +8,14 @@ describe(`gatsby-plugin-image / intersection observer`, () => {
   })
 
   it(`lazy loads an image when scrolling`, () => {
+    cy.window().then(win => {
+      expect(win.HTMLImageElement.prototype.loading).to.equal(undefined)
+    })
+
     // We need to wait for a decent amount of time so that the image
     // can resolve. This is necessary because the assertion
     // is done outside the Cypress scheduler and so, Cypress is not able
-    // to ping for the specific assertion to be truthy.
+    // t o ping for the specific assertion to be truthy.
     cy.wait(500)
     cy.get(`[data-cy=already-loaded]`)
       .should(`be.visible`)

--- a/e2e-tests/gatsby-static-image/cypress/integration/native-lazy-loading.js
+++ b/e2e-tests/gatsby-static-image/cypress/integration/native-lazy-loading.js
@@ -2,7 +2,7 @@ describe(`gatsby-plugin-image / native lazy loading`, () => {
   beforeEach(() => {
     // /!\ Make sure to run this one using a real build: not in develop
     // because we need SSR rendering in that scenario
-    cy.wrap(Cypress.config().baseUrl).should(`contain`, `:9000`)
+    cy.wrap(Cypress.config().baseUrl).should(`not.contain`, `:8000`)
     cy.visit(`/lazy-loading`)
   })
 

--- a/e2e-tests/gatsby-static-image/cypress/integration/native-lazy-loading.js
+++ b/e2e-tests/gatsby-static-image/cypress/integration/native-lazy-loading.js
@@ -1,7 +1,8 @@
 describe(`gatsby-plugin-image / native lazy loading`, () => {
-  // /!\ Make sure to run this one using a real build: not in develop
-  // because we need SSR rendering in that scenario
   beforeEach(() => {
+    // /!\ Make sure to run this one using a real build: not in develop
+    // because we need SSR rendering in that scenario
+    cy.wrap(Cypress.config().baseUrl).should(`contain`, `:9000`)
     cy.visit(`/lazy-loading`)
   })
 

--- a/e2e-tests/gatsby-static-image/cypress/integration/native-lazy-loading.js
+++ b/e2e-tests/gatsby-static-image/cypress/integration/native-lazy-loading.js
@@ -1,0 +1,35 @@
+describe(`gatsby-plugin-image / native lazy loading`, () => {
+  // /!\ Make sure to run this one using a real build: not in develop
+  // because we need SSR rendering in that scenario
+  beforeEach(() => {
+    cy.visit(`/lazy-loading`)
+  })
+
+  it(`lazy loads an image when scrolling`, () => {
+    // We need to wait for a decent amount of time so that the image
+    // can resolve. This is necessary because the assertion
+    // is done outside the Cypress scheduler and so, Cypress is not able
+    // to ping for the specific assertion to be truthy.
+    cy.wait(500)
+    cy.get(`[data-cy=already-loaded]`)
+      .should(`be.visible`)
+      .then($img => {
+        expect($img[0].complete).to.equal(true)
+      })
+
+    cy.get(`[data-cy=lazy-loaded]`)
+      .should(`exist`)
+      .then($img => {
+        expect($img[0].complete).to.equal(false)
+      })
+
+    cy.scrollTo(`bottom`)
+
+    cy.wait(500)
+    cy.get(`[data-cy=lazy-loaded]`)
+      .should(`exist`)
+      .then($img => {
+        expect($img[0].complete).to.equal(true)
+      })
+  })
+})

--- a/e2e-tests/gatsby-static-image/src/pages/lazy-loading.js
+++ b/e2e-tests/gatsby-static-image/src/pages/lazy-loading.js
@@ -1,0 +1,28 @@
+import * as React from "react"
+import { StaticImage } from "gatsby-plugin-image"
+
+export default function NativeLazyLoadingPage() {
+  return (
+    <div>
+      <StaticImage
+        data-cy="already-loaded"
+        src="../images/citrus-fruits.jpg"
+        width={124}
+        height={59}
+        alt="Citrus fruits"
+        loading="lazy"
+      />
+
+      <div style={{ height: `5000px`, background: `#F4F4F4` }} />
+
+      <StaticImage
+        data-cy="lazy-loaded"
+        src="../images/cornwall.jpg"
+        width={126}
+        height={59}
+        alt="Citrus fruits"
+        loading="lazy"
+      />
+    </div>
+  )
+}

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.browser.tsx
@@ -107,7 +107,7 @@ describe(`GatsbyImage browser`, () => {
   })
 
   it(`cleans up the DOM when unmounting`, async () => {
-    ;(hooks as any).hasNativeLazyLoadSupport = false
+    ;(hooks as any).hasNativeLazyLoadSupport = (): boolean => false
 
     const { container, unmount } = render(
       <GatsbyImage image={image} alt="Alt content" />
@@ -124,7 +124,7 @@ describe(`GatsbyImage browser`, () => {
     // In this scenario,
     // hasSSRHtml is true and resolved through "beforeHydrationContent" and hydrate: true
     // hydrated.current is false and not resolved yet
-    ;(hooks as any).hasNativeLazyLoadSupport = true
+    ;(hooks as any).hasNativeLazyLoadSupport = (): boolean => true
 
     const { container } = render(
       <GatsbyImage image={image} alt="Alt content" />,
@@ -146,7 +146,7 @@ describe(`GatsbyImage browser`, () => {
 
     // In this scenario,
     // hasSSRHtml is true and resolved through "beforeHydrationContent" and hydrate: true
-    ;(hooks as any).hasNativeLazyLoadSupport = true
+    ;(hooks as any).hasNativeLazyLoadSupport = (): boolean => true
     ;(hooks as any).storeImageloaded = jest.fn()
 
     const { container } = render(
@@ -173,7 +173,7 @@ describe(`GatsbyImage browser`, () => {
   })
 
   it(`relies on intersection observer when the SSR element is not resolved`, async () => {
-    ;(hooks as any).hasNativeLazyLoadSupport = true
+    ;(hooks as any).hasNativeLazyLoadSupport = (): boolean => true
     const onStartLoadSpy = jest.fn()
 
     const { container } = render(
@@ -190,7 +190,7 @@ describe(`GatsbyImage browser`, () => {
   })
 
   it(`relies on intersection observer when browser does not support lazy loading`, async () => {
-    ;(hooks as any).hasNativeLazyLoadSupport = false
+    ;(hooks as any).hasNativeLazyLoadSupport = (): boolean => false
     const onStartLoadSpy = jest.fn()
 
     const { container } = render(

--- a/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
@@ -68,7 +68,7 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
   >(null)
   const lazyHydrator = useRef<(() => void) | null>(null)
   const ref = useRef<HTMLImageElement | undefined>()
-  const [isLoading, toggleIsLoading] = useState(hasNativeLazyLoadSupport)
+  const [isLoading, toggleIsLoading] = useState(hasNativeLazyLoadSupport())
   const [isLoaded, toggleIsLoaded] = useState(false)
 
   if (!global.GATSBY___IMAGE && !hasShownWarning) {
@@ -91,7 +91,7 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
       ) as HTMLImageElement
 
       // when SSR and native lazyload is supported we'll do nothing ;)
-      if (hasNativeLazyLoadSupport && hasSSRHtml && global.GATSBY___IMAGE) {
+      if (hasNativeLazyLoadSupport() && hasSSRHtml && global.GATSBY___IMAGE) {
         onStartLoad?.({ wasCached: false })
 
         if (hasSSRHtml.complete) {
@@ -140,7 +140,7 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
     if (root.current) {
       const hasSSRHtml = root.current.querySelector(`[data-gatsby-image-ssr]`)
       // On first server hydration do nothing
-      if (hasNativeLazyLoadSupport && hasSSRHtml && !hydrated.current) {
+      if (hasNativeLazyLoadSupport() && hasSSRHtml && !hydrated.current) {
         return
       }
 

--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -17,7 +17,7 @@ import { IGatsbyImageHelperArgs, generateImageData } from "../image-utils"
 const imageCache = new Set<string>()
 
 // Native lazy-loading support: https://addyosmani.com/blog/lazy-loading/
-export const hasNativeLazyLoadSupport =
+export const hasNativeLazyLoadSupport = (): boolean =>
   typeof HTMLImageElement !== `undefined` &&
   `loading` in HTMLImageElement.prototype
 

--- a/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
+++ b/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
@@ -40,7 +40,7 @@ export function lazyHydrate(
 
   const hasSSRHtml = root.current.querySelector(`[data-gatsby-image-ssr]`)
   // On first server hydration do nothing
-  if (hasNativeLazyLoadSupport && hasSSRHtml && !hydrated.current) {
+  if (hasNativeLazyLoadSupport() && hasSSRHtml && !hydrated.current) {
     return null
   }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add E2E tests for native image lazy loading and intersection observer loading