### PR TITLE
chore: remove multiple h1s from official plugin docs

### DIFF
--- a/packages/gatsby-plugin-styled-components/README.md
+++ b/packages/gatsby-plugin-styled-components/README.md
@@ -25,7 +25,7 @@ module.exports = {
 }
 ```
 
-# Options
+## Options
 
 You can pass options to the plugin, see the [Styled Components docs](https://styled-components.com/docs/tooling#babel-plugin) for a full list of options.
 

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -260,7 +260,7 @@ For details, refer to [https://www.graphql-tools.com/docs/schema-wrapping](https
 
 An use case for this feature can be seen in [this issue](https://github.com/gatsbyjs/gatsby/issues/23552).
 
-# Refetching data
+## Refetching data
 
 By default, `gatsby-source-graphql` will only refetch the data once the server is restarted. It's also possible to configure the plugin to periodically refetch the data. The option is called `refetchInterval` and specifies the timeout in seconds.
 
@@ -286,7 +286,7 @@ module.exports = {
 }
 ```
 
-# Performance tuning
+## Performance tuning
 
 By default, `gatsby-source-graphql` executes each query in a separate network request.
 But the plugin also supports query batching to improve query performance.


### PR DESCRIPTION
Updating a couple official plugins to not use multiple h1 tags in their READMEs to adhere to SEO and a11y best practices