### PR TITLE
docs: release notes for 2.29

### DIFF
--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -59,7 +59,7 @@ Similarily as with Query on Demand also Lazy Images will be automatically delive
 
 > As more and more images are added to a Gatsby site, the slower the local development experience oftentimes becomes. You spend time waiting for images to process, instead of you know, developing! No longer! This experimental version of `gatsby-plugin-sharp` only does image processing when the page gets requested.
 
-By slowly rolling out this feature to more and more users we'll be getting closer to a GA (general availability) release that will benefit all users of Gatsby. Please give us your feedback in the [umbrella discussion](https://github.com/gatsbyjs/gatsby/discussions/27603).
+By slowly rolling out this feature to more and more users we'll be getting closer to a GA release that will benefit all users of Gatsby. Please give us your feedback in the [umbrella discussion](https://github.com/gatsbyjs/gatsby/discussions/27603).
 
 If you want to turn it on/off, you can set the corresponding flag inside `gatsby-config.js`:
 
@@ -81,7 +81,7 @@ A couple of papercuts were fixed but we also added new features:
 
 - Prompt for your site name instead of a folder name
 - Automatically add this name to your `siteMetadata` and `package.json`
-- Add `-y` flag. This flag bypasses all prompts other than namin your site
+- Add `-y` flag. This flag bypasses all prompts other than naming your site
 
 The regular `gatsby-cli` received a new command to list out all plugins in your site by running `gatsby plugin ls`.
 
@@ -110,7 +110,7 @@ Please give us your feedback in the [umbrella discussion](https://github.com/gat
 We were able to ship a bunch of performance improvements both to Gatsby itself and its plugins:
 
 - The PR [#28375](https://github.com/gatsbyjs/gatsby/pull/28375) fixed an unguided search in `gatsby-source-contentful` that can significantly drop your time for an incremental build (and perhaps others). In this case (for a site with 80k elements) it dropped the time from 5 minutes to sub-second.
-- The PR [#28438](https://github.com/gatsbyjs/gatsby/pull/28438) prevents some redudant calculations resulting in 5% improvements for bigger sites
+- The PR [#28438](https://github.com/gatsbyjs/gatsby/pull/28438) prevents some redudant calculations resulting in 5% improvements for bigger sites using `gatsby-source-contentful`
 - The PR [#28525](https://github.com/gatsbyjs/gatsby/pull/28525) drops the `async` keyword from the `wrappingResolver` that wraps all resolvers passed on to GraphQL. In practice this means a 5-10% overall improvement to the runtime of a site.
 
 ## Slugify option for File System Route API

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -119,7 +119,7 @@ The File System Route API uses [slugify](https://github.com/sindresorhus/slugify
 
 ## gatsby-image codemod
 
-If you want to try out the new `gatsby-plugin-image` that we introduced in [v2.26](../v2.26/index.md#gatsby-plugin-image010-beta) you now can run it: #TODO
+We introduced some API changes for working with images when we published the new `gatsby-plugin-image` in [v2.26](../v2.26/index.md#gatsby-plugin-image010-beta). In order to make it easier to migrate your code to work with the new plugin, we've created a codemod.Follow the migration instructions in the [README](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-image#upgrading-from-the-gatsby-image2) in order to run the codemod against your project.
 
 ## Notable bugfixes
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -53,6 +53,16 @@ module.exports = {
 }
 ```
 
+In v2.29 we improved the UX around it by adding a loading indicator and message to the browser console (only in `gatsby develop`). If you want or need to de-activate this indicator, you can! For more details please see the [umbrella discussion](https://github.com/gatsbyjs/gatsby/discussions/27620). Here's a preview of them in action:
+
+### Loading indicator
+
+![loading-indiactor](https://user-images.githubusercontent.com/16143594/102206937-9e4d0e80-3ecd-11eb-8a3f-3436f1b02a4d.gif)
+
+### Browser console
+
+![console](https://user-images.githubusercontent.com/16143594/102207048-c3da1800-3ecd-11eb-9caf-21c4e54c7f76.png)
+
 ## Lazy Images
 
 Similarily as with Query on Demand also Lazy Images will be automatically delivered to 10% of our users with this v2.29 release. We've first shipped this feature behind a flag in [v2.28](../v2.28/index.md#experimental-lazy-images-in-develop). Opt-in users will receive a notice in their terminal about that opt-in behavior and a hint on how to turn it off (in case it disturbs your workflow). As a recap of what Lazy Images will improve:

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -109,9 +109,14 @@ Please give us your feedback in the [umbrella discussion](https://github.com/gat
 
 We were able to ship a bunch of performance improvements both to Gatsby itself and its plugins:
 
-- The PR [#28375](https://github.com/gatsbyjs/gatsby/pull/28375) fixed an unguided search in `gatsby-source-contentful` that can significantly drop your time for an incremental build (and perhaps others). In this case (for a site with 80k elements) it dropped the time from 5 minutes to sub-second.
-- The PR [#28438](https://github.com/gatsbyjs/gatsby/pull/28438) prevents some redudant calculations resulting in 5% improvements for bigger sites using `gatsby-source-contentful`
-- The PR [#28525](https://github.com/gatsbyjs/gatsby/pull/28525) drops the `async` keyword from the `wrappingResolver` that wraps all resolvers passed on to GraphQL. In practice this means a 5-10% overall improvement to the runtime of a site.
+### `gatsby`
+
+- Improve query running performance for sites with large amount of data (up to 10% in our tests). See https://github.com/gatsbyjs/gatsby/pull/28525 for details.
+
+### `gatsby-source-contentful`
+
+- Improve performance of data sourcing for large Contentful spaces. See https://github.com/gatsbyjs/gatsby/pull/28375 for details.
+- Prevent concurrent requests to Contentful's image processing API. See https://github.com/gatsbyjs/gatsby/pull/28438 for details.
 
 ## Slugify option for File System Route API
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -12,7 +12,7 @@ Welcome to `gatsby@2.29.0` release (December 2020 #2)
 Key highlights of this release:
 
 - [Query on Demand](#query-on-demand) - improves `gatsby develop` bootup time
-- [Lazy Images](#lazy-images) - only do image processing when a page gets reqested
+- [Lazy Images](#lazy-images) - do not wait for all images to be processed to start the development
 - [Improvements to our CLI](#improvements-to-our-cli) - improved `create-gatsby` & new `plugin` command
 - [Experimental: Parallel data sourcing](#experimental-parallel-data-sourcing) - run source plugins in parallel to speedup sourcing on sites with multiple source plugins
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -23,10 +23,6 @@ Other notable changes:
 - [gatsby-image codemod](#gatsby-image-codemod)
 - [Notable bugfixes](#notable-bugfixes)
 
-Sneak peak to next releases:
-
-- TODO
-
 **Bleeding Edge:** Want to try new features as soon as possible? Install `gatsby@next` and let us know
 if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 
@@ -57,11 +53,13 @@ In v2.29 we improved the UX around it by adding a loading indicator and message 
 
 ### Loading indicator
 
-![loading-indiactor](https://user-images.githubusercontent.com/16143594/102206937-9e4d0e80-3ecd-11eb-8a3f-3436f1b02a4d.gif)
+The loading indicator respects the user's settings for `prefers-reduced-motion` and `prefers-color-scheme`. It also announces itself to screen readers.
+
+![Short gif demonstrating the loading indicator for Query on Demand -- this is shown when the requested page takes a bit longer](https://user-images.githubusercontent.com/16143594/102206937-9e4d0e80-3ecd-11eb-8a3f-3436f1b02a4d.gif)
 
 ### Browser console
 
-![console](https://user-images.githubusercontent.com/16143594/102207048-c3da1800-3ecd-11eb-9caf-21c4e54c7f76.png)
+![Picture showing a note in the browser console that explains on how to disable it](https://user-images.githubusercontent.com/16143594/102207048-c3da1800-3ecd-11eb-9caf-21c4e54c7f76.png)
 
 ## Lazy Images
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -160,3 +160,4 @@ A big **Thank You** to [our community who contributed](https://github.com/gatsby
 - [davidmauskop](https://github.com/davidmauskop): chore(docs): Update Deploying to Render guide [PR #28272](https://github.com/gatsbyjs/gatsby/pull/28272)
 - [saintmalik](https://github.com/saintmalik): chore(docs): fix broken url [PR #28197](https://github.com/gatsbyjs/gatsby/pull/28197)
 - [muescha](https://github.com/muescha): fix(docs): document pluginOptionsSchema - add file extension, code block language, quotation marks [PR #27844](https://github.com/gatsbyjs/gatsby/pull/27844)
+- [herecydev](https://github.com/herecydev) & [hoobdeebla](https://github.com/hoobdeebla): chore: update ink to v3 [PR #26190](https://github.com/gatsbyjs/gatsby/pull/26190)

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -11,11 +11,13 @@ Welcome to `gatsby@2.29.0` release (December 2020 #2)
 
 Key highlights of this release:
 
-- TODO
+- [Query on Demand](#query-on-demand) - TODO
+- [Lazy Images](#lazy-images) - TODO
+- [Improvements to our CLI](#improvements-to-our-cli) - improved `create-gatsby` & new `plugin` command
 
 Other notable changes:
 
-- TODO
+- [Performance improvements](#performance-improvements)
 
 Sneak peak to next releases:
 
@@ -27,7 +29,32 @@ if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 [Previous release notes](../v2.28/index.md)<br>
 [Full changelog](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.29.0-next.0...gatsby@2.29.0)
 
-## TODO
+## Query on Demand
+
+TODO
+
+## Lazy Images
+
+TODO
+
+## Improvements to our CLI
+
+In [v2.27](../v.27/index.md#create-gatsby) we introduced `create-gatsby`, a new and interactive way to create a Gatsby site. You can run it in your terminal with `npm init gatsby`.
+
+A couple of papercuts were fixed but we also added new features:
+
+- Prompt for your site name instead of a folder name
+- Automatically add this name to your `siteMetadata` and `package.json`
+- Add `-y` flag. This flag bypasses all prompts other than namin your site
+
+The regular `gatsby-cli` received a new command to list out all plugins in your site by running `gatsby plugin ls`.
+
+## Performance improvements
+
+We were able to ship a bunch of performance improvements both to Gatsby itself and its plugins:
+
+- The PR [28375](https://github.com/gatsbyjs/gatsby/pull/28375) fixed an unguided search in `gatsby-source-contentful` that can significantly drop your time for an incremental build (and perhaps others). In this case (for a site with 80k elements) it dropped the time from 5 minutes to sub-second.
+- The PR [28525](https://github.com/gatsbyjs/gatsby/pull/28525) drops the `async` keyword from the `wrappingResolver` that wraps all resolvers passed on to GraphQL. In practice this means a 5-10% overall improvement to the runtime of a site.
 
 ## Contributors
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -35,7 +35,7 @@ if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 
 ## Query on Demand
 
-Starting with v2.29, 10% of our users are automatically opt-in to this feature. We've first shipped this feature behind a flag in [v2.27](../v2.27/index.md#experimental-queries-on-demand) and feel confident now that more people can try it out. Opt-in users will receive a notice in their terminal about that opt-in in addition to a hint on how to turn it off (in case it disturbs your workflow). As a recap of what Query on Demand will improve:
+Starting with v2.29, 10% of our users are automatically opt-in to this feature. We've first shipped this feature behind a flag in [v2.27](../v2.27/index.md#experimental-queries-on-demand) and feel confident now that more people can try it out. Opt-in users will receive a notice in their terminal about that opt-in behavior and a hint on how to turn it off (in case it disturbs your workflow). As a recap of what Query on Demand will improve:
 
 > Gatsby will run queries for pages as they're requested by a browser. Think of it like lazily loading the data your pages need, when they need it! This avoids having to wait for slower queries (like image processing) if you're editing an unrelated part of a site. What this means for you: faster local development experience, up to 2x faster in many cases!
 
@@ -55,7 +55,7 @@ module.exports = {
 
 ## Lazy Images
 
-Similarily as with Query on Demand also Lazy Images will be automatically delivered to 10% of our users with this v2.29 release. We've first shipped this feature behind a flag in [v2.28](../v2.28/index.md#experimental-lazy-images-in-develop). Opt-in users will receive a notice in their terminal about that opt-in in addition to a hint on how to turn it off (in case it disturbs your workflow). As a recap of what Lazy Images will improve:
+Similarily as with Query on Demand also Lazy Images will be automatically delivered to 10% of our users with this v2.29 release. We've first shipped this feature behind a flag in [v2.28](../v2.28/index.md#experimental-lazy-images-in-develop). Opt-in users will receive a notice in their terminal about that opt-in behavior and a hint on how to turn it off (in case it disturbs your workflow). As a recap of what Lazy Images will improve:
 
 > As more and more images are added to a Gatsby site, the slower the local development experience oftentimes becomes. You spend time waiting for images to process, instead of you know, developing! No longer! This experimental version of `gatsby-plugin-sharp` only does image processing when the page gets requested.
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -1,0 +1,12 @@
+---
+date: "2020-12-15"
+version: "2.29.0"
+---
+
+# [v2.29](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.29.0-next.0...gatsby@2.29.0) (December 2020 #2)
+
+---
+
+Welcome to `gatsby@2.29.0` release (December 2020 #2)
+
+Key highlights of this release:

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -130,4 +130,22 @@ We introduced some API changes for working with images when we published the new
 
 ## Contributors
 
-A big **Thank You** to [everyone who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.29.0-next.0...gatsby@2.29.0) to this release 💜
+A big **Thank You** to [our community who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.29.0-next.0...gatsby@2.29.0) to this release 💜
+
+- [bappr](https://github.com/bappr): Update kintohub documentation with kintohub V1 deployment [PR #27016](https://github.com/gatsbyjs/gatsby/pull/27016)
+
+- [axe312ger](https://github.com/axe312ger)
+
+  - fix: improve error handling, always show API response status and message [PR #27730](https://github.com/gatsbyjs/gatsby/pull/27730)
+  - fix(documentationjs): fix example caption string [PR #27365](https://github.com/gatsbyjs/gatsby/pull/27365)
+
+- [olisteadman](https://github.com/olisteadman): Tell user to supply BOTH keys in .env.development. [PR #28405](https://github.com/gatsbyjs/gatsby/pull/28405)
+- [galihmelon](https://github.com/galihmelon): [docs][guides] improvements to Why Gatsby Uses GraphQL #15235 [PR #27640](https://github.com/gatsbyjs/gatsby/pull/27640)
+- [sreeharisj23](https://github.com/sreeharisj23): Remove Broken Link. [PR #28412](https://github.com/gatsbyjs/gatsby/pull/28412)
+- [vrabe](https://github.com/vrabe): fix(gatsby): scroll restoration issue in browser API [PR #27384](https://github.com/gatsbyjs/gatsby/pull/27384)
+- [WillMayger](https://github.com/WillMayger): fix(gatsby): re-render route when location state changes [PR #28346](https://github.com/gatsbyjs/gatsby/pull/28346)
+- [kasipavankumar](https://github.com/kasipavankumar): chore(gatsby-plugin-manifest): Update pluginOptionsSchema link [PR #28344](https://github.com/gatsbyjs/gatsby/pull/28344)
+- [rburgst](https://github.com/rburgst): fix: avoid joi validation error when using reporter.panic [PR #28291](https://github.com/gatsbyjs/gatsby/pull/28291)
+- [davidmauskop](https://github.com/davidmauskop): chore(docs): Update Deploying to Render guide [PR #28272](https://github.com/gatsbyjs/gatsby/pull/28272)
+- [saintmalik](https://github.com/saintmalik): chore(docs): fix broken url [PR #28197](https://github.com/gatsbyjs/gatsby/pull/28197)
+- [muescha](https://github.com/muescha): fix(docs): document pluginOptionsSchema - add file extension, code block language, quotation marks [PR #27844](https://github.com/gatsbyjs/gatsby/pull/27844)

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -47,7 +47,7 @@ If you want to turn it on/off, you can set the corresponding flag inside `gatsby
 // In your gatsby-config.js
 module.exports = {
   flags: {
-    QUERY_ON_DEMAND: true,
+    QUERY_ON_DEMAND: false,
   },
   plugins: [], // your plugins stay the same
 }
@@ -67,7 +67,7 @@ If you want to turn it on/off, you can set the corresponding flag inside `gatsby
 // In your gatsby-config.js
 module.exports = {
   flags: {
-    LAZY_IMAGES: true,
+    LAZY_IMAGES: false,
   },
   plugins: [], // your plugins stay the same
 }
@@ -138,12 +138,9 @@ We introduced some API changes for working with images when we published the new
 A big **Thank You** to [our community who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.29.0-next.0...gatsby@2.29.0) to this release 💜
 
 - [bappr](https://github.com/bappr): Update kintohub documentation with kintohub V1 deployment [PR #27016](https://github.com/gatsbyjs/gatsby/pull/27016)
-
 - [axe312ger](https://github.com/axe312ger)
-
   - fix: improve error handling, always show API response status and message [PR #27730](https://github.com/gatsbyjs/gatsby/pull/27730)
   - fix(documentationjs): fix example caption string [PR #27365](https://github.com/gatsbyjs/gatsby/pull/27365)
-
 - [olisteadman](https://github.com/olisteadman): Tell user to supply BOTH keys in .env.development. [PR #28405](https://github.com/gatsbyjs/gatsby/pull/28405)
 - [galihmelon](https://github.com/galihmelon): [docs][guides] improvements to Why Gatsby Uses GraphQL #15235 [PR #27640](https://github.com/gatsbyjs/gatsby/pull/27640)
 - [sreeharisj23](https://github.com/sreeharisj23): Remove Broken Link. [PR #28412](https://github.com/gatsbyjs/gatsby/pull/28412)

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -132,7 +132,7 @@ The File System Route API uses [slugify](https://github.com/sindresorhus/slugify
 
 ## gatsby-image codemod
 
-We introduced some API changes for working with images when we published the new `gatsby-plugin-image` in [v2.26](../v2.26/index.md#gatsby-plugin-image010-beta). In order to make it easier to migrate your code to work with the new plugin, we've created a codemod.Follow the migration instructions in the [README](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-image#upgrading-from-the-gatsby-image2) in order to run the codemod against your project.
+We introduced some API changes for working with images when we published the new `gatsby-plugin-image` in [v2.26](../v2.26/index.md#gatsby-plugin-image010-beta). In order to make it easier to migrate your code to work with the new plugin, we've created a codemod. Follow the migration instructions in the [README](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-image#upgrading-from-the-gatsby-image2) in order to run the codemod against your project.
 
 ## Notable bugfixes
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -18,6 +18,9 @@ Key highlights of this release:
 Other notable changes:
 
 - [Performance improvements](#performance-improvements)
+- [Slugify option for File System Route API](#slugify-option-for-file-system-route-api)
+- [gatsby-image codemod](#gatsby-image-codemod)
+- [Notable bugfixes](#notable-bugfixes)
 
 Sneak peak to next releases:
 
@@ -53,8 +56,23 @@ The regular `gatsby-cli` received a new command to list out all plugins in your 
 
 We were able to ship a bunch of performance improvements both to Gatsby itself and its plugins:
 
-- The PR [28375](https://github.com/gatsbyjs/gatsby/pull/28375) fixed an unguided search in `gatsby-source-contentful` that can significantly drop your time for an incremental build (and perhaps others). In this case (for a site with 80k elements) it dropped the time from 5 minutes to sub-second.
-- The PR [28525](https://github.com/gatsbyjs/gatsby/pull/28525) drops the `async` keyword from the `wrappingResolver` that wraps all resolvers passed on to GraphQL. In practice this means a 5-10% overall improvement to the runtime of a site.
+- The PR [#28375](https://github.com/gatsbyjs/gatsby/pull/28375) fixed an unguided search in `gatsby-source-contentful` that can significantly drop your time for an incremental build (and perhaps others). In this case (for a site with 80k elements) it dropped the time from 5 minutes to sub-second.
+- The PR [#28438](https://github.com/gatsbyjs/gatsby/pull/28438) prevents some redudant calculations resulting in 5% improvements for bigger sites
+- The PR [#28525](https://github.com/gatsbyjs/gatsby/pull/28525) drops the `async` keyword from the `wrappingResolver` that wraps all resolvers passed on to GraphQL. In practice this means a 5-10% overall improvement to the runtime of a site.
+
+## Slugify option for File System Route API
+
+The File System Route API uses [slugify](https://github.com/sindresorhus/slugify) to create slugs for the generated routes. You're now able to pass custom options to that instance, e.g. when you want to change the separator. The full details are listed in the [README](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator) of `gatsby-plugin-page-creator`.
+
+## gatsby-image codemod
+
+If you want to try out the new `gatsby-plugin-image` that we introduced in [v2.26](../v2.26/index.md#gatsby-plugin-image010-beta) you now can run it: #TODO
+
+## Notable bugfixes
+
+- Scroll restoration issue in the browser API was fixed in [#27384](https://github.com/gatsbyjs/gatsby/pull/27384) that affected e.g. page transitions
+- Do not fail in develop when eslint loader is removed in [#28494](https://github.com/gatsbyjs/gatsby/pull/28494)
+- Respect hash as source of truth for scroll position in [#28555](https://github.com/gatsbyjs/gatsby/pull/28555)
 
 ## Contributors
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -10,3 +10,25 @@ version: "2.29.0"
 Welcome to `gatsby@2.29.0` release (December 2020 #2)
 
 Key highlights of this release:
+
+- TODO
+
+Other notable changes:
+
+- TODO
+
+Sneak peak to next releases:
+
+- TODO
+
+**Bleeding Edge:** Want to try new features as soon as possible? Install `gatsby@next` and let us know
+if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
+
+[Previous release notes](../v2.28/index.md)<br>
+[Full changelog](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.29.0-next.0...gatsby@2.29.0)
+
+## TODO
+
+## Contributors
+
+A big **Thank You** to [everyone who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.29.0-next.0...gatsby@2.29.0) to this release 💜

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -11,9 +11,10 @@ Welcome to `gatsby@2.29.0` release (December 2020 #2)
 
 Key highlights of this release:
 
-- [Query on Demand](#query-on-demand) - TODO
-- [Lazy Images](#lazy-images) - TODO
+- [Query on Demand](#query-on-demand) - improves `gatsby develop` bootup time
+- [Lazy Images](#lazy-images) - only do image processing when a page gets reqested
 - [Improvements to our CLI](#improvements-to-our-cli) - improved `create-gatsby` & new `plugin` command
+- [Experimental: Parallel data sourcing](#experimental-parallel-data-sourcing) - run source plugins in parallel to speedup sourcing on sites with multiple source plugins
 
 Other notable changes:
 
@@ -34,11 +35,43 @@ if you have any [issues](https://github.com/gatsbyjs/gatsby/issues).
 
 ## Query on Demand
 
-TODO
+Starting with v2.29, 10% of our users are automatically opt-in to this feature. We've first shipped this feature behind a flag in [v2.27](../v2.27/index.md#experimental-queries-on-demand) and feel confident now that more people can try it out. Opt-in users will receive a notice in their terminal about that opt-in in addition to a hint on how to turn it off (in case it disturbs your workflow). As a recap of what Query on Demand will improve:
+
+> Gatsby will run queries for pages as they're requested by a browser. Think of it like lazily loading the data your pages need, when they need it! This avoids having to wait for slower queries (like image processing) if you're editing an unrelated part of a site. What this means for you: faster local development experience, up to 2x faster in many cases!
+
+By slowly rolling out this feature to more and more users we'll be getting closer to a GA (general availability) release that will benefit all users of Gatsby. Please give us your feedback in the [umbrella discussion](https://github.com/gatsbyjs/gatsby/discussions/27620).
+
+If you want to turn it on/off, you can set the corresponding flag inside `gatsby-config.js`:
+
+```js
+// In your gatsby-config.js
+module.exports = {
+  flags: {
+    QUERY_ON_DEMAND: true,
+  },
+  plugins: [], // your plugins stay the same
+}
+```
 
 ## Lazy Images
 
-TODO
+Similarily as with Query on Demand also Lazy Images will be automatically delivered to 10% of our users with this v2.29 release. We've first shipped this feature behind a flag in [v2.28](../v2.28/index.md#experimental-lazy-images-in-develop). Opt-in users will receive a notice in their terminal about that opt-in in addition to a hint on how to turn it off (in case it disturbs your workflow). As a recap of what Lazy Images will improve:
+
+> As more and more images are added to a Gatsby site, the slower the local development experience oftentimes becomes. You spend time waiting for images to process, instead of you know, developing! No longer! This experimental version of `gatsby-plugin-sharp` only does image processing when the page gets requested.
+
+By slowly rolling out this feature to more and more users we'll be getting closer to a GA (general availability) release that will benefit all users of Gatsby. Please give us your feedback in the [umbrella discussion](https://github.com/gatsbyjs/gatsby/discussions/27603).
+
+If you want to turn it on/off, you can set the corresponding flag inside `gatsby-config.js`:
+
+```js
+// In your gatsby-config.js
+module.exports = {
+  flags: {
+    LAZY_IMAGES: true,
+  },
+  plugins: [], // your plugins stay the same
+}
+```
 
 ## Improvements to our CLI
 
@@ -51,6 +84,26 @@ A couple of papercuts were fixed but we also added new features:
 - Add `-y` flag. This flag bypasses all prompts other than namin your site
 
 The regular `gatsby-cli` received a new command to list out all plugins in your site by running `gatsby plugin ls`.
+
+## Experimental: Parallel data sourcing
+
+In [v2.28](../v2.28/index.md#experimental-parallel-data-sourcing) we gave a sneak peak at a new feature that enables parallel data sourcing. As a recap:
+
+> Plugin APIs in Gatsby run serially. Generally this what we want as most API calls are CPU/IO bound so things are fastest letting each plugin have the full undivided attention of your computer. But source plugins are often _network_ bound as they're hitting remote APIs and waiting for responses. We tried [changing the invocation of `sourceNodes` to parallel](https://github.com/gatsbyjs/gatsby/pull/28214) on a few sites with 4+ source plugins and saw a big speedup on sourcing (40%+) as they were no longer waiting on each other to start their API calls.
+
+You're now able to activate this experiment in the stable release of Gatsby by adding a flag to your `gatsby-config.js`:
+
+```js
+// In your gatsby-config.js
+module.exports = {
+  flags: {
+    PARALLEL_SOURCING: true,
+  },
+  plugins: [], // your plugins stay the same
+}
+```
+
+Please give us your feedback in the [umbrella discussion](https://github.com/gatsbyjs/gatsby/discussions/28336).
 
 ## Performance improvements
 
@@ -73,6 +126,7 @@ If you want to try out the new `gatsby-plugin-image` that we introduced in [v2.2
 - Scroll restoration issue in the browser API was fixed in [#27384](https://github.com/gatsbyjs/gatsby/pull/27384) that affected e.g. page transitions
 - Do not fail in develop when eslint loader is removed in [#28494](https://github.com/gatsbyjs/gatsby/pull/28494)
 - Respect hash as source of truth for scroll position in [#28555](https://github.com/gatsbyjs/gatsby/pull/28555)
+- Wait for jobs to complete in `onPostBuild` in [#28534](https://github.com/gatsbyjs/gatsby/pull/28534)
 
 ## Contributors
 

--- a/docs/reference/release-notes/v2.29/index.md
+++ b/docs/reference/release-notes/v2.29/index.md
@@ -142,6 +142,7 @@ We introduced some API changes for working with images when we published the new
 - Do not fail in develop when eslint loader is removed in [#28494](https://github.com/gatsbyjs/gatsby/pull/28494)
 - Respect hash as source of truth for scroll position in [#28555](https://github.com/gatsbyjs/gatsby/pull/28555)
 - Wait for jobs to complete in `onPostBuild` in [#28534](https://github.com/gatsbyjs/gatsby/pull/28534)
+- Truncated long terminal messages fixed in [#26190](https://github.com/gatsbyjs/gatsby/pull/26190)
 
 ## Contributors
 


### PR DESCRIPTION
Release notes for 2.29 -- please add anything you want mentioned/highlighted in this release via PR suggestions.

[Rendered version](https://github.com/gatsbyjs/gatsby/blob/release-notes-2.29/docs/reference/release-notes/v2.29/index.md)