### PR TITLE
chore(gatsby): Add `flags` to GatsbyConfig interface

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -185,6 +185,8 @@ export interface GatsbyConfig {
   siteMetadata?: Record<string, unknown>
   /** Plugins are Node.js packages that implement Gatsby APIs. The config file accepts an array of plugins. Some plugins may need only to be listed by name, while others may take options. */
   plugins?: Array<PluginRef>
+  /** You can activate and deactivate current experiments here. These are experimental features that are currently under development and need testing. When opting in to an experiment you'll receive a console message with more information of what it does and links to an umbrella discussion. */
+  flags?: Record<string, boolean>
   /** It’s common for sites to be hosted somewhere other than the root of their domain. Say we have a Gatsby site at `example.com/blog/`. In this case, we would need a prefix (`/blog`) added to all paths on the site. */
   pathPrefix?: string
   /** In some circumstances you may want to deploy assets (non-HTML resources such as JavaScript, CSS, etc.) to a separate domain. `assetPrefix` allows you to use Gatsby with assets hosted from a separate domain */

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -185,7 +185,7 @@ export interface GatsbyConfig {
   siteMetadata?: Record<string, unknown>
   /** Plugins are Node.js packages that implement Gatsby APIs. The config file accepts an array of plugins. Some plugins may need only to be listed by name, while others may take options. */
   plugins?: Array<PluginRef>
-  /** You can activate and deactivate current experiments here. These are experimental features that are currently under development and need testing. When opting in to an experiment you'll receive a console message with more information of what it does and links to an umbrella discussion. */
+  /** You can activate and deactivate current experiments here. These are experimental features that are currently under development and need testing. When opting in to an experiment you'll receive a console message with more information of what it does and a link to an umbrella discussion. */
   flags?: Record<string, boolean>
   /** It’s common for sites to be hosted somewhere other than the root of their domain. Say we have a Gatsby site at `example.com/blog/`. In this case, we would need a prefix (`/blog`) added to all paths on the site. */
   pathPrefix?: string


### PR DESCRIPTION
## Description

The `flags` were missing from the `GatsbyConfig` interface.

Side note: In a later iteration we could think of creating string literals instead of `string` so that people would get type hints for all experiments based of our current flags (so dynamically created)