### PR TITLE
[gatsby-source-contentful] Update missing important field for resolving embedded asset

### DIFF
--- a/packages/gatsby-source-contentful/CHANGELOG.md
+++ b/packages/gatsby-source-contentful/CHANGELOG.md
@@ -112,6 +112,8 @@ export const pageQuery = graphql`
           ... on ContentfulAsset {
             # contentful_id is required to resolve the references
             contentful_id
+            # __typename is very important and must-have field for resolving embedded asset
+            __typename
             fluid(maxWidth: 600) {
               ...GatsbyContentfulFluid_withWebp
             }


### PR DESCRIPTION
## Description

Source code of `gatsby-source-contentful` use field `__typename` value for filtering out and resolve embedded asset entries [here](https://github.com/gatsbyjs/gatsby/blob/98f22e702ee3defefd8e99d49aa50b080bbe0d6f/packages/gatsby-source-contentful/src/rich-text.js#L20). But this part is not mentioned as part of the documentation.

Without this changes included as part of the doc, the **BREAKING CHANGES** warning is kinda useless especially with embedded asset part cause they will never work without `__typename` field.

### Documentation

Update [CHANGELOG](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/CHANGELOG.md)

## Related Issues
https://github.com/contentful/rich-text/issues/61
https://github.com/contentful/rich-text/issues/189
