### PR TITLE
fix(gatsby-plugin-image): Correct layout proptypes in StaticImage

### DIFF
--- a/packages/gatsby-plugin-image/src/components/static-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/static-image.server.tsx
@@ -91,12 +91,12 @@ export const propTypes = {
     if (props.layout === undefined) {
       return undefined
     }
-    if (validLayouts.has(props.layout.toLowerCase())) {
+    if (validLayouts.has(props.layout)) {
       return undefined
     }
 
     return new Error(
-      `Invalid value ${props.layout}" provided for prop "layout". Defaulting to "fixed". Valid values are "fixed", "fullWidth" or "constrained".`
+      `Invalid value ${props.layout}" provided for prop "layout". Defaulting to "constrained". Valid values are "fixed", "fullWidth" or "constrained".`
     )
   },
 }


### PR DESCRIPTION
Fix the proptype comparison, as it was trying to compare a lower-case value with a camel-case option. I think it's fine to insist on correct casing here.