### PR TITLE
experiment: Prematurely pull sharp metadata for images during bootstrap

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -22,7 +22,7 @@ const { IMAGE_PROCESSING_JOB_NAME } = require(`./gatsby-worker`)
 const { getDimensionsAndAspectRatio } = require(`./utils`)
 // const { rgbToHex } = require(`./utils`)
 
-const imageSizeCache = new Map()
+export const imageSizeCache = new Map()
 
 const getImageSizeAsync = async file => {
   if (

--- a/packages/gatsby-transformer-sharp/src/on-node-create.js
+++ b/packages/gatsby-transformer-sharp/src/on-node-create.js
@@ -21,6 +21,7 @@ module.exports.onCreateNode = async function onCreateNode({
     id: createNodeId(`${node.id} >> ImageSharp`),
     children: [],
     parent: node.id,
+    absolutePath: node.absolutePath,
     internal: {
       contentDigest: `${node.internal.contentDigest}`,
       type: `ImageSharp`,


### PR DESCRIPTION
This experiment will fetch the metadata for all images sourced through sharp at bootstrap time and prime the metadata cache.

This change is better but it only saves a few seconds, but only a few seconds, even at scale. So it's probably not worth moving further into this direction.