### PR TITLE
fix(gatsby-plugin-image): Remove preload tag

### DIFF
--- a/packages/gatsby-plugin-image/src/components/main-image.tsx
+++ b/packages/gatsby-plugin-image/src/components/main-image.tsx
@@ -4,21 +4,9 @@ import { Picture, PictureProps } from "./picture"
 export type MainImageProps = PictureProps
 
 export const MainImage = forwardRef<HTMLImageElement, MainImageProps>(
-  function MainImage({ ...props }, ref) {
+  function MainImage(props, ref) {
     return (
       <>
-        {props.loading === `eager` && (
-          <link
-            rel="preload"
-            as="image"
-            href={props.fallback.src}
-            // TODO: remove this if imagesrcset is added to the types
-            // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-            // @ts-ignore
-            imagesrcset={props.fallback.srcSet}
-            imagesizes={props.fallback.sizes}
-          />
-        )}
         <Picture ref={ref} {...props} />
         <noscript>
           <Picture {...props} shouldLoad={true} />


### PR DESCRIPTION
This PR removes the preload tag, because there's no way to offer multiple image types without the browser downloading them all, and the speed benefit seems to be minimal.