### PR TITLE
fix(gatsby-plugin-sass): fix brand name, code block around names

### DIFF
--- a/packages/gatsby-plugin-sass/CHANGELOG.md
+++ b/packages/gatsby-plugin-sass/CHANGELOG.md
@@ -353,7 +353,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- **gatsby-plugin-sass:** Support Dart SASS ([#10159](https://github.com/gatsbyjs/gatsby/issues/10159)) ([a48843e](https://github.com/gatsbyjs/gatsby/commit/a48843e))
+- **gatsby-plugin-sass:** Support Dart Sass ([#10159](https://github.com/gatsbyjs/gatsby/issues/10159)) ([a48843e](https://github.com/gatsbyjs/gatsby/commit/a48843e))
 
 <a name="2.0.6"></a>
 

--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -128,7 +128,7 @@ plugins: [
 Using CSS Modules requires no additional configuration. Simply prepend `.module` to the extension. For example: `App.scss` -> `App.module.scss`.
 Any file with the `module` extension will use CSS Modules.
 
-## SASS & CSS Modules file Regexes
+## Sass & CSS Modules file Regexes
 
 To override the file regex for Sass or CSS modules,
 
@@ -137,7 +137,7 @@ plugins: [
   {
     resolve: `gatsby-plugin-sass`,
     options: {
-      // Override the file regex for SASS
+      // Override the file regex for Sass
       sassRuleTest: /\.global\.s(a|c)ss$/,
       // Override the file regex for CSS modules
       sassRuleModulesTest: /\.mod\.s(a|c)ss$/,

--- a/packages/gatsby-plugin-sass/README.md
+++ b/packages/gatsby-plugin-sass/README.md
@@ -31,7 +31,7 @@ import "./src/index.scss"
 
 ## Other options
 
-If you need to pass options to Sass use the plugins options, see [node-sass](https://github.com/sass/node-sass)/[dart-sass](https://github.com/sass/dart-sass) docs
+If you need to pass options to Sass use the plugins options, see [`node-sass`](https://github.com/sass/node-sass)/[`dart-sass`](https://github.com/sass/dart-sass) docs
 for all available options.
 
 ```javascript:title=gatsby-config.js
@@ -155,9 +155,9 @@ in the plugin options.
 
 ## Relative paths & `url()`
 
-This plugin resolves `url()` paths relative to the entry SCSS/Sass file not – as might be expected – the location relative to the declaration. Under the hood, it makes use of [sass-loader](https://github.com/webpack-contrib/sass-loader/blob/master/README.md#problems-with-url) and this is documented in the [readme](https://github.com/webpack-contrib/sass-loader/blob/master/README.md#problems-with-url).
+This plugin resolves `url()` paths relative to the entry SCSS/Sass file not – as might be expected – the location relative to the declaration. Under the hood, it makes use of [`sass-loader`](https://github.com/webpack-contrib/sass-loader/blob/master/README.md#problems-with-url) and this is documented in the [readme](https://github.com/webpack-contrib/sass-loader/blob/master/README.md#problems-with-url).
 
-Using [resolve-url-loader](https://github.com/bholloway/resolve-url-loader) provides a workaround, if you want to use relative url just install the plugin and then add it to your sass plugin options configuration.
+Using [`resolve-url-loader`](https://github.com/bholloway/resolve-url-loader) provides a workaround, if you want to use relative url just install the plugin and then add it to your Sass plugin options configuration.
 
 First:
 
@@ -178,7 +178,7 @@ plugins: [
 ]
 ```
 
-You can also configure resolve-url-plugin providing some options (see [plugin documentation](https://github.com/bholloway/resolve-url-loader) for all options):
+You can also configure `resolve-url-plugin` providing some options (see [plugin documentation](https://github.com/bholloway/resolve-url-loader) for all options):
 
 ```javascript:title=gatsby-config.js
 plugins: [
@@ -195,7 +195,7 @@ plugins: [
 ]
 ```
 
-**Please note:** Adding resolve-url-loader will use `sourceMap: true` on sass-loader (as it is required for the plugin to work), you can then activate/deactivate source-map for Sass files in the plugin:
+**Please note:** Adding `resolve-url-loader` will use `sourceMap: true` on `sass-loader` (as it is required for the plugin to work), you can then activate/deactivate source-map for Sass files in the plugin:
 
 ```javascript:title=gatsby-config.js
 plugins: [

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-sass",
-  "description": "Gatsby plugin to handle scss/sass files",
+  "description": "Gatsby plugin to handle SCSS/Sass files",
   "version": "3.1.0-next.0",
   "author": "Daniel Farrell <daniel@mobelux.com>",
   "bugs": {

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -98,10 +98,10 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       .description(`An array of postCss plugins`),
     sassRuleTest: Joi.object()
       .instance(RegExp)
-      .description(`Override the file regex for SASS`),
+      .description(`Override the file regex for Sass`),
     sassRuleModulesTest: Joi.object()
       .instance(RegExp)
-      .description(`Override the file regex for SASS`),
+      .description(`Override the file regex for Sass`),
     useResolveUrlLoader: Joi.alternatives().try(
       Joi.boolean(),
       Joi.object({}).unknown(true)

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -108,7 +108,7 @@ exports.pluginOptionsSchema = function ({ Joi }) {
     )
       .description(`This plugin resolves url() paths relative to the entry SCSS/Sass file not – as might be expected – the location relative to the declaration. Under the hood, it makes use of sass-loader and this is documented in the readme.
 
-        Using resolve-url-loader provides a workaround, if you want to use relative url just install the plugin and then add it to your sass plugin options configuration.`),
+        Using resolve-url-loader provides a workaround, if you want to use relative url just install the plugin and then add it to your Sass plugin options configuration.`),
     // TODO: Use alternatives() to also allow function. Currently some bug in our schema validation (test)
     sassOptions: Joi.object({
       file: Joi.string()
@@ -129,7 +129,7 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       functions: Joi.object()
         .pattern(MATCH_ALL_KEYS, Joi.function().maxArity(2))
         .description(
-          `functions is an Object that holds a collection of custom functions that may be invoked by the sass files being compiled.`
+          `functions is an Object that holds a collection of custom functions that may be invoked by the Sass files being compiled.`
         ),
       includePaths: Joi.array()
         .items(Joi.string())


### PR DESCRIPTION
## Description

changes:
- change `sass`/`SASS` to `Sass`
- add code block around names

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

- #27466 `chore(gatsby-plugin-sass): add pluginOptionsSchema export` 