### PR TITLE
test(create-gatsby): add test for handling errors in install plugins

### DIFF
--- a/packages/create-gatsby/src/__tests__/install-plugins.ts
+++ b/packages/create-gatsby/src/__tests__/install-plugins.ts
@@ -1,0 +1,77 @@
+import { installPlugins } from "../install-plugins"
+import { reporter } from "../reporter"
+import { requireResolve } from "../require-utils"
+
+jest.mock(`../require-utils`)
+jest.mock(`../reporter`)
+
+jest.mock(
+  `somewhere-virtually-existing`,
+  () => {
+    // Make sure not to resolve `addPlugins` in order to safely handle error
+    return {}
+  },
+  { virtual: true }
+)
+
+describe(`install-plugins`, () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it(`reports an error explaining that gatsby is not installed`, async () => {
+    ;(requireResolve as any).mockImplementation(() => undefined)
+
+    await installPlugins([], {}, `not-existing-path`, [])
+
+    // Test function behaviour but improves the DX, it probably worth it
+    expect(reporter.error).toBeCalledWith(
+      `Could not find "gatsby" in not-existing-path. Perhaps it wasn't installed properly?`
+    )
+  })
+
+  it(`reports an error when the gatsby cli is not installed`, async () => {
+    ;(requireResolve as any).mockImplementation(path => {
+      if (path === `gatsby-cli/lib/plugin-add`) {
+        throw new Error()
+      }
+      return `somewhere-i-belong`
+    })
+
+    await installPlugins([], {}, `not-existing-path`, [])
+
+    // Test function behaviour but improves the DX, it probably worth it
+    expect(reporter.error).toBeCalledWith(
+      `gatsby-cli not installed, or is too old`
+    )
+  })
+
+  it(`reports an error when the add plugin function fails somehow`, async () => {
+    ;(requireResolve as any).mockImplementation(path => {
+      if (path === `gatsby-cli/lib/plugin-add`) {
+        throw new Error()
+      }
+      return `somewhere-i-belong`
+    })
+
+    await installPlugins([], {}, `not-existing-path`, [])
+
+    // Test function behaviour but improves the DX, it probably worth it
+    expect(reporter.error).toBeCalledWith(
+      `gatsby-cli not installed, or is too old`
+    )
+  })
+
+  it(`reports an error when add plugins fails somehow`, async () => {
+    ;(requireResolve as any).mockImplementation(
+      () => `somewhere-virtually-existing`
+    )
+
+    await installPlugins([], {}, `not-existing-path`, [])
+
+    // Test function behaviour but improves the DX, it probably worth it
+    expect(reporter.error).toBeCalledWith(
+      `Something went wrong when trying to add the plugins to the project: addPlugins is not a function`
+    )
+  })
+})

--- a/packages/create-gatsby/src/__tests__/install-plugins.ts
+++ b/packages/create-gatsby/src/__tests__/install-plugins.ts
@@ -46,22 +46,6 @@ describe(`install-plugins`, () => {
     )
   })
 
-  it(`reports an error when the add plugin function fails somehow`, async () => {
-    ;(requireResolve as any).mockImplementation(path => {
-      if (path === `gatsby-cli/lib/handlers/plugin-add`) {
-        throw new Error()
-      }
-      return `somewhere-i-belong`
-    })
-
-    await installPlugins([], {}, `not-existing-path`, [])
-
-    // Test function behaviour but improves the DX, it probably worth it
-    expect(reporter.error).toBeCalledWith(
-      `gatsby-cli not installed, or is too old`
-    )
-  })
-
   it(`reports an error when add plugins fails somehow`, async () => {
     ;(requireResolve as any).mockImplementation(
       () => `somewhere-virtually-existing`

--- a/packages/create-gatsby/src/__tests__/install-plugins.ts
+++ b/packages/create-gatsby/src/__tests__/install-plugins.ts
@@ -32,7 +32,7 @@ describe(`install-plugins`, () => {
 
   it(`reports an error when the gatsby cli is not installed`, async () => {
     ;(requireResolve as any).mockImplementation(path => {
-      if (path === `gatsby-cli/lib/plugin-add`) {
+      if (path === `gatsby-cli/lib/handlers/plugin-add`) {
         throw new Error()
       }
       return `somewhere-i-belong`
@@ -48,7 +48,7 @@ describe(`install-plugins`, () => {
 
   it(`reports an error when the add plugin function fails somehow`, async () => {
     ;(requireResolve as any).mockImplementation(path => {
-      if (path === `gatsby-cli/lib/plugin-add`) {
+      if (path === `gatsby-cli/lib/handlers/plugin-add`) {
         throw new Error()
       }
       return `somewhere-i-belong`

--- a/packages/create-gatsby/src/require-utils.ts
+++ b/packages/create-gatsby/src/require-utils.ts
@@ -1,0 +1,4 @@
+export const requireResolve = (
+  id: string,
+  options?: { paths?: Array<string> | undefined } | undefined
+): string => require.resolve(id, options)


### PR DESCRIPTION
## Description

Unit test to catch and lock error on the the install plugins step of the create-gatsby cli
