### PR TITLE
fix(gatsby-source-shopify): Don't remove version string from Shopify image URLs

### DIFF
--- a/packages/gatsby-source-shopify/src/nodes.js
+++ b/packages/gatsby-source-shopify/src/nodes.js
@@ -99,7 +99,7 @@ export const CollectionNode = imageArgs =>
       node.image.localFile___NODE = await downloadImageAndCreateFileNode(
         {
           id: node.image.id,
-          url: node.image.src && node.image.src.split(`?`)[0],
+          url: node.image.src,
           nodeId: node.id,
         },
         imageArgs
@@ -142,7 +142,7 @@ export const ProductNode = imageArgs =>
         edge.node.localFile___NODE = await downloadImageAndCreateFileNode(
           {
             id: edge.node.id,
-            url: edge.node.originalSrc && edge.node.originalSrc.split(`?`)[0],
+            url: edge.node.originalSrc,
           },
           imageArgs
         )
@@ -172,7 +172,7 @@ export const ProductVariantNode = (imageArgs, productNode) =>
       node.image.localFile___NODE = await downloadImageAndCreateFileNode(
         {
           id: node.image.id,
-          url: node.image.originalSrc && node.image.originalSrc.split(`?`)[0],
+          url: node.image.originalSrc,
         },
         imageArgs
       )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This fixes [a bug](https://github.com/gatsbyjs/gatsby/issues/29409) where old images remain cached in Gatsby after they are updated in Shopify. 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #29409 