### PR TITLE
feat(gatsby): Hydrate in development when the page was server rendered

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -119,9 +119,11 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   const renderer = apiRunner(
     `replaceHydrateFunction`,
     undefined,
-    // TODO replace with hydrate once dev SSR is ready
-    // but only for SSRed pages.
-    ReactDOM.render
+    // Client only pages have any empty body so we just do a normal
+    // render to avoid React complaining about hydration mis-matches.
+    document.getElementById(`___gatsby`).children.length === 0
+      ? ReactDOM.render
+      : ReactDOM.hydrate
   )[0]
 
   let dismissLoadingIndicator


### PR DESCRIPTION
This is so we error with message when there's a mismatch between SSRed html and client-side HTML. Hydration errors are a common problem in production so we want to highlight then in dev.

With this PR, hydration problems now error like this in dev:

<img width="1043" alt="Screen Shot 2021-01-13 at 1 47 59 PM" src="https://user-images.githubusercontent.com/71047/104516350-fb111700-55a8-11eb-9382-c2c2173bca7c.png">
