### PR TITLE
fix(gatsby-plugin-image): Pass sizes for source

### DIFF
--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -297,6 +297,7 @@ icon.svg`,
         <picture>
           <source
             media="some-media"
+            sizes="192x192"
             srcset="icon32px.png 32w,icon64px.png 64w,icon-retina.png 2x,icon-ultra.png 3x,icon.svg"
           />
           <img

--- a/packages/gatsby-plugin-image/src/components/picture.tsx
+++ b/packages/gatsby-plugin-image/src/components/picture.tsx
@@ -66,17 +66,11 @@ const Image: FunctionComponent<ImageProps> = function Image({
 
 export const Picture = forwardRef<HTMLImageElement, PictureProps>(
   function Picture(
-    { fallback, sources = [], shouldLoad = true, sizes, ...props },
+    { fallback, sources = [], shouldLoad = true, ...props },
     ref
   ) {
     const fallbackImage = (
-      <Image
-        sizes={sizes}
-        {...props}
-        {...fallback}
-        shouldLoad={shouldLoad}
-        innerRef={ref}
-      />
+      <Image {...props} {...fallback} shouldLoad={shouldLoad} innerRef={ref} />
     )
 
     if (!sources.length) {
@@ -85,7 +79,7 @@ export const Picture = forwardRef<HTMLImageElement, PictureProps>(
 
     return (
       <picture>
-        {sources.map(({ media, srcSet, type }) => (
+        {sources.map(({ media, srcSet, type, sizes }) => (
           <source
             key={`${media}-${type}-${srcSet}`}
             type={type}

--- a/packages/gatsby-plugin-image/src/components/picture.tsx
+++ b/packages/gatsby-plugin-image/src/components/picture.tsx
@@ -69,8 +69,15 @@ export const Picture = forwardRef<HTMLImageElement, PictureProps>(
     { fallback, sources = [], shouldLoad = true, ...props },
     ref
   ) {
+    const sizes = props.sizes || fallback.sizes
     const fallbackImage = (
-      <Image {...props} {...fallback} shouldLoad={shouldLoad} innerRef={ref} />
+      <Image
+        {...props}
+        {...fallback}
+        sizes={sizes}
+        shouldLoad={shouldLoad}
+        innerRef={ref}
+      />
     )
 
     if (!sources.length) {
@@ -79,7 +86,7 @@ export const Picture = forwardRef<HTMLImageElement, PictureProps>(
 
     return (
       <picture>
-        {sources.map(({ media, srcSet, type, sizes }) => (
+        {sources.map(({ media, srcSet, type }) => (
           <source
             key={`${media}-${type}-${srcSet}`}
             type={type}

--- a/packages/gatsby-plugin-image/src/components/picture.tsx
+++ b/packages/gatsby-plugin-image/src/components/picture.tsx
@@ -69,7 +69,7 @@ export const Picture = forwardRef<HTMLImageElement, PictureProps>(
     { fallback, sources = [], shouldLoad = true, ...props },
     ref
   ) {
-    const sizes = props.sizes || fallback.sizes
+    const sizes = props.sizes || fallback?.sizes
     const fallbackImage = (
       <Image
         {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11629,13 +11629,6 @@ gatsby-node-helpers@^0.3.0:
     lodash "^4.17.4"
     p-is-promise "^1.1.0"
 
-gatsby-plugin-utils@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-0.8.0.tgz#2ecd848e6e3362ee929e496bc11528267d2fb96e"
-  integrity sha512-EQC1U7LQVHaI6jXMbx4ryvA8rV1yYrlyxwO2T4nuLUDOO1STUpKTYCH4ySOEtXi6f4P5v7NxgHkFoid6ayY9HA==
-  dependencies:
-    joi "^17.2.1"
-
 gatsby-plugin-webfonts@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-webfonts/-/gatsby-plugin-webfonts-1.1.4.tgz#f6fb8daf0acc4c59511c98964fceca35504014ac"


### PR DESCRIPTION
This results in sizes on the source element. However, we're still testing to make sure it's appropriately picked up by the browser.