### PR TITLE
fix(gatsby): move starting dev-ssr listener inside function & only init listeners once

### DIFF
--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -321,22 +321,29 @@ const debouncedWriteAll = _.debounce(
   }
 )
 
-if (process.env.GATSBY_EXPERIMENTAL_DEV_SSR) {
-  /**
-   * Start listening to CREATE_SERVER_VISITED_PAGE events so we can rewrite
-   * files as required
-   */
-  emitter.on(`CREATE_SERVER_VISITED_PAGE`, (): void => {
-    reporter.pendingActivity({ id: `requires-writer` })
-    debouncedWriteAll()
-  })
-}
-
 /**
  * Start listening to CREATE/DELETE_PAGE events so we can rewrite
  * files as required
  */
+let listenerStarted = false
 export const startListener = (): void => {
+  // Only start the listener once.
+  if (listenerStarted) {
+    return
+  }
+  listenerStarted = true
+
+  if (process.env.GATSBY_EXPERIMENTAL_DEV_SSR) {
+    /**
+     * Start listening to CREATE_SERVER_VISITED_PAGE events so we can rewrite
+     * files as required
+     */
+    emitter.on(`CREATE_SERVER_VISITED_PAGE`, (): void => {
+      reporter.pendingActivity({ id: `requires-writer` })
+      debouncedWriteAll()
+    })
+  }
+
   emitter.on(`CREATE_PAGE`, (): void => {
     reporter.pendingActivity({ id: `requires-writer` })
     debouncedWriteAll()

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
@@ -13,6 +13,13 @@ Object {
   ],
   "message": "The following flags are active:
 - ALL_COMMANDS · (Umbrella Issue (test)) · test
+
+There are 5 other flags available that you might be interested in:
+- FAST_DEV · Enable all experiments aimed at improving develop server start time
+- DEV_SSR · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/28138)) · SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.
+- QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
+- ONLY_BUILDS · (Umbrella Issue (test)) · test
+- YET_ANOTHER · (Umbrella Issue (test)) · test
 ",
   "unknownFlagMessage": "The following flag(s) found in your gatsby-config.js are not known:
 - FASTLY_DEV (did you mean: FAST_DEV)


### PR DESCRIPTION
The listeners were gettiing reattached on every SSR.

Also... ssr changes weren't getting compiled w/o a save. So this fixes two bugs.