### PR TITLE
chore(gatsby): Remove deprecated `gatsby-browser` APIs

### DIFF
--- a/docs/docs/resource-handling-and-service-workers.md
+++ b/docs/docs/resource-handling-and-service-workers.md
@@ -42,7 +42,7 @@ Another current problem is that we may start fetching the resources for a page b
 
 ### Resource loader (`loader.js`)
 
-There are two functions which perform a similar but distinct role in this file: `enqueue` and `getResourcesForPathname`. The former of these, `enqueue`, is designed to speed up navigation by prefetching resources for a page, before we need to display the page, and hence it doesn't return anything. On the other hand, `getResourcesForPathname` is used when we need the resources right now, usually in order to display the page, and therefore it fetches with higher priority than `enqueue` as well as returning them. Another difference between the two is that `getResourcesForPathname` returns the resources for the 404 page if the specified page doesn't exist.
+There are two functions which perform a similar but distinct role in this file: `enqueue` and `loadPage`. The former of these, `enqueue`, is designed to speed up navigation by prefetching resources for a page, before we need to display the page, and hence it doesn't return anything. On the other hand, `loadPage` is used when we need the resources right now, usually in order to display the page, and therefore it fetches with higher priority than `enqueue` as well as returning them. Another difference between the two is that `loadPage` returns the resources for the 404 page if the specified page doesn't exist.
 
 In the future, we could refactor these into a single function which takes parameters for whether or not to return the 404 page if the specified page is missing, and for whether to fetch with high or low priority.
 
@@ -67,7 +67,7 @@ Here is how the `EnsureResources` component handles each of these scenarios:
 The following are some invalid reasons why we might not have resources, i.e. things which we should never have to worry about:
 
 1. 404s from external links, without a custom 404 page - the page will load from the server in the first place, so Gatsby won't even kick in at this point
-2. 404s, with a custom 404 page - `getResourcesForPathname` will automatically return the resources for the custom 404 page
+2. 404s, with a custom 404 page - `loadPage` will automatically return the resources for the custom 404 page
 3. Visiting a previously-visited page via an external link, when the site's resources have since updated - previously-visited pages are cached, so they'll work even if the site has updated since. Unvisited pages will always load from the server and get the latest resources.
 
 ### Service worker update handling

--- a/packages/gatsby/cache-dir/api-runner-browser.js
+++ b/packages/gatsby/cache-dir/api-runner-browser.js
@@ -1,7 +1,5 @@
 const plugins = require(`./api-runner-browser-plugins`)
 const {
-  getResourcesForPathname,
-  getResourcesForPathnameSync,
   getResourceURLsForPathname,
   loadPage,
   loadPageSync,
@@ -24,10 +22,6 @@ exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
       return undefined
     }
 
-    // Deprecated April 2019. Use `loadPageSync` instead
-    args.getResourcesForPathnameSync = getResourcesForPathnameSync
-    // Deprecated April 2019. Use `loadPage` instead
-    args.getResourcesForPathname = getResourcesForPathname
     args.getResourceURLsForPathname = getResourceURLsForPathname
     args.loadPage = loadPage
     args.loadPageSync = loadPageSync

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -504,21 +504,6 @@ export const setLoader = _loader => {
 }
 
 export const publicLoader = {
-  // Deprecated methods. As far as we're aware, these are only used by
-  // core gatsby and the offline plugin, however there's a very small
-  // chance they're called by others.
-  getResourcesForPathname: rawPath => {
-    console.warn(
-      `Warning: getResourcesForPathname is deprecated. Use loadPage instead`
-    )
-    return instance.i.loadPage(rawPath)
-  },
-  getResourcesForPathnameSync: rawPath => {
-    console.warn(
-      `Warning: getResourcesForPathnameSync is deprecated. Use loadPageSync instead`
-    )
-    return instance.i.loadPageSync(rawPath)
-  },
   enqueue: rawPath => instance.prefetch(rawPath),
 
   // Real methods

--- a/packages/gatsby/cache-dir/page-renderer.js
+++ b/packages/gatsby/cache-dir/page-renderer.js
@@ -1,6 +1,5 @@
 import React, { createElement } from "react"
 import PropTypes from "prop-types"
-import { publicLoader } from "./loader"
 import { apiRunner } from "./api-runner-browser"
 import { grabMatchParams } from "./find-path"
 
@@ -16,17 +15,10 @@ class PageRenderer extends React.Component {
       pathContext: this.props.pageContext,
     }
 
-    const [replacementElement] = apiRunner(`replaceComponentRenderer`, {
-      props: this.props,
-      loader: publicLoader,
+    const pageElement = createElement(this.props.pageResources.component, {
+      ...props,
+      key: this.props.path || this.props.pageResources.page.path,
     })
-
-    const pageElement =
-      replacementElement ||
-      createElement(this.props.pageResources.component, {
-        ...props,
-        key: this.props.path || this.props.pageResources.page.path,
-      })
 
     const wrappedPage = apiRunner(
       `wrapPageElement`,

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -566,10 +566,6 @@ export interface GatsbyBrowser {
     options: PluginOptions
   ): any
   registerServiceWorker?(args: BrowserPluginArgs, options: PluginOptions): any
-  replaceComponentRenderer?(
-    args: ReplaceComponentRendererArgs,
-    options: PluginOptions
-  ): any
   replaceHydrateFunction?(
     args: BrowserPluginArgs,
     options: PluginOptions
@@ -1483,11 +1479,6 @@ export interface PrefetchPathnameArgs extends BrowserPluginArgs {
 export interface RouteUpdateArgs extends BrowserPluginArgs {
   location: Location
   prevLocation: Location | null;
-}
-
-export interface ReplaceComponentRendererArgs extends BrowserPluginArgs {
-  props: PageProps
-  loader: object
 }
 
 export interface ShouldUpdateScrollArgs extends BrowserPluginArgs {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1515,8 +1515,6 @@ export interface WrapRootElementBrowserArgs extends BrowserPluginArgs {
 }
 
 export interface BrowserPluginArgs {
-  getResourcesForPathnameSync: Function
-  getResourcesForPathname: Function
   getResourceURLsForPathname: Function
   [key: string]: unknown
 }

--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -25,9 +25,6 @@ it("generates the expected api output", done => {
           "onServiceWorkerUpdateFound": Object {},
           "onServiceWorkerUpdateReady": Object {},
           "registerServiceWorker": Object {},
-          "replaceComponentRenderer": Object {
-            "deprecated": true,
-          },
           "replaceHydrateFunction": Object {},
           "shouldUpdateScroll": Object {},
           "wrapPageElement": Object {},

--- a/packages/gatsby/src/utils/api-browser-docs.ts
+++ b/packages/gatsby/src/utils/api-browser-docs.ts
@@ -115,17 +115,6 @@ export const shouldUpdateScroll = true
 export const registerServiceWorker = true
 
 /**
- * Allow a plugin to replace the page component renderer.
- * @deprecated Use [wrapPageElement](#wrapPageElement) to decorate page element.
- * @param {object} $0
- * @param {object} $0.props The props of the page.
- * @param {object} $0.loader The gatsby loader.
- * @param {pluginOptions} pluginOptions
- * @returns {ReactNode} Replaced default page renderer
- */
-export const replaceComponentRenderer = true
-
-/**
  * Allow a plugin to wrap the page element.
  *
  * This is useful for setting wrapper components around pages that won't get


### PR DESCRIPTION
## Description

This removes `getResourcesForPathnameSync`, `getResourcesForPathname`, and `replaceComponentRenderer`.

### Documentation

## Related Issues

[ch23864]
