### PR TITLE
docs(gatsby-source-wordpress): remove broken links

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -37,13 +37,11 @@ This plugin works by merging the [WPGraphQL schema & data](https://docs.wpgraphq
 - 🐾 [Features](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/features/index.md)
 - 🔌 [Plugin options](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/plugin-options.md)
 - ⛵️ [Migrating from other WP source plugins](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/migrating-from-other-wp-source-plugins.md)
-- 💻 [Using Data](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/using-data.md)
 - 🏠 [Hosting WordPress](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/hosting.md)
 - 👟 [Themes, Starters, and Examples](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/themes-starters-examples.md)
 - 🏅 [Usage with popular WPGraphQL extensions](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/usage-with-popular-wp-graphql-extensions.md)
 - 🛠 [Debugging and troubleshooting](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/debugging-and-troubleshooting.md)
 - 🏞 [Community and Support](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/community-and-support.md)
-- 💡 [Contribution](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/contribution.md)
 - 🧓 [v3 Documentation](https://github.com/gatsbyjs/gatsby/blob/1da331a5352e3f7cb18f69050b7199481d85fbcb/packages/gatsby-source-wordpress/README.md)
 
 ## Relevant Links 🔗


### PR DESCRIPTION
There are a couple broken links on the WP readme