### PR TITLE
chore(create-gatsby): reorder style options by popularity and change postcss title

### DIFF
--- a/packages/create-gatsby/src/styles.json
+++ b/packages/create-gatsby/src/styles.json
@@ -1,8 +1,17 @@
 {
-  "gatsby-plugin-postcss": { "message": "CSS Modules/PostCSS", "dependencies": ["postcss"] },
-  "gatsby-plugin-styled-components": { "message": "styled-components", "dependencies": ["styled-components", "babel-plugin-styled-components"] },
-  "gatsby-plugin-emotion": { "message": "Emotion", "dependencies": ["@emotion/react", "@emotion/styled"] },
   "gatsby-plugin-sass": { "message": "Sass", "dependencies": ["node-sass"] },
+  "gatsby-plugin-styled-components": {
+    "message": "styled-components",
+    "dependencies": ["styled-components", "babel-plugin-styled-components"]
+  },
+  "gatsby-plugin-emotion": {
+    "message": "Emotion",
+    "dependencies": ["@emotion/react", "@emotion/styled"]
+  },
+  "gatsby-plugin-postcss": {
+    "message": "PostCSS",
+    "dependencies": ["postcss"]
+  },
   "gatsby-plugin-theme-ui": {
     "message": "Theme UI",
     "dependencies": ["theme-ui"]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Styles from the `create-gatsby` package didn't seem to be in any particular order. This clarifies the title for PostCSS and orders the other plugins by number of downloads.

![image](https://user-images.githubusercontent.com/21114044/101660769-c7b8f680-3a04-11eb-99ce-f88ffec96488.png)

