### PR TITLE
fix(gatsby-plugin-page-creator): add missing telemetry dependency

### DIFF
--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -29,6 +29,7 @@
     "chokidar": "^3.4.2",
     "fs-exists-cached": "^1.0.0",
     "gatsby-page-utils": "^0.7.0-next.0",
+    "gatsby-telemetry": "^1.8.0-next.0",
     "globby": "^11.0.1",
     "lodash": "^4.17.20"
   },


### PR DESCRIPTION
## Description

We import `gatsby-telemetry` in `gatsby-plugin-page-creator` but we don't set it as dependency so sometimes depending how package managers install `node_modules` this can result in "Module not found" errors

https://github.com/gatsbyjs/gatsby/blob/787bc2325b5f02a86a2ab984725214e2a972d86c/packages/gatsby-plugin-page-creator/src/gatsby-node.ts#L12

## Related Issues

Fixes #28646
