### PR TITLE
fix(gatsby): do not fail in develop when eslint loader is removed

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -713,7 +713,7 @@ export const createWebpackUtils = (
   }
 }
 
-function reactHasJsxRuntime(): boolean {
+export function reactHasJsxRuntime(): boolean {
   // We've got some complains about the ecosystem not being ready for automatic so we disable it by default.
   // People can use a custom babelrc file to support it
   // try {


### PR DESCRIPTION
## Description

This PR fixes a bug when `gatsby develop` breaks in the unfortunate (and very rare) edge case when the `eslint` loader is removed from the webpack config (in site's `onCreateWebpackConfig`).

Before this PR we assume eslint loader always exists. This PR removes this assumption and makes the failing code more robust.

## Related Issues

Fixes #28429