### PR TITLE
Fixed typo brackets in file-system-route-api.md

### DIFF
--- a/docs/docs/file-system-route-api.md
+++ b/docs/docs/file-system-route-api.md
@@ -125,7 +125,7 @@ export default function Component(props) {
 // to connect to this GraphQL query.
 
 export const query = graphql`
-  query ($id: String) {
+  query($id: String) {
     product(id: { eq: $id }) {
       fields {
         sku
@@ -170,7 +170,8 @@ export default function HomePage(props) {
     <ul>
       {props.data.allProduct.map(product => (
         <li key={product.name}>
-          <Link to={product.productPath}>{product.name}</Link> (<Link to={product.discountPath}>Discount</Link>) // highlight-line
+          <Link to={product.productPath}>{product.name}</Link> (
+          <Link to={product.discountPath}>Discount</Link>) // highlight-line
         </li>
       ))}
     </ul>

--- a/docs/docs/file-system-route-api.md
+++ b/docs/docs/file-system-route-api.md
@@ -132,7 +132,7 @@ export const query = graphql`
       }
     }
   }
-}
+`
 ```
 
 If you need to customize the query used for collecting the nodes (e.g. filtering out any product of type "Food"), you should use the [`createPages`](/docs/node-apis#createPages) API instead as File System Route API doesn't support this at the moment.
@@ -185,7 +185,7 @@ export const query = graphql`
       discountPath: gatsbyPath(filePath: "/discounts/{Product.name}") // highlight-line
     }
   }
-}
+`
 ```
 
 By using [aliasing](/docs/graphql-reference/#aliasing) you can use `gatsbyPath` multiple times.


### PR DESCRIPTION
## Description

Docs fix a typo for file-system-route-api.md.
There was extra curly brackets and a missing backtick in 2 the examples. Noticed when I copy pasted an example.