### PR TITLE
query requires operation name

### DIFF
--- a/docs/docs/tutorial/part-four/index.md
+++ b/docs/docs/tutorial/part-four/index.md
@@ -246,7 +246,7 @@ export default function About({ data }) {
 
 // highlight-start
 export const query = graphql`
-  query {
+  query SiteTitleQuery {
     site {
       siteMetadata {
         title
@@ -294,7 +294,7 @@ import { rhythm } from "../utils/typography"
 export default function Layout({ children }) {
   const data = useStaticQuery(
     graphql`
-      query {
+      query SiteTitleQuery {
         site {
           siteMetadata {
             title


### PR DESCRIPTION
## Description

This changes tutorial part four so that the query examples include an operation name.  I chose SiteTitleQuery because it appears elsewhere in the docs.

### Documentation

GraphQL queries are up

## Related Issues

Related to #29416

Fixes #29635
