### PR TITLE
fix(gatsby-react-router-scroll): Respect hash as source of truth for scroll position

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/scroll-behavior.js
+++ b/e2e-tests/production-runtime/cypress/integration/scroll-behavior.js
@@ -48,7 +48,7 @@ describe(`Scroll behaviour`, () => {
       cy.go(`forward`).waitForRouteChange()
 
       cy.window().then(updatedWindow => {
-        expect(updatedWindow.scrollY).not.to.eq(idScrollY)
+        expect(updatedWindow.scrollY).to.eq(idScrollY)
       })
     })
   })

--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -61,7 +61,16 @@ export class ScrollHandler extends React.Component<
       scrollPosition = this._stateStorage.read(this.props.location, key)
     }
 
-    if (hash && scrollPosition === 0) {
+    /**  There are two pieces of state: the browser url and
+     * history state which keeps track of scroll position
+     * Native behaviour prescribes that we ought to restore scroll position
+     * when a user navigates back in their browser (this is the `POP` action)
+     * Currently, reach router has a bug that prevents this at https://github.com/reach/router/issues/228
+     * So we _always_ stick to the url as a source of truth — if the url
+     * contains a hash, we scroll to it
+     */
+
+    if (hash) {
       this.scrollToHash(decodeURI(hash), prevProps)
     } else {
       this.windowScroll(scrollPosition, prevProps)


### PR DESCRIPTION
Currently we do not navigate correctly to hashes unless the scroll position is zero. If you're scrolled to any position other than the top, you will need to click twice to scroll to the correct position. This behaviour is completely broken at the moment. 

This PR fixes this (albeit not completely) by _always_ respecting the hash and scrolling to it irrespective of if there is browser scrolling state or not. This is iteratively better than our current behaviour. However, the ideal behaviour (which we ought to handle in a separate PR) is to respect hash except when navigating back in the browser (in which case, we ought to restore scroll position). Reach currently has this bug which we can track at https://github.com/reach/router/issues/228

Closes #25778