### PR TITLE
perf(gatsby): do not force resolvers to be async

### DIFF
--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -525,6 +525,10 @@ It's likely that this has happened in a schemaCustomization with manually invoke
 export function wrappingResolver<TSource, TArgs>(
   resolver: GatsbyResolver<TSource, TArgs>
 ): GatsbyResolver<TSource, TArgs> {
+  // Note: we explicitly make an attempt to prevent using the `async` keyword because often
+  //       it does not return a promise and this makes a significant difference at scale.
+  //       GraphQL will gracefully handle the resolver result of a promise or non-promise.
+
   return function wrappedTracingResolver(
     parent,
     args,

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -241,10 +241,9 @@ export function link<TSource, TArgs>(
     })
 
     // Note: for this function, at scale, conditional .then is more efficient than generic await
-    if (fieldValueOrPromise?.then) {
-      return fieldValueOrPromise.then(
-        fieldValue => linkResolverValue(fieldValue, args, context, info),
-        err => Promise.reject(err)
+    if (typeof fieldValueOrPromise?.then === `function`) {
+      return fieldValueOrPromise.then(fieldValue =>
+        linkResolverValue(fieldValue, args, context, info)
       )
     }
 
@@ -314,10 +313,9 @@ export function link<TSource, TArgs>(
     )
 
     // Note: for this function, at scale, conditional .then is more efficient than generic await
-    if (resultOrPromise?.then) {
-      return resultOrPromise.then(
-        result => linkResolverQueryResult(fieldValue, result, returnType),
-        err => Promise.reject(err)
+    if (typeof resultOrPromise?.then === `function`) {
+      return resultOrPromise.then(result =>
+        linkResolverQueryResult(fieldValue, result, returnType)
       )
     }
 

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -234,21 +234,21 @@ export function link<TSource, TArgs>(
     info
   ): ResolvedLink | Promise<ResolvedLink> {
     const resolver = fieldConfig.resolve || context.defaultFieldResolver
-    const fieldValue = resolver(source, args, context, {
+    const fieldValueOrPromise = resolver(source, args, context, {
       ...info,
       from: options.from || info.from,
       fromNode: options.from ? options.fromNode : info.fromNode,
     })
 
     // Note: for this function, at scale, conditional .then is more efficient than generic await
-    if (fieldValue?.then) {
-      return fieldValue.then(
+    if (fieldValueOrPromise?.then) {
+      return fieldValueOrPromise.then(
         fieldValue => linkResolverValue(fieldValue, args, context, info),
         err => Promise.reject(err)
       )
     }
 
-    return linkResolverValue(fieldValue, args, context, info)
+    return linkResolverValue(fieldValueOrPromise, args, context, info)
   }
 
   function linkResolverValue(
@@ -302,7 +302,7 @@ export function link<TSource, TArgs>(
       }
     }
 
-    const result = context.nodeModel.runQuery(
+    const resultOrPromise = context.nodeModel.runQuery(
       {
         query: runQueryArgs,
         firstOnly,
@@ -314,14 +314,14 @@ export function link<TSource, TArgs>(
     )
 
     // Note: for this function, at scale, conditional .then is more efficient than generic await
-    if (result?.then) {
-      return result.then(
+    if (resultOrPromise?.then) {
+      return resultOrPromise.then(
         result => linkResolverQueryResult(fieldValue, result, returnType),
         err => Promise.reject(err)
       )
     }
 
-    return linkResolverQueryResult(fieldValue, result, returnType)
+    return linkResolverQueryResult(fieldValue, resultOrPromise, returnType)
   }
 
   function linkResolverQueryResult(

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -209,32 +209,6 @@ export function paginate<NodeType>(
   }
 }
 
-export const defaultFieldResolver: GatsbyResolver<
-  any,
-  any
-> = function defaultFieldResolver(source, args, context, info) {
-  if (
-    (typeof source == `object` && source !== null) ||
-    typeof source === `function`
-  ) {
-    if (info.from) {
-      if (info.fromNode) {
-        const node = context.nodeModel.findRootNodeAncestor(source)
-        if (!node) return null
-        return getValueAt(node, info.from)
-      }
-      return getValueAt(source, info.from)
-    }
-    const property = source[info.fieldName]
-    if (typeof property === `function`) {
-      return source[info.fieldName](args, context, info)
-    }
-    return property
-  }
-
-  return null
-}
-
 export function link<TSource, TArgs>(
   options: {
     by: string
@@ -508,6 +482,32 @@ function getFieldNodeByNameInSelectionSet(
     },
     []
   )
+}
+
+export const defaultFieldResolver: GatsbyResolver<
+  any,
+  any
+> = function defaultFieldResolver(source, args, context, info) {
+  if (
+    (typeof source == `object` && source !== null) ||
+    typeof source === `function`
+  ) {
+    if (info.from) {
+      if (info.fromNode) {
+        const node = context.nodeModel.findRootNodeAncestor(source)
+        if (!node) return null
+        return getValueAt(node, info.from)
+      }
+      return getValueAt(source, info.from)
+    }
+    const property = source[info.fieldName]
+    if (typeof property === `function`) {
+      return source[info.fieldName](args, context, info)
+    }
+    return property
+  }
+
+  return null
 }
 
 let WARNED_ABOUT_RESOLVERS = false

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -231,7 +231,7 @@ export function link<TSource, TArgs>(
     if (
       options.by === `id` &&
       (fieldConfig.resolve || context.defaultFieldResolver) ===
-        defaultFieldResolver
+        _defaultFieldResolver
     ) {
       return linkResolverDefaultId(source, args, context, info)
     }
@@ -245,7 +245,7 @@ export function link<TSource, TArgs>(
     context,
     info
   ): IGatsbyNode | Array<IGatsbyNode> | null {
-    const fieldValue = defaultFieldResolver(source, args, context, {
+    const fieldValue = _defaultFieldResolver(source, args, context, {
       ...info,
       from: options.from || info.from,
       fromNode: options.from ? options.fromNode : info.fromNode,
@@ -494,10 +494,7 @@ function getFieldNodeByNameInSelectionSet(
   )
 }
 
-export const defaultFieldResolver: GatsbyResolver<
-  any,
-  any
-> = function defaultFieldResolver(source, args, context, info) {
+function _defaultFieldResolver(source, args, context, info): any {
   if (
     (typeof source == `object` && source !== null) ||
     typeof source === `function`
@@ -519,6 +516,10 @@ export const defaultFieldResolver: GatsbyResolver<
 
   return null
 }
+export const defaultFieldResolver: GatsbyResolver<
+  any,
+  any
+> | null = _defaultFieldResolver
 
 let WARNED_ABOUT_RESOLVERS = false
 function badResolverInvocationMessage(missingVar: string, path?: Path): string {
@@ -569,4 +570,4 @@ export function wrappingResolver<TSource, TArgs>(
   }
 }
 
-export const defaultResolver = wrappingResolver(defaultFieldResolver)
+export const defaultResolver = wrappingResolver(_defaultFieldResolver)

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -27,6 +27,8 @@ import {
 } from "./type-definitions"
 import { IGatsbyNode } from "../redux/types"
 
+type ResolvedLink = IGatsbyNode | Array<IGatsbyNode> | null
+
 export function findMany<TSource, TArgs>(
   typeName: string
 ): GatsbyResolver<TSource, TArgs> {
@@ -256,13 +258,7 @@ export function link<TSource, TArgs>(
     args,
     context,
     info
-  ):
-    | null
-    | IGatsbyNode
-    | Array<IGatsbyNode>
-    | Promise<null>
-    | Promise<IGatsbyNode>
-    | Promise<Array<IGatsbyNode>> {
+  ): ResolvedLink | Promise<ResolvedLink> {
     const resolver = fieldConfig.resolve || context.defaultFieldResolver
     const fieldValue = resolver(source, args, context, {
       ...info,
@@ -286,13 +282,7 @@ export function link<TSource, TArgs>(
     args,
     context,
     info
-  ):
-    | null
-    | IGatsbyNode
-    | Array<IGatsbyNode>
-    | Promise<null>
-    | Promise<IGatsbyNode>
-    | Promise<Array<IGatsbyNode>> {
+  ): ResolvedLink | Promise<ResolvedLink> {
     if (fieldValue == null) {
       return null
     }


### PR DESCRIPTION
Drop the `async` keyword from the `wrappingResolver` that wraps all resolvers passed on to graphql. This keyword _forces_ the return value to be a promise, injecting tiny delays in each call. Most of the time you wouldn't notice these but at scale they add up.

In this case a large site was triggering the link resolver 35 million times. Only 1.5 million times did the wrapped resolver return a promise. And graphql will properly deal with promises vs non-promises. So we can drop the keyword.

The PR also updates the `linkResolver` to take the fast path (when target key is `id` and the resolver is our own `defaultResolver`) sync rather than also force it to be async. The `defaultResolver` already has no `async` keyword.

Doing so drops roughly 5-10% from the runtime of the site I was testing with (!). Promises can be expensive. They should put a warning sign around them.