### PR TITLE
Fix outdated docs links

### DIFF
--- a/docs/docs/how-to/sourcing-data/sourcing-from-the-filesystem.md
+++ b/docs/docs/how-to/sourcing-data/sourcing-from-the-filesystem.md
@@ -8,7 +8,7 @@ This guide will walk you through sourcing data from the filesystem.
 
 This guide assumes that you have a Gatsby project set up. If you need to set up a project, please reference the [Quick Start Guide](/docs/quick-start/).
 
-It will also be useful if you are familiar with [GraphiQL](/docs/introducing-graphiql/), a tool that helps you structure your queries correctly.
+It will also be useful if you are familiar with [GraphiQL](/docs/how-to/querying-data/running-queries-with-graphiql/), a tool that helps you structure your queries correctly.
 
 ## Using `gatsby-source-filesystem`
 

--- a/docs/docs/recipes/querying-data.md
+++ b/docs/docs/recipes/querying-data.md
@@ -145,7 +145,7 @@ export default NonPageComponent
 - [More on Static Query for querying data in components](/docs/how-to/querying-data/static-query/)
 - [The difference between a static query and a page query](/docs/how-to/querying-data/static-query/#how-staticquery-differs-from-page-query)
 - [More on the useStaticQuery hook](/docs/how-to/querying-data/use-static-query/)
-- [Visualize your data with GraphiQL](/docs/introducing-graphiql/)
+- [Visualize your data with GraphiQL](/docs/how-to/querying-data/running-queries-with-graphiql/)
 
 ## Limiting with GraphQL
 

--- a/docs/docs/recipes/sourcing-data.md
+++ b/docs/docs/recipes/sourcing-data.md
@@ -401,7 +401,7 @@ plugins: [
 
 7. Run `gatsby develop` and make sure the site compiled successfully.
 
-8. Query data with the [GraphiQL editor](/docs/introducing-graphiql/) at `http://localhost:8000/___graphql`. The Contentful plugin adds several new node types to your site, including every content type in your Contentful website. Your example space with a "Blog Post" content type produces a `allContentfulBlogPost` node type in GraphQL.
+8. Query data with the [GraphiQL editor](/docs/how-to/querying-data/running-queries-with-graphiql/) at `http://localhost:8000/___graphql`. The Contentful plugin adds several new node types to your site, including every content type in your Contentful website. Your example space with a "Blog Post" content type produces a `allContentfulBlogPost` node type in GraphQL.
 
 ![The GraphQL interface, with a sample query outlined below](../images/recipe-sourcing-contentful-graphql.png)
 

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -103,7 +103,7 @@ gatsby new my-awesome-site
 gatsby new my-awesome-blog-site https://github.com/gatsbyjs/gatsby-starter-blog
 ```
 
-See the [Gatsby starters docs](/docs/gatsby-starters/) for more details.
+See the [Gatsby starters docs](/docs/starters/) for more details.
 
 ### `develop`
 

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -239,7 +239,7 @@ You can type in a command, such as one of these:
 
 `staticQueries`
 
-When combined with the [GraphQL explorer](/docs/introducing-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.
+When combined with the [GraphQL explorer](/docs/how-to/querying-data/running-queries-with-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.
 
 For more information, check out the [Gatsby REPL documentation](/docs/gatsby-repl/).
 


### PR DESCRIPTION

## Description

This PR updates a number of outdated links in the docs.

 The links to `/docs/introducing-graphiql/` have been updated to  `/docs/how-to/querying-data/running-queries-with-graphiql/` on:
o https://www.gatsbyjs.com/docs/reference/gatsby-cli/
o https://www.gatsbyjs.com/docs/recipes/querying-data/
o https://www.gatsbyjs.com/docs/how-to/sourcing-data/sourcing-from-the-filesystem/
o https://www.gatsbyjs.com/docs/recipes/sourcing-data/

 The link to `docs/gatsby-starters/` has been updated to `docs/starters/` on:
o https://www.gatsbyjs.com/docs/reference/gatsby-cli/