### PR TITLE
fix(deps): update hicat per security warnings

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -37,7 +37,7 @@
     "graphql-compose": "^6.3.8",
     "graphql-subscriptions": "^1.1.0",
     "graphql-type-json": "^0.3.2",
-    "hicat": "^0.7.0",
+    "hicat": "^0.8.0",
     "is-binary-path": "^2.1.0",
     "is-url": "^1.2.4",
     "jest-diff": "^25.5.0",


### PR DESCRIPTION
## Description

Update `hicat` dependency per security alert.

https://github.com/JackHowa/marathon-run-log/security/dependabot/package-lock.json/highlight.js/open

└─┬ gatsby@2.29.1
  └─┬ gatsby-cli@2.16.1
    └─┬ gatsby-recipes@0.6.0
      └─┬ hicat@0.7.0
        └── highlight.js@8.9.1 

### Documentation

- Recipes dependency found via https://github.com/gatsbyjs/gatsby/issues/28781

## Related Issues

- Fixes #28084
- Related to https://github.com/rstacruz/hicat/pull/9/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19
- Related to more general updates https://github.com/gatsbyjs/gatsby/pull/28545
