### PR TITLE
Revert "fix(assert-changed-files): don't skip running tests on master"

### DIFF
--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -3,11 +3,6 @@
 IS_CI="${CI:-false}"
 GREP_PATTERN=$1
 
-if [ "$CIRCLE_BRANCH" = "master" ]; then
-  echo "On master branch; continuing."
-  exit 0
-fi
-
 if [ "$IS_CI" = true ]; then
   git config --local url."https://github.com/".insteadOf git@github.com:
   git config --local user.name "GatsbyJS Bot"


### PR DESCRIPTION
Reverts gatsbyjs/gatsby#28400

That seemed to cause very weird issues for windows tests for PRs that don't contain the change itself ( see https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/54414/workflows/4c08227f-9226-42e7-b8bb-1532a7ae15a2/jobs/570991 for example ):

```
#!bash.exe
./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*|.circleci/*"
error: unable to create file scripts/assert-changed-files.sh: Permission denied
Branch has conflicts with master, rolling back test.
fatal: There is no merge to abort (MERGE_HEAD missing).
error: unable to create file scripts/assert-changed-files.sh: Permission denied
fatal: Could not reset index file to revision 'HEAD@{1}'.
271 file(s) matching 'packages/*|(e2e|integration)-tests/*|.circleci/*'; continuing.
CircleCI received exit code 0
```

It leaves the dir with mess:
```
git rev-parse HEAD
95fb868359669f34b831e10a92acebf25e0d7dca
git status
On branch backport-2.28-28372
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    scripts/assert-changed-files.sh
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	e2e-tests/development-runtime/content/query-data-caches/adding-static-query-A-to-B-to-A-link.json
	e2e-tests/development-runtime/src/components/query-data-caches/adding-static-query-blank.js
	e2e-tests/development-runtime/src/components/query-data-caches/adding-static-query-with-data.js
	e2e-tests/development-runtime/src/pages/query-data-caches/adding-static-query-A-to-B-to-A-link/
	e2e-tests/gatsby-static-image/cypress/integration/intesection-observer.js
	e2e-tests/gatsby-static-image/cypress/integration/native-lazy-loading.js
	e2e-tests/gatsby-static-image/src/pages/lazy-loading.js
	packages/create-gatsby/src/__tests__/
	packages/create-gatsby/src/site-metadata.ts
	packages/gatsby-cli/src/login.ts
	packages/gatsby-cli/src/logout.ts
	packages/gatsby-cli/src/util/manage-token.ts
	packages/gatsby-cli/src/whoami.ts
```

and executes tests that are not in the PR branch but are on `master` branch ...

This needs to be solved properly in different ways - probably better way of getting list of changed files than merging anything in (why even make changes to current working directory in this script?)