### PR TITLE
Fix broken link in layout-components.md

### DIFF
--- a/docs/docs/how-to/routing/layout-components.md
+++ b/docs/docs/how-to/routing/layout-components.md
@@ -55,7 +55,7 @@ As mentioned earlier, Gatsby does not, by default, automatically wrap pages in a
 
 If you need to set a wrapper component around page components that won't get unmounted on page changes, use the **`wrapPageElement`** [browser API](/docs/reference/config-files/gatsby-browser/#wrapPageElement) and the [SSR equivalent](/docs/reference/config-files/gatsby-ssr/#wrapPageElement).
 
-Alternatively, you can prevent your layout component from unmounting by using [gatsby-plugin-layout](/packages/gatsby-plugin-layout/), which implements the `wrapPageElement` APIs for you.
+Alternatively, you can prevent your layout component from unmounting by using [gatsby-plugin-layout](/plugins/gatsby-plugin-layout/), which implements the `wrapPageElement` APIs for you.
 
 ## Other resources
 


### PR DESCRIPTION


## Description
This is a small fix that points a plugin link in the right direction 😁 

- A link to `gatsby-plugin-layout` was pointing to `/packages/...` instead of `/plugins/...`

### Documentation
You can see this link in all of its glory [on this page](https://www.gatsbyjs.com/docs/how-to/routing/layout-components/#gatsbys-approach-to-layouts), which takes the user to _Page not found_.

![gatsby-layout](https://user-images.githubusercontent.com/9451300/103339169-ab7e0780-4a4e-11eb-8cda-22f67aa90ca5.png)

