### PR TITLE
perf(develop): skip query extraction if files are not dirty and schema didn't change

### DIFF
--- a/packages/gatsby/src/services/listen-for-mutations.ts
+++ b/packages/gatsby/src/services/listen-for-mutations.ts
@@ -18,15 +18,21 @@ export const listenForMutations: InvokeCallback = (callback: Sender<any>) => {
     callback({ type: `QUERY_RUN_REQUESTED`, payload: event })
   }
 
+  const emitSchemaChange = (event: unknown): void => {
+    callback({ type: `SCHEMA_CHANGED`, payload: event })
+  }
+
   emitter.on(`ENQUEUE_NODE_MUTATION`, emitMutation)
   emitter.on(`WEBHOOK_RECEIVED`, emitWebhook)
   emitter.on(`SOURCE_FILE_CHANGED`, emitSourceChange)
   emitter.on(`QUERY_RUN_REQUESTED`, emitQueryRunRequest)
+  emitter.on(`SET_SCHEMA`, emitSchemaChange)
 
   return function unsubscribeFromMutationListening(): void {
     emitter.off(`ENQUEUE_NODE_MUTATION`, emitMutation)
     emitter.off(`WEBHOOK_RECEIVED`, emitWebhook)
     emitter.off(`SOURCE_FILE_CHANGED`, emitSourceChange)
     emitter.off(`QUERY_RUN_REQUESTED`, emitQueryRunRequest)
+    emitter.off(`SET_SCHEMA`, emitSchemaChange)
   }
 }

--- a/packages/gatsby/src/services/types.ts
+++ b/packages/gatsby/src/services/types.ts
@@ -43,4 +43,5 @@ export interface IBuildContext {
   queryFilesDirty?: boolean
   sourceFilesDirty?: boolean
   pendingQueryRuns?: Set<string>
+  schemaDirty?: boolean
 }

--- a/packages/gatsby/src/state-machines/develop/actions.ts
+++ b/packages/gatsby/src/state-machines/develop/actions.ts
@@ -175,6 +175,14 @@ export const clearPendingQueryRuns = assign<IBuildContext>(() => {
   }
 })
 
+export const markSchemaDirty = assign<IBuildContext>({
+  schemaDirty: true,
+})
+
+export const markSchemaClean = assign<IBuildContext>({
+  schemaDirty: false,
+})
+
 export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
   callApi,
   markNodesDirty,
@@ -200,4 +208,6 @@ export const buildActions: ActionFunctionMap<IBuildContext, AnyEventObject> = {
   logError,
   trackRequestedQueryRun,
   clearPendingQueryRuns,
+  markSchemaDirty,
+  markSchemaClean,
 }

--- a/packages/gatsby/src/state-machines/query-running/actions.ts
+++ b/packages/gatsby/src/state-machines/query-running/actions.ts
@@ -29,6 +29,14 @@ export const markSourceFilesClean = assign<IQueryRunningContext>({
   filesDirty: false,
 })
 
+export const markSchemaDirty = assign<IQueryRunningContext>({
+  schemaDirty: true,
+})
+
+export const markSchemaClean = assign<IQueryRunningContext>({
+  schemaDirty: false,
+})
+
 export const trackRequestedQueryRun = assign<
   IQueryRunningContext,
   AnyEventObject
@@ -55,4 +63,6 @@ export const queryActions: ActionFunctionMap<IQueryRunningContext, any> = {
   markSourceFilesClean,
   trackRequestedQueryRun,
   clearCurrentlyHandledPendingQueryRuns,
+  markSchemaDirty,
+  markSchemaClean,
 }

--- a/packages/gatsby/src/state-machines/query-running/types.ts
+++ b/packages/gatsby/src/state-machines/query-running/types.ts
@@ -21,4 +21,5 @@ export interface IQueryRunningContext {
   filesDirty?: boolean
   pendingQueryRuns?: Set<string>
   currentlyHandledPendingQueryRuns?: Set<string>
+  schemaDirty?: boolean
 }


### PR DESCRIPTION
## Description

Every time we invoke query running machine we go through extracting queries step. This adds quite a bit of unnecesary work (specifically on larger sites). This is particularly felt in query on demand mode where we enter query running state in response to user actions in browser (running queries that are not up date on navigation and link hovers). In one of sites this adds ~1s delay in on demand query running that is quite unnecessary and degrade experience.

Unknowns:
 - as usual - investigate spots we clear `schemaDirty` and assess if this is safe (my gut feeling say that this is actually safe because schema rebuilding is governed by state machine, so there should be no "rogue" `SET_SCHEMA` events going on - but 🤷‍♂️ )

## Related Issues

[ch19361]