### PR TITLE
chore(query-on-demand): prerun query for homepage for initial run

### DIFF
--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -132,6 +132,7 @@ module.exports = async (program: IDevelopArgs): Promise<void> => {
     program,
     parentSpan,
     app,
+    pendingQueryRuns: new Set([`/`]),
   })
 
   const service = interpret(machine)


### PR DESCRIPTION
## Description

This justs add `/` (index) page for list of queries to run initially. Main reason for doing so is that there is very high chance of user visiting it as we do print following message when dev server boots up that make it very likely for user to visit it:

```
You can now view [name-of-site] in the browser.
⠀
  http://localhost:8000/
```

[ch20215]