### PR TITLE
fix(gatsby-source-drupal): process included nodes on preview and incremental builds

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/webhook-included.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/webhook-included.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "type": "node--article",
+    "id": "article-3",
+    "attributes": {
+      "id": 23,
+      "uuid": "article-3",
+      "title": "Article #3",
+      "body": "Aliquam non varius libero, sit amet consequat ex. Aenean porta turpis quis vulputate blandit. Suspendisse in porta erat. Sed sit amet scelerisque turpis, at rutrum mauris. Sed tempor eleifend lobortis. Proin maximus, massa sed dignissim sollicitudin, quam risus mattis justo, sit amet aliquam odio ligula quis urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut mollis leo nisi, at interdum urna fermentum ut. Fusce id suscipit neque, eu fermentum lacus. Donec egestas laoreet felis ac luctus. Vestibulum molestie mattis ante, a vulputate nunc ullamcorper at. Ut hendrerit ipsum eget gravida ultricies."
+    },
+    "relationships": {
+      "field_main_image": {
+        "data": {
+          "type": "file--file",
+          "id": "file-added"
+        }
+      },
+      "field_tags": {
+        "data": [
+          {
+            "type": "taxonomy_term--tags",
+            "id": "tag-1"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "file--file",
+      "id": "file-added",
+      "attributes": {
+        "id": 2,
+        "uuid": "file-added",
+        "filename": "added-image.png",
+        "uri": {
+          "url" : "http://mysite/sites/default/files/added-image.png",
+          "value" : "private://added-image.png"
+        }
+      }
+    }
+  ],
+  "links": {}
+}

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -351,6 +351,38 @@ describe(`gatsby-source-drupal`, () => {
         })
       })
     })
+
+    describe(`Handle multiple nodes`, () => {
+      it(`Added image does not exist before webhook`, () => {
+        expect(nodes[createNodeId(`file-added`)]).not.toBeDefined()
+      })
+      it(`Tag #1 is not modified before webhook`, () => {
+        expect(nodes[createNodeId(`tag-1`)].name).toEqual(`Tag #1`)
+      })
+
+      describe(`After webhook update`, () => {
+        beforeAll(async () => {
+          const {
+            data: nodeToUpdate,
+            included: includedNodes,
+          } = require(`./fixtures/webhook-included.json`)
+
+          await handleWebhookUpdate({
+            nodeToUpdate: includedNodes.concat([nodeToUpdate]),
+            ...args,
+          })
+        })
+
+        it(`New image is added and related to article after webhook`, () => {
+          expect(nodes[createNodeId(`file-added`)]).toBeDefined()
+          expect(
+            nodes[createNodeId(`article-3`)].relationships[
+              `field_main_image___NODE`
+            ]
+          ).toContain(createNodeId(`file-added`))
+        })
+      })
+    })
   })
 
   it(`Control disallowed link types`, async () => {

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -62,7 +62,7 @@ exports.sourceNodes = async (
     changesActivity.start()
 
     try {
-      const { secret, action, id, data } = webhookBody
+      const { secret, action, id, data, included } = webhookBody
       if (pluginOptions.secret && pluginOptions.secret !== secret) {
         reporter.warn(
           `The secret in this request did not match your plugin options secret.`
@@ -82,22 +82,20 @@ exports.sourceNodes = async (
         nodesToUpdate = [data]
       }
 
-      for (const nodeToUpdate of nodesToUpdate) {
-        await handleWebhookUpdate(
-          {
-            nodeToUpdate,
-            actions,
-            cache,
-            createNodeId,
-            createContentDigest,
-            getCache,
-            getNode,
-            reporter,
-            store,
-          },
-          pluginOptions
-        )
-      }
+      await handleWebhookUpdate(
+        {
+          nodeToUpdate: nodesToUpdate.concat(included ?? []),
+          actions,
+          cache,
+          createNodeId,
+          createContentDigest,
+          getCache,
+          getNode,
+          reporter,
+          store,
+        },
+        pluginOptions
+      )
     } catch (e) {
       gracefullyRethrow(changesActivity, e)
       return
@@ -152,26 +150,25 @@ exports.sourceNodes = async (
             // The data could be a single Drupal entity or an array of Drupal
             // entities to update.
             let nodesToUpdate = nodeSyncData.data
+            let included = nodeSyncData.included
             if (!Array.isArray(nodeSyncData.data)) {
               nodesToUpdate = [nodeSyncData.data]
             }
 
-            for (const nodeToUpdate of nodesToUpdate) {
-              await handleWebhookUpdate(
-                {
-                  nodeToUpdate,
-                  actions,
-                  cache,
-                  createNodeId,
-                  createContentDigest,
-                  getCache,
-                  getNode,
-                  reporter,
-                  store,
-                },
-                pluginOptions
-              )
-            }
+            await handleWebhookUpdate(
+              {
+                nodeToUpdate: nodesToUpdate.concat(included ?? []),
+                actions,
+                cache,
+                createNodeId,
+                createContentDigest,
+                getCache,
+                getNode,
+                reporter,
+                store,
+              },
+              pluginOptions
+            )
           }
         }
 


### PR DESCRIPTION
## Description

This PR addresses two issues:

1. When multiple nodes are updated at the same time via the preview or fastbuild updates, references to newly created content can get lost, depending on the order in the payload.
2. Fields that are marked as `included` within Drupal (with JSON:API Extras) are passed, but not processed by Gatsby in the preview or fastbuild updates.

### Solution

I adapted `handleWebhookUpdate` to accept multiple nodes at once and process the references between them correctly to solve issue `#1`. Then I added `included` content from the json payload to the list of nodes to be processed on preview or fastbuild update.