### PR TITLE
Fix(gatsby-plugin-image): Render LayoutWrapper prior to loading of lazy-hydrate

### DIFF
--- a/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
@@ -17,7 +17,7 @@ import {
 import { PlaceholderProps } from "./placeholder"
 import { MainImageProps } from "./main-image"
 import { Layout } from "../image-utils"
-import { LayoutWrapper } from "./layout-wrapper"
+import { getSizer } from "./layout-wrapper"
 
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface GatsbyImageProps
@@ -195,6 +195,8 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
     props,
   ])
 
+  const sizer = getSizer(layout, width, height)
+
   return (
     <Type
       {...wrapperProps}
@@ -204,11 +206,12 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
         backgroundColor,
       }}
       className={`${wClass}${className ? ` ${className}` : ``}`}
+      ref={root}
+      dangerouslySetInnerHTML={{
+        __html: sizer,
+      }}
       suppressHydrationWarning
-    >
-      <LayoutWrapper layout={layout} width={width} height={height} />
-      <Type ref={root} dangerouslySetInnerHTML={{ __html: `` }} />
-    </Type>
+    />
   )
 }
 

--- a/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
@@ -17,6 +17,7 @@ import {
 import { PlaceholderProps } from "./placeholder"
 import { MainImageProps } from "./main-image"
 import { Layout } from "../image-utils"
+import { LayoutWrapper } from "./layout-wrapper"
 
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface GatsbyImageProps
@@ -203,10 +204,11 @@ export const GatsbyImageHydrator: FunctionComponent<GatsbyImageProps> = function
         backgroundColor,
       }}
       className={`${wClass}${className ? ` ${className}` : ``}`}
-      ref={root}
-      dangerouslySetInnerHTML={{ __html: `` }}
       suppressHydrationWarning
-    />
+    >
+      <LayoutWrapper layout={layout} width={width} height={height} />
+      <Type ref={root} dangerouslySetInnerHTML={{ __html: `` }} />
+    </Type>
   )
 }
 

--- a/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
+++ b/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
@@ -39,6 +39,23 @@ if (hasNativeLazyLoadSupport) {
   />
 )
 
+export function getSizer(
+  layout: Layout,
+  width: number,
+  height: number
+): string {
+  let sizer: string | null = null
+  if (layout === `fluid`) {
+    sizer = `<div aria-hidden="true" style="padding-top: ${
+      (height / width) * 100
+    }%;"></div>`
+  }
+  if (layout === `constrained`) {
+    sizer = `<div style="max-width: ${width}px; display: block;"><img alt="" role="presentation" aria-hidden="true" src="data:image/svg+xml;charset=utf-8,%3Csvg height='${height}' width='${width}' xmlns='http://www.w3.org/2000/svg' version='1.1'%3E%3C/svg%3E" style="max-width: 100%; display: block; position: static;"></div>`
+  }
+  return sizer
+}
+
 export const LayoutWrapper: FunctionComponent<ILayoutWrapperProps> = function LayoutWrapper({
   layout,
   width,
@@ -68,7 +85,6 @@ export const LayoutWrapper: FunctionComponent<ILayoutWrapperProps> = function La
       </div>
     )
   }
-
   return (
     <Fragment>
       {sizer}


### PR DESCRIPTION
Right now, fluid and constrained images trigger a re-layout because the sizer div (living in LayoutWrapper) hasn't loaded yet. This is not a challenge for SSR, but for route navigation.

This updates the dangerouslySetInnerHTML hack to use the sizer elements that fluid and constrained need.

[ch21582]