### PR TITLE
fix(gatsby-plugin-styled-components): add `namespace` option

### DIFF
--- a/packages/gatsby-plugin-styled-components/src/gatsby-node.js
+++ b/packages/gatsby-plugin-styled-components/src/gatsby-node.js
@@ -20,6 +20,11 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     minify: Joi.boolean()
       .default(true)
       .description(`Remove the whitespace from the CSS.`),
+    namespace: Joi.string()
+      .default(``)
+      .description(
+        `The namespace will ensure that your class names will be unique; this setting is handy when you are working with micro frontends where class name collision can occur.`
+      ),
     transpileTemplateLiterals: Joi.boolean()
       .default(true)
       .description(`Transpile tagged template literals into optimized code.`),


### PR DESCRIPTION
## Description
Adds the namespace option to `gatsby-plugin-styled-components`.
Since this is used as part of a classname, the regex `/^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/` could also be used, but I haven't included it

### Documentation
Already included in styled-components docs

## Related Issues
Fixes #29057
