### PR TITLE
chore(gatsby-transformer-csv): fix whitespace

### DIFF
--- a/packages/gatsby-transformer-csv/README.md
+++ b/packages/gatsby-transformer-csv/README.md
@@ -28,7 +28,7 @@ module.exports = {
 }
 ```
 
-### Configuration
+### Configuration
 
 The example above is the minimal configuration required to begin working. Additional
 customization of the parsing process is possible using the parameters listed in


### PR DESCRIPTION
## Description

Found a `NBSP` in the README.

<img width="443" alt="Screen Shot 2020-12-27 at 7 13 21 am" src="https://user-images.githubusercontent.com/418747/103159277-3ecaf900-4813-11eb-8880-40b4f90c0a56.png">

