### PR TITLE
Tell user to supply BOTH keys in .env.development for Gatsby E-commerce Tutorial.

### DIFF
--- a/docs/tutorial/ecommerce-tutorial/index.md
+++ b/docs/tutorial/ecommerce-tutorial/index.md
@@ -305,6 +305,7 @@ In the root directory of your project add a `.env.development` file:
 
 ```text:title=.env.development
 # Stripe secret API key
+STRIPE_PUBLISHABLE_KEY=pk_test_xxx
 STRIPE_SECRET_KEY=sk_test_xxx
 ```
 


### PR DESCRIPTION
## Description
Gatsby E-commerce Tutorial codeblock [Add the Stripe source plugin](https://github.com/gatsbyjs/gatsby/blob/master/docs/tutorial/ecommerce-tutorial/index.md#add-the-stripe-source-plugin) indicates config should include `STRIPE_SECRET_KEY` but does not mention `STRIPE_PUBLISHABLE_KEY`.

For users supplying *only* the `STRIPE_SECRET_KEY` (without also adding `STRIPE_PUBLISHABLE_KEY`), `gatsby-source-stripe` fails to load `allStripePrice` as a field to be tested in GraphiQL; a browser pointed at http://localhost:8000 responds with:
_Error: There was an error in your GraphQL query: Cannot query field "allStripePrice" on type "Query". Did you mean "allSitePage"?_

With this one-liner we can avoid newcomers being put off by an ambiguous instruction being given in tutorial codeblocks.

## Related Issues
Fixes #28385