### PR TITLE
feat(conditional-page-builds): track static query results

### DIFF
--- a/docs/docs/conditional-page-builds.md
+++ b/docs/docs/conditional-page-builds.md
@@ -6,8 +6,6 @@ If you have a large site, you may be able to improve build times for data update
 
 For more info on the standard build process, please see the [overview of the Gatsby build process](/docs/conceptual/overview-of-the-gatsby-build-process/).
 
-> ❗ Conditional page builds do not currently account for static queries. Any query result differences will not trigger pages to rebuild.
-
 ## How to use
 
 To enable conditional page builds, use the environment variable `GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true` in your `gatsby build` command, for example:

--- a/integration-tests/artifacts/__tests__/index.js
+++ b/integration-tests/artifacts/__tests__/index.js
@@ -359,12 +359,15 @@ describe(`Second run (different pages created, data changed)`, () => {
     `/stale-pages/only-not-in-first`,
     `/page-query-changing-data-but-not-id/`,
     `/page-query-dynamic-2/`,
+    `/static-query-result-tracking/should-invalidate/`,
   ]
 
   const expectedPagesToRemainFromPreviousBuild = [
     `/stale-pages/stable/`,
     `/page-query-stable/`,
     `/page-query-changing-but-not-invalidating-html/`,
+    `/static-query-result-tracking/stable/`,
+    `/static-query-result-tracking/rerun-query-but-dont-recreate-html/`,
   ]
 
   const expectedPages = [

--- a/integration-tests/artifacts/gatsby-node.js
+++ b/integration-tests/artifacts/gatsby-node.js
@@ -81,6 +81,23 @@ exports.sourceNodes = ({
     label: `This is run number {$runNumber}`,
   })
 
+  // used by static queries
+  createNodeHelper(`DepStaticQuery`, {
+    id: `static-query-stable`,
+    label: `Stable (always created)`,
+  })
+
+  createNodeHelper(`DepStaticQuery`, {
+    id: `static-query-changing-but-not-invalidating-html`,
+    label: `Stable (always created)`,
+    buildRun: runNumber, // important for test setup - this will invalidate static query, but shouldn't invalidate html (if it's not queried)
+  })
+
+  createNodeHelper(`DepStaticQuery`, {
+    id: `static-query-changing-data-but-not-id`,
+    label: `This is${isFirstRun ? `` : ` not`} a first run`, // this will be queried - we want to invalidate html here
+  })
+
   for (const prevNode of previouslyCreatedNodes.values()) {
     if (!currentlyCreatedNodes.has(prevNode.id)) {
       actions.deleteNode({ node: prevNode })

--- a/integration-tests/artifacts/src/pages/static-query-result-tracking/rerun-query-but-dont-recreate-html.js
+++ b/integration-tests/artifacts/src/pages/static-query-result-tracking/rerun-query-but-dont-recreate-html.js
@@ -1,0 +1,16 @@
+import React from "react"
+import { graphql, useStaticQuery } from "gatsby"
+
+export default function DepStaticQueryPageRerunQueryButDontRecreateHtml() {
+  const data = useStaticQuery(graphql`
+    {
+      depStaticQuery(
+        id: { eq: "static-query-changing-but-not-invalidating-html" }
+      ) {
+        label
+      }
+    }
+  `)
+
+  return <pre>{JSON.stringify(data, null, 2)}</pre>
+}

--- a/integration-tests/artifacts/src/pages/static-query-result-tracking/should-invalidate.js
+++ b/integration-tests/artifacts/src/pages/static-query-result-tracking/should-invalidate.js
@@ -1,0 +1,14 @@
+import React from "react"
+import { graphql, useStaticQuery } from "gatsby"
+
+export default function DepStaticQueryPageShouldInvalidate() {
+  const data = useStaticQuery(graphql`
+    {
+      depStaticQuery(id: { eq: "static-query-changing-data-but-not-id" }) {
+        label
+      }
+    }
+  `)
+
+  return <pre>{JSON.stringify(data, null, 2)}</pre>
+}

--- a/integration-tests/artifacts/src/pages/static-query-result-tracking/stable.js
+++ b/integration-tests/artifacts/src/pages/static-query-result-tracking/stable.js
@@ -1,0 +1,14 @@
+import React from "react"
+import { graphql, useStaticQuery } from "gatsby"
+
+export default function DepStaticQueryPageStable() {
+  const data = useStaticQuery(graphql`
+    {
+      depStaticQuery(id: { eq: "static-query-stable" }) {
+        label
+      }
+    }
+  `)
+
+  return <pre>{JSON.stringify(data, null, 2)}</pre>
+}

--- a/packages/gatsby/src/commands/build-utils.ts
+++ b/packages/gatsby/src/commands/build-utils.ts
@@ -85,3 +85,50 @@ export function calcDirtyHtmlFiles(
     toDelete,
   }
 }
+
+export function markHtmlDirtyIfResultOfUsedStaticQueryChanged(): void {
+  const state = store.getState()
+
+  const dirtyStaticQueryResults = new Set<string>()
+  state.html.trackedStaticQueryResults.forEach(function (
+    staticQueryResultState,
+    staticQueryHash
+  ) {
+    if (staticQueryResultState.dirty) {
+      dirtyStaticQueryResults.add(staticQueryHash)
+    }
+  })
+
+  // we have dirty static query hashes - now we need to find templates that use them
+  const dirtyTemplates = new Set<string>()
+  state.staticQueriesByTemplate.forEach(function (
+    staticQueryHashes,
+    componentPath
+  ) {
+    for (const dirtyStaticQueryHash of dirtyStaticQueryResults) {
+      if (staticQueryHashes.includes(dirtyStaticQueryHash)) {
+        dirtyTemplates.add(componentPath)
+        break // we already know this template need to rebuild, no need to check rest of queries
+      }
+    }
+  })
+
+  // mark html as dirty
+  const dirtyPages = new Set<string>()
+  for (const dirtyTemplate of dirtyTemplates) {
+    const component = state.components.get(dirtyTemplate)
+    if (component) {
+      for (const page of component.pages) {
+        dirtyPages.add(page)
+      }
+    }
+  }
+
+  store.dispatch({
+    type: `HTML_MARK_DIRTY_BECAUSE_STATIC_QUERY_RESULT_CHANGED`,
+    payload: {
+      pages: dirtyPages,
+      staticQueryHashes: dirtyStaticQueryResults,
+    },
+  })
+}

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -202,6 +202,8 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     buildSSRBundleActivityProgress.end()
   }
 
+  buildUtils.markHtmlDirtyIfResultOfUsedStaticQueryChanged()
+
   const { toRegenerate, toDelete } = process.env
     .GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES
     ? buildUtils.calcDirtyHtmlFiles(store.getState())

--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -208,6 +208,7 @@ export async function queryRunner(
       componentPath: queryJob.componentPath,
       isPage: queryJob.isPage,
       resultHash,
+      queryHash: queryJob.hash,
     })
   )
 

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -22,6 +22,7 @@ Object {
         "pageQueryHash": "",
       },
     },
+    "trackedStaticQueryResults": Map {},
   },
   "jobsV2": Object {
     "complete": Map {},

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -170,6 +170,11 @@ export interface IHtmlFileState {
   pageQueryHash: string // TODO: change to page-data hash
 }
 
+export interface IStaticQueryResultState {
+  dirty: number
+  staticQueryResultHash: string
+}
+
 export type GatsbyNodeAPI =
   | "onPreBoostrap"
   | "onPostBoostrap"
@@ -285,6 +290,7 @@ export interface IGatsbyState {
     trackedHtmlFiles: Map<Identifier, IHtmlFileState>
     browserCompilationHash: string
     ssrCompilationHash: string
+    trackedStaticQueryResults: Map<string, IStaticQueryResultState>
   }
 }
 
@@ -365,6 +371,7 @@ export type ActionsUnion =
   | IDeletedStalePageDataFiles
   | IRemovedHtml
   | IGeneratedHtml
+  | IMarkHtmlDirty
 
 export interface IApiFinishedAction {
   type: `API_FINISHED`
@@ -538,6 +545,7 @@ export interface IPageQueryRunAction {
     componentPath: string
     isPage: boolean
     resultHash: string
+    queryHash: string
   }
 }
 
@@ -832,4 +840,12 @@ interface IRemovedHtml {
 interface IGeneratedHtml {
   type: `HTML_GENERATED`
   payload: Array<string>
+}
+
+interface IMarkHtmlDirty {
+  type: `HTML_MARK_DIRTY_BECAUSE_STATIC_QUERY_RESULT_CHANGED`
+  payload: {
+    pages: Set<string>
+    staticQueryHashes: Set<string>
+  }
 }


### PR DESCRIPTION
## Description

For GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES:

Tracks static query results and mark html files as dirty if static query used by a template changes

PR builds on #29482

[ch23312]