### PR TITLE
fix(drupal): Support forward revisions for Drupal paragraphs

### DIFF
--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -266,6 +266,32 @@ module.exports = {
 }
 ```
 
+## Entity Reference revisions and relationships
+
+By default `gatsby-source-drupal` resolves Entity Reference relationships using just ID. If you are
+using the contrib module [Entity reference revisions](https://drupal.org/project/entity_reference_revisions) and [Paragraphs](https://drupal.org/project/paragraphs),
+you may have advanced use-cases such as fetching drafts where you want to resolve these relationships using both ID and
+revision ID. You can nominate entity-type IDs where you wish to resolve relationships using the revision ID by adding
+them to the `entityReferenceRevisions` configuration option. Please note that `gatsby-source-drupal` only ever fetches
+the default (published) revision, so this functionality is only needed in advanced cases where you have custom code
+Drupal side that is applying additional logic.
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-drupal`,
+      options: {
+        baseUrl: `https://live-contentacms.pantheonsite.io/`,
+        apiBase: `api`,
+        entityReferenceRevisions: ["paragraph"], // optional, defaults to `[]`
+      },
+    },
+  ],
+}
+```
+
 ## Gatsby Preview (experimental)
 
 You will need to have the Drupal module installed, more information on that here: https://www.drupal.org/project/gatsby

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/article-includes.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/article-includes.json
@@ -16,6 +16,17 @@
             "id": "file-1"
           }
         },
+        "content": {
+          "data": [
+            {
+              "type": "paragraph--text",
+              "id": "08d07c95-26ab-46b8-a56d-0a55567b2e31",
+              "meta": {
+                "target_version": "4"
+              }
+            }
+          ]
+        },
         "field_tags": {
           "data": [
             {
@@ -44,6 +55,28 @@
           "alias": null,
           "pid": null,
           "langcode": "en"
+        }
+      }
+    },
+    {
+      "type": "paragraph--text",
+      "id": "08d07c95-26ab-46b8-a56d-0a55567b2e31",
+      "attributes": {
+        "drupal_internal__id": 14,
+        "drupal_internal__revision_id": 4,
+        "langcode": "en",
+        "status": true,
+        "created": "2020-09-18T07:56:28+00:00",
+        "parent_id": "5",
+        "parent_type": "node",
+        "parent_field_name": "content",
+        "behavior_settings": [],
+        "default_langcode": true,
+        "revision_translation_affected": null,
+        "body": {
+          "value": "Aenean porta turpis quis vulputate blandit",
+          "format": "plain_text",
+          "processed": "Aenean porta turpis quis vulputate blandit"
         }
       }
     }

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi-includes.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi-includes.json
@@ -4,6 +4,7 @@
     "self": "http://fixture/jsonapi",
     "file--file": "http://fixture/jsonapi/file/file",
     "node--article": "http://fixture/jsonapi/node/article-includes",
+    "paragraph--text": "http://fixture/jsonapi/paragraph/text",
     "taxonomy_term--tags": {
       "href": "http://fixture/jsonapi/taxonomy_term/tags"
     },

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
@@ -4,6 +4,7 @@
     "self": "http://fixture/jsonapi",
     "file--file": "http://fixture/jsonapi/file/file",
     "node--article": "http://fixture/jsonapi/node/article",
+    "paragraph--text": "http://fixture/jsonapi/paragraph/text",
     "taxonomy_term--tags": {
       "href": "http://fixture/jsonapi/taxonomy_term/tags"
     },

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/text.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/text.json
@@ -1,0 +1,56 @@
+{
+  "jsonapi": {
+    "version": "1.0",
+    "meta": {
+      "links": {
+        "self": {
+          "href": "http:\/\/jsonapi.org\/format\/1.0\/"
+        }
+      }
+    }
+  },
+  "data": [
+    {
+      "type": "paragraph--text",
+      "id": "08d07c95-26ab-46b8-a56d-0a55567b2e31",
+      "links": {
+        "self": {
+          "href": "http:\/\/localhost:8080\/api\/jsonapi\/paragraph\/text\/08d07c95-26ab-46b8-a56d-0a55567b2e31"
+        }
+      },
+      "attributes": {
+        "drupal_internal__id": 14,
+        "drupal_internal__revision_id": 3,
+        "langcode": "en",
+        "status": true,
+        "created": "2020-09-18T07:28:27+00:00",
+        "parent_id": "5",
+        "parent_type": "node",
+        "parent_field_name": "content",
+        "behavior_settings": [],
+        "default_langcode": true,
+        "revision_translation_affected": true,
+        "body": {
+          "value": "Aliquam non varius libero, sit amet consequat ex",
+          "format": "plain_text",
+          "processed": "Aliquam non varius libero, sit amet consequat ex"
+        }
+      },
+      "relationships": {
+        "paragraph_type": {
+          "data": null,
+          "links": {
+            "self": {
+              "href": "http:\/\/localhost:8080\/api\/jsonapi\/paragraph\/text\/08d07c95-26ab-46b8-a56d-0a55567b2e31\/relationships\/paragraph_type"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": {
+      "href": "http:\/\/localhost:8080\/api\/jsonapi\/paragraph\/text"
+    }
+  }
+}

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -381,7 +381,24 @@ describe(`gatsby-source-drupal`, () => {
     expect(nodes[createNodeId(`tag-1`)]).toBeUndefined()
     expect(nodes[createNodeId(`tag-2`)]).toBeUndefined()
     expect(nodes[createNodeId(`tag-3`)]).toBeDefined()
-    expect(nodes[createNodeId(`article-5`)]).toBeDefined()
+    const paragraphForwardRevisionId = createNodeId(
+      `08d07c95-26ab-46b8-a56d-0a55567b2e31.4`
+    )
+    const paragraphDraft = nodes[paragraphForwardRevisionId]
+    expect(paragraphDraft).toBeDefined()
+    expect(
+      nodes[createNodeId(`08d07c95-26ab-46b8-a56d-0a55567b2e31.3`)]
+    ).toBeDefined()
+    expect(nodes[createNodeId(`tag-3`)]).toBeDefined()
+
+    const article = nodes[createNodeId(`article-5`)]
+    expect(article).toBeDefined()
+    const paragraphRelationships = article.relationships[`content___NODE`]
+    expect(paragraphRelationships).toContain(paragraphForwardRevisionId)
+
+    expect(paragraphDraft.body.value).toEqual(
+      `Aenean porta turpis quis vulputate blandit`
+    )
   })
 
   describe(`Fastbuilds sync`, () => {

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -372,11 +372,18 @@ describe(`gatsby-source-drupal`, () => {
     // Reset nodes and test includes relationships.
     Object.keys(nodes).forEach(key => delete nodes[key])
     const disallowedLinkTypes = [`self`, `describedby`, `taxonomy_term--tags`]
+    const entityReferenceRevisions = [`paragraph`]
     const filters = {
       "node--article": `include=field_tags`,
     }
     const apiBase = `jsonapi-includes`
-    await sourceNodes(args, { baseUrl, apiBase, disallowedLinkTypes, filters })
+    await sourceNodes(args, {
+      baseUrl,
+      apiBase,
+      disallowedLinkTypes,
+      filters,
+      entityReferenceRevisions,
+    })
     expect(Object.keys(nodes).length).not.toEqual(0)
     expect(nodes[createNodeId(`tag-1`)]).toBeUndefined()
     expect(nodes[createNodeId(`tag-2`)]).toBeUndefined()

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -54,6 +54,7 @@ exports.sourceNodes = async (
     disallowedLinkTypes,
     skipFileDownloads,
     fastBuilds,
+    entityReferenceRevisions = [],
   } = pluginOptions
   const { createNode, setPluginStatus, touchNode } = actions
 
@@ -158,7 +159,8 @@ exports.sourceNodes = async (
                   createNodeIdWithVersion(
                     nodeSyncData.id,
                     nodeSyncData.type,
-                    nodeSyncData.attributes?.drupal_internal__revision_id
+                    nodeSyncData.attributes?.drupal_internal__revision_id,
+                    entityReferenceRevisions
                   )
                 )
               )
@@ -309,7 +311,7 @@ exports.sourceNodes = async (
     if (!contentType) return
     _.each(contentType.data, datum => {
       if (!datum) return
-      const node = nodeFromData(datum, createNodeId)
+      const node = nodeFromData(datum, createNodeId, entityReferenceRevisions)
       nodes.set(node.id, node)
     })
   })
@@ -319,6 +321,7 @@ exports.sourceNodes = async (
     handleReferences(node, {
       getNode: nodes.get.bind(nodes),
       createNodeId,
+      entityReferenceRevisions,
     })
   })
 

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -1,7 +1,12 @@
 const axios = require(`axios`)
 const _ = require(`lodash`)
 
-const { nodeFromData, downloadFile, isFileNode } = require(`./normalize`)
+const {
+  nodeFromData,
+  downloadFile,
+  isFileNode,
+  createNodeIdWithVersion,
+} = require(`./normalize`)
 const { handleReferences, handleWebhookUpdate } = require(`./utils`)
 
 const asyncPool = require(`tiny-async-pool`)
@@ -147,7 +152,17 @@ exports.sourceNodes = async (
         const nodesToSync = data.data.entities
         for (const nodeSyncData of nodesToSync) {
           if (nodeSyncData.action === `delete`) {
-            actions.deleteNode(getNode(createNodeId(nodeSyncData.id)))
+            actions.deleteNode(
+              getNode(
+                createNodeId(
+                  createNodeIdWithVersion(
+                    nodeSyncData.id,
+                    nodeSyncData.type,
+                    nodeSyncData.attributes?.drupal_internal__revision_id
+                  )
+                )
+              )
+            )
           } else {
             // The data could be a single Drupal entity or an array of Drupal
             // entities to update.

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -38,13 +38,13 @@ const isEntityReferenceRevision = (type, entityReferenceRevisions = []) =>
 const createNodeIdWithVersion = (
   id,
   type,
-  revision_id,
+  revisionId,
   entityReferenceRevisions = []
 ) =>
   // The relationship between an entity and another entity also depends on the revision ID if the field is of type
   // entity reference revision such as for paragraphs.
   isEntityReferenceRevision(type, entityReferenceRevisions)
-    ? `${id}.${revision_id || 0}`
+    ? `${id}.${revisionId || 0}`
     : id
 
 exports.createNodeIdWithVersion = createNodeIdWithVersion

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -6,7 +6,13 @@ const nodeFromData = (datum, createNodeId) => {
   const preservedId =
     typeof attributeId !== `undefined` ? { _attributes_id: attributeId } : {}
   return {
-    id: createNodeId(datum.id),
+    id: createNodeId(
+      createNodeIdWithVersion(
+        datum.id,
+        datum.type,
+        attributes.drupal_internal__revision_id
+      )
+    ),
     drupal_id: datum.id,
     parent: null,
     drupal_parent_menu_item: attributes.parent,
@@ -22,6 +28,15 @@ const nodeFromData = (datum, createNodeId) => {
 }
 
 exports.nodeFromData = nodeFromData
+
+const isEntityReferenceRevision = type => type.indexOf(`paragraph`) === 0
+
+const createNodeIdWithVersion = (id, type, revision_id) =>
+  // The relationship between an entity and another entity also depends on the revision ID if the field is of type
+  // entity reference revision such as for paragraphs.
+  isEntityReferenceRevision(type) ? `${id}.${revision_id || 0}` : id
+
+exports.createNodeIdWithVersion = createNodeIdWithVersion
 
 const isFileNode = node =>
   node.internal.type === `files` || node.internal.type === `file__file`

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -1,7 +1,7 @@
 const { URL } = require(`url`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
-const nodeFromData = (datum, createNodeId) => {
+const nodeFromData = (datum, createNodeId, entityReferenceRevisions = []) => {
   const { attributes: { id: attributeId, ...attributes } = {} } = datum
   const preservedId =
     typeof attributeId !== `undefined` ? { _attributes_id: attributeId } : {}
@@ -10,7 +10,8 @@ const nodeFromData = (datum, createNodeId) => {
       createNodeIdWithVersion(
         datum.id,
         datum.type,
-        attributes.drupal_internal__revision_id
+        attributes.drupal_internal__revision_id,
+        entityReferenceRevisions
       )
     ),
     drupal_id: datum.id,
@@ -29,12 +30,22 @@ const nodeFromData = (datum, createNodeId) => {
 
 exports.nodeFromData = nodeFromData
 
-const isEntityReferenceRevision = type => type.indexOf(`paragraph`) === 0
+const isEntityReferenceRevision = (type, entityReferenceRevisions = []) =>
+  entityReferenceRevisions.findIndex(
+    revisionType => type.indexOf(revisionType) === 0
+  ) !== -1
 
-const createNodeIdWithVersion = (id, type, revision_id) =>
+const createNodeIdWithVersion = (
+  id,
+  type,
+  revision_id,
+  entityReferenceRevisions = []
+) =>
   // The relationship between an entity and another entity also depends on the revision ID if the field is of type
   // entity reference revision such as for paragraphs.
-  isEntityReferenceRevision(type) ? `${id}.${revision_id || 0}` : id
+  isEntityReferenceRevision(type, entityReferenceRevisions)
+    ? `${id}.${revision_id || 0}`
+    : id
 
 exports.createNodeIdWithVersion = createNodeIdWithVersion
 

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -1,5 +1,10 @@
 const _ = require(`lodash`)
-const { nodeFromData, downloadFile, isFileNode } = require(`./normalize`)
+const {
+  nodeFromData,
+  downloadFile,
+  isFileNode,
+  createNodeIdWithVersion,
+} = require(`./normalize`)
 
 const backRefsNamesLookup = new WeakMap()
 const referencedNodesLookup = new WeakMap()
@@ -15,7 +20,13 @@ const handleReferences = (node, { getNode, createNodeId }) => {
       if (_.isArray(v.data)) {
         relationships[nodeFieldName] = _.compact(
           v.data.map(data => {
-            const referencedNodeId = createNodeId(data.id)
+            const referencedNodeId = createNodeId(
+              createNodeIdWithVersion(
+                data.id,
+                data.type,
+                data.meta?.target_version
+              )
+            )
             if (!getNode(referencedNodeId)) {
               return null
             }
@@ -35,7 +46,13 @@ const handleReferences = (node, { getNode, createNodeId }) => {
           node[k] = meta
         }
       } else {
-        const referencedNodeId = createNodeId(v.data.id)
+        const referencedNodeId = createNodeId(
+          createNodeIdWithVersion(
+            v.data.id,
+            v.data.type,
+            v.data.meta?.target_revision_id
+          )
+        )
         if (getNode(referencedNodeId)) {
           relationships[nodeFieldName] = referencedNodeId
           referencedNodes.push(referencedNodeId)

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -9,7 +9,10 @@ const {
 const backRefsNamesLookup = new WeakMap()
 const referencedNodesLookup = new WeakMap()
 
-const handleReferences = (node, { getNode, createNodeId }) => {
+const handleReferences = (
+  node,
+  { getNode, createNodeId, entityReferenceRevisions = [] }
+) => {
   const relationships = node.relationships
 
   if (node.drupal_relationships) {
@@ -24,7 +27,8 @@ const handleReferences = (node, { getNode, createNodeId }) => {
               createNodeIdWithVersion(
                 data.id,
                 data.type,
-                data.meta?.target_version
+                data.meta?.target_version,
+                entityReferenceRevisions
               )
             )
             if (!getNode(referencedNodeId)) {
@@ -50,7 +54,8 @@ const handleReferences = (node, { getNode, createNodeId }) => {
           createNodeIdWithVersion(
             v.data.id,
             v.data.type,
-            v.data.meta?.target_revision_id
+            v.data.meta?.target_revision_id,
+            entityReferenceRevisions
           )
         )
         if (getNode(referencedNodeId)) {
@@ -114,13 +119,18 @@ const handleWebhookUpdate = async (
 ) => {
   const { createNode } = actions
 
-  const newNode = nodeFromData(nodeToUpdate, createNodeId)
+  const newNode = nodeFromData(
+    nodeToUpdate,
+    createNodeId,
+    pluginOptions.entityReferenceRevisions
+  )
 
   const nodesToUpdate = [newNode]
 
   handleReferences(newNode, {
     getNode,
     createNodeId,
+    entityReferenceRevisions: pluginOptions.entityReferenceRevisions,
   })
 
   const oldNode = getNode(newNode.id)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

### Background 

1) Drupal supports fetching a forward revision of content. This is typically used to fetch a draft version.
This is done via appending ?resourceVersion=rel:working-copy to the URI as a user with appropriate permissions.
2) Drupal module `paragraphs` stores the relationship between the parent content and the paragraph item using the [entity reference revisions](https://www.drupal.org/project/entity_reference_revisions) module. With paragraphs, the relationship between the entity, and the entity that it references can vary by revision. For example, a draft node, can have a draft paragraph.
3) This means that for draft content, with a paragraphs field, it is not enough to reference the relationship using ID alone
4) To allow for this, the relationship field for a paragraph includes the target version in its meta e.g.
```json
{
    "type": "paragraph--text",
    "id": "08d07c95-26ab-46b8-a56d-0a55567b2e31",
    "meta": {
      "target_version": "4"
    }
  }
```

## Proposed resolution
Address paragraph entities using their version ID as well as their ID, as more than one version of a paragraph may exist between the /jsonapi/paragraph/{bundle} collection and the `?include=some_paragraph_field` for a given draft request

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
