### PR TITLE
chore(gatsby): pin graphql-compose version to patch

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -34,7 +34,7 @@
     "gatsby-telemetry": "^2.0.0-next.0",
     "glob": "^7.1.6",
     "graphql": "^15.4.0",
-    "graphql-compose": "^7.25.0",
+    "graphql-compose": "~7.25.0",
     "graphql-subscriptions": "^1.1.0",
     "graphql-type-json": "^0.3.2",
     "hicat": "^0.8.0",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -91,7 +91,7 @@
     "glob": "^7.1.6",
     "got": "8.3.2",
     "graphql": "^15.4.0",
-    "graphql-compose": "^7.25.0",
+    "graphql-compose": "~7.25.0",
     "graphql-playground-middleware-express": "^1.7.18",
     "hasha": "^5.2.0",
     "http-proxy": "^1.18.1",


### PR DESCRIPTION
## Description

`graphql-compose` is so deeply integrated into our GraphQL layer that even minor changes there can cause unexpected side effects for schema building. We want to stay on a safer side of things with this key dependency.

So changing semver dependency from `minor` level to `patch`.

