### PR TITLE
fix(gatsby-plugin-image): Preload lazy-hydrator

### DIFF
--- a/packages/gatsby-plugin-image/gatsby-browser.js
+++ b/packages/gatsby-plugin-image/gatsby-browser.js
@@ -1,0 +1,11 @@
+const React = require("react")
+
+const { LaterHydrator } = require(".")
+
+exports.wrapRootElement = ({ element }) => {
+  return (
+    <LaterHydrator>
+      {element}
+    </LaterHydrator>
+  )
+}

--- a/packages/gatsby-plugin-image/src/components/later-hydrator.tsx
+++ b/packages/gatsby-plugin-image/src/components/later-hydrator.tsx
@@ -1,0 +1,10 @@
+import * as React from "react"
+export function LaterHydrator({
+  children,
+}: React.PropsWithChildren<{}>): React.ReactNode {
+  React.useEffect(() => {
+    import(`./lazy-hydrate`)
+  }, [])
+
+  return children
+}

--- a/packages/gatsby-plugin-image/src/index.browser.ts
+++ b/packages/gatsby-plugin-image/src/index.browser.ts
@@ -6,6 +6,7 @@ export {
 export { Placeholder } from "./components/placeholder"
 export { MainImage } from "./components/main-image"
 export { StaticImage } from "./components/static-image"
+export { LaterHydrator } from "./components/later-hydrator"
 export { getImage, getSrc, useGatsbyImage } from "./components/hooks"
 export {
   generateImageData,


### PR DESCRIPTION
Preloads the lazy-hydrate bundle, outside of the render path. This ensure there's no delay when navigating to a page with an image