### PR TITLE
chore(docs): Update sourcing-from-json-or-yaml

### DIFF
--- a/docs/docs/how-to/sourcing-data/sourcing-from-json-or-yaml.md
+++ b/docs/docs/how-to/sourcing-data/sourcing-from-json-or-yaml.md
@@ -223,7 +223,7 @@ const fs = require("fs")
 const yaml = require("js-yaml")
 exports.createPages = ({ actions }) => {
   const { createPage } = actions
-  const ymlDoc = yaml.safeLoad(fs.readFileSync("./content/index.yaml", "utf-8"))
+  const ymlDoc = yaml.load(fs.readFileSync("./content/index.yaml", "utf-8"))
   ymlDoc.forEach(element => {
     createPage({
       path: element.path,


### PR DESCRIPTION
Updating how-to guide in section "Configure Gatsby pages" with suggested yaml.load function.
Error says "Function yaml.safeLoad is removed in js-yaml 4. Use yaml. load instead, which is now safe by default."

