### PR TITLE
feat(gatsby): support interface inheritance

### DIFF
--- a/docs/docs/reference/graphql-data-layer/schema-customization.md
+++ b/docs/docs/reference/graphql-data-layer/schema-customization.md
@@ -1078,7 +1078,7 @@ data.allTeamMember.nodes.map(node => {
 })
 ```
 
-> Note: All types implementing a queryable interface must also implement the `Node` interface, e.g.:<br/> > `type Foo implements Node & TeamMember`
+> Note: All types implementing a queryable interface must also implement the `Node` interface
 
 ## Extending third-party types
 

--- a/docs/docs/reference/graphql-data-layer/schema-customization.md
+++ b/docs/docs/reference/graphql-data-layer/schema-customization.md
@@ -1000,18 +1000,17 @@ export const query = graphql`
 `
 ```
 
-### Queryable interfaces with the `@nodeInterface` extension
+### Queryable interfaces
 
-Since Gatsby 2.13.22, you can achieve the same thing as above by adding the `@nodeInterface`
-extension to the `TeamMember` interface. This will treat the interface like a normal
-top-level type that implements the `Node` interface, and thus automatically add root
-query fields for the interface.
+Since Gatsby 3.0.0, you can use interface inheritance to achieve the same thing as above:
+`TeamMember implements Node`. This will treat the interface like a normal top-level type that
+implements the `Node` interface, and thus automatically add root query fields for the interface.
 
 ```js:title=gatsby-node.js
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = `
-    interface TeamMember @nodeInterface {
+    interface TeamMember implements Node {
       id: ID!
       name: String!
       firstName: String!
@@ -1079,8 +1078,7 @@ data.allTeamMember.nodes.map(node => {
 })
 ```
 
-> Note: All types implementing an interface with the `@nodeInterface` extension
-> must also implement the `Node` interface.
+> Note: All types implementing a queryable interface must also implement the `Node` interface, e.g.:<br/> > `type Foo implements Node & TeamMember`
 
 ## Extending third-party types
 

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
@@ -41,6 +41,8 @@ directive @childOf(
 ) on OBJECT
 
 \\"\\"\\"
+DEPRECATED: Use interface inheritance instead, i.e. \\"interface Foo implements Node\\".
+
 Adds root query fields for an interface. All implementing types must also implement the Node interface.
 \\"\\"\\"
 directive @nodeInterface on INTERFACE

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
@@ -276,6 +276,11 @@ type OneMoreTest implements Node @dontInfer {
   bar: Boolean
 }
 
+interface ITest2 implements Node {
+  id: ID!
+  date: Date @dateformat(formatString: \\"YYYY\\")
+}
+
 union ThisOrThat = AnotherTest | OneMoreTest
 
 type Inline {
@@ -434,6 +439,11 @@ input Language {
 
 type OneMoreTest implements Node @dontInfer {
   bar: Boolean
+}
+
+interface ITest2 implements Node {
+  id: ID!
+  date: Date @dateformat(formatString: \\"YYYY\\")
 }
 
 union ThisOrThat = AnotherTest | OneMoreTest

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
@@ -41,6 +41,8 @@ directive @childOf(
 ) on OBJECT
 
 \\"\\"\\"
+DEPRECATED: Use interface inheritance instead, i.e. \\"interface Foo implements Node\\".
+
 Adds root query fields for an interface. All implementing types must also implement the Node interface.
 \\"\\"\\"
 directive @nodeInterface on INTERFACE

--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -211,19 +211,23 @@ describe(`Build schema`, () => {
 
     it(`allows adding abstract types in SDL`, async () => {
       createTypes(`
-        interface FooBar {
+        interface Text {
+          text: String
+        }
+
+        interface FooBar implements Text {
           text: String!
         }
 
-        type Foo implements Node & FooBar {
+        type Foo implements Node & Text & FooBar {
           text: String!
         }
 
-        type Bar implements Node & FooBar {
+        type Bar implements Node & Text & FooBar {
           text: String!
         }
 
-        type Author implements Node & FooBar {
+        type Author implements Node & Text & FooBar {
           text: String!
         }
 
@@ -232,17 +236,25 @@ describe(`Build schema`, () => {
 
       const schema = await buildSchema()
 
-      const interfaceType = schema.getType(`FooBar`)
-      expect(interfaceType).toBeInstanceOf(GraphQLInterfaceType)
+      const textType = schema.getType(`Text`)
+      expect(textType).toBeInstanceOf(GraphQLInterfaceType)
+      const fooBarType = schema.getType(`FooBar`)
+      expect(fooBarType).toBeInstanceOf(GraphQLInterfaceType)
+      expect(fooBarType.getInterfaces()).toEqual([schema.getType(`Text`)])
       const unionType = schema.getType(`UFooBar`)
       expect(unionType).toBeInstanceOf(GraphQLUnionType)
       ;[(`Foo`, `Bar`, `Author`)].forEach(typeName => {
         const type = schema.getType(typeName)
         const typeSample = { internal: { type: typeName } }
-        expect(interfaceType.resolveType(typeSample)).toBe(typeName)
+        expect(textType.resolveType(typeSample)).toBe(typeName)
+        expect(fooBarType.resolveType(typeSample)).toBe(typeName)
         expect(unionType.resolveType(typeSample)).toBe(typeName)
         expect(new Set(type.getInterfaces())).toEqual(
-          new Set([schema.getType(`Node`), schema.getType(`FooBar`)])
+          new Set([
+            schema.getType(`Node`),
+            schema.getType(`FooBar`),
+            schema.getType(`Text`),
+          ])
         )
       })
     })
@@ -250,31 +262,38 @@ describe(`Build schema`, () => {
     it(`allows adding abstract types in gatsby type def language`, async () => {
       createTypes([
         buildInterfaceType({
+          name: `Text`,
+          fields: {
+            text: `String!`,
+          },
+        }),
+        buildInterfaceType({
           name: `FooBar`,
           fields: {
             text: `String!`,
           },
+          interfaces: [`Text`],
         }),
         buildObjectType({
           name: `Foo`,
           fields: {
             text: `String!`,
           },
-          interfaces: [`Node`, `FooBar`],
+          interfaces: [`Node`, `Text`, `FooBar`],
         }),
         buildObjectType({
           name: `Bar`,
           fields: {
             text: `String!`,
           },
-          interfaces: [`Node`, `FooBar`],
+          interfaces: [`Node`, `Text`, `FooBar`],
         }),
         buildObjectType({
           name: `Author`,
           fields: {
             text: `String!`,
           },
-          interfaces: [`Node`, `FooBar`],
+          interfaces: [`Node`, `Text`, `FooBar`],
         }),
         buildUnionType({
           name: `UFooBar`,
@@ -284,18 +303,26 @@ describe(`Build schema`, () => {
 
       const schema = await buildSchema()
 
-      const interfaceType = schema.getType(`FooBar`)
-      expect(interfaceType).toBeInstanceOf(GraphQLInterfaceType)
-      const unionType = schema.getType(`UFooBar`)
-      expect(unionType).toBeInstanceOf(GraphQLUnionType)
-      expect(unionType.getTypes().length).toBe(3)
+      const textType = schema.getType(`Text`)
+      expect(textType).toBeInstanceOf(GraphQLInterfaceType)
+      const fooBarType = schema.getType(`FooBar`)
+      expect(fooBarType).toBeInstanceOf(GraphQLInterfaceType)
+      expect(fooBarType.getInterfaces()).toEqual([textType])
+      const unionFooBarType = schema.getType(`UFooBar`)
+      expect(unionFooBarType).toBeInstanceOf(GraphQLUnionType)
+      expect(unionFooBarType.getTypes().length).toBe(3)
       ;[(`Foo`, `Bar`, `Author`)].forEach(typeName => {
         const type = schema.getType(typeName)
         const typeSample = { internal: { type: typeName } }
-        expect(interfaceType.resolveType(typeSample)).toBe(typeName)
-        expect(unionType.resolveType(typeSample)).toBe(typeName)
+        expect(textType.resolveType(typeSample)).toBe(typeName)
+        expect(fooBarType.resolveType(typeSample)).toBe(typeName)
+        expect(unionFooBarType.resolveType(typeSample)).toBe(typeName)
         expect(new Set(type.getInterfaces())).toEqual(
-          new Set([schema.getType(`Node`), schema.getType(`FooBar`)])
+          new Set([
+            schema.getType(`Node`),
+            schema.getType(`FooBar`),
+            schema.getType(`Text`),
+          ])
         )
       })
     })

--- a/packages/gatsby/src/schema/__tests__/print.js
+++ b/packages/gatsby/src/schema/__tests__/print.js
@@ -93,6 +93,10 @@ describe(`Print type definitions`, () => {
         id: ID!
         date: Date @dateformat(formatString: "YYYY")
       }
+      interface ITest2 implements Node {
+        id: ID!
+        date: Date @dateformat(formatString: "YYYY")
+      }
       union ThisOrThat = AnotherTest | OneMoreTest
     `)
     typeDefs.push(

--- a/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/child-relations.js
@@ -830,7 +830,7 @@ describe(`Define parent-child relationships with field extensions`, () => {
     await buildSchema()
     expect(report.error).toBeCalledWith(
       `With the \`childOf\` extension, children fields can only be added to ` +
-        `interfaces which have the \`@nodeInterface\` extension.\n` +
+        `interfaces which implement the \`Node\` interface.\n` +
         `Check the type definition of \`Ancestors\`.`
     )
   })

--- a/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
@@ -35,7 +35,8 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
   }
 })
 
-describe(`Queryable Node interfaces`, () => {
+// TODO: remove @nodeInterface in Gatsby v4
+describe(`Queryable Node interfaces with @nodeInterface`, () => {
   beforeEach(() => {
     dispatch({ type: `DELETE_CACHE` })
     const nodes = [
@@ -515,6 +516,543 @@ describe(`Queryable Node interfaces`, () => {
     dispatch(
       createTypes(`
         interface FooInterface @nodeInterface {
+          id: ID!
+          title: String
+          slug: String
+        }
+
+        type FooConcrete implements Node & FooInterface {
+          id: ID!
+          title: String
+          slug: String @proxy(from: "slugInternal")
+        }
+      `)
+    )
+
+    expect(
+      await runQuery(`
+        {
+          allFooConcrete(filter: {slug: { eq: "foo-bar"}}) {
+            nodes {
+            id
+          }
+          }
+        }
+        `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "allFooConcrete": Object {
+          "nodes": Array [
+            Object {
+              "id": "0",
+            },
+          ],
+        },
+      }
+    `)
+
+    expect(
+      await runQuery(`
+        {
+          allFooInterface(filter: {slug: { eq: "foo-bar"}}) {
+            nodes {
+              id
+            }
+          }
+        }
+        `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "allFooInterface": Object {
+          "nodes": Array [
+            Object {
+              "id": "0",
+            },
+          ],
+        },
+      }
+    `)
+  })
+})
+
+describe(`Queryable Node interfaces with interface inheritance`, () => {
+  beforeEach(() => {
+    dispatch({ type: `DELETE_CACHE` })
+    const nodes = [
+      {
+        id: `test1`,
+        internal: { type: `Test`, contentDigest: `0` },
+        foo: `foo`,
+        bar: `bar`,
+        date: new Date(`2019-01-01`),
+      },
+      {
+        id: `anothertest1`,
+        internal: { type: `AnotherTest`, contentDigest: `0` },
+        foo: `foooo`,
+        baz: `baz`,
+        date: new Date(`2018-01-01`),
+      },
+      {
+        id: `tbtest1`,
+        internal: { type: `TBTest`, contentDigest: `0` },
+        foo: `foo`,
+        bar: `bar`,
+        date: new Date(`2019-01-01`),
+      },
+      {
+        id: `anotherbttest1`,
+        internal: { type: `AnotherTBTest`, contentDigest: `0` },
+        foo: `foooo`,
+        baz: `baz`,
+        date: new Date(`2018-01-01`),
+      },
+    ]
+    nodes.forEach(node =>
+      actions.createNode(node, { name: `test` })(store.dispatch)
+    )
+    dispatch(
+      createTypes(`
+        interface TestInterface implements Node {
+          id: ID!
+          foo: String
+          date: Date @dateformat
+        }
+        type Test implements Node & TestInterface {
+          foo: String
+          bar: String
+          date: Date @dateformat
+        }
+        type AnotherTest implements Node & TestInterface {
+          foo: String
+          baz: String
+          date: Date @dateformat
+        }
+      `)
+    )
+  })
+
+  it(`adds root query fields for interface with @nodeInterface extension`, async () => {
+    const { schema } = await buildSchema()
+    const rootQueryFields = schema.getType(`Query`).getFields()
+    expect(rootQueryFields.testInterface).toBeDefined()
+    expect(rootQueryFields.allTestInterface).toBeDefined()
+    expect(rootQueryFields.testInterface.resolve).toBeDefined()
+    expect(rootQueryFields.allTestInterface.resolve).toBeDefined()
+  })
+
+  it(`does not add root query fields for interface without Node inheritance`, async () => {
+    dispatch(
+      createTypes(`
+        interface WrongInterface {
+          id: ID!
+          foo: String
+        }
+        type Wrong implements Node & WrongInterface {
+          foo: String
+        }
+        type WrongAgain implements Node & WrongInterface {
+          foo: String
+        }
+      `)
+    )
+    const { schema } = await buildSchema()
+    const rootQueryFields = schema.getType(`Query`).getFields()
+    expect(rootQueryFields.wrongInterface).toBeUndefined()
+    expect(rootQueryFields.allWrongInterface).toBeUndefined()
+  })
+
+  it(`shows error when not all types implementing the queryable interface implement the Node interface`, async () => {
+    dispatch(
+      createTypes(`
+        interface WrongInterface implements Node {
+          id: ID!
+          foo: String
+        }
+        type Wrong implements WrongInterface {
+          foo: String
+        }
+        type WrongAgain implements WrongInterface {
+          foo: String
+        }
+      `)
+    )
+    await buildSchema()
+    expect(report.panic).toBeCalledWith(
+      `Interfaces with the \`nodeInterface\` extension must only be implemented ` +
+        `by types which also implement the \`Node\` interface. Check the type ` +
+        `definition of \`Wrong\`, \`WrongAgain\`.`
+    )
+  })
+
+  it(`adds root query fields for interface extending Node interface (type builder)`, async () => {
+    dispatch(
+      createTypes([
+        buildInterfaceType({
+          name: `TypeBuilderInterface`,
+          interfaces: [`Node`],
+          fields: {
+            id: `ID!`,
+            foo: `String`,
+            date: {
+              type: `Date`,
+              extensions: {
+                dateformat: {},
+              },
+            },
+          },
+        }),
+        buildObjectType({
+          name: `TBTest`,
+          interfaces: [`Node`, `TypeBuilderInterface`],
+          fields: {
+            foo: `String`,
+            date: {
+              type: `Date`,
+              extensions: {
+                dateformat: {},
+              },
+            },
+          },
+        }),
+        buildObjectType({
+          name: `AnotherTBTest`,
+          interfaces: [`Node`, `TypeBuilderInterface`],
+          fields: {
+            foo: `String`,
+            date: {
+              type: `Date`,
+              extensions: {
+                dateformat: {},
+              },
+            },
+          },
+        }),
+      ])
+    )
+    const query = `
+      {
+        allTypeBuilderInterface(
+          filter: { foo: { eq: "foooo" } }
+        ) {
+          nodes {
+            foo
+            date(formatString: "YYYY")
+          }
+        }
+        typeBuilderInterface(foo: { eq: "foooo" }) {
+          foo
+          date(formatString: "MM/DD/YYYY")
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allTypeBuilderInterface: {
+        nodes: [
+          {
+            foo: `foooo`,
+            date: `2018`,
+          },
+        ],
+      },
+      typeBuilderInterface: {
+        foo: `foooo`,
+        date: `01/01/2018`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`returns correct results for query`, async () => {
+    const query = `
+      {
+        allTestInterface {
+          nodes {
+            foo
+            ...on AnotherTest {
+              baz
+            }
+            ...on Node {
+              id
+            }
+          }
+        }
+        testInterface {
+          foo
+          ...on Test {
+            bar
+          }
+          ...on Node {
+            id
+          }
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allTestInterface: {
+        nodes: [
+          {
+            foo: `foo`,
+            id: `test1`,
+          },
+          {
+            foo: `foooo`,
+            baz: `baz`,
+            id: `anothertest1`,
+          },
+        ],
+      },
+      testInterface: {
+        foo: `foo`,
+        bar: `bar`,
+        id: `test1`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`returns correct results for query with args`, async () => {
+    const query = `
+      {
+        allTestInterface(
+          filter: { foo: { eq: "foooo" } }
+        ) {
+          nodes {
+            foo
+          }
+        }
+        testInterface(foo: { eq: "foooo" }) {
+          foo
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allTestInterface: {
+        nodes: [
+          {
+            foo: `foooo`,
+          },
+        ],
+      },
+      testInterface: {
+        foo: `foooo`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`adds input args from extensions to fields`, async () => {
+    const query = `
+      {
+        allTestInterface {
+          nodes {
+            date(formatString: "YYYY")
+          }
+        }
+        testInterface {
+          date(formatString: "MM/DD/YYYY")
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allTestInterface: {
+        nodes: [
+          {
+            date: `2019`,
+          },
+          {
+            date: `2018`,
+          },
+        ],
+      },
+      testInterface: {
+        date: `01/01/2019`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`shows error when interface implementing Node interface does not have id field`, async () => {
+    dispatch(
+      createTypes(`
+        interface NotWrongInterface implements Node {
+          id: ID!
+          foo: String
+        }
+        interface WrongInterface implements Node {
+          foo: String
+        }
+      `)
+    )
+    await build({})
+    expect(report.panic).toBeCalledTimes(1)
+    expect(report.panic).toBeCalledWith(
+      `Interfaces with the \`nodeInterface\` extension must have a field ` +
+        `\`id\` of type \`ID!\`. Check the type definition of \`WrongInterface\`.`
+    )
+  })
+
+  it(`works with special case id: { eq: $id } queries`, async () => {
+    const query = `
+      {
+        testInterface(id: { eq: "test1" }) {
+          id
+        }
+        test(id: { eq: "test1" }) {
+          id
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      testInterface: {
+        id: `test1`,
+      },
+      test: {
+        id: `test1`,
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`uses concrete type resolvers when filtering on interface fields`, async () => {
+    const nodes = [
+      {
+        id: `author1`,
+        internal: { type: `AuthorYaml`, counter: 0 },
+        name: `Author 1`,
+        birthday: new Date(Date.UTC(1978, 8, 26)),
+      },
+      {
+        id: `author2`,
+        internal: { type: `AuthorJson`, counter: 1 },
+        name: `Author 2`,
+        birthday: new Date(Date.UTC(1978, 8, 26)),
+      },
+      {
+        id: `post1`,
+        internal: { type: `ThisPost`, counter: 2 },
+        author: `author1`,
+      },
+      {
+        id: `post2`,
+        internal: { type: `ThatPost`, counter: 3 },
+        author: `author2`,
+      },
+    ]
+    nodes.forEach(node =>
+      dispatch({ type: `CREATE_NODE`, payload: { ...node } })
+    )
+    dispatch(
+      createFieldExtension({
+        name: `echo`,
+        args: {
+          value: `String!`,
+        },
+        extend(options) {
+          return {
+            resolve() {
+              return options.value
+            },
+          }
+        },
+      })
+    )
+    dispatch(
+      createTypes(`
+        interface Post implements Node {
+          id: ID!
+          author: Author @link
+        }
+        type ThisPost implements Node & Post {
+          author: Author @link
+        }
+        type ThatPost implements Node & Post {
+          author: Author @link
+        }
+        interface Author @nodeInterface {
+          id: ID!
+          name: String
+          echo: String @echo(value: "Interface")
+        }
+        type AuthorJson implements Node & Author {
+          name: String
+          echo: String @echo(value: "Concrete Type")
+        }
+        type AuthorYaml implements Node & Author {
+          name: String
+          echo: String @echo(value: "Another Concrete Type")
+        }
+      `)
+    )
+    const query = `
+      {
+        allPost(
+          filter: {
+            author: {
+              echo: {
+                in: ["Concrete Type", "Another Concrete Type"]
+              }
+            }
+          }
+        ) {
+          nodes {
+            author {
+              name
+              echo
+            }
+          }
+        }
+      }
+    `
+    const results = await runQuery(query)
+    const expected = {
+      allPost: {
+        nodes: [
+          {
+            author: {
+              name: `Author 1`,
+              echo: `Another Concrete Type`,
+            },
+          },
+          {
+            author: {
+              name: `Author 2`,
+              echo: `Concrete Type`,
+            },
+          },
+        ],
+      },
+    }
+    expect(results).toEqual(expected)
+  })
+
+  it(`materializes and searches by concrete type`, async () => {
+    dispatch({ type: `DELETE_CACHE` })
+
+    const nodes = [
+      {
+        id: `0`,
+        title: `Foo Bar`,
+        slugInternal: `foo-bar`,
+        internal: {
+          type: `FooConcrete`,
+          contentDigest: `0`,
+        },
+      },
+    ]
+
+    nodes.forEach(node =>
+      dispatch({ type: `CREATE_NODE`, payload: { ...node } })
+    )
+
+    dispatch(
+      createTypes(`
+        interface FooInterface implements Node {
           id: ID!
           title: String
           slug: String

--- a/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
@@ -9,8 +9,10 @@ const { createTypes, createFieldExtension } = actions
 
 const report = require(`gatsby-cli/lib/reporter`)
 report.panic = jest.fn()
+report.warn = jest.fn()
 afterEach(() => {
   report.panic.mockClear()
+  report.warn.mockClear()
 })
 
 jest.mock(`gatsby-cli/lib/reporter`, () => {
@@ -90,6 +92,44 @@ describe(`Queryable Node interfaces with @nodeInterface`, () => {
           date: Date @dateformat
         }
       `)
+    )
+  })
+
+  it(`displays a deprecation warning for interfaces with @nodeInterface directive`, async () => {
+    dispatch(
+      createTypes([
+        buildInterfaceType({
+          name: `TestInterface2`,
+          extensions: {
+            nodeInterface: true,
+          },
+          fields: {
+            id: `ID!`,
+          },
+        }),
+      ])
+    )
+    await buildSchema()
+    expect(report.warn).toBeCalledTimes(2)
+    expect(report.warn).toBeCalledWith(
+      `Deprecation warning: \`@nodeInterface\` extension is deprecated and will be removed in Gatsby v4. ` +
+        `Use interface inheritance instead.\n` +
+        `To upgrade replace the old format:\n` +
+        `  interface \`TestInterface\` @nodeInterface\n` +
+        `with the new one (in \`createTypes\` action of schema customization API):\n` +
+        `  interface \`TestInterface\` implements Node\n` +
+        `Read more about schema customization here:\n` +
+        `https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/`
+    )
+    expect(report.warn).toBeCalledWith(
+      `Deprecation warning: \`@nodeInterface\` extension is deprecated and will be removed in Gatsby v4. ` +
+        `Use interface inheritance instead.\n` +
+        `To upgrade replace the old format:\n` +
+        `  interface \`TestInterface2\` @nodeInterface\n` +
+        `with the new one (in \`createTypes\` action of schema customization API):\n` +
+        `  interface \`TestInterface2\` implements Node\n` +
+        `Read more about schema customization here:\n` +
+        `https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/`
     )
   })
 

--- a/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
@@ -180,9 +180,8 @@ describe(`Queryable Node interfaces with @nodeInterface`, () => {
     )
     await buildSchema()
     expect(report.panic).toBeCalledWith(
-      `Interfaces with the \`nodeInterface\` extension must only be implemented ` +
-        `by types which also implement the \`Node\` interface. Check the type ` +
-        `definition of \`Wrong\`, \`WrongAgain\`.`
+      `Types implementing queryable interfaces must also implement the \`Node\` interface. ` +
+        `Check the type definition of \`Wrong\`, \`WrongAgain\`.`
     )
   })
 
@@ -719,9 +718,8 @@ describe(`Queryable Node interfaces with interface inheritance`, () => {
     )
     await buildSchema()
     expect(report.panic).toBeCalledWith(
-      `Interfaces with the \`nodeInterface\` extension must only be implemented ` +
-        `by types which also implement the \`Node\` interface. Check the type ` +
-        `definition of \`Wrong\`, \`WrongAgain\`.`
+      `Types implementing queryable interfaces must also implement the \`Node\` interface. ` +
+        `Check the type definition of \`Wrong\`, \`WrongAgain\`.`
     )
   })
 

--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -67,6 +67,9 @@ const typeExtensions = {
       `Adds root query fields for an interface. All implementing types ` +
       `must also implement the Node interface.`,
     locations: [DirectiveLocation.INTERFACE],
+    deprecationReason:
+      `Use interface inheritance instead, i.e. "interface Foo implements Node" ` +
+      `vs. "interface Foo @nodeInterface"`,
   },
 }
 

--- a/packages/gatsby/src/schema/extensions/index.js
+++ b/packages/gatsby/src/schema/extensions/index.js
@@ -64,12 +64,10 @@ const typeExtensions = {
   },
   nodeInterface: {
     description:
+      `DEPRECATED: Use interface inheritance instead, i.e. "interface Foo implements Node".\n\n` +
       `Adds root query fields for an interface. All implementing types ` +
       `must also implement the Node interface.`,
     locations: [DirectiveLocation.INTERFACE],
-    deprecationReason:
-      `Use interface inheritance instead, i.e. "interface Foo implements Node" ` +
-      `vs. "interface Foo @nodeInterface"`,
   },
 }
 

--- a/packages/gatsby/src/schema/print.js
+++ b/packages/gatsby/src/schema/print.js
@@ -218,12 +218,16 @@ const printObjectType = tc => {
 
 const printInterfaceType = tc => {
   const type = tc.getType()
+  const interfaces = type.getInterfaces()
+  const implementedInterfaces = interfaces.length
+    ? ` implements ` + interfaces.map(i => i.name).join(` & `)
+    : ``
   const extensions = tc.getExtensions()
   const directives = tc.schemaComposer.getDirectives()
   const printedDirectives = printDirectives(extensions, directives)
   return (
     printDescription(type) +
-    `interface ${type.name}${printedDirectives}` +
+    `interface ${type.name}${implementedInterfaces}${printedDirectives}` +
     printFields(Object.values(type.getFields()), directives)
   )
 }

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1326,8 +1326,7 @@ const checkQueryableInterfaces = ({ schemaComposer }) => {
   })
   if (incorrectTypes.size) {
     report.panic(
-      `Interfaces with the \`nodeInterface\` extension must only be ` +
-        `implemented by types which also implement the \`Node\` ` +
+      `Types implementing queryable interfaces must also implement the \`Node\` ` +
         `interface. Check the type definition of ` +
         `${Array.from(incorrectTypes)
           .map(t => `\`${t}\``)

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -460,15 +460,34 @@ const addExtensions = ({
 
   if (
     typeComposer instanceof InterfaceTypeComposer &&
-    isNodeInterface(typeComposer) &&
-    (!typeComposer.hasField(`id`) ||
-      typeComposer.getFieldType(`id`).toString() !== `ID!`)
+    isNodeInterface(typeComposer)
   ) {
-    report.panic(
-      `Interfaces with the \`nodeInterface\` extension must have a field ` +
-        `\`id\` of type \`ID!\`. Check the type definition of ` +
-        `\`${typeComposer.getTypeName()}\`.`
-    )
+    // TODO: remove nodeInterface in Gatsby v4
+    if (typeComposer.hasExtension(`nodeInterface`)) {
+      report.warn(
+        `Deprecation warning: ` +
+          `\`@nodeInterface\` extension is deprecated and will be removed in Gatsby v4. ` +
+          `Use interface inheritance instead.\n` +
+          `To upgrade replace the old format:\n` +
+          `  interface \`${typeComposer.getTypeName()}\` @nodeInterface\n` +
+          `with the new one (in \`createTypes\` action of schema customization API):\n` +
+          `  interface \`${typeComposer.getTypeName()}\` implements Node\n` +
+          `Read more about schema customization here:\n` +
+          `https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/`
+      )
+    }
+
+    const hasCorrectIdField =
+      typeComposer.hasField(`id`) &&
+      typeComposer.getFieldType(`id`).toString() === `ID!`
+
+    if (!hasCorrectIdField) {
+      report.panic(
+        `Interfaces with the \`nodeInterface\` extension must have a field ` +
+          `\`id\` of type \`ID!\`. Check the type definition of ` +
+          `\`${typeComposer.getTypeName()}\`.`
+      )
+    }
   }
 
   if (

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1033,7 +1033,7 @@ const addConvenienceChildrenFields = ({ schemaComposer }) => {
     ) {
       report.error(
         `With the \`childOf\` extension, children fields can only be added to ` +
-          `interfaces which have the \`@nodeInterface\` extension.\n` +
+          `interfaces which implement the \`Node\` interface.\n` +
           `Check the type definition of \`${typeComposer.getTypeName()}\`.`
       )
       return
@@ -1054,7 +1054,7 @@ const addConvenienceChildrenFields = ({ schemaComposer }) => {
         ) {
           report.error(
             `With the \`childOf\` extension, children fields can only be added to ` +
-              `interfaces which have the \`@nodeInterface\` extension.\n` +
+              `interfaces which implement the \`Node\` interface.\n` +
               `Check the type definition of \`${typeComposer.getTypeName()}\`.`
           )
           return


### PR DESCRIPTION
## Description

This PR adds support for interface inheritance that effectively replaces `@nodeInterface` directive. Now you can write:

```graphql
interface TeamMember implements Node {
  id: ID!
}
```

The previous format is still supported but deprecated and will be removed in Gatsby v4:

```graphql
interface TeamMember @nodeInterface {
  id: ID!
}
```

TODO:
- [x] Add a deprecation warning for `@nodeInterface`
- [x] Add general tests for interface inheritance with schema customization (for any interface, not just the `Node` interface)
- [x] Update docs

### Documentation

See https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#queryable-interfaces-with-the-nodeinterface-extension

