### PR TITLE
chore(docs): Update "Adding Search with Algolia" guide

### DIFF
--- a/docs/docs/adding-search-with-algolia.md
+++ b/docs/docs/adding-search-with-algolia.md
@@ -331,10 +331,14 @@ export default function Search({ indices }) {
   const rootRef = createRef()
   const [query, setQuery] = useState()
   const [hasFocus, setFocus] = useState(false)
-  const searchClient = useMemo(() => algoliasearch(
-    process.env.GATSBY_ALGOLIA_APP_ID,
-    process.env.GATSBY_ALGOLIA_SEARCH_KEY
-  ), []);
+  const searchClient = useMemo(
+    () =>
+      algoliasearch(
+        process.env.GATSBY_ALGOLIA_APP_ID,
+        process.env.GATSBY_ALGOLIA_SEARCH_KEY
+      ),
+    []
+  )
 
   useClickOutside(rootRef, () => setFocus(false))
 

--- a/docs/docs/adding-search-with-algolia.md
+++ b/docs/docs/adding-search-with-algolia.md
@@ -313,7 +313,7 @@ You now need to hook up the two components to each other and perform the actual 
 
 ```jsx:title=src/components/search/index.js
 import algoliasearch from "algoliasearch/lite"
-import { createRef, default as React, useState } from "react"
+import { createRef, default as React, useState, useMemo } from "react"
 import { InstantSearch } from "react-instantsearch-dom"
 import { ThemeProvider } from "styled-components"
 import StyledSearchBox from "./styled-search-box"
@@ -331,10 +331,10 @@ export default function Search({ indices }) {
   const rootRef = createRef()
   const [query, setQuery] = useState()
   const [hasFocus, setFocus] = useState(false)
-  const searchClient = algoliasearch(
+  const searchClient = useMemo(() => algoliasearch(
     process.env.GATSBY_ALGOLIA_APP_ID,
     process.env.GATSBY_ALGOLIA_SEARCH_KEY
-  )
+  ), []);
 
   useClickOutside(rootRef, () => setFocus(false))
 
@@ -361,6 +361,8 @@ export default function Search({ indices }) {
 The `ThemeProvider` exports variables for the CSS to use (this is the [theming](https://styled-components.com/docs/advanced#theming) functionality of `styled-components`). If you are using `styled-components` elsewhere in your project you probably want to place it at the root of your widget hierarchy rather than in the search widget itself.
 
 The `hasFocus` variable tracks whether the search box is currently in focus. When it is, it should display the input field (if not, only the search icon button is visible).
+
+The `searchClient` variable is [memoized](https://reactjs.org/docs/hooks-reference.html#usememo) to avoid re-creating the Algolia search client when the `Search` component is re-rendered. This is important for performance, as the client caches searches to minimise the number of requests made to Algolia.
 
 `StyledSearchRoot` is the root of the whole component. The React hook `useClickOutside` provides a callback if the user clicks anywhere else on the page, in which case it should close.
 


### PR DESCRIPTION
Added memoization to example to avoid re-creating the Algolia search client unnecessarily, which impacts performance

## Description

In the existing example, it will recreate the Algolia search client every time the user types in the search box (as the query changes, causing the Search component to be re-rendered, which creates a new instance of the search client). This change adds memoization to the example, so that the search client is not re-created on every re-render. This is important for performance, as with the existing implementation, you would notice that every keystroke would cause two requests to be sent to Algolia, and any caching is destroyed by the fact that the client is constantly re-created. Since performance is important to Gatsby, this change to the example ensures that the search performs well when following this guide.