### PR TITLE
allow to skip cache persistence

### DIFF
--- a/packages/gatsby/src/redux/__tests__/index.js
+++ b/packages/gatsby/src/redux/__tests__/index.js
@@ -149,4 +149,23 @@ describe(`redux db`, () => {
 
     expect(mockWrittenContent.has(legacyLocation)).toBe(false)
   })
+
+  describe(`GATSBY_DISABLE_CACHE_PERSISTENCE`, () => {
+    beforeAll(() => {
+      process.env.GATSBY_DISABLE_CACHE_PERSISTENCE = `truthy`
+    })
+
+    afterAll(() => {
+      delete process.env.GATSBY_DISABLE_CACHE_PERSISTENCE
+    })
+    it(`shouldn't write redux cache to disk when GATSBY_DISABLE_CACHE_PERSISTENCE env var is used`, async () => {
+      expect(initialComponentsState).toEqual(new Map())
+
+      store.getState().nodes = getFakeNodes()
+
+      await saveState()
+
+      expect(writeToCache).not.toBeCalled()
+    })
+  })
 })

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -86,6 +86,13 @@ export const store: GatsbyReduxStore = configureStore(readState())
 
 // Persist state.
 export const saveState = (): void => {
+  if (process.env.GATSBY_DISABLE_CACHE_PERSISTENCE) {
+    // do not persist cache if above env var is set.
+    // this is to temporarily unblock builds that hit the v8.serialize related
+    // Node.js buffer size exceeding kMaxLength fatal crashes
+    return undefined
+  }
+
   const state = store.getState()
 
   return writeToCache({

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -74,6 +74,12 @@ export async function initialize({
   store: Store<IGatsbyState, AnyAction>
   workerPool: JestWorker
 }> {
+  if (process.env.GATSBY_DISABLE_CACHE_PERSISTENCE) {
+    reporter.info(
+      `GATSBY_DISABLE_CACHE_PERSISTENCE is enabled. Cache won't be persisted. Next builds will not be able to reuse any work done by current session.`
+    )
+    telemetry.trackFeatureIsUsed(`DisableCachePersistence`)
+  }
   if (!args) {
     reporter.panic(`Missing program args`)
   }


### PR DESCRIPTION
## Description

This is a solution to be able to temporarily disable cache persistance in case of hitting fatal process crash:
```
../src/node_buffer.cc:451:v8::MaybeLocal<v8::Object> node::Buffer::New(node::Environment*, char*, size_t, bool): Assertion `length <= kMaxLength' failed.
1: 0xa9d570 node::Abort() [/opt/hostedtoolcache/node/13.8.0/x64/bin/node]
2: 0xa9d5f7 [/opt/hostedtoolcache/node/13.8.0/x64/bin/node]
3: 0xa7e022 [/opt/hostedtoolcache/node/13.8.0/x64/bin/node]
4: 0xb1190a [/opt/hostedtoolcache/node/13.8.0/x64/bin/node]
5: 0xc7491c [/opt/hostedtoolcache/node/13.8.0/x64/bin/node]
6: 0xc76727 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [/opt/hostedtoolcache/node/13.8.0/x64/bin/node]
7: 0x145cef9 [/opt/hostedtoolcache/node/13.8.0/x64/bin/node]
Aborted (core dumped)
error Command failed with exit code 134.
```

Gatsby currently doesn't provide a way for users / sites to not hit the problem and this is sometimes blocking new deploys. This is related to https://github.com/gatsbyjs/gatsby/pull/29039 which allow sites to continue to use cache but is much more hands-on approach that might not be applicable to quickly workaround the problem (specifically when urgent deploy need to happen scenarios). Those 2 are not mutually exclussive - they both have their place. This PR is meant to immediately unblock deploys (with caveat of not being able to make use of cached work). Other PR is meant to give control over how we shard nodes to also workaround the problem, but without serious performance implicaiton of always using COLD builds. 

## Related Issues

[ch22889]
https://github.com/gatsbyjs/gatsby/issues/23627