### PR TITLE
fix(gatsby-recipes): Add postcss as a dependency

### DIFF
--- a/packages/gatsby-recipes/recipes/tailwindcss.mdx
+++ b/packages/gatsby-recipes/recipes/tailwindcss.mdx
@@ -9,13 +9,14 @@ This recipe:
 Installs necessary NPM packages.
 
 <NPMPackage name="tailwindcss" />
+<NPMPackage name="postcss" />
 <NPMPackage name="gatsby-plugin-postcss" />
 
 ---
 
 Installs necessary Gatsby plugins.
 
-<GatsbyPlugin name="gatsby-plugin-postcss"/>
+<GatsbyPlugin name="gatsby-plugin-postcss" />
 
 ---
 


### PR DESCRIPTION
The currently included Tailwind recipe is broken because it does not install PostCSS as recommended in https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users

This PR fixes that by adding `postcss` as a dependency 