### PR TITLE
fix(create-gatsby): Improve install

### DIFF
--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -158,12 +158,11 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
       `This command will generate a new Gatsby site for you in ${c.bold(
         process.cwd()
       )} with the setup you select. ${c.white.bold(
-        `Let's answer some questions:\n`
+        `Let's answer some questions:\n\n`
       )}`,
       process.stdout.columns
     )
   )
-  reporter.info(``)
 
   const enquirer = new Enquirer<IAnswers>()
 
@@ -301,7 +300,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
 
   await initStarter(DEFAULT_STARTER, data.project, packages.map(removeKey))
 
-  reporter.success(`Created site in ` + c.green(data.project))
+  reporter.success(`Created site in ${c.green(data.project)}`)
 
   const fullPath = path.resolve(data.project)
 

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -140,9 +140,9 @@ export async function run(): Promise<void> {
 
   const { version } = require(`../package.json`)
 
-  console.log(c.grey(`create-gatsby version ${version}`))
+  reporter.info(c.grey(`create-gatsby version ${version}`))
 
-  console.log(
+  reporter.info(
     `
 
 
@@ -152,7 +152,7 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
 `
   )
 
-  console.log(
+  reporter.info(
     wrap(
       `This command will generate a new Gatsby site for you in ${c.bold(
         process.cwd()
@@ -162,7 +162,7 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
       process.stdout.columns
     )
   )
-  console.log(``)
+  reporter.info(``)
 
   const enquirer = new Enquirer<IAnswers>()
 
@@ -262,7 +262,7 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
 
   const config = makePluginConfigQuestions(plugins)
   if (config.length) {
-    console.log(
+    reporter.info(
       `\nGreat! A few of the selections you made need to be configured. Please fill in the options for each plugin now:\n`
     )
 
@@ -276,7 +276,7 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
     trackCli(`CREATE_GATSBY_SET_PLUGINS_STOP`)
   }
 
-  console.log(`
+  reporter.info(`
 
 ${c.bold(`Thanks! Here's what we'll now do:`)}
 
@@ -294,7 +294,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
   if (!confirm) {
     trackCli(`CREATE_GATSBY_CANCEL`)
 
-    console.log(`OK, bye!`)
+    reporter.info(`OK, bye!`)
     return
   }
 
@@ -303,7 +303,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
   reporter.success(`Created site in ` + c.green(data.project))
 
   if (plugins.length) {
-    console.log(`${w(`🔌 `)}Setting-up plugins...`)
+    reporter.info(`${w(`🔌 `)}Setting-up plugins...`)
     await installPlugins(plugins, pluginConfig, path.resolve(data.project), [])
   }
 
@@ -312,7 +312,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
   const pm = await getPackageManager()
   const runCommand = pm === `npm` ? `npm run` : `yarn`
 
-  console.log(
+  reporter.info(
     stripIndent`
     ${w(`🎉  `)}Your new Gatsby site ${c.bold(
       data.project
@@ -320,15 +320,15 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
     at ${c.bold(path.resolve(data.project))}.
     `
   )
-  console.log(`Start by going to the directory with\n
+  reporter.info(`Start by going to the directory with\n
   ${c.magenta(`cd ${data.project}`)}
   `)
 
-  console.log(`Start the local development server with\n
+  reporter.info(`Start the local development server with\n
   ${c.magenta(`${runCommand} develop`)}
   `)
 
-  console.log(`See all commands at\n
+  reporter.info(`See all commands at\n
   ${c.blueBright(`https://www.gatsbyjs.com/docs/gatsby-cli/`)}
   `)
 

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -310,6 +310,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
   await gitSetup(data.project)
 
   const pm = await getPackageManager()
+  const runCommand = pm === `npm` ? `npm run` : `yarn`
 
   console.log(
     stripIndent`
@@ -324,7 +325,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
   `)
 
   console.log(`Start the local development server with\n
-  ${c.magenta(`${pm} start`)}
+  ${c.magenta(`${runCommand} develop`)}
   `)
 
   console.log(`See all commands at\n

--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -1,21 +1,35 @@
 import { execSync } from "child_process"
-import execa from "execa"
+import execa, { Options } from "execa"
 import fs from "fs-extra"
 import path from "path"
 import { reporter } from "./reporter"
 import { spin } from "tiny-spin"
 import { getConfigStore } from "./get-config-store"
 type PackageManager = "yarn" | "npm"
+import c from "ansi-colors"
 
-const packageMangerConfigKey = `cli.packageManager`
+const packageManagerConfigKey = `cli.packageManager`
+
+const kebabify = (str: string): string =>
+  str
+    .replace(/([a-z])([A-Z])/g, `$1-$2`)
+    .replace(/[^a-zA-Z]+/g, `-`)
+    .toLowerCase()
 
 export const getPackageManager = (): PackageManager =>
-  getConfigStore().get(packageMangerConfigKey)
+  getConfigStore().get(packageManagerConfigKey)
 
 export const setPackageManager = (packageManager: PackageManager): void => {
-  getConfigStore().set(packageMangerConfigKey, packageManager)
+  getConfigStore().set(packageManagerConfigKey, packageManager)
 }
 
+export const clearLine = (count = 1): Promise<boolean> =>
+  new Promise(resolve => {
+    process.stderr.moveCursor(0, -count, () => {
+      process.stderr.write(`\u001b[2K`)
+      resolve()
+    })
+  })
 // Checks the existence of yarn package
 // We use yarnpkg instead of yarn to avoid conflict with Hadoop yarn
 // Refer to https://github.com/yarnpkg/yarn/issues/673
@@ -31,11 +45,8 @@ const checkForYarn = (): boolean => {
 // Initialize newly cloned directory as a git repo
 const gitInit = async (
   rootPath: string
-): Promise<execa.ExecaReturnBase<string>> => {
-  reporter.info(`Initialising git in ${rootPath}`)
-
-  return await execa(`git`, [`init`], { cwd: rootPath })
-}
+): Promise<execa.ExecaReturnBase<string>> =>
+  await execa(`git`, [`init`], { cwd: rootPath })
 
 // Create a .gitignore file if it is missing in the new directory
 const maybeCreateGitIgnore = async (rootPath: string): Promise<void> => {
@@ -43,7 +54,6 @@ const maybeCreateGitIgnore = async (rootPath: string): Promise<void> => {
     return
   }
 
-  reporter.info(`Creating minimal .gitignore in ${rootPath}`)
   await fs.writeFile(
     path.join(rootPath, `.gitignore`),
     `.cache\nnode_modules\npublic\n`
@@ -52,8 +62,6 @@ const maybeCreateGitIgnore = async (rootPath: string): Promise<void> => {
 
 // Create an initial git commit in the new directory
 const createInitialGitCommit = async (rootPath: string): Promise<void> => {
-  reporter.info(`Create initial git commit in ${rootPath}`)
-
   await execa(`git`, [`add`, `-A`], { cwd: rootPath })
   // use execSync instead of spawn to handle git clients using
   // pgp signatures (with password)
@@ -68,6 +76,28 @@ const createInitialGitCommit = async (rootPath: string): Promise<void> => {
   }
 }
 
+const setNameInPackage = async (
+  sitePath: string,
+  name: string
+): Promise<void> => {
+  const packageJsonPath = path.join(sitePath, `package.json`)
+  const packageJson = await fs.readJSON(packageJsonPath)
+  packageJson.name = kebabify(name)
+  packageJson.description = `My Gatsby site`
+  try {
+    const result = await execa(`git`, [`config`, `user.name`])
+    if (result.failed) {
+      delete packageJson.author
+    } else {
+      packageJson.author = result.stdout
+    }
+  } catch (e) {
+    delete packageJson.author
+  }
+
+  await fs.writeJSON(packageJsonPath, packageJson)
+}
+
 // Executes `npm install` or `yarn install` in rootPath.
 const install = async (
   rootPath: string,
@@ -75,13 +105,11 @@ const install = async (
 ): Promise<void> => {
   const prevDir = process.cwd()
 
-  let stop = spin(`Installing packages...`)
+  reporter.info(`${c.blueBright(c.symbols.pointer)} Installing Gatsby...`)
 
   process.chdir(rootPath)
 
   const npmConfigUserAgent = process.env.npm_config_user_agent
-
-  const silent = `--silent`
 
   try {
     if (!getPackageManager()) {
@@ -93,23 +121,32 @@ const install = async (
     }
     if (getPackageManager() === `yarn` && checkForYarn()) {
       await fs.remove(`package-lock.json`)
-      const args = packages.length ? [`add`, silent, ...packages] : [silent]
+      const args = packages.length
+        ? [`add`, `--silent`, ...packages]
+        : [`--silent`]
       await execa(`yarnpkg`, args)
     } else {
       await fs.remove(`yarn.lock`)
+      const options: Options = {
+        stderr: `inherit`,
+      }
 
-      await execa(`npm`, [`install`, silent])
-      stop()
-      stop = spin(`Installing plugins...`)
-      await execa(`npm`, [`install`, silent, ...packages])
-      stop()
+      await execa(`npm`, [`install`, `--loglevel`, `error`], options)
+      await clearLine()
+      reporter.success(`Installed Gatsby`)
+      reporter.info(`${c.blueBright(c.symbols.pointer)} Installing plugins...`)
+      await execa(
+        `npm`,
+        [`install`, `--loglevel`, `error`, ...packages],
+        options
+      )
+      await clearLine()
+      reporter.success(`Installed plugins`)
     }
   } catch (e) {
     reporter.panic(e.message)
   } finally {
     process.chdir(prevDir)
-    stop()
-    reporter.success(`Installed packages`)
   }
 }
 
@@ -143,7 +180,7 @@ const clone = async (
   await fs.remove(path.join(rootPath, `.git`))
 }
 
-async function gitSetup(rootPath: string): Promise<void> {
+export async function gitSetup(rootPath: string): Promise<void> {
   await gitInit(rootPath)
   await maybeCreateGitIgnore(rootPath)
   await createInitialGitCommit(rootPath)
@@ -161,8 +198,9 @@ export async function initStarter(
 
   await clone(starter, sitePath)
 
+  await setNameInPackage(sitePath, rootPath)
+
   await install(rootPath, packages)
 
-  await gitSetup(rootPath)
   // trackCli(`NEW_PROJECT_END`);
 }

--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -124,27 +124,26 @@ const install = async (
         setPackageManager(`npm`)
       }
     }
+    const options: Options = {
+      stderr: `inherit`,
+    }
+
+    const config = [`--loglevel`, `error`, `--color`, `always`]
+
     if (getPackageManager() === `yarn` && checkForYarn()) {
       await fs.remove(`package-lock.json`)
       const args = packages.length
         ? [`add`, `--silent`, ...packages]
         : [`--silent`]
-      await execa(`yarnpkg`, args)
+      await execa(`yarnpkg`, args, options)
     } else {
       await fs.remove(`yarn.lock`)
-      const options: Options = {
-        stderr: `inherit`,
-      }
 
-      await execa(`npm`, [`install`, `--loglevel`, `error`], options)
+      await execa(`npm`, [`install`, ...config], options)
       await clearLine()
       reporter.success(`Installed Gatsby`)
       reporter.info(`${c.blueBright(c.symbols.pointer)} Installing plugins...`)
-      await execa(
-        `npm`,
-        [`install`, `--loglevel`, `error`, ...packages],
-        options
-      )
+      await execa(`npm`, [`install`, ...config, ...packages], options)
       await clearLine()
       reporter.success(`Installed plugins`)
     }

--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -23,10 +23,15 @@ export const setPackageManager = (packageManager: PackageManager): void => {
   getConfigStore().set(packageManagerConfigKey, packageManager)
 }
 
+const ESC = `\u001b`
+
 export const clearLine = (count = 1): Promise<boolean> =>
   new Promise(resolve => {
+    // First move the cursor up one line...
     process.stderr.moveCursor(0, -count, () => {
-      process.stderr.write(`\u001b[2K`)
+      // ... then clear that line. This is the ANSI escape sequence for "clear whole line"
+      // List of escape sequences: http://ascii-table.com/ansi-escape-sequences.php
+      process.stderr.write(`${ESC}[2K`)
       resolve()
     })
   })


### PR DESCRIPTION
This fixes a number of bugs, edge cases and papercuts in the `create-gatsby`/`gatsby new` process.

1. Fixes bug where git repo was left dirty, by moving the git init after the package install
2. Fixes a bug where whitespace was not trimmed from the created directory name
3. Improves feedback when installing, by not silencing the npm progress bar
4. Sets the site name in package.json [ch19597]
5. Sets the author's name in package.json if it's available from git (sorry, @laurieontech : you're not the author of every site anymore)
6. Replaces the starter's description in the package.json with a more relevant one
6. More consistency in logging output
