### PR TITLE
fix(gatsby): add pages to saved redux state

### DIFF
--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -50,6 +50,23 @@ Object {
   },
   "pageData": Map {},
   "pageDataStats": Map {},
+  "pages": Map {
+    "/my-sweet-new-page/" => Object {
+      "component": "/Users/username/dev/site/src/templates/my-sweet-new-page.js",
+      "componentChunkName": "component---users-username-dev-site-src-templates-my-sweet-new-page-js",
+      "componentPath": "/Users/username/dev/site/src/templates/my-sweet-new-page.js",
+      "context": Object {
+        "id": "123456",
+      },
+      "internalComponentName": "ComponentMySweetNewPage",
+      "isCreatedByStatefulCreatePages": false,
+      "matchPath": undefined,
+      "path": "/my-sweet-new-page/",
+      "pluginCreatorId": "",
+      "pluginCreator___NODE": "",
+      "updatedAt": 1606471951096,
+    },
+  },
   "pendingPageDataWrites": Object {
     "pagePaths": Set {},
   },

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -97,6 +97,7 @@ export const saveState = (): void => {
     webpackCompilationHash: state.webpackCompilationHash,
     pageDataStats: state.pageDataStats,
     pageData: state.pageData,
+    pages: state.pages,
     pendingPageDataWrites: state.pendingPageDataWrites,
     staticQueriesByTemplate: state.staticQueriesByTemplate,
     queries: state.queries,

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -288,6 +288,7 @@ export interface ICachedReduxState {
   webpackCompilationHash: IGatsbyState["webpackCompilationHash"]
   pageDataStats: IGatsbyState["pageDataStats"]
   pageData: IGatsbyState["pageData"]
+  pages: IGatsbyState["pages"]
   staticQueriesByTemplate: IGatsbyState["staticQueriesByTemplate"]
   pendingPageDataWrites: IGatsbyState["pendingPageDataWrites"]
   queries: IGatsbyState["queries"]

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/sample-site-for-experiment.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/sample-site-for-experiment.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 1`] = `true`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 2`] = `false`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 2`] = `true`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 3`] = `true`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 3`] = `false`;
 
 exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 4`] = `true`;
 
@@ -12,6 +12,6 @@ exports[`sampleSiteForExperiment returns true or false depending on if they rand
 
 exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 6`] = `true`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 7`] = `false`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 7`] = `true`;
 
 exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 8`] = `false`;


### PR DESCRIPTION
## Description

it looks like pages is needed for gatsby to figure out if the page context has been modified since the last build: https://github.com/gatsbyjs/gatsby/blob/2e3ec895a227c8de5a7d8c69e92548c935c0fdcc/packages%2Fgatsby%2Fsrc%2Fredux%2Factions%2Fpublic.js#L399-L401

but pages isn't included during saveState 🤔 

## Related Issues

fixes #28281 
fixes #26520
