### PR TITLE
fix: add missing dependencies

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -24,7 +24,8 @@
     "semver": "^7.3.5",
     "sharp": "^0.29.3",
     "svgo": "1.3.2",
-    "uuid": "3.4.0"
+    "uuid": "3.4.0",
+    "debug": "^4.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.15.4"
+    "@babel/runtime": "^7.15.4",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",


### PR DESCRIPTION
## Description

`gatsby-plugin-sharp` and `gatsby-react-router-scroll` is depending on some packages without without declaring them so this PR makes them explicit

### Documentation

N/A

## Related Issues