### PR TITLE
chore(gatsby-source-contentful): fix locale debug output, again

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -296,8 +296,17 @@ exports.sourceNodes = async (
   const allLocales = locales
   locales = locales.filter(pluginConfig.get(`localeFilter`))
   reporter.verbose(
-    `All locales: ${allLocales}, default: ${defaultLocale}, after plugin.options.localeFilter: ${locales}`
+    `Default locale: ${defaultLocale}.   All locales: ${allLocales
+      .map(({ code }) => code)
+      .join(`, `)}`
   )
+  if (allLocales.length !== locales.length) {
+    reporter.verbose(
+      `After plugin.options.localeFilter: ${locales
+        .map(({ code }) => code)
+        .join(`, `)}`
+    )
+  }
   if (locales.length === 0) {
     reporter.panic({
       id: CODES.LocalesMissing,


### PR DESCRIPTION
Before:
```
verbose 4.236316237 All locales: [object Object],[object Object],[object Object],[object Object], default: en, after plugin.options.localeFilter: [object Object]
```

After:
```
verbose 4.097874197 Default locale: en.   All locales: en, fr, es
verbose 4.098036228 After plugin.options.localeFilter: en
```