### PR TITLE
chore(docs): Fix grammar in add-404-page

### DIFF
--- a/docs/docs/how-to/adding-common-features/add-404-page.md
+++ b/docs/docs/how-to/adding-common-features/add-404-page.md
@@ -2,7 +2,7 @@
 title: Adding a 404 Page
 ---
 
-To create a 404 page create a page whose path matches the regex `^\/?404\/?$` (`/404/`, `/404`, `404/` or `404`). Most often you'll want to create a React component page at `src/pages/404.js`.
+To create a 404 page create a page whose path matches the regex `^\/?404\/?$` (`/404/`, `/404`, `404/` or `404`), most often you'll want to create a React component page at `src/pages/404.js`.
 
 Gatsby ensures that your 404 page is built as `404.html` as many static hosting platforms default to using this as your 404 error page. If you're hosting your site another way you'll need to set up a custom rule to serve this file for 404 errors.
 


### PR DESCRIPTION
## Description

I've fixed the phrasing in the add-404-page.md document:
```diff
- To create a 404 page create a page whose path matches the regex `^\/?404\/?$` (`/404/`, `/404`, `404/` or `404`). Most often you'll want to create a React component page at `src/pages/404.js`.
+ To create a 404 page create a page whose path matches the regex `^\/?404\/?$` (`/404/`, `/404`, `404/` or `404`), most often you'll want to create a React component page at `src/pages/404.js`.
```

### Documentation

N/A

## Related Issues

N/A

This is my first PR to gatsby, if there's anything I should do please tell me.