### PR TITLE
fix(gatsby-plugin-sharp): make sure to pass the failOnError option to base64 generation (#29254)

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -274,7 +274,9 @@ async function generateBase64({ file, args = {}, reporter }) {
   })
   let pipeline
   try {
-    pipeline = sharp(file.absolutePath)
+    pipeline = !options.failOnError
+      ? sharp(file.absolutePath, { failOnError: false })
+      : sharp(file.absolutePath)
 
     if (!options.rotate) {
       pipeline.rotate()


### PR DESCRIPTION
Backporting #29254 to the 2.32 release branch

(cherry picked from commit bc0f5c8f12c3bfd01c653e428566ffba5f01edcc)