### PR TITLE
fix(gatsby-plugin-image): do not return from preprocessSource if nothing is changed

### DIFF
--- a/packages/gatsby-plugin-image/src/node-apis/preprocess-source.ts
+++ b/packages/gatsby-plugin-image/src/node-apis/preprocess-source.ts
@@ -15,13 +15,13 @@ export async function preprocessSource({
   store,
   createNodeId,
   actions: { createNode },
-}: PreprocessSourceArgs): Promise<string> {
+}: PreprocessSourceArgs): Promise<void> {
   if (
     !contents.includes(`StaticImage`) ||
     !contents.includes(`gatsby-plugin-image`) ||
     !extensions.includes(path.extname(filename))
   ) {
-    return contents
+    return
   }
   const root = store.getState().program.directory
 
@@ -43,5 +43,5 @@ export async function preprocessSource({
     createNode,
   })
 
-  return contents
+  return
 }


### PR DESCRIPTION
## Description

It only makes sense to return the actual value from the `preprocessSource` if it changes the content. Otherwise, it causes a redundant babel parsing when `gatsby-plugin-image` is used alongside other plugins, i.e. `gatsby-plugin-mdx`.

Some context. We run this `preprocessSource` hook here when extracting queries:

https://github.com/gatsbyjs/gatsby/blob/8138b97d025b5aaa8f3a46e7d9911484a00591f7/packages/gatsby/src/query/file-parser.js#L83-L91

And then doing additional `babelParseToAst` for every returned value.

If we return `undefined` instead, results of `gatsby-plugin-image` will be simply ignored here and won't be added to `transpiled` array above. Here is where we filter empty plugin results:

https://github.com/gatsbyjs/gatsby/blob/8138b97d025b5aaa8f3a46e7d9911484a00591f7/packages/gatsby/src/utils/api-runner-node.js#L682-L683

**So to recap:**

If there are multiple plugins with `preprocessSource` (e.g. `gatsby-plugin-image` and `gatsby-plugin-mdx` - we'll do a redundant `babelParseToAst`.

Also, it will likely throw in this combination and hit another slow path as well as cause weird issues with query extraction, see #28676 for a related fix in the core.

