### PR TITLE
feat(gatsby-plugin-image): add keywords to package.json so it shows up in the plugin search

### DIFF
--- a/packages/gatsby-plugin-image/package.json
+++ b/packages/gatsby-plugin-image/package.json
@@ -22,6 +22,10 @@
     "clean": "del-cli dist/*"
   },
   "sideEffects": false,
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ],
   "main": "dist/gatsby-image.js",
   "module": "dist/gatsby-image.module.js",
   "esmodule": "dist/gatsby-image.modern.js",


### PR DESCRIPTION
I keep looking for it in /plugins and not finding it!