### PR TITLE
fix(create-gatsby): Default to gatsby-image until the plugin is GA

### DIFF
--- a/packages/create-gatsby/src/features.json
+++ b/packages/create-gatsby/src/features.json
@@ -2,13 +2,10 @@
   "gatsby-plugin-google-analytics": {
     "message": "Add the Google Analytics tracking script"
   },
-  "gatsby-plugin-image": {
+  "gatsby-plugin-sharp": {
     "message": "Add responsive images",
-    "plugins": [
-      "gatsby-plugin-sharp",
-      "gatsby-transformer-sharp",
-      "gatsby-source-filesystem:images"
-    ],
+    "plugins": ["gatsby-transformer-sharp", "gatsby-source-filesystem:images"],
+    "dependencies": ["gatsby-image"],
     "options": {
       "gatsby-source-filesystem:images": {
         "name": "images",


### PR DESCRIPTION
The current version of create-gatsby offers to install gatsby-plugin-image. That made sense when they were due to be launched around the same time, but gatbsy-plugin-image isn't planned for GA until January. This PR switches it to install gatsby-image for now.