### PR TITLE
update products.json for the graphql case

### DIFF
--- a/docs/docs/why-gatsby-uses-graphql.md
+++ b/docs/docs/why-gatsby-uses-graphql.md
@@ -201,7 +201,7 @@ There’s a bit more up-front setup required to get data into GraphQL, but the b
 Using `data/products.json` as an example, by using GraphQL we’re able to solve all of the limitations from the previous section:
 
 1. The images can be collocated with the products in `data/images/`.
-2. Image paths in `data/products.json` can be relative to the JSON file.
+2. Image paths in `data/products.json` can be relative to the JSON file.( prepend `image` field in our products.json with '.') 
 3. Gatsby can automatically optimize images for faster loading and better user experience.
 4. You no longer need to pass all product data into `context` when creating pages.
 5. Data is loaded using GraphQL in the components where it’s used, making it much easier to see where data comes from and how to change it.


### PR DESCRIPTION



## Description

In the last case when we use graphql, it throws error if products.json is same. image values must be like "./images/amberley-romo-riggins.jpg" instead of "/images/amberley-romo-riggins.jpg" for the last case. I just thought it can be clearer.

### Documentation

[this](https://www.gatsbyjs.com/docs/why-gatsby-uses-graphql/) blog

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
