### PR TITLE
Fix gatsby-source-contentful unable to use behind proxy

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -23,7 +23,6 @@
     "is-online": "^8.5.1",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.20",
-    "node-fetch": "^2.6.1",
     "progress": "^2.0.3",
     "qs": "^6.9.4"
   },

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -4,8 +4,8 @@ const _ = require(`lodash`)
 const fs = require(`fs-extra`)
 const { createClient } = require(`contentful`)
 const v8 = require(`v8`)
-const fetch = require(`node-fetch`)
 const { CODES } = require(`./report`)
+const axios = require(`axios`)
 
 const normalize = require(`./normalize`)
 const fetchData = require(`./fetch`)
@@ -25,30 +25,6 @@ const restrictedNodeFields = [
 ]
 
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`).extendNodeType
-
-const validateContentfulAccess = async pluginOptions => {
-  if (process.env.NODE_ENV === `test`) return undefined
-
-  await fetch(`https://${pluginOptions.host}/spaces/${pluginOptions.spaceId}`, {
-    headers: {
-      Authorization: `Bearer ${pluginOptions.accessToken}`,
-      "Content-Type": `application/json`,
-    },
-  })
-    .then(res => res.ok)
-    .then(ok => {
-      if (!ok)
-        throw new Error(
-          `Cannot access Contentful space "${maskText(
-            pluginOptions.spaceId
-          )}" with access token "${maskText(
-            pluginOptions.accessToken
-          )}". Make sure to double check them!`
-        )
-    })
-
-  return undefined
-}
 
 const pluginOptionsSchema = ({ Joi }) =>
   Joi.object()
@@ -131,7 +107,6 @@ List of locales and their codes can be found in Contentful app -> Settings -> Lo
       // default plugins passed by gatsby
       plugins: Joi.array(),
     })
-    .external(validateContentfulAccess)
 
 exports.pluginOptionsSchema = pluginOptionsSchema
 

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -5,7 +5,6 @@ const fs = require(`fs-extra`)
 const { createClient } = require(`contentful`)
 const v8 = require(`v8`)
 const { CODES } = require(`./report`)
-const axios = require(`axios`)
 
 const normalize = require(`./normalize`)
 const fetchData = require(`./fetch`)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
There is a problem when using gatsby-source-contentful behind proxy. The gatsby build process will be stuck in load plugins. I suggest to remove `validateContentfulAccess` function since it is optional and introduces a problem in the build process.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes https://github.com/gatsbyjs/gatsby/issues/28526

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
