### PR TITLE
fix(gatsby): fix broken GraphQL resolver tracing

### DIFF
--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -568,13 +568,19 @@ export function wrappingResolver<TSource, TArgs>(
     }
     const result = resolver(parent, args, context, info)
 
+    if (!activity) {
+      return result
+    }
+
     const endActivity = (): void => {
       if (activity) {
         activity.end()
       }
     }
-    if (typeof result?.then === `function` && activity) {
+    if (typeof result?.then === `function`) {
       result.then(endActivity, endActivity)
+    } else {
+      endActivity()
     }
     return result
   }

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -566,13 +566,17 @@ export function wrappingResolver<TSource, TArgs>(
       )
       activity.start()
     }
-    try {
-      return resolver(parent, args, context, info)
-    } finally {
+    const result = resolver(parent, args, context, info)
+
+    const endActivity = (): void => {
       if (activity) {
         activity.end()
       }
     }
+    if (typeof result?.then === `function` && activity) {
+      result.then(endActivity, endActivity)
+    }
+    return result
   }
 }
 


### PR DESCRIPTION
## Description

Our resolver tracing is broken ATM. Tracing simply counts sync resolver call. It doesn't await the returned promise and ends the activity immediately. So it kinda tracks sync resolvers but not async.

With this change, we track correctly in both cases.
