### PR TITLE
contentful: only (re)create new or updated nodes

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -561,6 +561,7 @@ exports.sourceNodes = async (
         restrictedNodeFields,
         conflictFieldPrefix,
         entries: entryList[i],
+        getNode,
         createNode,
         createNodeId,
         resolvable,

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -230,10 +230,10 @@ function prepareJSONNode(node, key, content, createNodeId, i = ``) {
 
 exports.createNodesForContentType = ({
   contentTypeItem,
-  contentTypeItems,
   restrictedNodeFields,
   conflictFieldPrefix,
   entries,
+  getNode,
   createNode,
   createNodeId,
   resolvable,
@@ -282,6 +282,12 @@ exports.createNodesForContentType = ({
 
     // First create nodes for each of the entries of that content type
     const entryNodes = entries.map(entryItem => {
+      const id = mId(space.sys.id, entryItem.sys.id, entryItem.sys.type)
+
+      if (getNode(id)?.internal?.contentDigest === entryItem.sys.updatedAt) {
+        return null
+      }
+
       // Get localized fields.
       const entryItemFields = _.mapValues(entryItem.fields, (v, k) => {
         const fieldProps = contentTypeItem.fields.find(field => field.id === k)
@@ -395,7 +401,7 @@ exports.createNodesForContentType = ({
       }
 
       let entryNode = {
-        id: mId(space.sys.id, entryItem.sys.id, entryItem.sys.type),
+        id,
         spaceId: space.sys.id,
         contentful_id: entryItem.sys.id,
         createdAt: entryItem.sys.createdAt,
@@ -553,7 +559,7 @@ exports.createNodesForContentType = ({
     contentTypeNode.internal.contentDigest = contentDigest
 
     createNodePromises.push(createNode(contentTypeNode))
-    entryNodes.forEach(entryNode => {
+    entryNodes.filter(Boolean).forEach(entryNode => {
       createNodePromises.push(createNode(entryNode))
     })
     childrenNodes.forEach(entryNode => {

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -404,6 +404,7 @@ exports.createNodesForContentType = ({
         children: [],
         internal: {
           type: `${makeTypeName(contentTypeItemId)}`,
+          contentDigest: entryItem.sys.updatedAt,
         },
         sys: {
           type: entryItem.sys.type,
@@ -526,11 +527,6 @@ exports.createNodesForContentType = ({
       })
 
       entryNode = { ...entryItemFields, ...entryNode, node_locale: locale.code }
-
-      // Get content digest of node.
-      const contentDigest = digest(entryNode.updatedAt)
-
-      entryNode.internal.contentDigest = contentDigest
 
       return entryNode
     })

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -528,7 +528,7 @@ exports.createNodesForContentType = ({
       entryNode = { ...entryItemFields, ...entryNode, node_locale: locale.code }
 
       // Get content digest of node.
-      const contentDigest = digest(stringify(entryNode))
+      const contentDigest = digest(entryNode.updatedAt)
 
       entryNode.internal.contentDigest = contentDigest
 


### PR DESCRIPTION
This is WIP!!

We want to improve the way Gatsby handles node creations and incremental updates.

Step 1: improve content digest generation and exit early if node was not touched by the user
Step 2: refactor the reference resolve logic to directly use [Contentfuls Link Object](https://www.contentful.com/developers/docs/concepts/links/) instead of doing everything "twice"- might be separate PR