### PR TITLE
chore(gatsby-source-npm-package-search): Upgrade algoliasearch

### DIFF
--- a/packages/gatsby-source-npm-package-search/package.json
+++ b/packages/gatsby-source-npm-package-search/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-npm-package-search#readme",
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "algoliasearch": "^3.35.1",
+    "algoliasearch": "^4.8.3",
     "got": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/gatsby-source-npm-package-search/src/search.js
+++ b/packages/gatsby-source-npm-package-search/src/search.js
@@ -4,11 +4,11 @@ const searchIndex = client.initIndex(`npm-search`)
 
 exports.browse = ({ ...params }) => {
   let hits = []
-  const browser = searchIndex.browseAll(params)
 
-  return new Promise((resolve, reject) => {
-    browser.on(`result`, content => (hits = hits.concat(content.hits)))
-    browser.on(`end`, () => resolve(hits))
-    browser.on(`error`, err => reject(err))
-  })
+  searchIndex
+    .browseObjects({
+      batch: batch => (hits = hits.concat(batch)),
+      ...params,
+    })
+    .then(() => hits)
 }


### PR DESCRIPTION
Upgrade algoliasearch js client to latest version. It is more stable and has better timeout defaults out of the box

```connect: 2 * 1000,
read: 5 * 1000,
write: 30 * 1000
```
versus 

```connect: 1 * 1000
read: 2 * 1000,
write: 30 * 1000```

Should make builds for gatsbyjs.com and other users more stable 