### PR TITLE
fix(gatsby-plugin-sharp): Add avif to pipeline

### DIFF
--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -123,6 +123,10 @@ exports.processFile = (file, transforms, options = {}) => {
           quality: transformArgs.quality,
           force: transformArgs.toFormat === `tiff`,
         })
+        .avif({
+          quality: transformArgs.quality,
+          force: transformArgs.toFormat === `avif`,
+        })
 
       // jpeg
       if (!options.useMozJpeg) {


### PR DESCRIPTION
Adds explicit `avif()` call to pipeline. It works locally without this, but fails in cloud worker