### PR TITLE
 fix: Back out resolutions, and add ignore-engines to dev cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
   },
   "resolutions": {
     "theme-ui": "0.4.0-rc.14",
-    "csstype": "2.6.14",
-    "extract-files": "^8.1.0"
+    "csstype": "2.6.14"
   },
   "engines": {
     "yarn": "^1.17.3",

--- a/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
@@ -118,7 +118,10 @@ const installPackages = async ({
 
     // package.json files are changed - so we just want to install
     // using verdaccio registry
-    installCmd = [`yarn`, [`install`, `--registry=${registryUrl}`]]
+    installCmd = [
+      `yarn`,
+      [`install`, `--registry=${registryUrl}`, `--ignore-engines`],
+    ]
   } else {
     installCmd = [
       `yarn`,
@@ -130,6 +133,7 @@ const installPackages = async ({
         }),
         `--registry=${registryUrl}`,
         `--exact`,
+        `--ignore-engines`,
       ],
     ]
   }

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -6,7 +6,7 @@ CUSTOM_COMMAND="${2:-yarn test}"
 GATSBY_PATH="${CIRCLE_WORKING_DIRECTORY:-../../}"
 
 # cypress docker does not support sudo and does not need it, but the default node executor does
-command -v gatsby-dev || command -v sudo && sudo npm install -g gatsby-dev-cli || npm install -g gatsby-dev-cli
+command -v gatsby-dev || command -v sudo && sudo npm install -g gatsby-dev-cli@next || npm install -g gatsby-dev-cli@next
 
 # setting up child integration test link to gatsby packages
 cd "$SRC_PATH"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10633,10 +10633,10 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-files@^8, extract-files@^9.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-8.1.0.tgz#46a0690d0fe77411a2e3804852adeaa65cd59288"
-  integrity sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==
+extract-files@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
+  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
 
 extract-zip@^1.6.6:
   version "1.7.0"


### PR DESCRIPTION
Revert #28459, as it was breaking gatsby-source-graphql. Instead add the `--ignore-engines` flag to the dev cli so that e2e tests can at least run