### PR TITLE
test(cache-resilience): update snapshots

### DIFF
--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-added/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-added/scenario.js
@@ -142,6 +142,9 @@ const queriesTest = ({ typesFirstRun, typesSecondRun, dataSecondRun }) => {
             "name": "foo",
           },
           Object {
+            "name": "childrenChildOfParentParentAdditionForTransformer",
+          },
+          Object {
             "name": "childChildOfParentParentAdditionForTransformer",
           },
         ],

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-changed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-changed/scenario.js
@@ -191,6 +191,9 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
     +         \\"name\\": \\"bar\\",
             },
             Object {
+              \\"name\\": \\"childrenChildOfParentParentChangeForTransformer\\",
+            },
+            Object {
               \\"name\\": \\"childChildOfParentParentChangeForTransformer\\",
             },
           ],

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-removed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-removed/scenario.js
@@ -142,6 +142,9 @@ const queriesTest = ({ typesFirstRun, typesSecondRun, dataFirstRun }) => {
             "name": "foo",
           },
           Object {
+            "name": "childrenChildOfParentParentDeletionForTransformer",
+          },
+          Object {
             "name": "childChildOfParentParentDeletionForTransformer",
           },
         ],

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-added/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-added/scenario.js
@@ -151,6 +151,9 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
               \\"name\\": \\"foo\\",
     +       },
     +       Object {
+    +         \\"name\\": \\"childrenChildOfParentChildAdditionForTransformer\\",
+    +       },
+    +       Object {
     +         \\"name\\": \\"childChildOfParentChildAdditionForTransformer\\",
             },
           ],

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-changed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-changed/scenario.js
@@ -177,6 +177,9 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
               \\"name\\": \\"foo\\",
             },
             Object {
+              \\"name\\": \\"childrenChildOfParentChildChangeForTransformer\\",
+            },
+            Object {
               \\"name\\": \\"childChildOfParentChildChangeForTransformer\\",
             },
           ],

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-removed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-removed/scenario.js
@@ -181,6 +181,9 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
               \\"name\\": \\"foo\\",
     -       },
     -       Object {
+    -         \\"name\\": \\"childrenChildOfParentChildDeletionForTransformer\\",
+    -       },
+    -       Object {
     -         \\"name\\": \\"childChildOfParentChildDeletionForTransformer\\",
             },
           ],


### PR DESCRIPTION
Currently not required cache resilience tests needed to be updated in https://github.com/gatsbyjs/gatsby/pull/28656 but we slapped merge on green which doesn't require "not required" tests to pass (ops). This just updates snapshots for those tests to match change from that PR (always adding both `childX` and `childrenX` fields. Snapshots here introspect schema for various scenarios and compares what happens to schema when adding/removing plugins between runs.

It only have cases for single child scenario so it did had just `childX` before - with change from PR we now have to account for `childrenX` too.

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/28656