### PR TITLE
fix(query-on-demand): don't resolve get-page-data if query is marked as dirty

### DIFF
--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -71,7 +71,7 @@ Object {
     },
     "trackedQueries": Map {
       "/my-sweet-new-page/" => Object {
-        "dirty": 1,
+        "dirty": 8,
         "running": 0,
       },
     },

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -71,7 +71,7 @@ Object {
     },
     "trackedQueries": Map {
       "/my-sweet-new-page/" => Object {
-        "dirty": 8,
+        "dirty": 1,
         "running": 0,
       },
     },

--- a/packages/gatsby/src/redux/reducers/__tests__/queries.ts
+++ b/packages/gatsby/src/redux/reducers/__tests__/queries.ts
@@ -1,5 +1,6 @@
 import {
-  FLAG_DIRTY_PAGE,
+  FLAG_DIRTY_NEW_PAGE,
+  FLAG_DIRTY_PAGE_CONTEXT,
   FLAG_DIRTY_TEXT,
   FLAG_ERROR_EXTRACTION,
   queriesReducer as reducer,
@@ -108,8 +109,8 @@ describe(`create page`, () => {
 
     expect(state).toMatchObject({
       trackedQueries: new Map([
-        [`/foo`, { dirty: FLAG_DIRTY_PAGE, running: 0 }],
-        [`/bar`, { dirty: FLAG_DIRTY_PAGE, running: 0 }],
+        [`/foo`, { dirty: FLAG_DIRTY_NEW_PAGE, running: 0 }],
+        [`/bar`, { dirty: FLAG_DIRTY_NEW_PAGE, running: 0 }],
       ]),
     })
   })
@@ -132,7 +133,7 @@ describe(`create page`, () => {
     state = createPage(state, Pages.foo, { contextModified: true })
 
     expect(state.trackedQueries.get(`/foo`)).toMatchObject({
-      dirty: FLAG_DIRTY_PAGE,
+      dirty: FLAG_DIRTY_PAGE_CONTEXT,
     })
   })
 
@@ -461,14 +462,14 @@ describe(`query extraction`, () => {
     state = reducer(state, queryExtracted(ComponentQueries.bar, {} as any))
 
     expect(state.trackedQueries.get(`/bar`)).toMatchObject({
-      dirty: FLAG_DIRTY_PAGE | FLAG_DIRTY_TEXT,
+      dirty: FLAG_DIRTY_NEW_PAGE | FLAG_DIRTY_TEXT,
     })
     expect(state.trackedQueries.get(`/bar2`)).toMatchObject({
-      dirty: FLAG_DIRTY_PAGE | FLAG_DIRTY_TEXT,
+      dirty: FLAG_DIRTY_NEW_PAGE | FLAG_DIRTY_TEXT,
     })
     // Sanity check
     expect(state.trackedQueries.get(`/foo`)).toMatchObject({
-      dirty: FLAG_DIRTY_PAGE,
+      dirty: FLAG_DIRTY_NEW_PAGE,
     })
   })
 
@@ -478,7 +479,7 @@ describe(`query extraction`, () => {
     expect(state.trackedQueries.get(`/foo`)).toMatchObject({ dirty: 0 })
     // sanity-check (we didn't run or extract /bar)
     expect(state.trackedQueries.get(`/bar`)).toMatchObject({
-      dirty: FLAG_DIRTY_PAGE,
+      dirty: FLAG_DIRTY_NEW_PAGE,
     })
   })
 

--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -10,10 +10,10 @@ type ComponentPath = string
 type NodeId = string
 type ConnectionName = string
 
-export const FLAG_DIRTY_PAGE_CONTEXT = 0b0001
+export const FLAG_DIRTY_NEW_PAGE = 0b0001
 export const FLAG_DIRTY_TEXT = 0b0010
 export const FLAG_DIRTY_DATA = 0b0100
-export const FLAG_DIRTY_NEW_PAGE = 0b1000
+export const FLAG_DIRTY_PAGE_CONTEXT = 0b1000
 
 export const FLAG_ERROR_EXTRACTION = 0b0001
 

--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -10,9 +10,10 @@ type ComponentPath = string
 type NodeId = string
 type ConnectionName = string
 
-export const FLAG_DIRTY_PAGE = 0b0001
+export const FLAG_DIRTY_PAGE_CONTEXT = 0b0001
 export const FLAG_DIRTY_TEXT = 0b0010
 export const FLAG_DIRTY_DATA = 0b0100
+export const FLAG_DIRTY_NEW_PAGE = 0b1000
 
 export const FLAG_ERROR_EXTRACTION = 0b0001
 
@@ -69,7 +70,10 @@ export function queriesReducer(
       let query = state.trackedQueries.get(path)
       if (!query || action.contextModified) {
         query = registerQuery(state, path)
-        query.dirty = setFlag(query.dirty, FLAG_DIRTY_PAGE)
+        query.dirty = setFlag(
+          query.dirty,
+          action.contextModified ? FLAG_DIRTY_PAGE_CONTEXT : FLAG_DIRTY_NEW_PAGE
+        )
         state = trackDirtyQuery(state, path)
       }
       registerComponent(state, componentPath).pages.add(path)

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -6,6 +6,7 @@ import { IGatsbyPage } from "../redux/types"
 import { websocketManager } from "./websocket-manager"
 import { isWebpackStatusPending } from "./webpack-status"
 import { store } from "../redux"
+import { hasFlag, FLAG_DIRTY_NEW_PAGE } from "../redux/reducers/queries"
 
 import { IExecutionResult } from "../query/types"
 
@@ -159,8 +160,8 @@ export async function flush(): Promise<void> {
           )
         }
 
-        if (query.dirty !== 0) {
-          // query results are not up to date, it's not safe to write page-data and emit results
+        if (hasFlag(query.dirty, FLAG_DIRTY_NEW_PAGE)) {
+          // query results are not written yet
           continue
         }
       }


### PR DESCRIPTION
## Description

We currently have potential dead lock situation as we skip writing `page-data` (in query on demand only!) when query is marked as dirty. This means that `getPageData` can not resolve (or rather resolve with stale data due to timeout guards) if:
 - page query did run but didn't flush yet and query was marked as dirty at some point after running query and before flushing

This PR only skips flushing page-data if query didn't run yet ( `FLAG_DIRTY_NEW_PAGE` check instead of checking if query is dirty for whatever reason) and triggers another run of `doGetPageData` that checks if query is dirty / running / pending to trigger another run if it's in fact still dirty after flushing page-data.

I'm uncertain about not touching part that does emit websocket message - in this case we **might not** resolve `getPageData` after flushing but still emit websocket update. This should not cause weirdness with `loadPage` that fetches data, but because we have single cache that is being saturated from fetch requests and websocket updates it could potentially result in weirdness but to repro it it would have to be real weird timing scenario.

[ch19354]