### PR TITLE
chore(docs): Updating Chakra UI docs

### DIFF
--- a/docs/docs/how-to/styling/other-css-frameworks.md
+++ b/docs/docs/how-to/styling/other-css-frameworks.md
@@ -37,15 +37,11 @@ Chakra UI is built on top of the [Emotion styling library](/docs/how-to/styling/
 
 Chakra UI provides a library of components, and it comes with dark mode out of the box. It also has a theme object which you can use to customize your site's color palette, typography, breakpoints, and more.
 
-**NOTE**
-The Gatsby plugin has been renamed from `gatsby-plugin-chakra-ui` to [`@chakra-ui/gatsby-plugin`](https://chakra-ui.com/guides/integrations/with-gatsby).
-
 If you're interested in using Chakra UI, check out the [`@chakra-ui/gatsby-plugin` documentation](/plugins/@chakra-ui/gatsby-plugin/).
-
 
 - [Chakra UI documentation](https://chakra-ui.com/getting-started)
 - [Chakra UI repo on GitHub](https://github.com/chakra-ui/chakra-ui/)
-- [Setting Up Chakra UI in a GatsbyJS App (YouTube)](https://www.youtube.com/watch?v=PjQHqDWnzGw)
+- [Chakra UI and Gatsby - Getting Started (YouTube)](https://www.youtube.com/watch?v=hXM9Ju_NIpU)
 
 ## Grommet
 

--- a/docs/docs/how-to/styling/other-css-frameworks.md
+++ b/docs/docs/how-to/styling/other-css-frameworks.md
@@ -37,7 +37,11 @@ Chakra UI is built on top of the [Emotion styling library](/docs/how-to/styling/
 
 Chakra UI provides a library of components, and it comes with dark mode out of the box. It also has a theme object which you can use to customize your site's color palette, typography, breakpoints, and more.
 
-If you're interested in using Chakra UI, check out the [`gatsby-plugin-chakra-ui` documentation](/plugins/gatsby-plugin-chakra-ui/?=chakra).
+**NOTE**
+The Gatsby plugin has been renamed from `gatsby-plugin-chakra-ui` to [`@chakra-ui/gatsby-plugin`](https://chakra-ui.com/guides/integrations/with-gatsby).
+
+If you're interested in using Chakra UI, check out the [`@chakra-ui/gatsby-plugin` documentation](/plugins/@chakra-ui/gatsby-plugin/).
+
 
 - [Chakra UI documentation](https://chakra-ui.com/getting-started)
 - [Chakra UI repo on GitHub](https://github.com/chakra-ui/chakra-ui/)


### PR DESCRIPTION
## Description

The Gatsby plugin has been renamed from gatsby-plugin-chakra-ui to @chakra-ui/gatsby-plugin.

The official chakra site states and recommends that you "have updated this when installing Chakra UI in your next Gatsby project.". This caused a burden for me, personally, when I tried to figure out why the old plugin was being installed but not working correctly out of the box. 

Link to official chakra ui + gatsby migration notes: https://chakra-ui.com/guides/integrations/with-gatsby

Also it seems we already have the correct info on gatsby own page but it was still linking to the old one. 

### Documentation

@gatsbyjs/documentation

I updated the links in https://www.gatsbyjs.com/docs/how-to/styling/other-css-frameworks/#chakra-ui referencing the new correct Chakra-UI plugin. 

## Related Issues

Closes #29017
