### PR TITLE
fix(gatsby): correct GraphQL warning text

### DIFF
--- a/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
@@ -179,8 +179,9 @@ describe(`Define parent-child relationships with field extensions`, () => {
         `because type \`Child\` does not explicitly list type \`Parent\` in \`childOf\` extension.\n` +
         `Add the following type definition to fix this:\n\n` +
         `  type Child implements Node @childOf(types: ["Parent"]) {\n` +
-        `    id\n` +
-        `  }`
+        `    id: ID!\n` +
+        `  }\n\n` +
+        `https://www.gatsbyjs.com/docs/actions/#createTypes`
     )
   })
 

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1049,8 +1049,9 @@ const addImplicitConvenienceChildrenFields = ({
             `type \`${typeName}\` does not explicitly list type \`${parentTypeName}\` in \`childOf\` extension.\n` +
             `Add the following type definition to fix this:\n\n` +
             `  type ${typeName} implements Node @childOf(types: ["${parentTypeName}"]${manyArg}) {\n` +
-            `    id\n` +
-            `  }`
+            `    id: ID!\n` +
+            `  }\n\n` +
+            `https://www.gatsbyjs.com/docs/actions/#createTypes`
         )
       }
     }


### PR DESCRIPTION
## Description

Add a missing piece to the incorrect warning text introduced in #28532 (didn't push this commit in that PR) 🤦‍♂️ 
