### PR TITLE
fix(gatsby): crossOrigin attr to scripts in headComponents

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -356,6 +356,7 @@ export default (pagePath, callback) => {
           rel={script.rel}
           key={script.name}
           href={`${__PATH_PREFIX__}/${script.name}`}
+          crossOrigin="anonymous"
         />
       )
     })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When running a site in production, I get a lot of duplicated warnings in the browser console, saying `A preload for '<URL>' is found, but is not used because the request headers do not match.` The site and assets are running on the same domain, and other header assets are included on the site without warnings.

I've tracked this down to `static-entry.js` and it looks like the `crossOrigin` attribute is set for other header assets (`pageData`, `staticQueryUrls` and `appDataUrl`) but not the `scripts` array.

I found [others with the same issue](https://github.com/gatsbyjs/gatsby/issues/14872#issuecomment-731772267), so wondered if this could go in, to fix the issue?

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<https://github.com/gatsbyjs/gatsby/issues/14872>
