### PR TITLE
fix(eslint-config): don't use .eslintrc and set parser settings

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -7,7 +7,15 @@ const eslintRequirePreset = require.resolve(`./eslint/required`)
 
 export const eslintRequiredConfig: CLIEngine.Options = {
   rulePaths: [eslintRulePaths],
+  useEslintrc: false,
   baseConfig: {
+    parserOptions: {
+      ecmaVersion: 2018,
+      sourceType: `module`,
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
     globals: {
       graphql: true,
       __PATH_PREFIX__: true,


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/28911 introduced some problems in case user has their own `.eslintrc` specifically when using `eslint` that is incompatible with version used currently by gatsby (we use `^6` now, `^7` is latest).

This change disallow using `.eslintrc` for minimal required config for fast-refresh rules ( 1.). But this is not sufficent change. after dissalowing the use of it, we end up with:

```
 ERROR #98123  WEBPACK

Generating development JavaScript bundle failed


/Users/misiek/test/i29105/src/pages/index.jsx
  1:1  error  Parsing error: The keyword 'import' is reserved
```

So `parserOptions` were added (2.) to handle that part are pretty much copy&paste from https://github.com/facebook/create-react-app/blob/0f6fc2bc71d78f0dcae67f3f08ce98a42fc0a57c/packages/eslint-config-react-app/base.js#L29-L35 which we use for our default eslint-loader setting (for cases where `.eslintrc` doesn't exist and we provide some generic set of rules).

## Related Issues

Fixes #29105