### PR TITLE
feat: [gatsby-source-contentful] Extend the functionality of renderRichText 

### DIFF
--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -1,7 +1,13 @@
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import resolveResponse from "contentful-resolve-response"
 
-function renderRichText({ raw, references }, options = {}) {
+function renderRichText(arg, options = {}) {
+  const { raw, references } = arg;
+
+  if (!raw) {
+    return documentToReactComponents(arg, options);
+  }
+
   const richText = JSON.parse(raw)
 
   // If no references are given, there is no need to resolve them


### PR DESCRIPTION
## Description

Extend the functionality such that we can use `renderRichText` just like how we use the original `documentToReactComponents `

## Why

Just want to use the following hack without re-constructing the object

https://github.com/contentful/rich-text/issues/126#issuecomment-636926522

What I did now
```
[BLOCKS.LIST_ITEM]: (node, children) => {
        const unTaggedChildren = renderRichText({ raw: JSON.stringify(node) }, {
          renderNode: {
            [BLOCKS.PARAGRAPH]: (node, children) => children,
            [BLOCKS.LIST_ITEM]: (node, children) => children,
          },
        });
        return <li>{unTaggedChildren}</li>;
      },
```

What I expect
```
[BLOCKS.LIST_ITEM]: (node, children) => {
        const unTaggedChildren = renderRichText(node, {
          renderNode: {
            [BLOCKS.PARAGRAPH]: (node, children) => children,
            [BLOCKS.LIST_ITEM]: (node, children) => children,
          },
        });
        return <li>{unTaggedChildren}</li>;
      },
```