### PR TITLE
fix(gatsby): Use fast-refresh for React 17

### DIFF
--- a/packages/gatsby/src/utils/get-react-hot-loader-strategy.ts
+++ b/packages/gatsby/src/utils/get-react-hot-loader-strategy.ts
@@ -1,4 +1,4 @@
-// import semver from "semver"
+import semver from "semver"
 
 // Fast refresh is supported as of React 16.9.
 // This package will do some sniffing to see if the current version of
@@ -13,22 +13,15 @@ export function getReactHotLoaderStrategy(): string {
   // Do some package sniffing to see if we can use fast-refresh if the user didn't
   // specify a specific hot loader with the environment variable.
 
-  // TODO: Probably use the flags for this
-  /*
   try {
     const reactVersion = require(`react/package.json`).version
 
-    // TODO React components need to be named to make fast-refresh work
-    // We need to create an eslint-rule that shows this error or create a babel plugin
-    // that converts arrow functions to generated named ones.
-    // When it's available we can switch the condition to >=16.9.0
     if (semver.satisfies(reactVersion, `>=17.0.0`)) {
       return `fast-refresh`
     }
   } catch (e) {
     return `react-hot-loader`
   }
-  */
 
   return `react-hot-loader`
 }


### PR DESCRIPTION
## Description

Use `fast-refresh` for React 17. This can only be merged after https://github.com/gatsbyjs/gatsby/pull/28689 is merged so that incorrect components are highlighted.

[ch19790]
