### PR TITLE
fix(gatsby-plugin-sharp): fix image url decoding for lazy images

### DIFF
--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -62,7 +62,7 @@ exports.onCreateDevServer = async ({ app, cache, reporter }) => {
   finishProgressBar()
 
   app.use(async (req, res, next) => {
-    const decodedURI = decodeURI(req.url)
+    const decodedURI = decodeURIComponent(req.path)
     const pathOnDisk = path.resolve(path.join(`./public/`, decodedURI))
 
     if (await pathExists(pathOnDisk)) {


### PR DESCRIPTION
## Description

We incorrectly decode path segments with `decodeURI`. Instead, we should be using `decodeURIComponent` because the encoding is done with `encodeURIComponent` here:

https://github.com/gatsbyjs/gatsby/blob/498fbbfc5ecdd3da5d8f3dbe6a10ae908af2786a/packages/gatsby-plugin-sharp/src/index.js#L106

`encodeURI` and `encodeURIComponent` encode stuff differently so we must be consistent. To clarify:

`encodeURI` will not encode any of those: `~!@#$&*()=:/,;?+` characters (as a result, `decodeURI` won't decode those too).
`encodeURIComponent` will encode all the characters except `-_.!~*'()`

## Related Issues

#27603 - Umbrella discussion