### PR TITLE
fix(gatsby-plugin-image): Use ESM for gatsby-browser

### DIFF
--- a/packages/gatsby-plugin-image/gatsby-browser.js
+++ b/packages/gatsby-plugin-image/gatsby-browser.js
@@ -1,11 +1,6 @@
-const React = require("react")
+import React from "react"
+import { LaterHydrator } from "."
 
-const { LaterHydrator } = require(".")
-
-exports.wrapRootElement = ({ element }) => {
-  return (
-    <LaterHydrator>
-      {element}
-    </LaterHydrator>
-  )
+export function wrapRootElement({ element }) {
+  return <LaterHydrator>{element}</LaterHydrator>
 }


### PR DESCRIPTION
Using CJS modules was causing errors in an example project