### PR TITLE
feat(gatsby): improve refresh endpoint output

### DIFF
--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -264,7 +264,9 @@ module.exports = {
     } else {
       res.status(authorizedRefresh ? 404 : 403)
       res.json({
-        error: `Refresh failed`,
+        error: enableRefresh
+          ? `Authorization failed. Make sure you add authorization header to your refresh requests`
+          : `Refresh endpoint is not enabled. Run gatsby with "ENABLE_GATSBY_REFRESH_ENDPOINT=true" environment variable set.`,
         isEnabled: !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT,
       })
     }

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -262,7 +262,7 @@ module.exports = {
       res.status(200)
       res.setHeader(`content-type`, `application/json`)
     } else {
-      res.status(404)
+      res.status(authorizedRefresh ? 404 : 403)
       res.json({
         error: `Refresh failed`,
         isEnabled: !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT,
@@ -469,6 +469,12 @@ module.exports = {
   }
 
   app.use(async (req, res) => {
+    // in this catch-all block we don't support POST so we should 404
+    if (req.method === `POST`) {
+      res.status(404).end()
+      return
+    }
+
     const fullUrl = req.protocol + `://` + req.get(`host`) + req.originalUrl
     // This isn't used in development.
     if (fullUrl.endsWith(`app-data.json`)) {

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -259,6 +259,14 @@ module.exports = {
 
     if (enableRefresh && authorizedRefresh) {
       refresh(req, pluginName)
+      res.status(200)
+      res.setHeader(`content-type`, `application/json`)
+    } else {
+      res.status(404)
+      res.json({
+        error: `Refresh failed`,
+        isEnabled: !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT,
+      })
     }
     res.end()
   })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add status-code and extra information when it's not available. This will help us adopt the /__refresh/<pluginname> endpoint. This makes it easier to feature detect the specific endpoint.
