### PR TITLE
chore(gatsby): refactor try/finally to .finally

### DIFF
--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -98,15 +98,15 @@ async function startQueryJob(
     }
   }, 15000)
 
-  try {
-    return await graphqlRunner.query(queryJob.query, queryJob.context, {
+  return graphqlRunner
+    .query(queryJob.query, queryJob.context, {
       parentSpan,
       queryName: queryJob.id,
     })
-  } finally {
-    isPending = false
-    clearTimeout(timeoutId)
-  }
+    .finally(() => {
+      isPending = false
+      clearTimeout(timeoutId)
+    })
 }
 
 export async function queryRunner(


### PR DESCRIPTION
I've experienced some odd behavior with `try/catch` and `await` and this way we don't need to `await` the promise inside this call. Instead we can return the promise that should still stop the timeout-timer before resolving further promises.