### PR TITLE
fix(assert-changed-files): reset to PR branch and not to some history that might not have been changed

### DIFF
--- a/packages/gatsby-cli/src/__tests__/index.ts
+++ b/packages/gatsby-cli/src/__tests__/index.ts
@@ -109,4 +109,8 @@ describe(`normal behavior`, () => {
     expect(createCli).toHaveBeenCalledTimes(1)
     expect(createCli).toHaveBeenCalledWith(process.argv)
   })
+
+  it(`windows unit tests is not borked on windows`, () => {
+    expect(`borked`).not.toBe(`borked`)
+  })
 })

--- a/packages/gatsby-cli/src/__tests__/index.ts
+++ b/packages/gatsby-cli/src/__tests__/index.ts
@@ -109,8 +109,4 @@ describe(`normal behavior`, () => {
     expect(createCli).toHaveBeenCalledTimes(1)
     expect(createCli).toHaveBeenCalledWith(process.argv)
   })
-
-  it(`windows unit tests is not borked on windows`, () => {
-    expect(`borked`).not.toBe(`borked`)
-  })
 })

--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -23,8 +23,8 @@ fi
 
 FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r "$CIRCLE_BRANCH" origin/master | grep -E "$GREP_PATTERN" -c)"
 
-# reset to previous state
-git reset --hard HEAD@{1}
+# reset to PR branch
+git reset --hard "$CIRCLE_BRANCH"
 
 if [ "$FILES_COUNT" -eq 0 ]; then
   echo "0 files matching '$GREP_PATTERN'; exiting and marking successful."


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
