### PR TITLE
docs(wordpress): fix broken assets link after migration

### DIFF
--- a/packages/gatsby-source-wordpress/docs/tutorials/configuring-wp-gatsby.md
+++ b/packages/gatsby-source-wordpress/docs/tutorials/configuring-wp-gatsby.md
@@ -13,7 +13,7 @@ Navigate to your GatsbyJS WordPress settings by visiting this path in your WP in
 
 You should see the following "Builds Webhook" field at the top of the page:
 
-![WPGatsby Builds Webhook Screenshot](/docs/assets/wp-gatsby-builds-webhook-settings.png)
+![WPGatsby Builds Webhook Screenshot](/packages/gatsby-source-wordpress/docs/assets/wp-gatsby-builds-webhook-settings.png)
 
 Enter the Webhook that should be used, a POST request will be sent to the Webhook when content is updated in WordPress.
 
@@ -21,7 +21,7 @@ If you're using [Gatsby Cloud](https://www.gatsbyjs.com/dashboard/sites), you ca
 
 Below your "Preview Webhook" you should see your "Builds Webhook". Copy this webhook and enter it into your WordPress settings.
 
-![Gatsby Cloud Builds Webhook Screenshot](/docs/assets/gatsby-cloud-builds-webhook.png)
+![Gatsby Cloud Builds Webhook Screenshot](/packages/gatsby-source-wordpress/docs/assets/gatsby-cloud-builds-webhook.png)
 
 Now that your Builds webhook is set up, when content is updated in WordPress your content will update in 4 to 12 seconds if you're using Gatsby Cloud with Incremental Builds, and in 45 seconds to a few minutes (and beyond) if you're using other services! :rocket:
 
@@ -41,7 +41,7 @@ You will see 4 fields related to Gatsby Preview. "Enable Gatsby Preview?", "Prev
 
 If you don't see this settings page, or you don't see these 4 fields, make sure the latest version of [WPGatsby](https://github.com/gatsbyjs/wp-gatsby) is installed in your WordPress instance.
 
-![wp-gatsbyjs-preview-settings](/docs/assets/wp-gatsbyjs-preview-settings.png)
+![wp-gatsbyjs-preview-settings](/packages/gatsby-source-wordpress/docs/assets/wp-gatsbyjs-preview-settings.png)
 
 #### 1. Check the "Enable Gatsby Preview?" Checkbox
 
@@ -53,13 +53,13 @@ This field should be filled with the public frontend URL of your Gatsby Preview 
 
 To find your **Preview Instance URL**, navigate to the "Preview" tab in [Gatsby Cloud](https://www.gatsbyjs.com/dashboard/sites), wait for your first Preview build to complete, and then copy the frontend URL from above the build history list in the center of the page.
 
-![Gatsby Cloud Preview frontend URL Screenshot](/docs/assets/gatsby-cloud-preview-frontend-url.png)
+![Gatsby Cloud Preview frontend URL Screenshot](/packages/gatsby-source-wordpress/docs/assets/gatsby-cloud-preview-frontend-url.png)
 
 #### 3. Fill the "Preview Webhook" Field
 
 You can find your **Preview webhook** by navigating to "Site Settings" in Gatsby Cloud and then navigating to "Webhooks" via the left-side menu.
 
-![Gatsby Cloud Preview Webhook URL](/docs/assets/gatsby-cloud-preview-webhook-url.png)
+![Gatsby Cloud Preview Webhook URL](/packages/gatsby-source-wordpress/docs/assets/gatsby-cloud-preview-webhook-url.png)
 
 #### 4. Double check the "Preview JWT secret" field
 

--- a/packages/gatsby-source-wordpress/docs/tutorials/configuring-wp-gatsby.md
+++ b/packages/gatsby-source-wordpress/docs/tutorials/configuring-wp-gatsby.md
@@ -13,7 +13,7 @@ Navigate to your GatsbyJS WordPress settings by visiting this path in your WP in
 
 You should see the following "Builds Webhook" field at the top of the page:
 
-![WPGatsby Builds Webhook Screenshot](/packages/gatsby-source-wordpress/docs/assets/wp-gatsby-builds-webhook-settings.png)
+![WPGatsby Builds Webhook Screenshot](../../docs/assets/wp-gatsby-builds-webhook-settings.png)
 
 Enter the Webhook that should be used, a POST request will be sent to the Webhook when content is updated in WordPress.
 
@@ -21,7 +21,7 @@ If you're using [Gatsby Cloud](https://www.gatsbyjs.com/dashboard/sites), you ca
 
 Below your "Preview Webhook" you should see your "Builds Webhook". Copy this webhook and enter it into your WordPress settings.
 
-![Gatsby Cloud Builds Webhook Screenshot](/packages/gatsby-source-wordpress/docs/assets/gatsby-cloud-builds-webhook.png)
+![Gatsby Cloud Builds Webhook Screenshot](../../docs/assets/gatsby-cloud-builds-webhook.png)
 
 Now that your Builds webhook is set up, when content is updated in WordPress your content will update in 4 to 12 seconds if you're using Gatsby Cloud with Incremental Builds, and in 45 seconds to a few minutes (and beyond) if you're using other services! :rocket:
 
@@ -41,7 +41,7 @@ You will see 4 fields related to Gatsby Preview. "Enable Gatsby Preview?", "Prev
 
 If you don't see this settings page, or you don't see these 4 fields, make sure the latest version of [WPGatsby](https://github.com/gatsbyjs/wp-gatsby) is installed in your WordPress instance.
 
-![wp-gatsbyjs-preview-settings](/packages/gatsby-source-wordpress/docs/assets/wp-gatsbyjs-preview-settings.png)
+![wp-gatsbyjs-preview-settings](../../docs/assets/wp-gatsbyjs-preview-settings.png)
 
 #### 1. Check the "Enable Gatsby Preview?" Checkbox
 
@@ -53,13 +53,13 @@ This field should be filled with the public frontend URL of your Gatsby Preview 
 
 To find your **Preview Instance URL**, navigate to the "Preview" tab in [Gatsby Cloud](https://www.gatsbyjs.com/dashboard/sites), wait for your first Preview build to complete, and then copy the frontend URL from above the build history list in the center of the page.
 
-![Gatsby Cloud Preview frontend URL Screenshot](/packages/gatsby-source-wordpress/docs/assets/gatsby-cloud-preview-frontend-url.png)
+![Gatsby Cloud Preview frontend URL Screenshot](../../docs/assets/gatsby-cloud-preview-frontend-url.png)
 
 #### 3. Fill the "Preview Webhook" Field
 
 You can find your **Preview webhook** by navigating to "Site Settings" in Gatsby Cloud and then navigating to "Webhooks" via the left-side menu.
 
-![Gatsby Cloud Preview Webhook URL](/packages/gatsby-source-wordpress/docs/assets/gatsby-cloud-preview-webhook-url.png)
+![Gatsby Cloud Preview Webhook URL](../../docs/assets/gatsby-cloud-preview-webhook-url.png)
 
 #### 4. Double check the "Preview JWT secret" field
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Links to assets have been broken after migration from `wordpress-experimental` pointing to root `docs/assets` folder.
The proper URL should be prefixed with `/packages/gatsby-source-wordpress`

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
