### PR TITLE
fix(gatsby-plugin-image): Update types

### DIFF
--- a/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
@@ -42,11 +42,11 @@ export interface GatsbyImageProps
 
 export interface IGatsbyImageData {
   layout: Layout
-  height?: number
+  width: number
+  height: number
   backgroundColor?: string
   images: Pick<MainImageProps, "sources" | "fallback">
   placeholder?: Pick<PlaceholderProps, "sources" | "fallback">
-  width?: number
 }
 
 let hasShownWarning = false

--- a/packages/gatsby-plugin-image/src/image-utils.ts
+++ b/packages/gatsby-plugin-image/src/image-utils.ts
@@ -262,7 +262,7 @@ export function generateImageData(
     }
   })
 
-  const imageProps: IGatsbyImageData = { images: result, layout }
+  const imageProps: Partial<IGatsbyImageData> = { images: result, layout }
   switch (layout) {
     case `fixed`:
       imageProps.width = imageSizes.presentationWidth
@@ -279,7 +279,7 @@ export function generateImageData(
       imageProps.height = (imageProps.width || 1) / imageSizes.aspectRatio
   }
 
-  return imageProps
+  return imageProps as IGatsbyImageData
 }
 
 const dedupeAndSortDensities = (values: Array<number>): Array<number> =>


### PR DESCRIPTION
width and height are not optional. This was causing a type error.