### PR TITLE
feat(gatsby): display GraphQL deprecations as CLI warnings

### DIFF
--- a/packages/gatsby/src/query/__tests__/graphql-runner.ts
+++ b/packages/gatsby/src/query/__tests__/graphql-runner.ts
@@ -1,0 +1,175 @@
+import { ExecutionResult } from "graphql"
+import { GraphQLRunner } from "../graphql-runner"
+import { actions } from "../../redux/actions"
+import { store } from "../../redux"
+import { build } from "../../schema"
+
+jest.mock(`gatsby-cli/lib/reporter`, () => {
+  return {
+    log: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    activityTimer: () => {
+      return {
+        start: jest.fn(),
+        setStatus: jest.fn(),
+        end: jest.fn(),
+      }
+    },
+    phantomActivity: () => {
+      return {
+        start: jest.fn(),
+        end: jest.fn(),
+      }
+    },
+  }
+})
+
+const reporter = require(`gatsby-cli/lib/reporter`)
+afterEach(() => {
+  reporter.error.mockClear()
+  reporter.warn.mockClear()
+})
+
+const FooNodes = {
+  Node1: {
+    id: `1`,
+    foo: `foo`,
+    bar: `bar`,
+    internal: { type: `Foo`, contentDigest: `1` },
+  },
+}
+
+describe(`Deprecation warnings`, () => {
+  it(`displays warnings when querying deprecated fields`, async () => {
+    await buildSchema(
+      `
+      type Foo implements Node {
+        id: ID!
+        foo: String @deprecated(reason: "Tired.")
+        bar: String
+      }
+      `,
+      [FooNodes.Node1]
+    )
+    const result = await runQuery(`
+      query {
+        foo {
+          foo
+          bar
+        }
+      }
+    `)
+    expect(result.errors).not.toBeDefined()
+    expect(result.data).toEqual({
+      foo: {
+        foo: `foo`,
+        bar: `bar`,
+      },
+    })
+    expect(reporter.warn).toHaveBeenCalledTimes(1)
+    expect(reporter.warn).toHaveBeenCalledWith(
+      `The field Foo.foo is deprecated. Tired.\nQueried in /test`
+    )
+    expect(reporter.error).not.toHaveBeenCalled()
+  })
+
+  // Skipping due to graphql-compose bug
+  // see https://github.com/graphql-compose/graphql-compose/issues/317
+  // TODO: enable once the above bug is fixed in graphql-compose
+  it.skip(`displays warnings when when using deprecated arguments`, async () => {
+    await buildSchema(
+      `
+      type Foo implements Node {
+        id: ID!
+        foo(
+          arg: String @deprecated(reason: "Tired")
+        ): String
+        bar: String
+      }
+    `,
+      [FooNodes.Node1]
+    )
+    const result = await runQuery(`
+      query {
+        foo {
+          foo(arg: "Tired")
+          bar
+        }
+      }
+    `)
+    expect(result.errors).not.toBeDefined()
+    expect(result.data).toEqual({
+      foo: {
+        foo: `foo`,
+        bar: `bar`,
+      },
+    })
+    expect(reporter.warn).toHaveBeenCalledTimes(1)
+    expect(reporter.warn).toHaveBeenCalledWith(
+      `The field "Foo.foo" argument "arg" is deprecated. Tired.\n` +
+        `Queried in /test`
+    )
+  })
+
+  it(`displays warnings when when using deprecated input fields`, async () => {
+    await buildSchema(
+      `
+      input Filter {
+        foo: String @deprecated(reason: "Tired.")
+      }
+      type Foo implements Node {
+        id: ID!
+        foo(arg: Filter): String
+        bar: String
+      }
+    `,
+      [FooNodes.Node1]
+    )
+    const result = await runQuery(`
+      query {
+        foo {
+          foo(arg: { foo: "whatever" })
+          bar
+        }
+      }
+    `)
+    expect(result.errors).not.toBeDefined()
+    expect(result.data).toEqual({
+      foo: {
+        foo: `foo`,
+        bar: `bar`,
+      },
+    })
+    expect(reporter.warn).toHaveBeenCalledTimes(1)
+    expect(reporter.warn).toHaveBeenCalledWith(
+      `The input field Filter.foo is deprecated. Tired.\nQueried in /test`
+    )
+  })
+})
+
+async function buildSchema(typeDefs, nodes = []): Promise<void> {
+  store.dispatch(actions.createTypes(typeDefs))
+  nodes.forEach(nodeInput => {
+    // Satisfy node validation
+    const node = {
+      children: [],
+      ...nodeInput,
+      internal: { ...nodeInput.internal },
+    }
+    store.dispatch(actions.createNode(node, { name: `test-plugin` }))
+  })
+  await build({})
+}
+
+async function runQuery(
+  query: string,
+  context = { path: `/test` }
+): Promise<ExecutionResult> {
+  const graphqlRunner = new GraphQLRunner(store)
+  return graphqlRunner.query(query, context, {
+    parentSpan: undefined,
+    queryName: context.path,
+  })
+}

--- a/packages/gatsby/src/query/__tests__/graphql-runner.ts
+++ b/packages/gatsby/src/query/__tests__/graphql-runner.ts
@@ -147,6 +147,26 @@ describe(`Deprecation warnings`, () => {
       `The input field Filter.foo is deprecated. Tired.\nQueried in /test`
     )
   })
+
+  it(`formats paths of static queries`, async () => {
+    await buildSchema(`
+      type Foo implements Node {
+        id: ID!
+        foo: String @deprecated(reason: "Tired.")
+      }
+    `)
+    await runQuery(
+      `query {
+        foo { foo }
+      }`,
+      {
+        path: `sq--src-components-bio-js`,
+      }
+    )
+    expect(reporter.warn).toHaveBeenCalledWith(
+      `The field Foo.foo is deprecated. Tired.\nQueried in src/components/bio.js`
+    )
+  })
 })
 
 async function buildSchema(typeDefs, nodes = []): Promise<void> {

--- a/packages/gatsby/src/query/__tests__/graphql-runner.ts
+++ b/packages/gatsby/src/query/__tests__/graphql-runner.ts
@@ -10,14 +10,14 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
-    activityTimer: () => {
+    activityTimer: (): any => {
       return {
         start: jest.fn(),
         setStatus: jest.fn(),
         end: jest.fn(),
       }
     },
-    phantomActivity: () => {
+    phantomActivity: (): any => {
       return {
         start: jest.fn(),
         end: jest.fn(),

--- a/packages/gatsby/src/query/__tests__/graphql-runner.ts
+++ b/packages/gatsby/src/query/__tests__/graphql-runner.ts
@@ -148,7 +148,7 @@ describe(`Deprecation warnings`, () => {
     )
   })
 
-  it(`formats paths of static queries`, async () => {
+  it(`displays componentPath when passed`, async () => {
     await buildSchema(`
       type Foo implements Node {
         id: ID!
@@ -159,12 +159,10 @@ describe(`Deprecation warnings`, () => {
       `query {
         foo { foo }
       }`,
-      {
-        path: `sq--src-components-bio-js`,
-      }
+      { componentPath: `/example/path` }
     )
     expect(reporter.warn).toHaveBeenCalledWith(
-      `The field Foo.foo is deprecated. Tired.\nQueried in src/components/bio.js`
+      `The field Foo.foo is deprecated. Tired.\nQueried in /example/path`
     )
   })
 })
@@ -185,11 +183,13 @@ async function buildSchema(typeDefs, nodes = []): Promise<void> {
 
 async function runQuery(
   query: string,
-  context = { path: `/test` }
+  params = { componentPath: `/test` }
 ): Promise<ExecutionResult> {
+  const context = { path: `/test` }
   const graphqlRunner = new GraphQLRunner(store)
   return graphqlRunner.query(query, context, {
     parentSpan: undefined,
     queryName: context.path,
+    componentPath: params.componentPath,
   })
 }

--- a/packages/gatsby/src/query/graphql-runner.ts
+++ b/packages/gatsby/src/query/graphql-runner.ts
@@ -173,15 +173,15 @@ export class GraphQLRunner {
     // TODO: consider a better strategy for cache purging/invalidation
     this.scheduleClearCache()
 
-    if (errors.length > 0) {
-      return { errors }
-    }
-
     if (warnings.length > 0) {
       warnings.forEach(err => {
         const message = context.path ? `\nQueried in ${context.path}` : ``
         reporter.warn(err.message + message)
       })
+    }
+
+    if (errors.length > 0) {
+      return { errors }
     }
 
     let tracer

--- a/packages/gatsby/src/query/graphql-runner.ts
+++ b/packages/gatsby/src/query/graphql-runner.ts
@@ -9,8 +9,10 @@ import {
   Source,
   GraphQLError,
   ExecutionResult,
+  NoDeprecatedCustomRule,
 } from "graphql"
 import { debounce } from "lodash"
+import reporter from "gatsby-cli/lib/reporter"
 import { createPageDependency } from "../redux/actions/add-page-dependency"
 
 import withResolverContext from "../schema/context"
@@ -93,15 +95,20 @@ export class GraphQLRunner {
   validate(
     schema: GraphQLSchema,
     document: DocumentNode
-  ): ReadonlyArray<GraphQLError> {
+  ): {
+    errors: ReadonlyArray<GraphQLError>
+    warnings: ReadonlyArray<GraphQLError>
+  } {
+    let errors: ReadonlyArray<GraphQLError> = []
+    let warnings: ReadonlyArray<GraphQLError> = []
     if (!this.validDocuments.has(document)) {
-      const errors = validate(schema, document)
+      errors = validate(schema, document)
+      warnings = validate(schema, document, [NoDeprecatedCustomRule])
       if (!errors.length) {
         this.validDocuments.add(document)
       }
-      return errors as Array<GraphQLError>
     }
-    return []
+    return { errors, warnings }
   }
 
   getStats(): IGraphQLRunnerStatResults | null {
@@ -159,7 +166,7 @@ export class GraphQLRunner {
     }
 
     const document = this.parse(query)
-    const errors = this.validate(schema, document)
+    const { errors, warnings } = this.validate(schema, document)
 
     // Queries are usually executed in batch. But after the batch is finished
     // cache just wastes memory without much benefits.
@@ -168,6 +175,13 @@ export class GraphQLRunner {
 
     if (errors.length > 0) {
       return { errors }
+    }
+
+    if (warnings.length > 0) {
+      warnings.forEach(err => {
+        const message = context.path ? `\nQueried in ${context.path}` : ``
+        reporter.warn(err.message + message)
+      })
     }
 
     let tracer

--- a/packages/gatsby/src/query/graphql-runner.ts
+++ b/packages/gatsby/src/query/graphql-runner.ts
@@ -174,8 +174,12 @@ export class GraphQLRunner {
     this.scheduleClearCache()
 
     if (warnings.length > 0) {
+      // TODO: move those warnings to the caller side, e.g. query-runner.ts
       warnings.forEach(err => {
-        const message = context.path ? `\nQueried in ${context.path}` : ``
+        const message =
+          typeof context.path === `string` && context.path
+            ? `\nQueried in ${formatQueryPath(context.path)}`
+            : ``
         reporter.warn(err.message + message)
       })
     }
@@ -219,4 +223,16 @@ export class GraphQLRunner {
       }
     }
   }
+}
+
+function formatQueryPath(path: string): string {
+  // Meh
+  if (path.startsWith(`sq--`)) {
+    // e.g. "sq--src-components-bio-js" -> "src/components/bio.js"
+    const parts = path.split(`-`)
+    return parts.length > 3
+      ? `${parts.slice(2, -1).join(`/`)}.${parts[parts.length - 1]}`
+      : path
+  }
+  return path
 }

--- a/packages/gatsby/src/query/graphql-runner.ts
+++ b/packages/gatsby/src/query/graphql-runner.ts
@@ -144,7 +144,12 @@ export class GraphQLRunner {
     {
       parentSpan,
       queryName,
-    }: { parentSpan: Span | undefined; queryName: string }
+      componentPath,
+    }: {
+      parentSpan: Span | undefined
+      queryName: string
+      componentPath?: string | undefined
+    }
   ): Promise<ExecutionResult> {
     const { schema, schemaCustomization } = this.store.getState()
 
@@ -176,10 +181,7 @@ export class GraphQLRunner {
     if (warnings.length > 0) {
       // TODO: move those warnings to the caller side, e.g. query-runner.ts
       warnings.forEach(err => {
-        const message =
-          typeof context.path === `string` && context.path
-            ? `\nQueried in ${formatQueryPath(context.path)}`
-            : ``
+        const message = componentPath ? `\nQueried in ${componentPath}` : ``
         reporter.warn(err.message + message)
       })
     }
@@ -223,16 +225,4 @@ export class GraphQLRunner {
       }
     }
   }
-}
-
-function formatQueryPath(path: string): string {
-  // Meh
-  if (path.startsWith(`sq--`)) {
-    // e.g. "sq--src-components-bio-js" -> "src/components/bio.js"
-    const parts = path.split(`-`)
-    return parts.length > 3
-      ? `${parts.slice(2, -1).join(`/`)}.${parts[parts.length - 1]}`
-      : path
-  }
-  return path
 }

--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -103,6 +103,7 @@ async function startQueryJob(
     .query(queryJob.query, queryJob.context, {
       parentSpan,
       queryName: queryJob.id,
+      componentPath: queryJob.componentPath,
     })
     .finally(() => {
       isPending = false


### PR DESCRIPTION
## Description

When querying `deprecated` field, argument or input field in your query Gatsby will show a deprecation warning in CLI.

Example type def:

```js
exports.createSchemaCustomization = ({ actions }) => {
  const { createTypes } = actions

  createTypes(`
    type MarkdownRemark implements Node {
      frontmatter: Frontmatter
    }
    type Frontmatter {
      description: String @deprecated(reason: "Use title instead.")
    }
  `)
}
```

Example query:

```graphql
  query {
    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
      nodes {
        frontmatter {
          description
        }
      }
    }
  }
```

Will produce a warning like this:

![image](https://user-images.githubusercontent.com/115628/107630761-970c6c00-6c96-11eb-9b24-477928c217ac.png)

