### PR TITLE
chore(docs): Update TypeScript Unit Testing Docs

### DIFF
--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -217,7 +217,7 @@ by running `npm test -- -u`.
 
 ## Using TypeScript
 
-If you are using TypeScript, you need to install typings packages and make 
+If you are using TypeScript, you need to install typings packages and make
 two changes to your config.
 
 ```shell

--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -217,8 +217,12 @@ by running `npm test -- -u`.
 
 ## Using TypeScript
 
-If you are using TypeScript, you need to make two changes to your
-config.
+If you are using TypeScript, you need to install typings packages and make 
+two changes to your config.
+
+```shell
+npm install --save-dev @types/jest @types/react-test-renderer
+```
 
 Update the transform in `jest.config.js` to run `jest-preprocess` on files in your project's root directory.
 


### PR DESCRIPTION
## Description

Adding `@types/jest` and `@types/react-test-renderer` was an extra step that I had to do in order to get tests to work with TypeScript and Gatsby, so I thought it would be a good contribution to the official docs.

### Documentation

This is the docs 😊

## Related Issues

N/A
