### PR TITLE
feat(gatsby-source-mongodb): Add support for aggregations

### DIFF
--- a/packages/gatsby-source-mongodb/README.md
+++ b/packages/gatsby-source-mongodb/README.md
@@ -22,7 +22,7 @@ module.exports = {
 }
 ```
 
-### multiple collections
+### Multiple collections
 
 ```javascript
 // In your gatsby-config.js
@@ -42,6 +42,7 @@ module.exports = {
 - **dbName**: indicates the database name that you want to use
 - **collection**: the collection name within Mongodb, this can also be an array
   for multiple collections
+- **aggregations**: define a set of aggregations per collection (if defined the `collection`-option is ignored). See section below for more instructions.
 - **query**: add a query when retriving a collection. This is a key value object where key's are collection names, and value is the query object. Defaults to {} (i.e. the whole collection)
 - **server**: contains the server info, with sub properties address and port ex.
   server: { address: `ds143532.mlab.com`, port: 43532 }. Defaults to a server
@@ -106,14 +107,61 @@ query($id: String!) {
 }
 ```
 
+### Use MongoDB Aggregations
+
+By setting the `aggregations` parameter you have direct access to the full set of stages and pipelines of a [MongoDB Aggregation](https://docs.mongodb.com/manual/aggregation/). With that you can apply filter, map or add new values, calculate sums and averages, limit the amount of results, and much more. **Important:** If you have one (valid) aggregation defined the `collection` value/option is ignored and only aggregations are queried from the database.
+
+You can define aggregations in multiple ways:
+```js
+// Named aggregations per collection
+aggregations: {
+  'collectionName' : {
+    'customAggregationName': [
+      { $set: { a: '$b' } },
+      { $limit: 5 },
+    ],
+    'aggregationReturns5Objects': [
+      { $limit: 5 }
+    ],
+  }
+}
+// Shorthand (unnamed) aggregation per collection
+aggregations: {
+  'collectionName' : [
+    { $limit: 5 }
+   ],
+   // Tip: Empty Aggregations return the complete collection
+  'otherCollectionName' : []
+}
+```
+
+You can find more on naming of aggregations within the GraphQL layer in the section below.
+
+
 ## How to query your MongoDB data using GraphQL
 
 Below is a sample query for fetching all MongoDB document nodes from a db named
-**'Cloud'** and a collection named **'documents'**.
+**'Cloud'** and a collection named **'documents'** with the `collection` option.
 
 ```graphql
 query {
   allMongodbCloudDocuments {
+    edges {
+      node {
+        id
+        url
+        name
+      }
+    }
+  }
+}
+```
+
+If you use the `aggregations` option to query data from the database the naming of generated sets is slightly different. If the db and the collections are named like above an aggregation named **'niceAggregation'** would result in the query below. *Note:* If you have used an unnamed aggregation its default name is **'aggregation'**.
+
+```graphql
+query {
+  allMongodbNiceAggregationCloudDocuments {
     edges {
       node {
         id

--- a/packages/gatsby-source-mongodb/src/__tests__/preprocess-aggregations.js
+++ b/packages/gatsby-source-mongodb/src/__tests__/preprocess-aggregations.js
@@ -1,0 +1,66 @@
+const preprocessAggregations = require(`../preprocess-aggregations`)
+
+
+test(`Collection keys with empty (non-array) values are removed`, () => {
+  const before = {
+    'collection_1': {
+      'aggregation_1': []
+    },
+    'collection_2': null,
+    'collection_3': {},
+  }
+  const after = {
+    'collection_1': {
+      'aggregation_1': []
+    },
+  }
+  expect(preprocessAggregations(before)).toEqual(after)
+})
+
+
+test(`Nested aggregation keys with non-array values are removed`, () => {
+  const before = {
+    'collection_1': {
+      'aggregation_1': [],
+      'aggregation_2': {},
+      'aggregation_3': null,
+      'aggregation_4': [
+        { $set: { a: 1 } }
+      ],
+    },
+    'collection_2': {
+      'aggregation_1': {},
+      'aggregation_2': null,
+    },
+  }
+  const after = {
+    'collection_1': {
+      'aggregation_1': [],
+      'aggregation_4': [
+        { $set: { a: 1 } }
+      ],
+    },
+  }
+  expect(preprocessAggregations(before)).toEqual(after)
+})
+
+
+test(`Collection values with unnamed (array) aggregations are transformed into named format`, () => {
+  const before = {
+    'collection_1': [],
+    'collection_2': [
+      { $set: { a: 1 } }
+    ],
+  }
+  const after = {
+    'collection_1': {
+      'aggregation': []
+    },
+    'collection_2': {
+      'aggregation': [
+        { $set: { a: 1 } }
+      ]
+    },
+  }
+  expect(preprocessAggregations(before)).toEqual(after)
+})

--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -3,6 +3,7 @@ const prepareMappingChildNode = require(`./mapping`)
 const sanitizeName = require(`./sanitize-name`)
 const queryString = require(`query-string`)
 const stringifyObjectIds = require(`./stringify-object-ids`)
+const preprocessAggregations = require(`./preprocess-aggregations`)
 
 exports.sourceNodes = (
   { actions, getNode, createNodeId, hasNodeChanged, createContentDigest },
@@ -34,24 +35,47 @@ exports.sourceNodes = (
     .connect()
     .then(client => {
       const db = client.db(dbName)
+
       let collection = pluginOptions.collection || [`documents`]
       if (!Array.isArray(collection)) {
         collection = [collection]
       }
 
-      return Promise.all(
-        collection.map(col =>
-          createNodes(
-            db,
-            pluginOptions,
-            dbName,
-            createNode,
-            createNodeId,
-            col,
-            createContentDigest
-          )
+      // Format aggregations & Determine whether to use `collection.find` or `collection.aggregate`
+      const aggregations = preprocessAggregations(pluginOptions.aggregations || {})
+      const useCollection = !Object.keys(aggregations).length
+
+      return Promise
+        .all(
+          Object.entries(useCollection ? collection : aggregations)
+            .reduce((acc, [key, value]) => {
+              if (useCollection) {
+                // Map to `createNodes` calls for collection
+                return [...acc, createNodes(
+                  db,
+                  pluginOptions,
+                  dbName,
+                  createNode,
+                  createNodeId,
+                  value,
+                  createContentDigest
+                )]
+
+              } else {
+                // Flatten & map to `createNodes` calls for aggregation
+                return [...acc, ...Object.entries(value).map(aggregation => createNodes(
+                  db,
+                  pluginOptions,
+                  dbName,
+                  createNode,
+                  createNodeId,
+                  key,
+                  createContentDigest,
+                  aggregation
+                ))]
+              }
+            }, [])
         )
-      )
         .then(() => {
           mongoClient.close()
         })
@@ -67,7 +91,7 @@ exports.sourceNodes = (
     })
 }
 
-function idToString(id) {
+function mongoIdToString(id) {
   return id.hasOwnProperty(`toHexString`) ? id.toHexString() : String(id)
 }
 
@@ -78,14 +102,19 @@ function createNodes(
   createNode,
   createNodeId,
   collectionName,
-  createContentDigest
+  createContentDigest,
+  aggregation
 ) {
   const { preserveObjectIds = false, query = {} } = pluginOptions
   return new Promise((resolve, reject) => {
     let collection = db.collection(collectionName)
-    let cursor = collection.find(
-      query[collectionName] ? query[collectionName] : {}
-    )
+
+    // Create cursor via `find` or `aggregate` depending on if `aggregation` is given
+    let cursor = !!aggregation
+      ? collection.aggregate(aggregation[1])
+      : collection.find(
+        query[collectionName] ? query[collectionName] : {}
+      )
 
     // Execute the each command, triggers for each document
     cursor.toArray((err, documents) => {
@@ -94,8 +123,6 @@ function createNodes(
       }
 
       documents.forEach(({ _id, ...item }) => {
-        const id = idToString(_id)
-
         // only call recursive function to preserve relations represented by objectids if pluginoption set.
         if (preserveObjectIds) {
           for (let key in item) {
@@ -103,17 +130,19 @@ function createNodes(
           }
         }
 
+        const mongodb_id = mongoIdToString(_id)
+        const id = `${!!aggregation ? aggregation[0] : ''}${dbName}${collectionName}${mongodb_id}`
+        const sanitizedAggregationName = !!aggregation ? sanitizeName(aggregation[0]) : ''
+        const internalType = `mongodb${sanitizedAggregationName}${sanitizeName(dbName)}${sanitizeName(collectionName)}`
         const node = {
           // Data for the node.
           ...item,
           id: createNodeId(`${id}`),
-          mongodb_id: id,
+          mongodb_id: mongodb_id,
           parent: `__${collectionName}__`,
           children: [],
           internal: {
-            type: `mongodb${sanitizeName(dbName)}${sanitizeName(
-              collectionName
-            )}`,
+            type: internalType,
             content: JSON.stringify(item),
             contentDigest: createContentDigest(item),
           },

--- a/packages/gatsby-source-mongodb/src/preprocess-aggregations.js
+++ b/packages/gatsby-source-mongodb/src/preprocess-aggregations.js
@@ -1,0 +1,49 @@
+/**
+ * Filters out empty or wrong formatted aggregations.
+ * Re-formats unnamed aggregations (shorthand format) into named format.
+ * ```
+ * {
+ *  'collection_1' : {
+ *    'aggregation_1': [ … ],
+ *    'aggregation_2': [ … ],
+ *  },
+ *  'collection_2' : {
+ *    'aggregation_1': [ … ],
+ *  },
+ *  …
+ * }
+ * ```
+ * See tests for more information about exact behavior.
+ */
+module.exports = function preprocessAggregations(aggregations) {
+  const isNonEmptyObject = (o) => !!o && typeof o === 'object' && !!Object.keys(o).length
+  const isArray = (a) => !!a && Array.isArray(a)
+
+  return Object.entries(aggregations)
+    // Filter out illegal collection-keys (empty values or non-objects)
+    .filter(([_, value]) => {
+      if (!isNonEmptyObject(value) && !isArray(value)) return false
+      return true
+    })
+    // Filter out illegal aggregation-keys (non-arrays)
+    .map(([key, value]) => {
+      if (!isArray(value)) {
+        value = Object.entries(value)
+          .filter(([_, childValue]) => isArray(childValue))
+          .reduce((acc, [childKey, childValue]) => ({ ...acc, [childKey]: childValue }), {})
+        if (!Object.keys(value).length) return null
+      }
+      return [key, value]
+    })
+    // Filter out collection-keys with only incorrect aggregations
+    .filter(Boolean)
+    // Re-build & format object
+    .reduce((acc, [key, value]) => {
+      if (isArray(value)) {
+        value = {
+          'aggregation': value
+        }
+      }
+      return { ...acc, [key]: value }
+    }, {})
+}


### PR DESCRIPTION
Hey there 👋
I needed this for a project of mine and thought this could be really helpful for others as well. It adds the power of [MongoDB Aggregations](https://docs.mongodb.com/manual/aggregation/) to the mongodb-source-plugin.

## Description

This PR adds a new option `aggregations` to the plugin-settings where aggregations can be defined for each collection. Multiple aggregations must be named and a single aggregation can be added anonymously as a shorthand (see docs). If `aggregations` is defined the `collections` are ignored as empty aggregations do exactly the same thing and having both could be confusing.

**Detailed changes:**
* For aggregations the `collection.aggregate()` function is used instead of `collection.find()`.
* For uniqueness the aggregation name was added within the internal GraphQL type.
* The internal `id` of documents is made unique as the same document can be queried multiple times in multiple aggregations.
* The `aggregations` object is preprocessed to exclude malformed inputs. I've also written **tests** (inside `__tests__`) for this preprocessing which are all passing.
* I've written a detailed explanation with examples in the **documentation** (`README.md`) of the source-plugin.

I would be thrilled if that PR makes it into the Gatsby project. It already helps me a lot in my daily work as I find MongoDB Aggregations very powerful (and also more performant if some data-preprocessing happens before it finds is way into the Gatsby cache).

Regards from Germany,
Dennis