### PR TITLE
Adds guidance for Emotion + TypeScript setup

### DIFF
--- a/packages/gatsby-plugin-emotion/README.md
+++ b/packages/gatsby-plugin-emotion/README.md
@@ -37,6 +37,16 @@ module.exports = {
 }
 ```
 
+If you're using TypeScript and Emotion's `css` prop, you will also need to add an additional type to your `tsconfig.json`.
+
+```json
+{
+  "compilerOptions": {
+    "types": ["@emotion/react/types/css-prop"]
+  }
+}
+```
+
 ## Options
 
 The plugin supports the same options that you can pass into [`@emotion/babel-plugin`](https://emotion.sh/docs/@emotion/babel-plugin#options).


### PR DESCRIPTION
Updates the Emotion plugin documentation with the knowledge from the community in https://github.com/emotion-js/emotion/issues/1249#issuecomment-727590944.

This additional step should only be required until Gatsby upgrades to React v17 and the new JSX transform can be used.