### PR TITLE
perf(develop): don't use debug config for bluebird

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -36,7 +36,7 @@ const { loadNodeContent } = require(`../db/nodes`)
 if (!process.env.BLUEBIRD_DEBUG && !process.env.BLUEBIRD_LONG_STACK_TRACES) {
   // Unless specified - disable longStackTraces
   // as this have severe perf penalty ( http://bluebirdjs.com/docs/api/promise.longstacktraces.html )
-  // This is main for `gatsby develop` due to NODE_ENV being set to development
+  // This is mainly for `gatsby develop` due to NODE_ENV being set to development
   // which cause bluebird to enable longStackTraces
   // `gatsby build` (with NODE_ENV=production) already doesn't enable longStackTraces
   Promise.config({ longStackTraces: false })

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -33,6 +33,15 @@ const { trackBuildError, decorateEvent } = require(`gatsby-telemetry`)
 import errorParser from "./api-runner-error-parser"
 const { loadNodeContent } = require(`../db/nodes`)
 
+if (!process.env.BLUEBIRD_DEBUG && !process.env.BLUEBIRD_LONG_STACK_TRACES) {
+  // Unless specified - disable longStackTraces
+  // as this have severe perf penalty ( http://bluebirdjs.com/docs/api/promise.longstacktraces.html )
+  // This is main for `gatsby develop` due to NODE_ENV being set to development
+  // which cause bluebird to enable longStackTraces
+  // `gatsby build` (with NODE_ENV=production) already doesn't enable longStackTraces
+  Promise.config({ longStackTraces: false })
+}
+
 // Bind action creators per plugin so we can auto-add
 // metadata to actions they create.
 const boundPluginActionCreators = {}


### PR DESCRIPTION
## Description

In `gatsby develop` we use debug build of `bluebird` currently which adds quite significant overhead. This is particularly visible on larger sites with large amount of nodes when we spawn tens of thousands `onCreateNode` runs.

 - In tested site `gatsby develop` was crashing with OOM error. This change allow to not hit this crash without adjusting `--max_old_space_size`.
 - Tested site with `--max_old_space_size=10000` before and after this change - source nodes step drops from ~67.87s (average across 3 runs) to ~21.7s (average across 3 runs)

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/28916
Fixes https://github.com/datocms/gatsby-source-datocms/issues/123
Fixes https://github.com/datocms/gatsby-source-datocms/issues/134
[ch21729]