### PR TITLE
chore: fix mdx for release notes with backticks around <sources>

### DIFF
--- a/docs/docs/reference/release-notes/v2.32/index.md
+++ b/docs/docs/reference/release-notes/v2.32/index.md
@@ -68,7 +68,7 @@ A big **Thank You** to [our community who contributed](https://github.com/gatsby
   - chore(docs): Fix grammar in add-404-page [PR #29079](https://github.com/gatsbyjs/gatsby/pull/29079)
   - fix(gatsby-plugin-styled-components): add `namespace` option [PR #29095](https://github.com/gatsbyjs/gatsby/pull/29095)
 
-- [Grsmto](https://github.com/Grsmto): fix(gatsby-plugin-image): pass down missing sizes attribute to <sources> [PR #29092](https://github.com/gatsbyjs/gatsby/pull/29092)
+- [Grsmto](https://github.com/Grsmto): fix(gatsby-plugin-image): pass down missing sizes attribute to `<sources>` [PR #29092](https://github.com/gatsbyjs/gatsby/pull/29092)
 
 - [StefanSelfTaught](https://github.com/StefanSelfTaught): Update creating-a-local-plugin.md [PR #28072](https://github.com/gatsbyjs/gatsby/pull/28072)
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Rendering the release notes as MDX seems to break builds of content sourcing from here (ie on gatsbyjs.com):

```
unknown: Expected corresponding JSX closing tag for  (57:273)
  56 | <li parentName="ul">
> 57 | <p parentName="li"><a parentName="p" {...{"href":"https://github.com/Grsmto"}}>{`Grsmto`}</a>{`: fix(gatsby-plugin-image): pass down missing sizes attribute to `}<sources>{` `}<a parentName="p" {...{"href":"https://github.com/gatsbyjs/gatsby/pull/29092"}}>{`PR #29092`}</a></p>
     |                                                                                                                                                                                                                                                                                  ^
  58 | </li>
```

MDX thinks <sources> needs a closing tag for it. I believe backticks will fix this.
