### PR TITLE
Reduce Gatsby framework blocking time

### DIFF
--- a/packages/gatsby/cache-dir/api-runner-browser.js
+++ b/packages/gatsby/cache-dir/api-runner-browser.js
@@ -18,7 +18,9 @@ exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
   }
 
   let results = plugins.map(plugin => {
-    if (!plugin.plugin[api]) {
+    const mod = plugin.plugin()
+
+    if (!mod[api]) {
       return undefined
     }
 
@@ -26,7 +28,7 @@ exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
     args.loadPage = loadPage
     args.loadPageSync = loadPageSync
 
-    const result = plugin.plugin[api](args, plugin.options)
+    const result = mod[api](args, plugin.options)
     if (result && argTransform) {
       args = argTransform({ args, result, plugin })
     }
@@ -46,10 +48,10 @@ exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
 }
 
 exports.apiRunnerAsync = (api, args, defaultReturn) =>
-  plugins.reduce(
-    (previous, next) =>
-      next.plugin[api]
-        ? previous.then(() => next.plugin[api](args, next.options))
-        : previous,
-    Promise.resolve()
-  )
+  plugins.reduce((previous, next) => {
+    const mod = next.plugin()
+
+    return mod[api]
+      ? previous.then(() => mod[api](args, next.options))
+      : previous
+  }, Promise.resolve())

--- a/packages/gatsby/cache-dir/next-tick.js
+++ b/packages/gatsby/cache-dir/next-tick.js
@@ -1,0 +1,46 @@
+/**
+ * Code mainly copied from https://github.com/GlobeletJS/zero-timeout
+ *
+ * This code lets us schedule tasks for the next tick, similar to Node.JS's process.nextTick().
+ * This is handy for reducing blocking times and freeing the main thread
+ */
+
+//
+const timeouts = []
+let taskId = 0
+
+// Make a unique message, that won't be confused with messages from
+// other scripts or browser tabs
+const messageKey = `zeroTimeout_$` + Math.random().toString(36).slice(2)
+
+// Make it clear where the messages should be coming from
+const loc = window.location
+let targetOrigin = loc.protocol + `//` + loc.hostname
+if (loc.port !== ``) targetOrigin += `:` + loc.port
+
+// When a message is received, execute a timeout from the list
+window.addEventListener(
+  `message`,
+  evnt => {
+    if (evnt.source != window || evnt.data !== messageKey) return
+    evnt.stopPropagation()
+
+    const task = timeouts.shift()
+    if (!task || task.canceled) return
+    task.func(...task.args)
+  },
+  true
+)
+
+// Now define the external functions to set or cancel a timeout
+export const nextTick = (func, ...args) => {
+  taskId += 1
+  timeouts.push({ id: taskId, func, args })
+  window.postMessage(messageKey, targetOrigin)
+  return taskId
+}
+
+export const cancelNextTick = id => {
+  const task = timeouts.find(timeout => timeout.id === id)
+  if (task) task.canceled = true
+}

--- a/packages/gatsby/cache-dir/production-app/app.js
+++ b/packages/gatsby/cache-dir/production-app/app.js
@@ -1,4 +1,4 @@
-import { apiRunner, apiRunnerAsync } from "./api-runner-browser"
+import { apiRunner, apiRunnerAsync } from "../api-runner-browser"
 import React from "react"
 import ReactDOM from "react-dom"
 import { Router, navigate, Location, BaseContext } from "@gatsbyjs/reach-router"
@@ -9,9 +9,9 @@ import {
   shouldUpdateScroll,
   init as navigationInit,
   RouteUpdates,
-} from "./navigation"
-import emitter from "./emitter"
-import PageRenderer from "./page-renderer"
+} from "../navigation"
+import emitter from "../emitter"
+import PageRenderer from "../page-renderer"
 import asyncRequires from "$virtual/async-requires"
 import {
   setLoader,
@@ -19,9 +19,9 @@ import {
   publicLoader,
   PageResourceStatus,
   getStaticQueryResults,
-} from "./loader"
-import EnsureResources from "./ensure-resources"
-import stripPrefix from "./strip-prefix"
+} from "../loader"
+import EnsureResources from "../ensure-resources"
+import stripPrefix from "../strip-prefix"
 
 // Generated during bootstrap
 import matchPaths from "$virtual/match-paths.json"
@@ -40,7 +40,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   // Let plugins register a service worker. The plugin just needs
   // to return true.
   if (apiRunner(`registerServiceWorker`).length > 0) {
-    require(`./register-service-worker`)
+    require(`../register-service-worker`)
   }
 
   // In gatsby v2 if Router is used in page using matchPaths

--- a/packages/gatsby/cache-dir/production-app/index.js
+++ b/packages/gatsby/cache-dir/production-app/index.js
@@ -23,31 +23,36 @@
  * React 17's Concurrent Mode
  */
 
-import { nextTick } from "../next-tick"
+import { setZeroTimeout } from "../zero-timeout"
 
-const nextTickAsync = cb =>
-  new Promise(resolve => nextTick(() => resolve(cb())))
+const scheduleTask = cb =>
+  new Promise(resolve => setZeroTimeout(() => resolve(cb())))
 
-nextTickAsync(() => {
-  // evaluate all heavy dependencies
+scheduleTask(() => {
+  // evaluate React in a single task
   require(`react-dom`)
-  require(`@reach/router`)
-  require(`@mikaelkristiansson/domready`)
-  require(`gatsby-react-router-scroll`)
 })
   .then(() =>
-    nextTickAsync(() => {
+    scheduleTask(() => {
+      // evaluate Gatsby dependencies
+      require(`@mikaelkristiansson/domready`)
+      require(`@gatsbyjs/reach-router`)
+      require(`gatsby-react-router-scroll`)
+    })
+  )
+  .then(() =>
+    scheduleTask(() => {
       // evaluate Gatsby framework
       require(`gatsby`)
     })
   )
   .then(() =>
-    nextTickAsync(() => {
+    scheduleTask(() => {
       const plugins = require(`../api-runner-browser-plugins`)
 
       // Evaluate each plugin on its own task
-      return Promise.all(plugins.map(plugin => nextTickAsync(plugin.plugin)))
+      return Promise.all(plugins.map(plugin => scheduleTask(plugin.plugin)))
     })
   )
   // finally evaluate and run the app
-  .then(() => nextTickAsync(() => require(`./app`)))
+  .then(() => scheduleTask(() => require(`./app`)))

--- a/packages/gatsby/cache-dir/production-app/index.js
+++ b/packages/gatsby/cache-dir/production-app/index.js
@@ -1,0 +1,53 @@
+/**
+ * Gatsby's production app entrypoint.
+ *
+ * `./app.js` is the entry point of a HUGE package dependency tree. Synchronously resolving this dependency
+ * tree (and thus evaluating all of this JavaScript) may result in a considerable blocking time, which
+ * is heavily penalized by Google's Lighthouse TBT metric.
+ *
+ * This file resolves this dependecy tree before evaluating `./app.js` so we don't block the JavaScript
+ * main thread for more than 50ms and thus not harming lighthouse scores and thus user experience
+ *
+ * The trick is to use the `nextTick` function. This function is heavily based on GlobeletJS's great work
+ * on https://github.com/GlobeletJS/zero-timeout and basically allows us to break big tasks into smaller ones
+ * so that we don't overrun our 50ms budget
+ *
+ * The dependency tree resolution is broken into 4 main steps:
+ * 1. Evaluate all third-party dependencies, like react-dom and router.
+ * 2. Evaluate all gastby-related code
+ * 3. Evaluate each plugin on it's own task, so heavy plugins (like gatsby-plugin-theme-ui) have enough time to do its thing
+ * 4. Evaluate `./app.js` and any other dependency not yet imported
+ *
+ * From time to time we should pay attention to this file again to make sure we are not running over our
+ * 50ms budget, however I think these four tasks are more than enough for the near future, specially after
+ * React 17's Concurrent Mode
+ */
+
+import { nextTick } from "../next-tick"
+
+const nextTickAsync = cb =>
+  new Promise(resolve => nextTick(() => resolve(cb())))
+
+nextTickAsync(() => {
+  // evaluate all heavy dependencies
+  require(`react-dom`)
+  require(`@reach/router`)
+  require(`@mikaelkristiansson/domready`)
+  require(`gatsby-react-router-scroll`)
+})
+  .then(() =>
+    nextTickAsync(() => {
+      // evaluate Gatsby framework
+      require(`gatsby`)
+    })
+  )
+  .then(() =>
+    nextTickAsync(() => {
+      const plugins = require(`../api-runner-browser-plugins`)
+
+      // Evaluate each plugin on its own task
+      return Promise.all(plugins.map(plugin => nextTickAsync(plugin.plugin)))
+    })
+  )
+  // finally evaluate and run the app
+  .then(() => nextTickAsync(() => require(`./app`)))

--- a/packages/gatsby/cache-dir/zero-timeout.js
+++ b/packages/gatsby/cache-dir/zero-timeout.js
@@ -33,14 +33,14 @@ window.addEventListener(
 )
 
 // Now define the external functions to set or cancel a timeout
-export const nextTick = (func, ...args) => {
+export const setZeroTimeout = (func, ...args) => {
   taskId += 1
   timeouts.push({ id: taskId, func, args })
   window.postMessage(messageKey, targetOrigin)
   return taskId
 }
 
-export const cancelNextTick = id => {
+export const cancelZeroTimeout = id => {
   const task = timeouts.find(timeout => timeout.id === id)
   if (task) task.canceled = true
 }

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -539,7 +539,7 @@ export async function initialize({
       // we need a relative import path to keep contenthash the same if directory changes
       const relativePluginPath = path.relative(siteDir, plugin.resolve)
       return `{
-      plugin: require('${slash(relativePluginPath)}'),
+      plugin: () => require('${slash(relativePluginPath)}'),
       options: ${JSON.stringify(plugin.options)},
     }`
     })


### PR DESCRIPTION
## Description
Hello people.

I'm developing an e-commerce using Gatsby and Theme-ui and I'm loving it. In the e-commerce world, performance is a must and Gatsby really shines in this regard. Our pages load instantly and navigation is pretty smooth too. However, since Google will soon use Web Vitals score in their search engine ranking system, our market is more and more paying attention to Web Vitals and Lighthouse.

Since Lighthouse V6, I'm noticing there is one metric that I've never really been able to get on the green spectrum of force, specially on Google's [PSI](https://developers.google.com/speed/pagespeed/insights/). This metric is the Total Blocking Time (TBT)

After a quick search on Gatsby's issues, I've came across issue #24332 where many people report having similar issues with Lighthouse V6. After spending many hours studying the problem I've decided to make a contribution to the community via this PR. 
As a test subject, I've chosen [ReactJS.org](https://reactjs.org/) website (that is built using Gatsby) and the method I'm using is Google Chrome's DevTools performance tab for comparing blocking times.

After cloning both gatsbyjs and reactjs.org website and setting up the dev environment correctly, I've run a profiling test with Chrome's performance tab locally with `6x CPU slowdown` on a `Fast 3G` internet connection. The result can be seem in the image below.
<img width="1218" alt="Screen Shot 2021-02-20 at 10 22 39 PM" src="https://user-images.githubusercontent.com/1753396/108612735-279b2880-73ca-11eb-9392-4e034ba55bdd.png">

As you can see, the blocking time is considerable. By studying the problem, I've found 3 main sources for this gigantic blocking time. The first one is the one with the arrow pointing to. This is React's hydrate function and there isn't much what Gatsby can do to fix this, however React's new concurrent mode should address this soon.
The second big blocking time is the one on the left of React's hydrate function. This is reactjs.org's own code being evaluated, and here again, there is not much what Gatsby can do to improve this blocking time. 
The third source, and the most interesting one, is on the left of the later. A closer inspection reveals the following flame chart
<img width="1218" alt="Screen Shot 2021-02-20 at 10 37 50 PM" src="https://user-images.githubusercontent.com/1753396/108613003-469aba00-73cc-11eb-857b-5c5b807aad3f.png">

As you can see, this is Gatsby's own code + plugins being evaluated, which, in this case, accounts for 195ms of blocking time.
This happens because `production-app.js` is the app's main entrypoint and requires synchronously (via the import foo from 'bar' construction) all of the framework's + plugins code.

To address the aforementioned problem I hand crafted a method for splitting all `production-app.js` dependencies evaluation into small tasks so the Gatsby framework does not generate unnecessary blocking times. This method is different from webpack's dynamic `import()` statement since we don't split the `app.js` bundle into different file, but rather split the evaluation of `app.js` file into multiple tasks. The image below show the evaluation of `prodution-app.js` after the changes included on this PR
<img width="1230" alt="Screen Shot 2021-02-20 at 10 54 38 PM" src="https://user-images.githubusercontent.com/1753396/108613215-a003e880-73ce-11eb-95df-cd926ba2327d.png">

As you can see, `production-app.js` evaluation is now split into multiple different tasks, greatly reducing the blocking time introduced by Gatsby.

I would love to hear your thoughts on this PR and how we could test this on Google's PSI on various websites (maybe releasing a canary) and even if this PR makes sense or if there is a webpack magic that we could use in here.

Thanks !

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Addresses #24332
