### PR TITLE
refactor(gatsby-plugin-utils): move validate plugin from gatsby to plugin utils

### DIFF
--- a/packages/gatsby-plugin-utils/package.json
+++ b/packages/gatsby-plugin-utils/package.json
@@ -21,6 +21,8 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-utils#readme",
   "dependencies": {
+    "gatsby-cli": "^2.16.0-next.0",
+    "gatsby-telemetry": "^1.7.0-next.0",
     "joi": "^17.2.1"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-utils/package.json
+++ b/packages/gatsby-plugin-utils/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-utils#readme",
   "dependencies": {
-    "gatsby-cli": "^2.16.0-next.0",
     "gatsby-telemetry": "^1.7.0-next.0",
     "joi": "^17.2.1"
   },

--- a/packages/gatsby-plugin-utils/package.json
+++ b/packages/gatsby-plugin-utils/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-utils#readme",
   "dependencies": {
+    "ansi-colors": "^4.1.1",
     "common-tags": "^1.8.0",
     "gatsby-telemetry": "^1.7.0-next.0",
     "joi": "^17.2.1"

--- a/packages/gatsby-plugin-utils/package.json
+++ b/packages/gatsby-plugin-utils/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-utils#readme",
   "dependencies": {
+    "common-tags": "^1.8.0",
     "gatsby-telemetry": "^1.7.0-next.0",
     "joi": "^17.2.1"
   },

--- a/packages/gatsby-plugin-utils/src/reporter.ts
+++ b/packages/gatsby-plugin-utils/src/reporter.ts
@@ -1,0 +1,16 @@
+import c from "ansi-colors"
+// We don't want to depend on the whole of gatsby-cli, so we can't use reporter
+export const reporter = {
+  info: (message: string): void => console.log(message),
+  verbose: (message: string): void => console.log(message),
+  log: (message: string): void => console.log(message),
+  success: (message: string): void =>
+    console.log(c.green(c.symbols.check + ` `) + message),
+  error: (message: string): void =>
+    console.error(c.red(c.symbols.cross + ` `) + message),
+  panic: (message: string): never => {
+    console.error(message)
+    process.exit(1)
+  },
+  warn: (message: string): void => console.warn(message),
+}

--- a/packages/gatsby-plugin-utils/src/reporter.ts
+++ b/packages/gatsby-plugin-utils/src/reporter.ts
@@ -6,9 +6,9 @@ export const reporter = {
   log: (message: string): void => console.log(message),
   success: (message: string): void =>
     console.log(c.green(c.symbols.check + ` `) + message),
-  error: (message: string): void =>
+  error: (message: any): void =>
     console.error(c.red(c.symbols.cross + ` `) + message),
-  panic: (message: string): never => {
+  panic: (message: any): never => {
     console.error(message)
     process.exit(1)
   },

--- a/packages/gatsby-plugin-utils/src/reporter.ts
+++ b/packages/gatsby-plugin-utils/src/reporter.ts
@@ -1,4 +1,5 @@
 import c from "ansi-colors"
+import { Reporter } from "gatsby"
 // We don't want to depend on the whole of gatsby-cli, so we can't use reporter
 export const reporter = {
   info: (message: string): void => console.log(message),
@@ -13,4 +14,4 @@ export const reporter = {
     process.exit(1)
   },
   warn: (message: string): void => console.warn(message),
-}
+} as Reporter

--- a/packages/gatsby-plugin-utils/src/reporter.ts
+++ b/packages/gatsby-plugin-utils/src/reporter.ts
@@ -1,5 +1,4 @@
 import c from "ansi-colors"
-import { Reporter } from "gatsby"
 // We don't want to depend on the whole of gatsby-cli, so we can't use reporter
 export const reporter = {
   info: (message: string): void => console.log(message),
@@ -14,4 +13,4 @@ export const reporter = {
     process.exit(1)
   },
   warn: (message: string): void => console.warn(message),
-} as Reporter
+}

--- a/packages/gatsby-plugin-utils/src/validate.ts
+++ b/packages/gatsby-plugin-utils/src/validate.ts
@@ -3,7 +3,6 @@ import { ValidationOptions } from "joi"
 import { Joi, ObjectSchema } from "./joi"
 import { IPluginInfoOptions, IPluginRefObject, ISiteConfig } from "./types"
 import path from "path"
-import reporter from "gatsby-cli/lib/reporter"
 import { stripIndent } from "common-tags"
 import { trackCli } from "gatsby-telemetry"
 
@@ -63,7 +62,7 @@ async function validatePluginsOptions(
 
       // Validate correct usage of pluginOptionsSchema
       if (!Joi.isSchema(optionsSchema) || optionsSchema.type !== `object`) {
-        reporter.warn(
+        console.warn(
           `Plugin "${plugin.resolve}" has an invalid options schema so we cannot verify your configuration for it.`
         )
         return plugin
@@ -113,7 +112,7 @@ async function validatePluginsOptions(
               path.relative(rootDir, plugin.parentDir)) ||
             null
           if (validationErrors.length > 0) {
-            reporter.error({
+            console.error({
               id: `11331`,
               context: {
                 configDir,
@@ -125,7 +124,7 @@ async function validatePluginsOptions(
           }
 
           if (validationWarnings.length > 0) {
-            reporter.warn(
+            console.warn(
               stripIndent(`
                 Warning: there are unknown plugin options for "${
                   plugin.resolve

--- a/packages/gatsby-plugin-utils/src/validate.ts
+++ b/packages/gatsby-plugin-utils/src/validate.ts
@@ -1,6 +1,11 @@
+import { GatsbyNode } from "gatsby"
 import { ValidationOptions } from "joi"
-import { ObjectSchema } from "./joi"
-import { IPluginInfoOptions } from "./types"
+import { Joi, ObjectSchema } from "./joi"
+import { IPluginInfoOptions, IPluginRefObject, ISiteConfig } from "./types"
+import path from "path"
+import reporter from "gatsby-cli/lib/reporter"
+import { stripIndent } from "common-tags"
+import { trackCli } from "gatsby-telemetry"
 
 const validationOptions: ValidationOptions = {
   // Show all errors at once, rather than only the first one every time
@@ -27,4 +32,148 @@ export async function validateOptionsSchema(
   })
 
   return value
+}
+
+async function validatePluginsOptions(
+  plugins: Array<IPluginRefObject>,
+  rootDir: string | null
+): Promise<{
+  errors: number
+  plugins: Array<IPluginRefObject>
+}> {
+  let errors = 0
+  const newPlugins = await Promise.all(
+    plugins.map(async plugin => {
+      let gatsbyNode
+
+      try {
+        gatsbyNode = require(`${plugin.resolve}/gatsby-node`)
+      } catch (err) {
+        gatsbyNode = {}
+      }
+
+      if (!gatsbyNode.pluginOptionsSchema) return plugin
+
+      let optionsSchema = (gatsbyNode.pluginOptionsSchema as Exclude<
+        GatsbyNode["pluginOptionsSchema"],
+        undefined
+      >)({
+        Joi,
+      })
+
+      // Validate correct usage of pluginOptionsSchema
+      if (!Joi.isSchema(optionsSchema) || optionsSchema.type !== `object`) {
+        reporter.warn(
+          `Plugin "${plugin.resolve}" has an invalid options schema so we cannot verify your configuration for it.`
+        )
+        return plugin
+      }
+
+      try {
+        if (!optionsSchema.describe().keys.plugins) {
+          // All plugins have "plugins: []"" added to their options in load.ts, even if they
+          // do not have subplugins. We add plugins to the schema if it does not exist already
+          // to make sure they pass validation.
+          optionsSchema = optionsSchema.append({
+            plugins: Joi.array().length(0),
+          })
+        }
+
+        plugin.options = await validateOptionsSchema(
+          optionsSchema,
+          (plugin.options as IPluginInfoOptions) || {}
+        )
+
+        if (plugin.options?.plugins) {
+          const {
+            errors: subErrors,
+            plugins: subPlugins,
+          } = await validatePluginsOptions(
+            plugin.options.plugins as Array<IPluginRefObject>,
+            rootDir
+          )
+          plugin.options.plugins = subPlugins
+          errors += subErrors
+        }
+      } catch (error) {
+        if (error instanceof Joi.ValidationError) {
+          // Show a small warning on unknown options rather than erroring
+          const validationWarnings = error.details.filter(
+            err => err.type === `object.unknown`
+          )
+          const validationErrors = error.details.filter(
+            err => err.type !== `object.unknown`
+          )
+
+          // If rootDir and plugin.parentDir are the same, i.e. if this is a plugin a user configured in their gatsby-config.js (and not a sub-theme that added it), this will be ""
+          // Otherwise, this will contain (and show) the relative path
+          const configDir =
+            (plugin.parentDir &&
+              rootDir &&
+              path.relative(rootDir, plugin.parentDir)) ||
+            null
+          if (validationErrors.length > 0) {
+            reporter.error({
+              id: `11331`,
+              context: {
+                configDir,
+                validationErrors,
+                pluginName: plugin.resolve,
+              },
+            })
+            errors++
+          }
+
+          if (validationWarnings.length > 0) {
+            reporter.warn(
+              stripIndent(`
+                Warning: there are unknown plugin options for "${
+                  plugin.resolve
+                }"${
+                configDir ? `, configured by ${configDir}` : ``
+              }: ${validationWarnings
+                .map(error => error.path.join(`.`))
+                .join(`, `)}
+                Please open an issue at ghub.io/${
+                  plugin.resolve
+                } if you believe this option is valid.
+              `)
+            )
+            trackCli(`UNKNOWN_PLUGIN_OPTION`, {
+              name: plugin.resolve,
+              valueString: validationWarnings
+                .map(error => error.path.join(`.`))
+                .join(`, `),
+            })
+            // We do not increment errors++ here as we do not want to process.exit if there are only warnings
+          }
+
+          return plugin
+        }
+
+        throw error
+      }
+
+      return plugin
+    })
+  )
+  return { errors, plugins: newPlugins }
+}
+
+export async function validateConfigPluginsOptions(
+  config: ISiteConfig = {},
+  rootDir: string | null
+): Promise<void> {
+  if (!config.plugins) return
+
+  const { errors, plugins } = await validatePluginsOptions(
+    config.plugins,
+    rootDir
+  )
+
+  config.plugins = plugins
+
+  if (errors > 0) {
+    process.exit(1)
+  }
 }

--- a/packages/gatsby-plugin-utils/src/validate.ts
+++ b/packages/gatsby-plugin-utils/src/validate.ts
@@ -1,11 +1,10 @@
-import { GatsbyNode } from "gatsby"
+import { GatsbyNode, Reporter } from "gatsby"
 import { ValidationOptions } from "joi"
 import { Joi, ObjectSchema } from "./joi"
 import { IPluginInfoOptions, IPluginRefObject, ISiteConfig } from "./types"
 import path from "path"
 import { stripIndent } from "common-tags"
 import { trackCli } from "gatsby-telemetry"
-import { Reporter } from "gatsby-cli/lib/reporter/reporter"
 
 const validationOptions: ValidationOptions = {
   // Show all errors at once, rather than only the first one every time

--- a/packages/gatsby-plugin-utils/src/validate.ts
+++ b/packages/gatsby-plugin-utils/src/validate.ts
@@ -37,7 +37,7 @@ export async function validateOptionsSchema(
 async function validatePluginsOptions(
   plugins: Array<IPluginRefObject>,
   rootDir: string | null,
-  reporter: Reporter
+  reporter: Reporter | typeof shimReporter
 ): Promise<{
   errors: number
   plugins: Array<IPluginRefObject>
@@ -90,9 +90,9 @@ async function validatePluginsOptions(
             errors: subErrors,
             plugins: subPlugins,
           } = await validatePluginsOptions(
-            reporter,
             plugin.options.plugins as Array<IPluginRefObject>,
-            rootDir
+            rootDir,
+            reporter
           )
           plugin.options.plugins = subPlugins
           errors += subErrors

--- a/packages/gatsby-plugin-utils/src/validate.ts
+++ b/packages/gatsby-plugin-utils/src/validate.ts
@@ -5,6 +5,7 @@ import { IPluginInfoOptions, IPluginRefObject, ISiteConfig } from "./types"
 import path from "path"
 import { stripIndent } from "common-tags"
 import { trackCli } from "gatsby-telemetry"
+import { reporter as shimReporter } from "./reporter"
 
 const validationOptions: ValidationOptions = {
   // Show all errors at once, rather than only the first one every time
@@ -34,9 +35,9 @@ export async function validateOptionsSchema(
 }
 
 async function validatePluginsOptions(
-  reporter: Reporter,
   plugins: Array<IPluginRefObject>,
-  rootDir: string | null
+  rootDir: string | null,
+  reporter: Reporter
 ): Promise<{
   errors: number
   plugins: Array<IPluginRefObject>
@@ -162,16 +163,16 @@ async function validatePluginsOptions(
 }
 
 export async function validateConfigPluginsOptions(
-  reporter: Reporter,
   config: ISiteConfig = {},
-  rootDir: string | null
+  rootDir: string | null,
+  reporter?: Reporter
 ): Promise<void> {
   if (!config.plugins) return
 
   const { errors, plugins } = await validatePluginsOptions(
-    reporter,
     config.plugins,
-    rootDir
+    rootDir,
+    reporter || shimReporter
   )
 
   config.plugins = plugins

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -1,23 +1,9 @@
-jest.mock(`gatsby-cli/lib/reporter`, () => {
-  return {
-    error: jest.fn(),
-    panic: jest.fn(),
-    log: jest.fn(),
-    warn: jest.fn(),
-    success: jest.fn(),
-    info: jest.fn(),
-  }
-})
 const mockProcessExit = jest.spyOn(process, `exit`).mockImplementation(() => {})
 import { loadPlugins } from "../index"
 import { slash } from "gatsby-core-utils"
-import reporter from "gatsby-cli/lib/reporter"
 import { IFlattenedPlugin } from "../types"
 
 afterEach(() => {
-  Object.keys(reporter).forEach(method => {
-    reporter[method].mockClear()
-  })
   mockProcessExit.mockClear()
 })
 
@@ -198,6 +184,15 @@ describe(`Load plugins`, () => {
   })
 
   describe(`plugin options validation`, () => {
+    beforeEach(() => {
+      console.error = jest.fn()
+      console.warn = jest.fn()
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
     it(`throws a structured error with invalid plugin options`, async () => {
       const invalidPlugins = [
         {
@@ -218,11 +213,10 @@ describe(`Load plugins`, () => {
         plugins: invalidPlugins,
       })
 
-      expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(
+      expect(console.error as jest.Mock).toHaveBeenCalledTimes(
         invalidPlugins.length
       )
-      expect((reporter.error as jest.Mock).mock.calls[0])
-        .toMatchInlineSnapshot(`
+      expect((console.error as jest.Mock).mock.calls[0]).toMatchInlineSnapshot(`
         Array [
           Object {
             "context": Object {
@@ -259,8 +253,7 @@ describe(`Load plugins`, () => {
           },
         ]
       `)
-      expect((reporter.error as jest.Mock).mock.calls[1])
-        .toMatchInlineSnapshot(`
+      expect((console.error as jest.Mock).mock.calls[1]).toMatchInlineSnapshot(`
         Array [
           Object {
             "context": Object {
@@ -302,9 +295,9 @@ describe(`Load plugins`, () => {
         plugins,
       })
 
-      expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(0)
-      expect(reporter.warn as jest.Mock).toHaveBeenCalledTimes(1)
-      expect((reporter.warn as jest.Mock).mock.calls[0]).toMatchInlineSnapshot(`
+      expect(console.error as jest.Mock).toHaveBeenCalledTimes(0)
+      expect(console.warn as jest.Mock).toHaveBeenCalledTimes(1)
+      expect((console.warn as jest.Mock).mock.calls[0]).toMatchInlineSnapshot(`
         Array [
           "Warning: there are unknown plugin options for \\"gatsby-plugin-google-analytics\\": doesThisExistInTheSchema
         Please open an issue at ghub.io/gatsby-plugin-google-analytics if you believe this option is valid.",
@@ -361,9 +354,8 @@ describe(`Load plugins`, () => {
         ],
       })
 
-      expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(1)
-      expect((reporter.error as jest.Mock).mock.calls[0])
-        .toMatchInlineSnapshot(`
+      expect(console.error as jest.Mock).toHaveBeenCalledTimes(1)
+      expect((console.error as jest.Mock).mock.calls[0]).toMatchInlineSnapshot(`
         Array [
           Object {
             "context": Object {

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -51,7 +51,7 @@ describe(`Load plugins`, () => {
     })
 
   it(`Load plugins for a site`, async () => {
-    let plugins = await loadPlugins({ plugins: [] })
+    let plugins = await loadPlugins(reporter, { plugins: [] })
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -67,7 +67,7 @@ describe(`Load plugins`, () => {
       ],
     }
 
-    let plugins = await loadPlugins(config)
+    let plugins = await loadPlugins(reporter, config)
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -88,7 +88,7 @@ describe(`Load plugins`, () => {
     }
 
     try {
-      await loadPlugins(config)
+      await loadPlugins(reporter, config)
     } catch (err) {
       expect(err.message).toMatchSnapshot()
     }
@@ -107,7 +107,7 @@ describe(`Load plugins`, () => {
       ],
     }
 
-    let plugins = await loadPlugins(config)
+    let plugins = await loadPlugins(reporter, config)
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -120,7 +120,7 @@ describe(`Load plugins`, () => {
         plugins: [],
       }
 
-      let plugins = await loadPlugins(config)
+      let plugins = await loadPlugins(reporter, config)
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -145,7 +145,7 @@ describe(`Load plugins`, () => {
         ],
       }
 
-      let plugins = await loadPlugins(config)
+      let plugins = await loadPlugins(reporter, config)
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -183,7 +183,7 @@ describe(`Load plugins`, () => {
         ],
       }
 
-      let plugins = await loadPlugins(config)
+      let plugins = await loadPlugins(reporter, config)
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -214,7 +214,7 @@ describe(`Load plugins`, () => {
           },
         },
       ]
-      await loadPlugins({
+      await loadPlugins(reporter, {
         plugins: invalidPlugins,
       })
 
@@ -298,7 +298,7 @@ describe(`Load plugins`, () => {
           },
         },
       ]
-      await loadPlugins({
+      await loadPlugins(reporter, {
         plugins,
       })
 
@@ -314,7 +314,7 @@ describe(`Load plugins`, () => {
     })
 
     it(`defaults plugin options to the ones defined in the schema`, async () => {
-      let plugins = await loadPlugins({
+      let plugins = await loadPlugins(reporter, {
         plugins: [
           {
             resolve: `gatsby-plugin-google-analytics`,
@@ -343,7 +343,7 @@ describe(`Load plugins`, () => {
     })
 
     it(`validates subplugin schemas`, async () => {
-      await loadPlugins({
+      await loadPlugins(reporter, {
         plugins: [
           {
             resolve: `gatsby-transformer-remark`,

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -51,7 +51,7 @@ describe(`Load plugins`, () => {
     })
 
   it(`Load plugins for a site`, async () => {
-    let plugins = await loadPlugins(reporter, { plugins: [] })
+    let plugins = await loadPlugins({ plugins: [] }, undefined, reporter)
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -67,7 +67,7 @@ describe(`Load plugins`, () => {
       ],
     }
 
-    let plugins = await loadPlugins(reporter, config)
+    let plugins = await loadPlugins(config, undefined, reporter)
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -88,7 +88,7 @@ describe(`Load plugins`, () => {
     }
 
     try {
-      await loadPlugins(reporter, config)
+      await loadPlugins(config, undefined, reporter)
     } catch (err) {
       expect(err.message).toMatchSnapshot()
     }
@@ -107,7 +107,7 @@ describe(`Load plugins`, () => {
       ],
     }
 
-    let plugins = await loadPlugins(reporter, config)
+    let plugins = await loadPlugins(config, undefined, reporter)
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -120,7 +120,7 @@ describe(`Load plugins`, () => {
         plugins: [],
       }
 
-      let plugins = await loadPlugins(reporter, config)
+      let plugins = await loadPlugins(config, undefined, reporter)
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -145,7 +145,7 @@ describe(`Load plugins`, () => {
         ],
       }
 
-      let plugins = await loadPlugins(reporter, config)
+      let plugins = await loadPlugins(config, undefined, reporter)
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -183,7 +183,7 @@ describe(`Load plugins`, () => {
         ],
       }
 
-      let plugins = await loadPlugins(reporter, config)
+      let plugins = await loadPlugins(config, undefined, reporter)
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -214,9 +214,13 @@ describe(`Load plugins`, () => {
           },
         },
       ]
-      await loadPlugins(reporter, {
-        plugins: invalidPlugins,
-      })
+      await loadPlugins(
+        {
+          plugins: invalidPlugins,
+        },
+        undefined,
+        reporter
+      )
 
       expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(
         invalidPlugins.length
@@ -298,9 +302,13 @@ describe(`Load plugins`, () => {
           },
         },
       ]
-      await loadPlugins(reporter, {
-        plugins,
-      })
+      await loadPlugins(
+        {
+          plugins,
+        },
+        undefined,
+        reporter
+      )
 
       expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(0)
       expect(reporter.warn as jest.Mock).toHaveBeenCalledTimes(1)
@@ -314,16 +322,20 @@ describe(`Load plugins`, () => {
     })
 
     it(`defaults plugin options to the ones defined in the schema`, async () => {
-      let plugins = await loadPlugins(reporter, {
-        plugins: [
-          {
-            resolve: `gatsby-plugin-google-analytics`,
-            options: {
-              trackingId: `fake`,
+      let plugins = await loadPlugins(
+        {
+          plugins: [
+            {
+              resolve: `gatsby-plugin-google-analytics`,
+              options: {
+                trackingId: `fake`,
+              },
             },
-          },
-        ],
-      })
+          ],
+        },
+        undefined,
+        reporter
+      )
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -343,23 +355,27 @@ describe(`Load plugins`, () => {
     })
 
     it(`validates subplugin schemas`, async () => {
-      await loadPlugins(reporter, {
-        plugins: [
-          {
-            resolve: `gatsby-transformer-remark`,
-            options: {
-              plugins: [
-                {
-                  resolve: `gatsby-remark-autolink-headers`,
-                  options: {
-                    maintainCase: `should be boolean`,
+      await loadPlugins(
+        {
+          plugins: [
+            {
+              resolve: `gatsby-transformer-remark`,
+              options: {
+                plugins: [
+                  {
+                    resolve: `gatsby-remark-autolink-headers`,
+                    options: {
+                      maintainCase: `should be boolean`,
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        ],
-      })
+          ],
+        },
+        undefined,
+        reporter
+      )
 
       expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(1)
       expect((reporter.error as jest.Mock).mock.calls[0])

--- a/packages/gatsby/src/bootstrap/load-plugins/index.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.ts
@@ -11,7 +11,6 @@ import {
   handleMultipleReplaceRenderers,
   ExportType,
   ICurrentAPIs,
-  validateConfigPluginsOptions,
 } from "./validate"
 import {
   IPluginInfo,
@@ -19,6 +18,7 @@ import {
   ISiteConfig,
   IRawSiteConfig,
 } from "./types"
+import { validateConfigPluginsOptions } from "gatsby-plugin-utils"
 import { IPluginRefObject, PluginRef } from "gatsby-plugin-utils/dist/types"
 
 const getAPI = (

--- a/packages/gatsby/src/bootstrap/load-plugins/index.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./types"
 import { validateConfigPluginsOptions } from "gatsby-plugin-utils"
 import { IPluginRefObject, PluginRef } from "gatsby-plugin-utils/dist/types"
+import reporter from "gatsby-cli/lib/reporter"
 
 const getAPI = (
   api: { [exportType in ExportType]: { [api: string]: boolean } }
@@ -88,7 +89,7 @@ export async function loadPlugins(
   const config = normalizeConfig(rawConfig)
 
   // Show errors for invalid plugin configuration
-  await validateConfigPluginsOptions(config, rootDir)
+  await validateConfigPluginsOptions(reporter, config, rootDir)
 
   const currentAPIs = getAPI({
     browser: browserAPIs,

--- a/packages/gatsby/src/bootstrap/load-plugins/index.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.ts
@@ -20,7 +20,7 @@ import {
 } from "./types"
 import { validateConfigPluginsOptions } from "gatsby-plugin-utils"
 import { IPluginRefObject, PluginRef } from "gatsby-plugin-utils/dist/types"
-import reporter from "gatsby-cli/lib/reporter"
+import { Reporter } from "gatsby-cli/lib/reporter/reporter"
 
 const getAPI = (
   api: { [exportType in ExportType]: { [api: string]: boolean } }
@@ -82,6 +82,7 @@ const normalizeConfig = (config: IRawSiteConfig = {}): ISiteConfig => {
 }
 
 export async function loadPlugins(
+  reporter: Reporter,
   rawConfig: IRawSiteConfig = {},
   rootDir: string | null = null
 ): Promise<Array<IFlattenedPlugin>> {

--- a/packages/gatsby/src/bootstrap/load-plugins/index.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.ts
@@ -90,7 +90,7 @@ export async function loadPlugins(
   const config = normalizeConfig(rawConfig)
 
   // Show errors for invalid plugin configuration
-  await validateConfigPluginsOptions(reporter, config, rootDir)
+  await validateConfigPluginsOptions(config, rootDir, reporter)
 
   const currentAPIs = getAPI({
     browser: browserAPIs,

--- a/packages/gatsby/src/bootstrap/load-plugins/index.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.ts
@@ -82,9 +82,9 @@ const normalizeConfig = (config: IRawSiteConfig = {}): ISiteConfig => {
 }
 
 export async function loadPlugins(
-  reporter: Reporter,
   rawConfig: IRawSiteConfig = {},
-  rootDir: string | null = null
+  rootDir: string | null = null,
+  reporter?: Reporter
 ): Promise<Array<IFlattenedPlugin>> {
   // Turn all strings in plugins: [`...`] into the { resolve: ``, options: {} } form
   const config = normalizeConfig(rawConfig)

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -1,22 +1,11 @@
 import _ from "lodash"
-import path from "path"
 import * as semver from "semver"
 import * as stringSimilarity from "string-similarity"
 import { version as gatsbyVersion } from "gatsby/package.json"
 import reporter from "gatsby-cli/lib/reporter"
-import { validateOptionsSchema, Joi } from "gatsby-plugin-utils"
 import { resolveModuleExports } from "../resolve-module-exports"
 import { getLatestAPIs } from "../../utils/get-latest-apis"
-import { GatsbyNode } from "../../../"
-import {
-  IPluginInfo,
-  IFlattenedPlugin,
-  IPluginInfoOptions,
-  ISiteConfig,
-} from "./types"
-import { IPluginRefObject } from "gatsby-plugin-utils/dist/types"
-import { stripIndent } from "common-tags"
-import { trackCli } from "gatsby-telemetry"
+import { IPluginInfo, IFlattenedPlugin } from "./types"
 
 interface IApi {
   version?: string
@@ -173,150 +162,6 @@ export async function handleBadExports({
         })
       }
     })
-  }
-}
-
-async function validatePluginsOptions(
-  plugins: Array<IPluginRefObject>,
-  rootDir: string | null
-): Promise<{
-  errors: number
-  plugins: Array<IPluginRefObject>
-}> {
-  let errors = 0
-  const newPlugins = await Promise.all(
-    plugins.map(async plugin => {
-      let gatsbyNode
-
-      try {
-        gatsbyNode = require(`${plugin.resolve}/gatsby-node`)
-      } catch (err) {
-        gatsbyNode = {}
-      }
-
-      if (!gatsbyNode.pluginOptionsSchema) return plugin
-
-      let optionsSchema = (gatsbyNode.pluginOptionsSchema as Exclude<
-        GatsbyNode["pluginOptionsSchema"],
-        undefined
-      >)({
-        Joi,
-      })
-
-      // Validate correct usage of pluginOptionsSchema
-      if (!Joi.isSchema(optionsSchema) || optionsSchema.type !== `object`) {
-        reporter.warn(
-          `Plugin "${plugin.resolve}" has an invalid options schema so we cannot verify your configuration for it.`
-        )
-        return plugin
-      }
-
-      try {
-        if (!optionsSchema.describe().keys.plugins) {
-          // All plugins have "plugins: []"" added to their options in load.ts, even if they
-          // do not have subplugins. We add plugins to the schema if it does not exist already
-          // to make sure they pass validation.
-          optionsSchema = optionsSchema.append({
-            plugins: Joi.array().length(0),
-          })
-        }
-
-        plugin.options = await validateOptionsSchema(
-          optionsSchema,
-          (plugin.options as IPluginInfoOptions) || {}
-        )
-
-        if (plugin.options?.plugins) {
-          const {
-            errors: subErrors,
-            plugins: subPlugins,
-          } = await validatePluginsOptions(
-            plugin.options.plugins as Array<IPluginRefObject>,
-            rootDir
-          )
-          plugin.options.plugins = subPlugins
-          errors += subErrors
-        }
-      } catch (error) {
-        if (error instanceof Joi.ValidationError) {
-          // Show a small warning on unknown options rather than erroring
-          const validationWarnings = error.details.filter(
-            err => err.type === `object.unknown`
-          )
-          const validationErrors = error.details.filter(
-            err => err.type !== `object.unknown`
-          )
-
-          // If rootDir and plugin.parentDir are the same, i.e. if this is a plugin a user configured in their gatsby-config.js (and not a sub-theme that added it), this will be ""
-          // Otherwise, this will contain (and show) the relative path
-          const configDir =
-            (plugin.parentDir &&
-              rootDir &&
-              path.relative(rootDir, plugin.parentDir)) ||
-            null
-          if (validationErrors.length > 0) {
-            reporter.error({
-              id: `11331`,
-              context: {
-                configDir,
-                validationErrors,
-                pluginName: plugin.resolve,
-              },
-            })
-            errors++
-          }
-
-          if (validationWarnings.length > 0) {
-            reporter.warn(
-              stripIndent(`
-                Warning: there are unknown plugin options for "${
-                  plugin.resolve
-                }"${
-                configDir ? `, configured by ${configDir}` : ``
-              }: ${validationWarnings
-                .map(error => error.path.join(`.`))
-                .join(`, `)}
-                Please open an issue at ghub.io/${
-                  plugin.resolve
-                } if you believe this option is valid.
-              `)
-            )
-            trackCli(`UNKNOWN_PLUGIN_OPTION`, {
-              name: plugin.resolve,
-              valueString: validationWarnings
-                .map(error => error.path.join(`.`))
-                .join(`, `),
-            })
-            // We do not increment errors++ here as we do not want to process.exit if there are only warnings
-          }
-
-          return plugin
-        }
-
-        throw error
-      }
-
-      return plugin
-    })
-  )
-  return { errors, plugins: newPlugins }
-}
-
-export async function validateConfigPluginsOptions(
-  config: ISiteConfig = {},
-  rootDir: string | null
-): Promise<void> {
-  if (!config.plugins) return
-
-  const { errors, plugins } = await validatePluginsOptions(
-    config.plugins,
-    rootDir
-  )
-
-  config.plugins = plugins
-
-  if (errors > 0) {
-    process.exit(1)
   }
 }
 

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -186,9 +186,9 @@ export async function initialize({
       reporter.warn(
         reporter.stripIndent(`
           Both FAST_REFRESH gatsby-config flag and GATSBY_HOT_LOADER environment variable is used with conflicting setting ("${process.env.GATSBY_HOT_LOADER}").
-          
+
           Will use react-hot-loader.
-          
+
           To use Fast Refresh either do not use GATSBY_HOT_LOADER environment variable or set it to "fast-refresh".
         `)
       )
@@ -288,7 +288,11 @@ export async function initialize({
     parentSpan,
   })
   activity.start()
-  const flattenedPlugins = await loadPlugins(config, program.directory)
+  const flattenedPlugins = await loadPlugins(
+    reporter,
+    config,
+    program.directory
+  )
   activity.end()
 
   // Multiple occurrences of the same name-version-pair can occur,

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -289,10 +289,11 @@ export async function initialize({
   })
   activity.start()
   const flattenedPlugins = await loadPlugins(
-    reporter,
     config,
-    program.directory
+    program.directory,
+    reporter
   )
+
   activity.end()
 
   // Multiple occurrences of the same name-version-pair can occur,


### PR DESCRIPTION
## Description

Moving validate options schema from gatsby to gatsby-plugin-utils
