### PR TITLE
chore(build): move html generation to separate function

### DIFF
--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -4,12 +4,16 @@ import reporter from "gatsby-cli/lib/reporter"
 import { createErrorFromString } from "gatsby-cli/lib/reporter/errors"
 import { chunk } from "lodash"
 import webpack from "webpack"
+import * as path from "path"
 
 import { emitter, store } from "../redux"
 import webpackConfig from "../utils/webpack.config"
 import { structureWebpackErrors } from "../utils/webpack-error-utils"
+import * as buildUtils from "./build-utils"
 
+import { Span } from "opentracing"
 import { IProgram, Stage } from "./types"
+import { PackageJson } from "../.."
 
 type IActivity = any // TODO
 type IWorkerPool = any // TODO
@@ -17,6 +21,17 @@ type IWorkerPool = any // TODO
 export interface IWebpackWatchingPauseResume extends webpack.Watching {
   suspend: () => void
   resume: () => void
+}
+
+export interface IBuildArgs extends IProgram {
+  directory: string
+  sitePackageJson: PackageJson
+  prefixPaths: boolean
+  noUglify: boolean
+  profile: boolean
+  graphqlTracing: boolean
+  openTracingConfigFile: string
+  keepPageRenderer: boolean
 }
 
 let devssrWebpackCompiler: webpack.Compiler
@@ -104,7 +119,7 @@ const doBuildRenderer = async (
   }
 
   if (
-    stage === Stage.BuildHTML &&
+    stage === `build-html` &&
     store.getState().html.ssrCompilationHash !== stats.hash
   ) {
     store.dispatch({
@@ -238,4 +253,90 @@ export const buildHTML = async ({
   const rendererPath = await buildRenderer(program, stage, activity.span)
   await doBuildPages(rendererPath, pagePaths, activity, workerPool, stage)
   await deleteRenderer(rendererPath)
+}
+
+export async function buildHTMLPagesAndDeleteStaleArtifacts({
+  pageRenderer,
+  workerPool,
+  buildSpan,
+  program,
+}: {
+  pageRenderer: string
+  workerPool: IWorkerPool
+  buildSpan?: Span
+  program: IBuildArgs
+}): Promise<{
+  toRegenerate: Array<string>
+  toDelete: Array<string>
+}> {
+  buildUtils.markHtmlDirtyIfResultOfUsedStaticQueryChanged()
+
+  const { toRegenerate, toDelete } = process.env
+    .GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES
+    ? buildUtils.calcDirtyHtmlFiles(store.getState())
+    : {
+        toRegenerate: [...store.getState().pages.keys()],
+        toDelete: [],
+      }
+
+  const buildHTMLActivityProgress = reporter.createProgress(
+    `Building static HTML for pages`,
+    toRegenerate.length,
+    0,
+    {
+      parentSpan: buildSpan,
+    }
+  )
+  buildHTMLActivityProgress.start()
+  try {
+    await doBuildPages(
+      pageRenderer,
+      toRegenerate,
+      buildHTMLActivityProgress,
+      workerPool,
+      Stage.BuildHTML
+    )
+  } catch (err) {
+    let id = `95313` // TODO: verify error IDs exist
+    const context = {
+      errorPath: err.context && err.context.path,
+      ref: ``,
+    }
+
+    const match = err.message.match(
+      /ReferenceError: (window|document|localStorage|navigator|alert|location) is not defined/i
+    )
+    if (match && match[1]) {
+      id = `95312`
+      context.ref = match[1]
+    }
+
+    buildHTMLActivityProgress.panic({
+      id,
+      context,
+      error: err,
+    })
+  }
+  buildHTMLActivityProgress.end()
+
+  if (!program.keepPageRenderer) {
+    try {
+      await deleteRenderer(pageRenderer)
+    } catch (err) {
+      // pass through
+    }
+  }
+
+  if (toDelete.length > 0) {
+    const publicDir = path.join(program.directory, `public`)
+    const deletePageDataActivityTimer = reporter.activityTimer(
+      `Delete previous page data`
+    )
+    deletePageDataActivityTimer.start()
+    await buildUtils.removePageFiles(publicDir, toDelete)
+
+    deletePageDataActivityTimer.end()
+  }
+
+  return { toRegenerate, toDelete }
 }


### PR DESCRIPTION
## Description

This just moves "nitty-gritty" details into service-like function to make `build.ts` command leaner and easier to scan

PR builds on https://github.com/gatsbyjs/gatsby/pull/29498