### PR TITLE
fix(gatsby-source-drupal): Drupal does not properly encode its media urls

### DIFF
--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -57,8 +57,10 @@ exports.downloadFile = async (
               htaccess_pass: basicAuth.password,
             }
           : {}
+      // drupal does not properly encode it's media urls
+      const encodedSourceUrl = encodeURI(url.href)
       fileNode = await createRemoteFileNode({
-        url: url.href,
+        url: encodedSourceUrl,
         store,
         cache,
         createNode,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Hi guys,
I am facing the same issues for Drupal, which have been fixed for Wordpress already last year.
Also see https://github.com/gatsbyjs/gatsby/pull/15835
Therefore I simply applied the same changes for the gatsby-source-drupal package and hope that this resolves the issue.

Sorry for not creating an issue before creating a PR, but to me it was so obvious that this is the same problem you once had with wordpress.
Thanks in advance for reviewing my PR. 
Please let me know if I can help further or some things need to be adjusted. 

### Documentation

IMHO no documentation needed.

## Related Issues

This issue also occured for the gatsby-source-workpress plugin. See https://github.com/gatsbyjs/gatsby/pull/15835
