### PR TITLE
fix(gatsby-plugin-image): Correctly handle formats in StaticImage (#28618)

### DIFF
--- a/e2e-tests/gatsby-static-image/src/pages/lazy-loading.js
+++ b/e2e-tests/gatsby-static-image/src/pages/lazy-loading.js
@@ -11,6 +11,7 @@ export default function NativeLazyLoadingPage() {
         height={59}
         alt="Citrus fruits"
         loading="lazy"
+        formats={["jpg"]}
       />
 
       <div style={{ height: `5000px`, background: `#F4F4F4` }} />
@@ -22,6 +23,7 @@ export default function NativeLazyLoadingPage() {
         height={59}
         alt="Citrus fruits"
         loading="lazy"
+        formats={["jpg"]}
       />
     </div>
   )

--- a/packages/gatsby-plugin-image/src/babel-helpers.ts
+++ b/packages/gatsby-plugin-image/src/babel-helpers.ts
@@ -6,6 +6,7 @@ import { getAttributeValues } from "babel-jsx-utils"
 export const SHARP_ATTRIBUTES = new Set([
   `src`,
   `layout`,
+  `formats`,
   `maxWidth`,
   `maxHeight`,
   `quality`,

--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -110,6 +110,8 @@ export async function generateImageData({
     quality,
   } = args
 
+  args.formats = args.formats || [`auto`, `webp`]
+
   const {
     fit = `cover`,
     cropFocus = sharp.strategy.attention,


### PR DESCRIPTION
Backporting #28618 to the 2.29 release branch

(cherry picked from commit 912f30c099f98fa382fe653a3a2c07253bd6b452)