### PR TITLE
fix(gatsby): Avoid undefined object errors

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/index.ts
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /*  eslint-disable new-cap */
 import graphql from "gatsby/graphql"
 import { murmurhash } from "./murmur"

--- a/packages/babel-plugin-remove-graphql-queries/src/index.ts
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.ts
@@ -103,7 +103,7 @@ const isGlobalIdentifier = (
   tag.isIdentifier({ name: tagName }) && tag.scope.hasGlobal(tagName)
 
 export function followVariableDeclarations(binding: Binding): Binding {
-  const node = binding.path?.node
+  const node = binding?.path?.node
   if (
     node?.type === `VariableDeclarator` &&
     node?.id.type === `Identifier` &&
@@ -493,7 +493,7 @@ export default function ({ types: t }): PluginObj {
               const binding = hookPath.scope.getBinding(varName)
 
               if (binding) {
-                followVariableDeclarations(binding).path.traverse({
+                followVariableDeclarations(binding)?.path?.traverse({
                   TaggedTemplateExpression,
                 })
               }

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 // @flow
 const fs = require(`fs-extra`)
 const crypto = require(`crypto`)

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -42,7 +42,7 @@ const generateQueryName = ({ def, hash, file }) => {
 // taken from `babel-plugin-remove-graphql-queries`, in the future import from
 // there
 function followVariableDeclarations(binding) {
-  const node = binding.path?.node
+  const node = binding?.path?.node
   if (
     node?.type === `VariableDeclarator` &&
     node?.id.type === `Identifier` &&
@@ -376,7 +376,7 @@ async function findGraphQLTags(
                 const binding = followVariableDeclarations(
                   path.scope.getBinding(path.node.local.name)
                 )
-                binding.path.traverse({ TaggedTemplateExpression })
+                binding?.path?.traverse({ TaggedTemplateExpression })
               },
             })
           },


### PR DESCRIPTION
Compilation was failing in e2e tests because babel was failing when trying to extract queries from a compiled JS bundle. This adds some optional chains to avoid checking for propererties of undefined objects