### PR TITLE
fix(gatsby): remove redundant dispatch of query extraction error

### DIFF
--- a/e2e-tests/mdx/gatsby-config.js
+++ b/e2e-tests/mdx/gatsby-config.js
@@ -17,6 +17,7 @@ module.exports = {
         path: `${__dirname}/src/posts`,
       },
     },
+    `gatsby-plugin-test-regression1`,
     {
       resolve: `gatsby-plugin-mdx`,
       options: {

--- a/e2e-tests/mdx/plugins/gatsby-plugin-test-regression1/gatsby-node.js
+++ b/e2e-tests/mdx/plugins/gatsby-plugin-test-regression1/gatsby-node.js
@@ -1,0 +1,2 @@
+// See pages/regressions/index.mdx
+exports.preprocessSource = args => args.contents

--- a/e2e-tests/mdx/plugins/gatsby-plugin-test-regression1/package.json
+++ b/e2e-tests/mdx/plugins/gatsby-plugin-test-regression1/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "gatsby-plugin-test-regression1"
+}

--- a/e2e-tests/mdx/src/pages/regressions/index.mdx
+++ b/e2e-tests/mdx/src/pages/regressions/index.mdx
@@ -5,3 +5,6 @@ All of the following is required to hit this bug:
 1. There should be at least one other plugin implementing `preprocessSource`
 2. This plugin must be listed before `gatsby-plugin-mdx` in `gatsby-config.js`
 3. MDX file must contain word `graphql`
+
+!Important, do not remove the next line!
+`graphql`

--- a/e2e-tests/mdx/src/pages/regressions/index.mdx
+++ b/e2e-tests/mdx/src/pages/regressions/index.mdx
@@ -1,0 +1,7 @@
+This is a regression test for query extraction bug in Gatsby.
+
+All of the following is required to hit this bug:
+
+1. There should be at least one other plugin implementing `preprocessSource`
+2. This plugin must be listed before `gatsby-plugin-mdx` in `gatsby-config.js`
+3. MDX file must contain word `graphql`

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -92,10 +92,7 @@ async function parseToAst(filePath, fileStr, { parentSpan, addError } = {}) {
         ast = tmp
         break
       } catch (error) {
-        boundActionCreators.queryExtractionGraphQLError({
-          componentPath: filePath,
-        })
-        continue
+        // We emit the actual error below if every transpiled variant fails to parse
       }
     }
     if (ast === undefined) {


### PR DESCRIPTION
## Description

This PR fixes a bug where we incorrectly mark a component as having a query extraction error. Very edge case, pretty well explained in the test case:

```
This is a regression test for query extraction bug in Gatsby.

All of the following is required to hit this bug:

1. `gatsby-plugin-mdx` should be installed + at least one other plugin implementing `preprocessSource`
2. This plugin must be listed before `gatsby-plugin-mdx` in `gatsby-config.js`
3. MDX file must contain the word `graphql`
```

MDX is not requirement - any two plugins implementing `preprocessSource` could hit this. But it was easier to reproduce and write a test case with mdx.
