### PR TITLE
fix(sharp) wrap sharp calls in try/catch to avoid crashing on bad images

### DIFF
--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -6,6 +6,7 @@ import { rgbToHex, calculateImageSizes, getSrcSet, getSizes } from "./utils"
 import { traceSVG, getImageSizeAsync, base64, batchQueueImageResizing } from "."
 import sharp from "./safe-sharp"
 import { createTransformObject } from "./plugin-options"
+import { reportError } from './report-error';
 
 const DEFAULT_BLURRED_IMAGE_WIDTH = 20
 
@@ -48,7 +49,7 @@ const metadataCache = new Map<string, IImageMetadata>()
 export async function getImageMetadata(
   file: FileNode,
   getDominantColor?: boolean
-): Promise<IImageMetadata> {
+): Promise<IImageMetadata | undefined> {
   if (!getDominantColor) {
     // If we don't need the dominant color we can use the cheaper size function
     const { width, height, type } = await getImageSizeAsync(file)
@@ -58,19 +59,25 @@ export async function getImageMetadata(
   if (metadata && process.env.NODE_ENV !== `test`) {
     return metadata
   }
-  const pipeline = sharp(file.absolutePath)
 
-  const { width, height, density, format } = await pipeline.metadata()
+  try {
+    const pipeline = sharp(file.absolutePath)
 
-  const { dominant } = await pipeline.stats()
-  // Fallback in case sharp doesn't support dominant
-  const dominantColor = dominant
-    ? rgbToHex(dominant.r, dominant.g, dominant.b)
-    : `#000000`
+    const { width, height, density, format } = await pipeline.metadata()
 
-  metadata = { width, height, density, format, dominantColor }
-  metadataCache.set(file.internal.contentDigest, metadata)
-  return metadata
+    const { dominant } = await pipeline.stats()
+    // Fallback in case sharp doesn't support dominant
+    const dominantColor = dominant
+      ? rgbToHex(dominant.r, dominant.g, dominant.b)
+      : `#000000`
+
+    metadata = { width, height, density, format, dominantColor }
+    metadataCache.set(file.internal.contentDigest, metadata)
+    return metadata
+  } catch (err) {
+    reportError(`Failed to process image ${file.absolutePath}`, err)
+    return;
+  }
 }
 
 export interface IImageDataProps {
@@ -132,7 +139,7 @@ export async function generateImageData({
   let primaryFormat: ImageFormat | undefined
   let options: Record<string, unknown> | undefined
   if (useAuto) {
-    primaryFormat = normalizeFormat(metadata.format || file.extension)
+    primaryFormat = normalizeFormat(metadata?.format || file.extension)
   } else if (formats.has(`png`)) {
     primaryFormat = `png`
     options = args.pngOptions
@@ -275,7 +282,7 @@ export async function generateImageData({
     imageProps.placeholder = {
       fallback,
     }
-  } else if (metadata.dominantColor) {
+  } else if (metadata?.dominantColor) {
     imageProps.backgroundColor = metadata.dominantColor
   }
 

--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -6,7 +6,7 @@ import { rgbToHex, calculateImageSizes, getSrcSet, getSizes } from "./utils"
 import { traceSVG, getImageSizeAsync, base64, batchQueueImageResizing } from "."
 import sharp from "./safe-sharp"
 import { createTransformObject } from "./plugin-options"
-import { reportError } from './report-error';
+import { reportError } from "./report-error"
 
 const DEFAULT_BLURRED_IMAGE_WIDTH = 20
 
@@ -73,11 +73,11 @@ export async function getImageMetadata(
 
     metadata = { width, height, density, format, dominantColor }
     metadataCache.set(file.internal.contentDigest, metadata)
-    return metadata
   } catch (err) {
     reportError(`Failed to process image ${file.absolutePath}`, err)
-    return;
   }
+
+  return metadata
 }
 
 export interface IImageDataProps {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adds try/catch blocks where `gatsby-plugin-sharp` reads and writes images.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

[`gatsby-plugin-sharp` documentation.](https://www.gatsbyjs.com/plugins/gatsby-plugin-sharp/)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #28640
