### PR TITLE
chore(gatsby): remove noop filter

### DIFF
--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -92,18 +92,16 @@ const processPageQueries = async (
   // /dev-404-page/, whose SitePage node is created via
   // `internal-data-bridge`, but the actual page object is only
   // created during `gatsby develop`.
-  const pages = _.filter(queryIds.map(id => state.pages.get(id)))
-  await processQueries(
-    pages.map(page => createPageQueryJob(state, page)),
-    {
-      activity,
-      graphqlRunner,
-      graphqlTracing,
-    }
-  )
+  const jobs = queryIds.map(id => createPageQueryJob(state, id))
+  await processQueries(jobs, {
+    activity,
+    graphqlRunner,
+    graphqlTracing,
+  })
 }
 
-const createPageQueryJob = (state, page) => {
+const createPageQueryJob = (state, pageId) => {
+  const page = state.pages.get(pageId)
   const component = state.components.get(page.componentPath)
   const { path, componentPath, context } = page
   const { query } = component


### PR DESCRIPTION
I think this was introduced in https://github.com/gatsbyjs/gatsby/pull/13064

The `_.filter` with no predicate is basically a shallow clone. We don't need a shallow clone here.

This PR basically removes this call and refactors it a bit.