### PR TITLE
chore(develop): don't actually fetch async dummy.js chunk

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -33,8 +33,9 @@ window.___loader = publicLoader
 // Without this, the runtime breaks with a
 // "TypeError: __webpack_require__.e is not a function"
 // error.
-// eslint-disable-next-line
-import("./dummy")
+export function notCalledFunction() {
+  return import(`./dummy`)
+}
 
 // Let the site/plugins run code very early.
 apiRunnerAsync(`onClientEntry`).then(() => {

--- a/packages/gatsby/cache-dir/dummy.js
+++ b/packages/gatsby/cache-dir/dummy.js
@@ -1,3 +1,2 @@
 // Dummy file to work around a webpack hot reloading bug.
-// eslint-disable-next-line
-const a = 1
+export const a = 1


### PR DESCRIPTION
We don't actually have to fetch async chunk to cause `__webpack_require__.e` to be added to webpack runtime - we just need to have `import()` somewhere in code

This avoids making additional network request at a time where this a lot of contention for network requests 
