### PR TITLE
chore(gatsby-source-wordpress): remove multiple h1s from README

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -29,7 +29,7 @@ Source data from WordPress in a scaleable and efficient way with WPGraphQL 🚀
 
 This plugin works by merging the [WPGraphQL schema & data](https://docs.wpgraphql.com/guides/about-wpgraphql/) with the [Gatsby schema & Node model](https://www.gatsbyjs.com/docs/node-model/) which allows us to efficiently cache WP data in Gatsby. What this means is that incremental builds, fast builds, and CMS Previews work beautifully! 💅
 
-# Docs 📖
+## Docs 📖
 
 - 👩‍🎤 [Why use this plugin?](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/why-use-this-plugin.md)
 - 🏃‍ [Installation & Getting started](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/getting-started.md)


### PR DESCRIPTION
This change updates the README to not use multiple h1s, per SEO and a11y best practices