### PR TITLE
fix(gatsby-source-contentful): sync crash with error response

### DIFF
--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -37,13 +37,6 @@ module.exports = async function contentfulFetch({
           .join(` `)
       }
 
-      // Sync progress
-      if (response.config.url === `sync`) {
-        syncItemCount += response.data.items.length
-        syncProgress.total = syncItemCount
-        syncProgress.tick(response.data.items.length)
-      }
-
       // Log error and throw it in an extended shape
       if (response.isAxiosError) {
         reporter.verbose(
@@ -65,6 +58,13 @@ module.exports = async function contentfulFetch({
         contentfulApiError.config = response.config
 
         throw contentfulApiError
+      }
+
+      // Sync progress
+      if (response.config.url === `sync`) {
+        syncItemCount += response.data.items.length
+        syncProgress.total = syncItemCount
+        syncProgress.tick(response.data.items.length)
       }
 
       reporter.verbose(


### PR DESCRIPTION
When the Contentful API returns an error during sync, `response.data` is not populated here and the fetch fails with `Cannot read property 'items' of undefined`

Move the "Sync progress" below the error handling so we don't attempt to read `response.data.items` (which fails) and instead log the error.

If you have an idea how to test this, I'm happy to do so but it seems the `responseLogger` is currently not really test covered.