### PR TITLE
fix(eslint-config): set parser, don't fail the build on minimal eslint-loader errors

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -5,10 +5,22 @@ import path from "path"
 const eslintRulePaths = path.resolve(`${__dirname}/eslint-rules`)
 const eslintRequirePreset = require.resolve(`./eslint/required`)
 
-export const eslintRequiredConfig: CLIEngine.Options = {
+// eslint-loader options are few eslint-loader specific options and rest of it is passed to
+// eslint's CLIEngine
+type EslintLoaderOptions = CLIEngine.Options & {
+  emitWarning?: boolean
+}
+
+export const eslintRequiredConfig: EslintLoaderOptions = {
   rulePaths: [eslintRulePaths],
   useEslintrc: false,
+  // this forces any errors to be webpack warnings, minimal eslint-loader
+  // should NEVER prevent bundle from building. Our eslint config for it
+  // only contain rules set to warnings, but loader itself can emit errors
+  // if parsing failed etc.
+  emitWarning: true,
   baseConfig: {
+    parser: require.resolve(`babel-eslint`),
     parserOptions: {
       ecmaVersion: 2018,
       sourceType: `module`,
@@ -26,7 +38,7 @@ export const eslintRequiredConfig: CLIEngine.Options = {
 }
 
 export function mergeRequiredConfigIn(
-  existingOptions: CLIEngine.Options
+  existingOptions: EslintLoaderOptions
 ): void {
   // make sure rulePaths include our custom rules
   if (existingOptions.rulePaths) {
@@ -68,7 +80,7 @@ export function mergeRequiredConfigIn(
 export const eslintConfig = (
   schema: GraphQLSchema,
   usingJsxRuntime: boolean
-): CLIEngine.Options => {
+): EslintLoaderOptions => {
   return {
     useEslintrc: false,
     resolvePluginsRelativeTo: __dirname,


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/29109 was not sufficent. This also specify `parser` (by default it uses https://github.com/eslint/espree - but it seems like version we/eslint (also version of eslint we use) doesn't support optional chaining `?.` - used version is `espree@^6`, and according to https://github.com/eslint/espree/blob/master/CHANGELOG.md support was added in `espree@^7`).

Other part is `emitWarning: true`, which _should_ prevent errors coming from `eslint-loader` from blocking users - per https://github.com/webpack-contrib/eslint-loader#noemitonerrorsplugin

> `NoEmitOnErrorsPlugin` is now automatically enabled in webpack 4, when mode is either unset, or set to production. So even ESLint warnings will fail the build. No matter what error settings are used for `eslint-loader`, except if `emitWarning` enabled. 

Current:
![Screenshot 2021-01-21 at 20 30 47](https://user-images.githubusercontent.com/419821/105402460-bda32e00-5c27-11eb-89fe-120959287a68.png)

With `emitWarning: true` - so it still is confusing, and we need to fix those, but at least it doesn't prevent webpack from compiling (or rather emitting I guess):
![Screenshot 2021-01-21 at 20 30 36](https://user-images.githubusercontent.com/419821/105402481-c3007880-5c27-11eb-952a-0cf5ded70567.png)

It prooved to be whack'a'mole with this minimal eslint config for fast-refresh rules, so there are few things to consider here:
 - maybe we should disable it (for now)?
 - lack of tests for this code path doesn't inspire confidence

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/29105#issuecomment-764856608

Fixes https://github.com/gatsbyjs/gatsby/issues/29133
