### PR TITLE
fix(gatsby): Add missing prev location TS property for RouteUpdateArgs

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1482,6 +1482,7 @@ export interface PrefetchPathnameArgs extends BrowserPluginArgs {
 
 export interface RouteUpdateArgs extends BrowserPluginArgs {
   location: Location
+  prevLocation: Location | null;
 }
 
 export interface ReplaceComponentRendererArgs extends BrowserPluginArgs {


### PR DESCRIPTION
## Description

Adds the missing `prevLocation` property to the TypeScript definition for `RouteUpdateArgs`

### Documentation

https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#onRouteUpdate

## Related Issues

Fixes #29124
