### PR TITLE
chore(docs): Change cd path to "my-gatsby-site"

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -21,7 +21,7 @@ It will look like this, but use your project's directory.
 ```shell
 Start by going to the directory with
 
-cd gatsby-site
+cd my-gatsby-site
 
 Start the local development server with
 


### PR DESCRIPTION
## Description

The default site name is now `my-gatsby-site` in the cli flow so I have updated the docs to reflect this change 

```
√ Shall we do this? (Y/n) · Yes
√ Created site from template
PS C:\Users\source\repos\gatsby-app> cd gatsby-site
Set-Location: Cannot find path 'C:\Users\source\repos\gatsby-app\gatsby-site' because it does not exist.

PS C:\Users\source\repos\gatsby-app> cd my-gatsby-site
PS C:\Users\source\repos\gatsby-app\my-gatsby-site> npm run develop
```
