### PR TITLE
perf(gatsby): do not force runQuery to be async

### DIFF
--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -392,14 +392,13 @@ describe(`NodeModel`, () => {
         const query = {}
         const firstOnly = true
         nodeModel.replaceFiltersCache()
-        const result = nodeModel.runQuery({
-          query,
-          firstOnly,
-          type,
-        })
-        return expect(result).rejects.toThrowError(
-          `Querying GraphQLUnion types is not supported.`
-        )
+        return expect(() =>
+          nodeModel.runQuery({
+            query,
+            firstOnly,
+            type,
+          })
+        ).toThrowError(`Querying GraphQLUnion types is not supported.`)
       })
 
       it(`handles interface types`, async () => {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -227,7 +227,7 @@ class LocalNodeModel {
    * @param {PageDependencies} [pageDependencies]
    * @returns {Promise<Node[]>}
    */
-  async runQuery(args, pageDependencies) {
+  runQuery(args, pageDependencies) {
     const { query, firstOnly, type, stats, tracer } = args || {}
 
     // We don't support querying union types (yet?), because the combined types
@@ -261,8 +261,51 @@ class LocalNodeModel {
       nodeTypeNames
     )
 
-    await this.prepareNodes(gqlType, fields, fieldsToResolve, nodeTypeNames)
-
+    const result = this.prepareNodes(
+      gqlType,
+      fields,
+      fieldsToResolve,
+      nodeTypeNames
+    )
+    if (result?.then) {
+      return result.then(() =>
+        this._runQuery(
+          materializationActivity,
+          tracer,
+          query,
+          firstOnly,
+          gqlType,
+          fieldsToResolve,
+          nodeTypeNames,
+          stats,
+          pageDependencies
+        )
+      )
+    } else {
+      return this._runQuery(
+        materializationActivity,
+        tracer,
+        query,
+        firstOnly,
+        gqlType,
+        fieldsToResolve,
+        nodeTypeNames,
+        stats,
+        pageDependencies
+      )
+    }
+  }
+  _runQuery(
+    materializationActivity,
+    tracer,
+    query,
+    firstOnly,
+    gqlType,
+    fieldsToResolve,
+    nodeTypeNames,
+    stats,
+    pageDependencies
+  ) {
     if (materializationActivity) {
       materializationActivity.end()
     }


### PR DESCRIPTION
Testing with gabe-fs-markdown with one image per page. At 32k page this saves a remarkable ... 4 to 6 seconds, on a total build time of 346s. So it's not major, but 1% to 2% is still a nice cut to eliminate.

On a 128k build there is some variation. The build takes roughly 1600s and the PR is definitely lower, but only by like 30-60s. Still well worth it considering the minimal change.