### PR TITLE
Fix URL typo in sass recipe

### DIFF
--- a/packages/gatsby-recipes/recipes/sass.mdx
+++ b/packages/gatsby-recipes/recipes/sass.mdx
@@ -36,4 +36,4 @@ with Sass.
 
 Read more about Sass on the official Sass docs site:
 
-https://sass-lang.com/documentationb
+https://sass-lang.com/documentation


### PR DESCRIPTION
## Description

Changes `https://sass-lang.com/documentationb` to `https://sass-lang.com/documentation`, I checked `documentationb` to make sure and it 404s