### PR TITLE
fix(gatsby-source-contentful): Improve base64 placeholders

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -12,8 +12,6 @@
     "@contentful/rich-text-types": "^14.1.2",
     "@hapi/joi": "^15.1.1",
     "axios": "^0.21.1",
-    "base64-img": "^1.0.4",
-    "bluebird": "^3.7.2",
     "chalk": "^4.1.0",
     "contentful": "^8.1.7",
     "fs-extra": "^9.0.1",

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -63,6 +63,11 @@ const getBase64Image = imageProps => {
     return null
   }
 
+  // We only support images that are delivered thourgh Contentful's Image API
+  if (imageProps.baseUrl.indexOf(`images.ctfassets.net`) === -1) {
+    return null
+  }
+
   const requestUrl = `https:${imageProps.baseUrl}?w=20`
 
   // Prefer to return data sync if we already have it

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -102,7 +102,7 @@ const getBase64Image = imageProps => {
     })
   }
 
-  const promise = new Promise(async (resolve, reject) => {
+  const loadImage = async () => {
     const imageResponse = await axios.get(requestUrl, {
       responseType: `arraybuffer`,
     })
@@ -111,17 +111,19 @@ const getBase64Image = imageProps => {
 
     const body = `data:image/jpeg;base64,${base64}`
 
-    // TODO: against dogma, confirm whether writeFileSync is indeed slower
-    fs.promises
-      .writeFile(cacheFile, body)
-      .then(() => resolve(body))
-      .catch(e => {
-        console.error(
-          `Contentful:getBase64Image: failed to write ${body.length} bytes remotely fetched from \`${requestUrl}\` to: \`${cacheFile}\`\nError: ${e}`
-        )
-        reject(e)
-      })
-  })
+    try {
+      // TODO: against dogma, confirm whether writeFileSync is indeed slower
+      await fs.promises.writeFile(cacheFile, body)
+      return body
+    } catch (e) {
+      console.error(
+        `Contentful:getBase64Image: failed to write ${body.length} bytes remotely fetched from \`${requestUrl}\` to: \`${cacheFile}\`\nError: ${e}`
+      )
+      throw e
+    }
+  }
+
+  const promise = loadImage()
 
   inFlightBase64Cache.set(requestUrl, promise)
 

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -62,7 +62,7 @@ const getBase64Image = imageProps => {
     return null
   }
 
-  // We only support images that are delivered thourgh Contentful's Image API
+  // We only support images that are delivered through Contentful's Image API
   if (imageProps.baseUrl.indexOf(`images.ctfassets.net`) === -1) {
     return null
   }


### PR DESCRIPTION
This replaces the no more maintained `base64-img` package with a more native implementation.

Additionally it fixes the following bug:

* images that are too big for Contentful's Images API resulted in HUGE base64 placeholders.  (See limit in docs: https://www.contentful.com/developers/docs/references/images-api/#/introduction)

This should fix the security vulnerabilities from #24679