### PR TITLE
docs: update GraphQL docs for child fields

### DIFF
--- a/docs/docs/reference/graphql-data-layer/schema-customization.md
+++ b/docs/docs/reference/graphql-data-layer/schema-customization.md
@@ -224,7 +224,7 @@ The types passed in are used to determine child relations of the node.
 
 #### Defining child relations
 
-The `@childOf` extension can be used to explicitly define what node types or media types a node is a child of and immediately add `child[MyType]` or `children[MyType]` as a field on the parent.
+The `@childOf` extension can be used to explicitly define what node types or media types a node is a child of and immediately add `child[MyType]` and `children[MyType]` fields on the parent.
 
 The `types` argument takes an array of strings and determines what node types the node is a child of:
 
@@ -251,20 +251,6 @@ The `mimeTypes` and `types` arguments can be combined as follows:
 # Adds `childMdx` as a child to `File` nodes *and* nodes with `@mimeTypes` set to "text/markdown" or "text/x-markdown"
 type Mdx implements Node
   @childOf(types: ["File"], mimeTypes: ["text/markdown", "text/x-markdown"]) {
-  id: ID!
-}
-```
-
-If `many: true` is set, then instead of creating a single child field on the parent, it will create multiple:
-
-```graphql
-# Adds `childMdx1` with type `Mdx1` to `File`.
-type Mdx1 implements Node @childOf(types: ["File"]) {
-  id: ID!
-}
-
-# Adds `childrenMdx2` with type `[Mdx2]` as a field of `File`.
-type Mdx2 implements Node @childOf(types: ["File"], many: true) {
   id: ID!
 }
 ```

--- a/docs/docs/schema-generation.md
+++ b/docs/docs/schema-generation.md
@@ -38,7 +38,7 @@ This allows adding GraphQL Fields to any node type. This operates on GraphQL typ
 
 ## 4. Parent / children relationships
 
-Nodes can be connected into _child-parent_ relationships either by using [`createParentChildLink`](/docs/reference/config-files/actions/#createParentChildLink) or by adding the `parent` field to raw node data. Child types can always access parent with the `parent` field in GraphQL. Parent types also get `children` fields as well as "convenience child fields" `child[TypeName]` or `children[TypeName]`.
+Nodes can be connected into _child-parent_ relationships either by using [`createParentChildLink`](/docs/reference/config-files/actions/#createParentChildLink) or by adding the `parent` field to raw node data. Child types can always access parent with the `parent` field in GraphQL. Parent types also get `children` fields as well as "convenience child fields" `child[TypeName]` and `children[TypeName]`.
 
 Children types are either inferred from data or created using `@childOf` directive, either by parent type name or by `mimeType` (only for File parent types).
 


### PR DESCRIPTION
Updated docs for GraphQL to accommodate changes in #28656

Originally those docs were included as a part of that PR but had to remove them until the new release. Now that the release is published we are safe to update those docs.

This reverts commit 8687e2c0
