### PR TITLE
fix(gatsby): Always render the body component to ensure needed head & pre/post body components are added

### DIFF
--- a/packages/gatsby/cache-dir/ssr-develop-static-entry.js
+++ b/packages/gatsby/cache-dir/ssr-develop-static-entry.js
@@ -193,10 +193,22 @@ export default (pagePath, isClientOnlyPage, callback) => {
             : undefined,
         }
 
-        const pageElement = createElement(
-          syncRequires.ssrComponents[componentChunkName],
-          props
-        )
+        let pageElement
+        if (
+          syncRequires.ssrComponents[componentChunkName] &&
+          !isClientOnlyPage
+        ) {
+          pageElement = createElement(
+            syncRequires.ssrComponents[componentChunkName],
+            props
+          )
+        } else {
+          // If this is a client-only page or the pageComponent didn't finish
+          // compiling yet, just render an empty component.
+          pageElement = () => {
+            return null
+          }
+        }
 
         const wrappedPage = apiRunner(
           `wrapPageElement`,
@@ -276,7 +288,7 @@ export default (pagePath, isClientOnlyPage, callback) => {
     return bodyHtml
   }
 
-  const bodyStr = isClientOnlyPage ? `` : generateBodyHTML()
+  const bodyStr = generateBodyHTML()
 
   const htmlElement = React.createElement(Html, {
     ...bodyProps,

--- a/packages/gatsby/cache-dir/ssr-develop-static-entry.js
+++ b/packages/gatsby/cache-dir/ssr-develop-static-entry.js
@@ -205,9 +205,7 @@ export default (pagePath, isClientOnlyPage, callback) => {
         } else {
           // If this is a client-only page or the pageComponent didn't finish
           // compiling yet, just render an empty component.
-          pageElement = () => {
-            return null
-          }
+          pageElement = () => null
         }
 
         const wrappedPage = apiRunner(


### PR DESCRIPTION
For client-only pages, we just want to render an empty body but we do want the other components rendered.

Fixes problem raised by @martinhj and verified in @nikoladev's reproduction https://github.com/gatsbyjs/gatsby/discussions/28138#discussioncomment-285207