### PR TITLE
fix(gatsby): better text for missing inferred extension

### DIFF
--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -1422,7 +1422,8 @@ Object {
           `Add the following type definition to fix this:\n\n` +
           `  type Test implements Node {\n` +
           `    date: Date @dateformat\n` +
-          `  }`
+          `  }\n` +
+          `https://www.gatsbyjs.com/docs/actions/#createTypes`
       )
       expect(report.warn.mock.calls[1][0]).toEqual(
         `Deprecation warning: adding inferred extension \`link\` for field \`Test.linked\`.\n` +
@@ -1430,7 +1431,8 @@ Object {
           `Add the following type definition to fix this:\n\n` +
           `  type Test implements Node {\n` +
           `    linked: Foo @link(by: "id", from: "linked___NODE")\n` +
-          `  }`
+          `  }\n` +
+          `https://www.gatsbyjs.com/docs/actions/#createTypes`
       )
     })
   })

--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -1420,7 +1420,7 @@ Object {
         `Deprecation warning: adding inferred extension \`dateformat\` for field \`Test.date\`.\n` +
           `In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.\n` +
           `Add the following type definition to fix this:\n\n` +
-          `  type Test implements Node  {\n` +
+          `  type Test implements Node {\n` +
           `    date: Date @dateformat\n` +
           `  }`
       )
@@ -1428,7 +1428,7 @@ Object {
         `Deprecation warning: adding inferred extension \`link\` for field \`Test.linked\`.\n` +
           `In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.\n` +
           `Add the following type definition to fix this:\n\n` +
-          `  type Test implements Node  {\n` +
+          `  type Test implements Node {\n` +
           `    linked: Foo @link(by: "id", from: "linked___NODE")\n` +
           `  }`
       )

--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -1417,12 +1417,20 @@ Object {
       await buildTestSchema(nodes, {}, typeDefs)
       expect(report.warn.mock.calls.length).toEqual(2)
       expect(report.warn.mock.calls[0][0]).toEqual(
-        `Deprecation warning - adding inferred extension {"dateformat":{}} for field Test.date. ` +
-          `In Gatsby v3, only fields with an explicit directive/extension will get a resolver.`
+        `Deprecation warning: adding inferred extension \`dateformat\` for field \`Test.date\`.\n` +
+          `In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.\n` +
+          `Add the following type definition to fix this:\n\n` +
+          `  type Test implements Node  {\n` +
+          `    date: Date @dateformat\n` +
+          `  }`
       )
       expect(report.warn.mock.calls[1][0]).toEqual(
-        `Deprecation warning - adding inferred extension {"link":{"by":"id","from":"linked___NODE"}} for field Test.linked. ` +
-          `In Gatsby v3, only fields with an explicit directive/extension will get a resolver.`
+        `Deprecation warning: adding inferred extension \`link\` for field \`Test.linked\`.\n` +
+          `In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.\n` +
+          `Add the following type definition to fix this:\n\n` +
+          `  type Test implements Node  {\n` +
+          `    linked: Foo @link(by: "id", from: "linked___NODE")\n` +
+          `  }`
       )
     })
   })

--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -1422,7 +1422,7 @@ Object {
           `Add the following type definition to fix this:\n\n` +
           `  type Test implements Node {\n` +
           `    date: Date @dateformat\n` +
-          `  }\n` +
+          `  }\n\n` +
           `https://www.gatsbyjs.com/docs/actions/#createTypes`
       )
       expect(report.warn.mock.calls[1][0]).toEqual(
@@ -1431,7 +1431,7 @@ Object {
           `Add the following type definition to fix this:\n\n` +
           `  type Test implements Node {\n` +
           `    linked: Foo @link(by: "id", from: "linked___NODE")\n` +
-          `  }\n` +
+          `  }\n\n` +
           `https://www.gatsbyjs.com/docs/actions/#createTypes`
       )
     })

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -120,8 +120,11 @@ const addInferredFieldsImpl = ({
               .forEach(name => {
                 if (!typeComposer.hasFieldExtension(key, name)) {
                   typeComposer.setFieldExtension(key, name, extensions[name])
+                  const prettified = JSON.stringify({
+                    [name]: extensions[name],
+                  })
                   report.warn(
-                    `Deprecation warning - adding inferred resolver for field ` +
+                    `Deprecation warning - adding inferred extension ${prettified} for field ` +
                       `${typeComposer.getTypeName()}.${key}. In Gatsby v3, ` +
                       `only fields with an explicit directive/extension will ` +
                       `get a resolver.`

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -135,7 +135,7 @@ const addInferredFieldsImpl = ({
                       `Add the following type definition to fix this:\n\n` +
                       `  type ${typeComposer.getTypeName()} ${implementsNode}{\n` +
                       `    ${key}: ${field.type.toString()}${extension}\n` +
-                      `  }\n` +
+                      `  }\n\n` +
                       `https://www.gatsbyjs.com/docs/actions/#createTypes`
                   )
                 }

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -8,6 +8,7 @@ import { isFile } from "./is-file"
 import { isDate } from "../types/date"
 import { addDerivedType } from "../types/derived-types"
 import { is32BitInteger } from "../../utils/is-32-bit-integer"
+import { printDirectives } from "../print"
 const { getNode, getNodes } = require(`../../redux/nodes`)
 
 const addInferredFields = ({
@@ -120,14 +121,21 @@ const addInferredFieldsImpl = ({
               .forEach(name => {
                 if (!typeComposer.hasFieldExtension(key, name)) {
                   typeComposer.setFieldExtension(key, name, extensions[name])
-                  const prettified = JSON.stringify({
-                    [name]: extensions[name],
-                  })
+
+                  const typeName = typeComposer.getTypeName()
+                  const implementsNode =
+                    unsanitizedFieldPath.length === 1 ? `implements Node ` : ``
+                  const extension = printDirectives(
+                    { [name]: extensions[name] },
+                    schemaComposer.getDirectives()
+                  )
                   report.warn(
-                    `Deprecation warning - adding inferred extension ${prettified} for field ` +
-                      `${typeComposer.getTypeName()}.${key}. In Gatsby v3, ` +
-                      `only fields with an explicit directive/extension will ` +
-                      `get a resolver.`
+                    `Deprecation warning: adding inferred extension \`${name}\` for field \`${typeName}.${key}\`.\n` +
+                      `In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.\n` +
+                      `Add the following type definition to fix this:\n\n` +
+                      `  type ${typeComposer.getTypeName()} ${implementsNode} {\n` +
+                      `    ${key}: ${field.type.toString()}${extension}\n` +
+                      `  }`
                   )
                 }
               })

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -133,7 +133,7 @@ const addInferredFieldsImpl = ({
                     `Deprecation warning: adding inferred extension \`${name}\` for field \`${typeName}.${key}\`.\n` +
                       `In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.\n` +
                       `Add the following type definition to fix this:\n\n` +
-                      `  type ${typeComposer.getTypeName()} ${implementsNode} {\n` +
+                      `  type ${typeComposer.getTypeName()} ${implementsNode}{\n` +
                       `    ${key}: ${field.type.toString()}${extension}\n` +
                       `  }`
                   )

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -135,7 +135,8 @@ const addInferredFieldsImpl = ({
                       `Add the following type definition to fix this:\n\n` +
                       `  type ${typeComposer.getTypeName()} ${implementsNode}{\n` +
                       `    ${key}: ${field.type.toString()}${extension}\n` +
-                      `  }`
+                      `  }\n` +
+                      `https://www.gatsbyjs.com/docs/actions/#createTypes`
                   )
                 }
               })

--- a/packages/gatsby/src/schema/print.js
+++ b/packages/gatsby/src/schema/print.js
@@ -402,4 +402,5 @@ const breakLine = (line, maxLen) => {
 
 module.exports = {
   printTypeDefinitions,
+  printDirectives,
 }


### PR DESCRIPTION
## Description

This PR addresses a deprecation warning displayed when the type definition is missing inferred extension. Currently, the warning text is a bit confusing:

```
Deprecation warning - adding inferred resolver for field Test.date.
In Gatsby v3, only fields with an explicit directive/extension will get a resolver.
```

After this PR the warning text will be this:
```
Deprecation warning: adding inferred extension `dateformat` for field `Test.date`.
In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.
Add the following type definition to fix this:

  type Test implements Node {
    date: Date @dateformat
  }

https://www.gatsbyjs.com/docs/actions/#createTypes
```
