### PR TITLE
chore: Deprecate gatsby-image and old image resolvers

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -1,3 +1,7 @@
+## :warning: This package is now deprecated
+
+The `gatsby-image` package is now deprecated. The new [Gatsby image plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-image) has better performance, cool new features and a simpler API. See [the migration guide](https://www.gatsbyjs.com/docs/reference/release-notes/image-migration-guide/) to learn how to upgrade.
+
 # gatsby-image
 
 Speedy, optimized images without the work.

--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -1,6 +1,4 @@
-# gatsby-plugin-image (beta)
-
-_The new Gatsby Image plugin is currently in beta, but you can try it out now_
+# gatsby-plugin-image
 
 Adding responsive images to your site while maintaining high performance scores can be difficult to do manually. The Gatsby Image plugin handles the hard parts of producing images in multiple sizes and formats for you!
 

--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -52,7 +52,7 @@ function warnForDeprecation() {
   }
   warnedForDeprecation = true
   console.warn(
-    `[gatsby-transformer-sharp] The "fixed" and "fluid" resolvers are now deprecated. Switch to the new Gatsby image plugin for better performance and a simpler API. See https://gatsby.dev/migrate-images to learn how.`
+    `[gatsby-transformer-sharp] The "fixed" and "fluid" resolvers are now deprecated. Switch to "gatsby-plugin-image" for better performance and a simpler API. See https://gatsby.dev/migrate-images to learn how.`
   )
 }
 

--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -44,6 +44,18 @@ const {
 const { stripIndent } = require(`common-tags`)
 const { prefixId, CODES } = require(`./error-utils`)
 
+let warnedForDeprecation = false
+
+function warnForDeprecation() {
+  if (warnedForDeprecation) {
+    return
+  }
+  warnedForDeprecation = true
+  console.warn(
+    `[gatsby-transformer-sharp] The "fixed" and "fluid" resolvers are now deprecated. Switch to the new Gatsby image plugin for better performance and a simpler API. See https://gatsby.dev/migrate-images to learn how.`
+  )
+}
+
 function toArray(buf) {
   const arr = new Array(buf.length)
 
@@ -200,6 +212,7 @@ const fixedNodeType = ({
       },
     },
     resolve: (image, fieldArgs, context) => {
+      warnForDeprecation()
       const file = getNodeAndSavePathDependency(image.parent, context.path)
       const args = { ...fieldArgs, pathPrefix }
       return Promise.resolve(
@@ -366,6 +379,7 @@ const fluidNodeType = ({
       },
     },
     resolve: (image, fieldArgs, context) => {
+      warnForDeprecation()
       const file = getNodeAndSavePathDependency(image.parent, context.path)
       const args = { ...fieldArgs, pathPrefix }
       return Promise.resolve(
@@ -385,8 +399,6 @@ const fluidNodeType = ({
     },
   }
 }
-
-let warnedForBeta = false
 
 const imageNodeType = ({
   pathPrefix,
@@ -514,13 +526,6 @@ const imageNodeType = ({
       if (!generateImageData) {
         reporter.warn(`Please upgrade gatsby-plugin-sharp`)
         return null
-      }
-      if (!warnedForBeta) {
-        reporter.warn(
-          stripIndent`
-        Thank you for trying the beta version of the \`gatsbyImageData\` API. Please provide feedback and report any issues at: https://github.com/gatsbyjs/gatsby/discussions/27950`
-        )
-        warnedForBeta = true
       }
       const imageData = await generateImageData({
         file,


### PR DESCRIPTION
This adds a warning when using the fixed and fluid resolvers, as well as a warning to the top of the gatsby-image readme. It also removes the beta warnings for the new resolver.

[ch24890]