### PR TITLE
fix(gatsby-plugin-mdx): Add `root` to plugin validation

### DIFF
--- a/packages/gatsby-plugin-mdx/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/__tests__/gatsby-node.js
@@ -16,6 +16,7 @@ describe(`pluginOptionsSchema`, () => {
       `"mediaTypes[0]" must be a string`,
       `"mediaTypes[1]" must be a string`,
       `"shouldBlockNodeFromTransformation" must have an arity lesser or equal to 1`,
+      `"root" must be a string`,
     ]
 
     const { errors } = await testPluginOptionsSchema(pluginOptionsSchema, {
@@ -27,6 +28,7 @@ describe(`pluginOptionsSchema`, () => {
       plugins: [2],
       mediaTypes: [1, 2],
       shouldBlockNodeFromTransformation: (wrong, number) => null,
+      root: 1,
     })
 
     expect(errors).toEqual(expectedErrors)
@@ -60,6 +62,7 @@ describe(`pluginOptionsSchema`, () => {
       ],
       mediaTypes: [`text/markdown`, `text/x-markdown`, `custom-media/type`],
       shouldBlockNodeFromTransformation: node => Boolean(node),
+      root: `james-holden`,
     })
 
     expect(isValid).toBe(true)

--- a/packages/gatsby-plugin-mdx/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby-node.js
@@ -124,6 +124,6 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       ),
     root: Joi.string()
       .default(process.cwd())
-      .description(`Who knows what this does lol`)
+      .description(`[deprecated] This is a legacy option that used to define root directory of the project. It was needed to generate a cache directory location. It currently has no effect.`)
   })
 }

--- a/packages/gatsby-plugin-mdx/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby-node.js
@@ -122,5 +122,8 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       .description(
         `Disable MDX transformation for nodes where this function returns true`
       ),
+    root: Joi.string()
+      .default(process.cwd())
+      .description(`Who knows what this does lol`)
   })
 }

--- a/packages/gatsby-plugin-mdx/utils/default-options.js
+++ b/packages/gatsby-plugin-mdx/utils/default-options.js
@@ -17,6 +17,7 @@ module.exports = ({ mdPlugins, hastPlugins, ...pluginOptions }) => {
       plugins: [],
       root: process.cwd(),
       gatsbyRemarkPlugins: [],
+      // TODO: Remove globalScope option in next major as it's deprecated in favor of shortcodes, see https://github.com/ChristopherBiscardi/gatsby-mdx/issues/239#issuecomment-507322221
       globalScope: `export default {}`,
       shouldBlockNodeFromTransformation: () => false,
     },


### PR DESCRIPTION
## Description

Some users use `root` option and a warning is thrown for that. I couldn't really find what it does, so please comment if you know
