### PR TITLE
fix(gatsby-plugin-manifest): Add `webapp` key

### DIFF
--- a/packages/gatsby-plugin-manifest/src/pluginOptionsSchema.js
+++ b/packages/gatsby-plugin-manifest/src/pluginOptionsSchema.js
@@ -21,7 +21,8 @@ export default function pluginOptionSchema({ Joi }) {
       `chrome_web_store`,
       `play`,
       `itunes`,
-      `microsoft`
+      `microsoft`,
+      `webapp`
     ) //https://w3c.github.io/manifest-app-info/#platform-member
     .description(`The platform on which the application can be found.`)
 


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/29112

The latest draft (https://www.w3.org/TR/appmanifest/#platform-member) points the platform members to: https://github.com/w3c/manifest/wiki/Platforms

It now also contains `webapp` which I added here.
