### PR TITLE
feat: add deprecate function to reporter

### DIFF
--- a/packages/gatsby-cli/src/reporter/__tests__/index.ts
+++ b/packages/gatsby-cli/src/reporter/__tests__/index.ts
@@ -27,7 +27,7 @@ describe(`report.error`, () => {
     ;(reporterActions.createLog as jest.Mock).mockClear()
 
     jest.isolateModules(() => {
-      reporter = require("../reporter").reporter
+      reporter = require(`../reporter`).reporter
       // We don't care about this
       reporter.log = jest.fn()
     })
@@ -113,14 +113,14 @@ describe(`report.error`, () => {
 
 describe(`report.deprecate`, () => {
   const level = `DEPRECATION`
-  const code = "JEST"
-  const text = "deprecate me"
+  const code = `JEST`
+  const text = `deprecate me`
   let reporter: Reporter
   beforeEach(() => {
     ;(reporterActions.createLog as jest.Mock).mockClear()
 
     jest.isolateModules(() => {
-      reporter = require("../reporter").reporter
+      reporter = require(`../reporter`).reporter
       // We don't care about this
       reporter.log = jest.fn()
     })
@@ -134,7 +134,7 @@ describe(`report.deprecate`, () => {
 
     expect(reporterActions.createLog).toBeCalledWith({
       level,
-      category: "USER",
+      category: `USER`,
       text,
       pluginName: undefined,
     })
@@ -144,14 +144,14 @@ describe(`report.deprecate`, () => {
     reporter.deprecate({
       code,
       text,
-      pluginName: "gatsby-plugin-jest",
+      pluginName: `gatsby-plugin-jest`,
     })
 
     expect(reporterActions.createLog).toBeCalledWith({
       level,
-      category: "THIRD_PARTY",
+      category: `THIRD_PARTY`,
       text,
-      pluginName: "gatsby-plugin-jest",
+      pluginName: `gatsby-plugin-jest`,
     })
   })
 
@@ -159,31 +159,31 @@ describe(`report.deprecate`, () => {
     reporter.deprecate({
       code,
       text,
-      pluginName: "gatsby-plugin-jest",
+      pluginName: `gatsby-plugin-jest`,
     })
     reporter.deprecate({
       code,
       text,
-      pluginName: "gatsby-plugin-jest",
+      pluginName: `gatsby-plugin-jest`,
     })
     reporter.deprecate({
       code,
       text,
-      pluginName: "gatsby-plugin-test",
+      pluginName: `gatsby-plugin-test`,
     })
 
     expect(reporterActions.createLog).toBeCalledTimes(2)
     expect(reporterActions.createLog).toBeCalledWith({
       level,
-      category: "THIRD_PARTY",
+      category: `THIRD_PARTY`,
       text,
-      pluginName: "gatsby-plugin-jest",
+      pluginName: `gatsby-plugin-jest`,
     })
     expect(reporterActions.createLog).toBeCalledWith({
       level,
-      category: "THIRD_PARTY",
+      category: `THIRD_PARTY`,
       text,
-      pluginName: "gatsby-plugin-test",
+      pluginName: `gatsby-plugin-test`,
     })
   })
 })

--- a/packages/gatsby-cli/src/reporter/constants.ts
+++ b/packages/gatsby-cli/src/reporter/constants.ts
@@ -13,6 +13,7 @@ export enum Actions {
 }
 
 export enum LogLevels {
+  Deprecation = `DEPRECATION`,
   Debug = `DEBUG`,
   Success = `SUCCESS`,
   Info = `INFO`,

--- a/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
@@ -87,7 +87,7 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
         <Box flexDirection="column">
           <Static items={messages}>
             {(message): React.ReactElement => {
-              if (message.level === "ERROR") {
+              if (message.level === `ERROR`) {
                 return (
                   <ErrorComponent
                     details={message as IStructuredError}
@@ -96,7 +96,7 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
                 )
               }
 
-              if (message.level === "DEPRECATION") {
+              if (message.level === `DEPRECATION`) {
                 return (
                   <DeprecationComponent
                     details={message}

--- a/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "./components/spinner"
 import { ProgressBar } from "./components/progress-bar"
 import { Message, IMessageProps } from "./components/messages"
 import { Error as ErrorComponent } from "./components/error"
+import { Deprecation as DeprecationComponent } from "./components/deprecation"
 import Develop from "./components/develop"
 import { IGatsbyCLIState, IActivity } from "../../redux/types"
 import { ActivityLogLevels } from "../../constants"
@@ -85,19 +86,32 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
       <Box flexDirection="column">
         <Box flexDirection="column">
           <Static items={messages}>
-            {(message): React.ReactElement =>
-              message.level === `ERROR` ? (
-                <ErrorComponent
-                  details={message as IStructuredError}
-                  key={messages.indexOf(message)}
-                />
-              ) : (
+            {(message): React.ReactElement => {
+              if (message.level === "ERROR") {
+                return (
+                  <ErrorComponent
+                    details={message as IStructuredError}
+                    key={messages.indexOf(message)}
+                  />
+                )
+              }
+
+              if (message.level === "DEPRECATION") {
+                return (
+                  <DeprecationComponent
+                    details={message}
+                    key={messages.indexOf(message)}
+                  />
+                )
+              }
+
+              return (
                 <Message
                   key={messages.indexOf(message)}
                   {...(message as IMessageProps)}
                 />
               )
-            }
+            }}
           </Static>
 
           {spinners.map(activity => (

--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/deprecation.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/deprecation.tsx
@@ -1,0 +1,44 @@
+import React, { FunctionComponent } from "react"
+import { Box, Text } from "ink"
+
+export interface IDeprecationProps {
+  details: {
+    level: string
+    text?: string
+    pluginName?: string
+  }
+}
+
+export const Deprecation: FunctionComponent<IDeprecationProps> = React.memo(
+  ({ details }) => (
+    <Box marginY={1} flexDirection="column">
+      <Box flexDirection="column">
+        <Box flexDirection="column">
+          <Box>
+            <Box marginRight={1}>
+              <Text color="black" backgroundColor="yellow">
+                {` ${details.level} `}
+              </Text>
+            </Box>
+          </Box>
+          <Box marginTop={1}>
+            <Text>{details.text}</Text>
+          </Box>
+        </Box>
+        {details.pluginName && (
+          <Box marginTop={1} flexDirection="column">
+            <Text color="gray">
+              {`─`.repeat(`Plugin: ${details.pluginName}`.length)}
+            </Text>
+            <Text color="gray" dimColor>
+              Plugin: {details.pluginName}
+            </Text>
+            <Text color="gray">
+              {`─`.repeat(`Plugin: ${details.pluginName}`.length)}
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+)

--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/deprecation.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/deprecation.tsx
@@ -10,35 +10,38 @@ export interface IDeprecationProps {
 }
 
 export const Deprecation: FunctionComponent<IDeprecationProps> = React.memo(
-  ({ details }) => (
-    <Box marginY={1} flexDirection="column">
-      <Box flexDirection="column">
+  ({ details }) => {
+    let pluginNameMessage: string | null = null
+    if (details.pluginName) {
+      pluginNameMessage = `Plugin: ${details.pluginName} - upgrade to the latest version or contact the plugin author.`
+    }
+
+    return (
+      <Box marginY={1} flexDirection="column">
         <Box flexDirection="column">
-          <Box>
-            <Box marginRight={1}>
-              <Text color="black" backgroundColor="yellow">
-                {` ${details.level} `}
-              </Text>
+          <Box flexDirection="column">
+            <Box>
+              <Box marginRight={1}>
+                <Text color="black" backgroundColor="yellow">
+                  {` ${details.level} `}
+                </Text>
+              </Box>
+            </Box>
+            <Box marginTop={1}>
+              <Text>{details.text}</Text>
             </Box>
           </Box>
-          <Box marginTop={1}>
-            <Text>{details.text}</Text>
-          </Box>
+          {pluginNameMessage && (
+            <Box marginTop={1} flexDirection="column">
+              <Text color="gray">{`─`.repeat(pluginNameMessage.length)}</Text>
+              <Text color="gray" dimColor>
+                {pluginNameMessage}
+              </Text>
+              <Text color="gray">{`─`.repeat(pluginNameMessage.length)}</Text>
+            </Box>
+          )}
         </Box>
-        {details.pluginName && (
-          <Box marginTop={1} flexDirection="column">
-            <Text color="gray">
-              {`─`.repeat(`Plugin: ${details.pluginName}`.length)}
-            </Text>
-            <Text color="gray" dimColor>
-              Plugin: {details.pluginName}
-            </Text>
-            <Text color="gray">
-              {`─`.repeat(`Plugin: ${details.pluginName}`.length)}
-            </Text>
-          </Box>
-        )}
       </Box>
-    </Box>
-  )
+    )
+  }
 )

--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/deprecation.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/deprecation.tsx
@@ -13,7 +13,11 @@ export const Deprecation: FunctionComponent<IDeprecationProps> = React.memo(
   ({ details }) => {
     let pluginNameMessage: string | null = null
     if (details.pluginName) {
-      pluginNameMessage = `Plugin: ${details.pluginName} - upgrade to the latest version or contact the plugin author.`
+      if (details.pluginName === `default-site-plugin`) {
+        pluginNameMessage = `Your gatsby-node.js`
+      } else {
+        pluginNameMessage = `Plugin: ${details.pluginName} - upgrade to the latest version or contact the plugin author.`
+      }
     }
 
     return (

--- a/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
+++ b/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
@@ -31,6 +31,11 @@ export function initializeYurnalistLogger(): void {
     [LogLevels.Info]: yurnalist.info.bind(yurnalist),
     [LogLevels.Success]: yurnalist.success.bind(yurnalist),
     [LogLevels.Debug]: yurnalist.verbose.bind(yurnalist),
+    [LogLevels.Deprecation]: (text: string): void => {
+      yurnalist.log(
+        `\n${chalk.black.bgYellow(` ${LogLevels.Deprecation} `)}\n\n${text}\n`
+      )
+    },
     [ActivityLogLevels.Success]: yurnalist.success.bind(yurnalist),
     [ActivityLogLevels.Failed]: (text: string): void => {
       yurnalist.log(`${chalk.red(`failed`)} ${text}`)
@@ -53,6 +58,24 @@ export function initializeYurnalistLogger(): void {
           }
           if (action.payload.statusText) {
             message += ` - ${action.payload.statusText}`
+          }
+
+          if (
+            action.payload.level === LogLevels.Deprecation &&
+            action.payload.pluginName
+          ) {
+            let pluginNameMessage: null | string = null
+            if (action.payload.pluginName === `default-site-plugin`) {
+              pluginNameMessage = `Your gatsby-node.js`
+            } else {
+              pluginNameMessage = `Plugin: ${action.payload.pluginName} - upgrade to the latest version or contact the plugin author.`
+            }
+
+            message += `\n${chalk.gray(
+              `\n${`─`.repeat(
+                pluginNameMessage.length
+              )}\n${pluginNameMessage}\n${`─`.repeat(pluginNameMessage.length)}`
+            )}`
           }
           yurnalistMethod(message)
         }

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -7,7 +7,11 @@ import * as reporterActions from "./redux/actions"
 import { LogLevels, ActivityStatuses } from "./constants"
 import { getErrorFormatter } from "./errors"
 import constructError from "../structured-errors/construct-error"
-import { IErrorMapEntry, ErrorId } from "../structured-errors/error-map"
+import {
+  IErrorMapEntry,
+  ErrorId,
+  ErrorCategory,
+} from "../structured-errors/error-map"
 import { prematureEnd } from "./catch-exit-signals"
 import { IStructuredError } from "../structured-errors/types"
 import { createTimerReporter, ITimerReporter } from "./reporter-timer"
@@ -205,13 +209,19 @@ class Reporter {
 
     deprecationCache.add(cacheKey)
 
-    // TODO add telemetry
-    reporterActions.createLog({
+    const structuredLog = {
+      id: code,
       level: LogLevels.Deprecation,
-      category: pluginName ? `THIRD_PARTY` : `USER`,
+      category: (pluginName
+        ? `THIRD_PARTY`
+        : `USER`) as keyof typeof ErrorCategory,
       pluginName,
       ...messageObj,
-    })
+    }
+
+    trackError(`GENERIC_DEPRECATION`, { error: structuredLog, pluginName })
+
+    reporterActions.createLog(structuredLog)
   }
 
   success = (text?: string): CreateLogAction =>

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -26,6 +26,9 @@ export interface IActivityArgs {
 
 let isVerbose = false
 
+// only show deprecations once
+const deprecationCache = new Set()
+
 /**
  * Reporter module.
  * @module reporter
@@ -183,6 +186,32 @@ class Reporter {
         text,
       })
     }
+  }
+
+  deprecate = ({
+    pluginName,
+    code,
+    ...messageObj
+  }: {
+    code: string
+    text: string
+    pluginName?: string
+  }): void => {
+    const cacheKey = `${pluginName ?? ``}-${code}`
+
+    if (deprecationCache.has(cacheKey)) {
+      return
+    }
+
+    deprecationCache.add(cacheKey)
+
+    // TODO add telemetry
+    reporterActions.createLog({
+      level: LogLevels.Deprecation,
+      category: pluginName ? `THIRD_PARTY` : `USER`,
+      pluginName,
+      ...messageObj,
+    })
   }
 
   success = (text?: string): CreateLogAction =>

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -1,6 +1,6 @@
 import { stripIndent } from "common-tags"
 import chalk from "chalk"
-import { trackError } from "gatsby-telemetry"
+import { trackError, trackMessage } from "gatsby-telemetry"
 import { globalTracer, Span } from "opentracing"
 
 import * as reporterActions from "./redux/actions"
@@ -210,7 +210,7 @@ class Reporter {
     deprecationCache.add(cacheKey)
 
     const structuredLog = {
-      id: code,
+      ids: code,
       level: LogLevels.Deprecation,
       category: (pluginName
         ? `THIRD_PARTY`
@@ -219,7 +219,7 @@ class Reporter {
       ...messageObj,
     }
 
-    trackError(`GENERIC_DEPRECATION`, { error: structuredLog, pluginName })
+    trackMessage({ message: structuredLog, pluginName })
 
     reporterActions.createLog(structuredLog)
   }

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -201,6 +201,10 @@ class Reporter {
     text: string
     pluginName?: string
   }): void => {
+    if (!code) {
+      throw new Error(`"code" is required param for reporter.deprecate`)
+    }
+
     const cacheKey = `${pluginName ?? ``}-${code}`
 
     if (deprecationCache.has(cacheKey)) {

--- a/packages/gatsby-cli/src/structured-errors/error-schema.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-schema.ts
@@ -21,7 +21,13 @@ export const errorSchema: Joi.ObjectSchema<IStructuredError> = Joi.object().keys
       )
       .allow(null),
     category: Joi.string().valid([`USER`, `SYSTEM`, `THIRD_PARTY`]),
-    level: Joi.string().valid([`ERROR`, `WARNING`, `INFO`, `DEBUG`]),
+    level: Joi.string().valid([
+      `ERROR`,
+      `WARNING`,
+      `INFO`,
+      `DEBUG`,
+      `DEPRECATION`,
+    ]),
     type: Joi.string().valid([`GRAPHQL`, `CONFIG`, `WEBPACK`, `PLUGIN`]),
     filePath: Joi.string(),
     location: Joi.object({

--- a/packages/gatsby-cli/src/structured-errors/types.ts
+++ b/packages/gatsby-cli/src/structured-errors/types.ts
@@ -21,6 +21,16 @@ export interface IStructuredStackFrame {
   columnNumber?: number
 }
 
+export interface IStructuredLog {
+  code?: string
+  text: string
+  category?: keyof typeof ErrorCategory
+  group?: string
+  level: IErrorMapEntry["level"]
+  type?: IErrorMapEntry["type"]
+  docsUrl?: string
+}
+
 export interface IStructuredError {
   code?: string
   text: string
@@ -50,6 +60,7 @@ export enum Level {
   WARNING = `WARNING`,
   INFO = `INFO`,
   DEBUG = `DEBUG`,
+  DEPRECATION = `DEPRECATION`,
 }
 
 export enum Type {

--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -4,6 +4,7 @@ import {
   ITelemetryTagsPayload,
   ITelemetryOptsPayload,
   IDefaultTelemetryTagsPayload,
+  IStructuredError,
 } from "./telemetry"
 import { Request, Response } from "express"
 import { createFlush } from "./create-flush"
@@ -53,6 +54,16 @@ export function captureEvent(
 
 export function trackError(input: string, tags?: ITelemetryTagsPayload): void {
   instance.captureError(input, tags)
+}
+
+export function trackMessage(
+  tags: ITelemetryTagsPayload & {
+    message: IStructuredError & {
+      level: NonNullable<IStructuredError["level"]>
+    }
+  }
+): void {
+  instance.captureMessage(tags.message.level, tags)
 }
 
 export function trackBuildError(
@@ -127,6 +138,7 @@ module.exports = {
   trackFeatureIsUsed,
   trackCli,
   trackError,
+  trackMessage,
   trackBuildError,
   setDefaultTags,
   decorateEvent,

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -304,9 +304,21 @@ export class AnalyticsTracker {
 
     const decoration = this.metadataCache[type]
     delete this.metadataCache[type]
-    const eventType = `CLI_ERROR_${type}`
+    const eventType = `ERROR_${type}`
 
     this.formatErrorAndStoreEvent(eventType, lodash.merge({}, tags, decoration))
+  }
+
+  captureMessage(type: string, tags: ITelemetryTagsPayload = {}): void {
+    if (!this.isTrackingEnabled()) {
+      return
+    }
+
+    const decoration = this.metadataCache[type]
+    delete this.metadataCache[type]
+    const eventType = `MESSAGE_${type}`
+
+    this.buildAndStoreEvent(eventType, lodash.merge({}, tags, decoration))
   }
 
   captureBuildError(type: string, tags: ITelemetryTagsPayload = {}): void {

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -175,7 +175,6 @@ function extendLocalReporterToCatchPluginErrors({
   let panic = reporter.panic
   let panicOnBuild = reporter.panicOnBuild
 
-  const isDefaultPlugin = pluginName === `default-site-plugin`
   const addPluginNameToErrorMeta = (errorMeta, pluginName) =>
     typeof errorMeta === `string`
       ? {
@@ -236,7 +235,7 @@ function extendLocalReporterToCatchPluginErrors({
     deprecate: args => {
       reporter.deprecate({
         ...args,
-        pluginName: isDefaultPlugin ? pluginName : pluginName,
+        pluginName,
       })
     },
     activityTimer: (...args) => {

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -175,6 +175,7 @@ function extendLocalReporterToCatchPluginErrors({
   let panic = reporter.panic
   let panicOnBuild = reporter.panicOnBuild
 
+  const isDefaultPlugin = pluginName === `default-site-plugin`
   const addPluginNameToErrorMeta = (errorMeta, pluginName) =>
     typeof errorMeta === `string`
       ? {
@@ -232,6 +233,12 @@ function extendLocalReporterToCatchPluginErrors({
     error,
     panic,
     panicOnBuild,
+    deprecate: args => {
+      reporter.deprecate({
+        ...args,
+        pluginName: isDefaultPlugin ? pluginName : pluginName,
+      })
+    },
     activityTimer: (...args) => {
       const activity = reporter.activityTimer.apply(reporter, args)
 


### PR DESCRIPTION
## Description

Add `reporter.deprecate` to make it easier to show deprecation messages and automatically track usage.
An extra feature is that it only shows a message only once.

![deprecation message](https://user-images.githubusercontent.com/1120926/106677889-e2998880-65b9-11eb-8c21-8794e0de0ebc.png)
