### PR TITLE
feat(gatsby-plugin-sharp): run a single transformation for lazy images

### DIFF
--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -80,8 +80,8 @@ exports.onCreateDevServer = async ({ app, cache, reporter }) => {
 
     // We are going to run a job for a single operation only
     // and postpone all other operations
-    // This makes lazy images load at least 2+ times faster in the browser and
-    // also helps freeing browser connection queue earlier.
+    // This speeds up the loading of lazy images in the browser and
+    // also helps to free up the browser connection queue earlier.
     const {
       matchingJob,
       jobWithRemainingOperations,

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -80,6 +80,8 @@ exports.onCreateDevServer = async ({ app, cache, reporter }) => {
 
     // We are going to run a job for a single operation only
     // and postpone all other operations
+    // This makes lazy images load at least 2+ times faster in the browser and
+    // also helps freeing browser connection queue earlier.
     const {
       matchingJob,
       jobWithRemainingOperations,
@@ -107,11 +109,11 @@ exports.onCreateDevServer = async ({ app, cache, reporter }) => {
 function splitOperationsByRequestedFile(job, requestedPathOnDisk) {
   const matchingJob = {
     ...job,
-    args: { ...job, operations: [] },
+    args: { ...job.args, operations: [] },
   }
   const jobWithRemainingOperations = {
     ...job,
-    args: { ...job, operations: [] },
+    args: { ...job.args, operations: [] },
   }
 
   job.args.operations.forEach(op => {

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -78,13 +78,56 @@ exports.onCreateDevServer = async ({ app, cache, reporter }) => {
       return next()
     }
 
-    await _unstable_createJob(cacheResult, { reporter })
-    // we should implement cache.del inside our abstraction
-    await cache.cache.del(jobContentDigest)
+    // We are going to run a job for a single operation only
+    // and postpone all other operations
+    const {
+      matchingJob,
+      jobWithRemainingOperations,
+    } = splitOperationsByRequestedFile(cacheResult, pathOnDisk)
+
+    await _unstable_createJob(matchingJob, { reporter })
     await cache.cache.del(decodedURI)
+
+    if (jobWithRemainingOperations.args.operations.length > 0) {
+      // There are still some operations pending for this job - replace the cached job
+      await cache.cache.set(jobContentDigest, jobWithRemainingOperations)
+    } else {
+      // No operations left to process - purge the cache
+      await cache.cache.del(jobContentDigest)
+    }
 
     return res.sendFile(pathOnDisk)
   })
+}
+
+// Split the job into two jobs:
+//  - first job with a single operation matching requestedPathOnDisk
+//  - second job with all other operations
+// so the two resulting jobs are only different by their operations
+function splitOperationsByRequestedFile(job, requestedPathOnDisk) {
+  const matchingJob = {
+    ...job,
+    args: { ...job, operations: [] },
+  }
+  const jobWithRemainingOperations = {
+    ...job,
+    args: { ...job, operations: [] },
+  }
+
+  job.args.operations.forEach(op => {
+    const operationPath = path.resolve(path.join(job.outputDir, op.outputPath))
+    if (operationPath === requestedPathOnDisk) {
+      matchingJob.args.operations.push(op)
+    } else {
+      jobWithRemainingOperations.args.operations.push(op)
+    }
+  })
+  if (matchingJob.args.operations.length === 0) {
+    throw new Error(
+      `Could not find matching operation for ${requestedPathOnDisk}`
+    )
+  }
+  return { matchingJob, jobWithRemainingOperations }
 }
 
 // So something is wrong with the reporter, when I do this in preBootstrap,


### PR DESCRIPTION
## Description

Before this PR lazy images run all possible image transformations when a single transformed image is requested. After this PR only the requested image variant is processed and returned.

All the remaining transformations are still stored in the cached job, so whenever another image variant is requested - it will be also lazily transformed and returned.

Tried it on my current image-heavy test site. All transforms:
```
success Generating image thumbnails - 53.272s - 72/72 1.35/s
```

The same example with this PR:
```
success Generating image thumbnails - 25.650s - 24/24 0.94/s
```

## Related Issues

#27603 - umbrella discussion