### PR TITLE
fix(gatsby): invalidate queries if page context changes between runs

### DIFF
--- a/packages/gatsby/src/query/__tests__/data-tracking.js
+++ b/packages/gatsby/src/query/__tests__/data-tracking.js
@@ -186,8 +186,9 @@ const setup = async ({ restart = isFirstRun, clearCache = false } = {}) => {
 
   if (restart) {
     await require(`../../schema`).build({})
-    await apiRunner(`createPages`)
   }
+
+  await apiRunner(`createPages`)
 
   Object.entries(pageQueries).forEach(([componentPath, query]) => {
     store.dispatch({
@@ -806,7 +807,7 @@ describe(`query caching between builds`, () => {
     }, 99999)
   })
 
-  describe.skip(`Changing page context invalidates page queries`, () => {
+  describe(`Changing page context invalidates page queries`, () => {
     beforeAll(() => {
       let pageChangeCounter = 1
       let nodeChangeCounter = 1

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -48,6 +48,9 @@ Object {
       },
     },
   },
+  "pageContextHashes": Map {
+    "/my-sweet-new-page/" => "4cf9cfa61c013b4697445e9bb48dd436",
+  },
   "pageData": Map {},
   "pageDataStats": Map {},
   "pendingPageDataWrites": Object {

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/pages.ts.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/pages.ts.snap
@@ -77,6 +77,7 @@ Map {
 exports[`Add pages allows you to add pages 1`] = `
 Object {
   "contextModified": false,
+  "pageContextHash": "99914b932bd37a50b983c5e7c90ae93b",
   "payload": Object {
     "component": "/whatever/index.js",
     "componentChunkName": "component---whatever-index-js",
@@ -117,6 +118,7 @@ Map {
 exports[`Add pages allows you to add pages with context 1`] = `
 Object {
   "contextModified": false,
+  "pageContextHash": "426ef2719c86cbc77ce9d399793dd8d4",
   "payload": Object {
     "component": "/whatever/index.js",
     "componentChunkName": "component---whatever-index-js",
@@ -161,6 +163,7 @@ Map {
 exports[`Add pages allows you to add pages with matchPath 1`] = `
 Object {
   "contextModified": false,
+  "pageContextHash": "99914b932bd37a50b983c5e7c90ae93b",
   "payload": Object {
     "component": "/whatever/index.js",
     "componentChunkName": "component---whatever-index-js",

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -100,6 +100,7 @@ export const saveState = (): void => {
     pendingPageDataWrites: state.pendingPageDataWrites,
     staticQueriesByTemplate: state.staticQueriesByTemplate,
     queries: state.queries,
+    pageContextHashes: state.pageContextHashes,
   })
 }
 

--- a/packages/gatsby/src/redux/reducers/index.ts
+++ b/packages/gatsby/src/redux/reducers/index.ts
@@ -28,6 +28,7 @@ import { inferenceMetadataReducer } from "./inference-metadata"
 import { staticQueriesByTemplateReducer } from "./static-queries-by-template"
 import { queriesReducer } from "./queries"
 import { visitedPagesReducer } from "./visited-page"
+import { pageContextHashesReducer } from "./page-context-hashes"
 
 /**
  * @property exports.nodesTouched Set<string>
@@ -63,4 +64,5 @@ export {
   pendingPageDataWritesReducer as pendingPageDataWrites,
   staticQueriesByTemplateReducer as staticQueriesByTemplate,
   queriesReducer as queries,
+  pageContextHashesReducer as pageContextHashes,
 }

--- a/packages/gatsby/src/redux/reducers/page-context-hashes.ts
+++ b/packages/gatsby/src/redux/reducers/page-context-hashes.ts
@@ -1,0 +1,31 @@
+import {
+  IGatsbyState,
+  IDeleteCacheAction,
+  ICreatePageAction,
+  IDeletePageAction,
+} from "../types"
+
+export const pageContextHashesReducer = (
+  state: IGatsbyState["pageContextHashes"] = new Map<string, string>(),
+  action: IDeleteCacheAction | ICreatePageAction | IDeletePageAction
+): IGatsbyState["pageContextHashes"] => {
+  switch (action.type) {
+    case `DELETE_CACHE`:
+      return new Map()
+
+    case `CREATE_PAGE`: {
+      // Add page to the state with the path as key
+      state.set(action.payload.path, action.pageContextHash)
+      return state
+    }
+
+    case `DELETE_PAGE`: {
+      state.delete(action.payload.path)
+
+      return state
+    }
+
+    default:
+      return state
+  }
+}

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -277,6 +277,7 @@ export interface IGatsbyState {
   pageDataStats: Map<SystemPath, number>
   pageData: Map<Identifier, string>
   visitedPages: Map<string, Set<string>>
+  pageContextHashes: Map<string, string>
 }
 
 export interface ICachedReduxState {
@@ -291,6 +292,7 @@ export interface ICachedReduxState {
   staticQueriesByTemplate: IGatsbyState["staticQueriesByTemplate"]
   pendingPageDataWrites: IGatsbyState["pendingPageDataWrites"]
   queries: IGatsbyState["queries"]
+  pageContextHashes: IGatsbyState["pageContextHashes"]
 }
 
 export type ActionsUnion =
@@ -608,6 +610,7 @@ export interface ICreatePageAction {
   payload: IGatsbyPage
   plugin?: IGatsbyPlugin
   contextModified?: boolean
+  pageContextHash: string
 }
 
 export interface ICreateRedirectAction {


### PR DESCRIPTION
This is successor to https://github.com/gatsbyjs/gatsby/pull/28316 which had potential of causing OOM crashes when persisting/serializing data in case there was huge amount of data passed via page context.

Instead of persisting entire page objects this persists just hash generated from page context which should minimize how much more data will be persisted (and hopefully avoid OOM crashes)

TODO:
 - [ ] determine if https://github.com/gatsbyjs/gatsby/blob/c4978e948c5b0cebf85ef9af62da523169994bf9/packages/gatsby/src/services/create-pages.ts#L57 needs to be adjusted - right now it uses `pages` slice which is not persisted - so it's entirely possible that this will keep stale page context hashes around. Potential solution here would be to add timestamp to newly added reducer (maybe even just move current ones we have in `pages` to new one) and switch to using new (persisted) slice of redux state for finding pages that were not re-created.

## Related Issues

fixes #28281
fixes #26520
[ch19791]