### PR TITLE
fix(gatsby-plugin-image): pass down missing sizes attribute to <sources> (fixes #29093)

### DIFF
--- a/packages/gatsby-plugin-image/src/components/picture.tsx
+++ b/packages/gatsby-plugin-image/src/components/picture.tsx
@@ -66,11 +66,17 @@ const Image: FunctionComponent<ImageProps> = function Image({
 
 export const Picture = forwardRef<HTMLImageElement, PictureProps>(
   function Picture(
-    { fallback, sources = [], shouldLoad = true, ...props },
+    { fallback, sources = [], shouldLoad = true, sizes, ...props },
     ref
   ) {
     const fallbackImage = (
-      <Image {...props} {...fallback} shouldLoad={shouldLoad} innerRef={ref} />
+      <Image
+        sizes={sizes}
+        {...props}
+        {...fallback}
+        shouldLoad={shouldLoad}
+        innerRef={ref}
+      />
     )
 
     if (!sources.length) {
@@ -85,6 +91,7 @@ export const Picture = forwardRef<HTMLImageElement, PictureProps>(
             type={type}
             media={media}
             srcSet={srcSet}
+            sizes={sizes}
           />
         ))}
         {fallbackImage}


### PR DESCRIPTION
## Description

The new `gatsby-plugin-image` currently does not pass down the `sizes` prop to the `<source>` element, which cause the highest image to always be chosen by the browser. Only passing it to `<img>` is not sufficient.
By passing it down, the browser can now properly choose the right image based on the `sizes` property.

Also, the previous `gatsby-image` was working this way, so this is simply a bug fix and nothing more.

## Related Issues
#29093