### PR TITLE
chore(gatsby-starter-minimal): Add `serve` script

### DIFF
--- a/starters/gatsby-starter-minimal/package.json
+++ b/starters/gatsby-starter-minimal/package.json
@@ -11,6 +11,7 @@
     "develop": "gatsby develop",
     "start": "gatsby develop",
     "build": "gatsby build",
+    "serve": "gatsby serve",
     "clean": "gatsby clean"
   },
   "license": "0BSD",


### PR DESCRIPTION
I was missing this when using `npm init gatsby` :)