### PR TITLE
fix(gatsby): cleanup fullySpecified resolving

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -50,8 +50,6 @@ const ensureWindowsDriveIsUppercase = filePath => {
     : filePath
 }
 
-const deprecationWarnings = new Set()
-
 const findChildren = initialChildren => {
   const children = [...initialChildren]
   const queue = [...initialChildren]
@@ -953,24 +951,6 @@ actions.createParentChildLink = (
  * @param {Object} config partial webpack config, to be merged into the current one
  */
 actions.setWebpackConfig = (config: Object, plugin?: ?Plugin = null) => {
-  if (config.module?.rules) {
-    config.module.rules.forEach(rule => {
-      if (!rule.resolve) {
-        // TODO move message to gatsbyjs.com/docs - change to structured
-        const key = `${plugin.name}-setWebpackConfig`
-        if (!deprecationWarnings.has(key)) {
-          report.warn(
-            `[deprecation] ${plugin.name} added a new module rule to the webpack config without specyfing the resolve property. This option will become mandatory in the next release. For more information go to https://webpack.js.org/configuration/module/#ruleresolve`
-          )
-        }
-        deprecationWarnings.add(key)
-        rule.resolve = {
-          fullySpecified: false,
-        }
-      }
-    })
-  }
-
   return {
     type: `SET_WEBPACK_CONFIG`,
     plugin,
@@ -988,24 +968,6 @@ actions.setWebpackConfig = (config: Object, plugin?: ?Plugin = null) => {
  * @param {Object} config complete webpack config
  */
 actions.replaceWebpackConfig = (config: Object, plugin?: ?Plugin = null) => {
-  if (config.module?.rules && plugin) {
-    config.module.rules.forEach(rule => {
-      if (!rule.resolve) {
-        // TODO move message to gatsbyjs.com/docs - change to structured
-        const key = `${plugin.name}-setWebpackConfig`
-        if (!deprecationWarnings.has(key)) {
-          report.warn(
-            `[deprecation] ${plugin.name} added a new module rule to the webpack config without specyfing the resolve property. This option will become mandatory in the next release. For more information go to https://webpack.js.org/configuration/module/#ruleresolve`
-          )
-        }
-        deprecationWarnings.add(key)
-        rule.resolve = {
-          fullySpecified: false,
-        }
-      }
-    })
-  }
-
   return {
     type: `REPLACE_WEBPACK_CONFIG`,
     plugin,

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/sample-site-for-experiment.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/sample-site-for-experiment.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 1`] = `false`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 1`] = `true`;
 
 exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 2`] = `false`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 3`] = `false`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 3`] = `true`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 4`] = `false`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 4`] = `true`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 5`] = `true`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 5`] = `false`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 6`] = `false`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 6`] = `true`;
 
 exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 7`] = `false`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 8`] = `true`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 8`] = `false`;

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/sample-site-for-experiment.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/sample-site-for-experiment.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 1`] = `true`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 1`] = `false`;
 
 exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 2`] = `false`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 3`] = `true`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 3`] = `false`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 4`] = `true`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 4`] = `false`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 5`] = `false`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 5`] = `true`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 6`] = `true`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 6`] = `false`;
 
 exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 7`] = `false`;
 
-exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 8`] = `false`;
+exports[`sampleSiteForExperiment returns true or false depending on if they randomly are bucketed in or not 8`] = `true`;

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
@@ -3,9 +3,6 @@
 exports[`webpack utils dependencies returns default values without any options 1`] = `
 Object {
   "exclude": [Function],
-  "resolve": Object {
-    "fullySpecified": false,
-  },
   "test": /\\\\\\.\\(js\\|mjs\\)\\$/,
   "type": "javascript/auto",
   "use": Array [
@@ -35,9 +32,6 @@ Object {
 exports[`webpack utils js returns default values without any options 1`] = `
 Object {
   "include": [Function],
-  "resolve": Object {
-    "fullySpecified": false,
-  },
   "test": /\\\\\\.\\(js\\|mjs\\|jsx\\)\\$/,
   "type": "javascript/auto",
   "use": Array [

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -408,9 +408,6 @@ export const createWebpackUtils = (
     } = {}): RuleSetRule => {
       return {
         test: /\.(js|mjs|jsx)$/,
-        resolve: {
-          fullySpecified: false,
-        },
         include: (modulePath: string): boolean => {
           // when it's not coming from node_modules we treat it as a source file.
           if (!vendorRegex.test(modulePath)) {
@@ -504,9 +501,6 @@ export const createWebpackUtils = (
 
       return {
         test: /\.(js|mjs)$/,
-        resolve: {
-          fullySpecified: false,
-        },
         exclude: (modulePath: string): boolean => {
           // If dep is user land code, exclude
           if (!vendorRegex.test(modulePath)) {

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -290,15 +290,6 @@ module.exports = async (
       rules.js({
         modulesThatUseGatsby,
       }),
-      // Webpack expects extensions when importing to mimic ESM spec.
-      // Not all libraries have adapted so we don't enforce its behaviour
-      // @see https://github.com/webpack/webpack/issues/11467
-      {
-        test: /\.m?js/,
-        resolve: {
-            fullySpecified: false
-        }
-      },
       rules.yaml(),
       rules.fonts(),
       rules.images(),
@@ -423,6 +414,13 @@ module.exports = async (
         "react-dom": getPackageRoot(`react-dom`),
       },
       plugins: [new CoreJSResolver()],
+      // https://webpack.js.org/configuration/module/#resolvefullyspecified
+      // Does not force extensions for ESM modules
+      byDependency: {
+        esm: {
+          fullySpecified: false,
+        },
+      },
     }
 
     const target =

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -287,6 +287,32 @@ module.exports = async (
     // Common config for every env.
     // prettier-ignore
     let configRules = [
+      // Webpack expects extensions when importing ESM modules as that's what the spec describes.
+      // Not all libraries have adapted so we don't enforce its behaviour
+      // @see https://github.com/webpack/webpack/issues/11467
+      {
+        test: /\.mjs$/i,
+        resolve: {
+          byDependency: {
+            esm: {
+              fullySpecified: false
+            }
+          }
+        }
+      },
+      {
+        test: /\.js$/i,
+        descriptionData: {
+          type: `module`
+        },
+        resolve: {
+          byDependency: {
+            esm: {
+              fullySpecified: false
+            }
+          }
+        }
+      },
       rules.js({
         modulesThatUseGatsby,
       }),
@@ -414,13 +440,6 @@ module.exports = async (
         "react-dom": getPackageRoot(`react-dom`),
       },
       plugins: [new CoreJSResolver()],
-      // https://webpack.js.org/configuration/module/#resolvefullyspecified
-      // Does not force extensions for ESM modules
-      byDependency: {
-        esm: {
-          fullySpecified: false,
-        },
-      },
     }
 
     const target =


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I did some more researching and we can disable fullySpecified in better way for all ESM modules. This allows us to skip fullySpecified on all js loaders.

### How to test
`import ky from "ky"` inside your project to trigger this bug.
