### PR TITLE
Fix/contentful add header

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -15,7 +15,7 @@
     "base64-img": "^1.0.4",
     "bluebird": "^3.7.2",
     "chalk": "^4.1.0",
-    "contentful": "^7.14.12",
+    "contentful": "^8.1.7",
     "fs-extra": "^9.0.1",
     "gatsby-core-utils": "^1.9.0-next.0",
     "gatsby-plugin-utils": "^0.8.0-next.1",

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -3,6 +3,7 @@ const _ = require(`lodash`)
 const chalk = require(`chalk`)
 const { formatPluginOptionsForCLI } = require(`./plugin-options`)
 const { CODES } = require(`./report`)
+const { version } = require(`../package.json`)
 
 module.exports = async function contentfulFetch({
   syncToken,
@@ -19,6 +20,7 @@ module.exports = async function contentfulFetch({
     host: pluginConfig.get(`host`),
     environment: pluginConfig.get(`environment`),
     proxy: pluginConfig.get(`proxy`),
+    integration: `gatsby-source-contentful@${version}`,
     responseLogger: response => {
       function createMetadataLog(response) {
         if (process.env.gatsby_log_level === `verbose`) {

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -3,7 +3,6 @@ const _ = require(`lodash`)
 const chalk = require(`chalk`)
 const { formatPluginOptionsForCLI } = require(`./plugin-options`)
 const { CODES } = require(`./report`)
-const { version } = require(`../package.json`)
 
 module.exports = async function contentfulFetch({
   syncToken,
@@ -20,7 +19,7 @@ module.exports = async function contentfulFetch({
     host: pluginConfig.get(`host`),
     environment: pluginConfig.get(`environment`),
     proxy: pluginConfig.get(`proxy`),
-    integration: `gatsby-source-contentful@${version}`,
+    integration: `gatsby-source-contentful`,
     responseLogger: response => {
       function createMetadataLog(response) {
         if (process.env.gatsby_log_level === `verbose`) {


### PR DESCRIPTION
This fixes and extends our integration tracking. With this change, the engineers at Contentful are able to separate requests done via Gatsby from other JS applications.

It upgrades the Contentful Delivery SDK to the latest version as well.