### PR TITLE
fix(gatsby-source-filesystem):  Reduce default download concurrency to a saner value

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -74,7 +74,7 @@ const CONNECTION_TIMEOUT = process.env.GATSBY_CONNECTION_TIMEOUT || 30000
 const queue = new Queue(pushToQueue, {
   id: `url`,
   merge: (old, _, cb) => cb(old),
-  concurrent: process.env.GATSBY_CONCURRENT_DOWNLOAD || 200,
+  concurrent: process.env.GATSBY_CONCURRENT_DOWNLOAD || 10,
 })
 
 // when the queue is empty we stop the progressbar


### PR DESCRIPTION
Under the hood, `createRemoteFileNode` uses a Queue to process network requests. The number of concurrent workers for this queue is controlled by the `GATSBY_CONCURRENT_DOWNLOAD` env variable. 

However, when the variable is not set, this defaults to 200. 200 is a very high number of concurrent HTTP connections to open to pretty much any remote and such load sustained over a few seconds typically results in the remote rate limiting us and not accepting any other connections after 40-50 of them. 

It also results in timeouts, incomplete downloads etc which all result in extra retries required for most files. 

10 is a much saner default and ensures _consistent_, stable downloads for most remotes. 

A user may still choose to bump this up and may use the `GATSBY_CONCURRENT_DOWNLOAD` env var to do that. We are only changing the default so users without a opt in value can have a better default. 