### PR TITLE
Bug/duplicate id lost gt yaml

### DIFF
--- a/packages/gatsby-transformer-yaml/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-yaml/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -319,6 +319,7 @@ Array [
         "type": "FooBarYaml",
       },
       "parent": "whatever",
+      "publicId": "some",
     },
   ],
 ]
@@ -338,6 +339,7 @@ Array [
           "type": "FooBarYaml",
         },
         "parent": "whatever",
+        "publicId": "some",
       },
       "parent": Object {
         "children": Array [],
@@ -374,6 +376,7 @@ Array [
         "type": "fixed",
       },
       "parent": "whatever",
+      "publicId": "some",
     },
   ],
 ]
@@ -393,6 +396,7 @@ Array [
           "type": "fixed",
         },
         "parent": "whatever",
+        "publicId": "some",
       },
       "parent": Object {
         "children": Array [],
@@ -429,6 +433,7 @@ Array [
         "type": "yup",
       },
       "parent": "whatever",
+      "publicId": "some",
     },
   ],
 ]
@@ -448,6 +453,7 @@ Array [
           "type": "yup",
         },
         "parent": "whatever",
+        "publicId": "some",
       },
       "parent": Object {
         "children": Array [],
@@ -778,6 +784,7 @@ Array [
         "type": "OtherYaml",
       },
       "parent": "whatever",
+      "publicId": "some",
     },
   ],
 ]
@@ -797,6 +804,7 @@ Array [
           "type": "OtherYaml",
         },
         "parent": "whatever",
+        "publicId": "some",
       },
       "parent": Object {
         "children": Array [],
@@ -831,6 +839,7 @@ Array [
         "type": "fixed",
       },
       "parent": "whatever",
+      "publicId": "some",
     },
   ],
 ]
@@ -850,6 +859,7 @@ Array [
           "type": "fixed",
         },
         "parent": "whatever",
+        "publicId": "some",
       },
       "parent": Object {
         "children": Array [],
@@ -884,6 +894,7 @@ Array [
         "type": "yup",
       },
       "parent": "whatever",
+      "publicId": "some",
     },
   ],
 ]
@@ -903,6 +914,7 @@ Array [
           "type": "yup",
         },
         "parent": "whatever",
+        "publicId": "some",
       },
       "parent": Object {
         "children": Array [],

--- a/packages/gatsby-transformer-yaml/src/gatsby-node.js
+++ b/packages/gatsby-transformer-yaml/src/gatsby-node.js
@@ -48,8 +48,17 @@ async function onCreateNode(
   const content = await loadNodeContent(node)
   const parsedContent = jsYaml.load(content)
 
+  function createPublicId(obj) {
+    if (obj.id) {
+      console.log(`the id: ${obj.id} given will now be on the key publicId`)
+      obj.publicId = String(obj.id)
+    }
+    return obj
+  }
+
   if (_.isArray(parsedContent)) {
     parsedContent.forEach((obj, i) => {
+      obj = createPublicId(obj)
       transformObject(
         obj,
         obj.id ? obj.id : createNodeId(`${node.id} [${i}] >>> YAML`),
@@ -57,8 +66,9 @@ async function onCreateNode(
       )
     })
   } else if (_.isPlainObject(parsedContent)) {
+    const newParsedContent = createPublicId(parsedContent)
     transformObject(
-      parsedContent,
+      newParsedContent,
       parsedContent.id ? parsedContent.id : createNodeId(`${node.id} >>> YAML`),
       getType({ node, object: parsedContent, isArray: false })
     )


### PR DESCRIPTION
# Description
This pull request is a proposed solution to issue:#28846

Creates the key publicId on the object if the key id is present before the object is transformed

Fixes #28846