### PR TITLE
feat(conditional-page-builds): track ssr compilation hash

### DIFF
--- a/integration-tests/artifacts/gatsby-node.js
+++ b/integration-tests/artifacts/gatsby-node.js
@@ -6,12 +6,17 @@ let runNumber = parseInt(process.env.ARTIFACTS_RUN_SETUP, 10) || 1
 let isFirstRun = runNumber === 1
 
 let changedBrowserCompilationHash
+let changedSsrCompilationHash
 let regeneratedPages = []
 let deletedPages = []
 
 exports.onPreInit = ({ emitter }) => {
   emitter.on(`SET_WEBPACK_COMPILATION_HASH`, action => {
     changedBrowserCompilationHash = action.payload
+  })
+
+  emitter.on(`SET_SSR_WEBPACK_COMPILATION_HASH`, action => {
+    changedSsrCompilationHash = action.payload
   })
 
   emitter.on(`HTML_GENERATED`, action => {
@@ -131,6 +136,7 @@ exports.createPages = async ({ actions, graphql }) => {
 exports.onPreBuild = () => {
   console.log(`[test] onPreBuild`)
   changedBrowserCompilationHash = `not-changed`
+  changedSsrCompilationHash = `not-changed`
   regeneratedPages = []
   deletedPages = []
 }
@@ -157,6 +163,7 @@ exports.onPostBuild = async ({ graphql }) => {
     {
       allPages: data.allSitePage.nodes.map(node => node.path),
       changedBrowserCompilationHash,
+      changedSsrCompilationHash,
       generated: regeneratedPages,
       removed: deletedPages,
     }

--- a/integration-tests/artifacts/gatsby-ssr.js
+++ b/integration-tests/artifacts/gatsby-ssr.js
@@ -1,0 +1,5 @@
+import PostBodyComponents from "./src/components/post-body-components-ssr"
+
+export function onRenderBody({ setPostBodyComponents }) {
+  setPostBodyComponents(PostBodyComponents)
+}

--- a/integration-tests/artifacts/src/components/post-body-components-ssr.js
+++ b/integration-tests/artifacts/src/components/post-body-components-ssr.js
@@ -1,0 +1,7 @@
+import React from "react"
+
+export default (
+  <>
+    <div style={{ background: `yellow` }}>This is only affects SSR</div>
+  </>
+)

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -103,6 +103,16 @@ const doBuildRenderer = async (
     reporter.panic(structureWebpackErrors(stage, stats.compilation.errors))
   }
 
+  if (
+    stage === Stage.BuildHTML &&
+    store.getState().html.ssrCompilationHash !== stats.hash
+  ) {
+    store.dispatch({
+      type: `SET_SSR_WEBPACK_COMPILATION_HASH`,
+      payload: stats.hash,
+    })
+  }
+
   // render-page.js is hard coded in webpack.config
   return `${directory}/public/render-page.js`
 }

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -14,6 +14,7 @@ Object {
   },
   "html": Object {
     "browserCompilationHash": "",
+    "ssrCompilationHash": "",
     "trackedHtmlFiles": Map {
       "/my-sweet-new-page/" => Object {
         "dirty": 2,

--- a/packages/gatsby/src/redux/reducers/html.ts
+++ b/packages/gatsby/src/redux/reducers/html.ts
@@ -4,6 +4,7 @@ const FLAG_DIRTY_CLEARED_CACHE = 0b0000001
 const FLAG_DIRTY_NEW_PAGE = 0b0000010
 const FLAG_DIRTY_PAGE_QUERY_CHANGED = 0b0000100 // TODO: this need to be PAGE_DATA and not PAGE_QUERY, but requires some shuffling
 const FLAG_DIRTY_BROWSER_COMPILATION_HASH = 0b0100000
+const FLAG_DIRTY_SSR_COMPILATION_HASH = 0b1000000
 
 type PagePath = string
 
@@ -11,6 +12,7 @@ function initialState(): IGatsbyState["html"] {
   return {
     trackedHtmlFiles: new Map<PagePath, IHtmlFileState>(),
     browserCompilationHash: ``,
+    ssrCompilationHash: ``,
   }
 }
 
@@ -27,6 +29,7 @@ export function htmlReducer(
         // we can't just clear the cache here - we want to keep track of pages, so we mark them all as "deleted"
         // if they are recreated "isDeleted" flag will be removed
         state.browserCompilationHash = ``
+        state.ssrCompilationHash = ``
         state.trackedHtmlFiles.forEach(htmlFile => {
           htmlFile.isDeleted = true
           // there was a change somewhere, so just in case we mark those files are dirty as well
@@ -98,6 +101,16 @@ export function htmlReducer(
         state.browserCompilationHash = action.payload
         state.trackedHtmlFiles.forEach(htmlFile => {
           htmlFile.dirty |= FLAG_DIRTY_BROWSER_COMPILATION_HASH
+        })
+      }
+      return state
+    }
+
+    case `SET_SSR_WEBPACK_COMPILATION_HASH`: {
+      if (state.ssrCompilationHash !== action.payload) {
+        state.ssrCompilationHash = action.payload
+        state.trackedHtmlFiles.forEach(htmlFile => {
+          htmlFile.dirty |= FLAG_DIRTY_SSR_COMPILATION_HASH
         })
       }
       return state

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -284,6 +284,7 @@ export interface IGatsbyState {
   html: {
     trackedHtmlFiles: Map<Identifier, IHtmlFileState>
     browserCompilationHash: string
+    ssrCompilationHash: string
   }
 }
 
@@ -333,6 +334,7 @@ export type ActionsUnion =
   | ISetGraphQLDefinitionsAction
   | ISetSiteFlattenedPluginsAction
   | ISetWebpackCompilationHashAction
+  | ISetSSRWebpackCompilationHashAction
   | ISetWebpackConfigAction
   | ITouchNodeAction
   | IUpdatePluginsHashAction
@@ -693,6 +695,11 @@ export interface IRemoveStaticQuery {
 export interface ISetWebpackCompilationHashAction {
   type: `SET_WEBPACK_COMPILATION_HASH`
   payload: IGatsbyState["webpackCompilationHash"]
+}
+
+export interface ISetSSRWebpackCompilationHashAction {
+  type: `SET_SSR_WEBPACK_COMPILATION_HASH`
+  payload: string
 }
 
 export interface IUpdatePluginsHashAction {


### PR DESCRIPTION
## Description

For `GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES`:

Html files also will need to regenerate when SSR bundle changes (it can change even if browser bundle did not, which is what this feature was only tracking so far)

PR builds on https://github.com/gatsbyjs/gatsby/pull/29473

[ch23314]