### PR TITLE
fix(gatsby-source-contentful): Correct supported image formats

### DIFF
--- a/packages/gatsby-plugin-image/src/resolver-utils.ts
+++ b/packages/gatsby-plugin-image/src/resolver-utils.ts
@@ -176,7 +176,7 @@ export function getGatsbyImageFieldConfig<TSource, TContext>(
             The image formats to generate. Valid values are AUTO (meaning the same format as the source image), JPG, PNG, WEBP and AVIF.
             The default value is [AUTO, WEBP], and you should rarely need to change this. Take care if you specify JPG or PNG when you do
             not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
-            both PNG and JPG is not supported and will be ignored. AVIF support is currently experimental.
+            both PNG and JPG is not supported and will be ignored. 
         `,
         defaultValue: [`auto`, `webp`],
       },

--- a/packages/gatsby-source-contentful/src/schemes.js
+++ b/packages/gatsby-source-contentful/src/schemes.js
@@ -4,6 +4,7 @@ const ImageFormatType = new GraphQLEnumType({
   name: `ContentfulImageFormat`,
   values: {
     NO_CHANGE: { value: `` },
+    AUTO: { value: `` },
     JPG: { value: `jpg` },
     PNG: { value: `png` },
     WEBP: { value: `webp` },


### PR DESCRIPTION
Contentful doesn't support AVIF. This fixes the resolver, and adds a check in the url builder