### PR TITLE
docs(gatsby-source-wordpress): add migration from experimental instructions

### DIFF
--- a/packages/gatsby-source-wordpress/docs/migrating-from-other-wp-source-plugins.md
+++ b/packages/gatsby-source-wordpress/docs/migrating-from-other-wp-source-plugins.md
@@ -14,6 +14,14 @@ Since `v3` used the WP REST API and `v4` uses WPGraphQL, the data shape and avai
 
 If you have any custom code which you've added to make connections between nodes work in `v3`, you will get to delete that code (yay!) because WPGraphQL has excellent support built in for connection fields between nodes (for example `Page.author` or `User.pages`).
 
+## Migrating from `gatsby-source-wordpress-experimental`
+
+This is the easiest migration since both plugins are one and the same (as of `gatsby-source-wordpress@4.0.0`). 
+
+- Uninstall the experimental plugin `npm uninstall gatsby-source-wordpress-experimental`
+- Install the stable plugin `npm install gatsby-source-wordpress`
+- Then update `gatsby-config.js` to remove `-experimental` from the plugin name.
+
 ## Migrating from `gatsby-source-graphql`
 
 You're in luck! :four_leaf_clover: This will likely be a very easy migration!

--- a/packages/gatsby-source-wordpress/docs/migrating-from-other-wp-source-plugins.md
+++ b/packages/gatsby-source-wordpress/docs/migrating-from-other-wp-source-plugins.md
@@ -16,7 +16,7 @@ If you have any custom code which you've added to make connections between nodes
 
 ## Migrating from `gatsby-source-wordpress-experimental`
 
-This is the easiest migration since both plugins are one and the same (as of `gatsby-source-wordpress@4.0.0`). 
+This is the easiest migration since both plugins are one and the same (as of `gatsby-source-wordpress@4.0.0`).
 
 - Uninstall the experimental plugin `npm uninstall gatsby-source-wordpress-experimental`
 - Install the stable plugin `npm install gatsby-source-wordpress`


### PR DESCRIPTION
This PR adds a section to the docs on migrating from `gatsby-source-wordpress-experimental`.