### PR TITLE
fix (create-gatsby): Ignore confirmation prompt

### DIFF
--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -167,16 +167,18 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
 `
   )
 
-  reporter.info(
-    wrap(
-      `This command will generate a new Gatsby site for you in ${c.bold(
-        process.cwd()
-      )} with the setup you select. ${c.white.bold(
-        `Let's answer some questions:\n\n`
-      )}`,
-      process.stdout.columns
+  if (!yesFlag) {
+    reporter.info(
+      wrap(
+        `This command will generate a new Gatsby site for you in ${c.bold(
+          process.cwd()
+        )} with the setup you select. ${c.white.bold(
+          `Let's answer some questions:\n\n`
+        )}`,
+        process.stdout.columns
+      )
     )
-  )
+  }
 
   const enquirer = new Enquirer<IAnswers>()
 
@@ -312,15 +314,14 @@ ${center(c.blueBright.bold.underline(`Welcome to Gatsby!`))}
 
     trackCli(`CREATE_GATSBY_SET_PLUGINS_STOP`)
   }
-
-  reporter.info(`
+  if (!yesFlag) {
+    reporter.info(`
 
 ${c.bold(`Thanks! Here's what we'll now do:`)}
 
     ${messages.join(`\n    `)}
   `)
 
-  if (!yesFlag) {
     const { confirm } = await new Enquirer<{ confirm: boolean }>().prompt({
       type: `confirm`,
       name: `confirm`,

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -320,19 +320,21 @@ ${c.bold(`Thanks! Here's what we'll now do:`)}
     ${messages.join(`\n    `)}
   `)
 
-  const { confirm } = await new Enquirer<{ confirm: boolean }>().prompt({
-    type: `confirm`,
-    name: `confirm`,
-    initial: `Yes`,
-    message: `Shall we do this?`,
-    format: value => (value ? c.greenBright(`Yes`) : c.red(`No`)),
-  })
+  if (!yesFlag) {
+    const { confirm } = await new Enquirer<{ confirm: boolean }>().prompt({
+      type: `confirm`,
+      name: `confirm`,
+      initial: `Yes`,
+      message: `Shall we do this?`,
+      format: value => (value ? c.greenBright(`Yes`) : c.red(`No`)),
+    })
 
-  if (!confirm) {
-    trackCli(`CREATE_GATSBY_CANCEL`)
+    if (!confirm) {
+      trackCli(`CREATE_GATSBY_CANCEL`)
 
-    reporter.info(`OK, bye!`)
-    return
+      reporter.info(`OK, bye!`)
+      return
+    }
   }
 
   await initStarter(


### PR DESCRIPTION
The `-y` flag bypassed all of the prompts at the start of the interactive experience, but it still asked you to confirm if you wanted the site to be created. This removes that prompt and some of the extraneous reporter info calls to streamline the stdout and prevent the user from needing to interact at all.