### PR TITLE
feat(gatsby-remark-copy-linked-files) Adds support for source tags

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/README.md
+++ b/packages/gatsby-remark-copy-linked-files/README.md
@@ -222,3 +222,4 @@ plugins: [
 - `<video />`
 - `<audio />`
 - `<a />`
+- `<source />`

--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -219,6 +219,54 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).toHaveBeenCalledTimes(2)
   })
 
+  it(`can copy HTML images from source elements with the srcset attribute`, async () => {
+    const path = `images/sample-image.gif`
+
+    const markdownAST = remark.parse(
+      `<picture><source srcset="${path}"></picture>`
+    )
+
+    await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
+
+    expect(fsExtra.copy).toHaveBeenCalled()
+  })
+
+  it(`can copy HTML multiple images from source elements with the srcset attribute`, async () => {
+    const path1 = `images/sample-image.gif`
+    const path2 = `images/another-sample-image.gif`
+
+    const markdownAST = remark.parse(
+      `<picture><source srcset="${path1}"><source srcset="${path2}"></picture>`
+    )
+
+    await plugin({
+      files: [...getFiles(path1), ...getFiles(path2)],
+      markdownAST,
+      markdownNode,
+      getNode,
+    })
+
+    expect(fsExtra.copy).toHaveBeenCalledTimes(2)
+  })
+
+  it(`can copy HTML images from source elements with the srcset attribute and fallback img too`, async () => {
+    const path1 = `images/sample-image.gif`
+    const path2 = `images/another-sample-image.gif`
+
+    const markdownAST = remark.parse(
+      `<picture><source srcset="${path1}"><img src="${path2}"></picture>`
+    )
+
+    await plugin({
+      files: [...getFiles(path1), ...getFiles(path2)],
+      markdownAST,
+      markdownNode,
+      getNode,
+    })
+
+    expect(fsExtra.copy).toHaveBeenCalledTimes(2)
+  })
+
   it(`can copy flash from object elements with the value attribute`, async () => {
     const path = `myMovie.swf`
 

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -117,10 +117,10 @@ module.exports = (
 
   // Takes a node and generates the needed images and then returns
   // the needed HTML replacement for the image
-  const generateImagesAndUpdateNode = function (image, node) {
+  const generateImagesAndUpdateNode = function (image, node, attribute) {
     const imagePath = path.posix.join(
       getNode(markdownNode.parent).dir,
-      image.attr(`src`)
+      image.attr(attribute)
     )
     const imageNode = _.find(files, file => {
       if (file && file.absolutePath) {
@@ -132,13 +132,13 @@ module.exports = (
       return
     }
 
-    const initialImageSrc = image.attr(`src`)
+    const initialImageSrc = image.attr(attribute)
     // The link object will be modified to the new location so we'll
     // use that data to update our ref
-    const link = { url: image.attr(`src`) }
+    const link = { url: image.attr(attribute) }
     visitor(link)
     node.value = node.value.replace(
-      new RegExp(image.attr(`src`), `g`),
+      new RegExp(image.attr(attribute), `g`),
       link.url
     )
 
@@ -261,7 +261,7 @@ module.exports = (
         try {
           const ext = url.split(`.`).pop()
           if (!options.ignoreFileExtensions.includes(ext)) {
-            generateImagesAndUpdateNode(element, node)
+            generateImagesAndUpdateNode(element, node, `src`)
           }
         } catch (err) {
           // Ignore

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -269,6 +269,20 @@ module.exports = (
       }
     )
 
+    // Handle source tags
+    extractUrlAttributeAndElement($(`source[srcset]`), `srcset`).forEach(
+      ({ url, element }) => {
+        try {
+          const ext = url.split(`.`).pop()
+          if (!options.ignoreFileExtensions.includes(ext)) {
+            generateImagesAndUpdateNode(element, node, `srcset`)
+          }
+        } catch (err) {
+          // Ignore
+        }
+      }
+    )
+
     // Handle video tags.
     extractUrlAttributeAndElement(
       $(`video source[src], video[src]`),


### PR DESCRIPTION
## Description

This PR adds support for processing `<source>` tags in `gatsby-remark-copy-linked-files`. This enables the ability to add alternate representations for certain tags based on media queries, for example a different image for dark mode, bringing parity with how Gatsby processes images in React as well.

### Documentation

I’m not too familiar with the documentation setup (or the code setup even, this is my first time contributing to the project) so I haven’t updated that.

## Related Issues

Addressing #28497