### PR TITLE
chore(gatsby): Keep page renderer around

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -57,6 +57,7 @@ interface IBuildArgs extends IProgram {
   profile: boolean
   graphqlTracing: boolean
   openTracingConfigFile: string
+  keepPageRenderer: boolean
 }
 
 module.exports = async function build(program: IBuildArgs): Promise<void> {
@@ -284,10 +285,12 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   }
   buildHTMLActivityProgress.end()
 
-  try {
-    await deleteRenderer(pageRenderer)
-  } catch (err) {
-    // pass through
+  if (!program.keepPageRenderer) {
+    try {
+      await deleteRenderer(pageRenderer)
+    } catch (err) {
+      // pass through
+    }
   }
 
   let deletedPageKeys: Array<string> = []


### PR DESCRIPTION
This adds an option in program for the build command that allows one to specify that they would like to keep `public/render-page.js` around 