### PR TITLE
fix(gatsby-plugin-image): Correct image styles

### DIFF
--- a/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
@@ -57,6 +57,7 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
   as: Type = `div`,
   style,
   className,
+  class: preactClass,
   onStartLoad,
   image,
   onLoad: customOnLoad,
@@ -69,9 +70,8 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
     }
     return null
   }
-  if (`class` in props) {
-    className = props.class
-    delete props.class
+  if (preactClass) {
+    className = preactClass
   }
   const { width, height, layout, images } = image
 

--- a/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
@@ -27,6 +27,7 @@ export interface GatsbyImageProps
   alt: string
   as?: ElementType
   className?: string
+  class?: string
   imgClassName?: string
   image: IGatsbyImageData
   imgStyle?: CSSProperties
@@ -67,6 +68,10 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
       console.warn(`[gatsby-plugin-image] Missing image prop`)
     }
     return null
+  }
+  if (`class` in props) {
+    className = props.class
+    delete props.class
   }
   const { width, height, layout, images } = image
 

--- a/packages/gatsby-plugin-image/src/components/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.server.tsx
@@ -18,6 +18,7 @@ export const GatsbyImageHydrator: FunctionComponent<{
 export const GatsbyImage: FunctionComponent<GatsbyImageProps> = function GatsbyImage({
   as,
   className,
+  class: preactClass,
   style,
   image,
   loading = `lazy`,
@@ -32,9 +33,8 @@ export const GatsbyImage: FunctionComponent<GatsbyImageProps> = function GatsbyI
     console.warn(`[gatsby-plugin-image] Missing image prop`)
     return null
   }
-  if (`class` in props) {
-    className = props.class
-    delete props.class
+  if (preactClass) {
+    className = preactClass
   }
   imgStyle = {
     objectFit,

--- a/packages/gatsby-plugin-image/src/components/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.server.tsx
@@ -32,6 +32,16 @@ export const GatsbyImage: FunctionComponent<GatsbyImageProps> = function GatsbyI
     console.warn(`[gatsby-plugin-image] Missing image prop`)
     return null
   }
+  if (`class` in props) {
+    className = props.class
+    delete props.class
+  }
+  imgStyle = {
+    objectFit,
+    objectPosition,
+    backgroundColor,
+    ...imgStyle,
+  }
 
   const {
     width,
@@ -97,6 +107,8 @@ export const GatsbyImage: FunctionComponent<GatsbyImageProps> = function GatsbyI
         <MainImage
           data-gatsby-image-ssr=""
           sizes={sizes}
+          className={imgClassName}
+          style={imgStyle}
           {...(props as Omit<MainImageProps, "images" | "fallback">)}
           // When eager is set we want to start the isLoading state on true (we want to load the img without react)
           {...getMainProps(loading === `eager`, false, cleanedImages, loading)}

--- a/packages/gatsby-plugin-image/src/components/static-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/static-image.server.tsx
@@ -53,6 +53,7 @@ export function _getStaticImage(
     jpgOptions,
     pngOptions,
     webpOptions,
+    avifOptions,
     blurredOptions,
     /* eslint-enable @typescript-eslint/no-unused-vars */
     ...props


### PR DESCRIPTION
This PR contains two bugfixes to the handling of styles in gatsby-plugin-image. First, it correctly applies some styles that were msising in SSR. Second it fixes a compatibility issue when using preact, where the "class" prop was not intercepted, and was instead passed-down to the img tag. The same would happen if using the class prop in React (instead of className), but it less of an issue as that's not explicitly allowed (though does normally work).

Fixes bug reported in https://github.com/gatsbyjs/gatsby/discussions/27950#discussioncomment-252289