### PR TITLE
fix(gatsby): handle in dev-ssr when a page is deleted (#28325)

### DIFF
--- a/integration-tests/ssr/__tests__/ssr.js
+++ b/integration-tests/ssr/__tests__/ssr.js
@@ -36,20 +36,20 @@ describe(`SSR`, () => {
       `http://localhost:8000/bad-page/`
     ).then(res => res.text())
     expect(rawDevHtml).toMatchSnapshot()
-    // fs.remove(dest)
+    fs.remove(dest)
 
-    // // After the page is gone, it'll 404.
-    // await new Promise(resolve => {
-    // setTimeout(() => {
-    // const testInterval = setInterval(() => {
-    // fetch(pageUrl).then(res => {
-    // if (res.status === 404) {
-    // clearInterval(testInterval)
-    // resolve()
-    // }
-    // })
-    // }, 400)
-    // }, 400)
-    // })
+    // After the page is gone, it'll 404.
+    await new Promise(resolve => {
+      setTimeout(() => {
+        const testInterval = setInterval(() => {
+          fetch(pageUrl).then(res => {
+            if (res.status === 404) {
+              clearInterval(testInterval)
+              resolve()
+            }
+          })
+        }, 400)
+      }, 400)
+    })
   })
 })

--- a/packages/gatsby/src/utils/dev-ssr/render-dev-html.ts
+++ b/packages/gatsby/src/utils/dev-ssr/render-dev-html.ts
@@ -135,7 +135,13 @@ export const renderDevHTML = ({
     createServerVisitedPage(pageObj.componentChunkName)
 
     // Ensure the query has been run and written out.
-    await getPageDataExperimental(pageObj.path)
+    try {
+      await getPageDataExperimental(pageObj.path)
+    } catch {
+      // If we can't get the page, it was probably deleted recently
+      // so let's just do a 404 page.
+      return reject(`404 page`)
+    }
 
     // Wait for public/render-page.js to update w/ the page component.
     const found = await ensurePathComponentInSSRBundle(pageObj, directory)
@@ -158,8 +164,8 @@ export const renderDevHTML = ({
         directory,
         isClientOnlyPage,
       })
-      resolve(htmlString)
+      return resolve(htmlString)
     } catch (error) {
-      reject(error)
+      return reject(error)
     }
   })


### PR DESCRIPTION
Backporting #28325 to the 2.28 release branch

(cherry picked from commit a9f9a23705edaf393466b30bc89546b59de59158)