### PR TITLE
fix(gatsby-plugin-image): Use inline-block in class so users can override

### DIFF
--- a/e2e-tests/gatsby-static-image/cypress/integration/image.js
+++ b/e2e-tests/gatsby-static-image/cypress/integration/image.js
@@ -13,13 +13,6 @@ describe(`Production gatsby-image`, () => {
           .its(`length`)
           .should(`eq`, 1)
       })
-
-      it(`contains position relative`, () => {
-        cy.getTestElement(fluidTestId)
-          .find(`.gatsby-image-wrapper`)
-          .should(`have.attr`, `style`)
-          .and(`contains`, `position:relative`)
-      })
     })
   })
 

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.browser.tsx
@@ -36,9 +36,9 @@ describe(`GatsbyImage browser`, () => {
     beforeHydrationContent = document.createElement(`div`)
     beforeHydrationContent.innerHTML = `
       <div
-        class="gatsby-image-wrapper"
+        class="gatsby-image-wrapper gatsby-image-wrapper-constrained"
         data-gatsby-image-wrapper=""
-        style="position: relative; display: inline-block;"
+        style="position: relative;"
       >
         <div
           style="max-width: 100px; display: block;"

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -60,7 +60,7 @@ describe(`GatsbyImage server`, () => {
 
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
       expect((wrapper as HTMLElement).className).toMatchInlineSnapshot(
-        `gatsby-image-wrapper`
+        `"gatsby-image-wrapper"`
       )
     })
 
@@ -119,7 +119,7 @@ describe(`GatsbyImage server`, () => {
 
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
       expect((wrapper as HTMLElement).className).toMatchInlineSnapshot(
-        `gatsby-image-wrapper gatsby-image-wrapper-constrained`
+        `"gatsby-image-wrapper gatsby-image-wrapper-constrained"`
       )
     })
   })

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -141,16 +141,13 @@ describe(`GatsbyImage server`, () => {
         CSSStyleDeclaration {
           "0": "position",
           "1": "overflow",
-          "2": "display",
           "_importants": Object {
-            "display": undefined,
             "overflow": undefined,
             "position": undefined,
           },
-          "_length": 3,
+          "_length": 2,
           "_onChange": [Function],
           "_values": Object {
-            "display": "inline-block",
             "overflow": "hidden",
             "position": "relative",
           },

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -60,7 +60,7 @@ describe(`GatsbyImage server`, () => {
 
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
       expect((wrapper as HTMLElement).className).toMatchInlineSnapshot(
-        `"gatsby-image-wrapper"`
+        `\"gatsby-image-wrapper\"`
       )
     })
 
@@ -119,7 +119,7 @@ describe(`GatsbyImage server`, () => {
 
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
       expect((wrapper as HTMLElement).className).toMatchInlineSnapshot(
-        `"gatsby-image-wrapper gatsby-image-wrapper-constrained"`
+        `\"gatsby-image-wrapper gatsby-image-wrapper-constrained\"`
       )
     })
   })

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -41,7 +41,7 @@ describe(`GatsbyImage server`, () => {
   })
 
   describe(`style verifications`, () => {
-    it(`has a valid style attributes for fullWidth layout`, () => {
+    it(`has a valid className for fullWidth layout`, () => {
       const layout = `fullWidth`
 
       const image: IGatsbyImageData = {
@@ -59,22 +59,9 @@ describe(`GatsbyImage server`, () => {
       )
 
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
-      expect((wrapper as HTMLElement).style).toMatchInlineSnapshot(`
-        CSSStyleDeclaration {
-          "0": "position",
-          "1": "overflow",
-          "_importants": Object {
-            "overflow": undefined,
-            "position": undefined,
-          },
-          "_length": 2,
-          "_onChange": [Function],
-          "_values": Object {
-            "overflow": "hidden",
-            "position": "relative",
-          },
-        }
-      `)
+      expect((wrapper as HTMLElement).className).toMatchInlineSnapshot(
+        `gatsby-image-wrapper`
+      )
     })
 
     it(`has a valid style attributes for fixed layout`, () => {
@@ -97,29 +84,23 @@ describe(`GatsbyImage server`, () => {
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
       expect((wrapper as HTMLElement).style).toMatchInlineSnapshot(`
         CSSStyleDeclaration {
-          "0": "position",
-          "1": "overflow",
-          "2": "width",
-          "3": "height",
+          "0": "width",
+          "1": "height",
           "_importants": Object {
             "height": undefined,
-            "overflow": undefined,
-            "position": undefined,
             "width": undefined,
           },
-          "_length": 4,
+          "_length": 2,
           "_onChange": [Function],
           "_values": Object {
             "height": "100px",
-            "overflow": "hidden",
-            "position": "relative",
             "width": "100px",
           },
         }
       `)
     })
 
-    it(`has a valid style attributes for constrained layout`, () => {
+    it(`has a valid className for constrained layout`, () => {
       const layout = `constrained`
 
       const image: IGatsbyImageData = {
@@ -137,22 +118,9 @@ describe(`GatsbyImage server`, () => {
       )
 
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
-      expect((wrapper as HTMLElement).style).toMatchInlineSnapshot(`
-        CSSStyleDeclaration {
-          "0": "position",
-          "1": "overflow",
-          "_importants": Object {
-            "overflow": undefined,
-            "position": undefined,
-          },
-          "_length": 2,
-          "_onChange": [Function],
-          "_values": Object {
-            "overflow": "hidden",
-            "position": "relative",
-          },
-        }
-      `)
+      expect((wrapper as HTMLElement).className).toMatchInlineSnapshot(
+        `gatsby-image-wrapper gatsby-image-wrapper-constrained`
+      )
     })
   })
 

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -60,7 +60,7 @@ describe(`GatsbyImage server`, () => {
 
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
       expect((wrapper as HTMLElement).className).toMatchInlineSnapshot(
-        `\"gatsby-image-wrapper\"`
+        `gatsby-image-wrapper`
       )
     })
 
@@ -119,7 +119,7 @@ describe(`GatsbyImage server`, () => {
 
       const wrapper = document.querySelector(`[data-gatsby-image-wrapper=""]`)
       expect((wrapper as HTMLElement).className).toMatchInlineSnapshot(
-        `\"gatsby-image-wrapper gatsby-image-wrapper-constrained\"`
+        `gatsby-image-wrapper gatsby-image-wrapper-constrained`
       )
     })
   })

--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -54,20 +54,22 @@ export function getWrapperProps(
 ): Pick<HTMLAttributes<HTMLElement>, "className" | "style"> & {
   "data-gatsby-image-wrapper": string
 } {
-  const wrapperStyle: CSSProperties = {
-    position: `relative`,
-    overflow: `hidden`,
-  }
+  const wrapperStyle: CSSProperties = {}
+
+  let className = `gatsby-image-wrapper`
 
   if (layout === `fixed`) {
     wrapperStyle.width = width
     wrapperStyle.height = height
   } else if (layout === `constrained`) {
-    wrapperStyle.display = `inline-block`
+    if (!global.GATSBY___IMAGE) {
+      wrapperStyle.display = `inline-block`
+    }
+    className = `gatsby-image-wrapper gatsby-image-wrapper-constrained`
   }
 
   return {
-    className: `gatsby-image-wrapper`,
+    className,
     "data-gatsby-image-wrapper": ``,
     style: wrapperStyle,
   }

--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -17,6 +17,10 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
     <style
       key="gatsby-image-style"
       dangerouslySetInnerHTML={generateHtml(cssNanoMacro`
+  .gatsby-image-wrapper {
+    position: relative;
+    overflow: hidden;
+  }
   .gatsby-image-wrapper img {
     all: inherit;
     bottom: 0;
@@ -36,6 +40,9 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
     transform: translateZ(0px);
     transition: opacity 250ms linear;
     will-change: opacity;
+  }
+  .gatsby-image-wrapper-constrained {
+    display: inline-block;
   }
     `)}
     />,


### PR DESCRIPTION
Constrained images were getting an inline style of inline-block which users could not override without a !important. We consider that too opinionated but it's a necessary fallback when images are not otherwise in a container with a display rule.