### PR TITLE
fix(gatsby-plugin-typescript): add missing options validations

### DIFF
--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -95,6 +95,9 @@ describe(`gatsby-plugin-typescript`, () => {
         isTSX: false,
         jsxPragma: `ReactFunction`,
         allExtensions: false,
+        allowNamespaces: false,
+        allowDeclareFields: false,
+        onlyRemoveTypeImports: false,
       })
 
       expect(isValid).toBe(true)

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -45,25 +45,25 @@ exports.pluginOptionsSchema = ({ Joi }) =>
       .description(
         `Replace the function used when compiling JSX fragment expressions.`
       )
-      .default(`React.Fragment`),
+      .optional(),
     allExtensions: Joi.boolean()
       .description(`Indicates that every file should be parsed as TS or TSX.`)
       .default(false)
       .when(`isTSX`, { is: true, then: Joi.valid(true) }),
     allowNamespaces: Joi.boolean()
       .description(`Enables compilation of TypeScript namespaces.`)
-      .default(false),
+      .optional(),
     allowDeclareFields: Joi.boolean()
       .description(
         `When enabled, type-only class fields are only removed if they are prefixed with the declare modifier.`
       )
-      .default(false),
+      .optional(),
     onlyRemoveTypeImports: Joi.boolean()
       .description(
         `When set to true, the transform will only remove type-only imports (introduced in TypeScript 3.8).` +
           `This should only be used if you are using TypeScript >= 3.8.`
       )
-      .default(false),
+      .optional(),
   })
 
 exports.resolvableExtensions = resolvableExtensions

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -41,10 +41,29 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     jsxPragma: Joi.string()
       .description(`Replace the function used when compiling JSX expressions.`)
       .default(`React`),
+    jsxPragmaFrag: Joi.string()
+      .description(
+        `Replace the function used when compiling JSX fragment expressions.`
+      )
+      .default(`React.Fragment`),
     allExtensions: Joi.boolean()
       .description(`Indicates that every file should be parsed as TS or TSX.`)
       .default(false)
       .when(`isTSX`, { is: true, then: Joi.valid(true) }),
+    allowNamespaces: Joi.boolean()
+      .description(`Enables compilation of TypeScript namespaces.`)
+      .default(false),
+    allowDeclareFields: Joi.boolean()
+      .description(
+        `When enabled, type-only class fields are only removed if they are prefixed with the declare modifier.`
+      )
+      .default(false),
+    onlyRemoveTypeImports: Joi.boolean()
+      .description(
+        `When set to true, the transform will only remove type-only imports (introduced in TypeScript 3.8).` +
+          `This should only be used if you are using TypeScript >= 3.8.`
+      )
+      .default(false),
   })
 
 exports.resolvableExtensions = resolvableExtensions

--- a/yarn.lock
+++ b/yarn.lock
@@ -5129,13 +5129,6 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajax-request@^1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/ajax-request/-/ajax-request-1.2.3.tgz#99fcbec1d6d2792f85fa949535332bd14f5f3790"
-  dependencies:
-    file-system "^2.1.1"
-    utils-extend "^1.0.7"
-
 ajv-errors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.0.tgz#ecf021fa108fd17dfb5e6b383f2dd233e31ffc59"
@@ -6245,14 +6238,6 @@ balanced-match@^1.0.0:
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
-
-base64-img@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/base64-img/-/base64-img-1.0.4.tgz#3e22d55d6c74a24553d840d2b1bc12a7db078d35"
-  integrity sha1-PiLVXWx0okVT2EDSsbwSp9sHjTU=
-  dependencies:
-    ajax-request "^1.2.0"
-    file-system "^2.1.0"
 
 base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.3.0:
   version "1.3.0"
@@ -11049,19 +11034,6 @@ file-loader@^1.1.11:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
-
-file-match@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/file-match/-/file-match-1.0.2.tgz#c9cad265d2c8adf3a81475b0df475859069faef7"
-  dependencies:
-    utils-extend "^1.0.6"
-
-file-system@^2.1.0, file-system@^2.1.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/file-system/-/file-system-2.2.2.tgz#7d65833e3a2347dcd956a813c677153ed3edd987"
-  dependencies:
-    file-match "^1.0.1"
-    utils-extend "^1.0.4"
 
 file-type@5.2.0, file-type@^5.2.0:
   version "5.2.0"
@@ -25738,10 +25710,6 @@ utila@~0.3:
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
-
-utils-extend@^1.0.4, utils-extend@^1.0.6, utils-extend@^1.0.7:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/utils-extend/-/utils-extend-1.0.8.tgz#ccfd7b64540f8e90ee21eec57769d0651cab8a5f"
 
 utils-merge@1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5129,6 +5129,13 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+ajax-request@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/ajax-request/-/ajax-request-1.2.3.tgz#99fcbec1d6d2792f85fa949535332bd14f5f3790"
+  dependencies:
+    file-system "^2.1.1"
+    utils-extend "^1.0.7"
+
 ajv-errors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.0.tgz#ecf021fa108fd17dfb5e6b383f2dd233e31ffc59"
@@ -6238,6 +6245,14 @@ balanced-match@^1.0.0:
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
+
+base64-img@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/base64-img/-/base64-img-1.0.4.tgz#3e22d55d6c74a24553d840d2b1bc12a7db078d35"
+  integrity sha1-PiLVXWx0okVT2EDSsbwSp9sHjTU=
+  dependencies:
+    ajax-request "^1.2.0"
+    file-system "^2.1.0"
 
 base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.3.0:
   version "1.3.0"
@@ -11034,6 +11049,19 @@ file-loader@^1.1.11:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
+
+file-match@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/file-match/-/file-match-1.0.2.tgz#c9cad265d2c8adf3a81475b0df475859069faef7"
+  dependencies:
+    utils-extend "^1.0.6"
+
+file-system@^2.1.0, file-system@^2.1.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/file-system/-/file-system-2.2.2.tgz#7d65833e3a2347dcd956a813c677153ed3edd987"
+  dependencies:
+    file-match "^1.0.1"
+    utils-extend "^1.0.4"
 
 file-type@5.2.0, file-type@^5.2.0:
   version "5.2.0"
@@ -25710,6 +25738,10 @@ utila@~0.3:
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
+
+utils-extend@^1.0.4, utils-extend@^1.0.6, utils-extend@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/utils-extend/-/utils-extend-1.0.8.tgz#ccfd7b64540f8e90ee21eec57769d0651cab8a5f"
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION

## Description

Added missing field validations, as all options are passed to @babel//preset-typescript.

### Documentation

I'm not sure if the docs need to be updated. They already link to Babel docs.
https://www.gatsbyjs.com/plugins/gatsby-plugin-typescript/

## Related Issues

Closes #29063