### PR TITLE
fix(gatsby): correct tracing for GraphQL queries

### DIFF
--- a/packages/gatsby/src/query/graphql-runner.ts
+++ b/packages/gatsby/src/query/graphql-runner.ts
@@ -184,7 +184,7 @@ export class GraphQLRunner {
 
     try {
       // `execute` will return a promise
-      return execute({
+      return await execute({
         schema,
         document,
         rootValue: context,


### PR DESCRIPTION
## Description

Before this PR `GraphQL Query` trace was reporting incorrect numbers. It was always reporting `0-5ms` because we didn't wait for the query promise to resolve. So the tracer was ending immediately after the `execute()` call.
