### PR TITLE
feat(gatsby-plugin-image): Allow image helpers to take other node types

### DIFF
--- a/packages/gatsby-plugin-image/src/components/__tests__/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/__tests__/hooks.ts
@@ -35,75 +35,79 @@ const fileNode = {
 }
 
 describe(`The image helper functions`, () => {
-  it(`getImage returns the same data if passed gatsbyImageData`, () => {
-    expect(getImage(imageData)).toEqual(imageData)
+  describe(`getImage`, () => {
+    it(`returns the same data if passed gatsbyImageData`, () => {
+      expect(getImage(imageData)).toEqual(imageData)
+    })
+
+    it(`gets an image from a FileNode`, () => {
+      expect(getImage(fileNode)?.images.fallback?.src).toEqual(`imagesrc.jpg`)
+    })
+
+    it(`gets an image from an IGatsbyImageDataParent`, () => {
+      expect(getImage(dataParent)?.images.fallback?.src).toEqual(`imagesrc.jpg`)
+    })
+    it(`returns undefined from an invalid object`, () => {
+      expect(getImage(node)).toBeUndefined()
+    })
+
+    it(`returns undefined when passed a number`, () => {
+      expect(getImage((1 as any) as Node)).toBeUndefined()
+    })
+
+    it(`returns undefined when passed undefined`, () => {
+      expect(getImage((undefined as any) as Node)).toBeUndefined()
+    })
   })
 
-  it(`getImage gets an image from a FileNode`, () => {
-    expect(getImage(fileNode)?.images.fallback?.src).toEqual(`imagesrc.jpg`)
+  describe(`getSrc`, () => {
+    it(`gets src from an image data object`, () => {
+      expect(getSrc(imageData)).toEqual(`imagesrc.jpg`)
+    })
+
+    it(`gets src from a FileNode`, () => {
+      expect(getSrc(fileNode)).toEqual(`imagesrc.jpg`)
+    })
+
+    it(`gets src from an IGatsbyImageDataParent`, () => {
+      expect(getSrc(dataParent)).toEqual(`imagesrc.jpg`)
+    })
+
+    it(`returns undefined from an invalid object`, () => {
+      expect(getSrc(node)).toBeUndefined()
+    })
+    it(`returns undefined when passed undefined`, () => {
+      expect(getSrc((undefined as any) as Node)).toBeUndefined()
+    })
+
+    it(`returns undefined when passed a number`, () => {
+      expect(getSrc((1 as any) as Node)).toBeUndefined()
+    })
   })
 
-  it(`getImage gets an image from an IGatsbyImageDataParent`, () => {
-    expect(getImage(dataParent)?.images.fallback?.src).toEqual(`imagesrc.jpg`)
-  })
+  describe(`getSrcSet`, () => {
+    it(`gets srcSet from am image data object`, () => {
+      expect(getSrcSet(imageData)).toEqual(`imagesrcset.jpg 1x`)
+    })
 
-  it(`getSrc gets src from am image data object`, () => {
-    expect(getSrc(imageData)).toEqual(`imagesrc.jpg`)
-  })
+    it(`gets srcSet from a FileNode`, () => {
+      expect(getSrcSet(fileNode)).toEqual(`imagesrcset.jpg 1x`)
+    })
 
-  it(`getSrc gets src from a FileNode`, () => {
-    expect(getSrc(fileNode)).toEqual(`imagesrc.jpg`)
-  })
+    it(`gets srcSet from an IGatsbyImageDataParent`, () => {
+      expect(getSrcSet(dataParent)).toEqual(`imagesrcset.jpg 1x`)
+    })
 
-  it(`getSrc gets src from an IGatsbyImageDataParent`, () => {
-    expect(getSrc(dataParent)).toEqual(`imagesrc.jpg`)
-  })
+    it(`returns undefined from an invalid object`, () => {
+      expect(getSrcSet(node)).toBeUndefined()
+    })
 
-  it(`getSrcSet gets srcSet from am image data object`, () => {
-    expect(getSrcSet(imageData)).toEqual(`imagesrcset.jpg 1x`)
-  })
+    it(`returns undefined when passed undefined`, () => {
+      expect(getSrcSet((undefined as any) as Node)).toBeUndefined()
+    })
 
-  it(`getSrcSet gets srcSet from a FileNode`, () => {
-    expect(getSrcSet(fileNode)).toEqual(`imagesrcset.jpg 1x`)
-  })
-
-  it(`getSrcSet gets srcSet from an IGatsbyImageDataParent`, () => {
-    expect(getSrcSet(dataParent)).toEqual(`imagesrcset.jpg 1x`)
-  })
-
-  it(`getImage returns undefined from an invalid object`, () => {
-    expect(getImage(node)).toBeUndefined()
-  })
-
-  it(`getSrc returns undefined from an invalid object`, () => {
-    expect(getSrc(node)).toBeUndefined()
-  })
-
-  it(`getSrcSet returns undefined from an invalid object`, () => {
-    expect(getSrcSet(node)).toBeUndefined()
-  })
-
-  it(`getImage returns undefined when passed undefined`, () => {
-    expect(getImage((undefined as any) as Node)).toBeUndefined()
-  })
-
-  it(`getSrc returns undefined when passed undefined`, () => {
-    expect(getSrc((undefined as any) as Node)).toBeUndefined()
-  })
-
-  it(`getSrcSet returns undefined when passed undefined`, () => {
-    expect(getSrcSet((undefined as any) as Node)).toBeUndefined()
-  })
-
-  it(`getImage returns undefined when passed a number`, () => {
-    expect(getImage((1 as any) as Node)).toBeUndefined()
-  })
-
-  it(`getSrc returns undefined when passed a number`, () => {
-    expect(getSrc((1 as any) as Node)).toBeUndefined()
-  })
-
-  it(`getSrcSet returns undefined when passed a number`, () => {
-    expect(getSrcSet((1 as any) as Node)).toBeUndefined()
+    it(`returns undefined when passed a number`, () => {
+      expect(getSrcSet((1 as any) as Node)).toBeUndefined()
+    })
   })
 })

--- a/packages/gatsby-plugin-image/src/components/__tests__/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/__tests__/hooks.ts
@@ -1,0 +1,97 @@
+import { Node } from "gatsby"
+import { getSrc, getSrcSet, getImage, IGatsbyImageData } from "../../"
+
+const imageData: IGatsbyImageData = {
+  images: {
+    fallback: {
+      src: `imagesrc.jpg`,
+      srcSet: `imagesrcset.jpg 1x`,
+    },
+  },
+  layout: `constrained`,
+  width: 1,
+  height: 2,
+}
+
+const node: Node = {
+  id: ``,
+  parent: ``,
+  children: [],
+  internal: {
+    type: ``,
+    contentDigest: ``,
+    owner: ``,
+  },
+}
+
+const dataParent = {
+  ...node,
+  gatsbyImageData: imageData,
+}
+
+const fileNode = {
+  ...node,
+  childImageSharp: dataParent,
+}
+
+describe(`The image helper functions`, () => {
+  it(`getImage gets an image from a FileNode`, () => {
+    expect(getImage(fileNode)?.images.fallback?.src).toEqual(`imagesrc.jpg`)
+  })
+
+  it(`getImage gets an image from an IGatsbyImageDataParent`, () => {
+    expect(getImage(dataParent)?.images.fallback?.src).toEqual(`imagesrc.jpg`)
+  })
+
+  it(`getSrc gets src from a FileNode`, () => {
+    expect(getSrc(fileNode)).toEqual(`imagesrc.jpg`)
+  })
+
+  it(`getSrc gets src from an IGatsbyImageDataParent`, () => {
+    expect(getSrc(dataParent)).toEqual(`imagesrc.jpg`)
+  })
+
+  it(`getSrcSet gets srcSet from a FileNode`, () => {
+    expect(getSrcSet(fileNode)).toEqual(`imagesrcset.jpg 1x`)
+  })
+
+  it(`getSrcSet gets srcSet from an IGatsbyImageDataParent`, () => {
+    expect(getSrcSet(dataParent)).toEqual(`imagesrcset.jpg 1x`)
+  })
+
+  it(`getImage returns undefined from an invalid object`, () => {
+    expect(getImage(node)).toBeUndefined()
+  })
+
+  it(`getSrc returns undefined from an invalid object`, () => {
+    expect(getSrc(node)).toBeUndefined()
+  })
+
+  it(`getSrcSet returns undefined from an invalid object`, () => {
+    expect(getSrcSet(node)).toBeUndefined()
+  })
+
+  it(`getImage returns undefined when passed undefined`, () => {
+    expect(getImage((undefined as any) as Node)).toBeUndefined()
+  })
+
+  it(`getSrc returns undefined when passed undefined`, () => {
+    expect(getSrc((undefined as any) as Node)).toBeUndefined()
+  })
+
+  it(`getSrcSet returns undefined when passed undefined`, () => {
+    expect(getSrcSet((undefined as any) as Node)).toBeUndefined()
+  })
+
+  it(`getImage returns undefined when passed a number`, () => {
+    expect(getImage((1 as any) as Node)).toBeUndefined()
+  })
+
+  it(`getSrc returns undefined when passed a number`, () => {
+    expect(getSrc((1 as any) as Node)).toBeUndefined()
+  })
+
+  it(`getSrcSet returns undefined when passed a number`, () => {
+    expect(getSrcSet((1 as any) as Node)).toBeUndefined()
+  })
+})

--- a/packages/gatsby-plugin-image/src/components/__tests__/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/__tests__/hooks.ts
@@ -35,6 +35,10 @@ const fileNode = {
 }
 
 describe(`The image helper functions`, () => {
+  it(`getImage returns the same data if passed gatsbyImageData`, () => {
+    expect(getImage(imageData)).toEqual(imageData)
+  })
+
   it(`getImage gets an image from a FileNode`, () => {
     expect(getImage(fileNode)?.images.fallback?.src).toEqual(`imagesrc.jpg`)
   })
@@ -43,12 +47,20 @@ describe(`The image helper functions`, () => {
     expect(getImage(dataParent)?.images.fallback?.src).toEqual(`imagesrc.jpg`)
   })
 
+  it(`getSrc gets src from am image data object`, () => {
+    expect(getSrc(imageData)).toEqual(`imagesrc.jpg`)
+  })
+
   it(`getSrc gets src from a FileNode`, () => {
     expect(getSrc(fileNode)).toEqual(`imagesrc.jpg`)
   })
 
   it(`getSrc gets src from an IGatsbyImageDataParent`, () => {
     expect(getSrc(dataParent)).toEqual(`imagesrc.jpg`)
+  })
+
+  it(`getSrcSet gets srcSet from am image data object`, () => {
+    expect(getSrcSet(imageData)).toEqual(`imagesrcset.jpg 1x`)
   })
 
   it(`getSrcSet gets srcSet from a FileNode`, () => {

--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -45,11 +45,15 @@ export type FileNode = Node & {
   childImageSharp?: IGatsbyImageDataParent<Node>
 }
 
-export const isGatsbyImageData = (
+const isGatsbyImageData = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   node: IGatsbyImageData | any
-): node is IGatsbyImageData => Boolean(node?.images?.fallback?.src) // 🦆
+): node is IGatsbyImageData =>
+  // 🦆 check for a deep prop to be sure this is a valid gatsbyImageData object
+  Boolean(node?.images?.fallback?.src)
 
-export const isGatsbyImageDataParent = <T>(
+const isGatsbyImageDataParent = <T>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   node: IGatsbyImageDataParent<T> | any
 ): node is IGatsbyImageDataParent<T> => Boolean(node?.gatsbyImageData)
 

--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -38,18 +38,31 @@ export function storeImageloaded(cacheKey?: string): void {
 export function hasImageLoaded(cacheKey: string): boolean {
   return imageCache.has(cacheKey)
 }
-
+export type IGatsbyImageDataParent<T = never> = T & {
+  gatsbyImageData: IGatsbyImageData
+}
 export type FileNode = Node & {
-  childImageSharp?: Node & {
-    gatsbyImageData?: IGatsbyImageData
-  }
+  childImageSharp?: IGatsbyImageDataParent<Node>
 }
 
-export const getImage = (file: FileNode): IGatsbyImageData | undefined =>
-  file?.childImageSharp?.gatsbyImageData
+export const isGatsbyImageDataParent = <T>(
+  node: IGatsbyImageDataParent<T> | any
+): node is IGatsbyImageDataParent<T> => Boolean(node?.gatsbyImageData)
 
-export const getSrc = (file: FileNode): string | undefined =>
-  file?.childImageSharp?.gatsbyImageData?.images?.fallback?.src
+export const getImage = (
+  node: FileNode | IGatsbyImageDataParent
+): IGatsbyImageData | undefined =>
+  isGatsbyImageDataParent(node)
+    ? node.gatsbyImageData
+    : node?.childImageSharp?.gatsbyImageData
+
+export const getSrc = (
+  node: FileNode | IGatsbyImageDataParent
+): string | undefined => getImage(node)?.images?.fallback?.src
+
+export const getSrcSet = (
+  node: FileNode | IGatsbyImageDataParent
+): string | undefined => getImage(node)?.images?.fallback?.srcSet
 
 export function getWrapperProps(
   width: number,

--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -45,24 +45,30 @@ export type FileNode = Node & {
   childImageSharp?: IGatsbyImageDataParent<Node>
 }
 
+export const isGatsbyImageData = (
+  node: IGatsbyImageData | any
+): node is IGatsbyImageData => Boolean(node?.images?.fallback?.src) // 🦆
+
 export const isGatsbyImageDataParent = <T>(
   node: IGatsbyImageDataParent<T> | any
 ): node is IGatsbyImageDataParent<T> => Boolean(node?.gatsbyImageData)
 
-export const getImage = (
-  node: FileNode | IGatsbyImageDataParent
-): IGatsbyImageData | undefined =>
-  isGatsbyImageDataParent(node)
-    ? node.gatsbyImageData
-    : node?.childImageSharp?.gatsbyImageData
+type ImageDataLike = FileNode | IGatsbyImageDataParent | IGatsbyImageData
+export const getImage = (node: ImageDataLike): IGatsbyImageData | undefined => {
+  if (isGatsbyImageData(node)) {
+    return node
+  }
+  if (isGatsbyImageDataParent(node)) {
+    return node.gatsbyImageData
+  }
+  return node?.childImageSharp?.gatsbyImageData
+}
 
-export const getSrc = (
-  node: FileNode | IGatsbyImageDataParent
-): string | undefined => getImage(node)?.images?.fallback?.src
+export const getSrc = (node: ImageDataLike): string | undefined =>
+  getImage(node)?.images?.fallback?.src
 
-export const getSrcSet = (
-  node: FileNode | IGatsbyImageDataParent
-): string | undefined => getImage(node)?.images?.fallback?.srcSet
+export const getSrcSet = (node: ImageDataLike): string | undefined =>
+  getImage(node)?.images?.fallback?.srcSet
 
 export function getWrapperProps(
   width: number,

--- a/packages/gatsby-plugin-image/src/index.browser.ts
+++ b/packages/gatsby-plugin-image/src/index.browser.ts
@@ -10,6 +10,7 @@ export { LaterHydrator } from "./components/later-hydrator"
 export {
   getImage,
   getSrc,
+  getSrcSet,
   getImageData,
   withArtDirection,
   IArtDirectedImage,

--- a/packages/gatsby-plugin-image/src/index.ts
+++ b/packages/gatsby-plugin-image/src/index.ts
@@ -9,6 +9,7 @@ export { StaticImage } from "./components/static-image.server"
 export {
   getImage,
   getSrc,
+  getSrcSet,
   getImageData,
   withArtDirection,
   IArtDirectedImage,


### PR DESCRIPTION
This allows the `getImage` and `getSrc` helpers to take nodes other than `File` nodes, as long as they include a `gatsbyImageData` field, for example `ContentfulAsset`s, and allows `getSrc` to take imageData directly. It also adds a stack of unit tests, and a similar `getSrcSet` helper. 