### PR TITLE
feat(gatsby): use production React for dev-ssr when CI=true

### DIFF
--- a/packages/gatsby/cache-dir/ssr-develop-static-entry.js
+++ b/packages/gatsby/cache-dir/ssr-develop-static-entry.js
@@ -1,6 +1,4 @@
-import React from "react"
 import fs from "fs"
-import { renderToString, renderToStaticMarkup } from "react-dom/server"
 import { merge } from "lodash"
 import { join } from "path"
 import apiRunner from "./api-runner-ssr"
@@ -9,6 +7,16 @@ import syncRequires from "$virtual/ssr-sync-requires"
 
 import { RouteAnnouncerProps } from "./route-announcer-props"
 import { ServerLocation, Router, isRedirect } from "@reach/router"
+
+let React
+let ReactDom
+if (process.env.CI) {
+  React = require(`react/cjs/react.production.min.js`)
+  ReactDom = require(`react-dom/cjs/react-dom-server.node.production.min.js`)
+} else {
+  React = require(`react`)
+  ReactDom = require(`react-dom/server`)
+}
 
 // import testRequireError from "./test-require-error"
 // For some extremely mysterious reason, webpack adds the above module *after*
@@ -183,7 +191,7 @@ export default (pagePath, isClientOnlyPage, callback) => {
     // If no one stepped up, we'll handle it.
     if (!bodyHtml) {
       try {
-        bodyHtml = renderToString(bodyComponent)
+        bodyHtml = ReactDom.renderToString(bodyComponent)
       } catch (e) {
         // ignore @reach/router redirect errors
         if (!isRedirect(e)) throw e
@@ -229,7 +237,7 @@ export default (pagePath, isClientOnlyPage, callback) => {
       <script key={`commons`} src="/commons.js" />,
     ]),
   })
-  let htmlStr = renderToStaticMarkup(htmlElement)
+  let htmlStr = ReactDom.renderToStaticMarkup(htmlElement)
   htmlStr = `<!DOCTYPE html>${htmlStr}`
 
   callback(null, htmlStr)

--- a/packages/gatsby/cache-dir/ssr-develop-static-entry.js
+++ b/packages/gatsby/cache-dir/ssr-develop-static-entry.js
@@ -1,4 +1,6 @@
+import React from "react"
 import fs from "fs"
+import { renderToString, renderToStaticMarkup } from "react-dom/server"
 import { merge } from "lodash"
 import { join } from "path"
 import apiRunner from "./api-runner-ssr"
@@ -7,16 +9,6 @@ import syncRequires from "$virtual/ssr-sync-requires"
 
 import { RouteAnnouncerProps } from "./route-announcer-props"
 import { ServerLocation, Router, isRedirect } from "@reach/router"
-
-let React
-let ReactDom
-if (process.env.CI) {
-  React = require(`react/cjs/react.production.min.js`)
-  ReactDom = require(`react-dom/cjs/react-dom-server.node.production.min.js`)
-} else {
-  React = require(`react`)
-  ReactDom = require(`react-dom/server`)
-}
 
 // import testRequireError from "./test-require-error"
 // For some extremely mysterious reason, webpack adds the above module *after*
@@ -191,7 +183,7 @@ export default (pagePath, isClientOnlyPage, callback) => {
     // If no one stepped up, we'll handle it.
     if (!bodyHtml) {
       try {
-        bodyHtml = ReactDom.renderToString(bodyComponent)
+        bodyHtml = renderToString(bodyComponent)
       } catch (e) {
         // ignore @reach/router redirect errors
         if (!isRedirect(e)) throw e
@@ -237,7 +229,7 @@ export default (pagePath, isClientOnlyPage, callback) => {
       <script key={`commons`} src="/commons.js" />,
     ]),
   })
-  let htmlStr = ReactDom.renderToStaticMarkup(htmlElement)
+  let htmlStr = renderToStaticMarkup(htmlElement)
   htmlStr = `<!DOCTYPE html>${htmlStr}`
 
   callback(null, htmlStr)

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -96,10 +96,6 @@ module.exports = async (
       )
     }
 
-    if (stage === `develop-html`) {
-      envObject.CI = JSON.stringify(process.env.CI || `false`)
-    }
-
     const mergedEnvVars = Object.assign(envObject, gatsbyVarObject)
 
     return Object.keys(mergedEnvVars).reduce(

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -1,5 +1,6 @@
 require(`v8-compile-cache`)
 
+const { isCI } = require(`gatsby-core-utils`)
 const crypto = require(`crypto`)
 const fs = require(`fs-extra`)
 const path = require(`path`)
@@ -679,6 +680,23 @@ module.exports = async (
 
     config.externals = [
       function (context, request, callback) {
+        if (
+          stage === `develop-html` &&
+          isCI() &&
+          process.env.GATSBY_EXPERIMENTAL_DEV_SSR
+        ) {
+          if (request === `react`) {
+            callback(null, `react/cjs/react.production.min.js`)
+            return
+          } else if (request === `react-dom/server`) {
+            callback(
+              null,
+              `react-dom/cjs/react-dom-server.node.production.min.js`
+            )
+            return
+          }
+        }
+
         const external = isExternal(request)
         if (external !== null) {
           callback(null, external)

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -95,6 +95,10 @@ module.exports = async (
       )
     }
 
+    if (stage === `develop-html`) {
+      envObject.CI = JSON.stringify(process.env.CI || `false`)
+    }
+
     const mergedEnvVars = Object.assign(envObject, gatsbyVarObject)
 
     return Object.keys(mergedEnvVars).reduce(


### PR DESCRIPTION
We don't need React's dev hints & we want SSR to be as fast as possible on CI