### PR TITLE
docs: fix gatsby-plugin-google-gtag link

### DIFF
--- a/docs/docs/how-to/adding-common-features/adding-analytics.md
+++ b/docs/docs/how-to/adding-common-features/adding-analytics.md
@@ -56,7 +56,7 @@ module.exports = {
 
 > Note: Read more about [gatsby-config.js](/docs/reference/config-files/gatsby-config/)
 
-Full documentation for the plugin can be found [here](/packages/gatsby-plugin-google-gtag/).
+Full documentation for the plugin can be found [here](/plugins/gatsby-plugin-google-gtag).
 
 There are a number of extra configuration options--both with the Gatsby plugin and also in your Google Analytics account--so you can tailor things to meet your website's needs.
 


### PR DESCRIPTION
The link does working on Github - https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-gtag but not in the site.
In the order hand this fix is working on the site - https://www.gatsbyjs.com/plugins/gatsby-plugin-google-gtag/ but not in Github.

