### PR TITLE
chore: add cypress dashboard config to e2e dev runtime for fast refresh variant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,8 @@ jobs:
     environment:
       GATSBY_HOT_LOADER: fast-refresh
       CYPRESS_HOT_LOADER: fast-refresh
+      CYPRESS_PROJECT_ID: 917bea
+      CYPRESS_RECORD_KEY: 4750fb36-4576-4638-a617-d243a381acef
 
   e2e_tests_development_runtime_with_experimental_react:
     <<: *e2e_tests_development_runtime_alias


### PR DESCRIPTION
Similar to https://github.com/gatsbyjs/gatsby/pull/28169 this just adds needed env var keys to be able to upload cypress run results to cypress dashboard for fast refresh variant of our e2e dev runtime tests