### PR TITLE
chore(telemetry): allow sharing tags in a file and read it only when things change

### DIFF
--- a/packages/gatsby-telemetry/src/__tests__/telemetry.ts
+++ b/packages/gatsby-telemetry/src/__tests__/telemetry.ts
@@ -1,6 +1,10 @@
 jest.mock(`../event-storage`)
 import { EventStorage } from "../event-storage"
 import { AnalyticsTracker } from "../telemetry"
+import * as fs from "fs-extra"
+import * as os from "os"
+import * as path from "path"
+import uuidv4 from "uuid/v4"
 
 let telemetry
 beforeEach(() => {
@@ -57,4 +61,119 @@ describe(`Telemetry`, () => {
       )
     })
   })
+
+  describe(`allows reading tags from path`, () => {
+    it(`getTagsFromPath should read the file and detect updates`, async () => {
+      const t = new AnalyticsTracker({
+        componentId: `component`,
+      })
+
+      // Test it when env not set
+      let res = t.getTagsFromPath()
+      expect(res).toMatchObject({})
+      expect(t.lastEnvTagsFromFileTime).toBe(0)
+
+      // create file and write initial data
+      const filePath = path.join(fs.realpathSync(os.tmpdir()), uuidv4())
+      console.log(filePath)
+      process.env.GATSBY_TELEMETRY_METADATA_PATH = filePath
+
+      fs.writeFileSync(filePath, JSON.stringify({ componentId: `test` }))
+      await new Promise(resolve => {
+        setTimeout(resolve, 2000)
+      })
+      // get it and make sure we see it and the ts matches
+      res = t.getTagsFromPath()
+      expect(res).toMatchObject({ componentId: `test` })
+      let stat = fs.statSync(filePath)
+      expect(t.lastEnvTagsFromFileTime).toBe(stat.mtimeMs)
+
+      // Update the file
+      fs.writeFileSync(filePath, JSON.stringify({ componentId: `test2` }))
+
+      await new Promise(resolve => {
+        setTimeout(resolve, 2000)
+      })
+      stat = fs.statSync(filePath)
+      // make sure we see the change
+      res = t.getTagsFromPath()
+      expect(t.lastEnvTagsFromFileTime).toBe(stat.mtimeMs)
+      expect(res).toMatchObject({ componentId: `test2` })
+
+      // read it with out updating
+      res = t.getTagsFromPath()
+      expect(t.lastEnvTagsFromFileTime).toBe(stat.mtimeMs)
+      expect(res).toMatchObject({ componentId: `test2` })
+      fs.unlinkSync(filePath)
+
+      const filePath2 = path.join(fs.realpathSync(os.tmpdir()), uuidv4())
+      process.env.GATSBY_TELEMETRY_METADATA_PATH = filePath2
+      res = t.getTagsFromPath()
+      expect(t.lastEnvTagsFromFileTime).toBe(stat.mtimeMs)
+      expect(res).toMatchObject({})
+    }, 10000)
+  })
+
+  it(`getTagsFromPath is used for buildEvent`, async () => {
+    const t = new AnalyticsTracker({
+      componentId: `component`,
+    })
+    t.buildAndStoreEvent(`demo`, {})
+    expect(
+      (EventStorage as jest.Mock).mock.instances[1].addEvent
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: `demo`,
+        componentId: `component`,
+      })
+    )
+    const filePath = path.join(fs.realpathSync(os.tmpdir()), uuidv4())
+    process.env.GATSBY_TELEMETRY_METADATA_PATH = filePath
+    fs.writeFileSync(filePath, JSON.stringify({ componentId: `test` }))
+    await new Promise(resolve => {
+      setTimeout(resolve, 2000)
+    })
+    const stat = fs.statSync(filePath)
+    t.buildAndStoreEvent(`demo2`, {})
+
+    expect(t.lastEnvTagsFromFileTime).toBe(stat.mtimeMs)
+    expect(
+      (EventStorage as jest.Mock).mock.instances[1].addEvent
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: `demo2`,
+        componentId: `test`,
+      })
+    )
+
+    t.buildAndStoreEvent(`demo3`, {})
+    expect(
+      (EventStorage as jest.Mock).mock.instances[1].addEvent
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: `demo3`,
+        componentId: `test`,
+      })
+    )
+
+    expect(t.lastEnvTagsFromFileTime).toBe(stat.mtimeMs)
+
+    fs.writeFileSync(filePath, JSON.stringify({ componentId: `4` }))
+    await new Promise(resolve => {
+      setTimeout(resolve, 2000)
+    })
+    const stat2 = fs.statSync(filePath)
+
+    t.buildAndStoreEvent(`demo4`, {})
+    expect(t.lastEnvTagsFromFileTime).toBe(stat2.mtimeMs)
+    expect(
+      (EventStorage as jest.Mock).mock.instances[1].addEvent
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: `demo4`,
+        componentId: `4`,
+      })
+    )
+    fs.unlinkSync(filePath)
+  }, 10000)
 })

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -1,4 +1,5 @@
 import uuidv4 from "uuid/v4"
+import * as fs from "fs-extra"
 import os from "os"
 import {
   isCI,
@@ -136,6 +137,8 @@ export class AnalyticsTracker {
   features = new Set<string>()
   machineId: string
   siteHash?: string = createContentDigest(process.cwd())
+  lastEnvTagsFromFileTime = 0
+  lastEnvTagsFromFileValue: ITelemetryTagsPayload = {}
 
   constructor({
     componentId,
@@ -361,6 +364,7 @@ export class AnalyticsTracker {
       dbEngine,
       features: Array.from(this.features),
       ...this.getRepositoryId(),
+      ...this.getTagsFromPath(),
     }
     this.store.addEvent(event)
     if (this.isFinalEvent(eventType)) {
@@ -368,6 +372,26 @@ export class AnalyticsTracker {
       const flush = createFlush(this.isTrackingEnabled())
       flush()
     }
+  }
+
+  getTagsFromPath(): ITelemetryTagsPayload {
+    const path = process.env.GATSBY_TELEMETRY_METADATA_PATH
+
+    if (!path) {
+      return {}
+    }
+    try {
+      const stat = fs.statSync(path)
+      if (this.lastEnvTagsFromFileTime < stat.mtimeMs) {
+        this.lastEnvTagsFromFileTime = stat.mtimeMs
+        const data = fs.readFileSync(path)
+        this.lastEnvTagsFromFileValue = JSON.parse(data)
+      }
+    } catch (e) {
+      // nop
+      return {}
+    }
+    return this.lastEnvTagsFromFileValue
   }
 
   getIsTTY(): boolean {

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -384,7 +384,7 @@ export class AnalyticsTracker {
       const stat = fs.statSync(path)
       if (this.lastEnvTagsFromFileTime < stat.mtimeMs) {
         this.lastEnvTagsFromFileTime = stat.mtimeMs
-        const data = fs.readFileSync(path)
+        const data = fs.readFileSync(path, `utf8`)
         this.lastEnvTagsFromFileValue = JSON.parse(data)
       }
     } catch (e) {


### PR DESCRIPTION
Allow reading telemetry data from a file