### PR TITLE
feat(gatsby): bump opt-in % to dev-ssr to 20%

### DIFF
--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -95,7 +95,7 @@ const activeFlags: Array<IFlag> = [
     description: `Server Side Render (SSR) pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.`,
     umbrellaIssue: `https://gatsby.dev/dev-ssr-feedback`,
     testFitness: (): fitnessEnum => {
-      if (sampleSiteForExperiment(`DEV_SSR`, 5)) {
+      if (sampleSiteForExperiment(`DEV_SSR`, 20)) {
         return `OPT_IN`
       } else {
         return true


### PR DESCRIPTION
The partial rollout this past release has been *mostly* smooth but a few bugs popped up in the [umbrella issue](https://github.com/gatsbyjs/gatsby/discussions/28138) so let's get more testers to ensure we've covered all our bases.