### PR TITLE
chore(gatsby-source-wordpress): Update querying-data tutorial

### DIFF
--- a/packages/gatsby-source-wordpress/docs/tutorials/querying-data.md
+++ b/packages/gatsby-source-wordpress/docs/tutorials/querying-data.md
@@ -72,7 +72,7 @@ We can add this to our previous snippet, so it will become the following:
 
 ```js
 exports.createPages = async ({ actions, graphql, reporter }) => {
-  const result = graphql(`
+  const result = await graphql(`
     {
       allWpPost {
         nodes {
@@ -171,7 +171,7 @@ The full snippet should now look like the following:
 
 ```js
 exports.createPages = async ({ actions, graphql, reporter }) => {
-  const result = graphql(`
+  const result = await graphql(`
     {
       allWpPost {
         nodes {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

When following these steps I ran into errors as `const { allWpPost } = result.data` was being ran before the graphql promise had finished, `await` was not being used. Adding `await` fixed said errors.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

I have added `await` before the `graphql` function in 2 snippets

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
