### PR TITLE
fix(gatsby): Turn off react/jsx-pascal-case rule in ESLint to fix Theme-UI console warnings for Styled Components

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -100,7 +100,7 @@ export const eslintConfig = (
             tagName: `graphql`,
           },
         ],
-        "react/jsx-pascal-case": `warn`,
+        "react/jsx-pascal-case": `off`, // Prevents console warnings for Theme-UI Styled Components
         // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/master/docs/rules
         "jsx-a11y/accessible-emoji": `warn`,
         "jsx-a11y/alt-text": `warn`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Turns off react/jsx-pascal-case in ESLint due to warnings in the console with Theme-UI and the <Styled> component as previously done in [PR #24560](https://github.com/gatsbyjs/gatsby/pull/24560) but changed in [PR #28689](https://github.com/gatsbyjs/gatsby/pull/28689).

Mostly just a cosmetic change but definitely clears a lot of console clutter while building.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #29287

Related to #24327