### PR TITLE
hack: overwrite contenthash set by mini-css-extract-plugin

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -18,6 +18,7 @@ import { createWebpackUtils } from "./webpack-utils"
 import { hasLocalEslint } from "./local-eslint-config-finder"
 import { getAbsolutePathForVirtualModule } from "./gatsby-webpack-virtual-modules"
 import { StaticQueryMapper } from "./webpack/static-query-mapper"
+import { TmpMiniCssExtractContentHashOverWrite } from "./webpack/tmp-mini-css-extract-contenthash-overwrite"
 import { getBrowsersList } from "./browserslist"
 
 const FRAMEWORK_BUNDLES = [`react`, `react-dom`, `scheduler`, `prop-types`]
@@ -247,6 +248,8 @@ module.exports = async (
             filename: `[name].[contenthash].css`,
             chunkFilename: `[name].[contenthash].css`,
           }),
+          // remove after https://github.com/webpack-contrib/mini-css-extract-plugin/issues/701
+          new TmpMiniCssExtractContentHashOverWrite(),
           // Write out stats object mapping named dynamic imports (aka page
           // components) to all their async chunks.
           plugins.extractStats(),

--- a/packages/gatsby/src/utils/webpack/tmp-mini-css-extract-contenthash-overwrite.ts
+++ b/packages/gatsby/src/utils/webpack/tmp-mini-css-extract-contenthash-overwrite.ts
@@ -1,0 +1,67 @@
+import { Compiler, Module } from "webpack"
+
+const MODULE_TYPE = `css/mini-extract`
+
+function deterministicModuleOrderComparator(
+  modA: Module,
+  modB: Module
+): -1 | 0 | 1 {
+  const modAIdentifier = modA.identifier()
+  const modBIdentifier = modB.identifier()
+  if (modAIdentifier < modBIdentifier) {
+    return -1
+  } else if (modAIdentifier > modBIdentifier) {
+    return 1
+  } else {
+    return 0
+  }
+}
+
+/**
+ * This is temporary hack to override `contentHash` that `mini-css-extract-plugin` sets
+ * because it's not deterministic currently (at least for webpack@5).
+ * Important part is to have this temporary plugin instance AFTER `mini-css-extract-plugin`
+ * because we can't really remove what that plugin is doing, we can only overwrite it
+ * @see https://github.com/webpack-contrib/mini-css-extract-plugin/issues/701
+ */
+export class TmpMiniCssExtractContentHashOverWrite {
+  private name: string
+
+  constructor() {
+    this.name = `TmpMiniCssExtractContentHashOverWrite`
+  }
+
+  apply(compiler: Compiler): void {
+    compiler.hooks.thisCompilation.tap(this.name, compilation => {
+      compilation.hooks.contentHash.tap(this.name, chunk => {
+        const { outputOptions, chunkGraph } = compilation
+        if (!chunkGraph) {
+          throw new Error(`No chunkGraph`)
+        }
+        const modules = chunkGraph.getOrderedChunkModulesIterableBySourceType(
+          chunk,
+          MODULE_TYPE,
+          deterministicModuleOrderComparator
+        )
+
+        if (modules) {
+          const { hashFunction, hashDigest, hashDigestLength } = outputOptions
+
+          if (!hashFunction) {
+            throw new Error(`No hashFunction`)
+          }
+          const createHash = compiler.webpack.util.createHash
+          const hash = createHash(hashFunction)
+
+          for (const m of modules) {
+            m.updateHash(hash, { chunkGraph, runtime: undefined })
+          }
+
+          chunk.contentHash[MODULE_TYPE] = (hash.digest(
+            hashDigest
+          ) as string).substring(0, hashDigestLength)
+        }
+      })
+    })
+  }
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
