### PR TITLE
chore(gatsby): remove unused await

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -275,7 +275,7 @@ class LocalNodeModel {
       runQueryActivity.start()
     }
 
-    const queryResult = await runFastFiltersAndSort({
+    const queryResult = runFastFiltersAndSort({
       queryArgs: query,
       firstOnly,
       gqlSchema: this.schema,


### PR DESCRIPTION
All the filter code is sync so this `await` is redundant.

Unfortunately it makes no difference to perf in my quick tests. Maybe at very large scale but even then it would be minimal.