### PR TITLE
fix(gatsby-plugin-image): Add overflow hidden back to wrapper CSS

### DIFF
--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -141,7 +141,7 @@ describe(`GatsbyImage server`, () => {
         CSSStyleDeclaration {
           "0": "position",
           "1": "overflow",
-          "12: "display",
+          "2: "display",
           "_importants": Object {
             "display": undefined,
             "overflow": undefined,

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -62,14 +62,16 @@ describe(`GatsbyImage server`, () => {
       expect((wrapper as HTMLElement).style).toMatchInlineSnapshot(`
         CSSStyleDeclaration {
           "0": "position",
+          "1": "overflow",
           "_importants": Object {
+            "overflow": undefined,
             "position": undefined,
           },
-          "_length": 1,
+          "_length": 2,
           "_onChange": [Function],
           "_values": Object {
-            "position": "relative",
             "overflow": "hidden",
+            "position": "relative",
           },
         }
       `)
@@ -96,19 +98,21 @@ describe(`GatsbyImage server`, () => {
       expect((wrapper as HTMLElement).style).toMatchInlineSnapshot(`
         CSSStyleDeclaration {
           "0": "position",
-          "1": "width",
-          "2": "height",
+          "1": "overflow",
+          "2": "width",
+          "3": "height",
           "_importants": Object {
             "height": undefined,
+            "overflow": undefined,
             "position": undefined,
             "width": undefined,
           },
-          "_length": 3,
+          "_length": 4,
           "_onChange": [Function],
           "_values": Object {
             "height": "100px",
-            "position": "relative",
             "overflow": "hidden",
+            "position": "relative",
             "width": "100px",
           },
         }
@@ -136,17 +140,19 @@ describe(`GatsbyImage server`, () => {
       expect((wrapper as HTMLElement).style).toMatchInlineSnapshot(`
         CSSStyleDeclaration {
           "0": "position",
-          "1": "display",
+          "1": "overflow",
+          "12: "display",
           "_importants": Object {
             "display": undefined,
+            "overflow": undefined,
             "position": undefined,
           },
-          "_length": 2,
+          "_length": 3,
           "_onChange": [Function],
           "_values": Object {
             "display": "inline-block",
-            "position": "relative",
             "overflow": "hidden",
+            "position": "relative",
           },
         }
       `)

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -141,7 +141,7 @@ describe(`GatsbyImage server`, () => {
         CSSStyleDeclaration {
           "0": "position",
           "1": "overflow",
-          "2: "display",
+          "2": "display",
           "_importants": Object {
             "display": undefined,
             "overflow": undefined,

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -69,6 +69,7 @@ describe(`GatsbyImage server`, () => {
           "_onChange": [Function],
           "_values": Object {
             "position": "relative",
+            "overflow": "hidden",
           },
         }
       `)
@@ -107,6 +108,7 @@ describe(`GatsbyImage server`, () => {
           "_values": Object {
             "height": "100px",
             "position": "relative",
+            "overflow": "hidden",
             "width": "100px",
           },
         }
@@ -144,6 +146,7 @@ describe(`GatsbyImage server`, () => {
           "_values": Object {
             "display": "inline-block",
             "position": "relative",
+            "overflow": "hidden",
           },
         }
       `)

--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -52,6 +52,7 @@ export function getWrapperProps(
 } {
   const wrapperStyle: CSSProperties = {
     position: `relative`,
+    overflow: `hidden`,
   }
 
   if (layout === `fixed`) {


### PR DESCRIPTION
We expect breaking changes with CSS for users with element selectors, but those passing a classname should expect similar behavior. Adding this rule back in will make the new component more compatible.