### PR TITLE
perf(gatsby-plugin-sharp): change approach to concurrency for image processing

### DIFF
--- a/packages/gatsby-plugin-sharp/src/gatsby-worker.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-worker.js
@@ -1,5 +1,6 @@
 const path = require(`path`)
 const queue = require(`async/queue`)
+const { cpuCoreCount } = require(`gatsby-core-utils`)
 const { processFile } = require(`./process-file`)
 
 exports.IMAGE_PROCESSING_JOB_NAME = `IMAGE_PROCESSING`
@@ -31,7 +32,7 @@ const q = queue(
         args.pluginOptions
       )
     ),
-  1
+  cpuCoreCount()
 )
 
 /**

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -8,7 +8,7 @@ const imageminMozjpeg = require(`imagemin-mozjpeg`)
 const imageminPngquant = require(`imagemin-pngquant`)
 const { healOptions } = require(`./plugin-options`)
 const { SharpError } = require(`./sharp-error`)
-const { cpuCoreCount, createContentDigest } = require(`gatsby-core-utils`)
+const { createContentDigest } = require(`gatsby-core-utils`)
 
 // Try to enable the use of SIMD instructions. Seems to provide a smallish
 // speedup on resizing heavy loads (~10%). Sharp disables this feature by
@@ -16,10 +16,8 @@ const { cpuCoreCount, createContentDigest } = require(`gatsby-core-utils`)
 // adventurous and see what happens with it on.
 sharp.simd(true)
 
-// Handle Sharp's concurrency based on the Gatsby CPU count
-// See: http://sharp.pixelplumbing.com/en/stable/api-utility/#concurrency
-// See: https://www.gatsbyjs.org/docs/multi-core-builds/
-sharp.concurrency(cpuCoreCount())
+// Concurrency is handled in gatsby-worker queue instead
+sharp.concurrency(1)
 
 /**
  * @typedef DuotoneArgs


### PR DESCRIPTION
## Description

My tests for lazy images (#27603) showed that increasing sharp queue concurrency results in a better overall image transformation performance. Tested on two image-heavy sites.

First one (based on [this starter](https://github.com/baobabKoodaa/gatsby-starter-photo-book)):

Before this PR:
```
success Generating image thumbnails - 174.163s - 532/532 3.05/s
info Done building in 179.6475083 sec
```

After this PR:
```
success Generating image thumbnails - 311.836s - 532/532 1.71/s
info Done building in 317.3029042 sec
```

[Second site](https://github.com/kentcdodds/kentcdodds.com):

Before this PR:
```
Generating image thumbnails - 436.176s
```

After this PR:
```
Generating image thumbnails - 259.491s
```

Note that for this site the build has failed for me with unrelated SSR error - for both checks. Just don't have time to figure it out now - my fork is pretty outdated. But image processing was significantly faster this way.

I also see similar good effect on lazy images - images load about `30-40%` faster.

CC @pvdz @wardpeet 