### PR TITLE
docs: Add gatsby-plugin-image How-To guide

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -1,0 +1,161 @@
+---
+title: Using the beta Gatsby Image plugin
+---
+
+The Gatsby Image plugin gives you the tools you need to add high-performance, responsive images to your site. This gives the best experience for your users and helps you achieve high performance scores. This can be hard to do manually, as you need to produce images in multiple sizes and formats, but the Gatsby Image plugin handles the hard parts for you.
+
+> Want to dig deeper into using high-performance images with Gatsby? Read the conceptual guide.
+
+The new Gatsby Image plugin is currently in beta, but you can try it out now and see what it can do for the performance of your site.
+
+## Getting started
+
+First you need to install the following packages:
+
+```shell
+npm install gatsby-plugin-image gatsby-plugin-sharp gatsby-transformer-sharp
+```
+
+You then need to add the plugins to your `gatsby-config.js`:
+
+```js
+module.exports = {
+  plugins: [
+    `gatsby-plugin-image`,
+    `gatsby-plugin-sharp`,
+    `gatsby-transformer-sharp`,
+  ],
+}
+```
+
+If you already have some of these plugins installed, please check that they're updated to the latest version.
+
+## Using the Gatsby Image components
+
+### Decide which component to use
+
+The Gatsby Image plugin includes two image components: one for static and one for dynamic images. The simplest way to decide which you need to is to ask yourself: _"will this image be the same every time the component or template is used?"_. If it will always be the same, then use `StaticImage`. If it will change, whether through data coming from a CMS or different values passed to a component each time you use it, then it is a dynamic image and you should use the `GatsbyImage` component.
+
+### Static images
+
+If you are using an image that will be the same each time the component is used, such as a logo or hero image, you can use the `StaticImage` component. The image can be either a local file in your project, or an image hosted on a remote server. Any remote images are downloaded and resized at build time.
+
+1. **Add the image to your project**
+
+   If you are using a local image, copy it into the project. A folder such as `src/images` is a good choice.
+
+2. **Add the `StaticImage` component to your template**
+
+   Import the component, then set the `src` prop to point to the image you added earlier, or to the URL of the image if hosted elsewhere. The path is relative to the source file itself. If your component file was `src/components/dino.js`, then you would load the image like this:
+
+   ```jsx
+   import { StaticImage } from "gatsby-plugin-image"
+
+   export function Dino() {
+     return (
+       <section>
+         <StaticImage src="../images/dino.png" alt="A dinosaur" />
+         <StaticImage src="https://placekitten.com/800/600" alt="A kitten" />
+       </section>
+     )
+   }
+   ```
+
+   When you build your site, this will load the image from your filesystem or from the remote URL, and generate all the sizes and formats that you need to support a responsive image. Because the image is loaded at build time, you cannot pass the filename in as a prop, or otherwise generate it outside of the component. It should either be a static string, or a local variable in the component's scope.
+
+   > **Important:** remote images are downloaded and resized at build time. If the image is changed on the other server, it will not be updated on your site until you rebuild
+
+3. **Configure the image**:
+
+   You configure the image by passing props to the `<StaticImage />` component. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
+
+   ```jsx
+   import { StaticImage } from "gatsby-plugin-image"
+
+   export function Dino() {
+     return (
+       <StaticImage
+         src="../images/dino.png"
+         alt="A dinosaur"
+         placeholder="blurred"
+         layout="fixed"
+         width={200}
+         height={200}
+       />
+     )
+   }
+   ```
+
+### Dynamic images
+
+If you need to have dynamic images, such as if they are coming from a CMS, they are loaded via GraphQL and displayed using the `GatsbyImage` component.
+
+1. **Add the image to your page query**:
+
+   Any GraphQL File object that includes an image will have a `childImageSharp` field that you can use to query the image data. The exact data structure will vary according to your data source, but the syntax is like this:
+
+   ```graphql
+   query {
+     blogPost(id: { eq: $Id }) {
+       title
+       body
+       avatar {
+         childImageSharp {
+           gatsbyImageData(maxWidth: 200)
+         }
+       }
+     }
+   }
+   ```
+
+2. **Configure your image**:
+
+   You configure the image by passing arguments to the `gatsbyImageData` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
+
+   ```graphql
+   query {
+     blogPost(id: { eq: $Id }) {
+       title
+       body
+       author
+       avatar {
+         childImageSharp {
+           gatsbyImageData(
+             maxWidth: 200
+             placeholder: BLURRED
+             formats: [AUTO, WEBP, AVIF]
+           )
+         }
+       }
+     }
+   }
+   ```
+
+3. **Display the image:**
+
+   You can then use the `GatbsyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImageData`, which can be passed to the `GatsbyImage` component.
+
+   ```jsx
+   import { GatsbyImage, getImage } from "gatsby-plugin-image"
+
+   function BlogPost({ data }) {
+     const image = getImage(data.blogPost.avatar)
+     return (
+       <section>
+         <h2>{data.blogPost.title}</h2>
+         <GatsbyImage image={image} alt={data.blogPost.author} />
+         <p>{data.blogPost.body}</p>
+       </section>
+     )
+   }
+   ```
+
+## Migrating
+
+If your site uses the old `gatsby-image` component, you can use a codemod to help you migrate to the new Gatsby Image components. This can update the code for most sites. To use the codemod, run this command in the root of your site:
+
+```shell
+npx gatsby-codemods gatsby-plugin-image
+```
+
+This will convert all GraphQL queries and components to use the new plugin. For more information see the full migration guide.

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -72,7 +72,7 @@ If you are using an image that will be the same each time the component is used,
 
    Because the image is loaded at build time, you cannot pass the filename in as a prop, or otherwise generate it outside of the component. It should either be a static string, or a local variable in the component's scope.
 
-   > **Important:** Remote images are downloaded and resized at build time. If the image is changed on the other server, it will not be updated on your site until you rebuild.
+**Important:** Remote images are downloaded and resized at build time. If the image is changed on the other server, it will not be updated on your site until you rebuild.
 
 3. **Configure the image.**
 

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -4,7 +4,7 @@ title: Using the beta Gatsby Image plugin
 
 Adding responsive images to your site while maintaining high performance scores can be difficult to do manually. The Gatsby Image plugin handles the hard parts of producing images in multiple sizes and formats for you!
 
-> Want to learn more about image optimization challenges? Read the Conceptual Guide: [title of conceptual guide, hyperlinked].
+Want to learn more about image optimization challenges? Read the Conceptual Guide: [Why Gatsby's Automatic Image Optimizations Matter](docs/conceptual/using-gatsby-image/). For full documentation on all configuration options, see [the reference guide](/docs/reference/built-in-components/gatsby-plugin-image).
 
 The new Gatsby Image plugin is currently in beta, but you can try it out now and see what it can do for the performance of your site.
 
@@ -13,7 +13,7 @@ The new Gatsby Image plugin is currently in beta, but you can try it out now and
 First you need to install the following packages:
 
 ```shell
-npm install gatsby-plugin-image gatsby-plugin-sharp gatsby-transformer-sharp
+npm install gatsby-plugin-image gatsby-plugin-sharp gatsby-source-filesystem gatsby-transformer-sharp
 ```
 
 You then need to add the plugins to your `gatsby-config.js`:
@@ -23,6 +23,7 @@ module.exports = {
   plugins: [
     `gatsby-plugin-image`,
     `gatsby-plugin-sharp`,
+    `gatsby-source-filesystem`,
     `gatsby-transformer-sharp`,
   ],
 }
@@ -72,7 +73,7 @@ If you are using an image that will be the same each time the component is used,
 
    Because the image is loaded at build time, you cannot pass the filename in as a prop, or otherwise generate it outside of the component. It should either be a static string, or a local variable in the component's scope.
 
-**Important:** Remote images are downloaded and resized at build time. If the image is changed on the other server, it will not be updated on your site until you rebuild.
+   **Important:** Remote images are downloaded and resized at build time. If the image is changed on the other server, it will not be updated on your site until you rebuild.
 
 3. **Configure the image.**
 

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -2,9 +2,9 @@
 title: Using the beta Gatsby Image plugin
 ---
 
-The Gatsby Image plugin gives you the tools you need to add high-performance, responsive images to your site. This gives the best experience for your users and helps you achieve high performance scores. This can be hard to do manually, as you need to produce images in multiple sizes and formats, but the Gatsby Image plugin handles the hard parts for you.
+Adding responsive images to your site while maintaining high performance scores can be difficult to do manually. The Gatsby Image plugin handles the hard parts of producing images in multiple sizes and formats for you!
 
-> Want to dig deeper into using high-performance images with Gatsby? Read the conceptual guide.
+> Want to learn more about image optimization challenges? Read the Conceptual Guide: [title of conceptual guide, hyperlinked].
 
 The new Gatsby Image plugin is currently in beta, but you can try it out now and see what it can do for the performance of your site.
 
@@ -18,7 +18,7 @@ npm install gatsby-plugin-image gatsby-plugin-sharp gatsby-transformer-sharp
 
 You then need to add the plugins to your `gatsby-config.js`:
 
-```js
+```js:title=gatsby-config.js
 module.exports = {
   plugins: [
     `gatsby-plugin-image`,
@@ -40,15 +40,15 @@ The Gatsby Image plugin includes two image components: one for static and one fo
 
 If you are using an image that will be the same each time the component is used, such as a logo or hero image, you can use the `StaticImage` component. The image can be either a local file in your project, or an image hosted on a remote server. Any remote images are downloaded and resized at build time.
 
-1. **Add the image to your project**
+1. **Add the image to your project.**
 
    If you are using a local image, copy it into the project. A folder such as `src/images` is a good choice.
 
-2. **Add the `StaticImage` component to your template**
+2. **Add the `StaticImage` component to your template.**
 
    Import the component, then set the `src` prop to point to the image you added earlier, or to the URL of the image if hosted elsewhere. The path is relative to the source file itself. If your component file was `src/components/dino.js`, then you would load the image like this:
 
-   ```jsx
+   ```jsx:title=src/components/dino.js
    import { StaticImage } from "gatsby-plugin-image"
 
    export function Dino() {
@@ -63,9 +63,9 @@ If you are using an image that will be the same each time the component is used,
 
    When you build your site, this will load the image from your filesystem or from the remote URL, and generate all the sizes and formats that you need to support a responsive image. Because the image is loaded at build time, you cannot pass the filename in as a prop, or otherwise generate it outside of the component. It should either be a static string, or a local variable in the component's scope.
 
-   > **Important:** remote images are downloaded and resized at build time. If the image is changed on the other server, it will not be updated on your site until you rebuild
+   > **Important:** Remote images are downloaded and resized at build time. If the image is changed on the other server, it will not be updated on your site until you rebuild.
 
-3. **Configure the image**:
+3. **Configure the image.**
 
    You configure the image by passing props to the `<StaticImage />` component. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
 
@@ -88,9 +88,9 @@ If you are using an image that will be the same each time the component is used,
 
 ### Dynamic images
 
-If you need to have dynamic images, such as if they are coming from a CMS, they are loaded via GraphQL and displayed using the `GatsbyImage` component.
+If you need to have dynamic images (such as if they are coming from a CMS), you can load them via GraphQL and display them using the `GatsbyImage` component.
 
-1. **Add the image to your page query**:
+1. **Add the image to your page query.**
 
    Any GraphQL File object that includes an image will have a `childImageSharp` field that you can use to query the image data. The exact data structure will vary according to your data source, but the syntax is like this:
 
@@ -108,7 +108,7 @@ If you need to have dynamic images, such as if they are coming from a CMS, they 
    }
    ```
 
-2. **Configure your image**:
+2. **Configure your image.**
 
    You configure the image by passing arguments to the `gatsbyImageData` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
 
@@ -119,6 +119,7 @@ If you need to have dynamic images, such as if they are coming from a CMS, they 
        body
        author
        avatar {
+         // highlight-start
          childImageSharp {
            gatsbyImageData(
              maxWidth: 200
@@ -126,23 +127,27 @@ If you need to have dynamic images, such as if they are coming from a CMS, they 
              formats: [AUTO, WEBP, AVIF]
            )
          }
+         // highlight-end
        }
      }
    }
    ```
 
-3. **Display the image:**
+3. **Display the image.**
 
    You can then use the `GatbsyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImageData`, which can be passed to the `GatsbyImage` component.
 
    ```jsx
+   // highlight-next-line
    import { GatsbyImage, getImage } from "gatsby-plugin-image"
 
    function BlogPost({ data }) {
+     // highlight-next-line
      const image = getImage(data.blogPost.avatar)
      return (
        <section>
          <h2>{data.blogPost.title}</h2>
+         // highlight-next-line
          <GatsbyImage image={image} alt={data.blogPost.author} />
          <p>{data.blogPost.body}</p>
        </section>

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -30,6 +30,8 @@ module.exports = {
 
 If you already have some of these plugins installed, please check that they're updated to the latest version.
 
+<!-- TODO: add exact minimum version when we reach GA -->
+
 ## Using the Gatsby Image components
 
 ### Decide which component to use
@@ -38,7 +40,7 @@ The Gatsby Image plugin includes two image components: one for static and one fo
 
 ### Static images
 
-If you are using an image that will be the same each time the component is used, such as a logo or hero image, you can use the `StaticImage` component. The image can be either a local file in your project, or an image hosted on a remote server. Any remote images are downloaded and resized at build time.
+If you are using an image that will be the same each time the component is used, such as a logo or front page hero image, you can use the `StaticImage` component. The image can be either a local file in your project, or an image hosted on a remote server. Any remote images are downloaded and resized at build time.
 
 1. **Add the image to your project.**
 
@@ -46,18 +48,23 @@ If you are using an image that will be the same each time the component is used,
 
 2. **Add the `StaticImage` component to your template.**
 
-   Import the component, then set the `src` prop to point to the image you added earlier, or to the URL of the image if hosted elsewhere. The path is relative to the source file itself. If your component file was `src/components/dino.js`, then you would load the image like this:
+   Import the component, then set the `src` prop to point to the image you added earlier. The path is relative to the source file itself. If your component file was `src/components/dino.js`, then you would load the image like this:
 
    ```jsx:title=src/components/dino.js
    import { StaticImage } from "gatsby-plugin-image"
 
    export function Dino() {
-     return (
-       <section>
-         <StaticImage src="../images/dino.png" alt="A dinosaur" />
-         <StaticImage src="https://placekitten.com/800/600" alt="A kitten" />
-       </section>
-     )
+     return <StaticImage src="../images/dino.png" alt="A dinosaur" />
+   }
+   ```
+
+   If you are using a remote image, pass the image URL in the `src` prop:
+
+   ```jsx:title=src/components/kitten.js
+   import { StaticImage } from "gatsby-plugin-image"
+
+   export function Kitten() {
+     return <StaticImage src="https://placekitten.com/800/600" alt="A kitten" />
    }
    ```
 
@@ -69,7 +76,9 @@ If you are using an image that will be the same each time the component is used,
 
    You configure the image by passing props to the `<StaticImage />` component. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
 
-   ```jsx
+   This component renders a 200px by 200px image of a dinosaur. Before loading it will have a blurred, low-resolution placeholder. It uses the `"fixed"` layout, which means the image does not resize with its container.
+
+   ```jsx:title=src/components/dino.js
    import { StaticImage } from "gatsby-plugin-image"
 
    export function Dino() {
@@ -86,6 +95,8 @@ If you are using an image that will be the same each time the component is used,
    }
    ```
 
+   > To learn more about the different types of image layout, see the API docs.
+
 ### Dynamic images
 
 If you need to have dynamic images (such as if they are coming from a CMS), you can load them via GraphQL and display them using the `GatsbyImage` component.
@@ -94,7 +105,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
 
    Any GraphQL File object that includes an image will have a `childImageSharp` field that you can use to query the image data. The exact data structure will vary according to your data source, but the syntax is like this:
 
-   ```graphql
+   ```graphql:title=src/templates/blogpost.js
    query {
      blogPost(id: { eq: $Id }) {
        title
@@ -112,14 +123,14 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
 
    You configure the image by passing arguments to the `gatsbyImageData` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
 
-   ```graphql
+   ```graphql:title=src/templates/blogpost.js
    query {
      blogPost(id: { eq: $Id }) {
        title
        body
        author
        avatar {
-         // highlight-start
+         # highlight-start
          childImageSharp {
            gatsbyImageData(
              maxWidth: 200
@@ -127,7 +138,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
              formats: [AUTO, WEBP, AVIF]
            )
          }
-         // highlight-end
+         # highlight-end
        }
      }
    }
@@ -137,7 +148,8 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
 
    You can then use the `GatbsyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImageData`, which can be passed to the `GatsbyImage` component.
 
-   ```jsx
+   ```jsx:title=src/templates/blogpost.js
+   import { graphql } from "gatsby"
    // highlight-next-line
    import { GatsbyImage, getImage } from "gatsby-plugin-image"
 
@@ -147,12 +159,31 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
      return (
        <section>
          <h2>{data.blogPost.title}</h2>
-         // highlight-next-line
+         {/* highlight-next-line */}
          <GatsbyImage image={image} alt={data.blogPost.author} />
          <p>{data.blogPost.body}</p>
        </section>
      )
    }
+
+   export const pageQuery = graphql`
+     query {
+       blogPost(id: { eq: $Id }) {
+         title
+         body
+         author
+         avatar {
+           childImageSharp {
+             gatsbyImageData(
+               maxWidth: 200
+               placeholder: BLURRED
+               formats: [AUTO, WEBP, AVIF]
+             )
+           }
+         }
+       }
+     }
+   `
    ```
 
 ## Migrating

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -76,7 +76,7 @@ If you are using an image that will be the same each time the component is used,
 
 3. **Configure the image.**
 
-   You configure the image by passing props to the `<StaticImage />` component. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
+   You configure the image by passing props to the `<StaticImage />` component. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options [in the API docs](/docs/reference/built-in-components/gatsby-plugin-image).
 
    This component renders a 200px by 200px image of a dinosaur. Before loading it will have a blurred, low-resolution placeholder. It uses the `"fixed"` layout, which means the image does not resize with its container.
 
@@ -97,7 +97,58 @@ If you are using an image that will be the same each time the component is used,
    }
    ```
 
-   > To learn more about the different types of image layout, see the API docs.
+#### Restrictions on using `StaticImage`
+
+The images are loaded and processed at build time, so there are restrictions on how you pass props to the component. The values need to be statically-analyzed at build time, which means you can't pass them as props from outside the component, or use the results of function calls, for example. You can either use static values, or variables within the component's local scope. See the following examples:
+
+This does not work:
+
+```js
+// ⚠️ Doesn't work
+
+export function Logo({ logo }) {
+  // You can't use a prop passed into the parent component
+  return <StaticImage src={logo}>
+}
+```
+
+...and nor does this:
+
+```js
+// ⚠️ Doesn't work
+
+export function Dino() {
+    // Props can't come from function calls
+    const width = getTheWidthFromSomewhere();
+    return <StaticImage src="trex.png" width={width}>
+}
+```
+
+You can use variables and expressions if they're in the scope of the file, e.g.:
+
+```js
+// OK
+export function Dino()  {
+    // Local variables are fine
+    const width = 300
+    return <StaticImage src="trex.png" width={width}>
+}
+```
+
+```js
+// Also OK
+
+// A variable in the same file is fine.
+const width = 300
+
+export function Dino()  {
+    // This works because the value can be statically-analyzed
+    const height = width * 16 / 9
+    return <StaticImage src="trex.png" width={width} height={height}>
+}
+```
+
+If you find yourself wishing you could use a prop for the image `src` then it's likely that you should be using a dynamic image.
 
 ### Dynamic images
 
@@ -115,7 +166,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
        # highlight-start
        avatar {
          childImageSharp {
-           gatsbyImageData(maxWidth: 200)
+           gatsbyImageData(width: 200)
          }
        }
        # highlight-end
@@ -137,7 +188,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
          # highlight-start
          childImageSharp {
            gatsbyImageData(
-             maxWidth: 200
+             width: 200
              placeholder: BLURRED
              formats: [AUTO, WEBP, AVIF]
            )
@@ -179,7 +230,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
          avatar {
            childImageSharp {
              gatsbyImageData(
-               maxWidth: 200
+               width: 200
                placeholder: BLURRED
                formats: [AUTO, WEBP, AVIF]
              )


### PR DESCRIPTION
This is documentation for the new plugin. I'd see it sitting alongside the old docs for now, outside of the main navigation. I've split off the API docs, which I will add separately. 

[rendered version](https://github.com/gatsbyjs/gatsby/blob/docs/using-image-plugin/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md)

[ch19266]