### PR TITLE
experiment: generate file digests in worker threads

### DIFF
--- a/packages/gatsby-source-filesystem/src/worker.js
+++ b/packages/gatsby-source-filesystem/src/worker.js
@@ -1,0 +1,83 @@
+const path = require(`path`)
+const fs = require(`fs-extra`)
+const mime = require(`mime`)
+const crypto = require('crypto')
+
+const md5File = require(`md5-file`)
+
+let Worker, isMainThread, parentPort, workerData
+try {
+  // worker_threads is node 10.15 ...
+  ;({
+    Worker,
+    isMainThread,
+    parentPort,
+    workerData,
+  } = require("worker_threads"))
+} catch (e) {
+  console.info(
+    "Not using threads to generate file digests. This requires node >= 10.15, currently on " +
+      process.version
+  )
+}
+
+// Web worker path
+if (typeof Worker !== "undefined" && !isMainThread) {
+  const { i } = workerData // Data that was passed in constructor of Worker
+  console.log("Worker " + i + "; listening")
+
+  parentPort.on("message", msg => {
+    setImmediate(() => action(msg))
+  })
+
+  function action(msg) {
+    const { fname, ext } = msg
+    //console.log("Worker " + i + "; generating hash for", fname)
+
+    if (true) {
+      const hash = crypto.createHash('md5')
+      const data =  fs.readFileSync(fname)
+      hash.update(data);
+      const contentDigest = hash.digest('hex')
+      const mediaType = mime.getType(ext)
+      const internal = {
+        contentDigest,
+        type: `File`,
+        mediaType: mediaType ? mediaType : `application/octet-stream`,
+        description: `File "${path.relative(process.cwd(), fname)}"`,
+      }
+
+      //console.log("Worker " + i + "; sending generated hash")
+
+      parentPort.postMessage(internal)
+
+    } else if (true) {
+      const contentDigest = md5File.sync(fname);
+      const mediaType = mime.getType(ext)
+      const internal = {
+        contentDigest,
+        type: `File`,
+        mediaType: mediaType ? mediaType : `application/octet-stream`,
+        description: `File "${path.relative(process.cwd(), fname)}"`,
+      }
+
+      //console.log("Worker " + i + "; sending generated hash")
+
+      parentPort.postMessage(internal)
+    } else {
+      md5File(fname).then(contentDigest => {
+        const mediaType = mime.getType(ext)
+        const internal = {
+          contentDigest,
+          type: `File`,
+          mediaType: mediaType ? mediaType : `application/octet-stream`,
+          description: `File "${path.relative(process.cwd(), fname)}"`,
+        }
+
+        //console.log("Worker " + i + "; sending generated hash")
+
+        parentPort.postMessage(internal)
+      })
+    }
+  }
+}


### PR DESCRIPTION
This is an experiment where the digest of locally sourced files is generated in a thread, rather than on the main thread.

The digest is created by feeding the entire file to crytpo and generating an md5 hash from it. Currently this is done through md5file, which will async stream the file to crypto but all of it still happens on the main thread.

Additionally, the experiment tests whether it makes a difference to read the files sync or async.

Tested on gabe-fs-markdown @ 128k pages, mind you these files are tiny. Bigger files give better yields but then you're probably talking about images at which point image processing dwarfs any gains here.

The only difference is in the sourcing step, since that's where the `node.internal.contentDigest` is generated. Nothing else is really affected.

On my machine, the sourcing step of 128k md is roughly 75s.
Moving the step off thread with the worker drops it by 6 seconds.
Moving to use [md5file.sync](https://github.com/kodie/md5-file/blob/master/index.js). It reads the file sync, in chunks, and feeds the chunk to crypto. Drops it by another 6 seconds.
Trying to read the whole file at once and feed it to crypto at once (in a worker), doesn't make a difference beyond the chunked approach.
Using more than one worker only makes it marginally faster.

Note that the whole build takes like 6 or 7 minutes. So dropping 15 seconds on that is not that impressive. Putting it here to look back on it later but we're not likely to merge this.

Oh PS. this PR only works on node 10.15+ since the API is not available before.