### PR TITLE
feat(gatsby): track how long query-on-demand querying takes

### DIFF
--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -278,13 +278,22 @@ module.exports = {
 
       if (page) {
         try {
-          const pageData: IPageDataWithQueryResult = process.env
-            .GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
-            ? await getPageDataExperimental(page.path)
-            : await readPageData(
-                path.join(store.getState().program.directory, `public`),
-                page.path
-              )
+          let pageData: IPageDataWithQueryResult = ``
+          if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+            const start = Date.now()
+
+            pageData = await getPageDataExperimental(page.path)
+
+            telemetry.trackCli(`RUN_QUERY_ON_DEMAND`, {
+              name: `getPageData`,
+              duration: Date.now() - start,
+            })
+          } else {
+            pageData = await readPageData(
+              path.join(store.getState().program.directory, `public`),
+              page.path
+            )
+          }
 
           res.status(200).send(pageData)
           return

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -278,7 +278,7 @@ module.exports = {
 
       if (page) {
         try {
-          let pageData: IPageDataWithQueryResult = ``
+          let pageData: IPageDataWithQueryResult
           if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
             const start = Date.now()
 


### PR DESCRIPTION
So we can see how long things get out in the wild. They're generally fast in testing but there's edge cases that can cause long runs hurting the user experience that might need protected against.