### PR TITLE
fix(gatsby-source-graphql): Pin resolution of extract-files

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
   },
   "resolutions": {
     "theme-ui": "0.4.0-rc.14",
-    "csstype": "2.6.14"
+    "csstype": "2.6.14",
+    "extract-files": "^8.1.0"
   },
   "engines": {
     "yarn": "^1.17.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10633,10 +10633,10 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-files@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
-  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
+extract-files@^8, extract-files@^9.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-8.1.0.tgz#46a0690d0fe77411a2e3804852adeaa65cd59288"
+  integrity sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==
 
 extract-zip@^1.6.6:
   version "1.7.0"


### PR DESCRIPTION
The transitive dependency `extract-files@9.0.0` has a `engines` field set that is incompatible with our minimum supported node version. This adds a resolutions field to pin it to 8.1.0, which is API-compatible. This won;t fix things for npm, but will at least let the monorepo build.