### PR TITLE
fix(gatsby-plugin-image): Correct default enum value

### DIFF
--- a/packages/gatsby-plugin-image/src/resolver-utils.ts
+++ b/packages/gatsby-plugin-image/src/resolver-utils.ts
@@ -178,7 +178,7 @@ export function getGatsbyImageFieldConfig<TSource, TContext>(
             not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
             both PNG and JPG is not supported and will be ignored. 
         `,
-        defaultValue: [`auto`, `webp`],
+        defaultValue: [``, `webp`],
       },
       outputPixelDensities: {
         type: GraphQLList(GraphQLFloat),


### PR DESCRIPTION
Although the ENUM is `[AUTO, WEBP]`, the string value of `AUTO` is `""`, so this was causing errors.