### PR TITLE
fix: avoid joi validation error when using reporter.panic (#28291)

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -145,7 +145,7 @@ function createJob(job, { reporter }) {
   }
 
   promise.catch(err => {
-    reporter.panic(err)
+    reporter.panic(`error converting image`, err)
   })
 
   return promise


### PR DESCRIPTION
Backporting #28291 to the 2.27 release branch

(cherry picked from commit 231cf9f8c0ad077c8c1324a5c89c791a2da775a1)