### PR TITLE
chore(gatsby): fold three loops into one

### DIFF
--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -92,15 +92,21 @@ const processPageQueries = async (
   // /dev-404-page/, whose SitePage node is created via
   // `internal-data-bridge`, but the actual page object is only
   // created during `gatsby develop`.
-  const pages = _.filter(queryIds.map(id => state.pages.get(id)))
-  await processQueries(
-    pages.map(page => createPageQueryJob(state, page)),
-    {
-      activity,
-      graphqlRunner,
-      graphqlTracing,
+
+  const jobs = []
+  queryIds.forEach(id => {
+    const page = state.pages.get(id)
+    if (page) {
+      const job = createPageQueryJob(state, page)
+      jobs.push(job)
     }
-  )
+  })
+
+  await processQueries(jobs, {
+    activity,
+    graphqlRunner,
+    graphqlTracing,
+  })
 }
 
 const createPageQueryJob = (state, page) => {


### PR DESCRIPTION
In followup to https://github.com/gatsbyjs/gatsby/pull/28377

This folds three loops (filter, map, map) over the query ids into a single loop that does 'em all.