### PR TITLE
fix(gatsby): fast-refresh eslint loader should be less intrusive

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -8,9 +8,13 @@ const eslintRequirePreset = require.resolve(`./eslint/required`)
 export const eslintRequiredConfig: CLIEngine.Options = {
   rulePaths: [eslintRulePaths],
   useEslintrc: false,
+  allowInlineConfig: false,
+  // @ts-ignore
+  emitWarning: true,
+  parser: require.resolve(`babel-eslint`),
   baseConfig: {
     parserOptions: {
-      ecmaVersion: 2018,
+      ecmaVersion: 2020,
       sourceType: `module`,
       ecmaFeatures: {
         jsx: true,


### PR DESCRIPTION
## Description

Basically, a follow up for #29130 that also adds `allowInlineConfig: false` to fix this part: https://github.com/gatsbyjs/gatsby/issues/29105#issuecomment-766398875

## Related Issues

Fixes #29105

Fixes #29133