### PR TITLE
fix(gatsbu-source-contentful): apply useNameForId when creating the g…

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -346,7 +346,15 @@ exports.sourceNodes = async (
 
   const gqlTypes = contentTypeItems.map(contentTypeItem =>
     schema.buildObjectType({
-      name: _.upperFirst(_.camelCase(`Contentful ${contentTypeItem.name}`)),
+      name: _.upperFirst(
+        _.camelCase(
+          `Contentful ${
+            pluginConfig.get(`useNameForId`)
+              ? contentTypeItem.name
+              : contentTypeItem.sys.id
+          }`
+        )
+      ),
       fields: {
         contentful_id: { type: `String!` },
         id: { type: `ID!` },


### PR DESCRIPTION
## Description

Apply `useNameForId` when the graphql schema on gatsby build phase.

It was degraded by [the commit](https://github.com/gatsbyjs/gatsby/commit/a25634698205181e84f1067ebba0c4816fb742ed#diff-b2ca51ba722d6b47f74a2227bfebd74836ff08c1e0184236b001ae30b52d25e0R307).

### Documentation

This is [the document](https://www.gatsbyjs.com/plugins/gatsby-source-contentful/) but it doesn't need to update.

## Related Issues

Fixes #28329
