### PR TITLE
Updated dead link for typography-js in styling-css.md

### DIFF
--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -429,7 +429,7 @@ body {
 ### Additional resources
 
 - [Fontsource repo on GitHub](https://github.com/fontsource/fontsource)
-- [Typography.js](/docs/typography-js/) - Another option for using Google fonts on a Gatsby site
+- [Typography.js](/docs/using-typography-js/) - Another option for using Google fonts on a Gatsby site
 
 ## Using Font Awesome
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
The [typography-js](https://www.gatsbyjs.com/docs/typography-js/) hyperlink given in the additional resources in [css styling](https://www.gatsbyjs.com/docs/recipes/styling-css/) was a dead one. I have replaced it with the correct [one](https://www.gatsbyjs.com/docs/using-typography-js/)
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
[docs link](https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/recipes/styling-css.md)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
