### PR TITLE
fix(gatsby-plugin-image): Rename hooks

### DIFF
--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -97,7 +97,7 @@ export interface IUrlBuilderArgs<OptionsType> {
   format: ImageFormat
   options: OptionsType
 }
-export interface IUseGatsbyImageArgs<OptionsType = {}> {
+export interface IGetImageDataArgs<OptionsType = {}> {
   baseUrl: string
   /**
    * For constrained and fixed images, the size of the image element
@@ -145,7 +145,7 @@ export interface IUseGatsbyImageArgs<OptionsType = {}> {
 /**
  * Use this hook to generate gatsby-plugin-image data in the browser.
  */
-export function useGatsbyImage<OptionsType>({
+export function getImageData<OptionsType>({
   baseUrl,
   urlBuilder,
   sourceWidth,
@@ -155,7 +155,7 @@ export function useGatsbyImage<OptionsType>({
   breakpoints = EVERY_BREAKPOINT,
   options,
   ...props
-}: IUseGatsbyImageArgs<OptionsType>): IGatsbyImageData {
+}: IGetImageDataArgs<OptionsType>): IGatsbyImageData {
   const generateImageSource = (
     baseUrl: string,
     width: number,
@@ -393,7 +393,7 @@ export interface IArtDirectedImage {
  * @param artDirected Array of objects which each contains a `media` string which is a media query
  * such as `(min-width: 320px)`, and the image object to use when that query matches.
  */
-export function useArtDirection(
+export function withArtDirection(
   defaultImage: IGatsbyImageData,
   artDirected: Array<IArtDirectedImage>
 ): IGatsbyImageData {

--- a/packages/gatsby-plugin-image/src/index.browser.ts
+++ b/packages/gatsby-plugin-image/src/index.browser.ts
@@ -10,10 +10,10 @@ export { LaterHydrator } from "./components/later-hydrator"
 export {
   getImage,
   getSrc,
-  useGatsbyImage,
-  useArtDirection,
+  getImageData,
+  withArtDirection,
   IArtDirectedImage,
-  IUseGatsbyImageArgs,
+  IGetImageDataArgs,
   IUrlBuilderArgs,
 } from "./components/hooks"
 export {

--- a/packages/gatsby-plugin-image/src/index.ts
+++ b/packages/gatsby-plugin-image/src/index.ts
@@ -9,10 +9,10 @@ export { StaticImage } from "./components/static-image.server"
 export {
   getImage,
   getSrc,
-  useGatsbyImage,
-  useArtDirection,
+  getImageData,
+  withArtDirection,
   IArtDirectedImage,
-  IUseGatsbyImageArgs,
+  IGetImageDataArgs,
   IUrlBuilderArgs,
 } from "./components/hooks"
 export {


### PR DESCRIPTION
By giving the helper function hook names (beginnign with `use`), the eslint React hooks plugin enforces rules of hooks. This is not needed, and prevents people e.g. using them inside loops or in other functions. As we don;t use any React hooks ourselves, we're free to choose other names.