### PR TITLE
fix(gatsby): fix deprecation export messages

### DIFF
--- a/packages/gatsby/cache-dir/gatsby-browser-entry.js
+++ b/packages/gatsby/cache-dir/gatsby-browser-entry.js
@@ -105,9 +105,6 @@ export {
   graphql,
   parsePath,
   navigate,
-  push, // TODO replace for v3
-  replace, // TODO remove replace for v3
-  navigateTo, // TODO: remove navigateTo for v3
   useScrollRestoration,
   StaticQueryContext,
   StaticQuery,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Fixes
```
warn export 'push' (reexported as 'push') was not found in 'gatsby-link' (possible exports: __esModule, default, navigate, parsePath, withAssetPrefix,
withPrefix)
warn export 'replace' (reexported as 'replace') was not found in 'gatsby-link' (possible exports: __esModule, default, navigate, parsePath, withAssetPrefix,
withPrefix)
warn export 'navigateTo' (reexported as 'navigateTo') was not found in 'gatsby-link' (possible exports: __esModule, default, navigate, parsePath,
withAssetPrefix, withPrefix)
```