### PR TITLE
docs: restore the most actual docs for gatsby-plugin-sass

### DIFF
--- a/docs/docs/how-to/styling/bulma.md
+++ b/docs/docs/how-to/styling/bulma.md
@@ -10,7 +10,7 @@ This guide assumes that you have a Gatsby project set up. If you need to set up 
 
 For starters, let's install all the required packages we're going to need.
 
-`yarn add bulma node-sass gatsby-plugin-sass`
+`yarn add bulma sass gatsby-plugin-sass`
 
 Then, add the `gatsby-plugin-sass` in to `gatsby-config.js`.
 

--- a/docs/docs/how-to/styling/sass.md
+++ b/docs/docs/how-to/styling/sass.md
@@ -12,9 +12,9 @@ Sass will compile `.sass` and `.scss` files to `.css` files for you, so you can 
 
 This guide assumes that you have a Gatsby project set up. If you need to set up a project, head to the [**Quick Start guide**](/docs/quick-start/), then come back.
 
-1. Install the Gatsby plugin [**gatsby-plugin-sass**](/plugins/gatsby-plugin-sass/) and `node-sass`, a required peer dependency as of v2.0.0.
+1. Install the Gatsby plugin [**gatsby-plugin-sass**](/plugins/gatsby-plugin-sass/) and `sass`, a required peer dependency as of v3.0.0.
 
-`npm install node-sass gatsby-plugin-sass`
+`npm install sass gatsby-plugin-sass`
 
 2. Include the plugin in your `gatsby-config.js` file.
 

--- a/docs/docs/how-to/styling/tailwind-css.md
+++ b/docs/docs/how-to/styling/tailwind-css.md
@@ -118,10 +118,10 @@ See the [Twin + Gatsby + Emotion installation guide](https://github.com/ben-roge
 
 #### Option #3: SCSS
 
-1. Install the Gatsby SCSS plugin [**gatsby-plugin-sass**](/plugins/gatsby-plugin-sass) and `node-sass`.
+1. Install the Gatsby SCSS plugin [**gatsby-plugin-sass**](/plugins/gatsby-plugin-sass) and `sass`.
 
 ```shell
-npm install node-sass gatsby-plugin-sass
+npm install sass gatsby-plugin-sass
 ```
 
 2. To be able to use Tailwind classes in your SCSS files, add the `tailwindcss` package into the `postCssPlugins` parameter in your `gatsby-config.js`.

--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -230,9 +230,9 @@ Sass will compile `.scss` and `.sass` files to `.css` files for you, so you can 
 
 ### Directions
 
-1. Install the Gatsby plugin [gatsby-plugin-sass](/plugins/gatsby-plugin-sass/) and `node-sass`.
+1. Install the Gatsby plugin [gatsby-plugin-sass](/plugins/gatsby-plugin-sass/) and `sass`.
 
-`npm install node-sass gatsby-plugin-sass`
+`npm install sass gatsby-plugin-sass`
 
 2. Include the plugin in your `gatsby-config.js` file.
 


### PR DESCRIPTION
## Description

At the moment docs for `gatsby-plugin-sass` are outdated. We had a major bump of `gatsby-plugin-sass` in #27991 which also included the new docs.

But then we had to revert those docs in #28666 until the new version is actually published. Now that the new major of this plugin is published, we restore the correct docs from #27991.

This reverts commit 9dbd02b1
