### PR TITLE
chore(gatsby): drop unused friendly-errors-webpack-plugin dep

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -19,7 +19,6 @@
     "@hapi/joi": "^15.1.1",
     "@mikaelkristiansson/domready": "^1.0.10",
     "@nodelib/fs.walk": "^1.2.4",
-    "@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@reach/router": "^1.3.4",
     "@types/http-proxy": "^1.17.4",


### PR DESCRIPTION
## Description

Noticed in one of recent PRs that we still had `friendly-errors-webpack-plugin` package as dependency even tho we didn't use it for a long time.

lock file not changed because this package is still used in https://github.com/gatsbyjs/gatsby/blob/7e03dc75971e325987712d4f8c5c821db28812d8/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js 