### PR TITLE
[FIX] Path prefix issue

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -223,7 +223,7 @@ export class BaseLoader {
 
     const inFlightPromise = Promise.all([
       this.loadAppData(),
-      this.loadPageDataJson(pagePath),
+      this.loadPageDataJson(rawPath),
     ]).then(allData => {
       const result = allData[1]
       if (result.status === PageResourceStatus.Error) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Previously, the Path prefix didn't work when the page URL started with the same path prefix. (Refer to issue mentioned below)
It was because of the loadPageDataJson function in loader.js
It already includes a findPath function that finds the actual location to get page data but here we used findPath function twice (before sending rawpath to loadPageDataJson) which luckily didn't affect the loaded data when a prefix is different but when it is the same it sliced the URL twice thinking it to be prefix because of the same name.
### Documentation
NA
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Link to the issue that is fixed by this PR:
#27604
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
