### PR TITLE
fix(gatsby): re-render route when location state changes

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -173,7 +173,7 @@ describe(`navigation`, () => {
       it(`should trigger an effect after the state has changed`, () => {
         cy.findByTestId(`effect-message`).should(`have.text`, ``)
         cy.findByTestId(`send-state-message`).click().waitForRouteChange()
-        cy.findByTestId(`effect-message`).should(`have.text`, `state message`)
+        cy.findByTestId(`effect-message`).should(`have.text`, `this is a message using the state`)
       })
     })
   }
@@ -203,7 +203,7 @@ describe(`navigation`, () => {
       it(`should trigger an effect after the state has changed`, () => {
         cy.findByTestId(`effect-message`).should(`have.text`, ``)
         cy.findByTestId(`send-state-message`).click().waitForRouteChange()
-        cy.findByTestId(`effect-message`).should(`have.text`, `state message`)
+        cy.findByTestId(`effect-message`).should(`have.text`, `this is a message using the state`)
       })
     })
   }

--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -150,15 +150,30 @@ describe(`navigation`, () => {
       })
 
       it(`should trigger an effect after a search param has changed`, () => {
-        cy.findByTestId(`effect-message`).should(`have.text`, `Waiting for effect`)
+        cy.findByTestId(`effect-message`).should(
+          `have.text`,
+          `Waiting for effect`
+        )
         cy.findByTestId(`send-search-message`).click().waitForRouteChange()
-        cy.findByTestId(`effect-message`).should(`have.text`, `?message=searchParam`)
+        cy.findByTestId(`effect-message`).should(
+          `have.text`,
+          `?message=searchParam`
+        )
       })
 
       it(`should trigger an effect after the hash has changed`, () => {
-        cy.findByTestId(`effect-message`).should(`have.text`, `Waiting for effect`)
+        cy.findByTestId(`effect-message`).should(
+          `have.text`,
+          `Waiting for effect`
+        )
         cy.findByTestId(`send-hash-message`).click().waitForRouteChange()
         cy.findByTestId(`effect-message`).should(`have.text`, `#message-hash`)
+      })
+
+      it(`should trigger an effect after the state has changed`, () => {
+        cy.findByTestId(`effect-message`).should(`have.text`, ``)
+        cy.findByTestId(`send-state-message`).click().waitForRouteChange()
+        cy.findByTestId(`effect-message`).should(`have.text`, `state message`)
       })
     })
   }
@@ -173,13 +188,22 @@ describe(`navigation`, () => {
       it(`should trigger an effect after a search param has changed`, () => {
         cy.findByTestId(`effect-message`).should(`have.text`, ``)
         cy.findByTestId(`send-search-message`).click().waitForRouteChange()
-        cy.findByTestId(`effect-message`).should(`have.text`, `?message=searchParam`)
+        cy.findByTestId(`effect-message`).should(
+          `have.text`,
+          `?message=searchParam`
+        )
       })
 
       it(`should trigger an effect after the hash has changed`, () => {
         cy.findByTestId(`effect-message`).should(`have.text`, ``)
         cy.findByTestId(`send-hash-message`).click().waitForRouteChange()
         cy.findByTestId(`effect-message`).should(`have.text`, `#message-hash`)
+      })
+
+      it(`should trigger an effect after the state has changed`, () => {
+        cy.findByTestId(`effect-message`).should(`have.text`, ``)
+        cy.findByTestId(`send-state-message`).click().waitForRouteChange()
+        cy.findByTestId(`effect-message`).should(`have.text`, `state message`)
       })
     })
   }

--- a/e2e-tests/development-runtime/src/pages/navigation-effects.js
+++ b/e2e-tests/development-runtime/src/pages/navigation-effects.js
@@ -8,6 +8,7 @@ export default function NavigationEffects({ location }) {
 
   const searchParam = location.search
   const searchHash = location.hash
+  const searchState = location?.state?.message
 
   useEffect(() => {
     setMessage(searchParam)
@@ -17,7 +18,12 @@ export default function NavigationEffects({ location }) {
     setMessage(searchHash)
   }, [searchHash])
 
-  const handleClick = next => navigate(`${next}`, { replace: true })
+  useEffect(() => {
+    setMessage(searchState)
+  }, [searchState])
+
+  const handleClick = (next, options = { replace: true }) =>
+    navigate(`${next}`, options)
 
   return (
     <Layout>
@@ -34,6 +40,17 @@ export default function NavigationEffects({ location }) {
         onClick={() => handleClick("#message-hash")}
       >
         Send Hash
+      </button>
+
+      <button
+        data-testid="send-state-message"
+        onClick={() =>
+          handleClick("/navigation-effects", {
+            state: { message: "state message" },
+          })
+        }
+      >
+        Send state
       </button>
     </Layout>
   )

--- a/e2e-tests/development-runtime/src/pages/navigation-effects.js
+++ b/e2e-tests/development-runtime/src/pages/navigation-effects.js
@@ -46,7 +46,7 @@ export default function NavigationEffects({ location }) {
         data-testid="send-state-message"
         onClick={() =>
           handleClick("/navigation-effects", {
-            state: { message: "state message" },
+            state: { message: "this is a message using the state" },
           })
         }
       >

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -200,18 +200,7 @@ const compareLocationProps = (prevLocation, nextLocation) => {
     return true
   }
 
-  if (
-    (prevLocation.state === null && nextLocation.state !== null) ||
-    (prevLocation.state !== null && nextLocation.state === null)
-  ) {
-    return true
-  }
-
-  if (
-    prevLocation.state !== null &&
-    nextLocation.state !== null &&
-    prevLocation.state.key !== nextLocation.state.key
-  ) {
+  if (prevLocation?.state?.key !== nextLocation?.state?.key) {
     return true
   }
 

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -195,6 +195,29 @@ class RouteAnnouncer extends React.Component {
   }
 }
 
+const compareLocationProps = (prevLocation, nextLocation) => {
+  if (prevLocation.href !== nextLocation.href) {
+    return true
+  }
+
+  if (
+    (prevLocation.state === null && nextLocation.state !== null) ||
+    (prevLocation.state !== null && nextLocation.state === null)
+  ) {
+    return true
+  }
+
+  if (
+    prevLocation.state !== null &&
+    nextLocation.state !== null &&
+    prevLocation.state.key !== nextLocation.state.key
+  ) {
+    return true
+  }
+
+  return false
+}
+
 // Fire on(Pre)RouteUpdate APIs
 class RouteUpdates extends React.Component {
   constructor(props) {
@@ -207,16 +230,15 @@ class RouteUpdates extends React.Component {
   }
 
   shouldComponentUpdate(prevProps) {
-    if (this.props.location.href !== prevProps.location.href) {
+    if (compareLocationProps(prevProps.location, this.props.location)) {
       onPreRouteUpdate(this.props.location, prevProps.location)
       return true
     }
-
     return false
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.href !== prevProps.location.href) {
+    if (compareLocationProps(prevProps.location, this.props.location)) {
       onRouteUpdate(this.props.location, prevProps.location)
     }
   }


### PR DESCRIPTION
## Description

Fix for issue: [Using navigate() function with a state change doesn't re-render the page #27617](https://github.com/gatsbyjs/gatsby/issues/27617)

Currently we are comparing location props in the `RouteUpdates` component to see if it needs to be updated, however because we are comparing props we need to also check if the location state has been changed as well.

We can do this by:
1. Checking if it is equal to null or not
2. Checking if the state `key` property has changed between the previous and next set of props.

The `key` prop is always added to each route state update via `@reach/router` [here](https://github.com/reach/router/blob/master/src/lib/history.js#L79).

**This seems to be part of a bigger issue where in an ideal world we should probably just leave these comparisons to the router lib, but changing it now may introduce bugs and would probably fall under another issue/ticket.**

If others agree and an issue is created for it, I will happily take a look into it.

#### E2E tests added

## Related Issues

Fixes [#27617](https://github.com/gatsbyjs/gatsby/issues/27617)
