### PR TITLE
fix: clear tracked queries when deleting stale page-data files

### DIFF
--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -90,6 +90,18 @@ export function queriesReducer(
       state.deletedQueries.add(action.payload.path)
       return state
     }
+    case `DELETED_STALE_PAGE_DATA_FILES`: {
+      for (const queryId of action.payload.pagePathsToClear) {
+        for (const component of state.trackedComponents.values()) {
+          component.pages.delete(queryId)
+        }
+        state = clearNodeDependencies(state, queryId)
+        state = clearConnectionDependencies(state, queryId)
+        state.trackedQueries.delete(queryId)
+      }
+
+      return state
+    }
     case `API_FINISHED`: {
       if (action.payload.apiName !== `createPages`) {
         return state

--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -91,6 +91,8 @@ export function queriesReducer(
       return state
     }
     case `DELETED_STALE_PAGE_DATA_FILES`: {
+      // this action is a hack/hot fix
+      // it should be removed/reverted when we start persisting pages state
       for (const queryId of action.payload.pagePathsToClear) {
         for (const component of state.trackedComponents.values()) {
           component.pages.delete(queryId)

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -352,6 +352,7 @@ export type ActionsUnion =
   | IDisableTypeInferenceAction
   | ISetProgramAction
   | ISetProgramExtensions
+  | IDeletedStalePageDataFiles
 
 export interface IApiFinishedAction {
   type: `API_FINISHED`
@@ -803,4 +804,11 @@ interface ISetProgramAction {
 interface ISetProgramExtensions {
   type: `SET_PROGRAM_EXTENSIONS`
   payload: Array<string>
+}
+
+interface IDeletedStalePageDataFiles {
+  type: `DELETED_STALE_PAGE_DATA_FILES`
+  payload: {
+    pagePathsToClear: Set<string>
+  }
 }

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -256,10 +256,20 @@ export async function handleStalePageData(): Promise<void> {
   })
 
   const deletionPromises: Array<Promise<void>> = []
-  pageDataFilesFromPreviousBuilds.forEach(pageDataFilePath => {
+  const pagePathsToClear = new Set<string>()
+  for (const pageDataFilePath of pageDataFilesFromPreviousBuilds) {
     if (!expectedPageDataFiles.has(pageDataFilePath)) {
+      const stalePageDataContent = await fs.readJson(pageDataFilePath)
+      pagePathsToClear.add(stalePageDataContent.path)
       deletionPromises.push(fs.remove(pageDataFilePath))
     }
+  }
+
+  store.dispatch({
+    type: `DELETED_STALE_PAGE_DATA_FILES`,
+    payload: {
+      pagePathsToClear,
+    },
   })
 
   await Promise.all(deletionPromises)


### PR DESCRIPTION
## Description

Deleting stale page-data files from previous builds doesn't clean up our query tracking state. This can result in following kind of errors at SSG step:

```
error: ENOENT: no such file or directory, open '/Users/misiek/dev/pgs-gatsby/integration-tests/artifac
  ts/public/page-data/stale-pages/only-in-first/page-data.json'
```

It can be reproduced by conditionally adding/removing page between builds where we wouldn't clear cache in between runs:

- page 1: build page X
- page 2: don't build page X (just not create this page) - here page-data for page X will be deleted, but `queries` reducer will still keep track of it
- page 3: build page X again (page-data doesn't exist but we don't recreate page-data because cache thinks it still exists) -> result in error trying to read file that doesn't exist

Note - this is more of a hot fix. Proper fix #28590 and #28760 (as in persisting pages to be able to rely on already existing `DELETE_PAGE` action handler in `queries` reducer (which just doesn't happen right now because pages are not persisted)