### PR TITLE
fix(gatsby-plugin-sharp): Sanitize tmp filename

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -11,6 +11,7 @@
     "async": "^3.2.0",
     "bluebird": "^3.7.2",
     "fs-extra": "^9.1.0",
+    "filenamify": "^4.2.0",
     "gatsby-core-utils": "^1.10.0-next.0",
     "gatsby-telemetry": "^1.10.0-next.1",
     "got": "^10.7.0",

--- a/packages/gatsby-plugin-sharp/src/trace-svg.js
+++ b/packages/gatsby-plugin-sharp/src/trace-svg.js
@@ -1,8 +1,9 @@
 const { promisify } = require(`bluebird`)
 const _ = require(`lodash`)
 const tmpDir = require(`os`).tmpdir()
+const path = require(`path`)
 const sharp = require(`./safe-sharp`)
-
+const filenamify = require(`filenamify`)
 const duotone = require(`./duotone`)
 const { getPluginOptions, healOptions } = require(`./plugin-options`)
 const { reportError } = require(`./report-error`)
@@ -109,7 +110,12 @@ exports.notMemoizedtraceSVG = async ({ file, args, fileArgs, reporter }) => {
 
   const optionsHash = createContentDigest(options)
 
-  const tmpFilePath = `${tmpDir}/${file.internal.contentDigest}-${file.name}-${optionsHash}.${file.extension}`
+  const tmpFilePath = path.join(
+    tmpDir,
+    filenamify(
+      `${file.internal.contentDigest}-${file.name}-${optionsHash}.${file.extension}`
+    )
+  )
 
   try {
     await exports.memoizedPrepareTraceSVGInputFile({

--- a/yarn.lock
+++ b/yarn.lock
@@ -11105,6 +11105,15 @@ filenamify@^2.0.0:
     strip-outer "^1.0.0"
     trim-repeated "^1.0.0"
 
+filenamify@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.2.0.tgz#c99716d676869585b3b5d328b3f06590d032e89f"
+  integrity sha512-pkgE+4p7N1n7QieOopmn3TqJaefjdWXwEkj2XLZJLKfOgcQKkn11ahvGNgTD8mLggexLiDFQxeTs14xVU22XPA==
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.1"
+    trim-repeated "^1.0.0"
+
 filesize@3.5.11:
   version "3.5.11"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
@@ -23891,7 +23900,7 @@ strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strip-outer@^1.0.0:
+strip-outer@^1.0.0, strip-outer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
   dependencies:


### PR DESCRIPTION
Ensures that the generated filename is valid. It was breaking on WIndows as the digest included colons.

Fixes #29071 