### PR TITLE
chore(gatsby-source-contentful): drop unnecessary promise, _.get

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -439,7 +439,7 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
         defaultValue: null,
       },
     },
-    resolve: (image, options, context) => {
+    resolve(image, options, context) {
       const node = resolveFixed(image, options)
       if (!node) return null
 
@@ -538,7 +538,7 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
         type: GraphQLString,
       },
     },
-    resolve: (image, options, context) => {
+    resolve(image, options, context) {
       const node = resolveFluid(image, options)
       if (!node) return null
 

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -380,7 +380,7 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
           type: GraphQLString,
           resolve({ image, options, context }) {
             if (
-              _.get(image, `file.contentType`) === `image/webp` ||
+              image?.file?.contentType === `image/webp` ||
               options.toFormat === `webp`
             ) {
               return null
@@ -390,14 +390,14 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
               ...options,
               toFormat: `webp`,
             })
-            return _.get(fixed, `src`)
+            return fixed?.src
           },
         },
         srcSetWebp: {
           type: GraphQLString,
           resolve({ image, options, context }) {
             if (
-              _.get(image, `file.contentType`) === `image/webp` ||
+              image?.file?.contentType === `image/webp` ||
               options.toFormat === `webp`
             ) {
               return null
@@ -407,7 +407,7 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
               ...options,
               toFormat: `webp`,
             })
-            return _.get(fixed, `srcSet`)
+            return fixed?.srcSet
           },
         },
       },
@@ -439,17 +439,17 @@ const fixedNodeType = ({ name, getTracedSVG }) => {
         defaultValue: null,
       },
     },
-    resolve: (image, options, context) =>
-      Promise.resolve(resolveFixed(image, options)).then(node => {
-        if (!node) return null
+    resolve: (image, options, context) => {
+      const node = resolveFixed(image, options)
+      if (!node) return null
 
-        return {
-          ...node,
-          image,
-          options,
-          context,
-        }
-      }),
+      return {
+        ...node,
+        image,
+        options,
+        context,
+      }
+    },
   }
 }
 
@@ -475,7 +475,7 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
           type: GraphQLString,
           resolve({ image, options, context }) {
             if (
-              _.get(image, `file.contentType`) === `image/webp` ||
+              image?.file?.contentType === `image/webp` ||
               options.toFormat === `webp`
             ) {
               return null
@@ -485,14 +485,14 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
               ...options,
               toFormat: `webp`,
             })
-            return _.get(fluid, `src`)
+            return fluid?.src
           },
         },
         srcSetWebp: {
           type: GraphQLString,
           resolve({ image, options, context }) {
             if (
-              _.get(image, `file.contentType`) === `image/webp` ||
+              image?.file?.contentType === `image/webp` ||
               options.toFormat === `webp`
             ) {
               return null
@@ -502,7 +502,7 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
               ...options,
               toFormat: `webp`,
             })
-            return _.get(fluid, `srcSet`)
+            return fluid?.srcSet
           },
         },
         sizes: { type: new GraphQLNonNull(GraphQLString) },
@@ -538,17 +538,17 @@ const fluidNodeType = ({ name, getTracedSVG }) => {
         type: GraphQLString,
       },
     },
-    resolve: (image, options, context) =>
-      Promise.resolve(resolveFluid(image, options)).then(node => {
-        if (!node) return null
+    resolve: (image, options, context) => {
+      const node = resolveFluid(image, options)
+      if (!node) return null
 
-        return {
-          ...node,
-          image,
-          options,
-          context,
-        }
-      }),
+      return {
+        ...node,
+        image,
+        options,
+        context,
+      }
+    },
   }
 }
 


### PR DESCRIPTION
This PR does three things twice;

- Drop a `Promise.resolve` for a value that is not a promise in a function (resolver) that can but does not need to return a promise
- Makes the resolver a proper method, rather than an arrow property
- Drop a few cases of `_.get` in favor of actual `?.` syntax