### PR TITLE
perf(gatsby): cache babel config items

### DIFF
--- a/packages/gatsby/src/utils/babel-loader-helpers.js
+++ b/packages/gatsby/src/utils/babel-loader-helpers.js
@@ -21,10 +21,23 @@ const getCustomOptions = stage => {
   return pluginBabelConfig.stages[stage].options
 }
 
-const prepareOptions = (babel, options = {}, resolve = require.resolve) => {
-  const pluginBabelConfig = loadCachedConfig()
+/**
+ * https://babeljs.io/docs/en/babel-core#createconfigitem
+ * If this function is called multiple times for a given plugin,
+ * Babel will call the plugin's function itself multiple times.
+ * If you have a clear set of expected plugins and presets to inject,
+ * pre-constructing the config items would be recommended.
+ */
+const configItemsMemoCache = new Map()
 
+const prepareOptions = (babel, options = {}, resolve = require.resolve) => {
   const { stage, reactRuntime } = options
+
+  if (configItemsMemoCache.has(stage)) {
+    return configItemsMemoCache.get(stage)
+  }
+
+  const pluginBabelConfig = loadCachedConfig()
 
   // Required plugins/presets
   const requiredPlugins = [
@@ -95,13 +108,17 @@ const prepareOptions = (babel, options = {}, resolve = require.resolve) => {
     )
   })
 
-  return [
+  const toReturn = [
     reduxPresets,
     reduxPlugins,
     requiredPresets,
     requiredPlugins,
     fallbackPresets,
   ]
+
+  configItemsMemoCache.set(stage, toReturn)
+
+  return toReturn
 }
 
 const addRequiredPresetOptions = (

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -21,6 +21,7 @@ import { StaticQueryMapper } from "./webpack/static-query-mapper"
 import { ForceCssHMRForEdgeCases } from "./webpack/force-css-hmr-for-edge-cases"
 import { getBrowsersList } from "./browserslist"
 import { builtinModules } from "module"
+const { BabelConfigItemsCacheInvalidatorPlugin } = require(`./babel-loader`)
 
 const FRAMEWORK_BUNDLES = [`react`, `react-dom`, `scheduler`, `prop-types`]
 
@@ -211,6 +212,7 @@ module.exports = async (
       }),
 
       plugins.virtualModules(),
+      new BabelConfigItemsCacheInvalidatorPlugin(),
     ]
 
     switch (stage) {


### PR DESCRIPTION
On certain site:

Current:

```
success Building development bundle - 162.795s
success Building development bundle - 171.725s
success Building development bundle - 171.985s
success Building development bundle - 162.793s
success Building development bundle - 183.253s
```

With this change:

```
success Building development bundle - 113.453s
success Building development bundle - 110.612s
success Building development bundle - 112.168s
success Building development bundle - 112.159s
success Building development bundle - 110.889s
```

Just the `packages/gatsby/src/utils/babel-loader-helpers.js` change (biggest gain of all the caching added in this PR - at least for site I was benchmarking)

```
success Building development bundle - 118.803s
success Building development bundle - 123.173s
success Building development bundle - 119.359s
success Building development bundle - 120.030s
success Building development bundle - 118.143s
```

There might be more things to cache around this, but this was likely the most heavy thing that will yield biggest benefit

Explanation for changes:

`babelLoader.custom(callback)` runs callback function for every input file. `babel.createConfigItem` seems to instantiate new plugin/preset every time it's called. This seems to run https://github.com/babel/babel/blob/5b5b548036cde05b424d481c65c1c4a27c6eabc6/packages/babel-preset-env/src/normalize-options.js#L202-L263 separately for every input file even tho our options for `@babel/preset-env` don't change for given stage (`@babel/preset-env` is just example - it's similar for every babel plugin/preset, just this one seemed to be heaviest on site I was profiling).

Because `babel@7` support nested `.babelrc` we can't not use `babelLoader.custom` (that would be breaking change/regression), but we can cache/memoize things we know don't change and avoid doing repetitive work.

The tricky part would be to memoize the partial config merging internals - https://github.com/gatsbyjs/gatsby/blob/146b1975cc83f862c883b27415b914e152c708e8/packages/gatsby/src/utils/babel-loader-helpers.js#L117-L139

So instead I opted to memoize one level higher - https://github.com/gatsbyjs/gatsby/blob/146b1975cc83f862c883b27415b914e152c708e8/packages/gatsby/src/utils/babel-loader.js#L64-L98

Rationale behind this is that number of `.babelrc` files wouldn't be very high and even if we do some repetitive merging for each .babelrc file - at least we won't be doing this for every input file. On the site I was profiling there actually wasn't any extra `.babelrc` files and memoizing on that level (on top of memoizing `prepareOptions`) yielded extra 5s-10s gains.

There is always opportunity to figure out better memoizing setup to support cases of multiple `.babelrc` files better - but it's not clear to me how common using multiple of those configs is (maybe we should track this with telemetry and count "cache misses" per stage)

[ch27747]