### PR TITLE
feat(contentful): add retry logic to asset downloading

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -23,14 +23,17 @@
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",
+    "p-queue": "^6.6.2",
     "progress": "^2.0.3",
-    "qs": "^6.9.6"
+    "qs": "^6.9.6",
+    "retry-axios": "^2.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",
     "babel-preset-gatsby-package": "^0.13.0-next.0",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "nock": "^13.0.6"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#readme",
   "keywords": [

--- a/packages/gatsby-source-contentful/src/__tests__/download-with-retry.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-with-retry.js
@@ -41,7 +41,9 @@ describe(`download-with-retry`, () => {
 
     await expect(
       downloadAndRetry({ method: `get`, url }, reporter)
-    ).rejects.toThrowError(`Request failed with status code 404`)
+    ).rejects.toThrowError(
+      `Unable to download asset from https://images.ctfassets.net/foo/bar/baz/image.jpg. Request failed with status code 404`
+    )
 
     expect(reporter.verbose).not.toHaveBeenCalled()
     expect(scope.isDone()).toBeFalsy()
@@ -68,7 +70,9 @@ describe(`download-with-retry`, () => {
 
     await expect(
       downloadAndRetry({ method: `get`, url }, reporter)
-    ).rejects.toThrowError(`Request failed with status code 503`)
+    ).rejects.toThrowError(
+      `Unable to download asset from https://images.ctfassets.net/foo/bar/baz/image.jpg. Request failed with status code 503`
+    )
 
     expect(reporter.verbose).toHaveBeenCalledTimes(3)
     expect(reporter.verbose).toHaveBeenCalledWith(

--- a/packages/gatsby-source-contentful/src/__tests__/download-with-retry.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-with-retry.js
@@ -1,0 +1,79 @@
+import nock from "nock"
+
+import downloadAndRetry from "../download-with-retry"
+
+nock.disableNetConnect()
+
+const host = `https://images.ctfassets.net`
+const path = `/foo/bar/baz/image.jpg`
+const url = [host, path].join(``)
+
+const reporter = {
+  verbose: jest.fn(),
+}
+
+describe(`download-with-retry`, () => {
+  afterEach(() => {
+    nock.cleanAll()
+    reporter.verbose.mockClear()
+  })
+
+  test(`resolves regular response`, async () => {
+    const scope = nock(host).get(path).reply(200)
+
+    await downloadAndRetry({ method: `get`, url }, reporter)
+
+    expect(reporter.verbose).not.toHaveBeenCalled()
+    expect(scope.isDone()).toBeTruthy()
+  })
+
+  test(`does not retry for no reason`, async () => {
+    const scope = nock(host).get(path).twice().reply(200)
+
+    await downloadAndRetry({ method: `get`, url }, reporter)
+
+    expect(reporter.verbose).not.toHaveBeenCalled()
+    expect(scope.isDone()).toBeFalsy()
+  })
+
+  test(`does not retry on 404`, async () => {
+    const scope = nock(host).get(path).twice().reply(404)
+
+    await expect(
+      downloadAndRetry({ method: `get`, url }, reporter)
+    ).rejects.toThrowError(`Request failed with status code 404`)
+
+    expect(reporter.verbose).not.toHaveBeenCalled()
+    expect(scope.isDone()).toBeFalsy()
+    scope.persist(false)
+  })
+
+  test(`does retry on 503`, async () => {
+    const scope = nock(host).get(path).twice().reply(503).get(path).reply(200)
+
+    await downloadAndRetry({ method: `get`, url }, reporter)
+
+    expect(reporter.verbose).toHaveBeenCalledTimes(2)
+    expect(reporter.verbose).toHaveBeenCalledWith(
+      `Retry attempt #1 for https://images.ctfassets.net/foo/bar/baz/image.jpg`
+    )
+    expect(reporter.verbose).toHaveBeenCalledWith(
+      `Retry attempt #2 for https://images.ctfassets.net/foo/bar/baz/image.jpg`
+    )
+    expect(scope.isDone()).toBeTruthy()
+  })
+
+  test(`stops retry after 3 attempts`, async () => {
+    const scope = nock(host).get(path).times(4).reply(503)
+
+    await expect(
+      downloadAndRetry({ method: `get`, url }, reporter)
+    ).rejects.toThrowError(`Request failed with status code 503`)
+
+    expect(reporter.verbose).toHaveBeenCalledTimes(3)
+    expect(reporter.verbose).toHaveBeenCalledWith(
+      `Retry attempt #3 for https://images.ctfassets.net/foo/bar/baz/image.jpg`
+    )
+    expect(scope.isDone()).toBeTruthy()
+  })
+})

--- a/packages/gatsby-source-contentful/src/__tests__/download-with-retry.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-with-retry.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import nock from "nock"
 
 import downloadAndRetry from "../download-with-retry"

--- a/packages/gatsby-source-contentful/src/cache-image.js
+++ b/packages/gatsby-source-contentful/src/cache-image.js
@@ -1,8 +1,9 @@
 const crypto = require(`crypto`)
 const { resolve, parse } = require(`path`)
 
-const axios = require(`axios`)
 const { pathExists, createWriteStream } = require(`fs-extra`)
+
+const downloadWithRetry = require(`./download-with-retry`)
 
 const inFlightImageCache = new Map()
 
@@ -58,8 +59,7 @@ module.exports = async function cacheImage(store, image, options) {
     const downloadPromise = new Promise(async (resolve, reject) => {
       const previewUrl = `http:${url}?${params.join(`&`)}`
 
-      const response = await axios({
-        method: `get`,
+      const response = await downloadWithRetry({
         url: previewUrl,
         responseType: `stream`,
       })

--- a/packages/gatsby-source-contentful/src/download-with-retry.js
+++ b/packages/gatsby-source-contentful/src/download-with-retry.js
@@ -25,12 +25,7 @@ export default async function downloadWithRetry(requestConfig, reporter) {
 
   try {
     const result = await queue.add(() =>
-      axiosInstance.get(requestConfig.url, {
-        ...requestConfig,
-        // This is required as we should not set `testEnvironment: "node"`
-        // in jest.config.js just to test this properly
-        adapter: require(`axios/lib/adapters/http`),
-      })
+      axiosInstance.get(requestConfig.url, requestConfig)
     )
     return result
   } catch (err) {

--- a/packages/gatsby-source-contentful/src/download-with-retry.js
+++ b/packages/gatsby-source-contentful/src/download-with-retry.js
@@ -1,0 +1,34 @@
+const axios = require(`axios`)
+const rax = require(`retry-axios`)
+const { default: PQueue } = require(`p-queue`)
+
+const queue = new PQueue({
+  concurrency: 100,
+})
+
+export default async function downloadWithRetry(requestConfig, reporter) {
+  if (!requestConfig.url) {
+    throw new Error(`requestConfig.url is missing`)
+  }
+  const axiosInstance = axios.create()
+
+  axiosInstance.defaults.raxConfig = {
+    instance: axiosInstance,
+    onRetryAttempt: err => {
+      const cfg = rax.getConfig(err)
+      reporter.verbose(
+        `Retry attempt #${cfg.currentRetryAttempt} for ${requestConfig.url}`
+      )
+    },
+  }
+  rax.attach(axiosInstance)
+
+  return await queue.add(() =>
+    axiosInstance.get(requestConfig.url, {
+      ...requestConfig,
+      // This is required as we should not set `testEnvironment: "node"`
+      // in jest.config.js just to test this properly
+      adapter: require(`axios/lib/adapters/http`),
+    })
+  )
+}

--- a/packages/gatsby-source-contentful/src/download-with-retry.js
+++ b/packages/gatsby-source-contentful/src/download-with-retry.js
@@ -2,6 +2,11 @@ const axios = require(`axios`)
 const rax = require(`retry-axios`)
 const { default: PQueue } = require(`p-queue`)
 
+/**
+ * Contentfuls APIs have a general rate limit of 79 uncached requests per second.
+ * A concurrency of 100 was recommended by Contentful backend and will ensure
+ * that we won't run into rate-limit errors.
+ */
 const queue = new PQueue({
   concurrency: 100,
 })

--- a/packages/gatsby-source-contentful/src/download-with-retry.js
+++ b/packages/gatsby-source-contentful/src/download-with-retry.js
@@ -23,12 +23,18 @@ export default async function downloadWithRetry(requestConfig, reporter) {
   }
   rax.attach(axiosInstance)
 
-  return await queue.add(() =>
-    axiosInstance.get(requestConfig.url, {
-      ...requestConfig,
-      // This is required as we should not set `testEnvironment: "node"`
-      // in jest.config.js just to test this properly
-      adapter: require(`axios/lib/adapters/http`),
-    })
-  )
+  try {
+    const result = await queue.add(() =>
+      axiosInstance.get(requestConfig.url, {
+        ...requestConfig,
+        // This is required as we should not set `testEnvironment: "node"`
+        // in jest.config.js just to test this properly
+        adapter: require(`axios/lib/adapters/http`),
+      })
+    )
+    return result
+  } catch (err) {
+    err.message = `Unable to download asset from ${requestConfig.url}. ${err.message}`
+    throw err
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17684,6 +17684,16 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
+nock@^13.0.6:
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.6.tgz#9f90573ea6e84883b94eeac374d1c73460afed56"
+  integrity sha512-W81UZ1Tv21SWDZcA8Lu9LXYVl2gO9ADY5GadC6gFV9690h4TXz0oCkEoMckN/sPMHkDA79Ka9dXga9Mt1+j+Sg==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
+
 node-abi@^2.7.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.8.0.tgz#bd2e88dbe6a6871e6dd08553e0605779325737ec"
@@ -20034,6 +20044,11 @@ prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
+
 proper-lockfile@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.1.tgz#284cf9db9e30a90e647afad69deb7cb06881262c"
@@ -22349,6 +22364,11 @@ retext@^7.0.1:
     retext-latin "^2.0.0"
     retext-stringify "^2.0.0"
     unified "^8.0.0"
+
+retry-axios@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-2.4.0.tgz#b5da2afed8dd0134c73c86206e1d1881d7c66a67"
+  integrity sha512-rK7UBYgbrNoVothbSmM0tEm9DIiXapmVUrnUYn+d9AuQvF0AY5RkJU2FQvlufe9hlFwrCdDhrJTwiyRtR7wUaA==
 
 retry@0.12.0, retry@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Contentful users with a huge number of assets might run into issues when requesting to many low quality image previews.

This adds a concurrency of 100 to the download process and a retry logic based on https://github.com/JustinBeckwith/retry-axios.

The very same logic will be applied when detecting the dominant color and creating a traced svg variant, for both gatsby-image and gatsby-plugin-image