### PR TITLE
fix(create-gatsby): Default to gatsby-image until the plugin is GA (#28607)

### DIFF
--- a/packages/create-gatsby/src/features.json
+++ b/packages/create-gatsby/src/features.json
@@ -2,13 +2,10 @@
   "gatsby-plugin-google-analytics": {
     "message": "Add the Google Analytics tracking script"
   },
-  "gatsby-plugin-image": {
+  "gatsby-plugin-sharp": {
     "message": "Add responsive images",
-    "plugins": [
-      "gatsby-plugin-sharp",
-      "gatsby-transformer-sharp",
-      "gatsby-source-filesystem:images"
-    ],
+    "plugins": ["gatsby-transformer-sharp", "gatsby-source-filesystem:images"],
+    "dependencies": ["gatsby-image"],
     "options": {
       "gatsby-source-filesystem:images": {
         "name": "images",


### PR DESCRIPTION
Backporting #28607 to the 2.29 release branch

(cherry picked from commit 84f3d08ac4ae2830bdb946da30a51c41ecb00ed1)