### PR TITLE
tests: Fix cli integration test (#29525)

### DIFF
--- a/integration-tests/gatsby-cli/__tests__/new.js
+++ b/integration-tests/gatsby-cli/__tests__/new.js
@@ -36,7 +36,6 @@ describe(`gatsby new`, () => {
     )
     logs.should.contain(`success Created starter directory layout`)
     logs.should.contain(`info Installing packages...`)
-    logs.should.contain(`success Saved lockfile.`)
     logs.should.contain(
       `Your new Gatsby site has been successfully bootstrapped. Start developing it by running:`
     )
@@ -57,7 +56,6 @@ describe(`gatsby new`, () => {
     )
     logs.should.contain(`success Created starter directory layout`)
     logs.should.contain(`info Installing packages...`)
-    logs.should.contain(`success Saved lockfile.`)
     logs.should.contain(
       `Your new Gatsby site has been successfully bootstrapped. Start developing it by running:`
     )


### PR DESCRIPTION
Backporting #29525 to the 2.32 release branch

(cherry picked from commit 6ef2f802c345796dab975c0f20802d18baf63fcd)