### PR TITLE
fix(gatsby-source-filesystem): Retry a download if a file is incomplete

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -61,6 +61,8 @@ const STALL_TIMEOUT = process.env.GATSBY_STALL_TIMEOUT || 30000
 
 const CONNECTION_TIMEOUT = process.env.GATSBY_CONNECTION_TIMEOUT || 30000
 
+const INCOMPLETE_RETRY_LIMIT = process.env.GATSBY_INCOMPLETE_RETRY_LIMIT || 3
+
 /********************
  * Queue Management *
  ********************/
@@ -150,6 +152,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
       }
       timeout = setTimeout(handleTimeout, STALL_TIMEOUT)
     }
+    let contentLength
     const responseStream = got.stream(url, {
       headers,
       timeout: {
@@ -178,8 +181,30 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
 
     responseStream.on(`response`, response => {
       resetTimeout()
+      contentLength = Number(response.headers[`content-length`])
 
       fsWriteStream.on(`finish`, () => {
+        // We have an incomplete download
+        if (contentLength && contentLength !== fsWriteStream.bytesWritten) {
+          fs.removeSync(tmpFilename)
+
+          if (attempt < INCOMPLETE_RETRY_LIMIT) {
+            resolve(
+              requestRemoteNode(
+                url,
+                headers,
+                tmpFilename,
+                httpOpts,
+                attempt + 1
+              )
+            )
+          } else {
+            reject(
+              `Failed to download ${url} after ${INCOMPLETE_RETRY_LIMIT} attempts`
+            )
+          }
+        }
+
         if (timeout) {
           clearTimeout(timeout)
         }

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -181,7 +181,8 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
 
     responseStream.on(`response`, response => {
       resetTimeout()
-      contentLength = Number(response.headers[`content-length`])
+      contentLength =
+        response.headers && Number(response.headers[`content-length`])
 
       fsWriteStream.on(`finish`, () => {
         // We have an incomplete download

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -152,7 +152,6 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
       }
       timeout = setTimeout(handleTimeout, STALL_TIMEOUT)
     }
-    let contentLength
     const responseStream = got.stream(url, {
       headers,
       timeout: {
@@ -181,7 +180,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
 
     responseStream.on(`response`, response => {
       resetTimeout()
-      contentLength =
+      const contentLength =
         response.headers && Number(response.headers[`content-length`])
 
       fsWriteStream.on(`finish`, () => {


### PR DESCRIPTION
When downloading a file from a remote under pressure, we have seen cases where the download might be incomplete, especially in cases of images. Such files will break `sharp` when it attempts to process them with an Error because they are corrupt. 

One (not exhaustive) nice to have check to prevent this is to assert that the bytes written to disk and equal to the `Content-Length` sent in HTTP headers (when present). 

This PR adds that check and retries if the check fails. 