### PR TITLE
 fix(docs): dead links sourcing-data -> querying-data

### DIFF
--- a/docs/docs/add-seo-component.md
+++ b/docs/docs/add-seo-component.md
@@ -4,7 +4,7 @@ title: "Adding an SEO Component"
 
 Every site on the web has basic _meta-tags_ like the title, favicon or description of the page in their `<head>` element. This information gets displayed in the browser and is used when someone shares your website, e.g. on Twitter. You can give your users and these websites additional data to embed your website with more data — and that's where this guide for a SEO component comes in. At the end you'll have a component you can place in your layout file and have rich previews for other clients, smartphone users, and search engines.
 
-_Note: This component will use `useStaticQuery`. If you're unfamiliar with that, have a look at the [useStaticQuery documentation](/docs/how-to/sourcing-data/use-static-query/). You also have to have `react-helmet` installed for which you can have a look at [this document](/docs/add-page-metadata)._
+_Note: This component will use `useStaticQuery`. If you're unfamiliar with that, have a look at the [useStaticQuery documentation](/docs/how-to/querying-data/use-static-query/). You also have to have `react-helmet` installed for which you can have a look at [this document](/docs/add-page-metadata)._
 
 ## gatsby-config.js
 

--- a/docs/docs/conceptual/building-with-components.md
+++ b/docs/docs/conceptual/building-with-components.md
@@ -175,4 +175,4 @@ the Gatsby repo.
 ### Non-page components
 
 A Non-page component is one that's embedded inside some other component, forming a component hierarchy. An example would be a Header component that's included in multiple page components.
-Gatsby uses GraphQL to enable components to declare the data they need. Using the [StaticQuery](/docs/how-to/sourcing-data/static-query/) component or [useStaticQuery hook](/docs/how-to/sourcing-data/use-static-query/), you can colocate a non-page component with its data.
+Gatsby uses GraphQL to enable components to declare the data they need. Using the [StaticQuery](/docs/how-to/querying-data/static-query/) component or [useStaticQuery hook](/docs/how-to/querying-data/use-static-query/), you can colocate a non-page component with its data.

--- a/docs/docs/conceptual/graphql-concepts.md
+++ b/docs/docs/conceptual/graphql-concepts.md
@@ -88,7 +88,7 @@ The result of the query is automatically inserted into your React component
 on the `data` prop. GraphQL and Gatsby let you ask for data and then
 immediately start using it.
 
-**Note:** To run GraphQL queries in non-page components you'll need to use [Gatsby's Static Query feature](/docs/how-to/sourcing-data/static-query/).
+**Note:** To run GraphQL queries in non-page components you'll need to use [Gatsby's Static Query feature](/docs/how-to/querying-data/static-query/).
 
 ### Understanding the parts of a query
 

--- a/docs/docs/data-fetching.md
+++ b/docs/docs/data-fetching.md
@@ -101,7 +101,7 @@ query {
 
 #### Writing a query to gather the static data needed for a page
 
-With the source plugin installed and added to your config, you can write a [static query](/docs/how-to/sourcing-data/use-static-query/) that will retrieve the necessary data from Gatsby's data layer while building the site.
+With the source plugin installed and added to your config, you can write a [static query](/docs/how-to/querying-data/use-static-query/) that will retrieve the necessary data from Gatsby's data layer while building the site.
 
 ```jsx:title=src/pages/index.js
 import React from "react"

--- a/docs/docs/data-storage-redux.md
+++ b/docs/docs/data-storage-redux.md
@@ -12,7 +12,7 @@ The namespaces in Gatsby's Redux store are a great overview of the Gatsby intern
 - **[Schema](/docs/schema-generation/)** - GraphQL [schema](/docs/glossary#schema) [inferred](/docs/glossary#inference) from Nodes, available for querying by page and static queries.
 - **[Pages](/docs/gatsby-internals-terminology/#page)** - A `Map` of page paths to page objects. Objects made via [Page Creation](/docs/page-creation) contain information needed to render a page such as component file path, page query and context.
 - **[Components](/docs/gatsby-internals-terminology/#component)** - A `Map` of component file paths to page objects.
-- **[Static Query Components](/docs/static-vs-normal-queries/#keeping-track-of-site-queries-during-build-in-redux-stores)** - A `Map` of any components detected with a [static query](/docs/how-to/sourcing-data/static-query/).
+- **[Static Query Components](/docs/static-vs-normal-queries/#keeping-track-of-site-queries-during-build-in-redux-stores)** - A `Map` of any components detected with a [static query](/docs/how-to/querying-data/static-query/).
 - **Jobs** - Long-running and CPU-intensive processes, generally started as a side-effect to a GraphQL query. Gatsby doesn’t finish its process until all jobs are ended.
 - **webpack** - Config for the [webpack](/docs/webpack-and-ssr/) bundler which handles code optimization and splitting of delivered JavaScript bundles.
 

--- a/docs/docs/glossary/static-site-generator.md
+++ b/docs/docs/glossary/static-site-generator.md
@@ -13,7 +13,7 @@ Static site generators are an alternative to database-driven content management 
 
 Static site generators, on the other hand, generate HTML pages during a [build](/docs/glossary/#build) process. Gatsby, for example, loads JSON from [GraphQL](/docs/glossary/graphql), and merges that data with components to create HTML pages. These generated pages are then deployed to a web server. When the server receives a request, it responds with rendered HTML. Static pages eliminate the latency that databases introduce.
 
-> Note: It's also possible to use Gatsby [without GraphQL](/docs/how-to/sourcing-data/using-gatsby-without-graphql/), using the `createPages` API.
+> Note: It's also possible to use Gatsby [without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/), using the `createPages` API.
 
 You can also use static site generators to create [JAMStack](/docs/glossary/#jamstack) sites. JAMStack is a modern website architecture that uses JavaScript, content APIs, and markup. Gatsby, for example, can use the [WordPress REST API](/docs/how-to/sourcing-data/sourcing-from-wordpress/) as a data source.
 

--- a/docs/docs/how-to/plugins-and-themes/theme-conventions.md
+++ b/docs/docs/how-to/plugins-and-themes/theme-conventions.md
@@ -34,7 +34,7 @@ exports.onPreBootstrap = ({ store, reporter }) => {
 
 ## Separating queries and presentational components
 
-As a theme author, it's preferable to separate your data gathering and the components that render the data. This makes it easier for end users to be able to shadow a component like `PostList` or `AuthorCard` without having to write a [pageQuery](/docs/how-to/querying-data/page-query) or [StaticQuery](/docs/how-to/sourcing-data/static-query).
+As a theme author, it's preferable to separate your data gathering and the components that render the data. This makes it easier for end users to be able to shadow a component like `PostList` or `AuthorCard` without having to write a [pageQuery](/docs/how-to/querying-data/page-query) or [StaticQuery](/docs/how-to/querying-data/static-query).
 
 ### Page queries
 

--- a/docs/docs/how-to/querying-data/static-query.md
+++ b/docs/docs/how-to/querying-data/static-query.md
@@ -47,7 +47,7 @@ By using `StaticQuery`, you can colocate a component with its data. It is no lon
 
 ### useStaticQuery
 
-There's also a React hooks version of StaticQuery: check out the documentation on [`useStaticQuery`](/docs/how-to/sourcing-data/use-static-query/)
+There's also a React hooks version of StaticQuery: check out the documentation on [`useStaticQuery`](/docs/how-to/querying-data/use-static-query/)
 
 ### Typechecking
 

--- a/docs/docs/how-to/querying-data/use-static-query.md
+++ b/docs/docs/how-to/querying-data/use-static-query.md
@@ -4,9 +4,9 @@ title: Querying Data in Components with the useStaticQuery Hook
 
 Gatsby v2.1.0 introduces `useStaticQuery`, a new Gatsby feature that provides the ability to use a [React Hook](https://reactjs.org/docs/hooks-intro.html) to query with GraphQL at _build time_.
 
-Just like the [StaticQuery](/docs/how-to/sourcing-data/static-query/) component, it allows your React components to retrieve data via a GraphQL query that will be parsed, evaluated, and injected into the component. However, `useStaticQuery` is a hook rather than a component that takes a render prop!
+Just like the [StaticQuery](/docs/how-to/querying-data/static-query/) component, it allows your React components to retrieve data via a GraphQL query that will be parsed, evaluated, and injected into the component. However, `useStaticQuery` is a hook rather than a component that takes a render prop!
 
-In this guide, you will walk through an example using `useStaticQuery`. If you're not familiar with static queries in Gatsby, you might want to check out [the difference between a static query and a page query](/docs/how-to/sourcing-data/static-query/#how-staticquery-differs-from-page-query).
+In this guide, you will walk through an example using `useStaticQuery`. If you're not familiar with static queries in Gatsby, you might want to check out [the difference between a static query and a page query](/docs/how-to/querying-data/static-query/#how-staticquery-differs-from-page-query).
 
 ## How to use useStaticQuery in components
 

--- a/docs/docs/how-to/sourcing-data/sourcing-from-private-apis.md
+++ b/docs/docs/how-to/sourcing-data/sourcing-from-private-apis.md
@@ -9,7 +9,7 @@ From the Gatsby perspective, there is no difference between sourcing from a publ
 There are 3 approaches that you can use to source data from your private API:
 
 1. If your private API is a GraphQL API, you can use [`gatsby-source-graphql`](/packages/gatsby-source-graphql/).
-2. If your private API is not a GraphQL API and you are new to GraphQL, treat the data as unstructured data and fetch it during build time, as described by the guide "[Using Gatsby without GraphQL](/docs/how-to/sourcing-data/using-gatsby-without-graphql/)". However, as highlighted in the guide, this approach comes with some tradeoffs.
+2. If your private API is not a GraphQL API and you are new to GraphQL, treat the data as unstructured data and fetch it during build time, as described by the guide "[Using Gatsby without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/)". However, as highlighted in the guide, this approach comes with some tradeoffs.
 3. Create a source plugin, as described in the tutorial "[Source plugin tutorial](/docs/how-to/plugins-and-themes/creating-a-source-plugin/)".
 
 ## Other considerations

--- a/docs/docs/porting-from-create-react-app-to-gatsby.md
+++ b/docs/docs/porting-from-create-react-app-to-gatsby.md
@@ -33,7 +33,7 @@ Plugins can also pull in data from any number of sources like APIs, CMSs, or the
 
 This data layer simplifies the process of pulling data from different sources and providing them in your pages and components. This combination of data from different sources stitched together in a modern workflow is referred to as [the content mesh](/blog/2018-10-04-journey-to-the-content-mesh/).
 
-> **Note**: GraphQL isn't required for managing data in a Gatsby app. Feel free to look over the guide on [using Gatsby without GraphQL](/docs/how-to/sourcing-data/using-gatsby-without-graphql/) as well
+> **Note**: GraphQL isn't required for managing data in a Gatsby app. Feel free to look over the guide on [using Gatsby without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/) as well
 
 ---
 

--- a/docs/docs/programmatically-create-pages-from-data.md
+++ b/docs/docs/programmatically-create-pages-from-data.md
@@ -121,5 +121,5 @@ programmatically create pages.
 ## Other resources
 
 - [Example Repository](https://github.com/jbranchaud/gatsby-programmatic-pages)
-- [Using Gatsby without GraphQL](/docs/how-to/sourcing-data/using-gatsby-without-graphql/)
+- [Using Gatsby without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/)
 - [CodeSandbox example creating pages from 3rd party data](https://codesandbox.io/s/b84oz)

--- a/docs/docs/recipes/pages-layouts.md
+++ b/docs/docs/recipes/pages-layouts.md
@@ -245,5 +245,5 @@ export default function DogTemplate({ pageContext: { dog } }) {
 ### Additional resources
 
 - Tutorial section on [programmatically creating pages from data](/docs/tutorial/part-seven/)
-- Reference guide on [using Gatsby without GraphQL](/docs/how-to/sourcing-data/using-gatsby-without-graphql/)
+- Reference guide on [using Gatsby without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/)
 - [Example repo](https://github.com/gatsbyjs/gatsby/tree/master/examples/recipe-createPage) for this recipe

--- a/docs/docs/recipes/querying-data.md
+++ b/docs/docs/recipes/querying-data.md
@@ -57,7 +57,7 @@ export default IndexPage
 
 ## Querying data with the StaticQuery Component
 
-`StaticQuery` is a component for retrieving data from Gatsby's data layer in [non-page components](/docs/how-to/sourcing-data/static-query/), such as a header, navigation, or any other child component.
+`StaticQuery` is a component for retrieving data from Gatsby's data layer in [non-page components](/docs/how-to/querying-data/static-query/), such as a header, navigation, or any other child component.
 
 ### Directions
 
@@ -142,9 +142,9 @@ export default NonPageComponent
 
 ### Additional resources
 
-- [More on Static Query for querying data in components](/docs/how-to/sourcing-data/static-query/)
-- [The difference between a static query and a page query](/docs/how-to/sourcing-data/static-query/#how-staticquery-differs-from-page-query)
-- [More on the useStaticQuery hook](/docs/how-to/sourcing-data/use-static-query/)
+- [More on Static Query for querying data in components](/docs/how-to/querying-data/static-query/)
+- [The difference between a static query and a page query](/docs/how-to/querying-data/static-query/#how-staticquery-differs-from-page-query)
+- [More on the useStaticQuery hook](/docs/how-to/querying-data/use-static-query/)
 - [Visualize your data with GraphiQL](/docs/introducing-graphiql/)
 
 ## Limiting with GraphQL

--- a/docs/docs/recipes/sourcing-data.md
+++ b/docs/docs/recipes/sourcing-data.md
@@ -534,7 +534,7 @@ export default function AllPokemon({ pageContext: { allPokemon } }) {
 ### Additional resources
 
 - [Full Pokemon data repo](https://github.com/jlengstorf/gatsby-with-unstructured-data/)
-- More on using unstructured data in [Using Gatsby without GraphQL](/docs/how-to/sourcing-data/using-gatsby-without-graphql/)
+- More on using unstructured data in [Using Gatsby without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/)
 - When and how to [query data with GraphQL](/docs/conceptual/graphql-concepts/) for more complex Gatsby sites
 
 ## Sourcing content from Drupal

--- a/docs/docs/reference/built-in-components/gatsby-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-image.md
@@ -37,7 +37,7 @@ _For in-depth install instructions, check out the docs on [Using Gatsby Image](/
 
 ### Gatsby image starts with a query
 
-To feed file data in to Gatsby Image, set up a [GraphQL query](/docs/graphql-reference/) and either pass it into a component as props or write it directly in the component. One technique is to leverage the [`useStaticQuery`](/docs/how-to/sourcing-data/use-static-query/) hook.
+To feed file data in to Gatsby Image, set up a [GraphQL query](/docs/graphql-reference/) and either pass it into a component as props or write it directly in the component. One technique is to leverage the [`useStaticQuery`](/docs/how-to/querying-data/use-static-query/) hook.
 
 Common GraphQL queries for sourcing images include `file` from [gatsby-source-filesystem](/packages/gatsby-source-filesystem/), and both `imageSharp` and `allImageSharp` from [gatsby-plugin-sharp](/packages/gatsby-plugin-sharp/), but ultimately the options available to you will depend on your content sources.
 

--- a/docs/docs/reference/graphql-data-layer/graphql-api.md
+++ b/docs/docs/reference/graphql-data-layer/graphql-api.md
@@ -15,7 +15,7 @@ GraphQL is available in Gatsby without a special install: a schema is automatica
 
 Data needs to be [sourced](/docs/content-and-data/) — or added to the GraphQL schema — to be queried and pulled into pages using GraphQL. Gatsby uses [source plugins](/plugins/?=gatsby-source) to pull in data.
 
-**Note**: GraphQL isn't required: you can still [use Gatsby without GraphQL](/docs/how-to/sourcing-data/using-gatsby-without-graphql/).
+**Note**: GraphQL isn't required: you can still [use Gatsby without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/).
 
 To source data with an existing plugin you have to install all needed packages. Furthermore you have to add the plugin to the plugins array in the `gatsby-config` with any optional configurations. If you want to source data from the filesystem for use with GraphQL, such as Markdown files, images, and more, refer to the [filesystem data sourcing docs](/docs/how-to/sourcing-data/sourcing-from-the-filesystem) and [recipes](/docs/recipes/sourcing-data).
 
@@ -84,7 +84,7 @@ StaticQuery is a built-in component for retrieving data from Gatsby’s data lay
 
 You can only have one `StaticQuery` per page: in order to include the data you need from multiple sources, you can use one query with multiple [root fields](/docs/conceptual/graphql-concepts/#query-fields). It cannot take variables as arguments.
 
-Also, refer to the [guide on querying data in components with static query](/docs/how-to/sourcing-data/static-query/).
+Also, refer to the [guide on querying data in components with static query](/docs/how-to/querying-data/static-query/).
 
 #### Params
 
@@ -137,7 +137,7 @@ The `useStaticQuery` hook can be used similar to `StaticQuery` in any component 
 
 Because it is a React hook, the [rules of hooks](https://reactjs.org/docs/hooks-rules.html) apply and you'll need to use it with React and ReactDOM version 16.8.0 or later. Because of how queries currently work in Gatsby, only one instance of `useStaticQuery` is supported in each file.
 
-Also, refer to the [guide on querying data in components with useStaticQuery](/docs/how-to/sourcing-data/use-static-query/).
+Also, refer to the [guide on querying data in components with useStaticQuery](/docs/how-to/querying-data/use-static-query/).
 
 #### Params
 

--- a/docs/docs/reference/release-notes/migrating-from-v1-to-v2.md
+++ b/docs/docs/reference/release-notes/migrating-from-v1-to-v2.md
@@ -218,7 +218,7 @@ export default function Home(props) {
 
 #### 5. Change the query to use `StaticQuery`
 
-If you were using the `data` prop in your Gatsby v1 layout, you now need to use Gatsby v2’s [StaticQuery feature](/docs/how-to/sourcing-data/static-query/). This is because a layout is now a normal component.
+If you were using the `data` prop in your Gatsby v1 layout, you now need to use Gatsby v2’s [StaticQuery feature](/docs/how-to/querying-data/static-query/). This is because a layout is now a normal component.
 
 Replacing a layout's query with `StaticQuery`:
 

--- a/docs/docs/sourcing-from-graphcms.md
+++ b/docs/docs/sourcing-from-graphcms.md
@@ -138,7 +138,7 @@ Using the generated schema, we can begin to write GraphQL queries for Gatsby dat
 
 ### Query implementation
 
-Gatsby offers two means of data querying: [page queries](/docs/how-to/querying-data/page-query) and [static queries](/docs/how-to/sourcing-data/static-query).
+Gatsby offers two means of data querying: [page queries](/docs/how-to/querying-data/page-query) and [static queries](/docs/how-to/querying-data/static-query).
 
 #### Page query
 

--- a/docs/docs/static-vs-normal-queries.md
+++ b/docs/docs/static-vs-normal-queries.md
@@ -10,7 +10,7 @@ Static queries differ from Gatsby page queries in a number of ways. For pages, G
 
 In contrast, static queries do not take variables. This is because static queries are used inside specific components, and can appear lower in the component tree. Data fetched with a static query won't be dynamic (i.e. **they can't use variables**, hence the name "static" query), but they can be called at any level in the component tree.
 
-_For more information on the practical differences in usage between static and normal queries, refer to the guide on [static query](/docs/how-to/sourcing-data/static-query/#how-staticquery-differs-from-page-query). This guide discusses the differences in how they are handled internally by Gatsby_
+_For more information on the practical differences in usage between static and normal queries, refer to the guide on [static query](/docs/how-to/querying-data/static-query/#how-staticquery-differs-from-page-query). This guide discusses the differences in how they are handled internally by Gatsby_
 
 ## Keeping track of site queries during build in Redux stores
 

--- a/docs/docs/tutorial/part-four/index.md
+++ b/docs/docs/tutorial/part-four/index.md
@@ -43,7 +43,7 @@ and APIs of all sorts.
 
 Absolutely not! You can use the node `createPages` API to pull unstructured data into Gatsby pages directly, rather than through the GraphQL data layer. This is a great choice for small sites, while GraphQL and source plugins can help save time with more complex sites.
 
-See the [Using Gatsby without GraphQL](/docs/how-to/sourcing-data/using-gatsby-without-graphql/) guide to learn how to pull data into your Gatsby site using the node `createPages` API and to see an example site!
+See the [Using Gatsby without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/) guide to learn how to pull data into your Gatsby site using the node `createPages` API and to see an example site!
 
 ### When do I use unstructured data vs GraphQL?
 
@@ -279,7 +279,7 @@ Page queries live outside of the component definition -- by convention at the en
 
 ### Use a StaticQuery
 
-[StaticQuery](/docs/how-to/sourcing-data/static-query/) is a new API introduced in Gatsby v2 that allows non-page components (like your `layout.js` component), to retrieve data via GraphQL queries. Let's use its newly introduced hook version — [`useStaticQuery`](/docs/how-to/sourcing-data/use-static-query/).
+[StaticQuery](/docs/how-to/querying-data/static-query/) is a new API introduced in Gatsby v2 that allows non-page components (like your `layout.js` component), to retrieve data via GraphQL queries. Let's use its newly introduced hook version — [`useStaticQuery`](/docs/how-to/querying-data/use-static-query/).
 
 Go ahead and make some changes to your `src/components/layout.js` file to use the `useStaticQuery` hook and a `{data.site.siteMetadata.title}` reference that uses this data. When you are done, your file will look like this:
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

Some pages were recently moved (#28165 I think) from `how-to/sourcing-data` to `how-to/querying-data` but the references were not updated.

```
how-to/querying-data
├── page-query.md
├── running-queries-with-graphiql.md
├── static-query.md
├── use-static-query.md
└── using-gatsby-without-graphql.md
how-to/sourcing-data
├── headless-cms.md
├── sourcing-from-contentful.md
├── sourcing-from-databases.md
├── sourcing-from-drupal.md
├── sourcing-from-hosted-services.md
├── sourcing-from-json-or-yaml.md
├── sourcing-from-netlify-cms.md
├── sourcing-from-prismic.md
├── sourcing-from-private-apis.md
├── sourcing-from-the-filesystem.md
└── sourcing-from-wordpress.md
```
