### PR TITLE
perf(gatsby-plugin-image): Handle disabled js, and add preload link

### DIFF
--- a/packages/gatsby-plugin-image/src/components/main-image.tsx
+++ b/packages/gatsby-plugin-image/src/components/main-image.tsx
@@ -5,7 +5,26 @@ export type MainImageProps = PictureProps
 
 export const MainImage = forwardRef<HTMLImageElement, MainImageProps>(
   function MainImage({ ...props }, ref) {
-    return <Picture ref={ref} {...props} />
+    return (
+      <>
+        {props.loading === `eager` && (
+          <link
+            rel="preload"
+            as="image"
+            href={props.fallback.src}
+            // TODO: remove this if imagesrcset is added to the types
+            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+            // @ts-ignore
+            imagesrcset={props.fallback.srcSet}
+            imagesizes={props.fallback.sizes}
+          />
+        )}
+        <Picture ref={ref} {...props} />
+        <noscript>
+          <Picture ref={ref} {...props} shouldLoad={true} />
+        </noscript>
+      </>
+    )
   }
 )
 

--- a/packages/gatsby-plugin-image/src/components/main-image.tsx
+++ b/packages/gatsby-plugin-image/src/components/main-image.tsx
@@ -21,7 +21,7 @@ export const MainImage = forwardRef<HTMLImageElement, MainImageProps>(
         )}
         <Picture ref={ref} {...props} />
         <noscript>
-          <Picture ref={ref} {...props} shouldLoad={true} />
+          <Picture {...props} shouldLoad={true} />
         </noscript>
       </>
     )

--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -44,9 +44,13 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
       dangerouslySetInnerHTML={generateHtml(
         `<style>` +
           cssNanoMacro`
-  .gatsby-image-wrapper [data-main-image] {
+  .gatsby-image-wrapper noscript [data-main-image] {
     opacity: 1 !important;
-  }` +
+  }
+  .gatsby-image-wrapper [data-placeholder-image] {
+    opacity: 0 !important;
+  }
+  ` +
           `</style>`
       )}
     />,


### PR DESCRIPTION
Shows an image if JS is disabled. Adds a preload link for loading=eager images.