### PR TITLE
fix(gatsby): skip unions in input types

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -34,7 +34,7 @@
     "gatsby-telemetry": "^2.0.0-next.0",
     "glob": "^7.1.6",
     "graphql": "^15.4.0",
-    "graphql-compose": "^7.24.4",
+    "graphql-compose": "^7.25.0",
     "graphql-subscriptions": "^1.1.0",
     "graphql-type-json": "^0.3.2",
     "hicat": "^0.8.0",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -91,7 +91,7 @@
     "glob": "^7.1.6",
     "got": "8.3.2",
     "graphql": "^15.4.0",
-    "graphql-compose": "^7.24.4",
+    "graphql-compose": "^7.25.0",
     "graphql-playground-middleware-express": "^1.7.18",
     "hasha": "^5.2.0",
     "http-proxy": "^1.18.1",

--- a/packages/gatsby/src/schema/types/__tests__/filter-input.js
+++ b/packages/gatsby/src/schema/types/__tests__/filter-input.js
@@ -68,15 +68,7 @@ describe(`Filter input`, () => {
     const parentFilterInput = schema.getType(`ParentFilterInput`)
     const fields = parentFilterInput.getFields()
     expect(fields.id).toBeDefined()
-
-    // graphql-compose v7 requires union type to be replaced by a fallback type
-    // (we chose to use boolean as a fallback as it is the least confusing of all options)
-    expect(fields.nested).toBeDefined()
-    expect(fields.nested.type.name).toEqual(`ParentNestedFilterInput`)
-    const nestedInput = schema.getType(`ParentNestedFilterInput`)
-    expect(nestedInput.getFields().union.type.name).toEqual(
-      `BooleanQueryOperatorInput`
-    )
+    expect(fields.nested).not.toBeDefined()
   })
 })
 

--- a/packages/gatsby/src/schema/types/sort.ts
+++ b/packages/gatsby/src/schema/types/sort.ts
@@ -155,10 +155,9 @@ export const getSortInput = <TSource = any, TContext = any>({
   //   type Baz {
   //     fooBar: FooBar
   //   }
-  // Unfortunately there is no way to just exclude such fields from the input type in graphql-compose v7+,
-  // so simply replacing them with booleans as the least confusing option :/
+  // Passing `fallbackType: null` allows us to skip this field in the input type
   const inputTypeComposer = toInputObjectType(typeComposer, {
-    fallbackType: schemaComposer.getSTC(`Boolean`),
+    fallbackType: null,
   })
   const sortOrderEnumTC = getSortOrderEnum({ schemaComposer })
   const fieldsEnumTC = getFieldsEnum({

--- a/yarn.lock
+++ b/yarn.lock
@@ -12514,10 +12514,10 @@ graphiql@^1.3.2:
     graphql-language-service "^3.1.2"
     markdown-it "^10.0.0"
 
-graphql-compose@^7.24.4:
-  version "7.24.4"
-  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-7.24.4.tgz#78e7bef8749cc59df1539dfab4fae0dab156188b"
-  integrity sha512-FcJwzn3nOtgC3UZR8OLn1LsQBA4xkV4utFVYDh6OIIUHWO5aINHUoarznc2/82aqlyF50MZzFa4hx9tZx2u0Yg==
+graphql-compose@^7.25.0:
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-7.25.0.tgz#cd893172616ce56b0566e62fd249fb7782332d38"
+  integrity sha512-Zd2G62Sq0ZQW+qXds/LgSi3YSulmk2t2YS3WJfHvNslkEbyAcE1mFiy7c1wU0tl3woB0vPRwI0jAYtSSG6llNA==
   dependencies:
     graphql-type-json "0.3.2"
     object-path "0.11.5"


### PR DESCRIPTION
## Description

This PR restores the behavior of v2 when converting types to input types. Now, whenever we see a field of union type we won't add it to the input type.

This fix in `graphq-compose` has made this possible: https://github.com/graphql-compose/graphql-compose/pull/318

