### PR TITLE
chore(build): use params from yargs and don't check process.argv

### DIFF
--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -24,6 +24,8 @@ export interface IBuildArgs extends IProgram {
   sitePackageJson: PackageJson
   prefixPaths: boolean
   noUglify: boolean
+  logPages: boolean
+  writeToFile: boolean
   profile: boolean
   graphqlTracing: boolean
   openTracingConfigFile: string

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -30,7 +30,6 @@ import {
   showFeedbackRequest,
   showSevenDayFeedbackRequest,
 } from "../utils/feedback"
-import * as buildUtils from "./build-utils"
 import { actions } from "../redux/actions"
 import { waitUntilAllJobsComplete } from "../utils/wait-until-jobs-complete"
 import { Stage } from "./types"
@@ -240,7 +239,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   workerPool.end()
   buildActivity.end()
 
-  if (process.argv.includes(`--log-pages`)) {
+  if (program.logPages) {
     if (toRegenerate.length) {
       report.info(
         `Built pages:\n${toRegenerate
@@ -258,7 +257,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     }
   }
 
-  if (process.argv.includes(`--write-to-file`)) {
+  if (program.writeToFile) {
     const createdFilesPath = path.resolve(
       `${program.directory}/.cache`,
       `newPages.txt`


### PR DESCRIPTION
## Description

just cleaning things up, `--log-pages` and `--write-to-file` are handled by yargs, so let's not check `process.argv` separately

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/29548#discussion_r577589506
[ch25550]