### PR TITLE
make sure to pass the failOnError option to base64 generation

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -275,8 +275,8 @@ async function generateBase64({ file, args = {}, reporter }) {
   let pipeline
   try {
     pipeline = !options.failOnError
-      ? sharp(file, { failOnError: false })
-      : sharp(file)
+      ? sharp(file.absolutePath, { failOnError: false })
+      : sharp(file.absolutePath)
 
     if (!options.rotate) {
       pipeline.rotate()

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -274,7 +274,9 @@ async function generateBase64({ file, args = {}, reporter }) {
   })
   let pipeline
   try {
-    pipeline = sharp(file.absolutePath)
+    pipeline = !options.failOnError
+      ? sharp(file, { failOnError: false })
+      : sharp(file)
 
     if (!options.rotate) {
       pipeline.rotate()


### PR DESCRIPTION
## Description

The gatsby-image-sharp plugin accepts (among others) a `failOnError` option. This option is not passed down properly during the creation of Base64 images. So if you send a "corrupted" file to it, it will fail, causing the whole build to fail.

### Documentation

## Related Issues
Addresses https://github.com/gatsbyjs/gatsby/issues/28203
