### PR TITLE
fix(gatsby-source-drupal): Do not swallow errors

### DIFF
--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -37,40 +37,36 @@ exports.downloadFile = async (
     let fileNode
     let fileType
 
-    try {
-      let fileUrl = node.url
-      if (typeof node.uri === `object`) {
-        // Support JSON API 2.x file URI format https://www.drupal.org/node/2982209
-        fileUrl = node.uri.url
-        // get file type from uri prefix ("S3:", "public:", etc.)
-        const uri_prefix = node.uri.value.match(/^\w*:/)
-        fileType = uri_prefix ? uri_prefix[0] : null
-      }
-      // Resolve w/ baseUrl if node.uri isn't absolute.
-      const url = new URL(fileUrl, baseUrl)
-      // If we have basicAuth credentials, add them to the request.
-      const basicAuthFileSystems = [`public:`, `private:`, `temporary:`]
-      const auth =
-        typeof basicAuth === `object` && basicAuthFileSystems.includes(fileType)
-          ? {
-              htaccess_user: basicAuth.username,
-              htaccess_pass: basicAuth.password,
-            }
-          : {}
-      fileNode = await createRemoteFileNode({
-        url: url.href,
-        store,
-        cache,
-        createNode,
-        createNodeId,
-        getCache,
-        parentNodeId: node.id,
-        auth,
-        reporter,
-      })
-    } catch (e) {
-      // Ignore
+    let fileUrl = node.url
+    if (typeof node.uri === `object`) {
+      // Support JSON API 2.x file URI format https://www.drupal.org/node/2982209
+      fileUrl = node.uri.url
+      // get file type from uri prefix ("S3:", "public:", etc.)
+      const uri_prefix = node.uri.value.match(/^\w*:/)
+      fileType = uri_prefix ? uri_prefix[0] : null
     }
+    // Resolve w/ baseUrl if node.uri isn't absolute.
+    const url = new URL(fileUrl, baseUrl)
+    // If we have basicAuth credentials, add them to the request.
+    const basicAuthFileSystems = [`public:`, `private:`, `temporary:`]
+    const auth =
+      typeof basicAuth === `object` && basicAuthFileSystems.includes(fileType)
+        ? {
+            htaccess_user: basicAuth.username,
+            htaccess_pass: basicAuth.password,
+          }
+        : {}
+    fileNode = await createRemoteFileNode({
+      url: url.href,
+      store,
+      cache,
+      createNode,
+      createNodeId,
+      getCache,
+      parentNodeId: node.id,
+      auth,
+      reporter,
+    })
     if (fileNode) {
       node.localFile___NODE = fileNode.id
     }


### PR DESCRIPTION
Currently the `downloadFile` function (which is used to download a file using `createRemoteFileNode` and to create a `File` node for it) wraps all logic in a try block and ignores any errors that are caught. 

This is problematic because it swallows real errors and can be frustrating to an end user because it makes debugging harder, for example a sharp transform may fail due to a broken download instead of the broken download itself failing. 

We fix this by removing the try catch block entirely. 