### PR TITLE
fix(gatsby-plugin-styled-components): Support `topLevelImportPaths` option

### DIFF
--- a/packages/gatsby-plugin-styled-components/src/gatsby-node.js
+++ b/packages/gatsby-plugin-styled-components/src/gatsby-node.js
@@ -28,6 +28,10 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     transpileTemplateLiterals: Joi.boolean()
       .default(true)
       .description(`Transpile tagged template literals into optimized code.`),
+    topLevelImportPaths: Joi.array()
+      .default([])
+      .items(Joi.string())
+      .description(`Top level import paths allowed to identify library`),
     pure: Joi.boolean()
       .default(false)
       .description(


### PR DESCRIPTION
## Description

Put back the option in the plugin: https://github.com/styled-components/babel-plugin-styled-components/pull/288