### PR TITLE
fix(gatsby-plugin-image): Apply inline styles and img size

### DIFF
--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -62,6 +62,12 @@ export function getWrapperProps(
 
   let className = `gatsby-image-wrapper`
 
+  // If the plugin isn't installed we need to apply the styles inline
+  if (!global.GATSBY___IMAGE) {
+    wrapperStyle.position = `relative`
+    wrapperStyle.overflow = `hidden`
+  }
+
   if (layout === `fixed`) {
     wrapperStyle.width = width
     wrapperStyle.height = height

--- a/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
+++ b/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
@@ -84,6 +84,8 @@ export function lazyHydrate(
       )}
       <MainImage
         {...(props as Omit<MainImageProps, "images" | "fallback">)}
+        width={width}
+        height={height}
         className={imgClassName}
         {...getMainProps(
           isLoading,


### PR DESCRIPTION
Apply inline styles to the wrapper element if the plugin isn't installed. Add width and height props to the img tag. They're not needed as we use CSS, but Lighthouse warns about them anyway