### PR TITLE
fix(gatsby): print childOf directive for implicit child fields

### DIFF
--- a/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
@@ -120,6 +120,10 @@ input Baz {
   qux: Boolean
 }
 
+type BarChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  bar: String
+}
+
 type FooChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
   bar: String
 }
@@ -152,6 +156,10 @@ type Nested {
 
 input Baz {
   qux: Boolean
+}
+
+type BarChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  bar: String
 }"
 `;
 
@@ -269,6 +277,10 @@ type OneMoreTest implements Node @dontInfer {
 }
 
 union ThisOrThat = AnotherTest | OneMoreTest
+
+type BarChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  bar: String
+}
 
 type FooChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
   bar: String
@@ -429,6 +441,10 @@ type Inline {
 
 input Baz {
   qux: Boolean
+}
+
+type BarChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  bar: String
 }
 
 type FooChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
@@ -120,6 +120,10 @@ input Baz {
   qux: Boolean
 }
 
+type FooChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  bar: String
+}
+
 type Test implements Node @dontInfer {
   foo: Int
 }"
@@ -265,6 +269,10 @@ type OneMoreTest implements Node @dontInfer {
 }
 
 union ThisOrThat = AnotherTest | OneMoreTest
+
+type FooChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  bar: String
+}
 
 type Test implements Node @dontInfer {
   foo: Int
@@ -421,6 +429,10 @@ type Inline {
 
 input Baz {
   qux: Boolean
+}
+
+type FooChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  bar: String
 }
 
 type Test implements Node @dontInfer {

--- a/packages/gatsby/src/schema/__tests__/print.js
+++ b/packages/gatsby/src/schema/__tests__/print.js
@@ -59,9 +59,19 @@ describe(`Print type definitions`, () => {
       },
       bar: `bar`,
     }
+    const node3 = {
+      id: `test3`,
+      parent: `test1`,
+      internal: {
+        type: `BarChild`,
+      },
+      bar: `bar`,
+    }
     store.dispatch({ type: `CREATE_NODE`, payload: { ...node1 } })
     store.dispatch({ type: `CREATE_NODE`, payload: { ...node2 } })
+    store.dispatch({ type: `CREATE_NODE`, payload: { ...node3 } })
     createParentChildLink({ parent: node1, child: node2 })
+    createParentChildLink({ parent: node1, child: node3 })
     const typeDefs = []
     typeDefs.push(`
       type AnotherTest implements Node & ITest {
@@ -109,6 +119,18 @@ describe(`Print type definitions`, () => {
             types: [`OneMoreTest`],
           },
         },
+      }),
+      buildObjectType({
+        name: `BarChild`,
+        fields: {
+          id: `ID!`,
+        },
+        interfaces: [`Node`],
+        extensions: {
+          childOf: {
+            types: [`Test`],
+          },
+        },
       })
     )
     store.dispatch({
@@ -119,6 +141,11 @@ describe(`Print type definitions`, () => {
     store.dispatch({
       type: `CREATE_TYPES`,
       payload: typeDefs[1],
+      plugin: { name: `gatsby-plugin-another-test` },
+    })
+    store.dispatch({
+      type: `CREATE_TYPES`,
+      payload: typeDefs[2],
       plugin: { name: `gatsby-plugin-another-test` },
     })
   })

--- a/packages/gatsby/src/schema/__tests__/print.js
+++ b/packages/gatsby/src/schema/__tests__/print.js
@@ -2,6 +2,8 @@ const { build } = require(`..`)
 import { buildObjectType } from "../types/type-builders"
 const { store } = require(`../../redux`)
 const { actions } = require(`../../redux/actions/restricted`)
+const { actions: publicActions } = require(`../../redux/actions/public`)
+const { createParentChildLink } = publicActions
 const { printTypeDefinitions } = actions
 
 jest.mock(`fs-extra`)
@@ -41,14 +43,25 @@ jest.spyOn(global.Date.prototype, `toISOString`).mockReturnValue(`2019-01-01`)
 describe(`Print type definitions`, () => {
   beforeEach(() => {
     store.dispatch({ type: `DELETE_CACHE` })
-    const node = {
+    const node1 = {
       id: `test1`,
       internal: {
         type: `Test`,
       },
+      children: [],
       foo: 26,
     }
-    store.dispatch({ type: `CREATE_NODE`, payload: { ...node } })
+    const node2 = {
+      id: `test2`,
+      parent: `test1`,
+      internal: {
+        type: `FooChild`,
+      },
+      bar: `bar`,
+    }
+    store.dispatch({ type: `CREATE_NODE`, payload: { ...node1 } })
+    store.dispatch({ type: `CREATE_NODE`, payload: { ...node2 } })
+    createParentChildLink({ parent: node1, child: node2 })
     const typeDefs = []
     typeDefs.push(`
       type AnotherTest implements Node & ITest {

--- a/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
@@ -186,6 +186,24 @@ describe(`Define parent-child relationships with field extensions`, () => {
     )
   })
 
+  it(`does not show deprecation warning for inferred child fields`, async () => {
+    dispatch(
+      createTypes(`
+        type Parent implements Node @dontInfer @mimeTypes(types: ["application/listenup"]) {
+          id: ID!
+        }
+        type Child implements Node @childOf(mimeTypes: ["application/listenup"]) {
+          id: ID!
+        }
+        type AnotherChild implements Node @childOf(types: ["Parent"]) {
+          id: ID!
+        }
+      `)
+    )
+    await buildSchema()
+    expect(report.warn).toBeCalledTimes(0)
+  })
+
   it(`adds children[Field] field to parent type with childOf extension`, async () => {
     dispatch(
       createTypes(`

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1060,7 +1060,7 @@ const addInferredChildOfExtension = ({ schemaComposer, typeComposer }) => {
     // to be added in `addConvenienceChildrenFields` method.
     // Also required for proper printing of the `@childOf` directive in the snapshot plugin
     if (!childOfExtension) {
-      childOfExtension = { types: [], mimeTypes: [] }
+      childOfExtension = {}
     }
     if (!childOfExtension.types) {
       childOfExtension.types = []

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1059,8 +1059,11 @@ const addInferredChildOfExtension = ({ schemaComposer, typeComposer }) => {
     // This will cause convenience children fields like `childImageSharp`
     // to be added in `addConvenienceChildrenFields` method.
     // Also required for proper printing of the `@childOf` directive in the snapshot plugin
-    if (!childOfExtension?.types) {
-      childOfExtension = { types: [] }
+    if (!childOfExtension) {
+      childOfExtension = {}
+    }
+    if (!childOfExtension.types) {
+      childOfExtension.types = []
     }
     childOfExtension.types.push(parentTypeName)
     childTypeComposer.setExtension(`childOf`, childOfExtension)

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1028,32 +1028,30 @@ const addInferredChildOfExtension = ({ schemaComposer, typeComposer }) => {
     const childTypeComposer = schemaComposer.getAnyTC(typeName)
     let childOfExtension = childTypeComposer.getExtension(`childOf`)
 
+    if (childOfExtension?.types.includes(parentTypeName)) {
+      return
+    }
     if (shouldInfer === false) {
       // Adding children fields to types with the `@dontInfer` extension is deprecated
       // Only warn when the parent-child relation has not been explicitly set with `childOf` directive
-      if (
-        !childOfExtension ||
-        !childOfExtension.types.includes(parentTypeName)
-      ) {
-        const childField = fieldNames.convenienceChild(typeName)
-        const childrenField = fieldNames.convenienceChildren(typeName)
-        const childOfTypes = (childOfExtension?.types ?? [])
-          .concat(parentTypeName)
-          .map(name => `"${name}"`)
-          .join(`,`)
+      const childField = fieldNames.convenienceChild(typeName)
+      const childrenField = fieldNames.convenienceChildren(typeName)
+      const childOfTypes = (childOfExtension?.types ?? [])
+        .concat(parentTypeName)
+        .map(name => `"${name}"`)
+        .join(`,`)
 
-        report.warn(
-          `Deprecation warning: ` +
-            `In Gatsby v3 fields \`${parentTypeName}.${childField}\` and \`${parentTypeName}.${childrenField}\` ` +
-            `will not be added automatically because ` +
-            `type \`${typeName}\` does not explicitly list type \`${parentTypeName}\` in \`childOf\` extension.\n` +
-            `Add the following type definition to fix this:\n\n` +
-            `  type ${typeName} implements Node @childOf(types: [${childOfTypes}]) {\n` +
-            `    id: ID!\n` +
-            `  }\n\n` +
-            `https://www.gatsbyjs.com/docs/actions/#createTypes`
-        )
-      }
+      report.warn(
+        `Deprecation warning: ` +
+          `In Gatsby v3 fields \`${parentTypeName}.${childField}\` and \`${parentTypeName}.${childrenField}\` ` +
+          `will not be added automatically because ` +
+          `type \`${typeName}\` does not explicitly list type \`${parentTypeName}\` in \`childOf\` extension.\n` +
+          `Add the following type definition to fix this:\n\n` +
+          `  type ${typeName} implements Node @childOf(types: [${childOfTypes}]) {\n` +
+          `    id: ID!\n` +
+          `  }\n\n` +
+          `https://www.gatsbyjs.com/docs/actions/#createTypes`
+      )
     }
     // Set `@childOf` extension automatically
     // This will cause convenience children fields like `childImageSharp`

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -997,6 +997,22 @@ const addConvenienceChildrenFields = ({ schemaComposer }) => {
   })
 }
 
+const isExplicitChild = ({ typeComposer, childTypeComposer }) => {
+  if (!childTypeComposer.hasExtension(`childOf`)) {
+    return false
+  }
+  const childOfExtension = childTypeComposer.getExtension(`childOf`)
+  const { types: parentMimeTypes = [] } =
+    typeComposer.getExtension(`mimeTypes`) ?? {}
+
+  return (
+    childOfExtension?.types?.includes(typeComposer.getTypeName()) ||
+    childOfExtension?.mimeTypes?.some(mimeType =>
+      parentMimeTypes.includes(mimeType)
+    )
+  )
+}
+
 const addInferredChildOfExtensions = ({ schemaComposer }) => {
   schemaComposer.forEach(typeComposer => {
     if (
@@ -1028,7 +1044,7 @@ const addInferredChildOfExtension = ({ schemaComposer, typeComposer }) => {
     const childTypeComposer = schemaComposer.getAnyTC(typeName)
     let childOfExtension = childTypeComposer.getExtension(`childOf`)
 
-    if (childOfExtension?.types.includes(parentTypeName)) {
+    if (isExplicitChild({ typeComposer, childTypeComposer })) {
       return
     }
     if (shouldInfer === false) {

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1060,7 +1060,7 @@ const addInferredChildOfExtension = ({ schemaComposer, typeComposer }) => {
     // to be added in `addConvenienceChildrenFields` method.
     // Also required for proper printing of the `@childOf` directive in the snapshot plugin
     if (!childOfExtension) {
-      childOfExtension = {}
+      childOfExtension = { types: [], mimeTypes: [] }
     }
     if (!childOfExtension.types) {
       childOfExtension.types = []

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1025,13 +1025,12 @@ const addInferredChildOfExtension = ({ schemaComposer, typeComposer }) => {
   const childNodesByType = groupChildNodesByType({ nodes })
 
   Object.keys(childNodesByType).forEach(typeName => {
-    // Adding children fields to types with the `@dontInfer` extension is deprecated
     const childTypeComposer = schemaComposer.getAnyTC(typeName)
     let childOfExtension = childTypeComposer.getExtension(`childOf`)
 
     if (shouldInfer === false) {
       // Adding children fields to types with the `@dontInfer` extension is deprecated
-      // Only warn when the parent-child relation has not been explicitly set with
+      // Only warn when the parent-child relation has not been explicitly set with `childOf` directive
       if (
         !childOfExtension ||
         !childOfExtension.types.includes(parentTypeName)


### PR DESCRIPTION
## Description

Fixes a bug with schema printing of inferred `childOf` directive. Before this PR if we print a schema with infered child fields (e.g. `File.childImageSharp`) it won't include `childOf` directive:

```graphql
type ImageSharp implements Node @dontInfer {
  id: ID!
}
```


After this PR it correctly prints this:
```graphql
type ImageSharp implements Node @dontInfer @childOf(types: ["File"]) {
  id: ID!
}
```

This fixed variant will correctly wotk in Gatsby v3. The variant before this PR will fail to work in Gatsby v3 (the printed schema snapshot won't add the `File.childImageSharp` field).

### ~Potentially a breaking change :/~

Worked around breaking change via #28656

<details>
<summary>
See details (no longer actual)
</summary>
Requires a bit of investigation. To illustrate a possible break. With this change, we automatically apply the `childOf` extension (instead of inferring child fields):

```graphql
type Foo implements Node @childOf(types: ["Bar", "Baz"], many: true) {
  id: ID!
}
```

The `many` argument here is what is problematic. Before this change (with simple inference) we could get these two types (at least theoretically):

```graphql
type Bar {
  childFoo: Foo
}
type Baz {
  childrenFoo: [Foo]
}
```

so in one case - singular `Bar.childFoo` in the other case - array `Baz.childrenFoo`. After this change, we will always have both singular or both arrays. Mixing is not allowed with this directive.

The `many` argument applies to all parent types. Not sure if it is intentional or an oversight.

## Ways to fix this

1. Suggested by @pieh : Always add both `child{Field}` and `children{Field}` to the schema and deprecate `many` option altogether. Wih this change `child{Field}` will always return the first child (as listed in node `children` array)

2. Support the new syntax in `childOf` directive where we can define `many` per type. Something like:

```graphql
type Foo implements Node @childOf(parents: [{name: "Bar", many: false}, { name: "Baz", many: true }]) {
  id: ID!
}
```
</details>

## Related issues 

Fixes #19674