### PR TITLE
fix(gatsby): Only set auto optin flags if not in config

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
@@ -33,16 +33,6 @@ Object {
       "testFitness": [Function],
       "umbrellaIssue": "test",
     },
-    Object {
-      "command": "all",
-      "description": "test",
-      "env": "GATSBY_ALWAYS_OPT_IN",
-      "experimental": false,
-      "name": "ALWAYS_OPT_IN",
-      "telemetryId": "test",
-      "testFitness": [Function],
-      "umbrellaIssue": "test",
-    },
   ],
   "message": "The following flags are active:
 - ALL_COMMANDS · (Umbrella Issue (test)) · test
@@ -59,7 +49,6 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
-- ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
 
 There are 5 other flags available that you might be interested in:
 - FAST_DEV · Enable all experiments aimed at improving develop server start time
@@ -95,16 +84,6 @@ Object {
       "testFitness": [Function],
       "umbrellaIssue": "test",
     },
-    Object {
-      "command": "all",
-      "description": "test",
-      "env": "GATSBY_ALWAYS_OPT_IN",
-      "experimental": false,
-      "name": "ALWAYS_OPT_IN",
-      "telemetryId": "test",
-      "testFitness": [Function],
-      "umbrellaIssue": "test",
-    },
   ],
   "message": "
 
@@ -120,7 +99,6 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
-- ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
 ",
   "unknownFlagMessage": "",
 }
@@ -159,16 +137,6 @@ Object {
       "testFitness": [Function],
       "umbrellaIssue": "test",
     },
-    Object {
-      "command": "all",
-      "description": "test",
-      "env": "GATSBY_ALWAYS_OPT_IN",
-      "experimental": false,
-      "name": "ALWAYS_OPT_IN",
-      "telemetryId": "test",
-      "testFitness": [Function],
-      "umbrellaIssue": "test",
-    },
   ],
   "message": "The following flags are active:
 - ALL_COMMANDS · (Umbrella Issue (test)) · test
@@ -185,7 +153,6 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
-- ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
 
 There are 5 other flags available that you might be interested in:
 - FAST_DEV · Enable all experiments aimed at improving develop server start time
@@ -247,16 +214,6 @@ Object {
       "umbrellaIssue": "test",
     },
     Object {
-      "command": "all",
-      "description": "test",
-      "env": "GATSBY_ALWAYS_OPT_IN",
-      "experimental": false,
-      "name": "ALWAYS_OPT_IN",
-      "telemetryId": "test",
-      "testFitness": [Function],
-      "umbrellaIssue": "test",
-    },
-    Object {
       "command": "develop",
       "description": "SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.",
       "env": "GATSBY_EXPERIMENTAL_DEV_SSR",
@@ -296,7 +253,6 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
-- ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
 
 There are 2 other flags available that you might be interested in:
 - ONLY_BUILDS · (Umbrella Issue (test)) · test

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
@@ -33,12 +33,22 @@ Object {
       "testFitness": [Function],
       "umbrellaIssue": "test",
     },
+    Object {
+      "command": "all",
+      "description": "test",
+      "env": "GATSBY_ALWAYS_OPT_IN",
+      "experimental": false,
+      "name": "ALWAYS_OPT_IN",
+      "telemetryId": "test",
+      "testFitness": [Function],
+      "umbrellaIssue": "test",
+    },
   ],
   "message": "The following flags are active:
 - ALL_COMMANDS · (Umbrella Issue (test)) · test
 
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 
@@ -49,6 +59,7 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
+- ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
 
 There are 5 other flags available that you might be interested in:
 - FAST_DEV · Enable all experiments aimed at improving develop server start time
@@ -84,11 +95,21 @@ Object {
       "testFitness": [Function],
       "umbrellaIssue": "test",
     },
+    Object {
+      "command": "all",
+      "description": "test",
+      "env": "GATSBY_ALWAYS_OPT_IN",
+      "experimental": false,
+      "name": "ALWAYS_OPT_IN",
+      "telemetryId": "test",
+      "testFitness": [Function],
+      "umbrellaIssue": "test",
+    },
   ],
   "message": "
 
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 
@@ -99,6 +120,7 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
+- ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
 ",
   "unknownFlagMessage": "",
 }
@@ -137,12 +159,22 @@ Object {
       "testFitness": [Function],
       "umbrellaIssue": "test",
     },
+    Object {
+      "command": "all",
+      "description": "test",
+      "env": "GATSBY_ALWAYS_OPT_IN",
+      "experimental": false,
+      "name": "ALWAYS_OPT_IN",
+      "telemetryId": "test",
+      "testFitness": [Function],
+      "umbrellaIssue": "test",
+    },
   ],
   "message": "The following flags are active:
 - ALL_COMMANDS · (Umbrella Issue (test)) · test
 
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 
@@ -153,6 +185,7 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
+- ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
 
 There are 5 other flags available that you might be interested in:
 - FAST_DEV · Enable all experiments aimed at improving develop server start time
@@ -214,6 +247,16 @@ Object {
       "umbrellaIssue": "test",
     },
     Object {
+      "command": "all",
+      "description": "test",
+      "env": "GATSBY_ALWAYS_OPT_IN",
+      "experimental": false,
+      "name": "ALWAYS_OPT_IN",
+      "telemetryId": "test",
+      "testFitness": [Function],
+      "umbrellaIssue": "test",
+    },
+    Object {
       "command": "develop",
       "description": "SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.",
       "env": "GATSBY_EXPERIMENTAL_DEV_SSR",
@@ -242,7 +285,7 @@ Object {
 - QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
 
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 
@@ -253,6 +296,7 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
+- ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
 
 There are 2 other flags available that you might be interested in:
 - ONLY_BUILDS · (Umbrella Issue (test)) · test

--- a/packages/gatsby/src/utils/__tests__/handle-flags.ts
+++ b/packages/gatsby/src/utils/__tests__/handle-flags.ts
@@ -149,6 +149,17 @@ describe(`handle flags`, () => {
         }
       },
     },
+    {
+      name: `ALWAYS_OPT_IN`,
+      env: `GATSBY_ALWAYS_OPT_IN`,
+      command: `all`,
+      description: `test`,
+      umbrellaIssue: `test`,
+      telemetryId: `test`,
+      experimental: false,
+      // this will always OPT IN
+      testFitness: (): fitnessEnum => `OPT_IN`,
+    },
   ]
 
   const configFlags = {
@@ -170,7 +181,7 @@ describe(`handle flags`, () => {
 
   it(`filters out flags marked false`, () => {
     const result = handleFlags(activeFlags, configFlagsWithFalse, `develop`)
-    expect(result.enabledConfigFlags).toHaveLength(3)
+    expect(result.enabledConfigFlags).toHaveLength(4)
     expect(result).toMatchSnapshot()
   })
 
@@ -178,13 +189,13 @@ describe(`handle flags`, () => {
     expect(
       handleFlags(activeFlags, configWithFlagsNoCi, `develop`)
         .enabledConfigFlags
-    ).toHaveLength(3)
+    ).toHaveLength(4)
   })
 
   it(`filters out flags that aren't for the current command`, () => {
     expect(
       handleFlags(activeFlags, configFlags, `build`).enabledConfigFlags
-    ).toHaveLength(3)
+    ).toHaveLength(4)
   })
 
   it(`returns a message about unknown flags in the config`, () => {
@@ -205,7 +216,11 @@ describe(`handle flags`, () => {
   it(`removes flags people explicitly opt out of and ignores flags that don't pass semver`, () => {
     const response = handleFlags(
       activeFlags,
-      { PARTIAL_RELEASE: false, PARTIAL_RELEASE_ONLY_NEW_LODASH: false },
+      {
+        PARTIAL_RELEASE: false,
+        PARTIAL_RELEASE_ONLY_NEW_LODASH: false,
+        ALWAYS_OPT_IN: false,
+      },
       `develop`
     )
     expect(response.enabledConfigFlags).toHaveLength(0)
@@ -218,6 +233,7 @@ describe(`handle flags`, () => {
         PARTIAL_RELEASE_ONLY_VERY_OLD_LODASH: true,
         PARTIAL_RELEASE: false,
         PARTIAL_RELEASE_ONLY_NEW_LODASH: false,
+        ALWAYS_OPT_IN: false,
       },
       `develop`
     )
@@ -229,6 +245,36 @@ describe(`handle flags`, () => {
         "message": "",
         "unknownFlagMessage": "",
       }
+    `)
+  })
+
+  it(`Prefers explicit opt-in over auto opt-in (for terminal message)`, () => {
+    const response = handleFlags(
+      activeFlags,
+      {
+        ALWAYS_OPT_IN: true,
+        DEV_SSR: true,
+        PARTIAL_RELEASE: false,
+        PARTIAL_RELEASE_ONLY_NEW_LODASH: false,
+      },
+      `develop`
+    )
+
+    expect(response.message).not.toContain(`automatically enabled`)
+    expect(response.message).toMatchInlineSnapshot(`
+      "The following flags are active:
+      - ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
+      - DEV_SSR · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/28138)) · SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.
+
+      There are 7 other flags available that you might be interested in:
+      - FAST_DEV · Enable all experiments aimed at improving develop server start time
+      - QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
+      - ONLY_BUILDS · (Umbrella Issue (test)) · test
+      - ALL_COMMANDS · (Umbrella Issue (test)) · test
+      - YET_ANOTHER · (Umbrella Issue (test)) · test
+      - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
+      - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
+      "
     `)
   })
 })

--- a/packages/gatsby/src/utils/__tests__/handle-flags.ts
+++ b/packages/gatsby/src/utils/__tests__/handle-flags.ts
@@ -149,17 +149,6 @@ describe(`handle flags`, () => {
         }
       },
     },
-    {
-      name: `ALWAYS_OPT_IN`,
-      env: `GATSBY_ALWAYS_OPT_IN`,
-      command: `all`,
-      description: `test`,
-      umbrellaIssue: `test`,
-      telemetryId: `test`,
-      experimental: false,
-      // this will always OPT IN
-      testFitness: (): fitnessEnum => `OPT_IN`,
-    },
   ]
 
   const configFlags = {
@@ -181,7 +170,7 @@ describe(`handle flags`, () => {
 
   it(`filters out flags marked false`, () => {
     const result = handleFlags(activeFlags, configFlagsWithFalse, `develop`)
-    expect(result.enabledConfigFlags).toHaveLength(4)
+    expect(result.enabledConfigFlags).toHaveLength(3)
     expect(result).toMatchSnapshot()
   })
 
@@ -189,13 +178,13 @@ describe(`handle flags`, () => {
     expect(
       handleFlags(activeFlags, configWithFlagsNoCi, `develop`)
         .enabledConfigFlags
-    ).toHaveLength(4)
+    ).toHaveLength(3)
   })
 
   it(`filters out flags that aren't for the current command`, () => {
     expect(
       handleFlags(activeFlags, configFlags, `build`).enabledConfigFlags
-    ).toHaveLength(4)
+    ).toHaveLength(3)
   })
 
   it(`returns a message about unknown flags in the config`, () => {
@@ -219,7 +208,6 @@ describe(`handle flags`, () => {
       {
         PARTIAL_RELEASE: false,
         PARTIAL_RELEASE_ONLY_NEW_LODASH: false,
-        ALWAYS_OPT_IN: false,
       },
       `develop`
     )
@@ -233,7 +221,6 @@ describe(`handle flags`, () => {
         PARTIAL_RELEASE_ONLY_VERY_OLD_LODASH: true,
         PARTIAL_RELEASE: false,
         PARTIAL_RELEASE_ONLY_NEW_LODASH: false,
-        ALWAYS_OPT_IN: false,
       },
       `develop`
     )
@@ -250,7 +237,19 @@ describe(`handle flags`, () => {
 
   it(`Prefers explicit opt-in over auto opt-in (for terminal message)`, () => {
     const response = handleFlags(
-      activeFlags,
+      activeFlags.concat([
+        {
+          name: `ALWAYS_OPT_IN`,
+          env: `GATSBY_ALWAYS_OPT_IN`,
+          command: `all`,
+          description: `test`,
+          umbrellaIssue: `test`,
+          telemetryId: `test`,
+          experimental: false,
+          // this will always OPT IN
+          testFitness: (): fitnessEnum => `OPT_IN`,
+        },
+      ]),
       {
         ALWAYS_OPT_IN: true,
         DEV_SSR: true,

--- a/packages/gatsby/src/utils/handle-flags.ts
+++ b/packages/gatsby/src/utils/handle-flags.ts
@@ -70,7 +70,9 @@ const handleFlags = (
   availableFlags.forEach(flag => {
     const fitness = flag.testFitness(flag)
 
-    if (configFlags[flag.name] !== false && fitness === `OPT_IN`) {
+    // if user didn't explicitly set a flag (either true or false)
+    // and it qualifies for auto opt-in - add it to optedInFlags
+    if (typeof configFlags[flag.name] === `undefined` && fitness === `OPT_IN`) {
       enabledConfigFlags.push(flag)
       optedInFlags.set(flag.name, flag)
     }
@@ -143,7 +145,7 @@ const handleFlags = (
     if (optedInFlags.size > 0) {
       message += `\n\n`
       message += `We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 


### PR DESCRIPTION
## Description

This doesn't change behaviour - this is only to address message that is displayed.

Currently when user explicitly opt-in in config AND site get's picked for auto opt-in we do display message that site was auto opted-in - this is confusing because user already did opt-in manually and we should prefer that over auto opt-in message.