### PR TITLE
docs: fix case of GitHub, JavaScript, TypeScript and WordPress

### DIFF
--- a/docs/docs/conceptual/choosing-a-cms.md
+++ b/docs/docs/conceptual/choosing-a-cms.md
@@ -18,7 +18,7 @@ In terms of popularity, you can see [top integrations listed by monthly download
 
 - **five general-purpose headless CMSs:** Contentful, DatoCMS, Prismic, Sanity and Strapi
 
-- **two general-purpose full-stack CMSs** running in "headless" mode: Drupal and Wordpress
+- **two general-purpose full-stack CMSs** running in "headless" mode: Drupal and WordPress
 
 - **one specialized CMS**: Shopify
 
@@ -28,7 +28,7 @@ In terms of popularity, you can see [top integrations listed by monthly download
 
 - If you're working on a personal project or prototype, a few of these have a generous free tier (Contentful, DatoCMS, Prismic, Sanity, Strapi).
 
-- If you're looking more at "Team", "Pro", or "Business" price points (eg $29, $99, or \$299 per month), the above CMSs are all good options, plus Drupal and Wordpress.
+- If you're looking more at "Team", "Pro", or "Business" price points (eg $29, $99, or \$299 per month), the above CMSs are all good options, plus Drupal and WordPress.
 
 - If you're looking more at an "enterprise" project in the four digits per month and up, your main options are Contentful, Contentstack, Sanity, and Strapi.
 
@@ -45,7 +45,7 @@ Users choosing other CMSs typically have a specific reason for their choice. Som
 - **Drupal** if open-source, configurability, or custom code are important.
 - **Prismic** if they like the content editing UI
 - **Sanity** or **Strapi** for the developer-friendliness or if they need something on-premise. In addition, Sanity tends to have significantly better build times, which can be a key usability consideration, especially for larger sites (we [benchmark build times by CMS here](https://willit.build/)).
-- **Wordpress** when the client or content team is already familiar with the Wordpress UI
+- **WordPress** when the client or content team is already familiar with the WordPress UI
 
 ## Using multiple CMS systems together
 
@@ -65,13 +65,13 @@ Typically, teams that use multiple CMSs use a specialized CMS for part of the we
 
 ### Considerations when using multiple CMSs
 
-One of the key considerations when using content in multiple systems is that - at some point - one content system often needs to "know about" another system. For example, a landing page with content in Contentful may need to embed information about a specific product SKU from Shopify or blog post in Wordpress.
+One of the key considerations when using content in multiple systems is that - at some point - one content system often needs to "know about" another system. For example, a landing page with content in Contentful may need to embed information about a specific product SKU from Shopify or blog post in WordPress.
 
 The easiest way to create relationship references across CMSs is through one CMS storing unique IDs of content living in another CMS.
 
-In this case, you'd store an array of Wordpress blog post IDs as a field of the relevant model in Contentful, then pull in the correct data via the appropriate queries in `gatsby-node.js.`
+In this case, you'd store an array of WordPress blog post IDs as a field of the relevant model in Contentful, then pull in the correct data via the appropriate queries in `gatsby-node.js.`
 
-To make that a bit more concrete, here's a screenshot of what this looks like currently (January 2020) in the Gatsbyjs.com Contentful setup for the [e-commerce use case page](https://www.gatsbyjs.com/use-cases/e-commerce); the model is called `Use Case Landing Page`, the field is called `Blog Posts`, and the items in the array are unique blog post IDs from Wordpress:
+To make that a bit more concrete, here's a screenshot of what this looks like currently (January 2020) in the Gatsbyjs.com Contentful setup for the [e-commerce use case page](https://www.gatsbyjs.com/use-cases/e-commerce); the model is called `Use Case Landing Page`, the field is called `Blog Posts`, and the items in the array are unique blog post IDs from WordPress:
 
 ![Screenshot of Gatsbyjs.com Contentful setup](../images/use-case-landing-page-screenshot.jpg)
 

--- a/docs/docs/conceptual/gatsby-for-ecommerce.md
+++ b/docs/docs/conceptual/gatsby-for-ecommerce.md
@@ -18,7 +18,7 @@ In this case, your options are likely between a technologically forward e-commer
 
 ### Choosing additional content systems
 
-Once an organization selects a main e-commerce platform, it may also want or need other content stores that will get pulled into the website. They might choose a CMS like Contentful for complex content modelling, or Wordpress for blog content authoring. They might choose Yotpo for customer reviews or Salsify for product information management.
+Once an organization selects a main e-commerce platform, it may also want or need other content stores that will get pulled into the website. They might choose a CMS like Contentful for complex content modelling, or WordPress for blog content authoring. They might choose Yotpo for customer reviews or Salsify for product information management.
 
 ### Why organizations build e-commerce sites with Gatsby
 
@@ -26,7 +26,7 @@ Organizations looking for a JAMStack e-commerce site that go with Gatsby typical
 
 From a conversion perspective, Gatsby’s lightning-fast performance is a huge win: Gatsby automates code splitting, image optimization, inlining critical styles, lazy-loading, prefetching resources, and more to ensure your site is fully optimized.
 
-And with Gatsby’s pre-built integrations, it can pull data in from all of these sources (Shopify, plus Wordpress, Contentful, Yotpo, etc) and make it available for the React components.
+And with Gatsby’s pre-built integrations, it can pull data in from all of these sources (Shopify, plus WordPress, Contentful, Yotpo, etc) and make it available for the React components.
 
 ### Specific e-commerce development considerations
 
@@ -42,6 +42,6 @@ Additional resources:
 
 - [What is Headless Commerce?](https://www.bigcommerce.com/articles/headless-commerce/#unlocking-flexibility-examples-of-headless-commerce-in-action), an overview from BigCommerce.
 - [Gatsby Shopify Starter](https://github.com/AlexanderProd/gatsby-shopify-starter)
-- Sell Things Fast With Gatsby and Shopify by Trevor Harmon [blog post](https://thetrevorharmon.com/blog/sell-things-fast-with-gatsby-and-shopify), [video](https://www.youtube.com/watch?v=tUtuGAFOjYI&t=16m59s) and [Github repo](https://github.com/thetrevorharmon/sell-things-fast/)
+- Sell Things Fast With Gatsby and Shopify by Trevor Harmon [blog post](https://thetrevorharmon.com/blog/sell-things-fast-with-gatsby-and-shopify), [video](https://www.youtube.com/watch?v=tUtuGAFOjYI&t=16m59s) and [GitHub repo](https://github.com/thetrevorharmon/sell-things-fast/)
 - [Gatsby Use Cases: E-commerce](https://www.gatsbyjs.com/use-cases/e-commerce)
 - [Best e-commerce solutions for Jamstack websites](https://bejamas.io/blog/jamstack-ecommerce/) from the Bejamas blog.

--- a/docs/docs/conceptual/using-gatsby-image.md
+++ b/docs/docs/conceptual/using-gatsby-image.md
@@ -22,7 +22,7 @@ We provide a [detailed guide on using Gatsby Image](docs/how-to/images-and-media
 
 ### Avoid hydration lag for React apps
 
-When you're building a website with React you face a bit of a catch-22 for optimizing image loads. If you send over React JavaScript files to be evaluated by the browser (client-side rendering), you can't start loading images until the browser evaluates all of the Javascript to figure out what images you want to load. On the other hand, if you evaluate the Javascript on the server and then send over the HTML (server-side rendering), then the initial request will take longer to load while it waits for this server-side evaluation.
+When you're building a website with React you face a bit of a catch-22 for optimizing image loads. If you send over React JavaScript files to be evaluated by the browser (client-side rendering), you can't start loading images until the browser evaluates all of the JavaScript to figure out what images you want to load. On the other hand, if you evaluate the JavaScript on the server and then send over the HTML (server-side rendering), then the initial request will take longer to load while it waits for this server-side evaluation.
 
 Because Gatsby does server rendering during the build process _(rather than when a user is loading the page)_ a Gatsby site will return HTML immediately without waiting for server rendering, and then the client's browser can start loading images as soon as it receives the HTML. Depending on the size of the app, this could save anything from a few hundred milliseconds to a few seconds.
 

--- a/packages/gatsby-remark-embed-snippet/README.md
+++ b/packages/gatsby-remark-embed-snippet/README.md
@@ -396,7 +396,7 @@ As an alternative to selecting a range of lines from a file, you can add `start-
 
 You can specify that you want to only include a named snippet from the embed by using the syntax `{snippet: "snippet-name"}`.
 
-**Javascript example**:
+**JavaScript example**:
 
 ```markdown
 The function to use is:

--- a/packages/gatsby-source-wordpress/docs/debugging-and-troubleshooting.md
+++ b/packages/gatsby-source-wordpress/docs/debugging-and-troubleshooting.md
@@ -87,14 +87,14 @@ Take that query and make the query directly to your WP instance GraphQL API like
 
     #### If it does have missing data:
 
-    this means you're experiencing a bug on the WPGraphQL side of things. Seek help in the [WPGraphQL Slack](https://wpgql-slack.herokuapp.com/) or open an issue in the [WPGraphQL Github repo](https://github.com/wp-graphql/wp-graphql), or the Github repo for the WPGraphQL extension that manages the fields you're having trouble with.
+    this means you're experiencing a bug on the WPGraphQL side of things. Seek help in the [WPGraphQL Slack](https://wpgql-slack.herokuapp.com/) or open an issue in the [WPGraphQL GitHub repo](https://github.com/wp-graphql/wp-graphql), or the GitHub repo for the WPGraphQL extension that manages the fields you're having trouble with.
     To help them debug you should narrow down exactly which combination of fields in the generated query you copied is causing issues. Comment out fields 1 by 1 until the problem goes away to determine which combination of fields isn't working.
 
     **Note:** A common cause of this problem is that you're using ACF and you've named multiple fields with the same name but in different field groups. Identify conflicting field names and rename them.
 
     #### If it does not have missing data:
 
-    This means it's a `gatsby-source-wordpress` bug. Open an issue in the [Github repo](https://github.com/gatsbyjs/gatsby/issues/new).
+    This means it's a `gatsby-source-wordpress` bug. Open an issue in the [GitHub repo](https://github.com/gatsbyjs/gatsby/issues/new).
 
 ### Node Sourcing GraphQL errors
 
@@ -117,7 +117,7 @@ Now run `gatsby develop` or `gatsby build` again. When the process exits on your
 
 Within this file will be the query made during node sourcing to fetch data from WPGraphQL into Gatsby.
 
-You can use this query to reproduce your error message and debug your error message outside of Gatsby. If you're stuck seek help in the [WPGraphQL Slack](https://wpgql-slack.herokuapp.com/) or open an issue in the [WPGraphQL Github repo](https://github.com/wp-graphql/wp-graphql), or the Github repo for the WPGraphQL extension that manages the fields you're having trouble with.
+You can use this query to reproduce your error message and debug your error message outside of Gatsby. If you're stuck seek help in the [WPGraphQL Slack](https://wpgql-slack.herokuapp.com/) or open an issue in the [WPGraphQL GitHub repo](https://github.com/wp-graphql/wp-graphql), or the GitHub repo for the WPGraphQL extension that manages the fields you're having trouble with.
 
 ### WordPress 50\* errors
 

--- a/packages/gatsby/CHANGELOG.md
+++ b/packages/gatsby/CHANGELOG.md
@@ -1298,7 +1298,7 @@ The migration is as simple as adding \_\_typename field to the query manually.
 ### Bug Fixes
 
 - **gatsby:** don't fail validation on fragments that are not used ([#24032](https://github.com/gatsbyjs/gatsby/issues/24032)) ([61d0ef4](https://github.com/gatsbyjs/gatsby/commit/61d0ef4))
-- **gatsby:** update script to generate apis.json to accommodate Typescript ([#24023](https://github.com/gatsbyjs/gatsby/issues/24023)) ([7878d0f](https://github.com/gatsbyjs/gatsby/commit/7878d0f))
+- **gatsby:** update script to generate apis.json to accommodate TypeScript ([#24023](https://github.com/gatsbyjs/gatsby/issues/24023)) ([7878d0f](https://github.com/gatsbyjs/gatsby/commit/7878d0f))
 
 ## [2.21.28](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.21.27...gatsby@2.21.28) (2020-05-13)
 


### PR DESCRIPTION
Changes were:

- `Github` -> `GitHub`
- `Javascript` -> `JavaScript`
- `Typescript` -> `TypeScript`
- `Wordpress` -> `WordPress`
