### PR TITLE
fix: Remove deprecated mini-css hmr option

### DIFF
--- a/packages/gatsby-plugin-less/src/gatsby-node.js
+++ b/packages/gatsby-plugin-less/src/gatsby-node.js
@@ -33,7 +33,7 @@ exports.onCreateWebpackConfig = (
   const lessRuleModules = {
     test: /\.module\.less$/,
     use: [
-      !isSSR && loaders.miniCssExtract({ hmr: false }),
+      !isSSR && loaders.miniCssExtract(),
       loaders.css({ ...cssLoaderOptions, modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       lessLoader,

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -62,9 +62,6 @@ function replaceRule(value, stage) {
         return {
           ...rule,
           loader: MiniCssExtractPlugin.loader,
-          options: {
-            hmr: true,
-          },
         }
       }
 

--- a/packages/gatsby-plugin-postcss/src/gatsby-node.js
+++ b/packages/gatsby-plugin-postcss/src/gatsby-node.js
@@ -52,7 +52,7 @@ exports.onCreateWebpackConfig = (
 
   if (!isSSR) {
     postcssRule.use.unshift(loaders.miniCssExtract())
-    postcssRuleModules.use.unshift(loaders.miniCssExtract({ hmr: false }))
+    postcssRuleModules.use.unshift(loaders.miniCssExtract())
   }
 
   const postcssRules = { oneOf: [] }

--- a/packages/gatsby-plugin-sass/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sass/src/gatsby-node.js
@@ -41,7 +41,7 @@ exports.onCreateWebpackConfig = (
   const sassRuleModules = {
     test: sassRuleModulesTest || /\.module\.s(a|c)ss$/,
     use: [
-      !isSSR && loaders.miniCssExtract({ hmr: false }),
+      !isSSR && loaders.miniCssExtract(),
       loaders.css({ importLoaders: 2, ...cssLoaderOptions, modules: true }),
       loaders.postcss({ plugins: postCssPlugins }),
       sassLoader,

--- a/packages/gatsby-plugin-stylus/src/gatsby-node.js
+++ b/packages/gatsby-plugin-stylus/src/gatsby-node.js
@@ -53,7 +53,7 @@ exports.onCreateWebpackConfig = (
   const stylusRuleModules = {
     test: /\.module\.styl$/,
     use: [
-      !isSSR && loaders.miniCssExtract({ hmr: false }),
+      !isSSR && loaders.miniCssExtract(),
       loaders.css({ modules: true, importLoaders: 2 }),
       loaders.postcss({ plugins: postCssPlugins }),
       stylusLoader,


### PR DESCRIPTION
Removes the invalid `hmr` option from `mini-css-extract-plugin`. It is enabled automatically in Webpack 5.

[ch25432]