### PR TITLE
chore(html): add context about not handling page query result directly in html reducer

### DIFF
--- a/packages/gatsby/src/redux/reducers/html.ts
+++ b/packages/gatsby/src/redux/reducers/html.ts
@@ -87,6 +87,12 @@ export function htmlReducer(
     }
 
     case `PAGE_QUERY_RUN`: {
+      // Despite action name, this action is actually emitted for both page and static queries.
+      // In here we actually only care about static query result (particularly its hash).
+      // We don't care about page query result because we don't actually use page query result
+      // directly when generating html. We care about page-data (which contains page query result).
+      // Handling of page-data that transitively handles page query result is done in handler for
+      // `ADD_PAGE_DATA_STATS` action.
       if (!action.payload.isPage) {
         // static query case
         let staticQueryResult = state.trackedStaticQueryResults.get(


### PR DESCRIPTION
## Description

This is just adding some context why `html` reducer doesn't "care" directly about page query result

## Related Issues

Addressing comment - https://github.com/gatsbyjs/gatsby/pull/29498#discussion_r576984765

[ch25549]