### PR TITLE
fix(conditional-page-builds): track page data and not page query

### DIFF
--- a/integration-tests/artifacts/src/templates/deps-page-query-alternative.js
+++ b/integration-tests/artifacts/src/templates/deps-page-query-alternative.js
@@ -1,10 +1,10 @@
 import React from "react"
 import { graphql } from "gatsby"
 
-export default function DepPageQueryPage({ data }) {
+export default function DepPageQueryAlternativePage({ data }) {
   return (
     <>
-      <h1>Default template for depPageQuery</h1>
+      <h1>Alternative template for depPageQuery</h1>
       <pre>{JSON.stringify(data, null, 2)}</pre>
     </>
   )

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ Object {
       "/my-sweet-new-page/" => Object {
         "dirty": 2,
         "isDeleted": false,
-        "pageQueryHash": "",
+        "pageDataHash": "",
       },
     },
     "trackedStaticQueryResults": Map {},

--- a/packages/gatsby/src/redux/reducers/html.ts
+++ b/packages/gatsby/src/redux/reducers/html.ts
@@ -7,7 +7,7 @@ import {
 
 const FLAG_DIRTY_CLEARED_CACHE = 0b0000001
 const FLAG_DIRTY_NEW_PAGE = 0b0000010
-const FLAG_DIRTY_PAGE_QUERY_CHANGED = 0b0000100 // TODO: this need to be PAGE_DATA and not PAGE_QUERY, but requires some shuffling
+const FLAG_DIRTY_PAGE_DATA_CHANGED = 0b0000100
 const FLAG_DIRTY_STATIC_QUERY_FIRST_RUN = 0b0001000
 const FLAG_DIRTY_STATIC_QUERY_RESULT_CHANGED = 0b0010000
 const FLAG_DIRTY_BROWSER_COMPILATION_HASH = 0b0100000
@@ -58,7 +58,7 @@ export function htmlReducer(
         htmlFile = {
           dirty: FLAG_DIRTY_NEW_PAGE,
           isDeleted: false,
-          pageQueryHash: ``,
+          pageDataHash: ``,
         }
         state.trackedHtmlFiles.set(path, htmlFile)
       } else if (htmlFile.isDeleted) {
@@ -87,20 +87,7 @@ export function htmlReducer(
     }
 
     case `PAGE_QUERY_RUN`: {
-      if (action.payload.isPage) {
-        const htmlFile = state.trackedHtmlFiles.get(action.payload.path)
-        if (!htmlFile) {
-          // invariant
-          throw new Error(
-            `[html reducer] I received event that query for a page finished running, but I'm not aware of the page it ran for (?)`
-          )
-        }
-
-        if (htmlFile.pageQueryHash !== action.payload.resultHash) {
-          htmlFile.pageQueryHash = action.payload.resultHash
-          htmlFile.dirty |= FLAG_DIRTY_PAGE_QUERY_CHANGED
-        }
-      } else {
+      if (!action.payload.isPage) {
         // static query case
         let staticQueryResult = state.trackedStaticQueryResults.get(
           action.payload.queryHash
@@ -121,6 +108,21 @@ export function htmlReducer(
         }
       }
 
+      return state
+    }
+    case `ADD_PAGE_DATA_STATS`: {
+      const htmlFile = state.trackedHtmlFiles.get(action.payload.pagePath)
+      if (!htmlFile) {
+        // invariant
+        throw new Error(
+          `[html reducer] I received event that query for a page finished running, but I'm not aware of the page it ran for (?)`
+        )
+      }
+
+      if (htmlFile.pageDataHash !== action.payload.pageDataHash) {
+        htmlFile.pageDataHash = action.payload.pageDataHash
+        htmlFile.dirty |= FLAG_DIRTY_PAGE_DATA_CHANGED
+      }
       return state
     }
 

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -167,7 +167,7 @@ export interface IComponentState {
 export interface IHtmlFileState {
   dirty: number
   isDeleted: boolean
-  pageQueryHash: string // TODO: change to page-data hash
+  pageDataHash: string
 }
 
 export interface IStaticQueryResultState {
@@ -788,8 +788,10 @@ export interface ISetResolvedNodesAction {
 export interface IAddPageDataStatsAction {
   type: `ADD_PAGE_DATA_STATS`
   payload: {
+    pagePath: string
     filePath: SystemPath
     size: number
+    pageDataHash: string
   }
 }
 

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -3,6 +3,7 @@ import fs from "fs-extra"
 import reporter from "gatsby-cli/lib/reporter"
 import fastq from "fastq"
 import path from "path"
+import { createContentDigest } from "gatsby-core-utils"
 import { IGatsbyPage } from "../redux/types"
 import { websocketManager } from "./websocket-manager"
 import { isWebpackStatusPending } from "./webpack-status"
@@ -100,8 +101,10 @@ export async function writePageData(
   store.dispatch({
     type: `ADD_PAGE_DATA_STATS`,
     payload: {
+      pagePath,
       filePath: outputFilePath,
       size: pageDataSize,
+      pageDataHash: createContentDigest(bodyStr),
     },
   })
 


### PR DESCRIPTION
## Description

For GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES:

Tracks page-data content and not just page query result (this will cover changes like used `component` (template) etc)

PR builds on #29486

[ch23316]