### PR TITLE
chore(docs): removed typo to run gatsby in automatic https

### DIFF
--- a/docs/docs/local-https.md
+++ b/docs/docs/local-https.md
@@ -9,7 +9,7 @@ Gatsby provides a way to use a local HTTPS server during development, thanks to 
 Start the development server using `npm run develop` as usual, and add either the `-S` or `--https` flag.
 
 ```shell
-npm run develop -- --https
+npm run develop --https
 ```
 
 ## Setup


### PR DESCRIPTION
## Description

I think this is a typo misstake?

### Documentation

https://www.gatsbyjs.com/docs/local-https/
