### PR TITLE
chore(gatsby): Do not force image metadata parts to be async

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -657,7 +657,11 @@ async function fixed({ file, args = {}, reporter, cache }) {
   sizes.push(options[fixedDimension])
   sizes.push(options[fixedDimension] * 1.5)
   sizes.push(options[fixedDimension] * 2)
-  const dimensions = await getImageSizeAsync(file)
+
+  let dimensions = getImageSizeAsync(file)
+  if (dimensions?.then) {
+    dimensions = await dimensions
+  }
 
   const filteredSizes = sizes.filter(size => size <= dimensions[fixedDimension])
 


### PR DESCRIPTION
Refactor the image meta data parsing stuff to not forcefully be async. This means that if the data is cached, the call can be executed in sync. By propagating this check we can bubble upward and prevent a lot of promises to be scheduled. These promises are cutting us at scale.

In essence, the promise is being checked to be thennable.

```js
const data = await foo
f(data);
// -->
const data = foo
if (data?.then) return data.then(data => f(data));
else f(data);
```

This way the caller will still behave the same. If it returns a promise it's good and if it's not a promise it should be good because `await` accepts both cases.