### PR TITLE
fix(gatsby): Only set auto optin flags if not in config (#28627)

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
@@ -38,7 +38,7 @@ Object {
 - ALL_COMMANDS · (Umbrella Issue (test)) · test
 
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 
@@ -88,7 +88,7 @@ Object {
   "message": "
 
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 
@@ -142,7 +142,7 @@ Object {
 - ALL_COMMANDS · (Umbrella Issue (test)) · test
 
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 
@@ -242,7 +242,7 @@ Object {
 - QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
 
 We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 

--- a/packages/gatsby/src/utils/__tests__/handle-flags.ts
+++ b/packages/gatsby/src/utils/__tests__/handle-flags.ts
@@ -205,7 +205,10 @@ describe(`handle flags`, () => {
   it(`removes flags people explicitly opt out of and ignores flags that don't pass semver`, () => {
     const response = handleFlags(
       activeFlags,
-      { PARTIAL_RELEASE: false, PARTIAL_RELEASE_ONLY_NEW_LODASH: false },
+      {
+        PARTIAL_RELEASE: false,
+        PARTIAL_RELEASE_ONLY_NEW_LODASH: false,
+      },
       `develop`
     )
     expect(response.enabledConfigFlags).toHaveLength(0)
@@ -229,6 +232,48 @@ describe(`handle flags`, () => {
         "message": "",
         "unknownFlagMessage": "",
       }
+    `)
+  })
+
+  it(`Prefers explicit opt-in over auto opt-in (for terminal message)`, () => {
+    const response = handleFlags(
+      activeFlags.concat([
+        {
+          name: `ALWAYS_OPT_IN`,
+          env: `GATSBY_ALWAYS_OPT_IN`,
+          command: `all`,
+          description: `test`,
+          umbrellaIssue: `test`,
+          telemetryId: `test`,
+          experimental: false,
+          // this will always OPT IN
+          testFitness: (): fitnessEnum => `OPT_IN`,
+        },
+      ]),
+      {
+        ALWAYS_OPT_IN: true,
+        DEV_SSR: true,
+        PARTIAL_RELEASE: false,
+        PARTIAL_RELEASE_ONLY_NEW_LODASH: false,
+      },
+      `develop`
+    )
+
+    expect(response.message).not.toContain(`automatically enabled`)
+    expect(response.message).toMatchInlineSnapshot(`
+      "The following flags are active:
+      - ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
+      - DEV_SSR · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/28138)) · SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.
+
+      There are 7 other flags available that you might be interested in:
+      - FAST_DEV · Enable all experiments aimed at improving develop server start time
+      - QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
+      - ONLY_BUILDS · (Umbrella Issue (test)) · test
+      - ALL_COMMANDS · (Umbrella Issue (test)) · test
+      - YET_ANOTHER · (Umbrella Issue (test)) · test
+      - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
+      - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
+      "
     `)
   })
 })

--- a/packages/gatsby/src/utils/handle-flags.ts
+++ b/packages/gatsby/src/utils/handle-flags.ts
@@ -70,7 +70,9 @@ const handleFlags = (
   availableFlags.forEach(flag => {
     const fitness = flag.testFitness(flag)
 
-    if (configFlags[flag.name] !== false && fitness === `OPT_IN`) {
+    // if user didn't explicitly set a flag (either true or false)
+    // and it qualifies for auto opt-in - add it to optedInFlags
+    if (typeof configFlags[flag.name] === `undefined` && fitness === `OPT_IN`) {
       enabledConfigFlags.push(flag)
       optedInFlags.set(flag.name, flag)
     }
@@ -143,7 +145,7 @@ const handleFlags = (
     if (optedInFlags.size > 0) {
       message += `\n\n`
       message += `We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
-and your site was automatically choosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
 
 We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
 


### PR DESCRIPTION
Backporting #28627 to the 2.29 release branch

(cherry picked from commit b81e6bdb70fbda4f02739728f79b12c166b1a188)