### PR TITLE
chore(gatsby-source-contentful): fix locale debug output, again (#28582)

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -296,8 +296,17 @@ exports.sourceNodes = async (
   const allLocales = locales
   locales = locales.filter(pluginConfig.get(`localeFilter`))
   reporter.verbose(
-    `All locales: ${allLocales}, default: ${defaultLocale}, after plugin.options.localeFilter: ${locales}`
+    `Default locale: ${defaultLocale}.   All locales: ${allLocales
+      .map(({ code }) => code)
+      .join(`, `)}`
   )
+  if (allLocales.length !== locales.length) {
+    reporter.verbose(
+      `After plugin.options.localeFilter: ${locales
+        .map(({ code }) => code)
+        .join(`, `)}`
+    )
+  }
   if (locales.length === 0) {
     reporter.panic({
       id: CODES.LocalesMissing,


### PR DESCRIPTION
Backporting #28582 to the 2.29 release branch

(cherry picked from commit 6a79ffcf0c464fac9a8153103e47868071e8415d)