### PR TITLE
chore: Add contributors to 2.26/2.27/2.28 release notes

### DIFF
--- a/docs/reference/release-notes/v2.26/index.md
+++ b/docs/reference/release-notes/v2.26/index.md
@@ -182,4 +182,21 @@ And that means having documentation that helps y’all find the information you 
 
 ## Contributors
 
-A big **Thank You** to [everyone who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.26.0-next.0...gatsby@2.26.0) to this release 💜
+A big **Thank You** to [our community who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.26.0-next.0...gatsby@2.26.0) to this release 💜
+
+- [muescha](https://github.com/muescha)
+  - fix(docs): Gatsby README - fix brand name GatsbyJS -> Gatsby [PR #27815](https://github.com/gatsbyjs/gatsby/pull/27815)
+  - fix(docs): Update gatsby-plugin-guess-js README [PR #27814](https://github.com/gatsbyjs/gatsby/pull/27814)
+  - fix(recipe): add brackets to directory names [PR #27812](https://github.com/gatsbyjs/gatsby/pull/27812)
+- [MichaelDeBoey](https://github.com/MichaelDeBoey): chore(gatsby-plugin-cxs): Add pluginOptionsSchema validation [PR #27600](https://github.com/gatsbyjs/gatsby/pull/27600)
+- [davad](https://github.com/davad): fix(docs): Update documentation for createPages [PR #27735](https://github.com/gatsbyjs/gatsby/pull/27735)
+- [me4502](https://github.com/me4502): fix(gatsby-plugin-sitemap): fixed missing sitemapSize config entry [PR #27866](https://github.com/gatsbyjs/gatsby/pull/27866)
+- [axe312ger](https://github.com/axe312ger)
+  - Refactor Rich Text implementation in gatsby-source-contentful [PR #25249](https://github.com/gatsbyjs/gatsby/pull/25249)
+- [ARKEOLOGIST](https://github.com/ARKEOLOGIST): fix(gatsby-plugin-google-tagmanager): allow functions for defaultDataLayer option [PR #27886](https://github.com/gatsbyjs/gatsby/pull/27886)
+- [hoobdeebla](https://github.com/hoobdeebla): fix(renovate): move express-graphql and react-reconciler from minor to major update groups [PR #27101](https://github.com/gatsbyjs/gatsby/pull/27101)
+- [StephanWeinhold](https://github.com/StephanWeinhold): chore(docs): Add required `path` import to modifying-pages doc [PR #27883](https://github.com/gatsbyjs/gatsby/pull/27883)
+- [ervasive](https://github.com/ervasive): fix(gatsby): Update TS types to allow Node 'parent' to be nullable [PR #26570](https://github.com/gatsbyjs/gatsby/pull/26570)
+- [manavm1990](https://github.com/manavm1990): chore(docs): Add children to styled-components doc [PR #27011](https://github.com/gatsbyjs/gatsby/pull/27011)
+- [kadhirash](https://github.com/kadhirash): fix(docs): dictionary.txt -> KintoBlock-kintoblock [PR #27580](https://github.com/gatsbyjs/gatsby/pull/27580)
+- [jerrydevs](https://github.com/jerrydevs): fix(gatsby-transformer-asciidoc): fails when doc doesn't have title [PR #27865](https://github.com/gatsbyjs/gatsby/pull/27865)

--- a/docs/reference/release-notes/v2.27/index.md
+++ b/docs/reference/release-notes/v2.27/index.md
@@ -124,4 +124,21 @@ And that means having documentation that helps y’all find the information you 
 
 ## Contributors
 
-A big **Thank You** to [everyone who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0) to this release 💜
+A big **Thank You** to [our community who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0) to this release 💜
+
+- [jerrydevs](https://github.com/jerrydevs): fix(gatsby-transformer-asciidoc): fails when doc doesn't have title [PR #27865](https://github.com/gatsbyjs/gatsby/pull/27865)
+- [shoxton](https://github.com/shoxton)
+  - feat(gatsby-recipes): add Chakra UI recipe [PR #27721](https://github.com/gatsbyjs/gatsby/pull/27721)
+  - feat(recipes-list): add chakra-ui [PR #28013](https://github.com/gatsbyjs/gatsby/pull/28013)
+- [vhiairrassary](https://github.com/vhiairrassary): Fix #26359: Support HTTPS for the develop status server [PR #27955](https://github.com/gatsbyjs/gatsby/pull/27955)
+- [stefanjudis](https://github.com/stefanjudis): docs(gatsby-source-contentful): clean up changelog [PR #28000](https://github.com/gatsbyjs/gatsby/pull/28000)
+- [lellky](https://github.com/lellky): chore(docs): Update add-seo-component [PR #28022](https://github.com/gatsbyjs/gatsby/pull/28022)
+- [MichaelDeBoey](https://github.com/MichaelDeBoey)
+  - chore(gatsby-plugin-glamor): Add pluginOptionsSchema validation [PR #27602](https://github.com/gatsbyjs/gatsby/pull/27602)
+  - chore(gatsby-plugin-twitter): Add pluginOptionsSchema validation [PR #27601](https://github.com/gatsbyjs/gatsby/pull/27601)
+- [trevorblades](https://github.com/trevorblades): Make optional SVG favicon come after the fallback [PR #27843](https://github.com/gatsbyjs/gatsby/pull/27843)
+- [moonmeister](https://github.com/moonmeister): fix(plugin-manifest): Allow for all valid WebAppManifest properties [PR #27951](https://github.com/gatsbyjs/gatsby/pull/27951)
+- [nm123github](https://github.com/nm123github): add query pluginOption for mongodb plugin [PR #27756](https://github.com/gatsbyjs/gatsby/pull/27756)
+- [sreeharisj23](https://github.com/sreeharisj23): chore: change .org to .com [PR #28053](https://github.com/gatsbyjs/gatsby/pull/28053)
+- [DecliningLotus](https://github.com/DecliningLotus): chore(docs): replace typefaces with fontsource [PR #27313](https://github.com/gatsbyjs/gatsby/pull/27313)
+- [yaacovCR](https://github.com/yaacovCR): chore(gatsby-source-graphql): upgrade graphql-tools to v7 [PR #27792](https://github.com/gatsbyjs/gatsby/pull/27792)

--- a/docs/reference/release-notes/v2.28/index.md
+++ b/docs/reference/release-notes/v2.28/index.md
@@ -172,4 +172,15 @@ module.exports = {
 
 ## Contributors
 
-A big **Thank You** to [everyone who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.28.0-next.0...gatsby@2.28.0) to this release 💜
+A big **Thank You** to [our community who contributed](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.28.0-next.0...gatsby@2.28.0) to this release 💜
+
+- [styxlab](https://github.com/styxlab): fix(gatsby-source-filesystem): fix race condition when using `publicURL` field [PR #28176](https://github.com/gatsbyjs/gatsby/pull/28176)
+- [visualfanatic](https://github.com/visualfanatic): link to issue fixed inside release notes [PR #28193](https://github.com/gatsbyjs/gatsby/pull/28193)
+- [oorestisime](https://github.com/oorestisime): feat(gatsby-plugin-sitemap): allow `serialize` plugin option to be async function # [PR #28207](https://github.com/gatsbyjs/gatsby/pull/28207)
+- [theskillwithin](https://github.com/theskillwithin): breaking(gatsby-plugin-emotion): update to emotion@11 [PR #27981](https://github.com/gatsbyjs/gatsby/pull/27981)
+- [hassankhan](https://github.com/hassankhan): fix(gatsby-transformer-remark): ensure `getNodesByType()` is passed through [PR #28218](https://github.com/gatsbyjs/gatsby/pull/28218)
+- [nina-py](https://github.com/nina-py): chore(gatsby-cli): Bump up update-notifier version to 5.0.1 [PR #28273](https://github.com/gatsbyjs/gatsby/pull/28273)
+- [leerob](https://github.com/leerob): Add Vercel Analytics to documentation. [PR #27841](https://github.com/gatsbyjs/gatsby/pull/27841)
+- [KKVANONYMOUS](https://github.com/KKVANONYMOUS): chore(docs): Fix link to inc builds [PR #28306](https://github.com/gatsbyjs/gatsby/pull/28306)
+- [jmiazga](https://github.com/jmiazga): fix(gatsby-recipes): updated chakra ui recipe after v1 release [PR #28270](https://github.com/gatsbyjs/gatsby/pull/28270)
+- [blainekasten](https://github.com/blainekasten): feat(gatsby): Add preliminary fast-refresh integration [PR #26664](https://github.com/gatsbyjs/gatsby/pull/26664)

--- a/docs/reference/release-notes/v2.28/index.md
+++ b/docs/reference/release-notes/v2.28/index.md
@@ -176,7 +176,7 @@ A big **Thank You** to [our community who contributed](https://github.com/gatsby
 
 - [styxlab](https://github.com/styxlab): fix(gatsby-source-filesystem): fix race condition when using `publicURL` field [PR #28176](https://github.com/gatsbyjs/gatsby/pull/28176)
 - [visualfanatic](https://github.com/visualfanatic): link to issue fixed inside release notes [PR #28193](https://github.com/gatsbyjs/gatsby/pull/28193)
-- [oorestisime](https://github.com/oorestisime): feat(gatsby-plugin-sitemap): allow `serialize` plugin option to be async function # [PR #28207](https://github.com/gatsbyjs/gatsby/pull/28207)
+- [oorestisime](https://github.com/oorestisime): feat(gatsby-plugin-sitemap): allow `serialize` plugin option to be async function [PR #28207](https://github.com/gatsbyjs/gatsby/pull/28207)
 - [theskillwithin](https://github.com/theskillwithin): breaking(gatsby-plugin-emotion): update to emotion@11 [PR #27981](https://github.com/gatsbyjs/gatsby/pull/27981)
 - [hassankhan](https://github.com/hassankhan): fix(gatsby-transformer-remark): ensure `getNodesByType()` is passed through [PR #28218](https://github.com/gatsbyjs/gatsby/pull/28218)
 - [nina-py](https://github.com/nina-py): chore(gatsby-cli): Bump up update-notifier version to 5.0.1 [PR #28273](https://github.com/gatsbyjs/gatsby/pull/28273)


### PR DESCRIPTION
Adds lists of external contributors to our older release notes via https://github.com/LekoArts/thanks-contributors