### PR TITLE
fix broken link to gatsby-remark-embed-video

### DIFF
--- a/docs/docs/how-to/images-and-media/working-with-video.md
+++ b/docs/docs/how-to/images-and-media/working-with-video.md
@@ -8,7 +8,8 @@ The easiest method for including video on a Gatsby site is to source an uploaded
 
 ## Embedding hosted videos in Markdown
 
-There are numerous Gatsby plugins for working with hosted video in your Markdown posts and pages. We recommend checking out the [gatsby-remark-embed-video](/packages/gatsby-remark-embed-video/?=video) plugin for sourcing from a variety of hosts like YouTube or Vimeo.
+There are numerous Gatsby plugins for working with hosted video in your Markdown posts and pages. We recommend checking out the [
+](/plugins/gatsby-remark-embed-video/?video#gatsby-remark-embed-video) plugin for sourcing from a variety of hosts like YouTube or Vimeo.
 
 ### Writing custom components for hosted video
 


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Updates an outdated link to gatsby-remark-embed-video so that it no longer 404s. 



### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
