### PR TITLE
fix(npm-package-search): declare mimeType so markdown trasformer children are added

### DIFF
--- a/packages/gatsby-source-npm-package-search/src/gatsby-node.js
+++ b/packages/gatsby-source-npm-package-search/src/gatsby-node.js
@@ -37,7 +37,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       lastPublisher: NPMPackageOwner
       _searchInternal: NPMPackage_searchInternal
     }
-    type NPMPackageReadme implements Node @dontInfer {
+    type NPMPackageReadme implements Node @dontInfer @mimeTypes(types: ["text/markdown"]) {
       slug: String!
     }
     type NPMPackageRepository {


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/29369 prevented `childMarkdownRemark` from ever being added due to `@dontInfer`, so let's actually annotate type, so remark handling children are attached (`MarkdownRemark` and `Mdx`) 

## Related Issues

Due to https://github.com/gatsbyjs/gatsby/pull/29369