### PR TITLE
tests: Fix cli integration test

### DIFF
--- a/integration-tests/gatsby-cli/__tests__/new.js
+++ b/integration-tests/gatsby-cli/__tests__/new.js
@@ -36,7 +36,6 @@ describe(`gatsby new`, () => {
     )
     logs.should.contain(`success Created starter directory layout`)
     logs.should.contain(`info Installing packages...`)
-    logs.should.contain(`success Saved lockfile.`)
     logs.should.contain(
       `Your new Gatsby site has been successfully bootstrapped. Start developing it by running:`
     )
@@ -57,7 +56,6 @@ describe(`gatsby new`, () => {
     )
     logs.should.contain(`success Created starter directory layout`)
     logs.should.contain(`info Installing packages...`)
-    logs.should.contain(`success Saved lockfile.`)
     logs.should.contain(
       `Your new Gatsby site has been successfully bootstrapped. Start developing it by running:`
     )


### PR DESCRIPTION
The CLI tests are failing because they're looking for specific messages from npm which aren't there. I've removed them, because it's not relevant to our own tests.