### PR TITLE
fix(develop): emit stale page data messages when staticQueryHashes change

### DIFF
--- a/e2e-tests/development-runtime/content/query-data-caches/adding-static-query-A-to-B-to-A-link.json
+++ b/e2e-tests/development-runtime/content/query-data-caches/adding-static-query-A-to-B-to-A-link.json
@@ -1,0 +1,4 @@
+{
+  "selector": "adding-static-query-A-to-B-to-A-link",
+  "status": "from-static-query-results"
+}

--- a/e2e-tests/development-runtime/cypress/integration/functionality/query-data-caches.js
+++ b/e2e-tests/development-runtime/cypress/integration/functionality/query-data-caches.js
@@ -87,19 +87,24 @@ function pageTitleAndDataAssertion(config) {
     cy.findByText(`Preview custom 404 page`).click()
   }
 
-  cy.findByTestId(`${config.prefix || ``}page-path`)
-    .should(`have.text`, getExpectedCanonicalPath(config))
+  cy.findByTestId(`${config.prefix || ``}page-path`).should(
+    `have.text`,
+    getExpectedCanonicalPath(config)
+  )
 
-  cy.findByTestId(`${config.prefix || ``}query-data-caches-page-title`)
-    .should(`have.text`, `This is page ${config.page}`)
+  cy.findByTestId(`${config.prefix || ``}query-data-caches-page-title`).should(
+    `have.text`,
+    `This is page ${config.page}`
+  )
 
-  cy.findByTestId(`${config.prefix || ``}${config.queryType}-query-result`)
-    .should(
-      `have.text`,
-      `${config.slug} / ${
-        config.page === config.initialPage ? `initial-page` : `second-page`
-      }: ${config.data}`
-    )
+  cy.findByTestId(
+    `${config.prefix || ``}${config.queryType}-query-result`
+  ).should(
+    `have.text`,
+    `${config.slug} / ${
+      config.page === config.initialPage ? `initial-page` : `second-page`
+    }: ${config.data}`
+  )
 }
 
 function runTests(config) {
@@ -145,204 +150,267 @@ function runTests(config) {
   assertNotReloading()
 }
 
-describe(`Navigate from static page A to page B, invalidate some data resources for static page A, navigate back to static page A`, () => {
-  describe(`Navigating back with gatsby-link`, () => {
-    it(`page query (page has trailing slash)`, () => {
-      const config = {
-        slug: `page-query-with-trailing-slash-A-to-B-to-A-link`,
-        queryType: `page`,
-        navigateBack: `link`,
-        initialPage: `A`,
-      }
+describe(`Keeping caches up-to-date when updating data`, () => {
+  describe(`Navigate from static page A to page B, invalidate some data resources for static page A, navigate back to static page A`, () => {
+    describe(`Navigating back with gatsby-link`, () => {
+      it(`page query (page has trailing slash)`, () => {
+        const config = {
+          slug: `page-query-with-trailing-slash-A-to-B-to-A-link`,
+          queryType: `page`,
+          navigateBack: `link`,
+          initialPage: `A`,
+        }
 
-      runTests(config)
+        runTests(config)
+      })
+
+      it(`page query (page doesn't have trailing slash)`, () => {
+        const config = {
+          slug: `page-query-no-trailing-slash-A-to-B-to-A-link`,
+          trailingSlash: false,
+          queryType: `page`,
+          navigateBack: `link`,
+          initialPage: `A`,
+        }
+
+        runTests(config)
+      })
+
+      it(`static query (page has trailing slash)`, () => {
+        const config = {
+          slug: `static-query-with-trailing-slash-A-to-B-to-A-link`,
+          queryType: `static`,
+          navigateBack: `link`,
+          initialPage: `A`,
+        }
+
+        runTests(config)
+      })
+
+      it(`static query (page doesn't have trailing slash)`, () => {
+        const config = {
+          slug: `static-query-no-trailing-slash-A-to-B-to-A-link`,
+          trailingSlash: false,
+          queryType: `static`,
+          navigateBack: `link`,
+          initialPage: `A`,
+        }
+
+        runTests(config)
+      })
     })
 
-    it(`page query (page doesn't have trailing slash)`, () => {
-      const config = {
-        slug: `page-query-no-trailing-slash-A-to-B-to-A-link`,
-        trailingSlash: false,
-        queryType: `page`,
-        navigateBack: `link`,
-        initialPage: `A`,
-      }
+    describe(`Navigating back with history.back()`, () => {
+      it(`page query (page has trailing slash)`, () => {
+        const config = {
+          slug: `page-query-with-trailing-slash-A-to-B-to-A-history`,
+          queryType: `page`,
+          navigateBack: `history`,
+          initialPage: `A`,
+        }
 
-      runTests(config)
-    })
+        runTests(config)
+      })
 
-    it(`static query (page has trailing slash)`, () => {
-      const config = {
-        slug: `static-query-with-trailing-slash-A-to-B-to-A-link`,
-        queryType: `static`,
-        navigateBack: `link`,
-        initialPage: `A`,
-      }
+      it(`page query (page doesn't have trailing slash)`, () => {
+        const config = {
+          slug: `page-query-no-trailing-slash-A-to-B-to-A-history`,
+          trailingSlash: false,
+          queryType: `page`,
+          navigateBack: `history`,
+          initialPage: `A`,
+        }
 
-      runTests(config)
-    })
+        runTests(config)
+      })
 
-    it(`static query (page doesn't have trailing slash)`, () => {
-      const config = {
-        slug: `static-query-no-trailing-slash-A-to-B-to-A-link`,
-        trailingSlash: false,
-        queryType: `static`,
-        navigateBack: `link`,
-        initialPage: `A`,
-      }
+      it(`static query (page has trailing slash)`, () => {
+        const config = {
+          slug: `static-query-with-trailing-slash-A-to-B-to-A-history`,
+          queryType: `static`,
+          navigateBack: `history`,
+          initialPage: `A`,
+        }
 
-      runTests(config)
+        runTests(config)
+      })
+
+      it(`static query (page doesn't have trailing slash)`, () => {
+        const config = {
+          slug: `static-query-no-trailing-slash-A-to-B-to-A-history`,
+          trailingSlash: false,
+          queryType: `static`,
+          navigateBack: `history`,
+          initialPage: `A`,
+        }
+
+        runTests(config)
+      })
     })
   })
 
-  describe(`Navigating back with history.back()`, () => {
-    it(`page query (page has trailing slash)`, () => {
-      const config = {
-        slug: `page-query-with-trailing-slash-A-to-B-to-A-history`,
-        queryType: `page`,
-        navigateBack: `history`,
-        initialPage: `A`,
-      }
+  describe(`Navigate from client-only page A to page B, invalidate some data resources for client-only page A, navigate back to client-only page A`, () => {
+    describe(`Navigating back with gatsby-link`, () => {
+      it(`page query`, () => {
+        const config = {
+          slug: `page-query-CO-to-B-to-CO-link`,
+          queryType: `page`,
+          navigateBack: `link`,
+          initialPage: `client-only`,
+        }
 
-      runTests(config)
+        runTests(config)
+      })
+
+      it(`static query`, () => {
+        const config = {
+          slug: `static-query-CO-to-B-to-CO-link`,
+          queryType: `static`,
+          navigateBack: `link`,
+          initialPage: `client-only`,
+        }
+
+        runTests(config)
+      })
     })
 
-    it(`page query (page doesn't have trailing slash)`, () => {
-      const config = {
-        slug: `page-query-no-trailing-slash-A-to-B-to-A-history`,
-        trailingSlash: false,
-        queryType: `page`,
-        navigateBack: `history`,
-        initialPage: `A`,
-      }
+    describe(`Navigating back with history.back()`, () => {
+      it(`page query`, () => {
+        const config = {
+          slug: `page-query-CO-to-B-to-CO-history`,
+          queryType: `page`,
+          navigateBack: `history`,
+          initialPage: `client-only`,
+        }
 
-      runTests(config)
+        runTests(config)
+      })
+
+      it(`static query`, () => {
+        const config = {
+          slug: `static-query-CO-to-B-to-CO-history`,
+          queryType: `static`,
+          navigateBack: `history`,
+          initialPage: `client-only`,
+        }
+
+        runTests(config)
+      })
+    })
+  })
+
+  describe(`Navigate from 404 page A to page B, invalidate some data resources for 404 page A, navigate back to 404 page A`, () => {
+    describe(`Navigating back with gatsby-link`, () => {
+      it(`page query`, () => {
+        const config = {
+          slug: `page-query-404-to-B-to-404-link`,
+          queryType: `page`,
+          navigateBack: `link`,
+          initialPage: `404`,
+          prefix: `page-link-`,
+        }
+
+        runTests(config)
+      })
+
+      it(`static query`, () => {
+        const config = {
+          slug: `static-query-404-to-B-to-404-link`,
+          queryType: `static`,
+          navigateBack: `link`,
+          initialPage: `404`,
+          prefix: `static-link-`,
+        }
+
+        runTests(config)
+      })
     })
 
-    it(`static query (page has trailing slash)`, () => {
-      const config = {
-        slug: `static-query-with-trailing-slash-A-to-B-to-A-history`,
-        queryType: `static`,
-        navigateBack: `history`,
-        initialPage: `A`,
-      }
+    describe(`Navigating back with history.back()`, () => {
+      it(`page query`, () => {
+        const config = {
+          slug: `page-query-404-to-B-to-404-history`,
+          queryType: `page`,
+          navigateBack: `history`,
+          initialPage: `404`,
+          prefix: `page-history-`,
+        }
 
-      runTests(config)
-    })
+        runTests(config)
+      })
 
-    it(`static query (page doesn't have trailing slash)`, () => {
-      const config = {
-        slug: `static-query-no-trailing-slash-A-to-B-to-A-history`,
-        trailingSlash: false,
-        queryType: `static`,
-        navigateBack: `history`,
-        initialPage: `A`,
-      }
+      it(`static query`, () => {
+        const config = {
+          slug: `static-query-404-to-B-to-404-history`,
+          queryType: `static`,
+          navigateBack: `history`,
+          initialPage: `404`,
+          prefix: `static-history-`,
+        }
 
-      runTests(config)
+        runTests(config)
+      })
     })
   })
 })
 
-describe(`Navigate from client-only page A to page B, invalidate some data resources for client-only page A, navigate back to client-only page A`, () => {
-  describe(`Navigating back with gatsby-link`, () => {
-    it(`page query`, () => {
+describe(`Keeping caches up to date when modifying list of static query hashes assigned to a template`, () => {
+  describe(`using gatsby-link`, () => {
+    it.only(`Navigate from page A to page B, add static query to page A, navigate back to page A`, () => {
       const config = {
-        slug: `page-query-CO-to-B-to-CO-link`,
-        queryType: `page`,
-        navigateBack: `link`,
-        initialPage: `client-only`,
-      }
-
-      runTests(config)
-    })
-
-    it(`static query`, () => {
-      const config = {
-        slug: `static-query-CO-to-B-to-CO-link`,
+        slug: `adding-static-query-A-to-B-to-A-link`,
         queryType: `static`,
         navigateBack: `link`,
-        initialPage: `client-only`,
+        initialPage: `A`,
       }
 
-      runTests(config)
-    })
-  })
+      cy.visit(`/query-data-caches/${config.slug}/page-A/`).waitForRouteChange()
 
-  describe(`Navigating back with history.back()`, () => {
-    it(`page query`, () => {
-      const config = {
-        slug: `page-query-CO-to-B-to-CO-history`,
-        queryType: `page`,
-        navigateBack: `history`,
-        initialPage: `client-only`,
+      setupForAssertingNotReloading()
+
+      // baseline assertions
+      pageTitleAndDataAssertion({
+        ...config,
+        page: config.initialPage,
+        data: `from-hardcoded-data`,
+      })
+
+      cy.getTestElement(`page-b-link`).click().waitForRouteChange()
+
+      // assert we navigated
+      pageTitleAndDataAssertion({
+        ...config,
+        page: `B`,
+        data: `from-static-query-results`,
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/query-data-caches/${config.slug}/page-A.js --replacements "adding-static-query-blank:adding-static-query-with-data" --exact`
+      )
+
+      // TODO: get rid of this wait
+      // We currently have timing issue when emitting both webpack's HMR and page-data.
+      // Problem is we need to potentially wait for webpack recompilation before we emit page-data (due to dependency graph traversal).
+      // Even if we could delay emitting data on the "server" side - this doesn't guarantee that messages are received
+      // and handled in correct order (ideally they are applied at the exact same time actually, because ordering might still cause issues if we change query text and component render function)
+      cy.wait(10000)
+
+      if (config.navigateBack === `link`) {
+        cy.getTestElement(`page-a-link`).click().waitForRouteChange()
+      } else if (config.navigateBack === `history`) {
+        // this is just making sure page components don't have link to navigate back (asserting correct setup)
+        cy.getTestElement(`page-a-link`).should(`not.exist`)
+        cy.go(`back`).waitForRouteChange()
       }
 
-      runTests(config)
-    })
+      // assert data on page we previously visited is updated
+      pageTitleAndDataAssertion({
+        ...config,
+        page: config.initialPage,
+        data: `from-static-query-results`,
+      })
 
-    it(`static query`, () => {
-      const config = {
-        slug: `static-query-CO-to-B-to-CO-history`,
-        queryType: `static`,
-        navigateBack: `history`,
-        initialPage: `client-only`,
-      }
-
-      runTests(config)
-    })
-  })
-})
-
-describe(`Navigate from 404 page A to page B, invalidate some data resources for 404 page A, navigate back to 404 page A`, () => {
-  describe(`Navigating back with gatsby-link`, () => {
-    it(`page query`, () => {
-      const config = {
-        slug: `page-query-404-to-B-to-404-link`,
-        queryType: `page`,
-        navigateBack: `link`,
-        initialPage: `404`,
-        prefix: `page-link-`,
-      }
-
-      runTests(config)
-    })
-
-    it(`static query`, () => {
-      const config = {
-        slug: `static-query-404-to-B-to-404-link`,
-        queryType: `static`,
-        navigateBack: `link`,
-        initialPage: `404`,
-        prefix: `static-link-`,
-      }
-
-      runTests(config)
-    })
-  })
-
-  describe(`Navigating back with history.back()`, () => {
-    it(`page query`, () => {
-      const config = {
-        slug: `page-query-404-to-B-to-404-history`,
-        queryType: `page`,
-        navigateBack: `history`,
-        initialPage: `404`,
-        prefix: `page-history-`,
-      }
-
-      runTests(config)
-    })
-
-    it(`static query`, () => {
-      const config = {
-        slug: `static-query-404-to-B-to-404-history`,
-        queryType: `static`,
-        navigateBack: `history`,
-        initialPage: `404`,
-        prefix: `static-history-`,
-      }
-
-      runTests(config)
+      assertNotReloading()
     })
   })
 })

--- a/e2e-tests/development-runtime/src/components/query-data-caches/adding-static-query-blank.js
+++ b/e2e-tests/development-runtime/src/components/query-data-caches/adding-static-query-blank.js
@@ -1,0 +1,9 @@
+export function useDataForAddingStaticQueryTest() {
+  return {
+    queryDataCachesJson: {
+      selector: `adding-static-query-A-to-B-to-A-link`,
+      status: `from-hardcoded-data`,
+      initialOrSecond: `initial-page`,
+    },
+  }
+}

--- a/e2e-tests/development-runtime/src/components/query-data-caches/adding-static-query-with-data.js
+++ b/e2e-tests/development-runtime/src/components/query-data-caches/adding-static-query-with-data.js
@@ -1,0 +1,13 @@
+import { graphql, useStaticQuery } from "gatsby"
+
+export function useDataForAddingStaticQueryTest() {
+  return useStaticQuery(graphql`
+    {
+      queryDataCachesJson(
+        selector: { eq: "adding-static-query-A-to-B-to-A-link" }
+      ) {
+        ...QueryDataCachesFragmentInitialPage
+      }
+    }
+  `)
+}

--- a/e2e-tests/development-runtime/src/pages/query-data-caches/adding-static-query-A-to-B-to-A-link/page-A.js
+++ b/e2e-tests/development-runtime/src/pages/query-data-caches/adding-static-query-A-to-B-to-A-link/page-A.js
@@ -1,0 +1,21 @@
+import React from "react"
+import { Link } from "gatsby"
+import { QueryDataCachesView } from "../../../components/query-data-caches/view"
+import { useDataForAddingStaticQueryTest } from "../../../components/query-data-caches/adding-static-query-blank"
+
+export default function AddingStaticQueryToPageTemplatePageA({ path }) {
+  const data = useDataForAddingStaticQueryTest()
+  return (
+    <>
+      <QueryDataCachesView
+        data={data}
+        pageType="A"
+        dataType="static-query"
+        path={path}
+      />
+      <Link to="../page-B" data-testid="page-b-link">
+        Go to page B
+      </Link>
+    </>
+  )
+}

--- a/e2e-tests/development-runtime/src/pages/query-data-caches/adding-static-query-A-to-B-to-A-link/page-B.js
+++ b/e2e-tests/development-runtime/src/pages/query-data-caches/adding-static-query-A-to-B-to-A-link/page-B.js
@@ -1,0 +1,28 @@
+import React from "react"
+import { Link, graphql, useStaticQuery } from "gatsby"
+import { QueryDataCachesView } from "../../../components/query-data-caches/view"
+
+export default function AddingStaticQueryToPageTemplatePageB({ path }) {
+  const data = useStaticQuery(graphql`
+    {
+      queryDataCachesJson(
+        selector: { eq: "adding-static-query-A-to-B-to-A-link" }
+      ) {
+        ...QueryDataCachesFragmentSecondPage
+      }
+    }
+  `)
+  return (
+    <>
+      <QueryDataCachesView
+        data={data}
+        pageType="B"
+        dataType="static-query"
+        path={path}
+      />
+      <Link to="../page-A" data-testid="page-a-link">
+        Go back to page A
+      </Link>
+    </>
+  )
+}

--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -38,8 +38,8 @@ class DevLoader extends BaseLoader {
           this.handleStaticQueryResultHotUpdate(msg)
         } else if (msg.type === `pageQueryResult`) {
           this.handlePageQueryResultHotUpdate(msg)
-        } else if (msg.type === `dirtyQueries`) {
-          this.handleDirtyPageQueryMessage(msg)
+        } else if (msg.type === `stalePageData`) {
+          this.handleStalePageDataMessage(msg)
         }
       })
     } else if (process.env.NODE_ENV !== `test`) {
@@ -103,6 +103,8 @@ class DevLoader extends BaseLoader {
     const cachedPageData = this.pageDataDb.get(pageDataDbCacheKey)?.payload
 
     if (!isEqual(newPageData, cachedPageData)) {
+      // TODO: if this is update for current page and there are any new static queries added
+      // that are not yet cached, there is currently no trigger to fetch them (yikes)
       // always update canonical key for pageDataDb
       this.pageDataDb.set(pageDataDbCacheKey, {
         pagePath: pageDataDbCacheKey,
@@ -146,8 +148,8 @@ class DevLoader extends BaseLoader {
     }
   }
 
-  handleDirtyPageQueryMessage(msg) {
-    msg.payload.dirtyQueries.forEach(dirtyQueryId => {
+  handleStalePageDataMessage(msg) {
+    msg.payload.stalePageDataPaths.forEach(dirtyQueryId => {
       if (dirtyQueryId === `/dev-404-page/` || dirtyQueryId === `/404.html`) {
         // those pages are not on demand so skipping
         return

--- a/packages/gatsby/cache-dir/ensure-resources.js
+++ b/packages/gatsby/cache-dir/ensure-resources.js
@@ -48,7 +48,7 @@ class EnsureResources extends React.Component {
     }
 
     if (
-      process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+      process.env.BUILD_STAGE === `develop` &&
       nextState.pageResources.stale
     ) {
       this.loadResources(nextProps.location.pathname)

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -191,7 +191,7 @@ export class BaseLoader {
     const pagePath = findPath(rawPath)
     if (this.pageDataDb.has(pagePath)) {
       const pageData = this.pageDataDb.get(pagePath)
-      if (!process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND || !pageData.stale) {
+      if (process.env.BUILD_STAGE !== `develop` || !pageData.stale) {
         return Promise.resolve(pageData)
       }
     }
@@ -212,10 +212,7 @@ export class BaseLoader {
     const pagePath = findPath(rawPath)
     if (this.pageDb.has(pagePath)) {
       const page = this.pageDb.get(pagePath)
-      if (
-        !process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND ||
-        !page.payload.stale
-      ) {
+      if (process.env.BUILD_STAGE !== `develop` || !page.payload.stale) {
         return Promise.resolve(page.payload)
       }
     }


### PR DESCRIPTION
## Description

Currently we don't reprocess page-data's `staticQueryHashes` array in develop when those change, which means if we have cached page-data we will not handle fetching any additions to that array. If the new static queries are not cached already this results in "Cannot fetch static query result", which can be fixed by refresh (but is bad experience of course).

This will mark cached pageData entries as stale which will cause dev runtime to refetch it next time `loadPage` is called instead of using (now stale) cached result and run all the regular processing (which will fetch static queries that are not fetched/cached yet).

This is not complete fix however. It doesn't exactly fix the problem when `staticQueryHashes` changed for a page user currently view in the browser ( note TODO comments I added in added e2e test scenario and dev-loader ), but it handles at least some cases.

Note - I initially thought this is query on demand specific problem, but it's not - it's generic problem (so changes in loader.js to refetch stale data had to be expanded to `gatsby develop` when not using query on demand)

The e2e test file changes are best checked with "Hide whitespace changes" ( https://github.com/gatsbyjs/gatsby/pull/28349/files?w=1 ) because I just did wrap existing test with additional `cy.describe` to mark that those are due to data updates and new block cover case of adding static query to `page-data` (which originates from source code changes and not data changes) 