### PR TITLE
fix(deps): Revert postcss upgrade which broke css macro

### DIFF
--- a/packages/gatsby-plugin-image/package.json
+++ b/packages/gatsby-plugin-image/package.json
@@ -68,7 +68,7 @@
     "do-sync": "^2.2.0",
     "microbundle": "^0.12.4",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8.1.7",
+    "postcss": "^8.1.6",
     "terser": "^5.3.8",
     "typescript": "^3.9.7"
   },


### PR DESCRIPTION
This reverts commit e304ddddcabe648ba2938feb83b528e2c942ca72 #28082
