### PR TITLE
fix(gatsby): prevent errors when backwards compat node.nodeId is for a deleted node in touchNode

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -830,8 +830,12 @@ actions.touchNode = (node: any, plugin?: Plugin) => {
     typeOwners[node.internal.type] = node.internal.owner
   }
 
-  // incase a node or node id that doesn't exist is passed
-  const nodeId = node?.id || false
+  const nodeId = node?.id
+
+  if (!nodeId) {
+    // if we don't have a node id, we don't want to dispatch this action
+    return []
+  }
 
   return {
     type: `TOUCH_NODE`,

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -830,10 +830,13 @@ actions.touchNode = (node: any, plugin?: Plugin) => {
     typeOwners[node.internal.type] = node.internal.owner
   }
 
+  // incase a node or node id that doesn't exist is passed
+  const nodeId = node?.id || false
+
   return {
     type: `TOUCH_NODE`,
     plugin,
-    payload: node.id,
+    payload: nodeId,
   }
 }
 


### PR DESCRIPTION
With the v3 change to touchNode, a subtle bug was introduced - previously calling touchNode on an id for a node that no longer exists worked fine, now Gatsby will throw errors about accessing `id` on undefined. This PR accounts for that situation 👍 