### PR TITLE
fix(gatsby): Wait for jobs to complete in onPostBuild

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -296,6 +296,10 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   })
   postBuildActivityTimer.end()
 
+  // Wait for any jobs that were started in onPostBuild
+  // This could occur due to queries being run which invoke sharp for instance
+  await waitUntilAllJobsComplete()
+
   // Make sure we saved the latest state so we have all jobs cached
   await db.saveState()
 


### PR DESCRIPTION
Plugins can currently run queries in `onPostBuild` if they like. If these queries trigger side effects like jobs, they are currently _not_ awaited in `onPostBuild`. This is a bug. 

We fix this by waiting till the jobs queue is empty. 

An example of a community plugin that does this is https://github.com/dominicfallows/gatsby-plugin-json-output