### PR TITLE
fix(gatsby): show multiple invites together & at end where people are more likely to see them

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -143,6 +143,7 @@
     "st": "^2.0.0",
     "stack-trace": "^0.0.10",
     "string-similarity": "^1.2.2",
+    "strip-ansi": "^5.2.0",
     "style-loader": "^0.23.1",
     "terminal-link": "^2.1.1",
     "terser-webpack-plugin": "^2.3.8",

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -71,7 +71,7 @@ if (
 
 module.exports = {
   flags : { DEV_SSR: true },
-  plugins: [...],
+  plugins: [...]
 }`,
     1 // Show this immediately to the subset of sites selected.
   )

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -70,7 +70,7 @@ if (
     `which helps surface issues with build errors more quickly. Here's how to try it:
 
 module.exports = {
-  flags : { DEV_SSR: true, },
+  flags : { DEV_SSR: true },
   plugins: [...],
 }`,
     1 // Show this immediately to the subset of sites selected.

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -6,7 +6,6 @@ import crypto from "crypto"
 import del from "del"
 import path from "path"
 import telemetry from "gatsby-telemetry"
-import chalk from "chalk"
 
 import apiRunnerNode from "../utils/api-runner-node"
 import handleFlags from "../utils/handle-flags"

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -69,7 +69,10 @@ if (
     `gatsby.dev/dev-ssr-feedback`,
     `which helps surface issues with build errors more quickly. Here's how to try it:
 
-flags : { DEV_SSR: true, }`,
+module.exports = {
+  flags : { DEV_SSR: true, },
+  plugins: [...],
+}`,
     1 // Show this immediately to the subset of sites selected.
   )
 }

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -65,20 +65,20 @@ if (
   sampleSiteForExperiment(`DEV_SSR`, 5)
 ) {
   showExperimentNoticeAfterTimeout(
-    `devSSR`,
-    `
-Your dev experience is about to get better, faster, and stronger!
+    `DEV_SSR`,
+    {
+      reason: `We'll soon be shipping support for SSR in development.`,
+      solution: `This will help the dev environment more closely mimic builds so you'll catch build errors earlier and fix them faster.
 
-We'll soon be shipping support for SSR in development.
+Try out develop SSR *today* by enabling it in your gatsby-config.js:
 
-This will help the dev environment more closely mimic builds so you'll catch build errors earlier and fix them faster.
-
-Try out develop SSR *today* by running your site with it enabled:
-
-GATSBY_EXPERIMENTAL_DEV_SSR=true gatsby develop
+flags: {
+  DEV_SSR: true
+}
 
 Please let us know how it goes good, bad, or otherwise at gatsby.dev/dev-ssr-feedback
       `,
+    },
     1 // Show this immediately to the subset of sites selected.
   )
 }

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -67,23 +67,10 @@ if (
 ) {
   showExperimentNoticeAfterTimeout(
     `SSR in Development`,
-    `We'll soon be shipping support for ${chalk.bold(
-      `server-side rendering (SSR)`
-    )} in development.
-This will help you as it'll more closely match the behavior of \`gatsby build\`
-which will enable you to catch errors more quickly and ultimately, fix them more
-quickly.
+    `gatsby.dev/dev-ssr-feedback`,
+    `which helps surface issues with build errors more quickly. Here's how to try it:
 
-Try out develop SSR *today* by enabling it in your gatsby-config.js:
-
-  module.exports = {
-    flags: {
-      DEV_SSR: true
-    }
-  }
-
-Please let us know how it goes good, bad, or otherwise at gatsby.dev/dev-ssr-feedback
-      `,
+flags : { DEV_SSR: true, }`,
     1 // Show this immediately to the subset of sites selected.
   )
 }

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -65,7 +65,7 @@ if (
   sampleSiteForExperiment(`DEV_SSR`, 5)
 ) {
   showExperimentNoticeAfterTimeout(
-    `SSR in Development`,
+    `Server Side Rendering (SSR) in Development`,
     `gatsby.dev/dev-ssr-feedback`,
     `which helps surface issues with build errors more quickly. Here's how to try it:
 

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -6,6 +6,7 @@ import crypto from "crypto"
 import del from "del"
 import path from "path"
 import telemetry from "gatsby-telemetry"
+import chalk from "chalk"
 
 import apiRunnerNode from "../utils/api-runner-node"
 import handleFlags from "../utils/handle-flags"
@@ -65,20 +66,24 @@ if (
   sampleSiteForExperiment(`DEV_SSR`, 5)
 ) {
   showExperimentNoticeAfterTimeout(
-    `DEV_SSR`,
-    {
-      reason: `We'll soon be shipping support for SSR in development.`,
-      solution: `This will help the dev environment more closely mimic builds so you'll catch build errors earlier and fix them faster.
+    `SSR in Development`,
+    `We'll soon be shipping support for ${chalk.bold(
+      `server-side rendering (SSR)`
+    )} in development.
+This will help you as it'll more closely match the behavior of \`gatsby build\`
+which will enable you to catch errors more quickly and ultimately, fix them more
+quickly.
 
 Try out develop SSR *today* by enabling it in your gatsby-config.js:
 
-flags: {
-  DEV_SSR: true
-}
+  module.exports = {
+    flags: {
+      DEV_SSR: true
+    }
+  }
 
 Please let us know how it goes good, bad, or otherwise at gatsby.dev/dev-ssr-feedback
       `,
-    },
     1 // Show this immediately to the subset of sites selected.
   )
 }

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -1,3 +1,4 @@
+import chalk from "chalk"
 import { processPageQueries } from "../query"
 import reporter from "gatsby-cli/lib/reporter"
 import { IQueryRunningContext } from "../state-machines/query-running/types"
@@ -50,16 +51,22 @@ export async function runPageQueries({
     !isCI()
   ) {
     cancelNotice = showExperimentNoticeAfterTimeout(
-      `QUERY_ON_DEMAND`,
-      {
-        reason: `We noticed your site takes longer than ideal to run page queries.`,
-        solution: `We're changing how we run queries in development so queries only run when you need them when you visit a page. This will help make starting your development server a lot faster.
+      `Query On Demand`,
+      `We noticed your site takes longer than ideal to run page queries. We're changing
+soon how we run queries in development so queries only run for pages as you
+visit them. This avoids a lot of upfront work which helps make starting your
+development server ${chalk.bold(`a whole lot faster`)}.
 
-You can enable it by adding "flags: { QUERY_ON_DEMAND: true }" to your gatsby-config.js
+You can try out Query on Demand *today* by enabling it in your gatsby-config.js:
 
-Please do let us know how it goes (good, bad, or otherwise) and learn more about it at https://gatsby.dev/query-on-demand-feedback
-      `,
-      },
+  module.exports = {
+    flags: {
+      QUERY_ON_DEMAND: true
+    }
+  }
+
+Please do let us know how it goes (good, bad, or otherwise) and learn more about it
+at https://gatsby.dev/query-on-demand-feedback`,
       ONE_MINUTE
     )
   }

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -52,21 +52,10 @@ export async function runPageQueries({
   ) {
     cancelNotice = showExperimentNoticeAfterTimeout(
       `Query On Demand`,
-      `We noticed your site takes longer than ideal to run page queries. We're changing
-soon how we run queries in development so queries only run for pages as you
-visit them. This avoids a lot of upfront work which helps make starting your
-development server ${chalk.bold(`a whole lot faster`)}.
+      `https://gatsby.dev/query-on-demand-feedback`,
+      `which avoids running queries in development until you visit a page — so a lot less upfront work. Here's how to try it:
 
-You can try out Query on Demand *today* by enabling it in your gatsby-config.js:
-
-  module.exports = {
-    flags: {
-      QUERY_ON_DEMAND: true
-    }
-  }
-
-Please do let us know how it goes (good, bad, or otherwise) and learn more about it
-at https://gatsby.dev/query-on-demand-feedback`,
+flags: { QUERY_ON_DEMAND: true }`,
       ONE_MINUTE
     )
   }

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk"
 import { processPageQueries } from "../query"
 import reporter from "gatsby-cli/lib/reporter"
 import { IQueryRunningContext } from "../state-machines/query-running/types"

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -54,7 +54,11 @@ export async function runPageQueries({
       `https://gatsby.dev/query-on-demand-feedback`,
       `which avoids running page queries in development until you visit a page — so a lot less upfront work. Here's how to try it:
 
-flags: { QUERY_ON_DEMAND: true }`,
+modules.exports = {
+  flags: { QUERY_ON_DEMAND: true },
+  plugins: [...]
+}
+`,
       ONE_MINUTE
     )
   }

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -52,7 +52,7 @@ export async function runPageQueries({
     cancelNotice = showExperimentNoticeAfterTimeout(
       `Query On Demand`,
       `https://gatsby.dev/query-on-demand-feedback`,
-      `which avoids running queries in development until you visit a page — so a lot less upfront work. Here's how to try it:
+      `which avoids running page queries in development until you visit a page — so a lot less upfront work. Here's how to try it:
 
 flags: { QUERY_ON_DEMAND: true }`,
       ONE_MINUTE

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -50,18 +50,16 @@ export async function runPageQueries({
     !isCI()
   ) {
     cancelNotice = showExperimentNoticeAfterTimeout(
-      `queryOnDemand`,
-      reporter.stripIndent(`
-        Your local development experience is about to get better, faster, and stronger!
+      `QUERY_ON_DEMAND`,
+      {
+        reason: `We noticed your site takes longer than ideal to run page queries.`,
+        solution: `We're changing how we run queries in development so queries only run when you need them when you visit a page. This will help make starting your development server a lot faster.
 
-        Your friendly Gatsby maintainers detected your site takes longer than ideal to run page queries. We're working right now to improve this.
+You can enable it by adding "flags: { QUERY_ON_DEMAND: true }" to your gatsby-config.js
 
-        If you're interested in trialing out one of these future improvements *today* which should make your local development experience faster, go ahead and run your site with QUERY_ON_DEMAND enabled.
-
-        You can enable it by adding "flags: { QUERY_ON_DEMAND: true }" to your gatsby-config.js
-
-        Please do let us know how it goes (good, bad, or otherwise) and learn more about it at https://gatsby.dev/query-on-demand-feedback
-      `),
+Please do let us know how it goes (good, bad, or otherwise) and learn more about it at https://gatsby.dev/query-on-demand-feedback
+      `,
+      },
       ONE_MINUTE
     )
   }

--- a/packages/gatsby/src/services/start-webpack-server.ts
+++ b/packages/gatsby/src/services/start-webpack-server.ts
@@ -12,6 +12,7 @@ import {
 } from "../utils/webpack-error-utils"
 
 import { printDeprecationWarnings } from "../utils/print-deprecation-warnings"
+import { showNotices } from "../utils/show-experiment-notice"
 import { printInstructions } from "../utils/print-instructions"
 import { prepareUrls } from "../utils/prepare-urls"
 import { startServer, IWebpackWatchingPauseResume } from "../utils/start-server"
@@ -97,6 +98,9 @@ export async function startWebpackServer({
       const isSuccessful = !messages.errors.length
 
       if (isSuccessful && isFirstCompile) {
+        // Show notices to users about potential experiments/feature flags they could
+        // try.
+        showNotices()
         printInstructions(
           program.sitePackageJson.name || `(Unnamed package)`,
           urls

--- a/packages/gatsby/src/services/start-webpack-server.ts
+++ b/packages/gatsby/src/services/start-webpack-server.ts
@@ -12,7 +12,7 @@ import {
 } from "../utils/webpack-error-utils"
 
 import { printDeprecationWarnings } from "../utils/print-deprecation-warnings"
-import { showNotices } from "../utils/show-experiment-notice"
+import { showExperimentNotices } from "../utils/show-experiment-notice"
 import { printInstructions } from "../utils/print-instructions"
 import { prepareUrls } from "../utils/prepare-urls"
 import { startServer, IWebpackWatchingPauseResume } from "../utils/start-server"
@@ -100,7 +100,7 @@ export async function startWebpackServer({
       if (isSuccessful && isFirstCompile) {
         // Show notices to users about potential experiments/feature flags they could
         // try.
-        showNotices()
+        showExperimentNotices()
         printInstructions(
           program.sitePackageJson.name || `(Unnamed package)`,
           urls

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/show-experiment-notice.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/show-experiment-notice.js.snap
@@ -3,11 +3,10 @@
 exports[`show-experiment-notice generates a message 1`] = `
 "
 
-Hello! Your friendly Gatsby maintainers detected ways to improve your site. We're
-working on new improvements and invite you to try them out *today* and help ready
-them for general release.
+Hi from the Gatsby maintainers! Based on what we see in your site, these coming
+features may help you. All of these can be enabled within gatsby-config.js via
+flags (samples below)
 
-[44m[1mThe Flag[22m[49m
-hi
+[44m[1mThe Flag (http://example.com)[22m[49m, hi
 "
 `;

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/show-experiment-notice.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/show-experiment-notice.js.snap
@@ -2,7 +2,6 @@
 
 exports[`show-experiment-notice generates a message 1`] = `
 "
-
 Hi from the Gatsby maintainers! Based on what we see in your site, these coming
 features may help you. All of these can be enabled within gatsby-config.js via
 flags (samples below)

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/show-experiment-notice.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/show-experiment-notice.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`show-experiment-notice generates a message 1`] = `
+"
+
+Hello! Your friendly Gatsby maintainers detected ways to improve your site. We're
+working on new improvements and invite you to try them out *today* and help ready
+them for general release.
+
+[44m[1mThe Flag[22m[49m
+hi
+"
+`;

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/show-experiment-notice.js.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/show-experiment-notice.js.snap
@@ -6,6 +6,6 @@ Hi from the Gatsby maintainers! Based on what we see in your site, these coming
 features may help you. All of these can be enabled within gatsby-config.js via
 flags (samples below)
 
-[44m[1mThe Flag (http://example.com)[22m[49m, hi
+The Flag (http://example.com), hi
 "
 `;

--- a/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
+++ b/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
@@ -1,15 +1,18 @@
 import { createNoticeMessage } from "../show-experiment-notice"
+import stripAnsi from "strip-ansi"
 
 describe(`show-experiment-notice`, () => {
   it(`generates a message`, () => {
     expect(
-      createNoticeMessage([
-        {
-          noticeText: `hi`,
-          umbrellaLink: `http://example.com`,
-          experimentIdentifier: `The Flag`,
-        },
-      ])
+      stripAnsi(
+        createNoticeMessage([
+          {
+            noticeText: `hi`,
+            umbrellaLink: `http://example.com`,
+            experimentIdentifier: `The Flag`,
+          },
+        ])
+      )
     ).toMatchSnapshot()
   })
 })

--- a/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
+++ b/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
@@ -6,6 +6,7 @@ describe(`show-experiment-notice`, () => {
       createNoticeMessage([
         {
           noticeText: `hi`,
+          umbrellaLink: `http://example.com`,
           experimentIdentifier: `The Flag`,
         },
       ])

--- a/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
+++ b/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
@@ -1,0 +1,14 @@
+import { createNoticeMessage } from "../show-experiment-notice"
+
+describe(`show-experiment-notice`, () => {
+  it(`generates a message`, () => {
+    expect(
+      createNoticeMessage([
+        {
+          noticeText: `hi`,
+          experimentIdentifier: `The Flag`,
+        },
+      ])
+    ).toMatchSnapshot()
+  })
+})

--- a/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
+++ b/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
@@ -1,6 +1,8 @@
 import { createNoticeMessage } from "../show-experiment-notice"
 import stripAnsi from "strip-ansi"
 
+jest.mock(`terminal-link`, () => (text, url) => `${text} (${url})`)
+
 describe(`show-experiment-notice`, () => {
   it(`generates a message`, () => {
     expect(

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -67,13 +67,11 @@ ${chalk.bgBlue.bold(
 
 export const showExperimentNotices = (): void => {
   if (noticesToShow.length > 0) {
-    telemetry.trackCli(`InviteToTryExperiment`, {
-      notices: noticesToShow.map(n => n.experimentIdentifier),
-    })
+    telemetry.trackCli(`InviteToTryExperiment`)
     // Store that we're showing the invite.
     noticesToShow.forEach(notice =>
       getConfigStore().set(
-        configStoreKey(notice.expermentIdentifier),
+        configStoreKey(notice.experimentIdentifier),
         Date.now()
       )
     )

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -46,7 +46,7 @@ export function showExperimentNoticeAfterTimeout(
   }
 }
 
-const showNotices = () => {
+const showNotices = (): void => {
   emitter.off(`COMPILATION_DONE`, showNotices)
   if (noticesToShow.length > 0) {
     telemetry.trackFeatureIsUsed(`InviteToTryExperiment`)

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -58,16 +58,19 @@ export function showExperimentNoticeAfterTimeout(
 }
 
 export const createNoticeMessage = (notices): string => {
-  let message = `\n
+  let message = `
 Hi from the Gatsby maintainers! Based on what we see in your site, these coming
 features may help you. All of these can be enabled within gatsby-config.js via
 flags (samples below)`
 
   notices.forEach(
     notice =>
-      (message += `\n\n${chalk.bgBlue.bold(
-        terminalLink(notice.experimentIdentifier, notice.umbrellaLink)
-      )}, ${notice.noticeText}\n`)
+      (message += `
+
+${chalk.bgBlue.bold(
+  terminalLink(notice.experimentIdentifier, notice.umbrellaLink)
+)}, ${notice.noticeText}
+`)
   )
 
   return message

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -1,6 +1,5 @@
 import { getConfigStore } from "gatsby-core-utils"
 import reporter from "gatsby-cli/lib/reporter"
-import { emitter } from "../redux"
 import chalk from "chalk"
 import telemetry from "gatsby-telemetry"
 import realTerminalLink from "terminal-link"
@@ -74,8 +73,7 @@ ${chalk.bgBlue.bold(
   return message
 }
 
-const showNotices = (): void => {
-  emitter.off(`COMPILATION_DONE`, showNotices)
+export const showNotices = (): void => {
   if (noticesToShow.length > 0) {
     telemetry.trackCli(`InviteToTryExperiment`, {
       notices: showNotices.map(n => n.experimentIdentifier),
@@ -87,9 +85,8 @@ const showNotices = (): void => {
         Date.now()
       )
     )
+
     const message = createNoticeMessage(noticesToShow)
     reporter.info(message)
   }
 }
-
-emitter.on(`COMPILATION_DONE`, showNotices)

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -46,9 +46,8 @@ export function showExperimentNoticeAfterTimeout(
   }
 }
 
-emitter.on(`COMPILATION_DONE`, () => {
-  emitter.off(`COMPILATION_DONE`, () => {})
-
+const showNotices = () => {
+  emitter.off(`COMPILATION_DONE`, showNotices)
   if (noticesToShow.length > 0) {
     telemetry.trackFeatureIsUsed(`InviteToTryExperiment`)
     let message = `\n
@@ -65,4 +64,6 @@ them for general release.`
 
     reporter.info(message)
   }
-})
+}
+
+emitter.on(`COMPILATION_DONE`, showNotices)

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -67,7 +67,7 @@ flags (samples below)`
     notice =>
       (message += `\n\n${chalk.bgBlue.bold(
         terminalLink(notice.experimentIdentifier, notice.umbrellaLink)
-      )}, ${notice.noticeText.trim()}\n`)
+      )}, ${notice.noticeText}\n`)
   )
 
   return message

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -23,6 +23,7 @@ const ONE_DAY = 24 * 60 * 60 * 1000
 
 interface INoticeObject {
   noticeText: string
+  umbrellaLink: string
   experimentIdentifier: string
 }
 

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -3,6 +3,15 @@ import reporter from "gatsby-cli/lib/reporter"
 import { emitter } from "../redux"
 import chalk from "chalk"
 import telemetry from "gatsby-telemetry"
+import realTerminalLink from "terminal-link"
+
+const terminalLink = (text, url): string => {
+  if (process.env.NODE_ENV === `test`) {
+    return `${text} (${url})`
+  } else {
+    return realTerminalLink(text, url)
+  }
+}
 
 type CancelExperimentNoticeCallback = () => void
 
@@ -21,6 +30,7 @@ const noticesToShow: Array<INoticeObject> = []
 
 export function showExperimentNoticeAfterTimeout(
   experimentIdentifier: string,
+  umbrellaLink: string,
   noticeText: string,
   showNoticeAfterMs: number,
   minimumIntervalBetweenNoticesMs: number = ONE_DAY
@@ -36,7 +46,7 @@ export function showExperimentNoticeAfterTimeout(
   }
 
   const noticeTimeout = setTimeout(() => {
-    noticesToShow.push({ noticeText, experimentIdentifier })
+    noticesToShow.push({ noticeText, umbrellaLink, experimentIdentifier })
 
     getConfigStore().set(configStoreKey, Date.now())
   }, showNoticeAfterMs)
@@ -48,15 +58,15 @@ export function showExperimentNoticeAfterTimeout(
 
 export const createNoticeMessage = (notices): string => {
   let message = `\n
-Hello! Your friendly Gatsby maintainers detected ways to improve your site. We're
-working on new improvements and invite you to try them out *today* and help ready
-them for general release.`
+Hi from the Gatsby maintainers! Based on what we see in your site, these coming
+features may help you. All of these can be enabled within gatsby-config.js via
+flags (samples below)`
 
   notices.forEach(
     notice =>
       (message += `\n\n${chalk.bgBlue.bold(
-        notice.experimentIdentifier
-      )}\n${notice.noticeText.trim()}\n`)
+        terminalLink(notice.experimentIdentifier, notice.umbrellaLink)
+      )}, ${notice.noticeText.trim()}\n`)
   )
 
   return message

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -13,19 +13,15 @@ export type CancelExperimentNoticeCallbackOrUndefined =
 const ONE_DAY = 24 * 60 * 60 * 1000
 
 interface INoticeObject {
-  reason: string
-  solution: string
-}
-
-type NoticesToShow = INoticeObject & {
+  noticeText: string
   experimentIdentifier: string
 }
 
-const noticesToShow: Array<NoticesToShow> = []
+const noticesToShow: Array<INoticeObject> = []
 
 export function showExperimentNoticeAfterTimeout(
   experimentIdentifier: string,
-  noticeObject: INoticeObject,
+  noticeText: string,
   showNoticeAfterMs: number,
   minimumIntervalBetweenNoticesMs: number = ONE_DAY
 ): CancelExperimentNoticeCallbackOrUndefined {
@@ -40,7 +36,7 @@ export function showExperimentNoticeAfterTimeout(
   }
 
   const noticeTimeout = setTimeout(() => {
-    noticesToShow.push({ ...noticeObject, experimentIdentifier })
+    noticesToShow.push({ noticeText, experimentIdentifier })
 
     getConfigStore().set(configStoreKey, Date.now())
   }, showNoticeAfterMs)
@@ -55,13 +51,16 @@ emitter.on(`COMPILATION_DONE`, () => {
 
   if (noticesToShow.length > 0) {
     telemetry.trackFeatureIsUsed(`InviteToTryExperiment`)
-    let message = `\n\nHello! Your friendly Gatsby maintainers detected ways to improve your site. We're working on new improvements and invite you to try them out *today* and help ready them for general release.`
+    let message = `\n
+Hello! Your friendly Gatsby maintainers detected ways to improve your site. We're
+working on new improvements and invite you to try them out *today* and help ready
+them for general release.`
 
     noticesToShow.forEach(
       notice =>
         (message += `\n\n${chalk.bgBlue.bold(
           notice.experimentIdentifier
-        )}\n-${notice.reason.trim()}\n-${notice.solution.trim()}\n`)
+        )}\n${notice.noticeText.trim()}\n`)
     )
 
     reporter.info(message)

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -2,15 +2,7 @@ import { getConfigStore } from "gatsby-core-utils"
 import reporter from "gatsby-cli/lib/reporter"
 import chalk from "chalk"
 import telemetry from "gatsby-telemetry"
-import realTerminalLink from "terminal-link"
-
-const terminalLink = (text, url): string => {
-  if (process.env.NODE_ENV === `test`) {
-    return `${text} (${url})`
-  } else {
-    return realTerminalLink(text, url)
-  }
-}
+import terminalLink from "terminal-link"
 
 type CancelExperimentNoticeCallback = () => void
 

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -58,8 +58,7 @@ export function showExperimentNoticeAfterTimeout(
 }
 
 export const createNoticeMessage = (notices): string => {
-  let message = `
-Hi from the Gatsby maintainers! Based on what we see in your site, these coming
+  let message = `\nHi from the Gatsby maintainers! Based on what we see in your site, these coming
 features may help you. All of these can be enabled within gatsby-config.js via
 flags (samples below)`
 
@@ -69,8 +68,7 @@ flags (samples below)`
 
 ${chalk.bgBlue.bold(
   terminalLink(notice.experimentIdentifier, notice.umbrellaLink)
-)}, ${notice.noticeText}
-`)
+)}, ${notice.noticeText}\n`)
   )
 
   return message

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -65,13 +65,13 @@ ${chalk.bgBlue.bold(
   return message
 }
 
-export const showNotices = (): void => {
+export const showExperimentNotices = (): void => {
   if (noticesToShow.length > 0) {
     telemetry.trackCli(`InviteToTryExperiment`, {
-      notices: showNotices.map(n => n.experimentIdentifier),
+      notices: noticesToShow.map(n => n.experimentIdentifier),
     })
     // Store that we're showing the invite.
-    showNotices.forEach(notice =>
+    noticesToShow.forEach(notice =>
       getConfigStore().set(
         configStoreKey(notice.expermentIdentifier),
         Date.now()

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -77,7 +77,9 @@ ${chalk.bgBlue.bold(
 const showNotices = (): void => {
   emitter.off(`COMPILATION_DONE`, showNotices)
   if (noticesToShow.length > 0) {
-    telemetry.trackFeatureIsUsed(`InviteToTryExperiment`)
+    telemetry.trackCli(`InviteToTryExperiment`, {
+      notices: showNotices.map(n => n.experimentIdentifier),
+    })
     const message = createNoticeMessage(noticesToShow)
     reporter.info(message)
   }

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -46,22 +46,27 @@ export function showExperimentNoticeAfterTimeout(
   }
 }
 
-const showNotices = (): void => {
-  emitter.off(`COMPILATION_DONE`, showNotices)
-  if (noticesToShow.length > 0) {
-    telemetry.trackFeatureIsUsed(`InviteToTryExperiment`)
-    let message = `\n
+export const createNoticeMessage = (notices): string => {
+  let message = `\n
 Hello! Your friendly Gatsby maintainers detected ways to improve your site. We're
 working on new improvements and invite you to try them out *today* and help ready
 them for general release.`
 
-    noticesToShow.forEach(
-      notice =>
-        (message += `\n\n${chalk.bgBlue.bold(
-          notice.experimentIdentifier
-        )}\n${notice.noticeText.trim()}\n`)
-    )
+  notices.forEach(
+    notice =>
+      (message += `\n\n${chalk.bgBlue.bold(
+        notice.experimentIdentifier
+      )}\n${notice.noticeText.trim()}\n`)
+  )
 
+  return message
+}
+
+const showNotices = (): void => {
+  emitter.off(`COMPILATION_DONE`, showNotices)
+  if (noticesToShow.length > 0) {
+    telemetry.trackFeatureIsUsed(`InviteToTryExperiment`)
+    const message = createNoticeMessage(noticesToShow)
     reporter.info(message)
   }
 }

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -2,6 +2,7 @@ import { getConfigStore } from "gatsby-core-utils"
 import reporter from "gatsby-cli/lib/reporter"
 import { emitter } from "../redux"
 import chalk from "chalk"
+import telemetry from "gatsby-telemetry"
 
 type CancelExperimentNoticeCallback = () => void
 
@@ -53,6 +54,7 @@ emitter.on(`COMPILATION_DONE`, () => {
   emitter.off(`COMPILATION_DONE`, () => {})
 
   if (noticesToShow.length > 0) {
+    telemetry.trackFeatureIsUsed(`InviteToTryExperiment`)
     let message = `\n\nHello! Your friendly Gatsby maintainers detected ways to improve your site. We're working on new improvements and invite you to try them out *today* and help ready them for general release.`
 
     noticesToShow.forEach(

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -93,19 +93,19 @@ export async function startServer(
   ) {
     cancelDevJSNotice = showExperimentNoticeAfterTimeout(
       `PRESERVE_WEBPACK_CACHE`,
-      report.stripIndent(`
-Your friendly Gatsby maintainers detected your site has more JavaScript than most sites! We're working to make your site's JS compile as quickly as possible by avoiding clearing your webpack cache as often.
+      {
+        reason: `We noticed your site has more JavaScript than most sites.`,
+        solution: `We're changing the cache clearing behavior to not clear webpack's cache unless really necessary. This will make your local development server load faster.
 
-If you're interested in trialing this coming change *today* — which should make your local development experience faster — go ahead and enable the PRESERVE_WEBPACK_CACHE flag and run your develop server again.
-
-To do so, add to your gatsby-config.js:
+To enable this behavior, add this flag to your gatsby-config.js:
 
 flags: {
   PRESERVE_WEBPACK_CACHE: true,
 }
 
 Visit the umbrella issue to learn more: https://github.com/gatsbyjs/gatsby/discussions/28331
-      `),
+      `,
+      },
       THIRTY_SECONDS
     )
   }

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -92,21 +92,12 @@ export async function startServer(
     !isCI()
   ) {
     cancelDevJSNotice = showExperimentNoticeAfterTimeout(
-      `Don't clear webpack's cache as often`,
-      `We noticed your site has more JavaScript than most sites. We're working to make
-compiling your code faster by not clearing webpack's cache unless really
-necessary. This will make your local development server load faster.
+      `Preserve webpack's Cache`,
+      `https://github.com/gatsbyjs/gatsby/discussions/28331`,
+      `which changes Gatsby's cache clearing behavior to not clear webpack's cache unless really
+necessary. Here's how to try it:
 
-To enable this behavior, add this flag to your gatsby-config.js:
-
-  module.exports = {
-    flags: {
-      PRESERVE_WEBPACK_CACHE: true,
-    },
-  }
-
-Visit the umbrella issue to learn more: https://github.com/gatsbyjs/gatsby/discussions/28331
-      `,
+flags: { PRESERVE_WEBPACK_CACHE: true }`,
       THIRTY_SECONDS
     )
   }

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -92,20 +92,21 @@ export async function startServer(
     !isCI()
   ) {
     cancelDevJSNotice = showExperimentNoticeAfterTimeout(
-      `PRESERVE_WEBPACK_CACHE`,
-      {
-        reason: `We noticed your site has more JavaScript than most sites.`,
-        solution: `We're changing the cache clearing behavior to not clear webpack's cache unless really necessary. This will make your local development server load faster.
+      `Don't clear webpack's cache as often`,
+      `We noticed your site has more JavaScript than most sites. We're working to make
+compiling your code faster by not clearing webpack's cache unless really
+necessary. This will make your local development server load faster.
 
 To enable this behavior, add this flag to your gatsby-config.js:
 
-flags: {
-  PRESERVE_WEBPACK_CACHE: true,
-}
+  module.exports = {
+    flags: {
+      PRESERVE_WEBPACK_CACHE: true,
+    },
+  }
 
 Visit the umbrella issue to learn more: https://github.com/gatsbyjs/gatsby/discussions/28331
       `,
-      },
       THIRTY_SECONDS
     )
   }

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -95,10 +95,13 @@ export async function startServer(
       `Preserve webpack's Cache`,
       `https://github.com/gatsbyjs/gatsby/discussions/28331`,
       `which changes Gatsby's cache clearing behavior to not clear webpack's
-      cache unless you run "gatsby clean" or delete the .cache folder manually.
-      Here's how to try it:
+cache unless you run "gatsby clean" or delete the .cache folder manually.
+Here's how to try it:
 
-flags: { PRESERVE_WEBPACK_CACHE: true }`,
+module.exports = {
+  flags: { PRESERVE_WEBPACK_CACHE: true },
+  plugins: [...]
+}`,
       THIRTY_SECONDS
     )
   }

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -94,8 +94,9 @@ export async function startServer(
     cancelDevJSNotice = showExperimentNoticeAfterTimeout(
       `Preserve webpack's Cache`,
       `https://github.com/gatsbyjs/gatsby/discussions/28331`,
-      `which changes Gatsby's cache clearing behavior to not clear webpack's cache unless really
-necessary. Here's how to try it:
+      `which changes Gatsby's cache clearing behavior to not clear webpack's
+      cache unless you run "gatsby clean" or delete the .cache folder manually.
+      Here's how to try it:
 
 flags: { PRESERVE_WEBPACK_CACHE: true }`,
       THIRTY_SECONDS


### PR DESCRIPTION
Also track when we show invites so we get a sense of how often that is happening

<img width="970" alt="Screen Shot 2020-12-03 at 11 03 09 AM" src="https://user-images.githubusercontent.com/71047/101075934-897c8c80-3557-11eb-9508-448a097f91fc.png">

