### PR TITLE
fix: drop terminal-link

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -147,7 +147,6 @@
     "string-similarity": "^1.2.2",
     "strip-ansi": "^5.2.0",
     "style-loader": "^0.23.1",
-    "terminal-link": "^2.1.1",
     "terser-webpack-plugin": "^2.3.8",
     "tmp": "^0.2.1",
     "true-case-path": "^2.2.1",

--- a/packages/gatsby/src/utils/__tests__/handle-flags.ts
+++ b/packages/gatsby/src/utils/__tests__/handle-flags.ts
@@ -10,10 +10,6 @@ jest.mock(`gatsby-core-utils`, () => {
   }
 })
 
-jest.mock(`terminal-link`, () => (text: string, url: string): string =>
-  `${text} (${url})`
-)
-
 describe(`satisfies semver`, () => {
   it(`returns false if a module doesn't exist`, () => {
     const semverConstraints = {

--- a/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
+++ b/packages/gatsby/src/utils/__tests__/show-experiment-notice.js
@@ -1,8 +1,6 @@
 import { createNoticeMessage } from "../show-experiment-notice"
 import stripAnsi from "strip-ansi"
 
-jest.mock(`terminal-link`, () => (text, url) => `${text} (${url})`)
-
 describe(`show-experiment-notice`, () => {
   it(`generates a message`, () => {
     expect(

--- a/packages/gatsby/src/utils/handle-flags.ts
+++ b/packages/gatsby/src/utils/handle-flags.ts
@@ -1,6 +1,5 @@
 import _ from "lodash"
 import { isCI } from "gatsby-core-utils"
-import terminalLink from "terminal-link"
 import { IFlag } from "./flags"
 import chalk from "chalk"
 import { commaListsAnd } from "common-tags"
@@ -133,7 +132,7 @@ const handleFlags = (
       message += ` · ${chalk.white.bgRed.bold(`EXPERIMENTAL`)}`
     }
     if (flag.umbrellaIssue) {
-      message += ` · (${terminalLink(`Umbrella Issue`, flag.umbrellaIssue)})`
+      message += ` · (Umbrella Issue (${flag.umbrellaIssue}))`
     }
     message += ` · ${flag.description}`
 

--- a/packages/gatsby/src/utils/show-experiment-notice.ts
+++ b/packages/gatsby/src/utils/show-experiment-notice.ts
@@ -2,7 +2,6 @@ import { getConfigStore } from "gatsby-core-utils"
 import reporter from "gatsby-cli/lib/reporter"
 import chalk from "chalk"
 import telemetry from "gatsby-telemetry"
-import terminalLink from "terminal-link"
 
 type CancelExperimentNoticeCallback = () => void
 
@@ -57,9 +56,9 @@ flags (samples below)`
     notice =>
       (message += `
 
-${chalk.bgBlue.bold(
-  terminalLink(notice.experimentIdentifier, notice.umbrellaLink)
-)}, ${notice.noticeText}\n`)
+${chalk.bgBlue.bold(notice.experimentIdentifier)} (${notice.umbrellaLink}), ${
+        notice.noticeText
+      }\n`)
   )
 
   return message


### PR DESCRIPTION
## Description

There is weird interaction in some terminals with our usage of terminal-link and ink where following lines turn blank.
Let's just remove our usage of terminal-link as value it provides is not worth spending a lot of time on figuring exact reason for this.

For details on how problem looks like, check #29293

Note - we do still use `terminal-link` in `create-gatsby` and `gatsby-recipes`, but it's not clear if it's usage there cause problems or not, so this PR is scoped just to `gatsby` core package

## Related Issues

Fixes #29293
