### PR TITLE
feat(gatsby): Add AVIF file support to image loader in webpack config

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -499,7 +499,7 @@ export const createWebpackUtils = (
   rules.images = (): RuleSetRule => {
     return {
       use: [loaders.url()],
-      test: /\.(ico|svg|jpg|jpeg|png|gif|webp)(\?.*)?$/,
+      test: /\.(ico|svg|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/,
     }
   }
 


### PR DESCRIPTION
**Description:**

Currently, gatsby allows to include as images supported image types (for example, jpeg, gif, webp). Most browsers recently added AVIF image support, but gatsby does not recognize AVIF as images and tries to include AVIF file in the bundle

*Expected behavior*:

`<img src="file.avif">` should create avif file in the folder with output and generate `<img src="path-to-file.avif">` in the resulting HTML file

*Current behavior*:

Gatsby tries to include the file (which is of binary format) in the bundle and crashes doing that