### PR TITLE
chore(tests): Enable node 14 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,17 +517,6 @@ workflows:
     jobs:
       - sync_translation_repo
 
-  weekly-node-14:
-    triggers:
-      - schedule:
-          cron: "0 1 * * 6"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - unit_tests_node14
-
   nightly-react-next:
     triggers:
       - schedule:
@@ -587,6 +576,12 @@ workflows:
           requires:
             - lint
       - unit_tests_node12:
+          <<: *ignore_docs
+          requires:
+            - lint
+            - typecheck
+            - bootstrap
+      - unit_tests_node14:
           <<: *ignore_docs
           requires:
             - lint


### PR DESCRIPTION
Node 14 tests are now set as required, but currently they're not set to run on every PR, just weekly. This PR makes them run every time, and removes the weekly run