### PR TITLE
[gatsby-plugin-layout] update documentation

### DIFF
--- a/packages/gatsby-plugin-layout/README.md
+++ b/packages/gatsby-plugin-layout/README.md
@@ -37,7 +37,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-layout`,
       options: {
-        component: require.resolve(`./relative/path/to/layout/component`),
+        component: `./relative/path/to/layout/component`,
       },
     },
   ],


### PR DESCRIPTION
It looks like the documentation is out of date.

https://github.com/gatsbyjs/gatsby/blob/721f42aa210943a5cfe9b08fe93ad31ae315c447/packages/gatsby-plugin-layout/src/gatsby-node.js#L7-L14

`defaultLayoutComponentPath` is a string and `component` option should be a string too

Fixes #28500 