### PR TITLE
feat(query-on-demand): loading indicator

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -7,6 +7,7 @@ import socketIo from "./socketIo"
 import emitter from "./emitter"
 import { apiRunner, apiRunnerAsync } from "./api-runner-browser"
 import { setLoader, publicLoader } from "./loader"
+import { Indicator } from "./loading-indicator/indicator"
 import DevLoader from "./dev-loader"
 import syncRequires from "$virtual/sync-requires"
 // Generated during bootstrap
@@ -122,6 +123,26 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     ReactDOM.render
   )[0]
 
+  let dismissLoadingIndicator
+  if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+    let indicatorMountElement
+
+    const showIndicatorTimeout = setTimeout(() => {
+      indicatorMountElement = document.createElement(
+        `first-render-loading-indicator`
+      )
+      document.body.append(indicatorMountElement)
+      ReactDOM.render(<Indicator />, indicatorMountElement)
+    }, 1000)
+
+    dismissLoadingIndicator = () => {
+      clearTimeout(showIndicatorTimeout)
+      if (indicatorMountElement) {
+        ReactDOM.unmountComponentAtNode(indicatorMountElement)
+      }
+    }
+  }
+
   Promise.all([
     loader.loadPage(`/dev-404-page/`),
     loader.loadPage(`/404.html`),
@@ -130,8 +151,15 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     const preferDefault = m => (m && m.default) || m
     const Root = preferDefault(require(`./root`))
     domReady(() => {
+      if (dismissLoadingIndicator) {
+        dismissLoadingIndicator()
+      }
+
       renderer(<Root />, rootElement, () => {
         apiRunner(`onInitialClientRender`)
+        if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+          emitter.emit(`onInitialClientRender`)
+        }
       })
     })
   })

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -124,7 +124,10 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   )[0]
 
   let dismissLoadingIndicator
-  if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+  if (
+    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+    process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`
+  ) {
     let indicatorMountElement
 
     const showIndicatorTimeout = setTimeout(() => {
@@ -157,9 +160,6 @@ apiRunnerAsync(`onClientEntry`).then(() => {
 
       renderer(<Root />, rootElement, () => {
         apiRunner(`onInitialClientRender`)
-        if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
-          emitter.emit(`onInitialClientRender`)
-        }
       })
     })
   })

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -142,6 +142,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       clearTimeout(showIndicatorTimeout)
       if (indicatorMountElement) {
         ReactDOM.unmountComponentAtNode(indicatorMountElement)
+        indicatorMountElement.remove()
       }
     }
   }

--- a/packages/gatsby/cache-dir/debug-log.js
+++ b/packages/gatsby/cache-dir/debug-log.js
@@ -1,0 +1,13 @@
+// inspired by https://github.com/GoogleChrome/workbox/blob/3d02230f0e977eb1dc86c48f16ea4bcefdae12af/packages/workbox-core/src/_private/logger.ts
+
+const styles = [
+  `background: rebeccapurple`,
+  `border-radius: 0.5em`,
+  `color: white`,
+  `font-weight: bold`,
+  `padding: 2px 0.5em`,
+].join(`;`)
+
+export function debugLog(...args) {
+  console.debug(`%cgatsby`, styles, ...args)
+}

--- a/packages/gatsby/cache-dir/loading-indicator/index.js
+++ b/packages/gatsby/cache-dir/loading-indicator/index.js
@@ -26,10 +26,6 @@ export class LoadingIndicatorEventHandler extends React.Component {
   }
 
   render() {
-    if (!this.state.visible) {
-      return null
-    }
-
-    return <Indicator />
+    return <Indicator visible={this.state.visible} />
   }
 }

--- a/packages/gatsby/cache-dir/loading-indicator/index.js
+++ b/packages/gatsby/cache-dir/loading-indicator/index.js
@@ -1,0 +1,35 @@
+import React from "react"
+
+import emitter from "../emitter"
+import { Indicator } from "./indicator"
+
+// no hooks because we support react versions without hooks support
+export class LoadingIndicatorEventHandler extends React.Component {
+  state = { visible: false }
+
+  show = () => {
+    this.setState({ visible: true })
+  }
+
+  hide = () => {
+    this.setState({ visible: false })
+  }
+
+  componentDidMount() {
+    emitter.on(`onDelayedLoadPageResources`, this.show)
+    emitter.on(`onRouteUpdate`, this.hide)
+  }
+
+  componentWillUnmount() {
+    emitter.off(`onDelayedLoadPageResources`, this.show)
+    emitter.off(`onRouteUpdate`, this.hide)
+  }
+
+  render() {
+    if (!this.state.visible) {
+      return null
+    }
+
+    return <Indicator />
+  }
+}

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -1,0 +1,19 @@
+import React from "react"
+import Portal from "./portal"
+
+export function Indicator() {
+  return (
+    <Portal>
+      <div
+        style={{
+          position: `fixed`,
+          bottom: `1em`,
+          left: `1em`,
+          border: `2px solid rebeccapurple`,
+        }}
+      >
+        Loading ...
+      </div>
+    </Portal>
+  )
+}

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -32,7 +32,7 @@ export function Indicator({ visible = true }) {
   if (!window.___gatsbyDidShowLoadingIndicatorBefore) {
     // not ideal to this in render function, but that's just console info
     debugLog(
-      `You might have seen "gatsby develop" loading indicator in the bottom left corner.\n\nIf you want to disable it you can visit ${window.location.origin}/___loading-indicator/disable (will disable it for current session).`
+      `A loading indicator is displayed in-browser whenever content is being requested upon navigation (Query On Demand).\n\nYou can disable the loading indicator for your current session by visiting ${window.location.origin}/___loading-indicator/disable`
     )
     window.___gatsbyDidShowLoadingIndicatorBefore = true
   }

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -32,7 +32,7 @@ export function Indicator() {
   if (!window.___gatsbyDidShowLoadingIndicatorBefore) {
     // not ideal to this in render function, but that's just console info
     debugLog(
-      `You might have seen "gatsby develop" loading indicator in the bottom left corner.\n\nTo disable it you can visit ${window.location.origin}/___loading-indicator/disable (will disable it for current session).`
+      `You might have seen "gatsby develop" loading indicator in the bottom left corner.\n\nIf you want to disable it you can visit ${window.location.origin}/___loading-indicator/disable (will disable it for current session) or add following snippet in gatsby-config.js:\n\nflags: {\n  QUERY_ON_DEMAND: {\n    loadingIndicator: false\n  }\n}`
     )
     window.___gatsbyDidShowLoadingIndicatorBefore = true
   }

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -2,6 +2,13 @@ import React from "react"
 import Portal from "./portal"
 import Style from "./style"
 import { isLoadingIndicatorEnabled } from "$virtual/loading-indicator"
+import { debugLog } from "../debug-log"
+
+if (typeof window === `undefined`) {
+  throw new Error(
+    `Loading indicator should never be imported in code that doesn't target only browsers`
+  )
+}
 
 if (module.hot) {
   module.hot.accept(`$virtual/loading-indicator`, () => {
@@ -20,6 +27,14 @@ if (typeof window.___gatsbyDidShowLoadingIndicatorBefore === `undefined`) {
 export function Indicator() {
   if (!isLoadingIndicatorEnabled()) {
     return null
+  }
+
+  if (!window.___gatsbyDidShowLoadingIndicatorBefore) {
+    // not ideal to this in render function, but that's just console info
+    debugLog(
+      `You might have seen "gatsby develop" loading indicator in the bottom left corner.\n\nTo disable it you can visit ${window.location.origin}/___loading-indicator/disable (will disable it for current session).`
+    )
+    window.___gatsbyDidShowLoadingIndicatorBefore = true
   }
 
   return (

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -1,18 +1,14 @@
 import React from "react"
 import Portal from "./portal"
+import Style from "./style"
 
 export function Indicator() {
   return (
     <Portal>
-      <div
-        style={{
-          position: `fixed`,
-          bottom: `1em`,
-          left: `1em`,
-          border: `2px solid rebeccapurple`,
-        }}
-      >
-        Loading ...
+      <Style />
+      <div data-gatsby-loading-indicator="root">
+        <div data-gatsby-loading-indicator="spinner" aria-hidden={true} />
+        <div data-gatsby-loading-indicator="text">Loading</div>
       </div>
     </Portal>
   )

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -1,8 +1,27 @@
 import React from "react"
 import Portal from "./portal"
 import Style from "./style"
+import { isLoadingIndicatorEnabled } from "$virtual/loading-indicator"
+
+if (module.hot) {
+  module.hot.accept(`$virtual/loading-indicator`, () => {
+    // isLoadingIndicatorEnabled is imported with ES import so no need
+    // for dedicated handling as HMR just replace it in that case
+  })
+}
+
+// HMR can rerun this, so check if it was set before
+// we also set it on window and not just in module scope because of HMR resetting
+// module scope
+if (typeof window.___gatsbyDidShowLoadingIndicatorBefore === `undefined`) {
+  window.___gatsbyDidShowLoadingIndicatorBefore = false
+}
 
 export function Indicator() {
+  if (!isLoadingIndicatorEnabled()) {
+    return null
+  }
+
   return (
     <Portal>
       <Style />

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -24,7 +24,7 @@ if (typeof window.___gatsbyDidShowLoadingIndicatorBefore === `undefined`) {
   window.___gatsbyDidShowLoadingIndicatorBefore = false
 }
 
-export function Indicator({ visible }) {
+export function Indicator({ visible = true }) {
   if (!isLoadingIndicatorEnabled()) {
     return null
   }
@@ -56,7 +56,7 @@ export function Indicator({ visible }) {
           </svg>
         </div>
         <div data-gatsby-loading-indicator="text">
-          {visible ? `Preparing requested page` : `Finished loading page`}
+          {visible ? `Preparing requested page` : ``}
         </div>
       </div>
     </Portal>

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -24,7 +24,7 @@ if (typeof window.___gatsbyDidShowLoadingIndicatorBefore === `undefined`) {
   window.___gatsbyDidShowLoadingIndicatorBefore = false
 }
 
-export function Indicator() {
+export function Indicator({ visible }) {
   if (!isLoadingIndicatorEnabled()) {
     return null
   }
@@ -40,9 +40,24 @@ export function Indicator() {
   return (
     <Portal>
       <Style />
-      <div data-gatsby-loading-indicator="root">
-        <div data-gatsby-loading-indicator="spinner" aria-hidden={true} />
-        <div data-gatsby-loading-indicator="text">Loading</div>
+      <div
+        data-gatsby-loading-indicator="root"
+        data-gatsby-loading-indicator-visible={visible}
+        aria-live="assertive"
+      >
+        <div data-gatsby-loading-indicator="spinner" aria-hidden="true">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path d="M0 0h24v24H0z" fill="none" />
+            <path d="M12 6v3l4-4-4-4v3c-4.42 0-8 3.58-8 8 0 1.57.46 3.03 1.24 4.26L6.7 14.8c-.45-.83-.7-1.79-.7-2.8 0-3.31 2.69-6 6-6zm6.76 1.74L17.3 9.2c.44.84.7 1.79.7 2.8 0 3.31-2.69 6-6 6v-3l-4 4 4 4v-3c4.42 0 8-3.58 8-8 0-1.57-.46-3.03-1.24-4.26z" />
+          </svg>
+        </div>
+        <div data-gatsby-loading-indicator="text">
+          {visible ? `Preparing requested page` : `Finished loading page`}
+        </div>
       </div>
     </Portal>
   )

--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -32,7 +32,7 @@ export function Indicator({ visible = true }) {
   if (!window.___gatsbyDidShowLoadingIndicatorBefore) {
     // not ideal to this in render function, but that's just console info
     debugLog(
-      `You might have seen "gatsby develop" loading indicator in the bottom left corner.\n\nIf you want to disable it you can visit ${window.location.origin}/___loading-indicator/disable (will disable it for current session) or add following snippet in gatsby-config.js:\n\nflags: {\n  QUERY_ON_DEMAND: {\n    loadingIndicator: false\n  }\n}`
+      `You might have seen "gatsby develop" loading indicator in the bottom left corner.\n\nIf you want to disable it you can visit ${window.location.origin}/___loading-indicator/disable (will disable it for current session).`
     )
     window.___gatsbyDidShowLoadingIndicatorBefore = true
   }

--- a/packages/gatsby/cache-dir/loading-indicator/portal.js
+++ b/packages/gatsby/cache-dir/loading-indicator/portal.js
@@ -1,0 +1,43 @@
+import * as React from "react"
+import { createPortal } from "react-dom"
+
+// this is `fast-refresh-overlay/portal` ported to class component
+// because we don't have guarantee that query on demand users will use
+// react version that supports hooks
+// TO-DO: consolidate both portals into single shared component (need testing)
+class ShadowPortal extends React.Component {
+  mountNode = React.createRef(null)
+  portalNode = React.createRef(null)
+  shadowNode = React.createRef(null)
+  state = {
+    createdElement: false,
+  }
+
+  componentDidMount() {
+    const ownerDocument = this.mountNode.current.ownerDocument
+    this.portalNode.current = ownerDocument.createElement(`gatsby-portal`)
+    this.shadowNode.current = this.portalNode.current.attachShadow({
+      mode: `open`,
+    })
+    ownerDocument.body.appendChild(this.portalNode.current)
+    this.setState({ createdElement: true })
+  }
+
+  componentWillUnmount() {
+    if (this.portalNode.current && this.portalNode.current.ownerDocument) {
+      this.portalNode.current.ownerDocument.body.removeChild(
+        this.portalNode.current
+      )
+    }
+  }
+
+  render() {
+    return this.shadowNode.current ? (
+      createPortal(this.props.children, this.shadowNode.current)
+    ) : (
+      <span ref={this.mountNode} />
+    )
+  }
+}
+
+export default ShadowPortal

--- a/packages/gatsby/cache-dir/loading-indicator/style.js
+++ b/packages/gatsby/cache-dir/loading-indicator/style.js
@@ -1,0 +1,79 @@
+import React from "react"
+
+function css(strings, ...keys) {
+  const lastIndex = strings.length - 1
+  return (
+    strings.slice(0, lastIndex).reduce((p, s, i) => p + s + keys[i], ``) +
+    strings[lastIndex]
+  )
+}
+
+const Style = () => (
+  <style
+    dangerouslySetInnerHTML={{
+      __html: css`
+        :host {
+          --gatsby: #663399;
+          --gatsbyLight: #b17acc;
+          --dimmedWhite: rgba(255, 255, 255, 0.8);
+          --white: #ffffff;
+          --black: #000000;
+          --grey-90: #232129;
+          --radii: 4px;
+          --z-index-normal: 5;
+          --z-index-elevated: 10;
+          --shadow: 0px 2px 4px rgba(46, 41, 51, 0.08),
+            0px 4px 8px rgba(71, 63, 79, 0.16);
+        }
+
+        [data-gatsby-loading-indicator="root"] {
+          font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+            Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+            "Segoe UI Symbol" !important;
+          background: var(--white);
+          color: var(--grey-90);
+          position: fixed;
+          bottom: 1.5em;
+          left: 1.5em;
+          box-shadow: var(--shadow);
+          border-radius: var(--radii);
+          z-index: var(--z-index-elevated);
+          border-left: 0.25em solid var(--gatsbyLight);
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          flex-wrap: nowrap;
+          padding: 0.75em 1em;
+        }
+
+        [data-gatsby-loading-indicator="spinner"] {
+          width: 20px;
+          height: 20px;
+          margin: 0 auto;
+          background-color: var(--gatsbyLight);
+
+          border-radius: 100%;
+          animation: scaleout 1s infinite ease-in-out;
+        }
+
+        [data-gatsby-loading-indicator="text"] {
+          margin-left: 1em;
+        }
+
+        @keyframes scaleout {
+          0% {
+            -webkit-transform: scale(0);
+            transform: scale(0);
+          }
+          100% {
+            -webkit-transform: scale(1);
+            transform: scale(1);
+            opacity: 0;
+          }
+        }
+      `,
+    }}
+  />
+)
+
+export default Style

--- a/packages/gatsby/cache-dir/loading-indicator/style.js
+++ b/packages/gatsby/cache-dir/loading-indicator/style.js
@@ -13,8 +13,10 @@ const Style = () => (
     dangerouslySetInnerHTML={{
       __html: css`
         :host {
-          --gatsby: #663399;
-          --gatsbyLight: #b17acc;
+          --purple-60: #663399;
+          --gatsby: var(--purple-60);
+          --purple-40: #b17acc;
+          --purple-20: #f1defa;
           --dimmedWhite: rgba(255, 255, 255, 0.8);
           --white: #ffffff;
           --black: #000000;
@@ -38,37 +40,70 @@ const Style = () => (
           box-shadow: var(--shadow);
           border-radius: var(--radii);
           z-index: var(--z-index-elevated);
-          border-left: 0.25em solid var(--gatsbyLight);
+          border-left: 0.25em solid var(--purple-40);
           display: flex;
           align-items: center;
           justify-content: space-between;
           flex-wrap: nowrap;
-          padding: 0.75em 1em;
+          padding: 0.75em 1.15em;
+        }
+
+        [data-gatsby-loading-indicator-visible="false"] {
+          opacity: 0;
+          visibility: hidden;
+          will-change: opacity, transform;
+          transform: translateY(45px);
+          transition: all 0.3s ease-in-out;
+        }
+
+        [data-gatsby-loading-indicator-visible="true"] {
+          opacity: 1;
+          visibility: visible;
+          transform: translateY(0px);
+          transition: all 0.3s ease-in-out;
         }
 
         [data-gatsby-loading-indicator="spinner"] {
-          width: 20px;
-          height: 20px;
-          margin: 0 auto;
-          background-color: var(--gatsbyLight);
-
-          border-radius: 100%;
-          animation: scaleout 1s infinite ease-in-out;
+          animation: spin 1s linear infinite;
+          height: 18px;
+          width: 18px;
+          color: var(--gatsby);
         }
 
         [data-gatsby-loading-indicator="text"] {
-          margin-left: 1em;
+          margin-left: 0.75em;
+          line-height: 18px;
         }
 
-        @keyframes scaleout {
+        @keyframes spin {
           0% {
-            -webkit-transform: scale(0);
-            transform: scale(0);
+            transform: rotate(0);
           }
           100% {
-            -webkit-transform: scale(1);
-            transform: scale(1);
-            opacity: 0;
+            transform: rotate(360deg);
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          [data-gatsby-loading-indicator="spinner"] {
+            animation: none;
+          }
+          [data-gatsby-loading-indicator-visible="false"] {
+            transition: none;
+          }
+
+          [data-gatsby-loading-indicator-visible="true"] {
+            transition: none;
+          }
+        }
+
+        @media (prefers-color-scheme: dark) {
+          [data-gatsby-loading-indicator="root"] {
+            background: var(--grey-90);
+            color: var(--white);
+          }
+          [data-gatsby-loading-indicator="spinner"] {
+            color: var(--purple-20);
           }
         }
       `,

--- a/packages/gatsby/cache-dir/loading-indicator/style.js
+++ b/packages/gatsby/cache-dir/loading-indicator/style.js
@@ -46,6 +46,7 @@ const Style = () => (
           justify-content: space-between;
           flex-wrap: nowrap;
           padding: 0.75em 1.15em;
+          min-width: 196px;
         }
 
         [data-gatsby-loading-indicator-visible="false"] {

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -43,7 +43,10 @@ const onPreRouteUpdate = (location, prevLocation) => {
 const onRouteUpdate = (location, prevLocation) => {
   if (!maybeRedirect(location.pathname)) {
     apiRunner(`onRouteUpdate`, { location, prevLocation })
-    if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+    if (
+      process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+      process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`
+    ) {
       emitter.emit(`onRouteUpdate`, { location, prevLocation })
     }
   }

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -43,6 +43,9 @@ const onPreRouteUpdate = (location, prevLocation) => {
 const onRouteUpdate = (location, prevLocation) => {
   if (!maybeRedirect(location.pathname)) {
     apiRunner(`onRouteUpdate`, { location, prevLocation })
+    if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+      emitter.emit(`onRouteUpdate`, { location, prevLocation })
+    }
   }
 }
 

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -14,6 +14,7 @@ import EnsureResources from "./ensure-resources"
 import FastRefreshOverlay from "./fast-refresh-overlay"
 
 import { reportError, clearError } from "./error-overlay-handler"
+import { LoadingIndicatorEventHandler } from "./loading-indicator"
 
 // TODO: Remove entire block when we make fast-refresh the default
 // In fast-refresh, this logic is all moved into the `error-overlay-handler`
@@ -147,5 +148,6 @@ const ConditionalFastRefreshOverlay = ({ children }) => {
 export default () => (
   <ConditionalFastRefreshOverlay>
     <StaticQueryStore>{WrappedRoot}</StaticQueryStore>
+    <LoadingIndicatorEventHandler />
   </ConditionalFastRefreshOverlay>
 )

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -148,6 +148,9 @@ const ConditionalFastRefreshOverlay = ({ children }) => {
 export default () => (
   <ConditionalFastRefreshOverlay>
     <StaticQueryStore>{WrappedRoot}</StaticQueryStore>
-    <LoadingIndicatorEventHandler />
+    {process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+      process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true` && (
+        <LoadingIndicatorEventHandler />
+      )}
   </ConditionalFastRefreshOverlay>
 )

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -227,21 +227,16 @@ export async function initialize({
 
   process.env.GATSBY_HOT_LOADER = getReactHotLoaderStrategy()
 
-  // TODO: this should be handled in QUERY_ON_DEMAND flag configuration and not be one-off here
-  // disable loading indicator if flag is set to QUERY_ON_DEMAND: { loadingIndicator: false }
+  // TODO: figure out proper way of disabling loading indicator
+  // for now GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR=false gatsby develop
+  // will work, but we don't want to force users into using env vars
   if (
-    config?.flags?.QUERY_ON_DEMAND &&
-    _.isPlainObject(config.flags.QUERY_ON_DEMAND) &&
-    !config.flags.QUERY_ON_DEMAND.loadingIndicator
+    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+    !process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR
   ) {
-    process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR = `false`
-  } else if (!process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR) {
-    // if env var for loading indicator was not explicitly set
-    // enable loading indicator if query on demand is enabled
-    process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR = process.env
-      .GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
-      ? `true`
-      : `false`
+    // if query on demand is enabled and GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR was not set at all
+    // enable loading indicator
+    process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR = `true`
   }
 
   // theme gatsby configs can be functions or objects

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -227,6 +227,23 @@ export async function initialize({
 
   process.env.GATSBY_HOT_LOADER = getReactHotLoaderStrategy()
 
+  // TODO: this should be handled in QUERY_ON_DEMAND flag configuration and not be one-off here
+  // disable loading indicator if flag is set to QUERY_ON_DEMAND: { loadingIndicator: false }
+  if (
+    config?.flags?.QUERY_ON_DEMAND &&
+    _.isPlainObject(config.flags.QUERY_ON_DEMAND) &&
+    !config.flags.QUERY_ON_DEMAND.loadingIndicator
+  ) {
+    process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR = `false`
+  } else if (!process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR) {
+    // if env var for loading indicator was not explicitly set
+    // enable loading indicator if query on demand is enabled
+    process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR = process.env
+      .GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
+      ? `true`
+      : `false`
+  }
+
   // theme gatsby configs can be functions or objects
   if (config && config.__experimentalThemes) {
     reporter.warn(

--- a/packages/gatsby/src/utils/loading-indicator.ts
+++ b/packages/gatsby/src/utils/loading-indicator.ts
@@ -37,10 +37,10 @@ export function writeVirtualLoadingIndicatorModule(): void {
 
 export function routeLoadingIndicatorRequests(app: Express): void {
   app.get(`/___loading-indicator/:method?`, (req, res) => {
-    if (req.params.method === `enable` && indicatorEnabled === false) {
+    if (req.params.method === `enable` && indicatorEnabled !== true) {
       indicatorEnabled = true
       writeVirtualLoadingIndicatorModule()
-    } else if (req.params.method === `disable` && indicatorEnabled === true) {
+    } else if (req.params.method === `disable` && indicatorEnabled !== false) {
       indicatorEnabled = false
       writeVirtualLoadingIndicatorModule()
     }

--- a/packages/gatsby/src/utils/loading-indicator.ts
+++ b/packages/gatsby/src/utils/loading-indicator.ts
@@ -1,25 +1,46 @@
 import { Express } from "express"
 import { writeModule } from "./gatsby-webpack-virtual-modules"
 
-let indicatorEnabled = true
+// set value to undefined first, because env vars needed to determine if indicator
+// should ever be enabled by default might not be set yet - we set it to "initial"
+// first time we write out module if loading indicator is allowed
+// "initial" means that browser will decide if it should show it
+// for now we do disable it by default when running in cypress
+// to not cause problems for users when they iterate on their E2E tests
+// this check could be expanded in the future to add support for more scenarios
+// like that.
+let indicatorEnabled: "initial" | true | false | undefined = undefined
 
-function writeVirtualLoadingIndicatorModule(): void {
+export function writeVirtualLoadingIndicatorModule(): void {
+  if (indicatorEnabled === undefined) {
+    indicatorEnabled =
+      process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+      process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`
+        ? `initial`
+        : false
+  }
+
   writeModule(
     `$virtual/loading-indicator.js`,
-    `export function isLoadingIndicatorEnabled() {
-    return ${JSON.stringify(indicatorEnabled)}
+    `
+    export function isLoadingIndicatorEnabled() {
+    return ${
+      indicatorEnabled === `initial`
+        ? `\`Cypress\` in window
+          ? false
+          : true`
+        : JSON.stringify(indicatorEnabled)
+    }
   }`
   )
 }
 
 export function routeLoadingIndicatorRequests(app: Express): void {
-  writeVirtualLoadingIndicatorModule()
-
   app.get(`/___loading-indicator/:method?`, (req, res) => {
-    if (req.params.method === `enable` && !indicatorEnabled) {
+    if (req.params.method === `enable` && indicatorEnabled === false) {
       indicatorEnabled = true
       writeVirtualLoadingIndicatorModule()
-    } else if (req.params.method === `disable` && indicatorEnabled) {
+    } else if (req.params.method === `disable` && indicatorEnabled === true) {
       indicatorEnabled = false
       writeVirtualLoadingIndicatorModule()
     }

--- a/packages/gatsby/src/utils/loading-indicator.ts
+++ b/packages/gatsby/src/utils/loading-indicator.ts
@@ -1,0 +1,31 @@
+import { Express } from "express"
+import { writeModule } from "./gatsby-webpack-virtual-modules"
+
+let indicatorEnabled = true
+
+function writeVirtualLoadingIndicatorModule(): void {
+  writeModule(
+    `$virtual/loading-indicator.js`,
+    `export function isLoadingIndicatorEnabled() {
+    return ${JSON.stringify(indicatorEnabled)}
+  }`
+  )
+}
+
+export function routeLoadingIndicatorRequests(app: Express): void {
+  writeVirtualLoadingIndicatorModule()
+
+  app.get(`/___loading-indicator/:method?`, (req, res) => {
+    if (req.params.method === `enable` && !indicatorEnabled) {
+      indicatorEnabled = true
+      writeVirtualLoadingIndicatorModule()
+    } else if (req.params.method === `disable` && indicatorEnabled) {
+      indicatorEnabled = false
+      writeVirtualLoadingIndicatorModule()
+    }
+
+    res.send({
+      status: indicatorEnabled ? `enabled` : `disabled`,
+    })
+  })
+}

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -46,7 +46,10 @@ import { Stage, IProgram } from "../commands/types"
 import JestWorker from "jest-worker"
 import { findOriginalSourcePositionAndContent } from "./stack-trace-utils"
 import { appendPreloadHeaders } from "./develop-preload-headers"
-import { routeLoadingIndicatorRequests } from "./loading-indicator"
+import {
+  routeLoadingIndicatorRequests,
+  writeVirtualLoadingIndicatorModule,
+} from "./loading-indicator"
 
 type ActivityTracker = any // TODO: Replace this with proper type once reporter is typed
 
@@ -437,7 +440,14 @@ module.exports = {
     route({ app, program, store })
   }
 
-  if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+  // loading indicator
+  // write virtual module always to not fail webpack compilation, but only add express route handlers when
+  // query on demand is enabled and loading indicator is not disabled
+  writeVirtualLoadingIndicatorModule()
+  if (
+    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+    process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`
+  ) {
     routeLoadingIndicatorRequests(app)
   }
 

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -46,6 +46,7 @@ import { Stage, IProgram } from "../commands/types"
 import JestWorker from "jest-worker"
 import { findOriginalSourcePositionAndContent } from "./stack-trace-utils"
 import { appendPreloadHeaders } from "./develop-preload-headers"
+import { routeLoadingIndicatorRequests } from "./loading-indicator"
 
 type ActivityTracker = any // TODO: Replace this with proper type once reporter is typed
 
@@ -434,6 +435,10 @@ module.exports = {
     // Setup HTML route.
     const { route } = require(`./dev-ssr/develop-html-route`)
     route({ app, program, store })
+  }
+
+  if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+    routeLoadingIndicatorRequests(app)
   }
 
   app.use(async (req, res) => {


### PR DESCRIPTION
This shows loading indicator in `gatsby develop` when using query on demand. It will show fixed element in bottom left if first render or navigation takes over 1s and dismiss it just before first render or when navigation completes.

TODO:
 - ability to disable it:
   - ~[x] permenently (gatsby-config)~ I backed out of it, because it sets precedent for configuration in flags which we might regret - it doesn't mean something like won't be added in the future - just that it needs more thinking and discussions
   - [x] for current session
 - [x] actually style indicator to match design language used for fast-refresh overlay
![Screenshot 2020-12-09 at 00 48 34](https://user-images.githubusercontent.com/419821/101655213-a4606c80-3a41-11eb-8575-452a304f5ec7.png)
 - [x] message in browser console after showing it for first time with instructions how to disable it
 - ~[ ] e2e tests~ indicator being shown in shadow-dom make it not feasible to test with our version of cypress - it seems like newer versions of cypress do support it, but upgrading cypress version is bigger lift and should be out of scope for this PR

## Related Issues

closes #28182
[ch19091]