### PR TITLE
fix(gatsby): improve deprecation text for missing childOf directive

### DIFF
--- a/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
@@ -174,13 +174,13 @@ describe(`Define parent-child relationships with field extensions`, () => {
     )
     await buildSchema()
     expect(report.warn).toBeCalledTimes(1)
-    expect(report.warn).toBeCalledWith(
-      `The type \`Parent\` does not explicitly define the field \`childChild\`.\n` +
-        `On types with the \`@dontInfer\` directive, or with the \`infer\` ` +
-        `extension set to \`false\`, automatically adding fields for ` +
-        `children types is deprecated.\n` +
-        `In Gatsby v3, only children fields explicitly set with the ` +
-        `\`childOf\` extension will be added.\n`
+    expect(report.warn.mock.calls[0][0]).toEqual(
+      `Deprecation warning: In Gatsby v3 field \`Parent.childChild\` will not be added automatically ` +
+        `because type \`Child\` does not explicitly list type \`Parent\` in childOf extension.\n` +
+        `Add the following type definition to fix this:\n\n` +
+        `  type Child implements Node @childOf(types: ["Parent"]) {\n` +
+        `    id\n` +
+        `  }`
     )
   })
 

--- a/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
@@ -176,7 +176,7 @@ describe(`Define parent-child relationships with field extensions`, () => {
     expect(report.warn).toBeCalledTimes(1)
     expect(report.warn.mock.calls[0][0]).toEqual(
       `Deprecation warning: In Gatsby v3 field \`Parent.childChild\` will not be added automatically ` +
-        `because type \`Child\` does not explicitly list type \`Parent\` in childOf extension.\n` +
+        `because type \`Child\` does not explicitly list type \`Parent\` in \`childOf\` extension.\n` +
         `Add the following type definition to fix this:\n\n` +
         `  type Child implements Node @childOf(types: ["Parent"]) {\n` +
         `    id\n` +

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1042,12 +1042,13 @@ const addImplicitConvenienceChildrenFields = ({
         const fieldName = many
           ? fieldNames.convenienceChildren(typeName)
           : fieldNames.convenienceChild(typeName)
+        const manyArg = many ? `, many: true` : ``
         report.warn(
           `Deprecation warning: ` +
             `In Gatsby v3 field \`${parentTypeName}.${fieldName}\` will not be added automatically because ` +
             `type \`${typeName}\` does not explicitly list type \`${parentTypeName}\` in \`childOf\` extension.\n` +
             `Add the following type definition to fix this:\n\n` +
-            `  type ${typeName} implements Node @childOf(types: ["${parentTypeName}"]) {\n` +
+            `  type ${typeName} implements Node @childOf(types: ["${parentTypeName}"]${manyArg}) {\n` +
             `    id\n` +
             `  }`
         )

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1045,7 +1045,7 @@ const addImplicitConvenienceChildrenFields = ({
         report.warn(
           `Deprecation warning: ` +
             `In Gatsby v3 field \`${parentTypeName}.${fieldName}\` will not be added automatically because ` +
-            `type \`${typeName}\` does not explicitly list type \`${parentTypeName}\` in childOf extension.\n` +
+            `type \`${typeName}\` does not explicitly list type \`${parentTypeName}\` in \`childOf\` extension.\n` +
             `Add the following type definition to fix this:\n\n` +
             `  type ${typeName} implements Node @childOf(types: ["${parentTypeName}"]) {\n` +
             `    id\n` +

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1043,13 +1043,13 @@ const addImplicitConvenienceChildrenFields = ({
           ? fieldNames.convenienceChildren(typeName)
           : fieldNames.convenienceChild(typeName)
         report.warn(
-          `The type \`${parentTypeName}\` does not explicitly define ` +
-            `the field \`${fieldName}\`.\n` +
-            `On types with the \`@dontInfer\` directive, or with the \`infer\` ` +
-            `extension set to \`false\`, automatically adding fields for ` +
-            `children types is deprecated.\n` +
-            `In Gatsby v3, only children fields explicitly set with the ` +
-            `\`childOf\` extension will be added.\n`
+          `Deprecation warning: ` +
+            `In Gatsby v3 field \`${parentTypeName}.${fieldName}\` will not be added automatically because ` +
+            `type \`${typeName}\` does not explicitly list type \`${parentTypeName}\` in childOf extension.\n` +
+            `Add the following type definition to fix this:\n\n` +
+            `  type ${typeName} implements Node @childOf(types: ["${parentTypeName}"]) {\n` +
+            `    id\n` +
+            `  }`
         )
       }
     }


### PR DESCRIPTION
## Description

This PR addresses a confusing deprecation warning when the `@childOf` directive is not set for some parent. Warning text before this PR:

```
The type `Parent` does not explicitly define the field `childChild`.
On types with the `@dontInfer` directive, or with the `infer ` extension set to `false`, automatically adding fields for
children types is deprecated. In Gatsby v3, only children fields explicitly set with the `childOf` extension will be added.`
```

After this PR:
```
Deprecation warning: In Gatsby v3 field `Parent.childChild` will not be added automatically
because type `Child` does not explicitly list type `Parent` in `childOf` extension.
Add the following type definition to fix this:

  type Child implements Node @childOf(types: ["Parent"]) {
    id
  }

https://www.gatsbyjs.com/docs/actions/#createTypes
```

## Related issues
See https://github.com/gatsbyjs/gatsby/issues/19674#issuecomment-567577179 as one example where it was confusing

Also related PR: #28483 (it fixes this warning in `gatsby-plugin-schema-snapshot`): 