### PR TITLE
fix(gatsby-plugin-image): Correct layout proptypes in StaticImage (#29298)

### DIFF
--- a/packages/gatsby-plugin-image/src/components/static-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/static-image.server.tsx
@@ -91,12 +91,12 @@ export const propTypes = {
     if (props.layout === undefined) {
       return undefined
     }
-    if (validLayouts.has(props.layout.toLowerCase())) {
+    if (validLayouts.has(props.layout)) {
       return undefined
     }
 
     return new Error(
-      `Invalid value ${props.layout}" provided for prop "layout". Defaulting to "fixed". Valid values are "fixed", "fullWidth" or "constrained".`
+      `Invalid value ${props.layout}" provided for prop "layout". Defaulting to "constrained". Valid values are "fixed", "fullWidth" or "constrained".`
     )
   },
 }


### PR DESCRIPTION
Backporting #29298 to the 2.32 release branch

(cherry picked from commit 0b6f2e31ec01ee277d9d1e9c91ae0450add3dcfa)