### PR TITLE
fix(gatsby): Do not activate inspect if already active

### DIFF
--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -66,6 +66,10 @@ interface IDevelopArgs extends IProgram {
 }
 
 const openDebuggerPort = (debugInfo: IDebugInfo): void => {
+  if (inspector.url() !== undefined) {
+    return // fixes #26708
+  }
+
   if (debugInfo.break) {
     inspector.open(debugInfo.port, undefined, true)
     // eslint-disable-next-line no-debugger


### PR DESCRIPTION
## Description

Avoids activating the inspector if already active, which cases issues https://github.com/gatsbyjs/gatsby/issues/26708

### Documentation

The behavior to throw was introduced in response to https://github.com/nodejs/node/issues/33012, where previously it just resulted in weird/broken behavior.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/26708