### PR TITLE
fix(gatsby-plugin-image): Handle imgStyle in SSR

### DIFF
--- a/packages/gatsby-plugin-image/src/components/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.server.tsx
@@ -106,10 +106,18 @@ export const GatsbyImage: FunctionComponent<GatsbyImageProps> = function GatsbyI
         <MainImage
           data-gatsby-image-ssr=""
           className={imgClassName}
-          style={imgStyle}
           {...(props as Omit<MainImageProps, "images" | "fallback">)}
           // When eager is set we want to start the isLoading state on true (we want to load the img without react)
-          {...getMainProps(loading === `eager`, false, cleanedImages, loading)}
+          {...getMainProps(
+            loading === `eager`,
+            false,
+            cleanedImages,
+            loading,
+            undefined,
+            undefined,
+            undefined,
+            imgStyle
+          )}
         />
       </LayoutWrapper>
     </GatsbyImageHydrator>


### PR DESCRIPTION
The imgStyle prop was working in develop, but not being handled in hydrated SSR