### PR TITLE
chore(dev-ssr): don't dispatch CREATE_SERVER_VISITED_PAGE if component is already tracked

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1398,6 +1398,12 @@ actions.removePageData = (id: PageDataRemove) => {
  * @param {string} $0.id the chunkName for the page component.
  */
 actions.createServerVisitedPage = (chunkName: string) => {
+  if (store.getState().visitedPages.get(`server`)?.has(chunkName)) {
+    // we already have given chunk tracked, let's not emit `CREATE_SERVER_VISITED_PAGE`
+    // action to not cause any additional work
+    return []
+  }
+
   return {
     type: `CREATE_SERVER_VISITED_PAGE`,
     payload: { componentChunkName: chunkName },


### PR DESCRIPTION

https://github.com/gatsbyjs/gatsby/blob/3ce476b1eac97aedd16f9d150cd6a81f36255380/packages/gatsby/src/bootstrap/requires-writer.ts#L336-L345 will uncodindionally run `requires-writer` on `CREATE_SERVER_VISITED_PAGE` actions. Let's skip emitting those actions that will be functionally no-ops (but still cause some extra work)