### PR TITLE
Update gatsby-source-wordpress-experimental and fix queries to work with update

### DIFF
--- a/benchmarks/source-wordpress/package.json
+++ b/benchmarks/source-wordpress/package.json
@@ -23,7 +23,7 @@
     "gatsby-plugin-benchmark-reporting": "*",
     "gatsby-plugin-sharp": "^2.6.2",
     "gatsby-source-filesystem": "^2.1.48",
-    "gatsby-source-wordpress-experimental": "^0.1.10",
+    "gatsby-source-wordpress-experimental": "^5.0.0",
     "gatsby-transformer-sharp": "^2.5.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/benchmarks/source-wordpress/src/templates/article.js
+++ b/benchmarks/source-wordpress/src/templates/article.js
@@ -9,8 +9,8 @@ const Article = ({ data: { article } }) => {
       <Link to="/">Go back to index page</Link>
       <div>
         <h2>{article.title}</h2>
-        {!!article.featuredImage?.remoteFile?.childImageSharp && (
-          <Img fluid={article.featuredImage.remoteFile.childImageSharp.fluid} />
+        {!!article.featuredImage?.node?.localFile?.childImageSharp && (
+          <Img fluid={article.featuredImage.node.localFile.childImageSharp.fluid} />
         )}
         <div dangerouslySetInnerHTML={{ __html: article.content }} />
       </div>
@@ -26,10 +26,12 @@ export const query = graphql`
       title
       content
       featuredImage {
-        remoteFile {
-          childImageSharp {
-            fluid(maxWidth: 960, quality: 90) {
-              ...GatsbyImageSharpFluid_withWebp_tracedSVG
+        node {
+          localFile {
+            childImageSharp {
+              fluid(maxWidth: 960, quality: 90) {
+                ...GatsbyImageSharpFluid_withWebp_tracedSVG
+              }
             }
           }
         }


### PR DESCRIPTION
## Description

* Update `gatsby-source-wordpress-experimental` so that it's using the latest version (`^5.0.0`)
* Fix broken query after updating