### PR TITLE
chore(docs): Update migrate-remark-to-mdx

### DIFF
--- a/docs/docs/how-to/routing/migrate-remark-to-mdx.md
+++ b/docs/docs/how-to/routing/migrate-remark-to-mdx.md
@@ -62,6 +62,14 @@ const result = await graphql(
       ) {
 ```
 
+Don't forget to update the `posts` constant by replacing `allMarkdownRemark` with `allMdx`.
+
+```diff:title=gatsby-node.js
+-const posts = result.data.allMarkdownRemark.nodes
++const posts = result.data.allMdx.nodes
+
+```
+
 Also, update `onCreateNode` which creates the blog post slugs to watch for the node type of `Mdx` instead of `MarkdownRemark`.
 
 ```diff:title=gatsby-node.js

--- a/docs/docs/how-to/routing/migrate-remark-to-mdx.md
+++ b/docs/docs/how-to/routing/migrate-remark-to-mdx.md
@@ -67,7 +67,6 @@ Don't forget to update the `posts` constant by replacing `allMarkdownRemark` wit
 ```diff:title=gatsby-node.js
 -const posts = result.data.allMarkdownRemark.nodes
 +const posts = result.data.allMdx.nodes
-
 ```
 
 Also, update `onCreateNode` which creates the blog post slugs to watch for the node type of `Mdx` instead of `MarkdownRemark`.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Clarified that `result.data.allMarkdownRemark.nodes` also needs to be changed to `result.data.allMdx.nodes`, otherwise creating the pages will fail.
