### PR TITLE
fix(gatsby): Add bodyComponent to replaceRenderer args

### DIFF
--- a/packages/gatsby/cache-dir/api-ssr-docs.js
+++ b/packages/gatsby/cache-dir/api-ssr-docs.js
@@ -9,6 +9,7 @@
  * rendering.
  * @param {object} $0
  * @param {string} $0.pathname The pathname of the page currently being rendered.
+ * @param {ReactNode} $0.bodyComponent The React element to be rendered as the page body
  * @param {function} $0.replaceBodyHTMLString Call this with the HTML string
  * you render. **WARNING** if multiple plugins implement this API it's the
  * last plugin that "wins". TODO implement an automated warning against this.

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -921,6 +921,7 @@ export interface RenderBodyArgs extends NodePluginArgs {
 
 export interface ReplaceRendererArgs extends NodePluginArgs {
   replaceBodyHTMLString: (str: string) => void
+  bodyComponent: React.ReactNode
   setHeadComponents: (comp: React.ReactNode[]) => void
   setHtmlAttributes: (attr: ReactProps<HTMLHtmlElement>) => void
   setBodyAttributes: (attr: ReactProps<HTMLBodyElement>) => void
@@ -1285,7 +1286,7 @@ export interface Actions {
     traceId?: string
   ): void
 
-  printTypeDefinitions (
+  printTypeDefinitions(
     path?: string,
     include?: { types?: Array<string>; plugins?: Array<string> },
     exclude?: { types?: Array<string>; plugins?: Array<string> },


### PR DESCRIPTION
Add missing `bodyComponent` to `replaceRenderer` typedefs and api docs. Fixes #28454 28454