### PR TITLE
docs: add missing word for alt tag

### DIFF
--- a/docs/docs/how-to/routing/mdx-plugins.md
+++ b/docs/docs/how-to/routing/mdx-plugins.md
@@ -59,7 +59,7 @@ by Gatsby image processing.
 ![my image](./my-awesome-image.png)
 ```
 
-By default, the text `my image` will be used as the alt attribute of the
+By default, the text `my awesome image` will be used as the alt attribute of the
 generated `img` tag. If an empty alt attribute like `alt=""` is wished,
 a reserved keyword `GATSBY_EMPTY_ALT` can be used.
 

--- a/packages/gatsby-remark-images/README.md
+++ b/packages/gatsby-remark-images/README.md
@@ -47,7 +47,7 @@ plugins: [
 You can reference an image using the relative path, where that path is relative to the location of the Markdown file you're typing in.
 
 ```md
-![Alt text here](./my-awesome-image.jpg)
+![Alt text here](./my-awesome-image.png)
 ```
 
 By default, the text `my awesome image` will be used as the alt attribute of the generated `img` tag. If an empty alt attribute like `alt=""` is wished,

--- a/packages/gatsby-remark-images/README.md
+++ b/packages/gatsby-remark-images/README.md
@@ -47,14 +47,14 @@ plugins: [
 You can reference an image using the relative path, where that path is relative to the location of the Markdown file you're typing in.
 
 ```md
-![Alt text here](./image.jpg)
+![Alt text here](./my-awesome-image.jpg)
 ```
 
-By default, the text `Alt text here` will be used as the alt attribute of the generated `img` tag. If an empty alt attribute like `alt=""` is wished,
+By default, the text `my awesome image` will be used as the alt attribute of the generated `img` tag. If an empty alt attribute like `alt=""` is wished,
 a reserved keyword `GATSBY_EMPTY_ALT` can be used.
 
 ```markdown
-![GATSBY_EMPTY_ALT](./image.png)
+![GATSBY_EMPTY_ALT](./my-awesome-image.png)
 ```
 
 ## Options


### PR DESCRIPTION
## Description

changed:
- changed in readme filename to my-awesome-image.png
- changed in readme the generated alt tag to match the file name
- fixed in docs the generated alt tag to match the file name (in line 67 - not visible in diff)


because the default alt description is generated from file name (`defaultAlt`):

https://github.com/gatsbyjs/gatsby/blob/3d100e306e59048ab7e980056c38815b8c9076c1/packages/gatsby-remark-images/src/index.js#L167-L178



### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

- #27218 `fix(gatsby-remark-images): enable creating img tag with empty alt attribute` 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
