### PR TITLE
fix(gatsby-plugin-sharp): don't recreate images that already exist

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -201,7 +201,7 @@ function queueImageResizing({ file, args = {}, reporter }) {
 }
 
 function batchQueueImageResizing({ file, transforms = [], reporter }) {
-  const operations = []
+  let operations = []
   const images = []
 
   // loop through all transforms to set correct variables
@@ -220,6 +220,10 @@ function batchQueueImageResizing({ file, transforms = [], reporter }) {
       outputPath: relativePath,
       args: options,
     })
+
+    operations = operations.filter(
+      operation => !fs.existsSync(path.join(outputDir, operation.outputPath))
+    )
 
     // create output results
     images.push({

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -221,6 +221,7 @@ function batchQueueImageResizing({ file, transforms = [], reporter }) {
       args: options,
     })
 
+    // Filter out operations if the output file already exists.
     operations = operations.filter(
       operation => !fs.existsSync(path.join(outputDir, operation.outputPath))
     )

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -226,6 +226,11 @@ const compressJpg = (pipeline, outputPath, options) =>
   )
 
 exports.createArgsDigest = args => {
+  // Add constant to args that we can change if we need a way to forcibly clear
+  // everyone's sharp cache.
+  const CACHE_VERSION = 1
+  args.CACHE_VERSION = CACHE_VERSION
+
   const argsDigest = createContentDigest(args)
 
   return argsDigest.substr(argsDigest.length - 5)

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -225,11 +225,6 @@ const compressJpg = (pipeline, outputPath, options) =>
   )
 
 exports.createArgsDigest = args => {
-  // Add constant to args that we can change if we need a way to forcibly clear
-  // everyone's sharp cache.
-  const CACHE_VERSION = 1
-  args.CACHE_VERSION = CACHE_VERSION
-
   const argsDigest = createContentDigest(args)
 
   return argsDigest.substr(argsDigest.length - 5)

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -48,7 +48,7 @@ sharp.concurrency(cpuCoreCount())
  * @property {import('sharp').FitEnum} fit
  */
 
-/** +
+/**
  * @typedef {Object} Transform
  * @property {string} outputPath
  * @property {TransformArgs} args

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -48,7 +48,7 @@ sharp.concurrency(cpuCoreCount())
  * @property {import('sharp').FitEnum} fit
  */
 
-/**+
+/** +
  * @typedef {Object} Transform
  * @property {string} outputPath
  * @property {TransformArgs} args
@@ -76,6 +76,13 @@ exports.processFile = (file, transforms, options = {}) => {
   return transforms.map(async transform => {
     try {
       const { outputPath, args } = transform
+
+      // If the outputPath already exists, we created the file at some
+      // point in the past so let's just return.
+      if (fs.existsSync(outputPath)) {
+        return transform
+      }
+
       debug(`Start processing ${outputPath}`)
       await fs.ensureDir(path.dirname(outputPath))
 

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -76,7 +76,6 @@ exports.processFile = (file, transforms, options = {}) => {
   return transforms.map(async transform => {
     try {
       const { outputPath, args } = transform
-
       debug(`Start processing ${outputPath}`)
       await fs.ensureDir(path.dirname(outputPath))
 

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -77,12 +77,6 @@ exports.processFile = (file, transforms, options = {}) => {
     try {
       const { outputPath, args } = transform
 
-      // If the outputPath already exists, we created the file at some
-      // point in the past so let's just return.
-      if (fs.existsSync(outputPath)) {
-        return transform
-      }
-
       debug(`Start processing ${outputPath}`)
       await fs.ensureDir(path.dirname(outputPath))
 


### PR DESCRIPTION
We clear the .cache folder when gatsby-node.js / gatsby-config.js etc change but not the public folder. So during development esp, we should leverage that to speed up image processing.