### PR TITLE
feat(gatsby): decouple html activities

### DIFF
--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -88,7 +88,7 @@ export const buildRenderer = async (
   return doBuildRenderer(program, config, stage)
 }
 
-const deleteRenderer = async (rendererPath: string): Promise<void> => {
+export const deleteRenderer = async (rendererPath: string): Promise<void> => {
   try {
     await fs.remove(rendererPath)
     await fs.remove(`${rendererPath}.map`)
@@ -143,7 +143,7 @@ class BuildHTMLError extends Error {
   }
 }
 
-const doBuildPages = async (
+export const doBuildPages = async (
   rendererPath: string,
   pagePaths: Array<string>,
   activity: IActivity,
@@ -166,6 +166,7 @@ const doBuildPages = async (
   }
 }
 
+// TODO remove in v4 - this could be a "public" api
 export const buildHTML = async ({
   program,
   stage,
@@ -181,7 +182,5 @@ export const buildHTML = async ({
 }): Promise<void> => {
   const rendererPath = await buildRenderer(program, stage, activity.span)
   await doBuildPages(rendererPath, pagePaths, activity, workerPool)
-  if (stage !== `develop-html`) {
-    await deleteRenderer(rendererPath)
-  }
+  await deleteRenderer(rendererPath)
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Decouple html ssr bundling from rendering pages to get better metrics on where html rendering is slow.
![image](https://user-images.githubusercontent.com/1120926/102323302-9a2df900-3f80-11eb-9e3e-1cb31e9e4435.png)



### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
