### PR TITLE
fix(create-gatsby): Switch dependency to sass

### DIFF
--- a/packages/create-gatsby/src/styles.json
+++ b/packages/create-gatsby/src/styles.json
@@ -1,5 +1,5 @@
 {
-  "gatsby-plugin-sass": { "message": "Sass", "dependencies": ["node-sass"] },
+  "gatsby-plugin-sass": { "message": "Sass", "dependencies": ["sass"] },
   "gatsby-plugin-styled-components": {
     "message": "styled-components",
     "dependencies": ["styled-components", "babel-plugin-styled-components"]


### PR DESCRIPTION
Switches the sass dependency to `sass` from `node-sass` because of https://github.com/gatsbyjs/gatsby/pull/27991/
It needs to be released alongside gatsby-plugin-sass@3.0.0