### PR TITLE
fix(assert-changed-files): don't skip running tests on master

### DIFF
--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -3,6 +3,11 @@
 IS_CI="${CI:-false}"
 GREP_PATTERN=$1
 
+if [ "$CIRCLE_BRANCH" = "master" ]; then
+  echo "On master branch; continuing."
+  exit 0
+fi
+
 if [ "$IS_CI" = true ]; then
   git config --local url."https://github.com/".insteadOf git@github.com:
   git config --local user.name "GatsbyJS Bot"


### PR DESCRIPTION
## Description

Our script asserting if anything related changed has flaw that it never allow tests to run on master - because it compares current branch to master and master compared to master shows no changes ;)