### PR TITLE
fix(gatsby-plugin-offline): Cache avif images (#29394)

### DIFF
--- a/packages/gatsby-plugin-offline/src/gatsby-node.js
+++ b/packages/gatsby-plugin-offline/src/gatsby-node.js
@@ -146,7 +146,7 @@ exports.onPostBuild = (
       },
       {
         // Add runtime caching of various other page resources
-        urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
+        urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|avif|svg|gif|tiff|js|woff|woff2|json|css)$/,
         handler: `StaleWhileRevalidate`,
       },
       {


### PR DESCRIPTION
Backporting #29394 to the 2.32 release branch

(cherry picked from commit 0a42d07b55644835ded4de2f8a6952a9f3f81602)