### PR TITLE
refactor(gatsby-plugin-manifest): don't import fs in ssr code

### DIFF
--- a/packages/gatsby-plugin-manifest/src/__tests__/common.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/common.js
@@ -1,22 +1,9 @@
-const path = require(`path`)
-const { defaultIcons, doesIconExist, addDigestToPath } = require(`../common`)
+const { defaultIcons, addDigestToPath } = require(`../common`)
 
 describe(`gatsby-plugin-manifest`, () => {
   describe(`defaultIcons`, () => {
     it(`includes all icon sizes`, () => {
       expect(defaultIcons).toMatchSnapshot()
-    })
-  })
-
-  describe(`doesIconExist`, () => {
-    it(`returns true if image exists on filesystem`, () => {
-      const iconSrc = path.resolve(__dirname, `./images/gatsby-logo.png`)
-      expect(doesIconExist(iconSrc)).toBeTruthy()
-    })
-
-    it(`returns false if image does not exist on filesystem`, () => {
-      const iconSrc = path.resolve(__dirname, `./images/non-existent-logo.png`)
-      expect(doesIconExist(iconSrc)).toBeFalsy()
     })
   })
 

--- a/packages/gatsby-plugin-manifest/src/__tests__/node-helpers.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/node-helpers.js
@@ -1,0 +1,16 @@
+const path = require(`path`)
+const { doesIconExist } = require(`../node-helpers`)
+
+describe(`gatsby-plugin-manifest`, () => {
+  describe(`doesIconExist`, () => {
+    it(`returns true if image exists on filesystem`, () => {
+      const iconSrc = path.resolve(__dirname, `./images/gatsby-logo.png`)
+      expect(doesIconExist(iconSrc)).toBeTruthy()
+    })
+
+    it(`returns false if image does not exist on filesystem`, () => {
+      const iconSrc = path.resolve(__dirname, `./images/non-existent-logo.png`)
+      expect(doesIconExist(iconSrc)).toBeFalsy()
+    })
+  })
+})

--- a/packages/gatsby-plugin-manifest/src/common.js
+++ b/packages/gatsby-plugin-manifest/src/common.js
@@ -1,4 +1,3 @@
-import fs from "fs"
 import sysPath from "path"
 
 exports.favicons = [
@@ -52,23 +51,6 @@ exports.defaultIcons = [
     type: `image/png`,
   },
 ]
-
-/**
- * Check if the icon exists on the filesystem
- *
- * @param {String} srcIcon Path of the icon
- */
-exports.doesIconExist = function doesIconExist(srcIcon) {
-  try {
-    return fs.statSync(srcIcon).isFile()
-  } catch (e) {
-    if (e.code !== `ENOENT`) {
-      throw e
-    }
-
-    return false
-  }
-}
 
 /**
  * @param {string} path The generic path to an icon

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -2,12 +2,8 @@ import * as fs from "fs"
 import * as path from "path"
 import sharp from "./safe-sharp"
 import { createContentDigest, cpuCoreCount, slash } from "gatsby-core-utils"
-import {
-  defaultIcons,
-  doesIconExist,
-  addDigestToPath,
-  favicons,
-} from "./common"
+import { defaultIcons, addDigestToPath, favicons } from "./common"
+import { doesIconExist } from "./node-helpers"
 
 import pluginOptionsSchema from "./pluginOptionsSchema"
 

--- a/packages/gatsby-plugin-manifest/src/node-helpers.js
+++ b/packages/gatsby-plugin-manifest/src/node-helpers.js
@@ -1,0 +1,18 @@
+import * as fs from "fs"
+
+/**
+ * Check if the icon exists on the filesystem
+ *
+ * @param {String} srcIcon Path of the icon
+ */
+export function doesIconExist(srcIcon) {
+  try {
+    return fs.statSync(srcIcon).isFile()
+  } catch (e) {
+    if (e.code !== `ENOENT`) {
+      throw e
+    }
+
+    return false
+  }
+}


### PR DESCRIPTION
This is just slight refactor - it moves code that use `fs` from `common.js` that is shared by `gatsby-node` and `gatsby-ssr` to separate helper to avoid using `fs` in SSR