### PR TITLE
feat(create-gatsby): Add name to site metadata

### DIFF
--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -13,6 +13,7 @@ import { center, rule, wrap } from "./components/utils"
 import { stripIndent } from "common-tags"
 import { trackCli } from "./tracking"
 import crypto from "crypto"
+import { setSiteMetadata } from "./site-metadata"
 
 const sha256 = (str: string): string =>
   crypto.createHash(`sha256`).update(str).digest(`hex`)
@@ -301,10 +302,13 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
     c.green(c.symbols.check) + ` Created site in ` + c.green(data.project)
   )
 
+  const fullPath = path.resolve(data.project)
+
   if (plugins.length) {
     console.log(c.bold(`${w(`🔌 `)}Installing plugins...`))
-    await installPlugins(plugins, pluginConfig, path.resolve(data.project), [])
+    await installPlugins(plugins, pluginConfig, fullPath, [])
   }
+  await setSiteMetadata(fullPath, `title`, data.project)
 
   const pm = await getPackageManager()
 
@@ -315,7 +319,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
     ${w(`🎉  `)}Your new Gatsby site ${c.bold(
       data.project
     )} has been successfully bootstrapped
-    at ${c.bold(path.resolve(data.project))}.
+    at ${c.bold(fullPath)}.
     `
   )
   console.log(`Start by going to the directory with\n
@@ -330,7 +334,7 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
   ${c.blueBright(`https://www.gatsbyjs.com/docs/gatsby-cli/`)}
   `)
 
-  const siteHash = md5(path.resolve(data.project))
+  const siteHash = md5(fullPath)
   trackCli(`CREATE_GATSBY_SUCCESS`, { siteHash })
 }
 

--- a/packages/create-gatsby/src/site-metadata.ts
+++ b/packages/create-gatsby/src/site-metadata.ts
@@ -1,0 +1,15 @@
+export async function setSiteMetadata(
+  root: string,
+  name: string,
+  value: string
+): Promise<void> {
+  try {
+    const recipesPath = require.resolve(`gatsby-recipes`, {
+      paths: [root],
+    })
+    const { GatsbySiteMetadata } = require(recipesPath)
+    await GatsbySiteMetadata?.create({ root }, { name, value })
+  } catch (e) {
+    // Silently fail, as it's fine if we don't add it to the config
+  }
+}


### PR DESCRIPTION
Add the created site's name to `siteMetadata`. Currently this is the folder name chosen by the user. We might want to prompt separately for the human-readable name, so this is nicer-looking.

[ch19597]