### PR TITLE
fix(gatsby-plugin-image): Fix onload race condition

### DIFF
--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -68,7 +68,6 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
 
       // if a main image does not have a ssr tag, we know it's not the first run anymore
       if (typeof e.target.dataset["gatsbyImageSsr"] === 'undefined') {
-        document.body.removeEventListener('load', gatsbyImageNativeLoader, true);
         return;
       }
 


### PR DESCRIPTION
We previously removed the onload listener if _any_ image had already been hydrated. This was causing a race condition where it was removed before some images had loaded.