### PR TITLE
fix(babel-plugin-remove-graphql-queries): make sure imports are posix

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -12,10 +12,12 @@
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",
     "babel-preset-gatsby-package": "^0.12.0-next.0",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "gatsby-core-utils": "^1.10.0-next.0"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0",
+    "@babel/core": "^7.0.0"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -11,6 +11,31 @@ export default (() => {
 });"
 `;
 
+exports[`Allow alternative import of useStaticQuery 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var Gatsby = _interopRequireWildcard(require(\\"gatsby\\"));
+
+var _default = () => {
+  const query = \\"426988268\\";
+  const siteTitle = _.default.data;
+  return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
+};
+
+exports.default = _default;"
+`;
+
 exports[`Doesn't add data import for non static queries 1`] = `
 "import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
@@ -26,6 +51,33 @@ export default Test;
 const fragment = \\"4176178832\\";"
 `;
 
+exports[`Doesn't add data import for non static queries 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _gatsby = require(\\"gatsby\\");
+
+const Test = () => /*#__PURE__*/React.createElement(_gatsby.StaticQuery, {
+  query: \\"426988268\\",
+  render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),
+  data: _.default
+});
+
+var _default = Test;
+exports.default = _default;
+const fragment = \\"4176178832\\";"
+`;
+
 exports[`Handles closing StaticQuery tag 1`] = `
 "import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
@@ -34,6 +86,30 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
   query: \\"426988268\\",
   data: staticQueryData
 }, data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title)));"
+`;
+
+exports[`Handles closing StaticQuery tag 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _gatsby = require(\\"gatsby\\");
+
+var _default = () => /*#__PURE__*/React.createElement(_gatsby.StaticQuery, {
+  query: \\"426988268\\",
+  data: _.default
+}, data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title));
+
+exports.default = _default;"
 `;
 
 exports[`Leaves other graphql tags alone 1`] = `
@@ -47,6 +123,29 @@ export const query = graphql\`
   \`;"
 `;
 
+exports[`Leaves other graphql tags alone 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+exports.__esModule = true;
+exports.query = exports.default = void 0;
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _relay = require(\\"relay\\");
+
+var _default = () => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title);
+
+exports.default = _default;
+const query = (0, _relay.graphql)\`
+     {
+       site { siteMetadata { title }}
+     }
+  \`;
+exports.query = query;"
+`;
+
 exports[`Only runs transforms if useStaticQuery is imported from gatsby 1`] = `
 "import * as React from 'react';
 export default (() => {
@@ -56,8 +155,40 @@ export default (() => {
 });"
 `;
 
+exports[`Only runs transforms if useStaticQuery is imported from gatsby 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _default = () => {
+  const query = \\"426988268\\";
+  const siteTitle = useStaticQuery(query);
+  return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
+};
+
+exports.default = _default;"
+`;
+
 exports[`Removes all gatsby queries 1`] = `
 "export default (() => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title));
+const siteMetaQuery = \\"504726680\\";
+const query = \\"3211238532\\";"
+`;
+
+exports[`Removes all gatsby queries 2`] = `
+"\\"use strict\\";
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _default = () => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title);
+
+exports.default = _default;
 const siteMetaQuery = \\"504726680\\";
 const query = \\"3211238532\\";"
 `;
@@ -77,6 +208,31 @@ export default (() => {
 });"
 `;
 
+exports[`Transformation does not break custom hooks 2`] = `
+"\\"use strict\\";
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var _react = _interopRequireDefault(require(\\"react\\"));
+
+const useSiteMetadata = () => {
+  const data = _.default.data;
+  return data.site.siteMetadata;
+};
+
+var _default = () => {
+  const siteMetadata = useSiteMetadata();
+  return /*#__PURE__*/_react.default.createElement(\\"h1\\", null, site.siteMetadata.title);
+};
+
+exports.default = _default;"
+`;
+
 exports[`Transforms exported queries in useStaticQuery 1`] = `
 "import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
@@ -85,6 +241,30 @@ export default (() => {
   return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, data.site.siteMetadata.title), /*#__PURE__*/React.createElement(\\"p\\", null, data.site.siteMetadata.description));
 });
 export const query = \\"426988268\\";"
+`;
+
+exports[`Transforms exported queries in useStaticQuery 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.query = exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _default = () => {
+  const data = _.default.data;
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, data.site.siteMetadata.title), /*#__PURE__*/React.createElement(\\"p\\", null, data.site.siteMetadata.description));
+};
+
+exports.default = _default;
+const query = \\"426988268\\";
+exports.query = query;"
 `;
 
 exports[`Transforms only the call expression in useStaticQuery 1`] = `
@@ -101,6 +281,30 @@ export default (() => {
 });"
 `;
 
+exports[`Transforms only the call expression in useStaticQuery 2`] = `
+"\\"use strict\\";
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var _react = _interopRequireDefault(require(\\"react\\"));
+
+const useSiteMetadata = () => {
+  return _.default.data.site.siteMetadata;
+};
+
+var _default = () => {
+  const siteMetadata = useSiteMetadata();
+  return /*#__PURE__*/_react.default.createElement(\\"h1\\", null, siteMetadata.title);
+};
+
+exports.default = _default;"
+`;
+
 exports[`Transforms queries and preserves destructuring in useStaticQuery 1`] = `
 "import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
@@ -111,6 +315,31 @@ export default (() => {
   } = staticQueryData.data;
   return /*#__PURE__*/React.createElement(\\"h1\\", null, site.siteMetadata.title);
 });"
+`;
+
+exports[`Transforms queries and preserves destructuring in useStaticQuery 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _default = () => {
+  const query = \\"426988268\\";
+  const {
+    site
+  } = _.default.data;
+  return /*#__PURE__*/React.createElement(\\"h1\\", null, site.siteMetadata.title);
+};
+
+exports.default = _default;"
 `;
 
 exports[`Transforms queries and preserves variable type in useStaticQuery 1`] = `
@@ -125,6 +354,31 @@ export default (() => {
 });"
 `;
 
+exports[`Transforms queries and preserves variable type in useStaticQuery 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _default = () => {
+  const query = \\"426988268\\";
+  let {
+    site
+  } = _.default.data;
+  return /*#__PURE__*/React.createElement(\\"h1\\", null, site.siteMetadata.title);
+};
+
+exports.default = _default;"
+`;
+
 exports[`Transforms queries defined in own variable in <StaticQuery> 1`] = `
 "import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
@@ -137,6 +391,33 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
 }));"
 `;
 
+exports[`Transforms queries defined in own variable in <StaticQuery> 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _gatsby = require(\\"gatsby\\");
+
+const query = \\"426988268\\";
+
+var _default = () => /*#__PURE__*/React.createElement(_gatsby.StaticQuery, {
+  query: query,
+  render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),
+  data: _.default
+});
+
+exports.default = _default;"
+`;
+
 exports[`Transforms queries defined in own variable in useStaticQuery 1`] = `
 "import staticQueryData from \\"public/static/d/426988268.json\\";
 import * as React from 'react';
@@ -145,6 +426,29 @@ export default (() => {
   const siteTitle = staticQueryData.data;
   return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
 });"
+`;
+
+exports[`Transforms queries defined in own variable in useStaticQuery 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _default = () => {
+  const query = \\"426988268\\";
+  const siteTitle = _.default.data;
+  return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
+};
+
+exports.default = _default;"
 `;
 
 exports[`Transforms queries in <StaticQuery> 1`] = `
@@ -158,7 +462,38 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
 }));"
 `;
 
+exports[`Transforms queries in <StaticQuery> 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _gatsby = require(\\"gatsby\\");
+
+var _default = () => /*#__PURE__*/React.createElement(_gatsby.StaticQuery, {
+  query: \\"426988268\\",
+  render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),
+  data: _.default
+});
+
+exports.default = _default;"
+`;
+
 exports[`Transforms queries in page components 1`] = `"const query = \\"426988268\\";"`;
+
+exports[`Transforms queries in page components 2`] = `
+"\\"use strict\\";
+
+const query = \\"426988268\\";"
+`;
 
 exports[`Transforms queries in useStaticQuery 1`] = `
 "import staticQueryData from \\"public/static/d/426988268.json\\";
@@ -169,7 +504,35 @@ export default (() => {
 });"
 `;
 
+exports[`Transforms queries in useStaticQuery 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _default = () => {
+  const siteTitle = _.default.data;
+  return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
+};
+
+exports.default = _default;"
+`;
+
 exports[`allows the global tag 1`] = `"const query = \\"426988268\\";"`;
+
+exports[`allows the global tag 2`] = `
+"\\"use strict\\";
+
+const query = \\"426988268\\";"
+`;
 
 exports[`distinguishes between the right tags 1`] = `
 "const foo = styled('div')\`
@@ -198,13 +561,66 @@ const pulse = keyframes\`
 const query = \\"426988268\\";"
 `;
 
+exports[`distinguishes between the right tags 2`] = `
+"\\"use strict\\";
+
+const foo = styled('div')\`
+     {
+       \${foo}
+     }
+  \`;
+const pulse = keyframes\`
+    0% {
+      transform: scale(1);
+      animation-timing-function: ease-in;
+    }
+    25% {
+      animation-timing-function: ease-out;
+      transform: scale(1.05);
+    }
+    50% {
+      transform: scale(1.12);
+      animation-timing-function: ease-in;
+    }
+    to {
+      transform: scale(1);
+      animation-timing-function: ease-out;
+    }
+  \`;
+const query = \\"426988268\\";"
+`;
+
 exports[`handles import aliasing 1`] = `"const query = \\"426988268\\";"`;
+
+exports[`handles import aliasing 2`] = `
+"\\"use strict\\";
+
+const query = \\"426988268\\";"
+`;
 
 exports[`handles require 1`] = `"const query = \\"426988268\\";"`;
 
+exports[`handles require 2`] = `
+"\\"use strict\\";
+
+const query = \\"426988268\\";"
+`;
+
 exports[`handles require alias 1`] = `"const query = \\"426988268\\";"`;
 
+exports[`handles require alias 2`] = `
+"\\"use strict\\";
+
+const query = \\"426988268\\";"
+`;
+
 exports[`handles require namespace 1`] = `"const query = \\"426988268\\";"`;
+
+exports[`handles require namespace 2`] = `
+"\\"use strict\\";
+
+const query = \\"426988268\\";"
+`;
 
 exports[`transforms exported variable queries in <StaticQuery> 1`] = `
 "import staticQueryData from \\"public/static/d/426988268.json\\";
@@ -216,4 +632,32 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
   render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),
   data: staticQueryData
 }));"
+`;
+
+exports[`transforms exported variable queries in <StaticQuery> 2`] = `
+"\\"use strict\\";
+
+var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
+
+var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
+
+exports.__esModule = true;
+exports.default = exports.query = void 0;
+
+var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+
+var React = _interopRequireWildcard(require(\\"react\\"));
+
+var _gatsby = require(\\"gatsby\\");
+
+const query = \\"426988268\\";
+exports.query = query;
+
+var _default = () => /*#__PURE__*/React.createElement(_gatsby.StaticQuery, {
+  query: query,
+  render: data => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title),
+  data: _.default
+});
+
+exports.default = _default;"
 `;

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
@@ -2,11 +2,17 @@ const babel = require(`@babel/core`)
 const plugin = require(`../`)
 
 function matchesSnapshot(query) {
-  const { code } = babel.transform(query, {
+  const { code: codeWithoutFileName } = babel.transform(query, {
     presets: [`@babel/preset-react`],
     plugins: [plugin],
   })
-  expect(code).toMatchSnapshot()
+  const { code: codeWithFileName } = babel.transform(query, {
+    presets: [`@babel/preset-react`],
+    plugins: [plugin],
+    filename: `src/components/test.js`,
+  })
+  expect(codeWithoutFileName).toMatchSnapshot()
+  expect(codeWithFileName).toMatchSnapshot()
 }
 
 it.todo(

--- a/packages/babel-plugin-remove-graphql-queries/src/index.ts
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.ts
@@ -4,6 +4,7 @@ import graphql from "gatsby/graphql"
 import { murmurhash } from "./murmur"
 import nodePath from "path"
 import { NodePath, PluginObj } from "@babel/core"
+import { slash } from "gatsby-core-utils"
 import { Binding } from "babel__traverse"
 import {
   CallExpression,
@@ -300,12 +301,14 @@ export default function ({ types: t }): PluginObj {
               const importDeclaration = t.importDeclaration(
                 [importDefaultSpecifier],
                 t.stringLiteral(
-                  filename
-                    ? nodePath.relative(
-                        nodePath.parse(filename).dir,
-                        resultPath
-                      )
-                    : shortResultPath
+                  slash(
+                    filename
+                      ? nodePath.relative(
+                          nodePath.dirname(filename),
+                          resultPath
+                        )
+                      : shortResultPath
+                  )
                 )
               )
               path.node.body.unshift(importDeclaration)
@@ -361,12 +364,14 @@ export default function ({ types: t }): PluginObj {
               const importDeclaration = t.importDeclaration(
                 [importDefaultSpecifier],
                 t.stringLiteral(
-                  filename
-                    ? nodePath.relative(
-                        nodePath.parse(filename).dir,
-                        resultPath
-                      )
-                    : shortResultPath
+                  slash(
+                    filename
+                      ? nodePath.relative(
+                          nodePath.dirname(filename),
+                          resultPath
+                        )
+                      : shortResultPath
+                  )
                 )
               )
               path.node.body.unshift(importDeclaration)


### PR DESCRIPTION
Added slash to babel-plugin-remove-graphql-queries so imports are following esm syntax on every platform.
`public\\sq\\d\\<hash.json` => `public/sq/d/<hash.json`

I've updated the tests to actually test this behaviour.


[ch22209]