### PR TITLE
perf(gatsby-source-contentful): fix unguided search in expensive loop

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -499,17 +499,17 @@ exports.sourceNodes = async (
 
   reporter.verbose(`Resolving Contentful references`)
 
-  const newOrUpdatedEntries = []
+  const newOrUpdatedEntries = new Set()
   entryList.forEach(entries => {
     entries.forEach(entry => {
-      newOrUpdatedEntries.push(`${entry.sys.id}___${entry.sys.type}`)
+      newOrUpdatedEntries.add(`${entry.sys.id}___${entry.sys.type}`)
     })
   })
 
   // Update existing entry nodes that weren't updated but that need reverse
   // links added.
   existingNodes
-    .filter(n => _.includes(newOrUpdatedEntries, `${n.id}___${n.sys.type}`))
+    .filter(n => newOrUpdatedEntries.has(`${n.id}___${n.sys.type}`))
     .forEach(n => {
       if (foreignReferenceMap[`${n.id}___${n.sys.type}`]) {
         foreignReferenceMap[`${n.id}___${n.sys.type}`].forEach(


### PR DESCRIPTION
The part first builds up a set of existing names and then loops through the received data to find new data.

A site I was testing with had n at 80k elements. So this was doing an unguided search through 80k elements for 80k times.

This little fix literally drops this 5 minute step in incremental builds (and perhaps others) for that case, down to be sub-second.

