### PR TITLE
fix: add common-tags to package.jsons

### DIFF
--- a/packages/gatsby-plugin-image/package.json
+++ b/packages/gatsby-plugin-image/package.json
@@ -78,6 +78,7 @@
     "babel-plugin-remove-graphql-queries": "^3.0.0-next.0",
     "camelcase": "^5.3.1",
     "chokidar": "^3.5.1",
+    "common-tags": "^1.8.0",
     "fs-extra": "^8.1.0",
     "gatsby-core-utils": "^2.0.0-next.0",
     "objectFitPolyfill": "^2.3.0",

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -13,6 +13,7 @@
     "@hapi/joi": "^15.1.1",
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
+    "common-tags": "^1.8.0",
     "contentful": "^7.15.2",
     "fs-extra": "^9.1.0",
     "gatsby-core-utils": "^2.0.0-next.0",

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "bluebird": "^3.7.2",
+    "common-tags": "^1.8.0",
     "fs-extra": "^9.1.0",
     "potrace": "^2.1.8",
     "probe-image-size": "^6.0.0",


### PR DESCRIPTION
## Description

These deps are missing from package.json and they fail with yarn2 resolutions.