### PR TITLE
Superwin

### DIFF
--- a/packages/gatsby/src/bootstrap/create-graphql-runner.ts
+++ b/packages/gatsby/src/bootstrap/create-graphql-runner.ts
@@ -79,6 +79,7 @@ export const createGraphQLRunner = (
                     },
                   },
                   filePath: file.getFileName(),
+                  error: e,
                 })
                 structuredError.context = {
                   ...structuredError.context,

--- a/packages/gatsby/src/query/__tests__/__snapshots__/error-parser.ts.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/error-parser.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`query-error-parser real error 1`] = `
+Object {
+  "context": Object {
+    "sourceMessage": "this error should show a trace",
+  },
+  "error": [Error: this error should show a trace],
+  "filePath": "test.js",
+  "id": "85901",
+  "location": Object {
+    "start": Object {
+      "column": 10,
+      "line": 5,
+    },
+  },
+}
+`;
+
 exports[`query-error-parser specific one 1`] = `
 Object {
   "context": Object {

--- a/packages/gatsby/src/query/__tests__/error-parser.ts
+++ b/packages/gatsby/src/query/__tests__/error-parser.ts
@@ -8,11 +8,18 @@ describe(`query-error-parser`, () => {
       `85920`,
     ],
     [`totally vague one`, `foo bar`, `85901`],
-  ])(`%s`, (_name, message, expectedId) => {
+    [
+      `real error`,
+      `this error should show a trace`,
+      `85901`,
+      new Error(`this error should show a trace`),
+    ],
+  ])(`%s`, (_name, message, expectedId, error = undefined) => {
     const structured = errorParser({
       message,
       filePath: `test.js`,
       location: { start: { line: 5, column: 10 } },
+      error: error instanceof Error ? error : undefined,
     })
     expect(structured).toMatchSnapshot()
     expect(structured.id).toEqual(expectedId)

--- a/packages/gatsby/src/query/error-parser.ts
+++ b/packages/gatsby/src/query/error-parser.ts
@@ -1,5 +1,5 @@
 import { IMatch } from "../types"
-import { SourceLocation } from "graphql"
+import { SourceLocation, GraphQLError } from "graphql"
 
 interface IErrorParser {
   message: string
@@ -10,12 +10,14 @@ interface IErrorParser {
         end?: SourceLocation
       }
     | undefined
+  error?: Error
 }
 
 const errorParser = ({
   message,
   filePath = undefined,
   location = undefined,
+  error = undefined,
 }: IErrorParser): IMatch => {
   // Handle GraphQL errors. A list of regexes to match certain
   // errors to specific callbacks
@@ -128,9 +130,17 @@ const errorParser = ({
     {
       regex: /[\s\S]*/gm,
       cb: (match): IMatch => {
-        return {
-          id: `85901`,
-          context: { sourceMessage: match[0] },
+        if (error instanceof Error && !(error instanceof GraphQLError)) {
+          return {
+            id: `85901`,
+            error, // show stack trace
+            context: { sourceMessage: match[0] },
+          }
+        } else {
+          return {
+            id: `85901`,
+            context: { sourceMessage: match[0] },
+          }
         }
       },
     },

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -217,7 +217,12 @@ const extractOperations = (schema, parsedQueries, addError, parentSpan) => {
           const location = {
             start: locInGraphQlToLocInFile(templateLoc, error.locations[0]),
           }
-          return errorParser({ message: error.message, filePath, location })
+          return errorParser({
+            message: error.message,
+            filePath,
+            location,
+            error,
+          })
         })
       )
 
@@ -384,6 +389,7 @@ const processDefinitions = ({
             },
             message,
             filePath,
+            error,
           })
         )
       }

--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -63,6 +63,7 @@ function panicQueryJobError(
       message: e.message,
       filePath: undefined,
       location: undefined,
+      error: e,
     })
 
     structuredError.context = {

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -370,22 +370,35 @@ export function fileByPath<TSource, TArgs>(
       node => node.internal && node.internal.type === `File`
     )
 
-    const findLinkedFileNode = (relativePath: string): any => {
-      // Use the parent File node to create the absolute path to
-      // the linked file.
-      const fileLinkPath = normalize(
-        systemPath.resolve(parentFileNode.dir, relativePath)
+    if (Array.isArray(fieldValue)) {
+      return Promise.all(
+        fieldValue.map(fieldValue =>
+          context.nodeModel.runQuery({
+            query: {
+              filter: {
+                absolutePath: {
+                  eq: systemPath.resolve(parentFileNode.dir, fieldValue),
+                },
+              },
+            },
+            firstOnly: true,
+            type: `File`,
+          })
+        )
       )
-
-      // Use that path to find the linked File node.
-      const linkedFileNode = _.find(
-        context.nodeModel.getAllNodes({ type: `File` }),
-        n => n.absolutePath === fileLinkPath
-      )
-      return linkedFileNode
+    } else {
+      return context.nodeModel.runQuery({
+        query: {
+          filter: {
+            absolutePath: {
+              eq: systemPath.resolve(parentFileNode.dir, fieldValue),
+            },
+          },
+        },
+        firstOnly: true,
+        type: `File`,
+      })
     }
-
-    return resolveValue(findLinkedFileNode, fieldValue)
   }
 }
 


### PR DESCRIPTION
This is a branch on a branch. The real change is the last commit, in packages/gatsby/src/schema/resolvers.ts

At 1k the builds are roughly the same (20s). At 16k it drops the build from 310s to 186s. 128k takes forever.

The reason is that `fileByPath` will call `context.nodeModel.getAllNodes({ type: `File` })` for _every_ file, not cache it. This causes loops-da-loops over all nodes. Over and over again.

The change I'm playing with is to directly call `runQuery`, which will take care of the caching for us. I think this change can be improved a bit but it may not be worth it.