### PR TITLE
chore(gatsby): refactor into await syntax

### DIFF
--- a/packages/gatsby/src/query/queue.ts
+++ b/packages/gatsby/src/query/queue.ts
@@ -36,10 +36,13 @@ const createBuildQueue = (
 
   const queueOptions: BetterQueue.QueueOptions<Task, TaskResult> = {
     ...createBaseOptions(),
-    process: ({ job, activity }, callback): void => {
-      queryRunner(graphqlRunner, job, activity?.span)
-        .then(result => callback(null, result))
-        .catch(callback)
+    async process({ job, activity }, callback): Promise<void> {
+      try {
+        const result = await queryRunner(graphqlRunner, job, activity?.span)
+        callback(null, result)
+      } catch (e) {
+        callback(e)
+      }
     },
   }
   return new Queue(queueOptions)
@@ -62,20 +65,20 @@ const createDevelopQueue = (getRunner: () => GraphQLRunner): Queue => {
     ): void => {
       cb(null, newTask)
     },
-    process: ({ job: queryJob, activity }, callback): void => {
-      queryRunner(getRunner(), queryJob, activity?.span).then(
-        result => {
-          if (!queryJob.isPage) {
-            websocketManager.emitStaticQueryData({
-              result,
-              id: queryJob.hash,
-            })
-          }
+    async process({ job: queryJob, activity }, callback): Promise<void> {
+      try {
+        const result = queryRunner(getRunner(), queryJob, activity?.span)
+        if (!queryJob.isPage) {
+          websocketManager.emitStaticQueryData({
+            result,
+            id: queryJob.hash,
+          })
+        }
 
-          callback(null, result)
-        },
-        error => callback(error)
-      )
+        callback(null, result)
+      } catch (e) {
+        callback(e)
+      }
     },
   }
 

--- a/packages/gatsby/src/query/queue.ts
+++ b/packages/gatsby/src/query/queue.ts
@@ -67,7 +67,7 @@ const createDevelopQueue = (getRunner: () => GraphQLRunner): Queue => {
     },
     async process({ job: queryJob, activity }, callback): Promise<void> {
       try {
-        const result = queryRunner(getRunner(), queryJob, activity?.span)
+        const result = await queryRunner(getRunner(), queryJob, activity?.span)
         if (!queryJob.isPage) {
           websocketManager.emitStaticQueryData({
             result,


### PR DESCRIPTION
I think it looks nicer this way? I don't think it changes anything else. I don't think better-queue cares about the return value of the `process` method (promise or otherwise) since it's driven by the callback.