### PR TITLE
Update index.js to stop React errors in console about the 'key'

### DIFF
--- a/starters/gatsby-starter-minimal/src/pages/index.js
+++ b/starters/gatsby-starter-minimal/src/pages/index.js
@@ -125,8 +125,8 @@ const IndexPage = () => {
             {docLink.text}
           </a>
         </li>
-        {links.map((link,indx) => (
-          <li key={indx} style={{ ...listItemStyles, color: link.color }}>
+        {links.map(link => (
+          <li key={link.url} style={{ ...listItemStyles, color: link.color }}>
             <span>
               <a
                 style={linkStyle}

--- a/starters/gatsby-starter-minimal/src/pages/index.js
+++ b/starters/gatsby-starter-minimal/src/pages/index.js
@@ -125,8 +125,8 @@ const IndexPage = () => {
             {docLink.text}
           </a>
         </li>
-        {links.map(link => (
-          <li style={{ ...listItemStyles, color: link.color }}>
+        {links.map((link,indx) => (
+          <li key={indx} style={{ ...listItemStyles, color: link.color }}>
             <span>
               <a
                 style={linkStyle}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->
This fixes react runtime errors in the console regarding missing key values for the HTMLLineItemElement
<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
