### PR TITLE
feat(gatsby): add preload headers for critical resources so those can started fetching before common.js is fetched

### DIFF
--- a/packages/gatsby/src/utils/dev-ssr/develop-html-route.ts
+++ b/packages/gatsby/src/utils/dev-ssr/develop-html-route.ts
@@ -3,6 +3,7 @@ import { trackFeatureIsUsed } from "gatsby-telemetry"
 
 import { findPageByPath } from "../find-page-by-path"
 import { renderDevHTML } from "./render-dev-html"
+import { appendPreloadHeaders } from "../develop-preload-headers"
 
 export const route = ({ app, program, store }): any =>
   // Render an HTML page and serve it.
@@ -14,6 +15,8 @@ export const route = ({ app, program, store }): any =>
     if (!pathObj) {
       return next()
     }
+
+    await appendPreloadHeaders(req.path, res)
 
     const htmlActivity = report.phantomActivity(`building HTML for path`, {})
     htmlActivity.start()

--- a/packages/gatsby/src/utils/develop-preload-headers.ts
+++ b/packages/gatsby/src/utils/develop-preload-headers.ts
@@ -1,0 +1,65 @@
+import { Response } from "express"
+import * as path from "path"
+
+import { findPageByPath } from "./find-page-by-path"
+import { fixedPagePath, readPageData } from "./page-data"
+import { store } from "../redux"
+
+/**
+ * Add preload link headers to responses for .html files. This allows browser to schedule fetching critical resources
+ * to render a page faster. Without them it would result in network waterfall (fetch js script -> parse and execute -> start downloading data)
+ * With them we can start downloading data before JS executes.
+ */
+export async function appendPreloadHeaders(
+  requestPath: string,
+  res: Response
+): Promise<void> {
+  // add common.js and socket.io.js preload headers
+  // TODO: make socket.io part not blocking - we don't need it anymore to render the page
+  res.append(`Link`, `</commons.js>; rel=preload; as=script`)
+  res.append(`Link`, `</socket.io/socket.io.js>; rel=preload; as=script`)
+
+  const page = findPageByPath(store.getState(), requestPath, true)
+  // we fallback to 404 pages - so there should always be a page (at worst dev-404)
+  // this is just sanity check to not crash server in case it doesn't find anything
+  if (page) {
+    // add app-data.json preload
+    res.append(
+      `Link`,
+      `</page-data/app-data.json>; rel=preload; as=fetch ; crossorigin`
+    )
+    // add page-data.json preload
+    // our runtime also demands 404 and dev-404 page-data to be fetched to even render (see cache-dir/app.js)
+    ;[page.path, `/404.html`, `/dev-404-page/`].forEach(pagePath => {
+      res.append(
+        `Link`,
+        `</${path.join(
+          `page-data`,
+          fixedPagePath(pagePath),
+          `page-data.json`
+        )}>; rel=preload; as=fetch ; crossorigin`
+      )
+    })
+
+    try {
+      const pageData = await readPageData(
+        path.join(store.getState().program.directory, `public`),
+        page.path
+      )
+      // iterate over needed static queries and add preload for each of them
+      pageData.staticQueryHashes.forEach(staticQueryHash => {
+        res.append(
+          `Link`,
+          `</page-data/sq/d/${staticQueryHash}.json>; rel=preload; as=fetch ; crossorigin`
+        )
+      })
+    } catch (e) {
+      // there might be timing reasons why this fails - page-data file is not created yet
+      // as page was just recently added (so page exists already but page-data doesn't yet)
+      // in those cases we just do nothing
+    }
+  } else {
+    // should we track cases when there is actually nothing returned to find cases
+    // where we don't add preload headers if above assumption turns out to be wrong?
+  }
+}

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -32,7 +32,6 @@ import {
   CancelExperimentNoticeCallbackOrUndefined,
 } from "../utils/show-experiment-notice"
 import {
-  fixedPagePath,
   reverseFixedPagePath,
   readPageData,
   IPageDataWithQueryResult,
@@ -46,6 +45,7 @@ import * as path from "path"
 import { Stage, IProgram } from "../commands/types"
 import JestWorker from "jest-worker"
 import { findOriginalSourcePositionAndContent } from "./stack-trace-utils"
+import { appendPreloadHeaders } from "./develop-preload-headers"
 
 type ActivityTracker = any // TODO: Replace this with proper type once reporter is typed
 
@@ -443,6 +443,8 @@ Visit the umbrella issue to learn more: https://github.com/gatsbyjs/gatsby/discu
     } else if (fullUrl.endsWith(`.json`)) {
       res.json({}).status(404)
     } else {
+      await appendPreloadHeaders(req.path, res)
+
       if (process.env.GATSBY_EXPERIMENTAL_DEV_SSR) {
         try {
           const { renderDevHTML } = require(`./dev-ssr/render-dev-html`)
@@ -461,56 +463,6 @@ Visit the umbrella issue to learn more: https://github.com/gatsbyjs/gatsby/discu
           res.send(e).status(500)
         }
       } else {
-        // add common.js and socket.io.js preload headers
-        // TODO: make socket.io part not blocking - we don't need it anymore to render the page
-        res.append(`Link`, `</commons.js>; rel=preload; as=script`)
-        res.append(`Link`, `</socket.io/socket.io.js>; rel=preload; as=script`)
-
-        const page = findPageByPath(store.getState(), req.path, true)
-        // we fallback to 404 pages - so there should always be a page (at worst dev-404)
-        // this is just sanity check to not crash server in case it doesn't find anything
-        if (page) {
-          // add app-data.json preload
-          res.append(
-            `Link`,
-            `</page-data/app-data.json>; rel=preload; as=fetch ; crossorigin`
-          )
-          // add page-data.json preload
-          // our runtime also demands 404 and dev-404 page-data to be fetched to even render (see cache-dir/app.js)
-          ;[page.path, `/404.html`, `/dev-404-page/`].forEach(pagePath => {
-            res.append(
-              `Link`,
-              `</${path.join(
-                `page-data`,
-                fixedPagePath(pagePath),
-                `page-data.json`
-              )}>; rel=preload; as=fetch ; crossorigin`
-            )
-          })
-
-          try {
-            const pageData = await readPageData(
-              directoryPath(`public`),
-              page.path
-            )
-            // iterate over needed static queries and add preload for each of them
-            pageData.staticQueryHashes.forEach(staticQueryHash => {
-              res.append(
-                `Link`,
-                `</page-data/sq/d/${staticQueryHash}.json>; rel=preload; as=fetch ; crossorigin`
-              )
-            })
-          } catch (e) {
-            console.error(e)
-            // there might be timing reasons why this fails - page-data file is not created yet
-            // as page was just recently added (so page exists already but page-data doesn't yet)
-            // in those cases we just do nothing
-          }
-        } else {
-          // should we track cases when there is actually nothing returned to find cases
-          // where we don't add preload headers if above assumption turns out to be wrong?
-        }
-
         res.sendFile(directoryPath(`public/index.html`), err => {
           if (err) {
             res.status(500).end()


### PR DESCRIPTION
## Description

Development runtime currently has network request waterfall where we wait to fetch critical resources to render a page until `common.js` is fetched, parsed and executed which triggers fetching those resources.

Adding preload header allow us to avoid network request waterfalls

### Comparisons:

#### Chrome dev tools, networks tab (slow 3g):

##### Master:

![Screenshot 2020-12-03 at 15 50 05](https://user-images.githubusercontent.com/419821/101046442-564ef300-3581-11eb-8530-b5759ebe3284.png)

This PR:

![Screenshot 2020-12-03 at 15 50 49](https://user-images.githubusercontent.com/419821/101046511-62d34b80-3581-11eb-938c-fe2f10dbe9f1.png)

#### Webpagetest 

- master - https://www.webpagetest.org/result/201203_DiFG_cd254e0dc1016ba4683a1aa8faaa54b3/
- this PR - https://www.webpagetest.org/result/201203_DiH5_55548d47e77b4bc91427d4c43d01215a/

#### First contentful paint

Running
```
performance.getEntriesByType('paint').find(entry => entry.name === 'first-contentful-paint').startTime
```
in dev tools console (with `slow-3g` throthling) result in:

- master: 20529.959999985294
- this PR: 16223.045000020647

(above was from single runs, so take it with grain of salt)

[ch20207]