### PR TITLE
Bug/duplicate ids lost gtjson

### DIFF
--- a/packages/gatsby-transformer-json/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-json/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -7,12 +7,13 @@ Array [
       "blue": true,
       "children": Array [],
       "funny": "yup",
-      "id": "12345",
+      "id": "uuid-from-gatsby",
       "internal": Object {
         "contentDigest": "contentDigest",
         "type": "FooJson",
       },
       "parent": "whatever",
+      "publicId": "12345",
     },
   ],
 ]
@@ -26,12 +27,13 @@ Array [
         "blue": true,
         "children": Array [],
         "funny": "yup",
-        "id": "12345",
+        "id": "uuid-from-gatsby",
         "internal": Object {
           "contentDigest": "contentDigest",
           "type": "FooJson",
         },
         "parent": "whatever",
+        "publicId": "12345",
       },
       "parent": Object {
         "children": Array [],
@@ -58,12 +60,13 @@ Array [
       "blue": true,
       "children": Array [],
       "funny": "yup",
-      "id": "foo",
+      "id": "uuid-from-gatsby",
       "internal": Object {
         "contentDigest": "contentDigest",
         "type": "FooJson",
       },
       "parent": "whatever",
+      "publicId": "foo",
     },
   ],
 ]
@@ -77,12 +80,13 @@ Array [
         "blue": true,
         "children": Array [],
         "funny": "yup",
-        "id": "foo",
+        "id": "uuid-from-gatsby",
         "internal": Object {
           "contentDigest": "contentDigest",
           "type": "FooJson",
         },
         "parent": "whatever",
+        "publicId": "foo",
       },
       "parent": Object {
         "children": Array [],
@@ -109,12 +113,13 @@ Array [
       "blue": true,
       "children": Array [],
       "funny": "yup",
-      "id": "foo",
+      "id": "uuid-from-gatsby",
       "internal": Object {
         "contentDigest": "contentDigest",
         "type": "NotFileJson",
       },
       "parent": "whatever",
+      "publicId": "foo",
     },
   ],
 ]
@@ -128,12 +133,13 @@ Array [
         "blue": true,
         "children": Array [],
         "funny": "yup",
-        "id": "foo",
+        "id": "uuid-from-gatsby",
         "internal": Object {
           "contentDigest": "contentDigest",
           "type": "NotFileJson",
         },
         "parent": "whatever",
+        "publicId": "foo",
       },
       "parent": Object {
         "children": Array [],
@@ -158,12 +164,13 @@ Array [
       "blue": true,
       "children": Array [],
       "funny": "yup",
-      "id": "foo",
+      "id": "uuid-from-gatsby",
       "internal": Object {
         "contentDigest": "contentDigest",
         "type": "NodeNameJson",
       },
       "parent": "whatever",
+      "publicId": "foo",
     },
   ],
   Array [
@@ -190,12 +197,13 @@ Array [
         "blue": true,
         "children": Array [],
         "funny": "yup",
-        "id": "foo",
+        "id": "uuid-from-gatsby",
         "internal": Object {
           "contentDigest": "contentDigest",
           "type": "NodeNameJson",
         },
         "parent": "whatever",
+        "publicId": "foo",
       },
       "parent": Object {
         "children": Array [],
@@ -250,12 +258,13 @@ Array [
       "blue": true,
       "children": Array [],
       "funny": "yup",
-      "id": "foo",
+      "id": "uuid-from-gatsby",
       "internal": Object {
         "contentDigest": "contentDigest",
         "type": "NotFileJson",
       },
       "parent": "whatever",
+      "publicId": "foo",
     },
   ],
   Array [
@@ -282,12 +291,13 @@ Array [
         "blue": true,
         "children": Array [],
         "funny": "yup",
-        "id": "foo",
+        "id": "uuid-from-gatsby",
         "internal": Object {
           "contentDigest": "contentDigest",
           "type": "NotFileJson",
         },
         "parent": "whatever",
+        "publicId": "foo",
       },
       "parent": Object {
         "children": Array [],
@@ -324,6 +334,59 @@ Array [
           "mediaType": "application/json",
           "type": "NotFile",
         },
+        "parent": null,
+      },
+    },
+  ],
+]
+`;
+
+exports[`Process JSON nodes correctly creates a publicId if id was given 1`] = `
+Array [
+  Array [
+    Object {
+      "blue": true,
+      "children": Array [],
+      "funny": "yup",
+      "id": "uuid-from-gatsby",
+      "internal": Object {
+        "contentDigest": "contentDigest",
+        "type": "FooJson",
+      },
+      "parent": "whatever",
+      "publicId": "123",
+    },
+  ],
+]
+`;
+
+exports[`Process JSON nodes correctly creates a publicId if id was given 2`] = `
+Array [
+  Array [
+    Object {
+      "child": Object {
+        "blue": true,
+        "children": Array [],
+        "funny": "yup",
+        "id": "uuid-from-gatsby",
+        "internal": Object {
+          "contentDigest": "contentDigest",
+          "type": "FooJson",
+        },
+        "parent": "whatever",
+        "publicId": "123",
+      },
+      "parent": Object {
+        "children": Array [],
+        "content": "{\\"id\\":\\"123\\",\\"blue\\":true,\\"funny\\":\\"yup\\"}",
+        "dir": "<TEMP_DIR>/foo/",
+        "id": "whatever",
+        "internal": Object {
+          "contentDigest": "whatever",
+          "mediaType": "application/json",
+          "type": "File",
+        },
+        "name": "nodeName",
         "parent": null,
       },
     },

--- a/packages/gatsby-transformer-json/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/__tests__/gatsby-node.js
@@ -108,6 +108,21 @@ describe(`Process JSON nodes correctly`, () => {
     })
   })
 
+  it(`creates a publicId if id was given`, async () => {
+    const data = { id: `123`, blue: true, funny: `yup` }
+    const node = {
+      ...baseFileNode,
+      content: JSON.stringify(data),
+    }
+
+    return bootstrapTest(node).then(({ createNode, createParentChildLink }) => {
+      expect(createNode.mock.calls).toMatchSnapshot()
+      expect(createParentChildLink.mock.calls).toMatchSnapshot()
+      expect(createNode).toHaveBeenCalledTimes(1)
+      expect(createParentChildLink).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it(`correctly sets node type for array of objects`, async () => {
     ;[
       {

--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -56,20 +56,28 @@ async function onCreateNode(
     throw new Error(`Unable to parse JSON: ${hint}`)
   }
 
+  function createPublicId(obj) {
+    if (obj.id) {
+      console.log(`the id: ${obj.id} given will now be on the key publicId`)
+      obj.publicId = String(obj.id)
+    }
+    return obj
+  }
+
   if (_.isArray(parsedContent)) {
     parsedContent.forEach((obj, i) => {
+      obj = createPublicId(obj)
       transformObject(
         obj,
-        obj.id ? String(obj.id) : createNodeId(`${node.id} [${i}] >>> JSON`),
+        createNodeId(`${node.id} [${i}] >>> JSON`),
         getType({ node, object: obj, isArray: true })
       )
     })
   } else if (_.isPlainObject(parsedContent)) {
+    parsedContent = createPublicId(parsedContent)
     transformObject(
       parsedContent,
-      parsedContent.id
-        ? String(parsedContent.id)
-        : createNodeId(`${node.id} >>> JSON`),
+      createNodeId(`${node.id} >>> JSON`),
       getType({ node, object: parsedContent, isArray: false })
     )
   }


### PR DESCRIPTION
# Description
This pull request is a proposed solution to issue:[#28846](https://github.com/gatsbyjs/gatsby/issues/28846)

Creates the key `publicId` on the object if the key `id` is present before the object is transformed

Fixes #28846
