### PR TITLE
fix(gatsby-plugin-manifest): Fix `or` Joi assertion

### DIFF
--- a/packages/gatsby-plugin-manifest/src/pluginOptionsSchema.js
+++ b/packages/gatsby-plugin-manifest/src/pluginOptionsSchema.js
@@ -93,10 +93,8 @@ export default function pluginOptionSchema({ Joi }) {
       platform: platform.required(),
       url: Joi.string()
         .uri()
-        .required()
         .description(`The URL at which the application can be found.`),
       id: Joi.string()
-        .required()
         .description(
           `The ID used to represent the application on the specified platform.`
         ),

--- a/packages/gatsby-plugin-manifest/src/pluginOptionsSchema.js
+++ b/packages/gatsby-plugin-manifest/src/pluginOptionsSchema.js
@@ -94,10 +94,9 @@ export default function pluginOptionSchema({ Joi }) {
       url: Joi.string()
         .uri()
         .description(`The URL at which the application can be found.`),
-      id: Joi.string()
-        .description(
-          `The ID used to represent the application on the specified platform.`
-        ),
+      id: Joi.string().description(
+        `The ID used to represent the application on the specified platform.`
+      ),
       min_version: Joi.string()
         .optional()
         .description(


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/29112#issuecomment-768449357

According to [the docs](https://joi.dev/api/?v=17.3.0#objectorpeers-options) with `or` already one of the two is required:

> Defines a relationship between keys where one of the peers is **required** (and more than one is allowed)

So having `required()` on both of them leads to the error that it's still required.
