### PR TITLE
chore(gatsby-source-graphql): docs on how to use apollo links

### DIFF
--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -197,8 +197,11 @@ module.exports = {
 
         // `options`: all plugin options
         //   (i.e. in this example object with keys `typeName`, `fieldName`, `url`, `createLink`)
-        createLink: options =>
-          ApolloLink.from([retryLink, createHttpLink({ url: options.url })]),
+        createLink: pluginOptions =>
+          ApolloLink.from([
+            retryLink,
+            createHttpLink({ url: pluginOptions.url }),
+          ]),
       },
     },
   ],

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -152,7 +152,7 @@ module.exports = {
 
 ## Composing Apollo Links for production network setup
 
-The plugin provides `createLink` option that you can use to enhance your network stack:
+The plugin provides a `createLink` option that you can use to enhance your network stack:
 add error handling, retries, timeouts, etc. Check out [this article](https://medium.com/@joanvila/productionizing-apollo-links-4cdc11d278eb)
 for an excellent explanation of how it works.
 

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -156,7 +156,7 @@ The plugin provides a `createLink` option that you can use to enhance your netwo
 add error handling, retries, timeouts, etc. Check out [this article](https://medium.com/@joanvila/productionizing-apollo-links-4cdc11d278eb)
 for an excellent explanation of how it works.
 
-Quick example of the http link with retries (using [apollo-link-retry](https://www.npmjs.com/package/apollo-link-retry)):
+Quick example of the HTTP link with retries (using [apollo-link-retry](https://www.npmjs.com/package/apollo-link-retry)):
 
 ```js
 // gatsby-config.js

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -195,7 +195,7 @@ module.exports = {
         fieldName: "swapi",
         url: "https://api.graphcms.com/simple/v1/swapi",
 
-        // `options`: all plugin options
+        // `pluginOptions`: all plugin options
         //   (i.e. in this example object with keys `typeName`, `fieldName`, `url`, `createLink`)
         createLink: pluginOptions =>
           ApolloLink.from([

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -159,6 +159,7 @@ for an excellent explanation of how it works.
 Quick example of the http link with retries (using [apollo-link-retry](https://www.npmjs.com/package/apollo-link-retry)):
 
 ```js
+// gatsby-config.js
 const { createHttpLink } = require(`apollo-link-http`)
 const { RetryLink } = require(`apollo-link-retry`)
 

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -152,11 +152,21 @@ module.exports = {
 
 ## Composing Apollo Links for production network setup
 
-The plugin provides a `createLink` option that you can use to enhance your network stack:
-add error handling, retries, timeouts, etc. Check out this [Medium article, Productionizing Apollo Links](https://medium.com/@joanvila/productionizing-apollo-links-4cdc11d278eb),
-for an excellent explanation of how it works.
+Network requests can fail, return errors or take too long. Use [Apollo Link](https://www.apollographql.com/docs/link/) to
+add retries, error handling, logging and more to your GraphQL requests.
 
-Quick example of the HTTP link with retries (using [apollo-link-retry](https://www.npmjs.com/package/apollo-link-retry)):
+Use the plugin's `createLink` option to add a custom Apollo Link to your GraphQL requests.
+
+You can compose different types of links, depending on the functionality you're trying to achieve.
+The most common links are:
+
+- `apollo-link-retry` for retrying queries that fail or time out
+- `apollo-link-error` for error handling
+- `apollo-link-http` for sending queries in http requests (used by default)
+
+For more explanation of how Apollo Links work together, check out this Medium article: [Productionizing Apollo Links](https://medium.com/@joanvila/productionizing-apollo-links-4cdc11d278eb).
+
+Here's an example of using the HTTP link with retries (using [apollo-link-retry](https://www.npmjs.com/package/apollo-link-retry)):
 
 ```js
 // gatsby-config.js
@@ -185,8 +195,10 @@ module.exports = {
         fieldName: "swapi",
         url: "https://api.graphcms.com/simple/v1/swapi",
 
+        // `options`: all plugin options
+        //   (i.e. in this example object with keys `typeName`, `fieldName`, `url`, `createLink`)
         createLink: options =>
-          ApolloLink.from([retryLink, createHttpLink(options)]),
+          ApolloLink.from([retryLink, createHttpLink({ url: options.url })]),
       },
     },
   ],

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -153,7 +153,7 @@ module.exports = {
 ## Composing Apollo Links for production network setup
 
 The plugin provides a `createLink` option that you can use to enhance your network stack:
-add error handling, retries, timeouts, etc. Check out [this article](https://medium.com/@joanvila/productionizing-apollo-links-4cdc11d278eb)
+add error handling, retries, timeouts, etc. Check out this [Medium article, Productionizing Apollo Links](https://medium.com/@joanvila/productionizing-apollo-links-4cdc11d278eb),
 for an excellent explanation of how it works.
 
 Quick example of the HTTP link with retries (using [apollo-link-retry](https://www.npmjs.com/package/apollo-link-retry)):


### PR DESCRIPTION
## Description

Add a section to the [gatsby-source-graphql](https://www.gatsbyjs.com/plugins/gatsby-source-graphql/) plugin docs about Apollo links and how to compose them.

## Related Issues

See https://github.com/gatsbyjs/gatsby/discussions/28680