### PR TITLE
perf(gatsby-source-contentful): dont re-create nodes

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/normalize.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/normalize.js.snap
@@ -10133,3 +10133,5662 @@ Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliff
   ],
 ]
 `;
+
+exports[`Process existing mutated nodes in warm build creates nodes for each asset 1`] = `
+Array [
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c3wtvPBbBjiMKqKKga8I2Cu",
+      "createdAt": "2017-06-27T09:35:37.178Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 353,
+            "width": 353,
+          },
+          "size": 12302,
+        },
+        "fileName": "zJYzDlGk.jpeg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/3wtvPBbBjiMKqKKga8I2Cu/c65cb9cce1107c2e7e63c17072fe7932/zJYzDlGk.jpeg",
+      },
+      "id": "rocybtov1ozk___c3wtvPBbBjiMKqKKga8I2Cu___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.178Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Normann Copenhagen",
+      "updatedAt": "2017-06-27T09:35:37.178Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c3wtvPBbBjiMKqKKga8I2Cu",
+      "createdAt": "2017-06-27T09:35:37.178Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 353,
+            "width": 353,
+          },
+          "size": 12302,
+        },
+        "fileName": "zJYzDlGk.jpeg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/3wtvPBbBjiMKqKKga8I2Cu/c65cb9cce1107c2e7e63c17072fe7932/zJYzDlGk.jpeg",
+      },
+      "id": "rocybtov1ozk___c3wtvPBbBjiMKqKKga8I2Cu___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.178Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Normann Copenhagen",
+      "updatedAt": "2017-06-27T09:35:37.178Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "KTRF62Q4gg60q6WCsWKw8",
+      "createdAt": "2017-06-27T09:35:37.064Z",
+      "description": "by Lemnos",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 1000,
+            "width": 1000,
+          },
+          "size": 66927,
+        },
+        "fileName": "soso.clock.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg",
+      },
+      "id": "rocybtov1ozk___KTRF62Q4gg60q6WCsWKw8___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.064Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "SoSo Wall Clock",
+      "updatedAt": "2017-06-27T09:35:37.064Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "KTRF62Q4gg60q6WCsWKw8",
+      "createdAt": "2017-06-27T09:35:37.064Z",
+      "description": "by Lemnos",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 1000,
+            "width": 1000,
+          },
+          "size": 66927,
+        },
+        "fileName": "soso.clock.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg",
+      },
+      "id": "rocybtov1ozk___KTRF62Q4gg60q6WCsWKw8___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.064Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "SoSo Wall Clock",
+      "updatedAt": "2017-06-27T09:35:37.064Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "Xc0ny7GWsMEMCeASWO2um",
+      "createdAt": "2017-06-27T09:35:37.027Z",
+      "description": "Merchandise image",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 600,
+            "width": 600,
+          },
+          "size": 48751,
+        },
+        "fileName": "jqvtazcyfwseah9fmysz.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg",
+      },
+      "id": "rocybtov1ozk___Xc0ny7GWsMEMCeASWO2um___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.027Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Hudson Wall Cup ",
+      "updatedAt": "2017-06-27T09:35:37.027Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "Xc0ny7GWsMEMCeASWO2um",
+      "createdAt": "2017-06-27T09:35:37.027Z",
+      "description": "Merchandise image",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 600,
+            "width": 600,
+          },
+          "size": 48751,
+        },
+        "fileName": "jqvtazcyfwseah9fmysz.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg",
+      },
+      "id": "rocybtov1ozk___Xc0ny7GWsMEMCeASWO2um___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.027Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Hudson Wall Cup ",
+      "updatedAt": "2017-06-27T09:35:37.027Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c2Y8LhXLnYAYqKCGEWG4EKI",
+      "createdAt": "2017-06-27T09:35:37.012Z",
+      "description": "company logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 32,
+            "width": 175,
+          },
+          "size": 7149,
+        },
+        "fileName": "lemnos-logo.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/2Y8LhXLnYAYqKCGEWG4EKI/eb29ab3c817906993f65e221523ef252/lemnos-logo.jpg",
+      },
+      "id": "rocybtov1ozk___c2Y8LhXLnYAYqKCGEWG4EKI___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.012Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Lemnos",
+      "updatedAt": "2017-06-27T09:35:37.012Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c2Y8LhXLnYAYqKCGEWG4EKI",
+      "createdAt": "2017-06-27T09:35:37.012Z",
+      "description": "company logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 32,
+            "width": 175,
+          },
+          "size": 7149,
+        },
+        "fileName": "lemnos-logo.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/2Y8LhXLnYAYqKCGEWG4EKI/eb29ab3c817906993f65e221523ef252/lemnos-logo.jpg",
+      },
+      "id": "rocybtov1ozk___c2Y8LhXLnYAYqKCGEWG4EKI___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.012Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Lemnos",
+      "updatedAt": "2017-06-27T09:35:37.012Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6t4HKjytPi0mYgs240wkG",
+      "createdAt": "2017-06-27T09:35:36.633Z",
+      "description": "Category icon set",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 128,
+            "width": 128,
+          },
+          "size": 6744,
+        },
+        "fileName": "toys_512pxGREY.png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png",
+      },
+      "id": "rocybtov1ozk___c6t4HKjytPi0mYgs240wkG___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.633Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Toys",
+      "updatedAt": "2017-06-27T09:35:36.633Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6t4HKjytPi0mYgs240wkG",
+      "createdAt": "2017-06-27T09:35:36.633Z",
+      "description": "Category icon set",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 128,
+            "width": 128,
+          },
+          "size": 6744,
+        },
+        "fileName": "toys_512pxGREY.png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png",
+      },
+      "id": "rocybtov1ozk___c6t4HKjytPi0mYgs240wkG___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.633Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Toys",
+      "updatedAt": "2017-06-27T09:35:36.633Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c1MgbdJNTsMWKI0W68oYqkU",
+      "createdAt": "2017-06-27T09:35:36.182Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 500,
+            "width": 500,
+          },
+          "size": 44089,
+        },
+        "fileName": "9ef190c59f0d375c0dea58b58a4bc1f0.jpeg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg",
+      },
+      "id": "rocybtov1ozk___c1MgbdJNTsMWKI0W68oYqkU___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.182Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Chive logo",
+      "updatedAt": "2017-06-27T09:35:36.182Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c1MgbdJNTsMWKI0W68oYqkU",
+      "createdAt": "2017-06-27T09:35:36.182Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 500,
+            "width": 500,
+          },
+          "size": 44089,
+        },
+        "fileName": "9ef190c59f0d375c0dea58b58a4bc1f0.jpeg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg",
+      },
+      "id": "rocybtov1ozk___c1MgbdJNTsMWKI0W68oYqkU___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.182Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Chive logo",
+      "updatedAt": "2017-06-27T09:35:36.182Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6m5AJ9vMPKc8OUoQeoCS4o",
+      "createdAt": "2017-06-27T09:35:36.172Z",
+      "description": "category icon",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 256,
+            "width": 256,
+          },
+          "size": 2977,
+        },
+        "fileName": "1418244847_Streamline-18-256.png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6m5AJ9vMPKc8OUoQeoCS4o/e782e3b291ff2b0287546a563af4683c/1418244847_Streamline-18-256.png",
+      },
+      "id": "rocybtov1ozk___c6m5AJ9vMPKc8OUoQeoCS4o___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.172Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Home and Kitchen",
+      "updatedAt": "2017-06-27T09:35:36.172Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6m5AJ9vMPKc8OUoQeoCS4o",
+      "createdAt": "2017-06-27T09:35:36.172Z",
+      "description": "category icon",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 256,
+            "width": 256,
+          },
+          "size": 2977,
+        },
+        "fileName": "1418244847_Streamline-18-256.png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6m5AJ9vMPKc8OUoQeoCS4o/e782e3b291ff2b0287546a563af4683c/1418244847_Streamline-18-256.png",
+      },
+      "id": "rocybtov1ozk___c6m5AJ9vMPKc8OUoQeoCS4o___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.172Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Home and Kitchen",
+      "updatedAt": "2017-06-27T09:35:36.172Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c4zj1ZOfHgQ8oqgaSKm4Qo2",
+      "createdAt": "2017-06-27T09:35:36.168Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 100,
+            "width": 100,
+          },
+          "size": 7003,
+        },
+        "fileName": "playsam.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/4zj1ZOfHgQ8oqgaSKm4Qo2/5d967c9c48d67eabff71a9a0232d4378/playsam.jpg",
+      },
+      "id": "rocybtov1ozk___c4zj1ZOfHgQ8oqgaSKm4Qo2___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.168Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Playsam",
+      "updatedAt": "2017-06-27T09:35:36.168Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c4zj1ZOfHgQ8oqgaSKm4Qo2",
+      "createdAt": "2017-06-27T09:35:36.168Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 100,
+            "width": 100,
+          },
+          "size": 7003,
+        },
+        "fileName": "playsam.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/4zj1ZOfHgQ8oqgaSKm4Qo2/5d967c9c48d67eabff71a9a0232d4378/playsam.jpg",
+      },
+      "id": "rocybtov1ozk___c4zj1ZOfHgQ8oqgaSKm4Qo2___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.168Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Playsam",
+      "updatedAt": "2017-06-27T09:35:36.168Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "wtrHxeu3zEoEce2MokCSi",
+      "createdAt": "2017-06-27T09:35:36.037Z",
+      "description": "Merchandise photo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 446,
+            "width": 600,
+          },
+          "size": 27187,
+        },
+        "fileName": "quwowooybuqbl6ntboz3.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg",
+      },
+      "id": "rocybtov1ozk___wtrHxeu3zEoEce2MokCSi___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.037Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Playsam Streamliner",
+      "updatedAt": "2017-06-27T09:35:36.037Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "wtrHxeu3zEoEce2MokCSi",
+      "createdAt": "2017-06-27T09:35:36.037Z",
+      "description": "Merchandise photo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 446,
+            "width": 600,
+          },
+          "size": 27187,
+        },
+        "fileName": "quwowooybuqbl6ntboz3.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg",
+      },
+      "id": "rocybtov1ozk___wtrHxeu3zEoEce2MokCSi___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.037Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Playsam Streamliner",
+      "updatedAt": "2017-06-27T09:35:36.037Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c10TkaLheGeQG6qQGqWYqUI",
+      "createdAt": "2017-06-27T09:35:36.032Z",
+      "description": "Merchandise photo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 600,
+            "width": 450,
+          },
+          "size": 28435,
+        },
+        "fileName": "ryugj83mqwa1asojwtwb.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg",
+      },
+      "id": "rocybtov1ozk___c10TkaLheGeQG6qQGqWYqUI___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.032Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Whisk beaters",
+      "updatedAt": "2017-06-27T09:35:36.032Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c10TkaLheGeQG6qQGqWYqUI",
+      "createdAt": "2017-06-27T09:35:36.032Z",
+      "description": "Merchandise photo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 600,
+            "width": 450,
+          },
+          "size": 28435,
+        },
+        "fileName": "ryugj83mqwa1asojwtwb.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg",
+      },
+      "id": "rocybtov1ozk___c10TkaLheGeQG6qQGqWYqUI___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.032Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Whisk beaters",
+      "updatedAt": "2017-06-27T09:35:36.032Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6s3iG2OVmoUcosmA8ocqsG",
+      "createdAt": "2017-06-27T09:35:35.994Z",
+      "description": "Category icon set",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 250,
+            "width": 250,
+          },
+          "size": 4244,
+        },
+        "fileName": "1418244847_Streamline-18-256 (1).png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6s3iG2OVmoUcosmA8ocqsG/286ac4c1be74e05d2e7e11bc5a55bc83/1418244847_Streamline-18-256__1_.png",
+      },
+      "id": "rocybtov1ozk___c6s3iG2OVmoUcosmA8ocqsG___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:35.994Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "House icon",
+      "updatedAt": "2017-06-27T09:35:35.994Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6s3iG2OVmoUcosmA8ocqsG",
+      "createdAt": "2017-06-27T09:35:35.994Z",
+      "description": "Category icon set",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 250,
+            "width": 250,
+          },
+          "size": 4244,
+        },
+        "fileName": "1418244847_Streamline-18-256 (1).png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6s3iG2OVmoUcosmA8ocqsG/286ac4c1be74e05d2e7e11bc5a55bc83/1418244847_Streamline-18-256__1_.png",
+      },
+      "id": "rocybtov1ozk___c6s3iG2OVmoUcosmA8ocqsG___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:35.994Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "House icon",
+      "updatedAt": "2017-06-27T09:35:35.994Z",
+    },
+  ],
+]
+`;
+
+exports[`Process existing mutated nodes in warm build creates nodes for each entry 1`] = `
+Array [
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "title",
+      "id": "Category",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:40:52.685Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Category",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription___NODE": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___EntrycategoryDescriptionTextNode",
+      "children": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___EntrytitleTextNode",
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___EntrycategoryDescriptionTextNode",
+      ],
+      "contentful_id": "c7LAnCobuuWYSqks6wAwY2a",
+      "createdAt": "2017-06-27T09:35:44.000Z",
+      "icon___NODE": "rocybtov1ozk___c6m5AJ9vMPKc8OUoQeoCS4o___Asset",
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      "internal": Object {
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "type": "ContentfulCategory",
+      },
+      "node_locale": "en-US",
+      "parent": "Category",
+      "product___NODE": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "6XwpTaSiiI2Ak2Ww0oi6qa",
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 4,
+        "type": "Entry",
+      },
+      "title___NODE": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___EntrytitleTextNode",
+      "updatedAt": "2020-06-30T11:22:54.201Z",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription___NODE": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrycategoryDescriptionTextNode",
+      "children": Array [
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrytitleTextNode",
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrycategoryDescriptionTextNode",
+      ],
+      "contentful_id": "c24DPGBDeGEaYy8ms4Y8QMQ",
+      "createdAt": "2017-06-27T09:35:44.992Z",
+      "icon___NODE": "rocybtov1ozk___c6t4HKjytPi0mYgs240wkG___Asset",
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "type": "ContentfulCategory",
+      },
+      "node_locale": "en-US",
+      "parent": "Category",
+      "product___NODE": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "6XwpTaSiiI2Ak2Ww0oi6qa",
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "title___NODE": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrytitleTextNode",
+      "updatedAt": "2017-06-27T09:46:43.477Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___EntrytitleTextNode",
+      "internal": Object {
+        "content": "Home & Kitchen",
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryTitleTextNode",
+      },
+      "parent": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+      "title": "Home & Kitchen",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription": "Shop for furniture, bedding, bath, vacuums, kitchen products, and more",
+      "children": Array [],
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___EntrycategoryDescriptionTextNode",
+      "internal": Object {
+        "content": "Shop for furniture, bedding, bath, vacuums, kitchen products, and more",
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryCategoryDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrytitleTextNode",
+      "internal": Object {
+        "content": "Toys",
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryTitleTextNode",
+      },
+      "parent": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+      "title": "Toys",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription": "Shop for toys, games, educational aids",
+      "children": Array [],
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrycategoryDescriptionTextNode",
+      "internal": Object {
+        "content": "Shop for toys, games, educational aids",
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryCategoryDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "title",
+      "id": "Category",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:40:52.685Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Category",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription___NODE": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___decategoryDescriptionTextNode",
+      "children": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___detitleTextNode",
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___decategoryDescriptionTextNode",
+      ],
+      "contentful_id": "c7LAnCobuuWYSqks6wAwY2a",
+      "createdAt": "2017-06-27T09:35:44.000Z",
+      "icon___NODE": "rocybtov1ozk___c6m5AJ9vMPKc8OUoQeoCS4o___Asset___de",
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      "internal": Object {
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "type": "ContentfulCategory",
+      },
+      "node_locale": "de",
+      "parent": "Category",
+      "product___NODE": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "6XwpTaSiiI2Ak2Ww0oi6qa",
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 4,
+        "type": "Entry",
+      },
+      "title___NODE": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___detitleTextNode",
+      "updatedAt": "2020-06-30T11:22:54.201Z",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription___NODE": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___decategoryDescriptionTextNode",
+      "children": Array [
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___detitleTextNode",
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___decategoryDescriptionTextNode",
+      ],
+      "contentful_id": "c24DPGBDeGEaYy8ms4Y8QMQ",
+      "createdAt": "2017-06-27T09:35:44.992Z",
+      "icon___NODE": "rocybtov1ozk___c6t4HKjytPi0mYgs240wkG___Asset___de",
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "type": "ContentfulCategory",
+      },
+      "node_locale": "de",
+      "parent": "Category",
+      "product___NODE": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "6XwpTaSiiI2Ak2Ww0oi6qa",
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "title___NODE": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___detitleTextNode",
+      "updatedAt": "2017-06-27T09:46:43.477Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___detitleTextNode",
+      "internal": Object {
+        "content": "Haus & Küche",
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryTitleTextNode",
+      },
+      "parent": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+      "title": "Haus & Küche",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription": "Shop für Möbel, Bettwäsche, Bad, Staubsauger, Küchenprodukte und vieles mehr",
+      "children": Array [],
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___decategoryDescriptionTextNode",
+      "internal": Object {
+        "content": "Shop für Möbel, Bettwäsche, Bad, Staubsauger, Küchenprodukte und vieles mehr",
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryCategoryDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___detitleTextNode",
+      "internal": Object {
+        "content": "Spielzeug",
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryTitleTextNode",
+      },
+      "parent": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+      "title": "Spielzeug",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription": "Spielzeugladen, Spiele, Lernhilfen",
+      "children": Array [],
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___decategoryDescriptionTextNode",
+      "internal": Object {
+        "content": "Spielzeugladen, Spiele, Lernhilfen",
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryCategoryDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "companyName",
+      "id": "Brand",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:41:09.339Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Brand",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyNameTextNode",
+        "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyNameTextNode",
+      "contentful_id": "c651CQ8rLoIYCeY6G0QG22q",
+      "createdAt": "2017-06-27T09:35:43.997Z",
+      "email": "normann@normann-copenhagen.com",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c3wtvPBbBjiMKqKKga8I2Cu___Asset",
+      "node_locale": "en-US",
+      "parent": "Brand",
+      "phone": Array [
+        "+45 35 55 44 59",
+      ],
+      "product___NODE": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "twitter": "https://twitter.com/NormannCPH",
+      "updatedAt": "2017-06-27T09:55:16.820Z",
+      "website": "http://www.normann-copenhagen.com/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyNameTextNode",
+        "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyNameTextNode",
+      "contentful_id": "c4LgMotpNF6W20YKmuemW0a",
+      "createdAt": "2017-06-27T09:35:44.396Z",
+      "email": "info@acgears.com",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c2Y8LhXLnYAYqKCGEWG4EKI___Asset",
+      "node_locale": "en-US",
+      "parent": "Brand",
+      "phone": Array [
+        "+1 212 260 2269",
+      ],
+      "product___NODE": Array [
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "updatedAt": "2017-06-27T09:51:15.647Z",
+      "website": "http://www.lemnos.jp/en/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyNameTextNode",
+        "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyNameTextNode",
+      "contentful_id": "JrePkDVYomE8AwcuCUyMi",
+      "createdAt": "2017-06-27T09:35:44.988Z",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c4zj1ZOfHgQ8oqgaSKm4Qo2___Asset",
+      "node_locale": "en-US",
+      "parent": "Brand",
+      "product___NODE": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "updatedAt": "2017-06-27T09:50:36.937Z",
+      "website": "http://playsam.com/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Normann Copenhagen",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyNameTextNode",
+      "internal": Object {
+        "content": "Normann Copenhagen",
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "Normann Copenhagen is a way of living - a mindset. We love to challenge the conventional design rules. This is why you will find traditional materials put into untraditional use such as a Stone Hook made of Icelandic stones, a vase made out of silicon and last but not least a dog made out of plastic.",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "Normann Copenhagen is a way of living - a mindset. We love to challenge the conventional design rules. This is why you will find traditional materials put into untraditional use such as a Stone Hook made of Icelandic stones, a vase made out of silicon and last but not least a dog made out of plastic.",
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Lemnos",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyNameTextNode",
+      "internal": Object {
+        "content": "Lemnos",
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "TAKATA Lemnos Inc. was founded in 1947 as a brass casting manufacturing industry in Takaoka-city, Toyama Prefecture, Japan and we launched out into the full-scale business trade with Seiko Clock Co., Ltd. since 1966.
+
+We entered into the development for the original planning from late 1980 and \\"Lemnos Brand\\" recognized as the global design clock by a masterpiece \\"HOLA\\" designed by Kazuo KAWASAKI which released in 1989.
+
+Afterwards, we made a lot of projects with well-known designers who took in active in Japan and overseas such as Riki WATANABE, Kazuo KAWASAKI, Shin AZUMI, Tomoko AZUMI, Kanae TSUKAMOTO etc. and we made announcement of their fine works abounding in artistry and prominent designs. In addition, we realized to make a special project by the collaboration with Andrea Branzi, a well-known architect in the world.
+
+Lemnos brand products are now highly praised from the design shops and the interior shops all over the world.
+
+In recent years, we also have been given high priority to develop interior accessories making full use of our traditional techniques by the founding manufacturer and we always focus our minds on the development for the new Lemnos products in the new market.
+
+Our Lemnos products are made carefully by our craftsmen finely honed skillful techniques in Japan. They surely bring out the attractiveness of the materials to the maximum and create fine products not being influenced on the fashion trend accordingly. TAKATA Lemnos Inc. definitely would like to be innovative and continuously propose the beauty lasts forever.",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "TAKATA Lemnos Inc. was founded in 1947 as a brass casting manufacturing industry in Takaoka-city, Toyama Prefecture, Japan and we launched out into the full-scale business trade with Seiko Clock Co., Ltd. since 1966.
+
+We entered into the development for the original planning from late 1980 and \\"Lemnos Brand\\" recognized as the global design clock by a masterpiece \\"HOLA\\" designed by Kazuo KAWASAKI which released in 1989.
+
+Afterwards, we made a lot of projects with well-known designers who took in active in Japan and overseas such as Riki WATANABE, Kazuo KAWASAKI, Shin AZUMI, Tomoko AZUMI, Kanae TSUKAMOTO etc. and we made announcement of their fine works abounding in artistry and prominent designs. In addition, we realized to make a special project by the collaboration with Andrea Branzi, a well-known architect in the world.
+
+Lemnos brand products are now highly praised from the design shops and the interior shops all over the world.
+
+In recent years, we also have been given high priority to develop interior accessories making full use of our traditional techniques by the founding manufacturer and we always focus our minds on the development for the new Lemnos products in the new market.
+
+Our Lemnos products are made carefully by our craftsmen finely honed skillful techniques in Japan. They surely bring out the attractiveness of the materials to the maximum and create fine products not being influenced on the fashion trend accordingly. TAKATA Lemnos Inc. definitely would like to be innovative and continuously propose the beauty lasts forever.",
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Playsam",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyNameTextNode",
+      "internal": Object {
+        "content": "Playsam",
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "Playsam is the leading Scandinavian design company for executive wooden toy gift. Scandinavian design playful creativity, integrity and sophistication are Playsam. Scandinavian design and wooden toy makes Playsam gift lovely to the world of design since 1984.",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "Playsam is the leading Scandinavian design company for executive wooden toy gift. Scandinavian design playful creativity, integrity and sophistication are Playsam. Scandinavian design and wooden toy makes Playsam gift lovely to the world of design since 1984.",
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "companyName",
+      "id": "Brand",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:41:09.339Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Brand",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyNameTextNode",
+        "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyNameTextNode",
+      "contentful_id": "c651CQ8rLoIYCeY6G0QG22q",
+      "createdAt": "2017-06-27T09:35:43.997Z",
+      "email": "normann@normann-copenhagen.com",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c3wtvPBbBjiMKqKKga8I2Cu___Asset___de",
+      "node_locale": "de",
+      "parent": "Brand",
+      "phone": Array [
+        "+45 35 55 44 59",
+      ],
+      "product___NODE": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "twitter": "https://twitter.com/NormannCPH",
+      "updatedAt": "2017-06-27T09:55:16.820Z",
+      "website": "http://www.normann-copenhagen.com/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyNameTextNode",
+        "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyNameTextNode",
+      "contentful_id": "c4LgMotpNF6W20YKmuemW0a",
+      "createdAt": "2017-06-27T09:35:44.396Z",
+      "email": "info@acgears.com",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c2Y8LhXLnYAYqKCGEWG4EKI___Asset___de",
+      "node_locale": "de",
+      "parent": "Brand",
+      "phone": Array [
+        "+1 212 260 2269",
+      ],
+      "product___NODE": Array [
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "updatedAt": "2017-06-27T09:51:15.647Z",
+      "website": "http://www.lemnos.jp/en/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyNameTextNode",
+        "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyNameTextNode",
+      "contentful_id": "JrePkDVYomE8AwcuCUyMi",
+      "createdAt": "2017-06-27T09:35:44.988Z",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c4zj1ZOfHgQ8oqgaSKm4Qo2___Asset___de",
+      "node_locale": "de",
+      "parent": "Brand",
+      "product___NODE": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "updatedAt": "2017-06-27T09:50:36.937Z",
+      "website": "http://playsam.com/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Normann Copenhagen",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyNameTextNode",
+      "internal": Object {
+        "content": "Normann Copenhagen",
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "Normann Kopenhagen ist eine Art zu leben - eine Denkweise. Wir lieben es, die konventionellen Designregeln herauszufordern. Aus diesem Grund finden Sie traditionelle Materialien, die in untraditionelle Verwendung wie ein Steinhaken aus isländischen Steinen, eine Vase aus Silizium und last but not least ein Hund aus Kunststoff.",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "Normann Kopenhagen ist eine Art zu leben - eine Denkweise. Wir lieben es, die konventionellen Designregeln herauszufordern. Aus diesem Grund finden Sie traditionelle Materialien, die in untraditionelle Verwendung wie ein Steinhaken aus isländischen Steinen, eine Vase aus Silizium und last but not least ein Hund aus Kunststoff.",
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Lemnos",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyNameTextNode",
+      "internal": Object {
+        "content": "Lemnos",
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "TAKATA Lemnos Inc. wurde im Jahre 1947 als Messing-Casting-Fertigungsindustrie in Takaoka-Stadt, Toyama Prefecture, Japan gegründet und wir starteten seit 1966 mit der Seiko Clock Co., Ltd.
+
+Wir haben die Entwicklung für die ursprüngliche Planung ab Ende 1980 eingegangen und \\"Lemnos Brand\\" wurde als globale Designuhr von einem Meisterwerk \\"HOLA\\" von Kazuo KAWASAKI entworfen, das 1989 erschien.
+
+Danach machten wir viele Projekte mit namhaften Designern, die in Japan und Übersee tätig waren, wie zB Riki WATANABE, Kazuo KAWASAKI, Shin AZUMI, Tomoko AZUMI, Kanae TSUKAMOTO etc. und wir kündigten ihre Werke in der Kunst an Und prominenten Designs. Darüber hinaus haben wir durch die Zusammenarbeit mit Andrea Branzi, einem bekannten Architekten der Welt, ein besonderes Projekt gemacht.
+
+Lemnos Markenprodukte werden nun von den Designläden und den Innenhandelsgeschäften auf der ganzen Welt hoch gelobt.
+
+In den vergangenen Jahren haben wir auch eine hohe Priorität für die Entwicklung von Innenausstattung, die den traditionellen Techniken des Gründungsherstellers voll ausnutzt, und wir konzentrieren uns immer auf die Entwicklung der neuen Lemnos-Produkte im neuen Markt.
+
+Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliffen geschickten Techniken in Japan gemacht. Sie bringen sicherlich die Attraktivität der Materialien auf das Maximum und schaffen feine Produkte nicht beeinflusst auf die Mode-Trend entsprechend. TAKATA Lemnos Inc. möchte definitiv innovativ sein und ständig vorschlagen, die Schönheit dauert ewig.",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "TAKATA Lemnos Inc. wurde im Jahre 1947 als Messing-Casting-Fertigungsindustrie in Takaoka-Stadt, Toyama Prefecture, Japan gegründet und wir starteten seit 1966 mit der Seiko Clock Co., Ltd.
+
+Wir haben die Entwicklung für die ursprüngliche Planung ab Ende 1980 eingegangen und \\"Lemnos Brand\\" wurde als globale Designuhr von einem Meisterwerk \\"HOLA\\" von Kazuo KAWASAKI entworfen, das 1989 erschien.
+
+Danach machten wir viele Projekte mit namhaften Designern, die in Japan und Übersee tätig waren, wie zB Riki WATANABE, Kazuo KAWASAKI, Shin AZUMI, Tomoko AZUMI, Kanae TSUKAMOTO etc. und wir kündigten ihre Werke in der Kunst an Und prominenten Designs. Darüber hinaus haben wir durch die Zusammenarbeit mit Andrea Branzi, einem bekannten Architekten der Welt, ein besonderes Projekt gemacht.
+
+Lemnos Markenprodukte werden nun von den Designläden und den Innenhandelsgeschäften auf der ganzen Welt hoch gelobt.
+
+In den vergangenen Jahren haben wir auch eine hohe Priorität für die Entwicklung von Innenausstattung, die den traditionellen Techniken des Gründungsherstellers voll ausnutzt, und wir konzentrieren uns immer auf die Entwicklung der neuen Lemnos-Produkte im neuen Markt.
+
+Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliffen geschickten Techniken in Japan gemacht. Sie bringen sicherlich die Attraktivität der Materialien auf das Maximum und schaffen feine Produkte nicht beeinflusst auf die Mode-Trend entsprechend. TAKATA Lemnos Inc. möchte definitiv innovativ sein und ständig vorschlagen, die Schönheit dauert ewig.",
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Playsam",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyNameTextNode",
+      "internal": Object {
+        "content": "Playsam",
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "Playsam ist die führende skandinavische Designfirma für Executive Holzspielzeug Geschenk. Skandinavisches Design spielerische Kreativität, Integrität und Raffinesse sind Playsam. Skandinavisches Design und hölzernes Spielzeug macht Playsam Geschenk schön in die Welt des Designs seit 1984.",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "Playsam ist die führende skandinavische Designfirma für Executive Holzspielzeug Geschenk. Skandinavisches Design spielerische Kreativität, Integrität und Raffinesse sind Playsam. Skandinavisches Design und hölzernes Spielzeug macht Playsam Geschenk schön in die Welt des Designs seit 1984.",
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "productName",
+      "id": "Product",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:40:36.821Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Product",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductNameTextNode",
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductDescriptionTextNode",
+      ],
+      "contentful_id": "c5KsDBWseXY6QegucYAoacS",
+      "createdAt": "2017-06-27T09:35:43.996Z",
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      "image___NODE": Array [
+        "rocybtov1ozk___wtrHxeu3zEoEce2MokCSi___Asset",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "en-US",
+      "parent": "Product",
+      "price": 44,
+      "productDescription___NODE": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductNameTextNode",
+      "quantity": 56,
+      "sizetypecolor": "Length: 135 mm | color: espresso, green, or icar (white)",
+      "sku": "B001R6JUZ2",
+      "slug": "playsam-streamliner-classic-car-espresso",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "wood",
+        "toy",
+        "car",
+        "sweden",
+        "design",
+      ],
+      "updatedAt": "2017-06-27T09:56:59.626Z",
+      "website": "http://www.amazon.com/dp/B001R6JUZ2/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductNameTextNode",
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductDescriptionTextNode",
+      ],
+      "contentful_id": "c3DVqIYj4dOwwcKu6sgqOgg",
+      "createdAt": "2017-06-27T09:35:44.006Z",
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+      "image___NODE": Array [
+        "rocybtov1ozk___Xc0ny7GWsMEMCeASWO2um___Asset",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "en-US",
+      "parent": "Product",
+      "price": 11,
+      "productDescription___NODE": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductNameTextNode",
+      "quantity": 101,
+      "sizetypecolor": "3 x 3 x 5 inches; 5.3 ounces",
+      "sku": "B00E82D7I8",
+      "slug": "hudson-wall-cup",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "vase",
+        "flowers",
+        "accessories",
+      ],
+      "updatedAt": "2017-06-27T09:54:51.159Z",
+      "website": "http://www.amazon.com/dp/B00E82D7I8/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductNameTextNode",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductDescriptionTextNode",
+      ],
+      "contentful_id": "c6dbjWqNd9SqccegcqYq224",
+      "createdAt": "2017-06-27T09:35:44.049Z",
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+      "image___NODE": Array [
+        "rocybtov1ozk___c10TkaLheGeQG6qQGqWYqUI___Asset",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "en-US",
+      "parent": "Product",
+      "price": 22,
+      "productDescription___NODE": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductNameTextNode",
+      "quantity": 89,
+      "sizetypecolor": "0.8 x 0.8 x 11.2 inches; 1.6 ounces",
+      "sku": "B0081F2CCK",
+      "slug": "whisk-beater",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "kitchen",
+        "accessories",
+        "whisk",
+        "scandinavia",
+        "design",
+      ],
+      "updatedAt": "2017-06-27T09:53:23.179Z",
+      "website": "http://www.amazon.com/dp/B0081F2CCK/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductNameTextNode",
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductDescriptionTextNode",
+      ],
+      "contentful_id": "c4BqrajvA8E6qwgkieoqmqO",
+      "createdAt": "2017-06-27T09:35:44.130Z",
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      "image___NODE": Array [
+        "rocybtov1ozk___KTRF62Q4gg60q6WCsWKw8___Asset",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "en-US",
+      "parent": "Product",
+      "price": 120,
+      "productDescription___NODE": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductNameTextNode",
+      "quantity": 3,
+      "sizetypecolor": "10\\" x 2.2\\"",
+      "sku": "B00MG4ULK2",
+      "slug": "soso-wall-clock",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "home décor",
+        "clocks",
+        "interior design",
+        "yellow",
+        "gifts",
+      ],
+      "updatedAt": "2017-06-27T09:52:29.215Z",
+      "website": "http://store.dwell.com/soso-wall-clock.html",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductNameTextNode",
+      "internal": Object {
+        "content": "Playsam Streamliner Classic Car, Espresso",
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      "productName": "Playsam Streamliner Classic Car, Espresso",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductDescriptionTextNode",
+      "internal": Object {
+        "content": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!",
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      "productDescription": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductNameTextNode",
+      "internal": Object {
+        "content": "Hudson Wall Cup",
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+      "productName": "Hudson Wall Cup",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Wall Hanging Glass Flower Vase and Terrarium",
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+      "productDescription": "Wall Hanging Glass Flower Vase and Terrarium",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductNameTextNode",
+      "internal": Object {
+        "content": "Whisk Beater",
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+      "productName": "Whisk Beater",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductDescriptionTextNode",
+      "internal": Object {
+        "content": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea.",
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+      "productDescription": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea.",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductNameTextNode",
+      "internal": Object {
+        "content": "SoSo Wall Clock",
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      "productName": "SoSo Wall Clock",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductDescriptionTextNode",
+      "internal": Object {
+        "content": "The newly released SoSo Clock from Lemnos marries simple, clean design and bold, striking features. Its saturated marigold face is a lively pop of color to white or grey walls, but would also pair nicely with navy and maroon. Where most clocks feature numbers at the border of the clock, the SoSo brings them in tight to the middle, leaving a wide space between the numbers and the slight frame. The hour hand provides a nice interruption to the black and yellow of the clock - it is featured in a brilliant white. Despite its bold color and contrast, the SoSo maintains a clean, pure aesthetic that is suitable to a variety of contemporary interiors.",
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      "productDescription": "The newly released SoSo Clock from Lemnos marries simple, clean design and bold, striking features. Its saturated marigold face is a lively pop of color to white or grey walls, but would also pair nicely with navy and maroon. Where most clocks feature numbers at the border of the clock, the SoSo brings them in tight to the middle, leaving a wide space between the numbers and the slight frame. The hour hand provides a nice interruption to the black and yellow of the clock - it is featured in a brilliant white. Despite its bold color and contrast, the SoSo maintains a clean, pure aesthetic that is suitable to a variety of contemporary interiors.",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "productName",
+      "id": "Product",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:40:36.821Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Product",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___de",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___de",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductNameTextNode",
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductDescriptionTextNode",
+      ],
+      "contentful_id": "c5KsDBWseXY6QegucYAoacS",
+      "createdAt": "2017-06-27T09:35:43.996Z",
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      "image___NODE": Array [
+        "rocybtov1ozk___wtrHxeu3zEoEce2MokCSi___Asset___de",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "de",
+      "parent": "Product",
+      "price": 44,
+      "productDescription___NODE": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductNameTextNode",
+      "quantity": 56,
+      "sizetypecolor": "Length: 135 mm | color: espresso, green, or icar (white)",
+      "sku": "B001R6JUZ2",
+      "slug": "playsam-streamliner-classic-car-espresso",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "wood",
+        "toy",
+        "car",
+        "sweden",
+        "design",
+      ],
+      "updatedAt": "2017-06-27T09:56:59.626Z",
+      "website": "http://www.amazon.com/dp/B001R6JUZ2/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductNameTextNode",
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductDescriptionTextNode",
+      ],
+      "contentful_id": "c3DVqIYj4dOwwcKu6sgqOgg",
+      "createdAt": "2017-06-27T09:35:44.006Z",
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+      "image___NODE": Array [
+        "rocybtov1ozk___Xc0ny7GWsMEMCeASWO2um___Asset___de",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "de",
+      "parent": "Product",
+      "price": 11,
+      "productDescription___NODE": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductNameTextNode",
+      "quantity": 101,
+      "sizetypecolor": "3 x 3 x 5 inches; 5.3 ounces",
+      "sku": "B00E82D7I8",
+      "slug": "hudson-wall-cup",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "vase",
+        "flowers",
+        "accessories",
+      ],
+      "updatedAt": "2017-06-27T09:54:51.159Z",
+      "website": "http://www.amazon.com/dp/B00E82D7I8/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductNameTextNode",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductDescriptionTextNode",
+      ],
+      "contentful_id": "c6dbjWqNd9SqccegcqYq224",
+      "createdAt": "2017-06-27T09:35:44.049Z",
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+      "image___NODE": Array [
+        "rocybtov1ozk___c10TkaLheGeQG6qQGqWYqUI___Asset___de",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "de",
+      "parent": "Product",
+      "price": 22,
+      "productDescription___NODE": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductNameTextNode",
+      "quantity": 89,
+      "sizetypecolor": "0.8 x 0.8 x 11.2 inches; 1.6 ounces",
+      "sku": "B0081F2CCK",
+      "slug": "whisk-beater",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "kitchen",
+        "accessories",
+        "whisk",
+        "scandinavia",
+        "design",
+      ],
+      "updatedAt": "2017-06-27T09:53:23.179Z",
+      "website": "http://www.amazon.com/dp/B0081F2CCK/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___de",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductNameTextNode",
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductDescriptionTextNode",
+      ],
+      "contentful_id": "c4BqrajvA8E6qwgkieoqmqO",
+      "createdAt": "2017-06-27T09:35:44.130Z",
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      "image___NODE": Array [
+        "rocybtov1ozk___KTRF62Q4gg60q6WCsWKw8___Asset___de",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "de",
+      "parent": "Product",
+      "price": 120,
+      "productDescription___NODE": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductNameTextNode",
+      "quantity": 3,
+      "sizetypecolor": "10\\" x 2.2\\"",
+      "sku": "B00MG4ULK2",
+      "slug": "soso-wall-clock",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "home décor",
+        "clocks",
+        "interior design",
+        "yellow",
+        "gifts",
+      ],
+      "updatedAt": "2017-06-27T09:52:29.215Z",
+      "website": "http://store.dwell.com/soso-wall-clock.html",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductNameTextNode",
+      "internal": Object {
+        "content": "Playsam Streamliner Klassisches Auto, Espresso",
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      "productName": "Playsam Streamliner Klassisches Auto, Espresso",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Ein klassisches Playsam-Design, das Streamliner Classic Car wurde als Swedish Design Classic vom Schwedischen Nationalmuseum für seinen erfinderischen Stil und seine schlanke Oberfläche ausgewählt. Es ist kein Wunder, dass dieses hölzerne Auto auch ein langjähriger Liebling für Kinder gewesen ist, die groß und klein sind!",
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      "productDescription": "Ein klassisches Playsam-Design, das Streamliner Classic Car wurde als Swedish Design Classic vom Schwedischen Nationalmuseum für seinen erfinderischen Stil und seine schlanke Oberfläche ausgewählt. Es ist kein Wunder, dass dieses hölzerne Auto auch ein langjähriger Liebling für Kinder gewesen ist, die groß und klein sind!",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductNameTextNode",
+      "internal": Object {
+        "content": "Becher",
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+      "productName": "Becher",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Wand-hängende Glas-Blumen-Vase und Terrarium",
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+      "productDescription": "Wand-hängende Glas-Blumen-Vase und Terrarium",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductNameTextNode",
+      "internal": Object {
+        "content": "Schneebesen",
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+      "productName": "Schneebesen",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Ein kreativer kleiner Schneebesen, der in 8 verschiedenen Farben kommt. Praktisch und nach dem Gebrauch leicht zu reinigen. Eine tolle Geschenkidee.",
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+      "productDescription": "Ein kreativer kleiner Schneebesen, der in 8 verschiedenen Farben kommt. Praktisch und nach dem Gebrauch leicht zu reinigen. Eine tolle Geschenkidee.",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductNameTextNode",
+      "internal": Object {
+        "content": "SoSo wanduhr",
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      "productName": "SoSo wanduhr",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Die neu veröffentlichte SoSo Clock von Lemnos heiratet einfaches, sauberes Design und fette, auffällige Features. Sein gesättigtes Ringelblumengesicht ist ein lebhafter Pop der Farbe zu den weißen oder grauen Wänden, aber würde auch gut mit Marine und kastanienbraun paaren. Wo die meisten Uhren am Rande der Uhr Nummern sind, bringt der SoSo sie in die Mitte und lässt einen weiten Raum zwischen den Zahlen und dem leichten Rahmen. Der Stundenzeiger bietet eine schöne Unterbrechung der schwarzen und gelben der Uhr - es ist in einem brillanten Weiß vorgestellt. Trotz seiner kräftigen Farbe und des Kontrastes behält der SoSo eine saubere, reine Ästhetik, die für eine Vielzahl von zeitgenössischen Interieurs geeignet ist.",
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      "productDescription": "Die neu veröffentlichte SoSo Clock von Lemnos heiratet einfaches, sauberes Design und fette, auffällige Features. Sein gesättigtes Ringelblumengesicht ist ein lebhafter Pop der Farbe zu den weißen oder grauen Wänden, aber würde auch gut mit Marine und kastanienbraun paaren. Wo die meisten Uhren am Rande der Uhr Nummern sind, bringt der SoSo sie in die Mitte und lässt einen weiten Raum zwischen den Zahlen und dem leichten Rahmen. Der Stundenzeiger bietet eine schöne Unterbrechung der schwarzen und gelben der Uhr - es ist in einem brillanten Weiß vorgestellt. Trotz seiner kräftigen Farbe und des Kontrastes behält der SoSo eine saubere, reine Ästhetik, die für eine Vielzahl von zeitgenössischen Interieurs geeignet ist.",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": "just for testing JSON fields",
+      "displayField": null,
+      "id": "JSON-test",
+      "internal": Object {
+        "contentDigest": "2018-08-13T14:21:13.985Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "JSON-test",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonTestJSONNode",
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonStringTest0JSONNode",
+      ],
+      "contentful_id": "c71mfnH4QKsSsQmgoaQuq6O",
+      "createdAt": "2017-11-28T02:16:10.604Z",
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry",
+      "internal": Object {
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "type": "ContentfulJsonTest",
+      },
+      "jsonStringTest___NODE": Array [
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonStringTest0JSONNode",
+      ],
+      "jsonTest___NODE": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonTestJSONNode",
+      "node_locale": "en-US",
+      "parent": "JSON-test",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "jsonTest",
+            "id": "jsonTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 4,
+        "type": "Entry",
+      },
+      "updatedAt": "2018-08-13T14:27:12.458Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "devDependencies": Object {
+        "babel-cli": "^6.26.0",
+        "babel-eslint": "^7.2.3",
+        "babel-jest": "^20.0.3",
+        "babel-plugin-add-module-exports": "^0.2.1",
+        "babel-plugin-lodash": "^3.2.11",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-flow-strip-types": "^6.22.0",
+        "babel-plugin-transform-runtime": "^6.23.0",
+        "babel-preset-env": "^1.6.0",
+        "babel-preset-flow": "^6.23.0",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-stage-0": "^6.24.1",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.7.0",
+        "cross-env": "^5.0.5",
+        "eslint": "^4.5.0",
+        "eslint-config-google": "^0.9.1",
+        "eslint-config-prettier": "^2.5.0",
+        "eslint-plugin-flow-vars": "^0.5.0",
+        "eslint-plugin-flowtype": "^2.35.0",
+        "eslint-plugin-import": "^2.7.0",
+        "eslint-plugin-jsx-a11y": "^6.0.2",
+        "eslint-plugin-prettier": "^2.2.0",
+        "eslint-plugin-react": "^7.3.0",
+        "flow-bin": "^0.42.0",
+        "glob": "^7.1.1",
+        "jest": "^20.0.4",
+        "jest-cli": "^20.0.4",
+        "lerna": "^2.1.1",
+        "plop": "^1.8.1",
+        "prettier": "^1.7.0",
+        "prettier-eslint-cli": "4.2.x",
+        "remotedev-server": "^0.2.3",
+        "rimraf": "^2.6.1",
+      },
+      "engines": Object {
+        "yarn": "^1.2.1",
+      },
+      "eslintIgnore": Array [
+        "interfaces",
+        "**/__tests__/fixtures/",
+      ],
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonTestJSONNode",
+      "internal": Object {
+        "content": "{\\"engines\\":{\\"yarn\\":\\"^1.2.1\\"},\\"private\\":true,\\"scripts\\":{\\"jest\\":\\"jest\\",\\"lint\\":\\"eslint --ext .js,.jsx packages/**/src\\",\\"plop\\":\\"plop\\",\\"test\\":\\"yarn lint && yarn jest\\",\\"lerna\\":\\"lerna\\",\\"watch\\":\\"lerna run watch --no-sort --stream --concurrency 999\\",\\"format\\":\\"npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts\\",\\"publish\\":\\"lerna publish\\",\\"bootstrap\\":\\"yarn && npm run check-versions && lerna run prepublish\\",\\"lint:flow\\":\\"babel-node scripts/flow-check.js\\",\\"remotedev\\":\\"remotedev --hostname=localhost --port=19999\\",\\"test_bkup\\":\\"npm run lint && npm run test-node && npm run test-integration\\",\\"format-www\\":\\"prettier-eslint --write /\\"www/*.js/\\" /\\"www/src/**/*.js/\\"\\",\\"test:watch\\":\\"jest --watch\\",\\"test:update\\":\\"jest --updateSnapshot\\",\\"publish-next\\":\\"lerna publish --npm-tag=next\\",\\"check-versions\\":\\"babel-node scripts/check-versions.js\\",\\"format-scripts\\":\\"prettier-eslint --write /\\"scripts/**/*.js/\\"\\",\\"publish-canary\\":\\"lerna publish --canary --yes\\",\\"format-examples\\":\\"prettier-eslint --write /\\"examples/**/gatsby-node.js/\\" /\\"examples/**/gatsby-config.js/\\" /\\"examples/**/src/**/*.js/\\"\\",\\"format-packages\\":\\"prettier-eslint --write /\\"packages/*/src/**/*.js/\\"\\",\\"format-cache-dir\\":\\"prettier-eslint --write /\\"packages/gatsby/cache-dir/*.js/\\"\\"},\\"workspaces\\":[\\"packages/*\\"],\\"eslintIgnore\\":[\\"interfaces\\",\\"**/__tests__/fixtures/\\"],\\"devDependencies\\":{\\"glob\\":\\"^7.1.1\\",\\"jest\\":\\"^20.0.4\\",\\"plop\\":\\"^1.8.1\\",\\"lerna\\":\\"^2.1.1\\",\\"eslint\\":\\"^4.5.0\\",\\"rimraf\\":\\"^2.6.1\\",\\"chokidar\\":\\"^1.7.0\\",\\"flow-bin\\":\\"^0.42.0\\",\\"jest-cli\\":\\"^20.0.4\\",\\"prettier\\":\\"^1.7.0\\",\\"babel-cli\\":\\"^6.26.0\\",\\"cross-env\\":\\"^5.0.5\\",\\"babel-jest\\":\\"^20.0.3\\",\\"babel-eslint\\":\\"^7.2.3\\",\\"babel-runtime\\":\\"^6.26.0\\",\\"babel-register\\":\\"^6.26.0\\",\\"babel-preset-env\\":\\"^1.6.0\\",\\"remotedev-server\\":\\"^0.2.3\\",\\"babel-preset-flow\\":\\"^6.23.0\\",\\"babel-preset-react\\":\\"^6.24.1\\",\\"babel-plugin-lodash\\":\\"^3.2.11\\",\\"eslint-plugin-react\\":\\"^7.3.0\\",\\"prettier-eslint-cli\\":\\"4.2.x\\",\\"babel-preset-stage-0\\":\\"^6.24.1\\",\\"eslint-config-google\\":\\"^0.9.1\\",\\"eslint-plugin-import\\":\\"^2.7.0\\",\\"eslint-config-prettier\\":\\"^2.5.0\\",\\"eslint-plugin-flowtype\\":\\"^2.35.0\\",\\"eslint-plugin-jsx-a11y\\":\\"^6.0.2\\",\\"eslint-plugin-prettier\\":\\"^2.2.0\\",\\"eslint-plugin-flow-vars\\":\\"^0.5.0\\",\\"babel-plugin-transform-runtime\\":\\"^6.23.0\\",\\"babel-plugin-add-module-exports\\":\\"^0.2.1\\",\\"babel-plugin-transform-flow-strip-types\\":\\"^6.22.0\\",\\"babel-plugin-transform-async-to-generator\\":\\"^6.24.1\\"}}",
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "mediaType": "application/json",
+        "type": "contentfulJsonTestJsonTestJsonNode",
+      },
+      "parent": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry",
+      "private": true,
+      "scripts": Object {
+        "bootstrap": "yarn && npm run check-versions && lerna run prepublish",
+        "check-versions": "babel-node scripts/check-versions.js",
+        "format": "npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts",
+        "format-cache-dir": "prettier-eslint --write \\"packages/gatsby/cache-dir/*.js\\"",
+        "format-examples": "prettier-eslint --write \\"examples/**/gatsby-node.js\\" \\"examples/**/gatsby-config.js\\" \\"examples/**/src/**/*.js\\"",
+        "format-packages": "prettier-eslint --write \\"packages/*/src/**/*.js\\"",
+        "format-scripts": "prettier-eslint --write \\"scripts/**/*.js\\"",
+        "format-www": "prettier-eslint --write \\"www/*.js\\" \\"www/src/**/*.js\\"",
+        "jest": "jest",
+        "lerna": "lerna",
+        "lint": "eslint --ext .js,.jsx packages/**/src",
+        "lint:flow": "babel-node scripts/flow-check.js",
+        "plop": "plop",
+        "publish": "lerna publish",
+        "publish-canary": "lerna publish --canary --yes",
+        "publish-next": "lerna publish --npm-tag=next",
+        "remotedev": "remotedev --hostname=localhost --port=19999",
+        "test": "yarn lint && yarn jest",
+        "test:update": "jest --updateSnapshot",
+        "test:watch": "jest --watch",
+        "test_bkup": "npm run lint && npm run test-node && npm run test-integration",
+        "watch": "lerna run watch --no-sort --stream --concurrency 999",
+      },
+      "sys": Object {
+        "type": "Entry",
+      },
+      "workspaces": Array [
+        "packages/*",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "content": "test",
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonStringTest0JSONNode",
+      "internal": Object {
+        "content": "\\"test\\"",
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "mediaType": "application/json",
+        "type": "contentfulJsonTestJsonStringTestJsonNode",
+      },
+      "parent": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": "just for testing JSON fields",
+      "displayField": null,
+      "id": "JSON-test",
+      "internal": Object {
+        "contentDigest": "2018-08-13T14:21:13.985Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "JSON-test",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonTestJSONNode",
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonStringTest0JSONNode",
+      ],
+      "contentful_id": "c71mfnH4QKsSsQmgoaQuq6O",
+      "createdAt": "2017-11-28T02:16:10.604Z",
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___de",
+      "internal": Object {
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "type": "ContentfulJsonTest",
+      },
+      "jsonStringTest___NODE": Array [
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonStringTest0JSONNode",
+      ],
+      "jsonTest___NODE": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonTestJSONNode",
+      "node_locale": "de",
+      "parent": "JSON-test",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "jsonTest",
+            "id": "jsonTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 4,
+        "type": "Entry",
+      },
+      "updatedAt": "2018-08-13T14:27:12.458Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "devDependencies": Object {
+        "babel-cli": "^6.26.0",
+        "babel-eslint": "^7.2.3",
+        "babel-jest": "^20.0.3",
+        "babel-plugin-add-module-exports": "^0.2.1",
+        "babel-plugin-lodash": "^3.2.11",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-flow-strip-types": "^6.22.0",
+        "babel-plugin-transform-runtime": "^6.23.0",
+        "babel-preset-env": "^1.6.0",
+        "babel-preset-flow": "^6.23.0",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-stage-0": "^6.24.1",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.7.0",
+        "cross-env": "^5.0.5",
+        "eslint": "^4.5.0",
+        "eslint-config-google": "^0.9.1",
+        "eslint-config-prettier": "^2.5.0",
+        "eslint-plugin-flow-vars": "^0.5.0",
+        "eslint-plugin-flowtype": "^2.35.0",
+        "eslint-plugin-import": "^2.7.0",
+        "eslint-plugin-jsx-a11y": "^6.0.2",
+        "eslint-plugin-prettier": "^2.2.0",
+        "eslint-plugin-react": "^7.3.0",
+        "flow-bin": "^0.42.0",
+        "glob": "^7.1.1",
+        "jest": "^20.0.4",
+        "jest-cli": "^20.0.4",
+        "lerna": "^2.1.1",
+        "plop": "^1.8.1",
+        "prettier": "^1.7.0",
+        "prettier-eslint-cli": "4.2.x",
+        "remotedev-server": "^0.2.3",
+        "rimraf": "^2.6.1",
+      },
+      "engines": Object {
+        "yarn": "^1.2.1",
+      },
+      "eslintIgnore": Array [
+        "interfaces",
+        "**/__tests__/fixtures/",
+      ],
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonTestJSONNode",
+      "internal": Object {
+        "content": "{\\"engines\\":{\\"yarn\\":\\"^1.2.1\\"},\\"private\\":true,\\"scripts\\":{\\"jest\\":\\"jest\\",\\"lint\\":\\"eslint --ext .js,.jsx packages/**/src\\",\\"plop\\":\\"plop\\",\\"test\\":\\"yarn lint && yarn jest\\",\\"lerna\\":\\"lerna\\",\\"watch\\":\\"lerna run watch --no-sort --stream --concurrency 999\\",\\"format\\":\\"npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts\\",\\"publish\\":\\"lerna publish\\",\\"bootstrap\\":\\"yarn && npm run check-versions && lerna run prepublish\\",\\"lint:flow\\":\\"babel-node scripts/flow-check.js\\",\\"remotedev\\":\\"remotedev --hostname=localhost --port=19999\\",\\"test_bkup\\":\\"npm run lint && npm run test-node && npm run test-integration\\",\\"format-www\\":\\"prettier-eslint --write /\\"www/*.js/\\" /\\"www/src/**/*.js/\\"\\",\\"test:watch\\":\\"jest --watch\\",\\"test:update\\":\\"jest --updateSnapshot\\",\\"publish-next\\":\\"lerna publish --npm-tag=next\\",\\"check-versions\\":\\"babel-node scripts/check-versions.js\\",\\"format-scripts\\":\\"prettier-eslint --write /\\"scripts/**/*.js/\\"\\",\\"publish-canary\\":\\"lerna publish --canary --yes\\",\\"format-examples\\":\\"prettier-eslint --write /\\"examples/**/gatsby-node.js/\\" /\\"examples/**/gatsby-config.js/\\" /\\"examples/**/src/**/*.js/\\"\\",\\"format-packages\\":\\"prettier-eslint --write /\\"packages/*/src/**/*.js/\\"\\",\\"format-cache-dir\\":\\"prettier-eslint --write /\\"packages/gatsby/cache-dir/*.js/\\"\\"},\\"workspaces\\":[\\"packages/*\\"],\\"eslintIgnore\\":[\\"interfaces\\",\\"**/__tests__/fixtures/\\"],\\"devDependencies\\":{\\"glob\\":\\"^7.1.1\\",\\"jest\\":\\"^20.0.4\\",\\"plop\\":\\"^1.8.1\\",\\"lerna\\":\\"^2.1.1\\",\\"eslint\\":\\"^4.5.0\\",\\"rimraf\\":\\"^2.6.1\\",\\"chokidar\\":\\"^1.7.0\\",\\"flow-bin\\":\\"^0.42.0\\",\\"jest-cli\\":\\"^20.0.4\\",\\"prettier\\":\\"^1.7.0\\",\\"babel-cli\\":\\"^6.26.0\\",\\"cross-env\\":\\"^5.0.5\\",\\"babel-jest\\":\\"^20.0.3\\",\\"babel-eslint\\":\\"^7.2.3\\",\\"babel-runtime\\":\\"^6.26.0\\",\\"babel-register\\":\\"^6.26.0\\",\\"babel-preset-env\\":\\"^1.6.0\\",\\"remotedev-server\\":\\"^0.2.3\\",\\"babel-preset-flow\\":\\"^6.23.0\\",\\"babel-preset-react\\":\\"^6.24.1\\",\\"babel-plugin-lodash\\":\\"^3.2.11\\",\\"eslint-plugin-react\\":\\"^7.3.0\\",\\"prettier-eslint-cli\\":\\"4.2.x\\",\\"babel-preset-stage-0\\":\\"^6.24.1\\",\\"eslint-config-google\\":\\"^0.9.1\\",\\"eslint-plugin-import\\":\\"^2.7.0\\",\\"eslint-config-prettier\\":\\"^2.5.0\\",\\"eslint-plugin-flowtype\\":\\"^2.35.0\\",\\"eslint-plugin-jsx-a11y\\":\\"^6.0.2\\",\\"eslint-plugin-prettier\\":\\"^2.2.0\\",\\"eslint-plugin-flow-vars\\":\\"^0.5.0\\",\\"babel-plugin-transform-runtime\\":\\"^6.23.0\\",\\"babel-plugin-add-module-exports\\":\\"^0.2.1\\",\\"babel-plugin-transform-flow-strip-types\\":\\"^6.22.0\\",\\"babel-plugin-transform-async-to-generator\\":\\"^6.24.1\\"}}",
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "mediaType": "application/json",
+        "type": "contentfulJsonTestJsonTestJsonNode",
+      },
+      "parent": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___de",
+      "private": true,
+      "scripts": Object {
+        "bootstrap": "yarn && npm run check-versions && lerna run prepublish",
+        "check-versions": "babel-node scripts/check-versions.js",
+        "format": "npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts",
+        "format-cache-dir": "prettier-eslint --write \\"packages/gatsby/cache-dir/*.js\\"",
+        "format-examples": "prettier-eslint --write \\"examples/**/gatsby-node.js\\" \\"examples/**/gatsby-config.js\\" \\"examples/**/src/**/*.js\\"",
+        "format-packages": "prettier-eslint --write \\"packages/*/src/**/*.js\\"",
+        "format-scripts": "prettier-eslint --write \\"scripts/**/*.js\\"",
+        "format-www": "prettier-eslint --write \\"www/*.js\\" \\"www/src/**/*.js\\"",
+        "jest": "jest",
+        "lerna": "lerna",
+        "lint": "eslint --ext .js,.jsx packages/**/src",
+        "lint:flow": "babel-node scripts/flow-check.js",
+        "plop": "plop",
+        "publish": "lerna publish",
+        "publish-canary": "lerna publish --canary --yes",
+        "publish-next": "lerna publish --npm-tag=next",
+        "remotedev": "remotedev --hostname=localhost --port=19999",
+        "test": "yarn lint && yarn jest",
+        "test:update": "jest --updateSnapshot",
+        "test:watch": "jest --watch",
+        "test_bkup": "npm run lint && npm run test-node && npm run test-integration",
+        "watch": "lerna run watch --no-sort --stream --concurrency 999",
+      },
+      "sys": Object {
+        "type": "Entry",
+      },
+      "workspaces": Array [
+        "packages/*",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "content": "test",
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonStringTest0JSONNode",
+      "internal": Object {
+        "content": "\\"test\\"",
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "mediaType": "application/json",
+        "type": "contentfulJsonTestJsonStringTestJsonNode",
+      },
+      "parent": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": "",
+      "displayField": "title",
+      "id": "Remark Test",
+      "internal": Object {
+        "contentDigest": "2018-05-28T08:43:09.218Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Remark Test",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___EntrycontentTextNode",
+      ],
+      "content___NODE": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___EntrycontentTextNode",
+      "contentful_id": "c4L2GhTsJtCseMYM8Wia64i",
+      "createdAt": "2018-05-28T08:49:06.230Z",
+      "id": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry",
+      "internal": Object {
+        "contentDigest": "2018-05-28T08:49:06.230Z",
+        "type": "ContentfulRemarkTest",
+      },
+      "node_locale": "en-US",
+      "parent": "Remark Test",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "remarkTest",
+            "id": "remarkTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 1,
+        "type": "Entry",
+      },
+      "title": "Contentful images inlined in Markdown",
+      "updatedAt": "2018-05-28T08:49:06.230Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "content": "## Toys
+
+![Toys](//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png) 
+
+## Chive
+
+![Chive logo](//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg) 
+
+## Playsam Streamliner
+
+![Playsam Streamliner](//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg) 
+
+## Whisk beaters
+
+![Whisk beaters](//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg) 
+
+## SoSo Wall Clock
+
+![SoSo Wall Clock](//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg) 
+
+## Hudson Wall Cup
+
+![Hudson Wall Cup ](//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg)",
+      "id": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___EntrycontentTextNode",
+      "internal": Object {
+        "content": "## Toys
+
+![Toys](//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png) 
+
+## Chive
+
+![Chive logo](//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg) 
+
+## Playsam Streamliner
+
+![Playsam Streamliner](//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg) 
+
+## Whisk beaters
+
+![Whisk beaters](//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg) 
+
+## SoSo Wall Clock
+
+![SoSo Wall Clock](//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg) 
+
+## Hudson Wall Cup
+
+![Hudson Wall Cup ](//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg)",
+        "contentDigest": "2018-05-28T08:49:06.230Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulRemarkTestContentTextNode",
+      },
+      "parent": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": "",
+      "displayField": "title",
+      "id": "Remark Test",
+      "internal": Object {
+        "contentDigest": "2018-05-28T08:43:09.218Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Remark Test",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___decontentTextNode",
+      ],
+      "content___NODE": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___decontentTextNode",
+      "contentful_id": "c4L2GhTsJtCseMYM8Wia64i",
+      "createdAt": "2018-05-28T08:49:06.230Z",
+      "id": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___de",
+      "internal": Object {
+        "contentDigest": "2018-05-28T08:49:06.230Z",
+        "type": "ContentfulRemarkTest",
+      },
+      "node_locale": "de",
+      "parent": "Remark Test",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "remarkTest",
+            "id": "remarkTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 1,
+        "type": "Entry",
+      },
+      "title": "Contentful images inlined in Markdown",
+      "updatedAt": "2018-05-28T08:49:06.230Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "content": "## Toys
+
+![Toys](//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png) 
+
+## Chive
+
+![Chive logo](//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg) 
+
+## Playsam Streamliner
+
+![Playsam Streamliner](//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg) 
+
+## Whisk beaters
+
+![Whisk beaters](//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg) 
+
+## SoSo Wall Clock
+
+![SoSo Wall Clock](//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg) 
+
+## Hudson Wall Cup
+
+![Hudson Wall Cup ](//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg)",
+      "id": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___decontentTextNode",
+      "internal": Object {
+        "content": "## Toys
+
+![Toys](//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png) 
+
+## Chive
+
+![Chive logo](//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg) 
+
+## Playsam Streamliner
+
+![Playsam Streamliner](//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg) 
+
+## Whisk beaters
+
+![Whisk beaters](//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg) 
+
+## SoSo Wall Clock
+
+![SoSo Wall Clock](//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg) 
+
+## Hudson Wall Cup
+
+![Hudson Wall Cup ](//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg)",
+        "contentDigest": "2018-05-28T08:49:06.230Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulRemarkTestContentTextNode",
+      },
+      "parent": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Skip existing nodes in warm build creates nodes for each asset 1`] = `
+Array [
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c3wtvPBbBjiMKqKKga8I2Cu",
+      "createdAt": "2017-06-27T09:35:37.178Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 353,
+            "width": 353,
+          },
+          "size": 12302,
+        },
+        "fileName": "zJYzDlGk.jpeg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/3wtvPBbBjiMKqKKga8I2Cu/c65cb9cce1107c2e7e63c17072fe7932/zJYzDlGk.jpeg",
+      },
+      "id": "rocybtov1ozk___c3wtvPBbBjiMKqKKga8I2Cu___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.178Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Normann Copenhagen",
+      "updatedAt": "2017-06-27T09:35:37.178Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c3wtvPBbBjiMKqKKga8I2Cu",
+      "createdAt": "2017-06-27T09:35:37.178Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 353,
+            "width": 353,
+          },
+          "size": 12302,
+        },
+        "fileName": "zJYzDlGk.jpeg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/3wtvPBbBjiMKqKKga8I2Cu/c65cb9cce1107c2e7e63c17072fe7932/zJYzDlGk.jpeg",
+      },
+      "id": "rocybtov1ozk___c3wtvPBbBjiMKqKKga8I2Cu___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.178Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Normann Copenhagen",
+      "updatedAt": "2017-06-27T09:35:37.178Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "KTRF62Q4gg60q6WCsWKw8",
+      "createdAt": "2017-06-27T09:35:37.064Z",
+      "description": "by Lemnos",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 1000,
+            "width": 1000,
+          },
+          "size": 66927,
+        },
+        "fileName": "soso.clock.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg",
+      },
+      "id": "rocybtov1ozk___KTRF62Q4gg60q6WCsWKw8___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.064Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "SoSo Wall Clock",
+      "updatedAt": "2017-06-27T09:35:37.064Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "KTRF62Q4gg60q6WCsWKw8",
+      "createdAt": "2017-06-27T09:35:37.064Z",
+      "description": "by Lemnos",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 1000,
+            "width": 1000,
+          },
+          "size": 66927,
+        },
+        "fileName": "soso.clock.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg",
+      },
+      "id": "rocybtov1ozk___KTRF62Q4gg60q6WCsWKw8___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.064Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "SoSo Wall Clock",
+      "updatedAt": "2017-06-27T09:35:37.064Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "Xc0ny7GWsMEMCeASWO2um",
+      "createdAt": "2017-06-27T09:35:37.027Z",
+      "description": "Merchandise image",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 600,
+            "width": 600,
+          },
+          "size": 48751,
+        },
+        "fileName": "jqvtazcyfwseah9fmysz.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg",
+      },
+      "id": "rocybtov1ozk___Xc0ny7GWsMEMCeASWO2um___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.027Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Hudson Wall Cup ",
+      "updatedAt": "2017-06-27T09:35:37.027Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "Xc0ny7GWsMEMCeASWO2um",
+      "createdAt": "2017-06-27T09:35:37.027Z",
+      "description": "Merchandise image",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 600,
+            "width": 600,
+          },
+          "size": 48751,
+        },
+        "fileName": "jqvtazcyfwseah9fmysz.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg",
+      },
+      "id": "rocybtov1ozk___Xc0ny7GWsMEMCeASWO2um___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.027Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Hudson Wall Cup ",
+      "updatedAt": "2017-06-27T09:35:37.027Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c2Y8LhXLnYAYqKCGEWG4EKI",
+      "createdAt": "2017-06-27T09:35:37.012Z",
+      "description": "company logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 32,
+            "width": 175,
+          },
+          "size": 7149,
+        },
+        "fileName": "lemnos-logo.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/2Y8LhXLnYAYqKCGEWG4EKI/eb29ab3c817906993f65e221523ef252/lemnos-logo.jpg",
+      },
+      "id": "rocybtov1ozk___c2Y8LhXLnYAYqKCGEWG4EKI___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.012Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Lemnos",
+      "updatedAt": "2017-06-27T09:35:37.012Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c2Y8LhXLnYAYqKCGEWG4EKI",
+      "createdAt": "2017-06-27T09:35:37.012Z",
+      "description": "company logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 32,
+            "width": 175,
+          },
+          "size": 7149,
+        },
+        "fileName": "lemnos-logo.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/2Y8LhXLnYAYqKCGEWG4EKI/eb29ab3c817906993f65e221523ef252/lemnos-logo.jpg",
+      },
+      "id": "rocybtov1ozk___c2Y8LhXLnYAYqKCGEWG4EKI___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:37.012Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Lemnos",
+      "updatedAt": "2017-06-27T09:35:37.012Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6t4HKjytPi0mYgs240wkG",
+      "createdAt": "2017-06-27T09:35:36.633Z",
+      "description": "Category icon set",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 128,
+            "width": 128,
+          },
+          "size": 6744,
+        },
+        "fileName": "toys_512pxGREY.png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png",
+      },
+      "id": "rocybtov1ozk___c6t4HKjytPi0mYgs240wkG___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.633Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Toys",
+      "updatedAt": "2017-06-27T09:35:36.633Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6t4HKjytPi0mYgs240wkG",
+      "createdAt": "2017-06-27T09:35:36.633Z",
+      "description": "Category icon set",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 128,
+            "width": 128,
+          },
+          "size": 6744,
+        },
+        "fileName": "toys_512pxGREY.png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png",
+      },
+      "id": "rocybtov1ozk___c6t4HKjytPi0mYgs240wkG___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.633Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Toys",
+      "updatedAt": "2017-06-27T09:35:36.633Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c1MgbdJNTsMWKI0W68oYqkU",
+      "createdAt": "2017-06-27T09:35:36.182Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 500,
+            "width": 500,
+          },
+          "size": 44089,
+        },
+        "fileName": "9ef190c59f0d375c0dea58b58a4bc1f0.jpeg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg",
+      },
+      "id": "rocybtov1ozk___c1MgbdJNTsMWKI0W68oYqkU___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.182Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Chive logo",
+      "updatedAt": "2017-06-27T09:35:36.182Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c1MgbdJNTsMWKI0W68oYqkU",
+      "createdAt": "2017-06-27T09:35:36.182Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 500,
+            "width": 500,
+          },
+          "size": 44089,
+        },
+        "fileName": "9ef190c59f0d375c0dea58b58a4bc1f0.jpeg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg",
+      },
+      "id": "rocybtov1ozk___c1MgbdJNTsMWKI0W68oYqkU___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.182Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Chive logo",
+      "updatedAt": "2017-06-27T09:35:36.182Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6m5AJ9vMPKc8OUoQeoCS4o",
+      "createdAt": "2017-06-27T09:35:36.172Z",
+      "description": "category icon",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 256,
+            "width": 256,
+          },
+          "size": 2977,
+        },
+        "fileName": "1418244847_Streamline-18-256.png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6m5AJ9vMPKc8OUoQeoCS4o/e782e3b291ff2b0287546a563af4683c/1418244847_Streamline-18-256.png",
+      },
+      "id": "rocybtov1ozk___c6m5AJ9vMPKc8OUoQeoCS4o___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.172Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Home and Kitchen",
+      "updatedAt": "2017-06-27T09:35:36.172Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6m5AJ9vMPKc8OUoQeoCS4o",
+      "createdAt": "2017-06-27T09:35:36.172Z",
+      "description": "category icon",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 256,
+            "width": 256,
+          },
+          "size": 2977,
+        },
+        "fileName": "1418244847_Streamline-18-256.png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6m5AJ9vMPKc8OUoQeoCS4o/e782e3b291ff2b0287546a563af4683c/1418244847_Streamline-18-256.png",
+      },
+      "id": "rocybtov1ozk___c6m5AJ9vMPKc8OUoQeoCS4o___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.172Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Home and Kitchen",
+      "updatedAt": "2017-06-27T09:35:36.172Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c4zj1ZOfHgQ8oqgaSKm4Qo2",
+      "createdAt": "2017-06-27T09:35:36.168Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 100,
+            "width": 100,
+          },
+          "size": 7003,
+        },
+        "fileName": "playsam.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/4zj1ZOfHgQ8oqgaSKm4Qo2/5d967c9c48d67eabff71a9a0232d4378/playsam.jpg",
+      },
+      "id": "rocybtov1ozk___c4zj1ZOfHgQ8oqgaSKm4Qo2___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.168Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Playsam",
+      "updatedAt": "2017-06-27T09:35:36.168Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c4zj1ZOfHgQ8oqgaSKm4Qo2",
+      "createdAt": "2017-06-27T09:35:36.168Z",
+      "description": "Brand logo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 100,
+            "width": 100,
+          },
+          "size": 7003,
+        },
+        "fileName": "playsam.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/4zj1ZOfHgQ8oqgaSKm4Qo2/5d967c9c48d67eabff71a9a0232d4378/playsam.jpg",
+      },
+      "id": "rocybtov1ozk___c4zj1ZOfHgQ8oqgaSKm4Qo2___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.168Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Playsam",
+      "updatedAt": "2017-06-27T09:35:36.168Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "wtrHxeu3zEoEce2MokCSi",
+      "createdAt": "2017-06-27T09:35:36.037Z",
+      "description": "Merchandise photo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 446,
+            "width": 600,
+          },
+          "size": 27187,
+        },
+        "fileName": "quwowooybuqbl6ntboz3.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg",
+      },
+      "id": "rocybtov1ozk___wtrHxeu3zEoEce2MokCSi___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.037Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Playsam Streamliner",
+      "updatedAt": "2017-06-27T09:35:36.037Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "wtrHxeu3zEoEce2MokCSi",
+      "createdAt": "2017-06-27T09:35:36.037Z",
+      "description": "Merchandise photo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 446,
+            "width": 600,
+          },
+          "size": 27187,
+        },
+        "fileName": "quwowooybuqbl6ntboz3.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg",
+      },
+      "id": "rocybtov1ozk___wtrHxeu3zEoEce2MokCSi___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.037Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Playsam Streamliner",
+      "updatedAt": "2017-06-27T09:35:36.037Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c10TkaLheGeQG6qQGqWYqUI",
+      "createdAt": "2017-06-27T09:35:36.032Z",
+      "description": "Merchandise photo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 600,
+            "width": 450,
+          },
+          "size": 28435,
+        },
+        "fileName": "ryugj83mqwa1asojwtwb.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg",
+      },
+      "id": "rocybtov1ozk___c10TkaLheGeQG6qQGqWYqUI___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.032Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Whisk beaters",
+      "updatedAt": "2017-06-27T09:35:36.032Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c10TkaLheGeQG6qQGqWYqUI",
+      "createdAt": "2017-06-27T09:35:36.032Z",
+      "description": "Merchandise photo",
+      "file": Object {
+        "contentType": "image/jpeg",
+        "details": Object {
+          "image": Object {
+            "height": 600,
+            "width": 450,
+          },
+          "size": 28435,
+        },
+        "fileName": "ryugj83mqwa1asojwtwb.jpg",
+        "url": "//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg",
+      },
+      "id": "rocybtov1ozk___c10TkaLheGeQG6qQGqWYqUI___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:36.032Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "Whisk beaters",
+      "updatedAt": "2017-06-27T09:35:36.032Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6s3iG2OVmoUcosmA8ocqsG",
+      "createdAt": "2017-06-27T09:35:35.994Z",
+      "description": "Category icon set",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 250,
+            "width": 250,
+          },
+          "size": 4244,
+        },
+        "fileName": "1418244847_Streamline-18-256 (1).png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6s3iG2OVmoUcosmA8ocqsG/286ac4c1be74e05d2e7e11bc5a55bc83/1418244847_Streamline-18-256__1_.png",
+      },
+      "id": "rocybtov1ozk___c6s3iG2OVmoUcosmA8ocqsG___Asset",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:35.994Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "en-US",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "House icon",
+      "updatedAt": "2017-06-27T09:35:35.994Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentful_id": "c6s3iG2OVmoUcosmA8ocqsG",
+      "createdAt": "2017-06-27T09:35:35.994Z",
+      "description": "Category icon set",
+      "file": Object {
+        "contentType": "image/png",
+        "details": Object {
+          "image": Object {
+            "height": 250,
+            "width": 250,
+          },
+          "size": 4244,
+        },
+        "fileName": "1418244847_Streamline-18-256 (1).png",
+        "url": "//images.ctfassets.net/rocybtov1ozk/6s3iG2OVmoUcosmA8ocqsG/286ac4c1be74e05d2e7e11bc5a55bc83/1418244847_Streamline-18-256__1_.png",
+      },
+      "id": "rocybtov1ozk___c6s3iG2OVmoUcosmA8ocqsG___Asset___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:35:35.994Z",
+        "type": "ContentfulAsset",
+      },
+      "node_locale": "de",
+      "parent": null,
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "revision": 1,
+        "type": "Asset",
+      },
+      "title": "House icon",
+      "updatedAt": "2017-06-27T09:35:35.994Z",
+    },
+  ],
+]
+`;
+
+exports[`Skip existing nodes in warm build creates nodes for each entry 1`] = `
+Array [
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "title",
+      "id": "Category",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:40:52.685Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Category",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription___NODE": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrycategoryDescriptionTextNode",
+      "children": Array [
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrytitleTextNode",
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrycategoryDescriptionTextNode",
+      ],
+      "contentful_id": "c24DPGBDeGEaYy8ms4Y8QMQ",
+      "createdAt": "2017-06-27T09:35:44.992Z",
+      "icon___NODE": "rocybtov1ozk___c6t4HKjytPi0mYgs240wkG___Asset",
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "type": "ContentfulCategory",
+      },
+      "node_locale": "en-US",
+      "parent": "Category",
+      "product___NODE": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "6XwpTaSiiI2Ak2Ww0oi6qa",
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "title___NODE": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrytitleTextNode",
+      "updatedAt": "2017-06-27T09:46:43.477Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrytitleTextNode",
+      "internal": Object {
+        "content": "Toys",
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryTitleTextNode",
+      },
+      "parent": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+      "title": "Toys",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription": "Shop for toys, games, educational aids",
+      "children": Array [],
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___EntrycategoryDescriptionTextNode",
+      "internal": Object {
+        "content": "Shop for toys, games, educational aids",
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryCategoryDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "title",
+      "id": "Category",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:40:52.685Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Category",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription___NODE": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___decategoryDescriptionTextNode",
+      "children": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___detitleTextNode",
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___decategoryDescriptionTextNode",
+      ],
+      "contentful_id": "c7LAnCobuuWYSqks6wAwY2a",
+      "createdAt": "2017-06-27T09:35:44.000Z",
+      "icon___NODE": "rocybtov1ozk___c6m5AJ9vMPKc8OUoQeoCS4o___Asset___de",
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      "internal": Object {
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "type": "ContentfulCategory",
+      },
+      "node_locale": "de",
+      "parent": "Category",
+      "product___NODE": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "6XwpTaSiiI2Ak2Ww0oi6qa",
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 4,
+        "type": "Entry",
+      },
+      "title___NODE": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___detitleTextNode",
+      "updatedAt": "2020-06-30T11:22:54.201Z",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription___NODE": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___decategoryDescriptionTextNode",
+      "children": Array [
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___detitleTextNode",
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___decategoryDescriptionTextNode",
+      ],
+      "contentful_id": "c24DPGBDeGEaYy8ms4Y8QMQ",
+      "createdAt": "2017-06-27T09:35:44.992Z",
+      "icon___NODE": "rocybtov1ozk___c6t4HKjytPi0mYgs240wkG___Asset___de",
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "type": "ContentfulCategory",
+      },
+      "node_locale": "de",
+      "parent": "Category",
+      "product___NODE": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "6XwpTaSiiI2Ak2Ww0oi6qa",
+            "id": "c6XwpTaSiiI2Ak2Ww0oi6qa",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "title___NODE": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___detitleTextNode",
+      "updatedAt": "2017-06-27T09:46:43.477Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___detitleTextNode",
+      "internal": Object {
+        "content": "Haus & Küche",
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryTitleTextNode",
+      },
+      "parent": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+      "title": "Haus & Küche",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription": "Shop für Möbel, Bettwäsche, Bad, Staubsauger, Küchenprodukte und vieles mehr",
+      "children": Array [],
+      "id": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___decategoryDescriptionTextNode",
+      "internal": Object {
+        "content": "Shop für Möbel, Bettwäsche, Bad, Staubsauger, Küchenprodukte und vieles mehr",
+        "contentDigest": "2020-06-30T11:22:54.201Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryCategoryDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___detitleTextNode",
+      "internal": Object {
+        "content": "Spielzeug",
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryTitleTextNode",
+      },
+      "parent": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+      "title": "Spielzeug",
+    },
+  ],
+  Array [
+    Object {
+      "categoryDescription": "Spielzeugladen, Spiele, Lernhilfen",
+      "children": Array [],
+      "id": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___decategoryDescriptionTextNode",
+      "internal": Object {
+        "content": "Spielzeugladen, Spiele, Lernhilfen",
+        "contentDigest": "2017-06-27T09:46:43.477Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulCategoryCategoryDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "companyName",
+      "id": "Brand",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:41:09.339Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Brand",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyNameTextNode",
+        "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyNameTextNode",
+      "contentful_id": "c651CQ8rLoIYCeY6G0QG22q",
+      "createdAt": "2017-06-27T09:35:43.997Z",
+      "email": "normann@normann-copenhagen.com",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c3wtvPBbBjiMKqKKga8I2Cu___Asset",
+      "node_locale": "en-US",
+      "parent": "Brand",
+      "phone": Array [
+        "+45 35 55 44 59",
+      ],
+      "product___NODE": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "twitter": "https://twitter.com/NormannCPH",
+      "updatedAt": "2017-06-27T09:55:16.820Z",
+      "website": "http://www.normann-copenhagen.com/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyNameTextNode",
+        "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyNameTextNode",
+      "contentful_id": "c4LgMotpNF6W20YKmuemW0a",
+      "createdAt": "2017-06-27T09:35:44.396Z",
+      "email": "info@acgears.com",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c2Y8LhXLnYAYqKCGEWG4EKI___Asset",
+      "node_locale": "en-US",
+      "parent": "Brand",
+      "phone": Array [
+        "+1 212 260 2269",
+      ],
+      "product___NODE": Array [
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "updatedAt": "2017-06-27T09:51:15.647Z",
+      "website": "http://www.lemnos.jp/en/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyNameTextNode",
+        "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyNameTextNode",
+      "contentful_id": "JrePkDVYomE8AwcuCUyMi",
+      "createdAt": "2017-06-27T09:35:44.988Z",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c4zj1ZOfHgQ8oqgaSKm4Qo2___Asset",
+      "node_locale": "en-US",
+      "parent": "Brand",
+      "product___NODE": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "updatedAt": "2017-06-27T09:50:36.937Z",
+      "website": "http://playsam.com/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Normann Copenhagen",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyNameTextNode",
+      "internal": Object {
+        "content": "Normann Copenhagen",
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "Normann Copenhagen is a way of living - a mindset. We love to challenge the conventional design rules. This is why you will find traditional materials put into untraditional use such as a Stone Hook made of Icelandic stones, a vase made out of silicon and last but not least a dog made out of plastic.",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___EntrycompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "Normann Copenhagen is a way of living - a mindset. We love to challenge the conventional design rules. This is why you will find traditional materials put into untraditional use such as a Stone Hook made of Icelandic stones, a vase made out of silicon and last but not least a dog made out of plastic.",
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Lemnos",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyNameTextNode",
+      "internal": Object {
+        "content": "Lemnos",
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "TAKATA Lemnos Inc. was founded in 1947 as a brass casting manufacturing industry in Takaoka-city, Toyama Prefecture, Japan and we launched out into the full-scale business trade with Seiko Clock Co., Ltd. since 1966.
+
+We entered into the development for the original planning from late 1980 and \\"Lemnos Brand\\" recognized as the global design clock by a masterpiece \\"HOLA\\" designed by Kazuo KAWASAKI which released in 1989.
+
+Afterwards, we made a lot of projects with well-known designers who took in active in Japan and overseas such as Riki WATANABE, Kazuo KAWASAKI, Shin AZUMI, Tomoko AZUMI, Kanae TSUKAMOTO etc. and we made announcement of their fine works abounding in artistry and prominent designs. In addition, we realized to make a special project by the collaboration with Andrea Branzi, a well-known architect in the world.
+
+Lemnos brand products are now highly praised from the design shops and the interior shops all over the world.
+
+In recent years, we also have been given high priority to develop interior accessories making full use of our traditional techniques by the founding manufacturer and we always focus our minds on the development for the new Lemnos products in the new market.
+
+Our Lemnos products are made carefully by our craftsmen finely honed skillful techniques in Japan. They surely bring out the attractiveness of the materials to the maximum and create fine products not being influenced on the fashion trend accordingly. TAKATA Lemnos Inc. definitely would like to be innovative and continuously propose the beauty lasts forever.",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___EntrycompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "TAKATA Lemnos Inc. was founded in 1947 as a brass casting manufacturing industry in Takaoka-city, Toyama Prefecture, Japan and we launched out into the full-scale business trade with Seiko Clock Co., Ltd. since 1966.
+
+We entered into the development for the original planning from late 1980 and \\"Lemnos Brand\\" recognized as the global design clock by a masterpiece \\"HOLA\\" designed by Kazuo KAWASAKI which released in 1989.
+
+Afterwards, we made a lot of projects with well-known designers who took in active in Japan and overseas such as Riki WATANABE, Kazuo KAWASAKI, Shin AZUMI, Tomoko AZUMI, Kanae TSUKAMOTO etc. and we made announcement of their fine works abounding in artistry and prominent designs. In addition, we realized to make a special project by the collaboration with Andrea Branzi, a well-known architect in the world.
+
+Lemnos brand products are now highly praised from the design shops and the interior shops all over the world.
+
+In recent years, we also have been given high priority to develop interior accessories making full use of our traditional techniques by the founding manufacturer and we always focus our minds on the development for the new Lemnos products in the new market.
+
+Our Lemnos products are made carefully by our craftsmen finely honed skillful techniques in Japan. They surely bring out the attractiveness of the materials to the maximum and create fine products not being influenced on the fashion trend accordingly. TAKATA Lemnos Inc. definitely would like to be innovative and continuously propose the beauty lasts forever.",
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Playsam",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyNameTextNode",
+      "internal": Object {
+        "content": "Playsam",
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "Playsam is the leading Scandinavian design company for executive wooden toy gift. Scandinavian design playful creativity, integrity and sophistication are Playsam. Scandinavian design and wooden toy makes Playsam gift lovely to the world of design since 1984.",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___EntrycompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "Playsam is the leading Scandinavian design company for executive wooden toy gift. Scandinavian design playful creativity, integrity and sophistication are Playsam. Scandinavian design and wooden toy makes Playsam gift lovely to the world of design since 1984.",
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "companyName",
+      "id": "Brand",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:41:09.339Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Brand",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyNameTextNode",
+        "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyNameTextNode",
+      "contentful_id": "c651CQ8rLoIYCeY6G0QG22q",
+      "createdAt": "2017-06-27T09:35:43.997Z",
+      "email": "normann@normann-copenhagen.com",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c3wtvPBbBjiMKqKKga8I2Cu___Asset___de",
+      "node_locale": "de",
+      "parent": "Brand",
+      "phone": Array [
+        "+45 35 55 44 59",
+      ],
+      "product___NODE": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "twitter": "https://twitter.com/NormannCPH",
+      "updatedAt": "2017-06-27T09:55:16.820Z",
+      "website": "http://www.normann-copenhagen.com/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyNameTextNode",
+        "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyNameTextNode",
+      "contentful_id": "c4LgMotpNF6W20YKmuemW0a",
+      "createdAt": "2017-06-27T09:35:44.396Z",
+      "email": "info@acgears.com",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c2Y8LhXLnYAYqKCGEWG4EKI___Asset___de",
+      "node_locale": "de",
+      "parent": "Brand",
+      "phone": Array [
+        "+1 212 260 2269",
+      ],
+      "product___NODE": Array [
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "updatedAt": "2017-06-27T09:51:15.647Z",
+      "website": "http://www.lemnos.jp/en/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyNameTextNode",
+        "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyDescriptionTextNode",
+      ],
+      "companyDescription___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyDescriptionTextNode",
+      "companyName___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyNameTextNode",
+      "contentful_id": "JrePkDVYomE8AwcuCUyMi",
+      "createdAt": "2017-06-27T09:35:44.988Z",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___de",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "type": "ContentfulBrand",
+      },
+      "logo___NODE": "rocybtov1ozk___c4zj1ZOfHgQ8oqgaSKm4Qo2___Asset___de",
+      "node_locale": "de",
+      "parent": "Brand",
+      "product___NODE": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      ],
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "sFzTZbSuM8coEwygeUYes",
+            "id": "sFzTZbSuM8coEwygeUYes",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "updatedAt": "2017-06-27T09:50:36.937Z",
+      "website": "http://playsam.com/",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Normann Copenhagen",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyNameTextNode",
+      "internal": Object {
+        "content": "Normann Copenhagen",
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "Normann Kopenhagen ist eine Art zu leben - eine Denkweise. Wir lieben es, die konventionellen Designregeln herauszufordern. Aus diesem Grund finden Sie traditionelle Materialien, die in untraditionelle Verwendung wie ein Steinhaken aus isländischen Steinen, eine Vase aus Silizium und last but not least ein Hund aus Kunststoff.",
+      "id": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___decompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "Normann Kopenhagen ist eine Art zu leben - eine Denkweise. Wir lieben es, die konventionellen Designregeln herauszufordern. Aus diesem Grund finden Sie traditionelle Materialien, die in untraditionelle Verwendung wie ein Steinhaken aus isländischen Steinen, eine Vase aus Silizium und last but not least ein Hund aus Kunststoff.",
+        "contentDigest": "2017-06-27T09:55:16.820Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Lemnos",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyNameTextNode",
+      "internal": Object {
+        "content": "Lemnos",
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "TAKATA Lemnos Inc. wurde im Jahre 1947 als Messing-Casting-Fertigungsindustrie in Takaoka-Stadt, Toyama Prefecture, Japan gegründet und wir starteten seit 1966 mit der Seiko Clock Co., Ltd.
+
+Wir haben die Entwicklung für die ursprüngliche Planung ab Ende 1980 eingegangen und \\"Lemnos Brand\\" wurde als globale Designuhr von einem Meisterwerk \\"HOLA\\" von Kazuo KAWASAKI entworfen, das 1989 erschien.
+
+Danach machten wir viele Projekte mit namhaften Designern, die in Japan und Übersee tätig waren, wie zB Riki WATANABE, Kazuo KAWASAKI, Shin AZUMI, Tomoko AZUMI, Kanae TSUKAMOTO etc. und wir kündigten ihre Werke in der Kunst an Und prominenten Designs. Darüber hinaus haben wir durch die Zusammenarbeit mit Andrea Branzi, einem bekannten Architekten der Welt, ein besonderes Projekt gemacht.
+
+Lemnos Markenprodukte werden nun von den Designläden und den Innenhandelsgeschäften auf der ganzen Welt hoch gelobt.
+
+In den vergangenen Jahren haben wir auch eine hohe Priorität für die Entwicklung von Innenausstattung, die den traditionellen Techniken des Gründungsherstellers voll ausnutzt, und wir konzentrieren uns immer auf die Entwicklung der neuen Lemnos-Produkte im neuen Markt.
+
+Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliffen geschickten Techniken in Japan gemacht. Sie bringen sicherlich die Attraktivität der Materialien auf das Maximum und schaffen feine Produkte nicht beeinflusst auf die Mode-Trend entsprechend. TAKATA Lemnos Inc. möchte definitiv innovativ sein und ständig vorschlagen, die Schönheit dauert ewig.",
+      "id": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___decompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "TAKATA Lemnos Inc. wurde im Jahre 1947 als Messing-Casting-Fertigungsindustrie in Takaoka-Stadt, Toyama Prefecture, Japan gegründet und wir starteten seit 1966 mit der Seiko Clock Co., Ltd.
+
+Wir haben die Entwicklung für die ursprüngliche Planung ab Ende 1980 eingegangen und \\"Lemnos Brand\\" wurde als globale Designuhr von einem Meisterwerk \\"HOLA\\" von Kazuo KAWASAKI entworfen, das 1989 erschien.
+
+Danach machten wir viele Projekte mit namhaften Designern, die in Japan und Übersee tätig waren, wie zB Riki WATANABE, Kazuo KAWASAKI, Shin AZUMI, Tomoko AZUMI, Kanae TSUKAMOTO etc. und wir kündigten ihre Werke in der Kunst an Und prominenten Designs. Darüber hinaus haben wir durch die Zusammenarbeit mit Andrea Branzi, einem bekannten Architekten der Welt, ein besonderes Projekt gemacht.
+
+Lemnos Markenprodukte werden nun von den Designläden und den Innenhandelsgeschäften auf der ganzen Welt hoch gelobt.
+
+In den vergangenen Jahren haben wir auch eine hohe Priorität für die Entwicklung von Innenausstattung, die den traditionellen Techniken des Gründungsherstellers voll ausnutzt, und wir konzentrieren uns immer auf die Entwicklung der neuen Lemnos-Produkte im neuen Markt.
+
+Unsere Lemnos Produkte werden sorgfältig von unseren Handwerkern fein geschliffen geschickten Techniken in Japan gemacht. Sie bringen sicherlich die Attraktivität der Materialien auf das Maximum und schaffen feine Produkte nicht beeinflusst auf die Mode-Trend entsprechend. TAKATA Lemnos Inc. möchte definitiv innovativ sein und ständig vorschlagen, die Schönheit dauert ewig.",
+        "contentDigest": "2017-06-27T09:51:15.647Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyName": "Playsam",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyNameTextNode",
+      "internal": Object {
+        "content": "Playsam",
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyNameTextNode",
+      },
+      "parent": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "companyDescription": "Playsam ist die führende skandinavische Designfirma für Executive Holzspielzeug Geschenk. Skandinavisches Design spielerische Kreativität, Integrität und Raffinesse sind Playsam. Skandinavisches Design und hölzernes Spielzeug macht Playsam Geschenk schön in die Welt des Designs seit 1984.",
+      "id": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___decompanyDescriptionTextNode",
+      "internal": Object {
+        "content": "Playsam ist die führende skandinavische Designfirma für Executive Holzspielzeug Geschenk. Skandinavisches Design spielerische Kreativität, Integrität und Raffinesse sind Playsam. Skandinavisches Design und hölzernes Spielzeug macht Playsam Geschenk schön in die Welt des Designs seit 1984.",
+        "contentDigest": "2017-06-27T09:50:36.937Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulBrandCompanyDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "productName",
+      "id": "Product",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:40:36.821Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Product",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductNameTextNode",
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductDescriptionTextNode",
+      ],
+      "contentful_id": "c5KsDBWseXY6QegucYAoacS",
+      "createdAt": "2017-06-27T09:35:43.996Z",
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      "image___NODE": Array [
+        "rocybtov1ozk___wtrHxeu3zEoEce2MokCSi___Asset",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "en-US",
+      "parent": "Product",
+      "price": 44,
+      "productDescription___NODE": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductNameTextNode",
+      "quantity": 56,
+      "sizetypecolor": "Length: 135 mm | color: espresso, green, or icar (white)",
+      "sku": "B001R6JUZ2",
+      "slug": "playsam-streamliner-classic-car-espresso",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "wood",
+        "toy",
+        "car",
+        "sweden",
+        "design",
+      ],
+      "updatedAt": "2017-06-27T09:56:59.626Z",
+      "website": "http://www.amazon.com/dp/B001R6JUZ2/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductNameTextNode",
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductDescriptionTextNode",
+      ],
+      "contentful_id": "c3DVqIYj4dOwwcKu6sgqOgg",
+      "createdAt": "2017-06-27T09:35:44.006Z",
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+      "image___NODE": Array [
+        "rocybtov1ozk___Xc0ny7GWsMEMCeASWO2um___Asset",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "en-US",
+      "parent": "Product",
+      "price": 11,
+      "productDescription___NODE": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductNameTextNode",
+      "quantity": 101,
+      "sizetypecolor": "3 x 3 x 5 inches; 5.3 ounces",
+      "sku": "B00E82D7I8",
+      "slug": "hudson-wall-cup",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "vase",
+        "flowers",
+        "accessories",
+      ],
+      "updatedAt": "2017-06-27T09:54:51.159Z",
+      "website": "http://www.amazon.com/dp/B00E82D7I8/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductNameTextNode",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductDescriptionTextNode",
+      ],
+      "contentful_id": "c6dbjWqNd9SqccegcqYq224",
+      "createdAt": "2017-06-27T09:35:44.049Z",
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+      "image___NODE": Array [
+        "rocybtov1ozk___c10TkaLheGeQG6qQGqWYqUI___Asset",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "en-US",
+      "parent": "Product",
+      "price": 22,
+      "productDescription___NODE": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductNameTextNode",
+      "quantity": 89,
+      "sizetypecolor": "0.8 x 0.8 x 11.2 inches; 1.6 ounces",
+      "sku": "B0081F2CCK",
+      "slug": "whisk-beater",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "kitchen",
+        "accessories",
+        "whisk",
+        "scandinavia",
+        "design",
+      ],
+      "updatedAt": "2017-06-27T09:53:23.179Z",
+      "website": "http://www.amazon.com/dp/B0081F2CCK/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductNameTextNode",
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductDescriptionTextNode",
+      ],
+      "contentful_id": "c4BqrajvA8E6qwgkieoqmqO",
+      "createdAt": "2017-06-27T09:35:44.130Z",
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      "image___NODE": Array [
+        "rocybtov1ozk___KTRF62Q4gg60q6WCsWKw8___Asset",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "en-US",
+      "parent": "Product",
+      "price": 120,
+      "productDescription___NODE": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductNameTextNode",
+      "quantity": 3,
+      "sizetypecolor": "10\\" x 2.2\\"",
+      "sku": "B00MG4ULK2",
+      "slug": "soso-wall-clock",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "home décor",
+        "clocks",
+        "interior design",
+        "yellow",
+        "gifts",
+      ],
+      "updatedAt": "2017-06-27T09:52:29.215Z",
+      "website": "http://store.dwell.com/soso-wall-clock.html",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductNameTextNode",
+      "internal": Object {
+        "content": "Playsam Streamliner Classic Car, Espresso",
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      "productName": "Playsam Streamliner Classic Car, Espresso",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___EntryproductDescriptionTextNode",
+      "internal": Object {
+        "content": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!",
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry",
+      "productDescription": "A classic Playsam design, the Streamliner Classic Car has been selected as Swedish Design Classic by the Swedish National Museum for its inventive style and sleek surface. It's no wonder that this wooden car has also been a long-standing favorite for children both big and small!",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductNameTextNode",
+      "internal": Object {
+        "content": "Hudson Wall Cup",
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+      "productName": "Hudson Wall Cup",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___EntryproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Wall Hanging Glass Flower Vase and Terrarium",
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry",
+      "productDescription": "Wall Hanging Glass Flower Vase and Terrarium",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductNameTextNode",
+      "internal": Object {
+        "content": "Whisk Beater",
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+      "productName": "Whisk Beater",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___EntryproductDescriptionTextNode",
+      "internal": Object {
+        "content": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea.",
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry",
+      "productDescription": "A creative little whisk that comes in 8 different colors. Handy and easy to clean after use. A great gift idea.",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductNameTextNode",
+      "internal": Object {
+        "content": "SoSo Wall Clock",
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      "productName": "SoSo Wall Clock",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___EntryproductDescriptionTextNode",
+      "internal": Object {
+        "content": "The newly released SoSo Clock from Lemnos marries simple, clean design and bold, striking features. Its saturated marigold face is a lively pop of color to white or grey walls, but would also pair nicely with navy and maroon. Where most clocks feature numbers at the border of the clock, the SoSo brings them in tight to the middle, leaving a wide space between the numbers and the slight frame. The hour hand provides a nice interruption to the black and yellow of the clock - it is featured in a brilliant white. Despite its bold color and contrast, the SoSo maintains a clean, pure aesthetic that is suitable to a variety of contemporary interiors.",
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry",
+      "productDescription": "The newly released SoSo Clock from Lemnos marries simple, clean design and bold, striking features. Its saturated marigold face is a lively pop of color to white or grey walls, but would also pair nicely with navy and maroon. Where most clocks feature numbers at the border of the clock, the SoSo brings them in tight to the middle, leaving a wide space between the numbers and the slight frame. The hour hand provides a nice interruption to the black and yellow of the clock - it is featured in a brilliant white. Despite its bold color and contrast, the SoSo maintains a clean, pure aesthetic that is suitable to a variety of contemporary interiors.",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": null,
+      "displayField": "productName",
+      "id": "Product",
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:40:36.821Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Product",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___JrePkDVYomE8AwcuCUyMi___Entry___de",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c24DPGBDeGEaYy8ms4Y8QMQ___Entry___de",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductNameTextNode",
+        "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductDescriptionTextNode",
+      ],
+      "contentful_id": "c5KsDBWseXY6QegucYAoacS",
+      "createdAt": "2017-06-27T09:35:43.996Z",
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      "image___NODE": Array [
+        "rocybtov1ozk___wtrHxeu3zEoEce2MokCSi___Asset___de",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "de",
+      "parent": "Product",
+      "price": 44,
+      "productDescription___NODE": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductNameTextNode",
+      "quantity": 56,
+      "sizetypecolor": "Length: 135 mm | color: espresso, green, or icar (white)",
+      "sku": "B001R6JUZ2",
+      "slug": "playsam-streamliner-classic-car-espresso",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "wood",
+        "toy",
+        "car",
+        "sweden",
+        "design",
+      ],
+      "updatedAt": "2017-06-27T09:56:59.626Z",
+      "website": "http://www.amazon.com/dp/B001R6JUZ2/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductNameTextNode",
+        "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductDescriptionTextNode",
+      ],
+      "contentful_id": "c3DVqIYj4dOwwcKu6sgqOgg",
+      "createdAt": "2017-06-27T09:35:44.006Z",
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+      "image___NODE": Array [
+        "rocybtov1ozk___Xc0ny7GWsMEMCeASWO2um___Asset___de",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "de",
+      "parent": "Product",
+      "price": 11,
+      "productDescription___NODE": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductNameTextNode",
+      "quantity": 101,
+      "sizetypecolor": "3 x 3 x 5 inches; 5.3 ounces",
+      "sku": "B00E82D7I8",
+      "slug": "hudson-wall-cup",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "vase",
+        "flowers",
+        "accessories",
+      ],
+      "updatedAt": "2017-06-27T09:54:51.159Z",
+      "website": "http://www.amazon.com/dp/B00E82D7I8/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c651CQ8rLoIYCeY6G0QG22q___Entry___de",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductNameTextNode",
+        "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductDescriptionTextNode",
+      ],
+      "contentful_id": "c6dbjWqNd9SqccegcqYq224",
+      "createdAt": "2017-06-27T09:35:44.049Z",
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+      "image___NODE": Array [
+        "rocybtov1ozk___c10TkaLheGeQG6qQGqWYqUI___Asset___de",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "de",
+      "parent": "Product",
+      "price": 22,
+      "productDescription___NODE": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductNameTextNode",
+      "quantity": 89,
+      "sizetypecolor": "0.8 x 0.8 x 11.2 inches; 1.6 ounces",
+      "sku": "B0081F2CCK",
+      "slug": "whisk-beater",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "kitchen",
+        "accessories",
+        "whisk",
+        "scandinavia",
+        "design",
+      ],
+      "updatedAt": "2017-06-27T09:53:23.179Z",
+      "website": "http://www.amazon.com/dp/B0081F2CCK/",
+    },
+  ],
+  Array [
+    Object {
+      "brand___NODE": "rocybtov1ozk___c4LgMotpNF6W20YKmuemW0a___Entry___de",
+      "categories___NODE": Array [
+        "rocybtov1ozk___c7LAnCobuuWYSqks6wAwY2a___Entry___de",
+      ],
+      "children": Array [
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductNameTextNode",
+        "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductDescriptionTextNode",
+      ],
+      "contentful_id": "c4BqrajvA8E6qwgkieoqmqO",
+      "createdAt": "2017-06-27T09:35:44.130Z",
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      "image___NODE": Array [
+        "rocybtov1ozk___KTRF62Q4gg60q6WCsWKw8___Asset___de",
+      ],
+      "internal": Object {
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "type": "ContentfulProduct",
+      },
+      "node_locale": "de",
+      "parent": "Product",
+      "price": 120,
+      "productDescription___NODE": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductDescriptionTextNode",
+      "productName___NODE": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductNameTextNode",
+      "quantity": 3,
+      "sizetypecolor": "10\\" x 2.2\\"",
+      "sku": "B00MG4ULK2",
+      "slug": "soso-wall-clock",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "2PqfXUJwE8qSYKuM0U6w8M",
+            "id": "c2PqfXUJwE8qSYKuM0U6w8M",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 2,
+        "type": "Entry",
+      },
+      "tags": Array [
+        "home décor",
+        "clocks",
+        "interior design",
+        "yellow",
+        "gifts",
+      ],
+      "updatedAt": "2017-06-27T09:52:29.215Z",
+      "website": "http://store.dwell.com/soso-wall-clock.html",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductNameTextNode",
+      "internal": Object {
+        "content": "Playsam Streamliner Klassisches Auto, Espresso",
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      "productName": "Playsam Streamliner Klassisches Auto, Espresso",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___deproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Ein klassisches Playsam-Design, das Streamliner Classic Car wurde als Swedish Design Classic vom Schwedischen Nationalmuseum für seinen erfinderischen Stil und seine schlanke Oberfläche ausgewählt. Es ist kein Wunder, dass dieses hölzerne Auto auch ein langjähriger Liebling für Kinder gewesen ist, die groß und klein sind!",
+        "contentDigest": "2017-06-27T09:56:59.626Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c5KsDBWseXY6QegucYAoacS___Entry___de",
+      "productDescription": "Ein klassisches Playsam-Design, das Streamliner Classic Car wurde als Swedish Design Classic vom Schwedischen Nationalmuseum für seinen erfinderischen Stil und seine schlanke Oberfläche ausgewählt. Es ist kein Wunder, dass dieses hölzerne Auto auch ein langjähriger Liebling für Kinder gewesen ist, die groß und klein sind!",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductNameTextNode",
+      "internal": Object {
+        "content": "Becher",
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+      "productName": "Becher",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___deproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Wand-hängende Glas-Blumen-Vase und Terrarium",
+        "contentDigest": "2017-06-27T09:54:51.159Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c3DVqIYj4dOwwcKu6sgqOgg___Entry___de",
+      "productDescription": "Wand-hängende Glas-Blumen-Vase und Terrarium",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductNameTextNode",
+      "internal": Object {
+        "content": "Schneebesen",
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+      "productName": "Schneebesen",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___deproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Ein kreativer kleiner Schneebesen, der in 8 verschiedenen Farben kommt. Praktisch und nach dem Gebrauch leicht zu reinigen. Eine tolle Geschenkidee.",
+        "contentDigest": "2017-06-27T09:53:23.179Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c6dbjWqNd9SqccegcqYq224___Entry___de",
+      "productDescription": "Ein kreativer kleiner Schneebesen, der in 8 verschiedenen Farben kommt. Praktisch und nach dem Gebrauch leicht zu reinigen. Eine tolle Geschenkidee.",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductNameTextNode",
+      "internal": Object {
+        "content": "SoSo wanduhr",
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductNameTextNode",
+      },
+      "parent": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      "productName": "SoSo wanduhr",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___deproductDescriptionTextNode",
+      "internal": Object {
+        "content": "Die neu veröffentlichte SoSo Clock von Lemnos heiratet einfaches, sauberes Design und fette, auffällige Features. Sein gesättigtes Ringelblumengesicht ist ein lebhafter Pop der Farbe zu den weißen oder grauen Wänden, aber würde auch gut mit Marine und kastanienbraun paaren. Wo die meisten Uhren am Rande der Uhr Nummern sind, bringt der SoSo sie in die Mitte und lässt einen weiten Raum zwischen den Zahlen und dem leichten Rahmen. Der Stundenzeiger bietet eine schöne Unterbrechung der schwarzen und gelben der Uhr - es ist in einem brillanten Weiß vorgestellt. Trotz seiner kräftigen Farbe und des Kontrastes behält der SoSo eine saubere, reine Ästhetik, die für eine Vielzahl von zeitgenössischen Interieurs geeignet ist.",
+        "contentDigest": "2017-06-27T09:52:29.215Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulProductProductDescriptionTextNode",
+      },
+      "parent": "rocybtov1ozk___c4BqrajvA8E6qwgkieoqmqO___Entry___de",
+      "productDescription": "Die neu veröffentlichte SoSo Clock von Lemnos heiratet einfaches, sauberes Design und fette, auffällige Features. Sein gesättigtes Ringelblumengesicht ist ein lebhafter Pop der Farbe zu den weißen oder grauen Wänden, aber würde auch gut mit Marine und kastanienbraun paaren. Wo die meisten Uhren am Rande der Uhr Nummern sind, bringt der SoSo sie in die Mitte und lässt einen weiten Raum zwischen den Zahlen und dem leichten Rahmen. Der Stundenzeiger bietet eine schöne Unterbrechung der schwarzen und gelben der Uhr - es ist in einem brillanten Weiß vorgestellt. Trotz seiner kräftigen Farbe und des Kontrastes behält der SoSo eine saubere, reine Ästhetik, die für eine Vielzahl von zeitgenössischen Interieurs geeignet ist.",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": "just for testing JSON fields",
+      "displayField": null,
+      "id": "JSON-test",
+      "internal": Object {
+        "contentDigest": "2018-08-13T14:21:13.985Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "JSON-test",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonTestJSONNode",
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonStringTest0JSONNode",
+      ],
+      "contentful_id": "c71mfnH4QKsSsQmgoaQuq6O",
+      "createdAt": "2017-11-28T02:16:10.604Z",
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry",
+      "internal": Object {
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "type": "ContentfulJsonTest",
+      },
+      "jsonStringTest___NODE": Array [
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonStringTest0JSONNode",
+      ],
+      "jsonTest___NODE": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonTestJSONNode",
+      "node_locale": "en-US",
+      "parent": "JSON-test",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "jsonTest",
+            "id": "jsonTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 4,
+        "type": "Entry",
+      },
+      "updatedAt": "2018-08-13T14:27:12.458Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "devDependencies": Object {
+        "babel-cli": "^6.26.0",
+        "babel-eslint": "^7.2.3",
+        "babel-jest": "^20.0.3",
+        "babel-plugin-add-module-exports": "^0.2.1",
+        "babel-plugin-lodash": "^3.2.11",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-flow-strip-types": "^6.22.0",
+        "babel-plugin-transform-runtime": "^6.23.0",
+        "babel-preset-env": "^1.6.0",
+        "babel-preset-flow": "^6.23.0",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-stage-0": "^6.24.1",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.7.0",
+        "cross-env": "^5.0.5",
+        "eslint": "^4.5.0",
+        "eslint-config-google": "^0.9.1",
+        "eslint-config-prettier": "^2.5.0",
+        "eslint-plugin-flow-vars": "^0.5.0",
+        "eslint-plugin-flowtype": "^2.35.0",
+        "eslint-plugin-import": "^2.7.0",
+        "eslint-plugin-jsx-a11y": "^6.0.2",
+        "eslint-plugin-prettier": "^2.2.0",
+        "eslint-plugin-react": "^7.3.0",
+        "flow-bin": "^0.42.0",
+        "glob": "^7.1.1",
+        "jest": "^20.0.4",
+        "jest-cli": "^20.0.4",
+        "lerna": "^2.1.1",
+        "plop": "^1.8.1",
+        "prettier": "^1.7.0",
+        "prettier-eslint-cli": "4.2.x",
+        "remotedev-server": "^0.2.3",
+        "rimraf": "^2.6.1",
+      },
+      "engines": Object {
+        "yarn": "^1.2.1",
+      },
+      "eslintIgnore": Array [
+        "interfaces",
+        "**/__tests__/fixtures/",
+      ],
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonTestJSONNode",
+      "internal": Object {
+        "content": "{\\"engines\\":{\\"yarn\\":\\"^1.2.1\\"},\\"private\\":true,\\"scripts\\":{\\"jest\\":\\"jest\\",\\"lint\\":\\"eslint --ext .js,.jsx packages/**/src\\",\\"plop\\":\\"plop\\",\\"test\\":\\"yarn lint && yarn jest\\",\\"lerna\\":\\"lerna\\",\\"watch\\":\\"lerna run watch --no-sort --stream --concurrency 999\\",\\"format\\":\\"npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts\\",\\"publish\\":\\"lerna publish\\",\\"bootstrap\\":\\"yarn && npm run check-versions && lerna run prepublish\\",\\"lint:flow\\":\\"babel-node scripts/flow-check.js\\",\\"remotedev\\":\\"remotedev --hostname=localhost --port=19999\\",\\"test_bkup\\":\\"npm run lint && npm run test-node && npm run test-integration\\",\\"format-www\\":\\"prettier-eslint --write /\\"www/*.js/\\" /\\"www/src/**/*.js/\\"\\",\\"test:watch\\":\\"jest --watch\\",\\"test:update\\":\\"jest --updateSnapshot\\",\\"publish-next\\":\\"lerna publish --npm-tag=next\\",\\"check-versions\\":\\"babel-node scripts/check-versions.js\\",\\"format-scripts\\":\\"prettier-eslint --write /\\"scripts/**/*.js/\\"\\",\\"publish-canary\\":\\"lerna publish --canary --yes\\",\\"format-examples\\":\\"prettier-eslint --write /\\"examples/**/gatsby-node.js/\\" /\\"examples/**/gatsby-config.js/\\" /\\"examples/**/src/**/*.js/\\"\\",\\"format-packages\\":\\"prettier-eslint --write /\\"packages/*/src/**/*.js/\\"\\",\\"format-cache-dir\\":\\"prettier-eslint --write /\\"packages/gatsby/cache-dir/*.js/\\"\\"},\\"workspaces\\":[\\"packages/*\\"],\\"eslintIgnore\\":[\\"interfaces\\",\\"**/__tests__/fixtures/\\"],\\"devDependencies\\":{\\"glob\\":\\"^7.1.1\\",\\"jest\\":\\"^20.0.4\\",\\"plop\\":\\"^1.8.1\\",\\"lerna\\":\\"^2.1.1\\",\\"eslint\\":\\"^4.5.0\\",\\"rimraf\\":\\"^2.6.1\\",\\"chokidar\\":\\"^1.7.0\\",\\"flow-bin\\":\\"^0.42.0\\",\\"jest-cli\\":\\"^20.0.4\\",\\"prettier\\":\\"^1.7.0\\",\\"babel-cli\\":\\"^6.26.0\\",\\"cross-env\\":\\"^5.0.5\\",\\"babel-jest\\":\\"^20.0.3\\",\\"babel-eslint\\":\\"^7.2.3\\",\\"babel-runtime\\":\\"^6.26.0\\",\\"babel-register\\":\\"^6.26.0\\",\\"babel-preset-env\\":\\"^1.6.0\\",\\"remotedev-server\\":\\"^0.2.3\\",\\"babel-preset-flow\\":\\"^6.23.0\\",\\"babel-preset-react\\":\\"^6.24.1\\",\\"babel-plugin-lodash\\":\\"^3.2.11\\",\\"eslint-plugin-react\\":\\"^7.3.0\\",\\"prettier-eslint-cli\\":\\"4.2.x\\",\\"babel-preset-stage-0\\":\\"^6.24.1\\",\\"eslint-config-google\\":\\"^0.9.1\\",\\"eslint-plugin-import\\":\\"^2.7.0\\",\\"eslint-config-prettier\\":\\"^2.5.0\\",\\"eslint-plugin-flowtype\\":\\"^2.35.0\\",\\"eslint-plugin-jsx-a11y\\":\\"^6.0.2\\",\\"eslint-plugin-prettier\\":\\"^2.2.0\\",\\"eslint-plugin-flow-vars\\":\\"^0.5.0\\",\\"babel-plugin-transform-runtime\\":\\"^6.23.0\\",\\"babel-plugin-add-module-exports\\":\\"^0.2.1\\",\\"babel-plugin-transform-flow-strip-types\\":\\"^6.22.0\\",\\"babel-plugin-transform-async-to-generator\\":\\"^6.24.1\\"}}",
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "mediaType": "application/json",
+        "type": "contentfulJsonTestJsonTestJsonNode",
+      },
+      "parent": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry",
+      "private": true,
+      "scripts": Object {
+        "bootstrap": "yarn && npm run check-versions && lerna run prepublish",
+        "check-versions": "babel-node scripts/check-versions.js",
+        "format": "npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts",
+        "format-cache-dir": "prettier-eslint --write \\"packages/gatsby/cache-dir/*.js\\"",
+        "format-examples": "prettier-eslint --write \\"examples/**/gatsby-node.js\\" \\"examples/**/gatsby-config.js\\" \\"examples/**/src/**/*.js\\"",
+        "format-packages": "prettier-eslint --write \\"packages/*/src/**/*.js\\"",
+        "format-scripts": "prettier-eslint --write \\"scripts/**/*.js\\"",
+        "format-www": "prettier-eslint --write \\"www/*.js\\" \\"www/src/**/*.js\\"",
+        "jest": "jest",
+        "lerna": "lerna",
+        "lint": "eslint --ext .js,.jsx packages/**/src",
+        "lint:flow": "babel-node scripts/flow-check.js",
+        "plop": "plop",
+        "publish": "lerna publish",
+        "publish-canary": "lerna publish --canary --yes",
+        "publish-next": "lerna publish --npm-tag=next",
+        "remotedev": "remotedev --hostname=localhost --port=19999",
+        "test": "yarn lint && yarn jest",
+        "test:update": "jest --updateSnapshot",
+        "test:watch": "jest --watch",
+        "test_bkup": "npm run lint && npm run test-node && npm run test-integration",
+        "watch": "lerna run watch --no-sort --stream --concurrency 999",
+      },
+      "sys": Object {
+        "type": "Entry",
+      },
+      "workspaces": Array [
+        "packages/*",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "content": "test",
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___EntryjsonStringTest0JSONNode",
+      "internal": Object {
+        "content": "\\"test\\"",
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "mediaType": "application/json",
+        "type": "contentfulJsonTestJsonStringTestJsonNode",
+      },
+      "parent": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": "just for testing JSON fields",
+      "displayField": null,
+      "id": "JSON-test",
+      "internal": Object {
+        "contentDigest": "2018-08-13T14:21:13.985Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "JSON-test",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonTestJSONNode",
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonStringTest0JSONNode",
+      ],
+      "contentful_id": "c71mfnH4QKsSsQmgoaQuq6O",
+      "createdAt": "2017-11-28T02:16:10.604Z",
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___de",
+      "internal": Object {
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "type": "ContentfulJsonTest",
+      },
+      "jsonStringTest___NODE": Array [
+        "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonStringTest0JSONNode",
+      ],
+      "jsonTest___NODE": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonTestJSONNode",
+      "node_locale": "de",
+      "parent": "JSON-test",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "jsonTest",
+            "id": "jsonTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 4,
+        "type": "Entry",
+      },
+      "updatedAt": "2018-08-13T14:27:12.458Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "devDependencies": Object {
+        "babel-cli": "^6.26.0",
+        "babel-eslint": "^7.2.3",
+        "babel-jest": "^20.0.3",
+        "babel-plugin-add-module-exports": "^0.2.1",
+        "babel-plugin-lodash": "^3.2.11",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-flow-strip-types": "^6.22.0",
+        "babel-plugin-transform-runtime": "^6.23.0",
+        "babel-preset-env": "^1.6.0",
+        "babel-preset-flow": "^6.23.0",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-stage-0": "^6.24.1",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.7.0",
+        "cross-env": "^5.0.5",
+        "eslint": "^4.5.0",
+        "eslint-config-google": "^0.9.1",
+        "eslint-config-prettier": "^2.5.0",
+        "eslint-plugin-flow-vars": "^0.5.0",
+        "eslint-plugin-flowtype": "^2.35.0",
+        "eslint-plugin-import": "^2.7.0",
+        "eslint-plugin-jsx-a11y": "^6.0.2",
+        "eslint-plugin-prettier": "^2.2.0",
+        "eslint-plugin-react": "^7.3.0",
+        "flow-bin": "^0.42.0",
+        "glob": "^7.1.1",
+        "jest": "^20.0.4",
+        "jest-cli": "^20.0.4",
+        "lerna": "^2.1.1",
+        "plop": "^1.8.1",
+        "prettier": "^1.7.0",
+        "prettier-eslint-cli": "4.2.x",
+        "remotedev-server": "^0.2.3",
+        "rimraf": "^2.6.1",
+      },
+      "engines": Object {
+        "yarn": "^1.2.1",
+      },
+      "eslintIgnore": Array [
+        "interfaces",
+        "**/__tests__/fixtures/",
+      ],
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonTestJSONNode",
+      "internal": Object {
+        "content": "{\\"engines\\":{\\"yarn\\":\\"^1.2.1\\"},\\"private\\":true,\\"scripts\\":{\\"jest\\":\\"jest\\",\\"lint\\":\\"eslint --ext .js,.jsx packages/**/src\\",\\"plop\\":\\"plop\\",\\"test\\":\\"yarn lint && yarn jest\\",\\"lerna\\":\\"lerna\\",\\"watch\\":\\"lerna run watch --no-sort --stream --concurrency 999\\",\\"format\\":\\"npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts\\",\\"publish\\":\\"lerna publish\\",\\"bootstrap\\":\\"yarn && npm run check-versions && lerna run prepublish\\",\\"lint:flow\\":\\"babel-node scripts/flow-check.js\\",\\"remotedev\\":\\"remotedev --hostname=localhost --port=19999\\",\\"test_bkup\\":\\"npm run lint && npm run test-node && npm run test-integration\\",\\"format-www\\":\\"prettier-eslint --write /\\"www/*.js/\\" /\\"www/src/**/*.js/\\"\\",\\"test:watch\\":\\"jest --watch\\",\\"test:update\\":\\"jest --updateSnapshot\\",\\"publish-next\\":\\"lerna publish --npm-tag=next\\",\\"check-versions\\":\\"babel-node scripts/check-versions.js\\",\\"format-scripts\\":\\"prettier-eslint --write /\\"scripts/**/*.js/\\"\\",\\"publish-canary\\":\\"lerna publish --canary --yes\\",\\"format-examples\\":\\"prettier-eslint --write /\\"examples/**/gatsby-node.js/\\" /\\"examples/**/gatsby-config.js/\\" /\\"examples/**/src/**/*.js/\\"\\",\\"format-packages\\":\\"prettier-eslint --write /\\"packages/*/src/**/*.js/\\"\\",\\"format-cache-dir\\":\\"prettier-eslint --write /\\"packages/gatsby/cache-dir/*.js/\\"\\"},\\"workspaces\\":[\\"packages/*\\"],\\"eslintIgnore\\":[\\"interfaces\\",\\"**/__tests__/fixtures/\\"],\\"devDependencies\\":{\\"glob\\":\\"^7.1.1\\",\\"jest\\":\\"^20.0.4\\",\\"plop\\":\\"^1.8.1\\",\\"lerna\\":\\"^2.1.1\\",\\"eslint\\":\\"^4.5.0\\",\\"rimraf\\":\\"^2.6.1\\",\\"chokidar\\":\\"^1.7.0\\",\\"flow-bin\\":\\"^0.42.0\\",\\"jest-cli\\":\\"^20.0.4\\",\\"prettier\\":\\"^1.7.0\\",\\"babel-cli\\":\\"^6.26.0\\",\\"cross-env\\":\\"^5.0.5\\",\\"babel-jest\\":\\"^20.0.3\\",\\"babel-eslint\\":\\"^7.2.3\\",\\"babel-runtime\\":\\"^6.26.0\\",\\"babel-register\\":\\"^6.26.0\\",\\"babel-preset-env\\":\\"^1.6.0\\",\\"remotedev-server\\":\\"^0.2.3\\",\\"babel-preset-flow\\":\\"^6.23.0\\",\\"babel-preset-react\\":\\"^6.24.1\\",\\"babel-plugin-lodash\\":\\"^3.2.11\\",\\"eslint-plugin-react\\":\\"^7.3.0\\",\\"prettier-eslint-cli\\":\\"4.2.x\\",\\"babel-preset-stage-0\\":\\"^6.24.1\\",\\"eslint-config-google\\":\\"^0.9.1\\",\\"eslint-plugin-import\\":\\"^2.7.0\\",\\"eslint-config-prettier\\":\\"^2.5.0\\",\\"eslint-plugin-flowtype\\":\\"^2.35.0\\",\\"eslint-plugin-jsx-a11y\\":\\"^6.0.2\\",\\"eslint-plugin-prettier\\":\\"^2.2.0\\",\\"eslint-plugin-flow-vars\\":\\"^0.5.0\\",\\"babel-plugin-transform-runtime\\":\\"^6.23.0\\",\\"babel-plugin-add-module-exports\\":\\"^0.2.1\\",\\"babel-plugin-transform-flow-strip-types\\":\\"^6.22.0\\",\\"babel-plugin-transform-async-to-generator\\":\\"^6.24.1\\"}}",
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "mediaType": "application/json",
+        "type": "contentfulJsonTestJsonTestJsonNode",
+      },
+      "parent": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___de",
+      "private": true,
+      "scripts": Object {
+        "bootstrap": "yarn && npm run check-versions && lerna run prepublish",
+        "check-versions": "babel-node scripts/check-versions.js",
+        "format": "npm run format-packages && npm run format-cache-dir && npm run format-www && npm run format-examples && npm run format-scripts",
+        "format-cache-dir": "prettier-eslint --write \\"packages/gatsby/cache-dir/*.js\\"",
+        "format-examples": "prettier-eslint --write \\"examples/**/gatsby-node.js\\" \\"examples/**/gatsby-config.js\\" \\"examples/**/src/**/*.js\\"",
+        "format-packages": "prettier-eslint --write \\"packages/*/src/**/*.js\\"",
+        "format-scripts": "prettier-eslint --write \\"scripts/**/*.js\\"",
+        "format-www": "prettier-eslint --write \\"www/*.js\\" \\"www/src/**/*.js\\"",
+        "jest": "jest",
+        "lerna": "lerna",
+        "lint": "eslint --ext .js,.jsx packages/**/src",
+        "lint:flow": "babel-node scripts/flow-check.js",
+        "plop": "plop",
+        "publish": "lerna publish",
+        "publish-canary": "lerna publish --canary --yes",
+        "publish-next": "lerna publish --npm-tag=next",
+        "remotedev": "remotedev --hostname=localhost --port=19999",
+        "test": "yarn lint && yarn jest",
+        "test:update": "jest --updateSnapshot",
+        "test:watch": "jest --watch",
+        "test_bkup": "npm run lint && npm run test-node && npm run test-integration",
+        "watch": "lerna run watch --no-sort --stream --concurrency 999",
+      },
+      "sys": Object {
+        "type": "Entry",
+      },
+      "workspaces": Array [
+        "packages/*",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "content": "test",
+      "id": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___dejsonStringTest0JSONNode",
+      "internal": Object {
+        "content": "\\"test\\"",
+        "contentDigest": "2018-08-13T14:27:12.458Z",
+        "mediaType": "application/json",
+        "type": "contentfulJsonTestJsonStringTestJsonNode",
+      },
+      "parent": "rocybtov1ozk___c71mfnH4QKsSsQmgoaQuq6O___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": "",
+      "displayField": "title",
+      "id": "Remark Test",
+      "internal": Object {
+        "contentDigest": "2018-05-28T08:43:09.218Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Remark Test",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___EntrycontentTextNode",
+      ],
+      "content___NODE": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___EntrycontentTextNode",
+      "contentful_id": "c4L2GhTsJtCseMYM8Wia64i",
+      "createdAt": "2018-05-28T08:49:06.230Z",
+      "id": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry",
+      "internal": Object {
+        "contentDigest": "2018-05-28T08:49:06.230Z",
+        "type": "ContentfulRemarkTest",
+      },
+      "node_locale": "en-US",
+      "parent": "Remark Test",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "remarkTest",
+            "id": "remarkTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 1,
+        "type": "Entry",
+      },
+      "title": "Contentful images inlined in Markdown",
+      "updatedAt": "2018-05-28T08:49:06.230Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "content": "## Toys
+
+![Toys](//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png) 
+
+## Chive
+
+![Chive logo](//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg) 
+
+## Playsam Streamliner
+
+![Playsam Streamliner](//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg) 
+
+## Whisk beaters
+
+![Whisk beaters](//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg) 
+
+## SoSo Wall Clock
+
+![SoSo Wall Clock](//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg) 
+
+## Hudson Wall Cup
+
+![Hudson Wall Cup ](//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg)",
+      "id": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___EntrycontentTextNode",
+      "internal": Object {
+        "content": "## Toys
+
+![Toys](//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png) 
+
+## Chive
+
+![Chive logo](//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg) 
+
+## Playsam Streamliner
+
+![Playsam Streamliner](//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg) 
+
+## Whisk beaters
+
+![Whisk beaters](//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg) 
+
+## SoSo Wall Clock
+
+![SoSo Wall Clock](//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg) 
+
+## Hudson Wall Cup
+
+![Hudson Wall Cup ](//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg)",
+        "contentDigest": "2018-05-28T08:49:06.230Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulRemarkTestContentTextNode",
+      },
+      "parent": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "description": "",
+      "displayField": "title",
+      "id": "Remark Test",
+      "internal": Object {
+        "contentDigest": "2018-05-28T08:43:09.218Z",
+        "type": "ContentfulContentType",
+      },
+      "name": "Remark Test",
+      "parent": null,
+      "sys": Object {
+        "type": "ContentType",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [
+        "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___decontentTextNode",
+      ],
+      "content___NODE": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___decontentTextNode",
+      "contentful_id": "c4L2GhTsJtCseMYM8Wia64i",
+      "createdAt": "2018-05-28T08:49:06.230Z",
+      "id": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___de",
+      "internal": Object {
+        "contentDigest": "2018-05-28T08:49:06.230Z",
+        "type": "ContentfulRemarkTest",
+      },
+      "node_locale": "de",
+      "parent": "Remark Test",
+      "spaceId": "rocybtov1ozk",
+      "sys": Object {
+        "contentType": Object {
+          "sys": Object {
+            "contentful_id": "remarkTest",
+            "id": "remarkTest",
+            "linkType": "ContentType",
+            "type": "Link",
+          },
+        },
+        "revision": 1,
+        "type": "Entry",
+      },
+      "title": "Contentful images inlined in Markdown",
+      "updatedAt": "2018-05-28T08:49:06.230Z",
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "content": "## Toys
+
+![Toys](//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png) 
+
+## Chive
+
+![Chive logo](//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg) 
+
+## Playsam Streamliner
+
+![Playsam Streamliner](//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg) 
+
+## Whisk beaters
+
+![Whisk beaters](//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg) 
+
+## SoSo Wall Clock
+
+![SoSo Wall Clock](//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg) 
+
+## Hudson Wall Cup
+
+![Hudson Wall Cup ](//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg)",
+      "id": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___decontentTextNode",
+      "internal": Object {
+        "content": "## Toys
+
+![Toys](//images.ctfassets.net/rocybtov1ozk/6t4HKjytPi0mYgs240wkG/6e730b1e6c2a46929239019240c037e6/toys_512pxGREY.png) 
+
+## Chive
+
+![Chive logo](//images.ctfassets.net/rocybtov1ozk/1MgbdJNTsMWKI0W68oYqkU/ad0200fe320b85ecdd823c711161c2f6/9ef190c59f0d375c0dea58b58a4bc1f0.jpeg) 
+
+## Playsam Streamliner
+
+![Playsam Streamliner](//images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg) 
+
+## Whisk beaters
+
+![Whisk beaters](//images.ctfassets.net/rocybtov1ozk/10TkaLheGeQG6qQGqWYqUI/f997e8e13c8c83c145e976d0905e64b7/ryugj83mqwa1asojwtwb.jpg) 
+
+## SoSo Wall Clock
+
+![SoSo Wall Clock](//images.ctfassets.net/rocybtov1ozk/KTRF62Q4gg60q6WCsWKw8/a8b2e93ac83fbbbb7bf9fba9f92b018e/soso.clock.jpg) 
+
+## Hudson Wall Cup
+
+![Hudson Wall Cup ](//images.ctfassets.net/rocybtov1ozk/Xc0ny7GWsMEMCeASWO2um/af8e29320c04af689798afe96e2345c7/jqvtazcyfwseah9fmysz.jpg)",
+        "contentDigest": "2018-05-28T08:49:06.230Z",
+        "mediaType": "text/markdown",
+        "type": "contentfulRemarkTestContentTextNode",
+      },
+      "parent": "rocybtov1ozk___c4L2GhTsJtCseMYM8Wia64i___Entry___de",
+      "sys": Object {
+        "type": "Entry",
+      },
+    },
+  ],
+]
+`;

--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -76,6 +76,177 @@ describe(`Process contentful data (by name)`, () => {
       })
     })
     expect(createNode.mock.calls).toMatchSnapshot()
+
+    // Relevant to compare to compare warm and cold situation. Actual number not relevant.
+    expect(createNode.mock.calls.length).toBe(74) // "cold build entries" count
+  })
+
+  it(`creates nodes for each asset`, () => {
+    const createNode = jest.fn()
+    const createNodeId = jest.fn(id => id)
+    const assets = currentSyncData.assets
+    assets.forEach(assetItem => {
+      normalize.createAssetNodes({
+        assetItem,
+        createNode,
+        createNodeId,
+        defaultLocale,
+        locales,
+        space,
+      })
+    })
+    expect(createNode.mock.calls).toMatchSnapshot()
+  })
+})
+
+describe(`Skip existing nodes in warm build`, () => {
+  it(`creates nodes for each entry`, () => {
+    let entryList = normalize.buildEntryList({
+      mergedSyncData: currentSyncData,
+      contentTypeItems,
+    })
+
+    let resolvable = normalize.buildResolvableSet({
+      assets: currentSyncData.assets,
+      entryList,
+      defaultLocale,
+      locales,
+    })
+
+    let foreignReferenceMap = normalize.buildForeignReferenceMap({
+      contentTypeItems,
+      entryList,
+      resolvable,
+      defaultLocale,
+      locales,
+      space,
+      useNameForId: true,
+    })
+
+    const createNode = jest.fn()
+    const createNodeId = jest.fn(id => id)
+    let doReturn = true
+    const getNode = jest.fn(id => {
+      if (doReturn) {
+        doReturn = false
+        // Note: the relevant part for this test is that the same digest is returned
+        // so it skips generating the node and any of its children. Actual shape of
+        // returned is not relevant to test so update if anything breaks.
+        return {
+          id,
+          internal: { contentDigest: entryList[0][0].sys.updatedAt },
+        }
+      }
+      // All other nodes are new ("unknown")
+      return undefined
+    })
+    contentTypeItems.forEach((contentTypeItem, i) => {
+      normalize.createNodesForContentType({
+        contentTypeItem,
+        restrictedNodeFields,
+        conflictFieldPrefix,
+        entries: entryList[i],
+        createNode,
+        createNodeId,
+        getNode,
+        resolvable,
+        foreignReferenceMap,
+        defaultLocale,
+        locales,
+        space,
+        useNameForId: true,
+      })
+    })
+    expect(createNode.mock.calls).toMatchSnapshot()
+
+    // Relevant to compare to compare warm and cold situation. Actual number not relevant.
+    // This number ought to be less than the cold build
+    expect(createNode.mock.calls.length).toBe(71) // "warm build where entry was not changed" count
+  })
+
+  it(`creates nodes for each asset`, () => {
+    const createNode = jest.fn()
+    const createNodeId = jest.fn(id => id)
+    const assets = currentSyncData.assets
+    assets.forEach(assetItem => {
+      normalize.createAssetNodes({
+        assetItem,
+        createNode,
+        createNodeId,
+        defaultLocale,
+        locales,
+        space,
+      })
+    })
+    expect(createNode.mock.calls).toMatchSnapshot()
+  })
+})
+
+describe(`Process existing mutated nodes in warm build`, () => {
+  it(`creates nodes for each entry`, () => {
+    let entryList = normalize.buildEntryList({
+      mergedSyncData: currentSyncData,
+      contentTypeItems,
+    })
+
+    let resolvable = normalize.buildResolvableSet({
+      assets: currentSyncData.assets,
+      entryList,
+      defaultLocale,
+      locales,
+    })
+
+    let foreignReferenceMap = normalize.buildForeignReferenceMap({
+      contentTypeItems,
+      entryList,
+      resolvable,
+      defaultLocale,
+      locales,
+      space,
+      useNameForId: true,
+    })
+
+    const createNode = jest.fn()
+    const createNodeId = jest.fn(id => id)
+    let doReturn = true
+    const getNode = jest.fn(id => {
+      if (doReturn) {
+        doReturn = false
+        // Note: the relevant part for this test is that the same digest is returned
+        // so it skips generating the node and any of its children. Actual shape of
+        // returned is not relevant to test so update if anything breaks.
+        return {
+          id,
+          internal: {
+            contentDigest: entryList[0][0].sys.updatedAt + `changed`,
+          },
+        }
+      }
+      // All other nodes are new ("unknown")
+      return undefined
+    })
+    contentTypeItems.forEach((contentTypeItem, i) => {
+      normalize.createNodesForContentType({
+        contentTypeItem,
+        restrictedNodeFields,
+        conflictFieldPrefix,
+        entries: entryList[i],
+        createNode,
+        createNodeId,
+        getNode,
+        resolvable,
+        foreignReferenceMap,
+        defaultLocale,
+        locales,
+        space,
+        useNameForId: true,
+      })
+    })
+    expect(createNode.mock.calls).toMatchSnapshot()
+
+    // Relevant to compare to compare warm and cold situation. Actual number not relevant.
+    // This number ought to be the same as the cold build
+    expect(createNode.mock.calls.length).toBe(74) // "warm build where entry was changed" count
   })
 
   it(`creates nodes for each asset`, () => {

--- a/packages/gatsby-source-contentful/src/__tests__/normalize.js
+++ b/packages/gatsby-source-contentful/src/__tests__/normalize.js
@@ -57,6 +57,7 @@ describe(`Process contentful data (by name)`, () => {
   it(`creates nodes for each entry`, () => {
     const createNode = jest.fn()
     const createNodeId = jest.fn(id => id)
+    const getNode = jest.fn(id => undefined) // All nodes are new
     contentTypeItems.forEach((contentTypeItem, i) => {
       normalize.createNodesForContentType({
         contentTypeItem,
@@ -65,6 +66,7 @@ describe(`Process contentful data (by name)`, () => {
         entries: entryList[i],
         createNode,
         createNodeId,
+        getNode,
         resolvable,
         foreignReferenceMap,
         defaultLocale,
@@ -133,6 +135,7 @@ describe(`Process contentful data (by id)`, () => {
   it(`creates nodes for each entry`, () => {
     const createNode = jest.fn()
     const createNodeId = jest.fn(id => id)
+    const getNode = jest.fn(id => undefined) // All nodes are new
     contentTypeItems.forEach((contentTypeItem, i) => {
       normalize.createNodesForContentType({
         contentTypeItem,
@@ -141,6 +144,7 @@ describe(`Process contentful data (by id)`, () => {
         entries: entryList[i],
         createNode,
         createNodeId,
+        getNode,
         resolvable,
         foreignReferenceMap,
         defaultLocale,

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -589,6 +589,7 @@ exports.sourceNodes = async (
         entries: entryList[i],
         createNode,
         createNodeId,
+        getNode,
         resolvable,
         foreignReferenceMap,
         defaultLocale,

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -236,6 +236,7 @@ exports.createNodesForContentType = ({
   entries,
   createNode,
   createNodeId,
+  getNode,
   resolvable,
   foreignReferenceMap,
   defaultLocale,
@@ -281,257 +282,279 @@ exports.createNodesForContentType = ({
     const childrenNodes = []
 
     // First create nodes for each of the entries of that content type
-    const entryNodes = entries.map(entryItem => {
-      // Get localized fields.
-      const entryItemFields = _.mapValues(entryItem.fields, (v, k) => {
-        const fieldProps = contentTypeItem.fields.find(field => field.id === k)
+    const entryNodes = entries
+      .map(entryItem => {
+        const entryNodeId = mId(
+          space.sys.id,
+          entryItem.sys.id,
+          entryItem.sys.type
+        )
 
-        const localizedField = fieldProps.localized
-          ? getField(v)
-          : v[defaultLocale]
+        const existingNode = getNode(entryNodeId)
+        if (existingNode?.internal?.contentDigest === entryItem.sys.updatedAt) {
+          // The Contentful model has `.sys.updatedAt` leading for an entry. If the updatedAt value
+          // of an entry did not change, then we can trust that none of its children were changed either.
+          return null
+        }
 
-        return localizedField
-      })
+        // Get localized fields.
+        const entryItemFields = _.mapValues(entryItem.fields, (v, k) => {
+          const fieldProps = contentTypeItem.fields.find(
+            field => field.id === k
+          )
 
-      // Prefix any conflicting fields
-      // https://github.com/gatsbyjs/gatsby/pull/1084#pullrequestreview-41662888
-      conflictFields.forEach(conflictField => {
-        entryItemFields[`${conflictFieldPrefix}${conflictField}`] =
-          entryItemFields[conflictField]
-        delete entryItemFields[conflictField]
-      })
+          const localizedField = fieldProps.localized
+            ? getField(v)
+            : v[defaultLocale]
 
-      // Add linkages to other nodes based on foreign references
-      Object.keys(entryItemFields).forEach(entryItemFieldKey => {
-        if (entryItemFields[entryItemFieldKey]) {
-          const entryItemFieldValue = entryItemFields[entryItemFieldKey]
-          if (Array.isArray(entryItemFieldValue)) {
-            if (
-              entryItemFieldValue[0] &&
-              entryItemFieldValue[0].sys &&
-              entryItemFieldValue[0].sys.type &&
-              entryItemFieldValue[0].sys.id
-            ) {
-              // Check if there are any values in entryItemFieldValue to prevent
-              // creating an empty node field in case when original key field value
-              // is empty due to links to missing entities
-              const resolvableEntryItemFieldValue = entryItemFieldValue
-                .filter(function (v) {
-                  return resolvable.has(
-                    `${v.sys.id}___${v.sys.linkType || v.sys.type}`
-                  )
-                })
-                .map(function (v) {
-                  return mId(
-                    space.sys.id,
-                    v.sys.id,
-                    v.sys.linkType || v.sys.type
-                  )
-                })
-              if (resolvableEntryItemFieldValue.length !== 0) {
-                entryItemFields[
-                  `${entryItemFieldKey}___NODE`
-                ] = resolvableEntryItemFieldValue
+          return localizedField
+        })
+
+        // Prefix any conflicting fields
+        // https://github.com/gatsbyjs/gatsby/pull/1084#pullrequestreview-41662888
+        conflictFields.forEach(conflictField => {
+          entryItemFields[`${conflictFieldPrefix}${conflictField}`] =
+            entryItemFields[conflictField]
+          delete entryItemFields[conflictField]
+        })
+
+        // Add linkages to other nodes based on foreign references
+        Object.keys(entryItemFields).forEach(entryItemFieldKey => {
+          if (entryItemFields[entryItemFieldKey]) {
+            const entryItemFieldValue = entryItemFields[entryItemFieldKey]
+            if (Array.isArray(entryItemFieldValue)) {
+              if (
+                entryItemFieldValue[0] &&
+                entryItemFieldValue[0].sys &&
+                entryItemFieldValue[0].sys.type &&
+                entryItemFieldValue[0].sys.id
+              ) {
+                // Check if there are any values in entryItemFieldValue to prevent
+                // creating an empty node field in case when original key field value
+                // is empty due to links to missing entities
+                const resolvableEntryItemFieldValue = entryItemFieldValue
+                  .filter(function (v) {
+                    return resolvable.has(
+                      `${v.sys.id}___${v.sys.linkType || v.sys.type}`
+                    )
+                  })
+                  .map(function (v) {
+                    return mId(
+                      space.sys.id,
+                      v.sys.id,
+                      v.sys.linkType || v.sys.type
+                    )
+                  })
+                if (resolvableEntryItemFieldValue.length !== 0) {
+                  entryItemFields[
+                    `${entryItemFieldKey}___NODE`
+                  ] = resolvableEntryItemFieldValue
+                }
+
+                delete entryItemFields[entryItemFieldKey]
               }
-
+            } else if (
+              entryItemFieldValue &&
+              entryItemFieldValue.sys &&
+              entryItemFieldValue.sys.type &&
+              entryItemFieldValue.sys.id
+            ) {
+              if (
+                resolvable.has(
+                  `${entryItemFieldValue.sys.id}___${
+                    entryItemFieldValue.sys.linkType ||
+                    entryItemFieldValue.sys.type
+                  }`
+                )
+              ) {
+                entryItemFields[`${entryItemFieldKey}___NODE`] = mId(
+                  space.sys.id,
+                  entryItemFieldValue.sys.id,
+                  entryItemFieldValue.sys.linkType ||
+                    entryItemFieldValue.sys.type
+                )
+              }
               delete entryItemFields[entryItemFieldKey]
             }
-          } else if (
-            entryItemFieldValue &&
-            entryItemFieldValue.sys &&
-            entryItemFieldValue.sys.type &&
-            entryItemFieldValue.sys.id
-          ) {
-            if (
-              resolvable.has(
-                `${entryItemFieldValue.sys.id}___${
-                  entryItemFieldValue.sys.linkType ||
-                  entryItemFieldValue.sys.type
-                }`
-              )
-            ) {
-              entryItemFields[`${entryItemFieldKey}___NODE`] = mId(
-                space.sys.id,
-                entryItemFieldValue.sys.id,
-                entryItemFieldValue.sys.linkType || entryItemFieldValue.sys.type
-              )
-            }
-            delete entryItemFields[entryItemFieldKey]
           }
-        }
-      })
+        })
 
-      // Add reverse linkages if there are any for this node
-      const foreignReferences =
-        foreignReferenceMap[`${entryItem.sys.id}___${entryItem.sys.type}`]
-      if (foreignReferences) {
-        foreignReferences.forEach(foreignReference => {
-          const existingReference = entryItemFields[foreignReference.name]
-          if (existingReference) {
-            // If the existing reference is a string, we're dealing with a
-            // many-to-one reference which has already been recorded, so we can
-            // skip it. However, if it is an array, add it:
-            if (Array.isArray(existingReference)) {
-              entryItemFields[foreignReference.name].push(
+        // Add reverse linkages if there are any for this node
+        const foreignReferences =
+          foreignReferenceMap[`${entryItem.sys.id}___${entryItem.sys.type}`]
+        if (foreignReferences) {
+          foreignReferences.forEach(foreignReference => {
+            const existingReference = entryItemFields[foreignReference.name]
+            if (existingReference) {
+              // If the existing reference is a string, we're dealing with a
+              // many-to-one reference which has already been recorded, so we can
+              // skip it. However, if it is an array, add it:
+              if (Array.isArray(existingReference)) {
+                entryItemFields[foreignReference.name].push(
+                  mId(
+                    foreignReference.spaceId,
+                    foreignReference.id,
+                    foreignReference.type
+                  )
+                )
+              }
+            } else {
+              // If there is one foreign reference, there can be many.
+              // Best to be safe and put it in an array to start with.
+              entryItemFields[foreignReference.name] = [
                 mId(
                   foreignReference.spaceId,
                   foreignReference.id,
                   foreignReference.type
-                )
-              )
+                ),
+              ]
             }
-          } else {
-            // If there is one foreign reference, there can be many.
-            // Best to be safe and put it in an array to start with.
-            entryItemFields[foreignReference.name] = [
-              mId(
-                foreignReference.spaceId,
-                foreignReference.id,
-                foreignReference.type
-              ),
-            ]
-          }
-        })
-      }
-
-      let entryNode = {
-        id: mId(space.sys.id, entryItem.sys.id, entryItem.sys.type),
-        spaceId: space.sys.id,
-        contentful_id: entryItem.sys.id,
-        createdAt: entryItem.sys.createdAt,
-        updatedAt: entryItem.sys.updatedAt,
-        parent: contentTypeItemId,
-        children: [],
-        internal: {
-          type: `${makeTypeName(contentTypeItemId)}`,
-        },
-        sys: {
-          type: entryItem.sys.type,
-        },
-      }
-
-      // Revision applies to entries, assets, and content types
-      if (entryItem.sys.revision) {
-        entryNode.sys.revision = entryItem.sys.revision
-      }
-
-      // Content type applies to entries only
-      if (entryItem.sys.contentType) {
-        entryNode.sys.contentType = entryItem.sys.contentType
-      }
-
-      // Replace text fields with text nodes so we can process their markdown
-      // into HTML.
-      Object.keys(entryItemFields).forEach(entryItemFieldKey => {
-        // Ignore fields with "___node" as they're already handled
-        // and won't be a text field.
-        if (entryItemFieldKey.split(`___`).length > 1) {
-          return
+          })
         }
 
-        const fieldType = contentTypeItem.fields.find(
-          f =>
-            (restrictedNodeFields.includes(f.id)
-              ? `${conflictFieldPrefix}${f.id}`
-              : f.id) === entryItemFieldKey
-        ).type
-        if (fieldType === `Text`) {
-          const textNode = prepareTextNode(
-            entryNode,
-            entryItemFieldKey,
-            entryItemFields[entryItemFieldKey],
-            createNodeId
-          )
+        let entryNode = {
+          id: entryNodeId,
+          spaceId: space.sys.id,
+          contentful_id: entryItem.sys.id,
+          createdAt: entryItem.sys.createdAt,
+          updatedAt: entryItem.sys.updatedAt,
+          parent: contentTypeItemId,
+          children: [],
+          internal: {
+            type: `${makeTypeName(contentTypeItemId)}`,
+          },
+          sys: {
+            type: entryItem.sys.type,
+          },
+        }
 
-          childrenNodes.push(textNode)
-          entryItemFields[`${entryItemFieldKey}___NODE`] = textNode.id
+        // Revision applies to entries, assets, and content types
+        if (entryItem.sys.revision) {
+          entryNode.sys.revision = entryItem.sys.revision
+        }
 
-          delete entryItemFields[entryItemFieldKey]
-        } else if (
-          fieldType === `RichText` &&
-          _.isPlainObject(entryItemFields[entryItemFieldKey])
-        ) {
-          const fieldValue = entryItemFields[entryItemFieldKey]
+        // Content type applies to entries only
+        if (entryItem.sys.contentType) {
+          entryNode.sys.contentType = entryItem.sys.contentType
+        }
 
-          const rawReferences = []
+        // Replace text fields with text nodes so we can process their markdown
+        // into HTML.
+        Object.keys(entryItemFields).forEach(entryItemFieldKey => {
+          // Ignore fields with "___node" as they're already handled
+          // and won't be a text field.
+          if (entryItemFieldKey.split(`___`).length > 1) {
+            return
+          }
 
-          // Locate all Contentful Links within the rich text data
-          const traverse = obj => {
-            for (let k in obj) {
-              const v = obj[k]
-              if (v && v.sys && v.sys.type === `Link`) {
-                rawReferences.push(v)
-              } else if (v && typeof v === `object`) {
-                traverse(v)
+          const fieldType = contentTypeItem.fields.find(
+            f =>
+              (restrictedNodeFields.includes(f.id)
+                ? `${conflictFieldPrefix}${f.id}`
+                : f.id) === entryItemFieldKey
+          ).type
+          if (fieldType === `Text`) {
+            const textNode = prepareTextNode(
+              entryNode,
+              entryItemFieldKey,
+              entryItemFields[entryItemFieldKey],
+              createNodeId
+            )
+
+            childrenNodes.push(textNode)
+            entryItemFields[`${entryItemFieldKey}___NODE`] = textNode.id
+
+            delete entryItemFields[entryItemFieldKey]
+          } else if (
+            fieldType === `RichText` &&
+            _.isPlainObject(entryItemFields[entryItemFieldKey])
+          ) {
+            const fieldValue = entryItemFields[entryItemFieldKey]
+
+            const rawReferences = []
+
+            // Locate all Contentful Links within the rich text data
+            const traverse = obj => {
+              for (let k in obj) {
+                const v = obj[k]
+                if (v && v.sys && v.sys.type === `Link`) {
+                  rawReferences.push(v)
+                } else if (v && typeof v === `object`) {
+                  traverse(v)
+                }
               }
             }
-          }
 
-          traverse(fieldValue)
+            traverse(fieldValue)
 
-          // Build up resolvable reference list
-          const resolvableReferenceIds = new Set()
-          rawReferences
-            .filter(function (v) {
-              return resolvable.has(
-                `${v.sys.id}___${v.sys.linkType || v.sys.type}`
-              )
-            })
-            .forEach(function (v) {
-              resolvableReferenceIds.add(
-                mId(space.sys.id, v.sys.id, v.sys.linkType || v.sys.type)
-              )
-            })
+            // Build up resolvable reference list
+            const resolvableReferenceIds = new Set()
+            rawReferences
+              .filter(function (v) {
+                return resolvable.has(
+                  `${v.sys.id}___${v.sys.linkType || v.sys.type}`
+                )
+              })
+              .forEach(function (v) {
+                resolvableReferenceIds.add(
+                  mId(space.sys.id, v.sys.id, v.sys.linkType || v.sys.type)
+                )
+              })
 
-          entryItemFields[entryItemFieldKey] = {
-            raw: stringify(fieldValue),
-            references___NODE: [...resolvableReferenceIds],
-          }
-        } else if (
-          fieldType === `Object` &&
-          _.isPlainObject(entryItemFields[entryItemFieldKey])
-        ) {
-          const jsonNode = prepareJSONNode(
-            entryNode,
-            entryItemFieldKey,
-            entryItemFields[entryItemFieldKey],
-            createNodeId
-          )
-
-          childrenNodes.push(jsonNode)
-          entryItemFields[`${entryItemFieldKey}___NODE`] = jsonNode.id
-
-          delete entryItemFields[entryItemFieldKey]
-        } else if (
-          fieldType === `Object` &&
-          _.isArray(entryItemFields[entryItemFieldKey])
-        ) {
-          entryItemFields[`${entryItemFieldKey}___NODE`] = []
-
-          entryItemFields[entryItemFieldKey].forEach((obj, i) => {
+            entryItemFields[entryItemFieldKey] = {
+              raw: stringify(fieldValue),
+              references___NODE: [...resolvableReferenceIds],
+            }
+          } else if (
+            fieldType === `Object` &&
+            _.isPlainObject(entryItemFields[entryItemFieldKey])
+          ) {
             const jsonNode = prepareJSONNode(
               entryNode,
               entryItemFieldKey,
-              obj,
-              createNodeId,
-              i
+              entryItemFields[entryItemFieldKey],
+              createNodeId
             )
 
             childrenNodes.push(jsonNode)
-            entryItemFields[`${entryItemFieldKey}___NODE`].push(jsonNode.id)
-          })
+            entryItemFields[`${entryItemFieldKey}___NODE`] = jsonNode.id
 
-          delete entryItemFields[entryItemFieldKey]
+            delete entryItemFields[entryItemFieldKey]
+          } else if (
+            fieldType === `Object` &&
+            _.isArray(entryItemFields[entryItemFieldKey])
+          ) {
+            entryItemFields[`${entryItemFieldKey}___NODE`] = []
+
+            entryItemFields[entryItemFieldKey].forEach((obj, i) => {
+              const jsonNode = prepareJSONNode(
+                entryNode,
+                entryItemFieldKey,
+                obj,
+                createNodeId,
+                i
+              )
+
+              childrenNodes.push(jsonNode)
+              entryItemFields[`${entryItemFieldKey}___NODE`].push(jsonNode.id)
+            })
+
+            delete entryItemFields[entryItemFieldKey]
+          }
+        })
+
+        entryNode = {
+          ...entryItemFields,
+          ...entryNode,
+          node_locale: locale.code,
         }
+
+        // The content of an entry is guaranteed to be updated if and only if the .sys.updatedAt field changed
+        entryNode.internal.contentDigest = entryItem.sys.updatedAt
+
+        return entryNode
       })
-
-      entryNode = { ...entryItemFields, ...entryNode, node_locale: locale.code }
-
-      // The content of an entry is guaranteed to be updated if and only if the .sys.updatedAt field changed
-      entryNode.internal.contentDigest = entryItem.sys.updatedAt
-
-      return entryNode
-    })
+      .filter(Boolean)
 
     // Create a node for each content type
     const contentTypeNode = {

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -180,10 +180,10 @@ exports.buildForeignReferenceMap = ({
   return foreignReferenceMap
 }
 
-function prepareTextNode(textNodeId, node, key, text) {
+function prepareTextNode(id, node, key, text) {
   const str = _.isString(text) ? text : ``
   const textNode = {
-    id: textNodeId,
+    id,
     parent: node.id,
     children: [],
     [key]: str,
@@ -199,7 +199,7 @@ function prepareTextNode(textNodeId, node, key, text) {
     },
   }
 
-  node.children = node.children.concat([textNode.id])
+  node.children = node.children.concat([id])
 
   return textNode
 }

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -443,7 +443,7 @@ exports.createNodesForContentType = ({
         Object.keys(entryItemFields).forEach(entryItemFieldKey => {
           // Ignore fields with "___node" as they're already handled
           // and won't be a text field.
-          if (entryItemFieldKey.split(`___`).length > 1) {
+          if (entryItemFieldKey.includes(`___`)) {
             return
           }
 


### PR DESCRIPTION
A warm build will currently still attempt to create the node even if it already exists. This PR will do an early check, compare the digest (`entry.sys.updatedAt`), and return early if the node already exists for that digest.

There might be a simpler solution but for now, this cuts the warm "no changes" build for a 2 million node site down from to about 894s (120s for node createion step) down to 512s (35s for the node creation step), saving about 5 minutes.

Need verification from Contentful that this approach is sound. But I think it is. (Tests will fail too, will fix them before we merge)