### PR TITLE
Clarified icon path configuration, fixes #27751

### DIFF
--- a/packages/gatsby-plugin-manifest/README.md
+++ b/packages/gatsby-plugin-manifest/README.md
@@ -52,7 +52,7 @@ For more information on configuring your web app [see here](https://developers.g
 
 ### Configure icons and their generations - **Required**
 
-There are three modes in which icon generation can function: automatic, hybrid, and manual(disabled). These modes can affect other configurations defaults.
+There are three modes in which icon generation can function: automatic, hybrid, and manual(disabled). These modes can affect other configurations defaults.`icons` is referring to the final URL and thus images need to be added to the static folder.
 
 - Automatic - Generate a pre-configured set of icons from a single source icon.
 


### PR DESCRIPTION
## Description

Added clarification that 'icons' is referring to the final URL and thus images need to be added to the static folder as per issue #27751.

### Documentation

[Documentation is here.](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-manifest/README.md)

## Related Issues

Fixes [#27751](https://github.com/gatsbyjs/gatsby/issues/27751)
