### PR TITLE
chore(e2e-development): bump cypress version

### DIFF
--- a/e2e-tests/development-runtime/cypress.json
+++ b/e2e-tests/development-runtime/cypress.json
@@ -3,5 +3,6 @@
   "failOnStatusCode": false,
   "chromeWebSecurity": false,
   "defaultCommandTimeout": 30000,
-  "retries": 2
+  "retries": 2,
+  "videoUploadOnPasses": false
 }

--- a/e2e-tests/development-runtime/cypress.json
+++ b/e2e-tests/development-runtime/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:8000",
   "failOnStatusCode": false,
   "chromeWebSecurity": false,
-  "defaultCommandTimeout": 30000
+  "defaultCommandTimeout": 30000,
+  "retries": 2
 }

--- a/e2e-tests/development-runtime/cypress/integration/functionality/data-update.js
+++ b/e2e-tests/development-runtime/cypress/integration/functionality/data-update.js
@@ -9,6 +9,14 @@ A brand new post
 
 `.trim()
 
+before(() => {
+  cy.exec(`npm run reset`)
+})
+
+after(() => {
+  cy.exec(`npm run reset`)
+})
+
 describe(`on new file`, () => {
   beforeEach(() => {
     cy.visit(`/`).waitForRouteChange()

--- a/e2e-tests/development-runtime/cypress/integration/functionality/query-data-caches.js
+++ b/e2e-tests/development-runtime/cypress/integration/functionality/query-data-caches.js
@@ -356,7 +356,7 @@ describe(`Keeping caches up-to-date when updating data`, () => {
 
 describe(`Keeping caches up to date when modifying list of static query hashes assigned to a template`, () => {
   describe(`using gatsby-link`, () => {
-    it.only(`Navigate from page A to page B, add static query to page A, navigate back to page A`, () => {
+    it(`Navigate from page A to page B, add static query to page A, navigate back to page A`, () => {
       const config = {
         slug: `adding-static-query-A-to-B-to-A-link`,
         queryType: `static`,

--- a/e2e-tests/development-runtime/cypress/integration/gatsby-preview/refreshing.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-preview/refreshing.js
@@ -9,46 +9,30 @@ after(() => reset())
 
 describe(`Gatsby Preview (Refreshing)`, () => {
   it(`displays initial data`, () => {
-    cy
-      .get(`#pinc-data li`)
-      .should(`have.length`, 1)
+    cy.get(`#pinc-data li`).should(`have.length`, 1)
 
-    cy
-      .get(`#fake-data li`)
-      .should(`have.length`, 1)
+    cy.get(`#fake-data li`).should(`have.length`, 1)
   })
 
   it(`updates no data for an unknown plugin`, () => {
     cy.exec(`npm run update:cms-webhook gatsby-source-unknown`)
 
-    cy
-      .get(`#pinc-data li`)
-      .should(`have.length`, 1)
+    cy.get(`#pinc-data li`).should(`have.length`, 1)
 
-    cy
-      .get(`#fake-data li`)
-      .should(`have.length`, 1)
+    cy.get(`#fake-data li`).should(`have.length`, 1)
   })
 
   it(`updates the data from the matching plugin`, () => {
     cy.exec(`npm run update:cms-webhook gatsby-source-pinc-data`)
 
-    cy
-      .get(`#pinc-data li`)
-      .should(`have.length`, 2)
+    cy.get(`#pinc-data li`).should(`have.length`, 2)
 
-    cy
-      .get(`#fake-data li`)
-      .should(`have.length`, 1)
+    cy.get(`#fake-data li`).should(`have.length`, 1)
 
     cy.exec(`npm run update:cms-webhook gatsby-source-fake-data`)
 
-    cy
-      .get(`#pinc-data li`)
-      .should(`have.length`, 2)
+    cy.get(`#pinc-data li`).should(`have.length`, 2)
 
-    cy
-      .get(`#fake-data li`)
-      .should(`have.length`, 2)
+    cy.get(`#fake-data li`).should(`have.length`, 2)
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/gatsby-preview/updating.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-preview/updating.js
@@ -13,7 +13,7 @@ const reset = () => cy.exec(`npm run reset:preview`)
 
 describe(`Gatsby Preview (Updating)`, () => {
   it(`displays initial data`, () => {
-    cy.get(`li:eq(0) a`).click().waitForRouteChange()
+    cy.get(`#fake-data li:eq(0) a`).click().waitForRouteChange()
 
     cy.findByText(`Hello World (1)`).should(`exist`)
 
@@ -21,7 +21,7 @@ describe(`Gatsby Preview (Updating)`, () => {
   })
 
   it(`updates and hot-reloads changes to content`, () => {
-    cy.get(`li:eq(0) a`).click().waitForRouteChange()
+    cy.get(`#fake-data li:eq(0) a`).click().waitForRouteChange()
 
     update()
 
@@ -32,9 +32,7 @@ describe(`Gatsby Preview (Updating)`, () => {
     const count = 5
     update(count)
 
-    cy.get(`li`)
-      .its(`length`)
-      .should(`be`, count + 1)
+    cy.get(`#fake-data li`).should(`have.length`, count + 1)
   })
 
   it(`updates when content is deleted`, () => {
@@ -42,14 +40,14 @@ describe(`Gatsby Preview (Updating)`, () => {
 
     reset()
 
-    cy.get(`li`).its(`length`).should(`be`, 1)
+    cy.get(`#fake-data li`).should(`have.length`, 1)
   })
 
   it(`can be triggered with webhook data`, () => {
     cy.exec(`npm run update:webhook`)
 
-    cy
-      .get(`#fake-data`)
-      .findByText(`Hello World from a Webhook (999)`).should(`exist`)
+    cy.get(`#fake-data`)
+      .findByText(`Hello World from a Webhook (999)`)
+      .should(`exist`)
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/page-queries.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/page-queries.js
@@ -4,6 +4,10 @@ beforeEach(() => {
   cy.visit(`/page-query/`).waitForRouteChange()
 })
 
+after(() => {
+  cy.exec(`npm run reset`)
+})
+
 describe(`hot-reloading page queries`, () => {
   it(`displays placeholder content on launch`, () => {
     cy.getTestElement(`hot`).invoke(`text`).should(`not.contain`, author)

--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -110,7 +110,7 @@ describe(`navigation`, () => {
 
   describe(`Supports unicode characters in urls`, () => {
     it(`Can navigate directly`, () => {
-      cy.visit(`/안녕`).waitForRouteChange()
+      cy.visit(encodeURI(`/안녕`)).waitForRouteChange()
       cy.getTestElement(`page-2-message`)
         .invoke(`text`)
         .should(`equal`, `Hi from the second page`)
@@ -126,7 +126,7 @@ describe(`navigation`, () => {
     })
 
     it(`should show 404 page when url with unicode characters point to a non-existent page route when navigating directly`, () => {
-      cy.visit(`/안녕404/`, {
+      cy.visit(encodeURI(`/안녕404/`), {
         failOnStatusCode: false,
       }).waitForRouteChange()
 
@@ -173,7 +173,10 @@ describe(`navigation`, () => {
       it(`should trigger an effect after the state has changed`, () => {
         cy.findByTestId(`effect-message`).should(`have.text`, ``)
         cy.findByTestId(`send-state-message`).click().waitForRouteChange()
-        cy.findByTestId(`effect-message`).should(`have.text`, `this is a message using the state`)
+        cy.findByTestId(`effect-message`).should(
+          `have.text`,
+          `this is a message using the state`
+        )
       })
     })
   }
@@ -203,7 +206,10 @@ describe(`navigation`, () => {
       it(`should trigger an effect after the state has changed`, () => {
         cy.findByTestId(`effect-message`).should(`have.text`, ``)
         cy.findByTestId(`send-state-message`).click().waitForRouteChange()
-        cy.findByTestId(`effect-message`).should(`have.text`, `this is a message using the state`)
+        cy.findByTestId(`effect-message`).should(
+          `have.text`,
+          `this is a message using the state`
+        )
       })
     })
   }

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -48,9 +48,9 @@
     "cy:run": "(is-ci && cypress run --browser chrome --record) || cypress run --browser chrome"
   },
   "devDependencies": {
-    "@testing-library/cypress": "^6.0.0",
+    "@testing-library/cypress": "^7.0.0",
     "cross-env": "^5.2.0",
-    "cypress": "3.4.1",
+    "cypress": "6.1.0",
     "fs-extra": "^7.0.1",
     "gatsby-cypress": "^0.1.7",
     "is-ci": "^2.0.0",
@@ -63,6 +63,6 @@
     "url": "https://github.com/gatsbyjs/gatsby"
   },
   "resolutions": {
-    "cypress": "3.4.1"
+    "cypress": "6.1.0"
   }
 }

--- a/e2e-tests/development-runtime/plugins/gatsby-source-fake-data/api.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-source-fake-data/api.js
@@ -52,6 +52,10 @@ module.exports = {
   dbFilePath: path.join(__dirname, `db.json`),
   nodeType: NODE_TYPE,
   nodes: [],
+  addNode(node) {
+    this.nodes = this.nodes.concat(node)
+    return node
+  },
   async sync(helpers) {
     // empty array
     const nodes = await readFile(this.dbFilePath)

--- a/e2e-tests/development-runtime/plugins/gatsby-source-fake-data/gatsby-node.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-source-fake-data/gatsby-node.js
@@ -27,7 +27,9 @@ exports.sourceNodes = async function sourceNodes({
 
   if (webhookBody && webhookBody.items) {
     reporter.info(`Webhook data detected; creating nodes`)
-    webhookBody.items.forEach(node => createNode(api.getNode(node, helpers)))
+    webhookBody.items.forEach(node =>
+      createNode(api.addNode(api.getNode(node, helpers)))
+    )
   } else {
     if (!(webhookBody && webhookBody[`fake-data-update`])) {
       await api.reset()

--- a/e2e-tests/development-runtime/plugins/gatsby-source-pinc-data/api.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-source-pinc-data/api.js
@@ -52,6 +52,10 @@ module.exports = {
   dbFilePath: path.join(__dirname, `db.json`),
   nodeType: NODE_TYPE,
   nodes: [],
+  addNode(node) {
+    this.nodes = this.nodes.concat(node)
+    return node
+  },
   async sync(helpers) {
     // empty array
     const nodes = await readFile(this.dbFilePath)

--- a/e2e-tests/development-runtime/plugins/gatsby-source-pinc-data/gatsby-node.js
+++ b/e2e-tests/development-runtime/plugins/gatsby-source-pinc-data/gatsby-node.js
@@ -27,7 +27,9 @@ exports.sourceNodes = async function sourceNodes({
 
   if (webhookBody && webhookBody.items) {
     reporter.info(`Webhook data detected; creating nodes`)
-    webhookBody.items.forEach(node => createNode(api.getNode(node, helpers)))
+    webhookBody.items.forEach(node =>
+      createNode(api.addNode(api.getNode(node, helpers)))
+    )
   } else {
     if (!(webhookBody && webhookBody[`fake-data-update`])) {
       await api.reset()

--- a/e2e-tests/development-runtime/scripts/update.js
+++ b/e2e-tests/development-runtime/scripts/update.js
@@ -34,13 +34,29 @@ const args = yargs
     `
     ).trim(),
     type: `string`,
+  })
+  .option(`restore`, {
+    default: false,
+    type: `boolean`,
   }).argv
 
 async function update() {
   const history = await getHistory()
 
-  const { file: fileArg, replacements } = args
+  const { file: fileArg, replacements, restore } = args
   const filePath = path.resolve(fileArg)
+  if (restore) {
+    const original = history.get(filePath)
+    if (original) {
+      await fs.writeFile(filePath, original, `utf-8`)
+    } else if (original === false) {
+      await fs.remove(filePath)
+    } else {
+      console.log(`Didn't make changes to "${fileArg}". Nothing to restore.`)
+    }
+    history.delete(filePath)
+    return
+  }
   let exists = true
   if (!fs.existsSync(filePath)) {
     exists = false


### PR DESCRIPTION
## Description

I had to skip adding e2e tests for loading indicator in https://github.com/gatsbyjs/gatsby/pull/28562 because we use old version of cypress that doesn't seem to have shadow dom support, newer ones seem to have - so let's see how this will go.

There some additional niceties here, like auto-retry (will see how that goes). I also added some cleanup after some of tests because running tests does leave mess behind and we need to clean that mess up manually if we want to rerun tests (when iterating on it).

Also ... some query data caches had `.only` on one of tests (yikes), luckily we didn't mess with runtime in that would affect it (I think), but just unskipping rest of tests too
