### PR TITLE
feature(gatsby): Add semver checks to flags & add FAST_REFRESH as flag for React >17

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
@@ -14,6 +14,20 @@ Object {
       },
       "umbrellaIssue": "test",
     },
+    Object {
+      "command": "all",
+      "description": "test",
+      "env": "GATSBY_READY_TO_GO_NEW_LODASH",
+      "name": "PARTIAL_RELEASE_ONLY_NEW_LODASH",
+      "partialRelease": Object {
+        "percentage": 100,
+        "releaseNotes": "https://example.com",
+      },
+      "semver": Object {
+        "lodash": ">=4.9",
+      },
+      "umbrellaIssue": "test",
+    },
   ],
   "message": "The following flags are active:
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
@@ -25,16 +39,9 @@ flags: {
   THE_FLAG: false
 }
 
-The following flags are enabled on your site:
+The following were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
-
-There are 6 other flags available that you might be interested in:
-- FAST_DEV · Enable all experiments aimed at improving develop server start time
-- DEV_SSR · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/28138)) · SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.
-- QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
-- ONLY_BUILDS · (Umbrella Issue (test)) · test
-- ALL_COMMANDS · (Umbrella Issue (test)) · test
-- YET_ANOTHER · (Umbrella Issue (test)) · test
+- PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
 ",
   "unknownFlagMessage": "",
 }
@@ -61,6 +68,20 @@ Object {
       },
       "umbrellaIssue": "test",
     },
+    Object {
+      "command": "all",
+      "description": "test",
+      "env": "GATSBY_READY_TO_GO_NEW_LODASH",
+      "name": "PARTIAL_RELEASE_ONLY_NEW_LODASH",
+      "partialRelease": Object {
+        "percentage": 100,
+        "releaseNotes": "https://example.com",
+      },
+      "semver": Object {
+        "lodash": ">=4.9",
+      },
+      "umbrellaIssue": "test",
+    },
   ],
   "message": "The following flags are active:
 - ALL_COMMANDS · (Umbrella Issue (test)) · test
@@ -73,8 +94,9 @@ flags: {
   THE_FLAG: false
 }
 
-The following flags are enabled on your site:
+The following were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
+- PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
 
 There are 5 other flags available that you might be interested in:
 - FAST_DEV · Enable all experiments aimed at improving develop server start time
@@ -89,7 +111,7 @@ There are 5 other flags available that you might be interested in:
 }
 `;
 
-exports[`handle flags returns validConfigFlags and a message 1`] = `
+exports[`handle flags returns enabledConfigFlags and a message 1`] = `
 Object {
   "enabledConfigFlags": Array [
     Object {
@@ -117,6 +139,20 @@ Object {
       "partialRelease": Object {
         "percentage": 100,
         "releaseNotes": "https://example.com",
+      },
+      "umbrellaIssue": "test",
+    },
+    Object {
+      "command": "all",
+      "description": "test",
+      "env": "GATSBY_READY_TO_GO_NEW_LODASH",
+      "name": "PARTIAL_RELEASE_ONLY_NEW_LODASH",
+      "partialRelease": Object {
+        "percentage": 100,
+        "releaseNotes": "https://example.com",
+      },
+      "semver": Object {
+        "lodash": ">=4.9",
       },
       "umbrellaIssue": "test",
     },
@@ -150,8 +186,9 @@ flags: {
   THE_FLAG: false
 }
 
-The following flags are enabled on your site:
+The following were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
+- PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
 
 There are 2 other flags available that you might be interested in:
 - ONLY_BUILDS · (Umbrella Issue (test)) · test

--- a/packages/gatsby/src/utils/__tests__/handle-flags.ts
+++ b/packages/gatsby/src/utils/__tests__/handle-flags.ts
@@ -64,6 +64,34 @@ describe(`handle flags`, () => {
         releaseNotes: `https://example.com`,
       },
     },
+    {
+      name: `PARTIAL_RELEASE_ONLY_VERY_OLD_LODASH`,
+      env: `GATSBY_READY_TO_GO_LODASH`,
+      command: `all`,
+      description: `test`,
+      umbrellaIssue: `test`,
+      semver: {
+        lodash: `<=3.9`,
+      },
+      partialRelease: {
+        percentage: 100,
+        releaseNotes: `https://example.com`,
+      },
+    },
+    {
+      name: `PARTIAL_RELEASE_ONLY_NEW_LODASH`,
+      env: `GATSBY_READY_TO_GO_NEW_LODASH`,
+      command: `all`,
+      description: `test`,
+      umbrellaIssue: `test`,
+      semver: {
+        lodash: `>=4.9`,
+      },
+      partialRelease: {
+        percentage: 100,
+        releaseNotes: `https://example.com`,
+      },
+    },
   ]
 
   const configFlags = {
@@ -79,7 +107,7 @@ describe(`handle flags`, () => {
     DEV_SSR: true,
   }
 
-  it(`returns validConfigFlags and a message`, () => {
+  it(`returns enabledConfigFlags and a message`, () => {
     expect(handleFlags(activeFlags, configFlags, `develop`)).toMatchSnapshot()
   })
 
@@ -87,20 +115,20 @@ describe(`handle flags`, () => {
     expect(
       handleFlags(activeFlags, configFlagsWithFalse, `develop`)
         .enabledConfigFlags
-    ).toHaveLength(2)
+    ).toHaveLength(3)
   })
 
   it(`filters out flags that are marked as not available on CI`, () => {
     expect(
       handleFlags(activeFlags, configWithFlagsNoCi, `develop`)
         .enabledConfigFlags
-    ).toHaveLength(2)
+    ).toHaveLength(3)
   })
 
   it(`filters out flags that aren't for the current command`, () => {
     expect(
       handleFlags(activeFlags, configFlags, `build`).enabledConfigFlags
-    ).toHaveLength(2)
+    ).toHaveLength(3)
   })
 
   it(`returns a message about unknown flags in the config`, () => {
@@ -118,10 +146,10 @@ describe(`handle flags`, () => {
     expect(response).toMatchSnapshot()
   })
 
-  it(`removes flags people explicitly opt out of`, () => {
+  it(`removes flags people explicitly opt out of and ignores flags that don't pass semver`, () => {
     const response = handleFlags(
       activeFlags,
-      { PARTIAL_RELEASE: false },
+      { PARTIAL_RELEASE: false, PARTIAL_RELEASE_ONLY_NEW_LODASH: false },
       `develop`
     )
     expect(response.enabledConfigFlags).toHaveLength(0)

--- a/packages/gatsby/src/utils/__tests__/handle-flags.ts
+++ b/packages/gatsby/src/utils/__tests__/handle-flags.ts
@@ -71,6 +71,7 @@ describe(`handle flags`, () => {
       description: `test`,
       umbrellaIssue: `test`,
       semver: {
+        // Because of this, this flag will never show up
         lodash: `<=3.9`,
       },
       partialRelease: {

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -23,6 +23,8 @@ export interface IFlag {
   partialRelease?: {
     percentage: number
   }
+  noCi?: boolean
+  semver?: object
 }
 
 const activeFlags: Array<IFlag> = [
@@ -65,6 +67,18 @@ const activeFlags: Array<IFlag> = [
     experimental: true,
     description: `Don't process images during development until they're requested from the browser. Speeds starting the develop server.`,
     umbrellaIssue: `https://github.com/gatsbyjs/gatsby/discussions/27603`,
+  },
+  {
+    name: `FAST_REFRESH`,
+    env: `GATSBY_FAST_REFRESH`,
+    command: `develop`,
+    telemetryId: `FastRefresh`,
+    experimental: false,
+    description: `Enables FastRefresh — the new React hot reloading technology for faster and more reliable hot reloading.`,
+    umbrellaIssue: `https://github.com/gatsbyjs/gatsby/discussions/28390`,
+    semver: {
+      react: `>=17.0.0`,
+    },
   },
 ]
 


### PR DESCRIPTION
Flags that don't pass semver won't be enabled or suggested.