### PR TITLE
fix(gatsby-plugin-page-creator): add missing telemetry dependency (#28652)

### DIFF
--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -29,6 +29,7 @@
     "chokidar": "^3.4.2",
     "fs-exists-cached": "^1.0.0",
     "gatsby-page-utils": "^0.6.0",
+    "gatsby-telemetry": "^1.7.0",
     "globby": "^11.0.1",
     "lodash": "^4.17.20"
   },


### PR DESCRIPTION
Backporting https://github.com/gatsbyjs/gatsby/pull/28652 to the 2.29 release branch

(cherry picked from commit a13827f1bea8282fa3ba85f73b4cdc910338b066)