### PR TITLE
fix(gatsby,gatsby-admin): Pin socket.io version to 2.3.0

### DIFF
--- a/packages/gatsby-admin/package.json
+++ b/packages/gatsby-admin/package.json
@@ -40,7 +40,7 @@
     "react-markdown": "^4.3.1",
     "remove-markdown": "^0.3.0",
     "rimraf": "^3.0.2",
-    "socket.io-client": "^2.3.1",
+    "socket.io-client": "2.3.1",
     "strict-ui": "^0.2.0-0",
     "subscriptions-transport-ws": "^0.9.18",
     "theme-ui": "^0.4.0-rc.8",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -136,7 +136,7 @@
     "shallow-compare": "^1.2.2",
     "signal-exit": "^3.0.3",
     "slugify": "^1.4.4",
-    "socket.io": "^2.3.0",
+    "socket.io": "2.3.0",
     "socket.io-client": "2.3.0",
     "source-map": "^0.7.3",
     "source-map-support": "^0.5.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23020,7 +23020,7 @@ socket.io-client@2.3.0:
     socket.io-parser "~3.3.0"
     to-array "0.1.4"
 
-socket.io-client@^2.3.1:
+socket.io-client@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.3.1.tgz#91a4038ef4d03c19967bb3c646fec6e0eaa78cff"
   integrity sha512-YXmXn3pA8abPOY//JtYxou95Ihvzmg8U6kQyolArkIyLd0pgVhrfor/iMsox8cn07WCOOvvuJ6XKegzIucPutQ==
@@ -23055,7 +23055,7 @@ socket.io-parser@~3.4.0:
     debug "~4.1.0"
     isarray "2.0.1"
 
-socket.io@^2.3.0:
+socket.io@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.3.0.tgz#cd762ed6a4faeca59bc1f3e243c0969311eb73fb"
   integrity sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/28877 as otherwise a breaking change would be pulled in.
