### PR TITLE
fix(gatsby-plugin-image): Correct img CSS (#28317)

### DIFF
--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -18,7 +18,7 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
       key="gatsby-image-style"
       dangerouslySetInnerHTML={generateHtml(cssNanoMacro`
   .gatsby-image-wrapper img {
-    all: initial;
+    all: inherit;
     bottom: 0;
     height: 100%;
     left: 0;


### PR DESCRIPTION
Backporting #28317 to the 2.28 release branch

(cherry picked from commit bfd86dfc5bdad881e9b4363fc00c4186e0124833)