### PR TITLE
gatsby-link: remove deprecated APIs

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { NavigateFn, LinkProps } from "@reach/router"
 
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
 export interface GatsbyLinkProps<TState> extends LinkProps<TState> {
   /** A class to apply when this Link is active */
   activeClassName?: string
@@ -41,21 +42,3 @@ export const navigate: NavigateFn
  */
 export const withPrefix: (path: string) => string
 export const withAssetPrefix: (path: string) => string
-
-/**
- * @deprecated
- * TODO: Remove for Gatsby v3
- */
-export const push: (to: string) => void
-
-/**
- * @deprecated
- * TODO: Remove for Gatsby v3
- */
-export const replace: (to: string) => void
-
-/**
- * @deprecated
- * TODO: Remove for Gatsby v3
- */
-export const navigateTo: (to: string) => void

--- a/packages/gatsby-link/src/__tests__/index.js
+++ b/packages/gatsby-link/src/__tests__/index.js
@@ -5,7 +5,7 @@ import {
   createHistory,
   LocationProvider,
 } from "@reach/router"
-import Link, { navigate, push, replace, withPrefix, withAssetPrefix } from "../"
+import Link, { navigate, withPrefix, withAssetPrefix } from "../"
 
 beforeEach(() => {
   global.__BASE_PATH__ = ``
@@ -22,16 +22,6 @@ const getInstance = (props, pathPrefix = ``) => {
 const getNavigate = () => {
   global.___navigate = jest.fn()
   return navigate
-}
-
-const getPush = () => {
-  global.___push = jest.fn()
-  return push
-}
-
-const getReplace = () => {
-  global.___replace = jest.fn()
-  return replace
 }
 
 const getWithPrefix = (pathPrefix = ``) => {
@@ -241,16 +231,6 @@ describe(`<Link />`, () => {
       setup({ linkProps: { to } })
       expect(console.warn).toBeCalled()
     })
-  })
-
-  it(`push is called with correct args`, () => {
-    getPush()(`/some-path`)
-    expect(global.___push).toHaveBeenCalledWith(`/some-path`)
-  })
-
-  it(`replace is called with correct args`, () => {
-    getReplace()(`/some-path`)
-    expect(global.___replace).toHaveBeenCalledWith(`/some-path`)
   })
 
   describe(`uses push or replace adequately`, () => {

--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -272,31 +272,10 @@ GatsbyLink.propTypes = {
   state: PropTypes.object,
 }
 
-const showDeprecationWarning = (functionName, altFunctionName, version) =>
-  console.warn(
-    `The "${functionName}" method is now deprecated and will be removed in Gatsby v${version}. Please use "${altFunctionName}" instead.`
-  )
-
 export default React.forwardRef((props, ref) => (
   <GatsbyLinkLocationWrapper innerRef={ref} {...props} />
 ))
 
 export const navigate = (to, options) => {
   window.___navigate(rewriteLinkPath(to, window.location.pathname), options)
-}
-
-export const push = to => {
-  showDeprecationWarning(`push`, `navigate`, 3)
-  window.___push(rewriteLinkPath(to, window.location.pathname))
-}
-
-export const replace = to => {
-  showDeprecationWarning(`replace`, `navigate`, 3)
-  window.___replace(rewriteLinkPath(to, window.location.pathname))
-}
-
-// TODO: Remove navigateTo for Gatsby v3
-export const navigateTo = to => {
-  showDeprecationWarning(`navigateTo`, `navigate`, 3)
-  return push(to)
 }

--- a/packages/gatsby-link/src/parse-path.js
+++ b/packages/gatsby-link/src/parse-path.js
@@ -1,15 +1,15 @@
 export function parsePath(path) {
-  var pathname = path || `/`
-  var search = ``
-  var hash = ``
+  let pathname = path || `/`
+  let search = ``
+  let hash = ``
 
-  var hashIndex = pathname.indexOf(`#`)
+  let hashIndex = pathname.indexOf(`#`)
   if (hashIndex !== -1) {
     hash = pathname.substr(hashIndex)
     pathname = pathname.substr(0, hashIndex)
   }
 
-  var searchIndex = pathname.indexOf(`?`)
+  let searchIndex = pathname.indexOf(`?`)
   if (searchIndex !== -1) {
     search = pathname.substr(searchIndex)
     pathname = pathname.substr(0, searchIndex)

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -19,9 +19,6 @@ export {
   default as Link,
   GatsbyLinkProps,
   navigate,
-  navigateTo,
-  push,
-  replace,
   withPrefix,
   withAssetPrefix,
 } from "gatsby-link"


### PR DESCRIPTION
## Description

This removes these deprecated `gatsby-link` APIs:

- `push`
- `replace`
- `navigateTo`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

[ch23293]