### PR TITLE
fix(gatsby-plugin-image): Correct img CSS

### DIFF
--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -18,7 +18,7 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
       key="gatsby-image-style"
       dangerouslySetInnerHTML={generateHtml(cssNanoMacro`
   .gatsby-image-wrapper img {
-    all: initial;
+    all: inherit;
     bottom: 0;
     height: 100%;
     left: 0;


### PR DESCRIPTION
Fix for incorrect CSS in image. Fixes https://github.com/gatsbyjs/gatsby/discussions/28311