### PR TITLE
feat: shim reporter from gatsby

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/__tests__/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/collection-extract-query-string.ts
@@ -1,9 +1,13 @@
 import sysPath from "path"
 import fs from "fs-extra"
 import { collectionExtractQueryString } from "../collection-extract-query-string"
-import reporter from "gatsby-cli/lib/reporter"
+import reporter from "gatsby/reporter"
 
-jest.mock(`gatsby-cli/lib/reporter`)
+jest.mock(`gatsby/reporter`, () => {
+  return {
+    panicOnBuild: jest.fn(),
+  }
+})
 
 // This makes the tests work on windows properly
 const createPath = (path: string): string => path.replace(/\//g, sysPath.sep)

--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -1,5 +1,5 @@
 import { derivePath } from "../derive-path"
-import reporter from "gatsby-cli/lib/reporter"
+import reporter from "gatsby/reporter"
 
 describe(`derive-path`, () => {
   it(`has basic support`, () => {

--- a/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/is-valid-collection-path-implementation.ts
@@ -1,8 +1,12 @@
 import { isValidCollectionPathImplementation } from "../is-valid-collection-path-implementation"
-import reporter from "gatsby-cli/lib/reporter"
+import reporter from "gatsby/reporter"
 import syspath from "path"
 
-jest.mock(`gatsby-cli/lib/reporter`)
+jest.mock(`gatsby/reporter`, () => {
+  return {
+    panicOnBuild: jest.fn(),
+  }
+})
 
 // windows and mac have different seperators, all code is written with unix-like
 // file systems, but the underlying code uses `path.sep`. So when running tests

--- a/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
@@ -1,8 +1,10 @@
 import { generateQueryFromString } from "./extract-query"
 import fs from "fs-extra"
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
 import { extractModel } from "./path-utils"
 import { CODES, prefixId } from "./error-utils"
+
+type Reporter = typeof reporter
 
 // This Function opens up the actual collection file and extracts the queryString used in the
 export function collectionExtractQueryString(

--- a/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
+++ b/packages/gatsby-plugin-page-creator/src/collection-extract-query-string.ts
@@ -1,10 +1,8 @@
 import { generateQueryFromString } from "./extract-query"
 import fs from "fs-extra"
-import reporter from "gatsby/reporter"
+import { Reporter } from "gatsby/reporter"
 import { extractModel } from "./path-utils"
 import { CODES, prefixId } from "./error-utils"
-
-type Reporter = typeof reporter
 
 // This Function opens up the actual collection file and extracts the queryString used in the
 export function collectionExtractQueryString(

--- a/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
@@ -10,7 +10,9 @@ import { createClientOnlyPage } from "./create-client-only-page"
 import { createPagesFromCollectionBuilder } from "./create-pages-from-collection-builder"
 import systemPath from "path"
 import { trackFeatureIsUsed } from "gatsby-telemetry"
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
+
+type Reporter = typeof reporter
 
 function pathIsCollectionBuilder(path: string): boolean {
   return path.includes(`{`)

--- a/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
@@ -10,9 +10,7 @@ import { createClientOnlyPage } from "./create-client-only-page"
 import { createPagesFromCollectionBuilder } from "./create-pages-from-collection-builder"
 import systemPath from "path"
 import { trackFeatureIsUsed } from "gatsby-telemetry"
-import reporter from "gatsby/reporter"
-
-type Reporter = typeof reporter
+import { Reporter } from "gatsby/reporter"
 
 function pathIsCollectionBuilder(path: string): boolean {
   return path.includes(`{`)

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -1,7 +1,7 @@
 // Move this to gatsby-core-utils?
 import { Actions, CreatePagesArgs } from "gatsby"
 import { createPath } from "gatsby-page-utils"
-import reporter from "gatsby/reporter"
+import { Reporter } from "gatsby/reporter"
 import { Options as ISlugifyOptions } from "@sindresorhus/slugify"
 import { reverseLookupParams } from "./extract-query"
 import { getMatchPath } from "./get-match-path"
@@ -11,8 +11,6 @@ import { watchCollectionBuilder } from "./watch-collection-builder"
 import { collectionExtractQueryString } from "./collection-extract-query-string"
 import { isValidCollectionPathImplementation } from "./is-valid-collection-path-implementation"
 import { CODES, prefixId } from "./error-utils"
-
-type Reporter = typeof reporter
 
 export async function createPagesFromCollectionBuilder(
   filePath: string,

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -1,7 +1,7 @@
 // Move this to gatsby-core-utils?
 import { Actions, CreatePagesArgs } from "gatsby"
 import { createPath } from "gatsby-page-utils"
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
 import { Options as ISlugifyOptions } from "@sindresorhus/slugify"
 import { reverseLookupParams } from "./extract-query"
 import { getMatchPath } from "./get-match-path"
@@ -11,6 +11,8 @@ import { watchCollectionBuilder } from "./watch-collection-builder"
 import { collectionExtractQueryString } from "./collection-extract-query-string"
 import { isValidCollectionPathImplementation } from "./is-valid-collection-path-implementation"
 import { CODES, prefixId } from "./error-utils"
+
+type Reporter = typeof reporter
 
 export async function createPagesFromCollectionBuilder(
   filePath: string,

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -1,12 +1,14 @@
 import _ from "lodash"
 import slugify, { Options as ISlugifyOptions } from "@sindresorhus/slugify"
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
 import {
   extractFieldWithoutUnion,
   extractAllCollectionSegments,
   switchToPeriodDelimiters,
   stripTrailingSlash,
 } from "./path-utils"
+
+type Reporter = typeof reporter
 
 const doubleForwardSlashes = /\/\/+/g
 

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -1,14 +1,12 @@
 import _ from "lodash"
 import slugify, { Options as ISlugifyOptions } from "@sindresorhus/slugify"
-import reporter from "gatsby/reporter"
+import { Reporter } from "gatsby/reporter"
 import {
   extractFieldWithoutUnion,
   extractAllCollectionSegments,
   switchToPeriodDelimiters,
   stripTrailingSlash,
 } from "./path-utils"
-
-type Reporter = typeof reporter
 
 const doubleForwardSlashes = /\/\/+/g
 

--- a/packages/gatsby-plugin-page-creator/src/error-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/error-utils.ts
@@ -1,4 +1,6 @@
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
+
+type Reporter = typeof reporter
 
 export const CODES = {
   Generic: `12101`,

--- a/packages/gatsby-plugin-page-creator/src/error-utils.ts
+++ b/packages/gatsby-plugin-page-creator/src/error-utils.ts
@@ -1,6 +1,4 @@
-import reporter from "gatsby/reporter"
-
-type Reporter = typeof reporter
+import { Reporter } from "gatsby/reporter"
 
 export const CODES = {
   Generic: `12101`,

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -1,9 +1,7 @@
 import sysPath from "path"
-import reporter from "gatsby/reporter"
+import { Reporter } from "gatsby/reporter"
 import { CODES, prefixId } from "./error-utils"
 import { matchAllPolyfill } from "./path-utils"
-
-type Reporter = typeof reporter
 
 // This file is a helper for consumers. It's going to log an error to them if they
 // in any way have an incorrect filepath setup for us to predictably use collection

--- a/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
+++ b/packages/gatsby-plugin-page-creator/src/is-valid-collection-path-implementation.ts
@@ -1,7 +1,9 @@
 import sysPath from "path"
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
 import { CODES, prefixId } from "./error-utils"
 import { matchAllPolyfill } from "./path-utils"
+
+type Reporter = typeof reporter
 
 // This file is a helper for consumers. It's going to log an error to them if they
 // in any way have an incorrect filepath setup for us to predictably use collection

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -38,7 +38,7 @@ const {
   setPluginOptions,
 } = require(`../plugin-options`)
 
-jest.mock(`gatsby-cli/lib/reporter`, () => {
+jest.mock(`gatsby/reporter`, () => {
   return {
     log: jest.fn(),
     info: jest.fn(),

--- a/packages/gatsby-plugin-sharp/src/__tests__/utils.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/utils.js
@@ -1,8 +1,7 @@
-jest.mock(`gatsby-cli/lib/reporter`)
+jest.mock(`gatsby/reporter`)
 jest.mock(`progress`)
 const { calculateImageSizes } = require(`../utils`)
-const reporter = require(`gatsby-cli/lib/reporter`)
-const progress = require(`progress`)
+const reporter = require(`gatsby/reporter`)
 const sharp = require(`sharp`)
 
 const file = {

--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -1,12 +1,14 @@
 /* eslint-disable no-unused-expressions */
 import { IGatsbyImageData, ISharpGatsbyImageArgs } from "gatsby-plugin-image"
 import { GatsbyCache, Node } from "gatsby"
-import { Reporter } from "gatsby-cli/lib/reporter/reporter"
+import reporter from "gatsby/reporter"
 import { rgbToHex, calculateImageSizes, getSrcSet, getSizes } from "./utils"
 import { traceSVG, getImageSizeAsync, base64, batchQueueImageResizing } from "."
 import sharp from "./safe-sharp"
 import { createTransformObject, mergeDefaults } from "./plugin-options"
 import { reportError } from "./report-error"
+
+type Reporter = typeof reporter
 
 const DEFAULT_BLURRED_IMAGE_WIDTH = 20
 

--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -1,14 +1,12 @@
 /* eslint-disable no-unused-expressions */
 import { IGatsbyImageData, ISharpGatsbyImageArgs } from "gatsby-plugin-image"
 import { GatsbyCache, Node } from "gatsby"
-import reporter from "gatsby/reporter"
+import { Reporter } from "gatsby/reporter"
 import { rgbToHex, calculateImageSizes, getSrcSet, getSizes } from "./utils"
 import { traceSVG, getImageSizeAsync, base64, batchQueueImageResizing } from "."
 import sharp from "./safe-sharp"
 import { createTransformObject, mergeDefaults } from "./plugin-options"
 import { reportError } from "./report-error"
-
-type Reporter = typeof reporter
 
 const DEFAULT_BLURRED_IMAGE_WIDTH = 20
 

--- a/packages/gatsby-remark-code-repls/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-remark-code-repls/src/__tests__/gatsby-node.js
@@ -5,7 +5,7 @@ jest.mock(`fs`, () => {
   }
 })
 jest.mock(`recursive-readdir`, () => jest.fn())
-jest.mock(`gatsby-cli/lib/reporter`, () => {
+jest.mock(`gatsby/reporter`, () => {
   return {
     panic: jest.fn(),
   }
@@ -15,7 +15,7 @@ const fs = require(`fs`)
 const nodePath = require(`path`)
 const readdir = require(`recursive-readdir`)
 
-const reporter = require(`gatsby-cli/lib/reporter`)
+const reporter = require(`gatsby/reporter`)
 
 const {
   OPTION_DEFAULT_REPL_DIRECTORY,

--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -27,7 +27,7 @@ jest.mock(`../create-file-node`, () => {
     createFileNode: jest.fn(),
   }
 })
-const reporter = require(`gatsby-cli/lib/reporter`)
+const reporter = require(`gatsby/reporter`)
 
 const got = require(`got`)
 const createRemoteFileNode = require(`../create-remote-file-node`)

--- a/packages/gatsby-source-filesystem/src/__tests__/utils.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/utils.js
@@ -1,5 +1,3 @@
-jest.mock(`gatsby-cli/lib/reporter`)
-jest.mock(`progress`)
 const { getRemoteFileExtension, getRemoteFileName } = require(`../utils`)
 
 describe(`create remote file node`, () => {

--- a/packages/gatsby-source-wordpress/src/models/logger.ts
+++ b/packages/gatsby-source-wordpress/src/models/logger.ts
@@ -1,8 +1,6 @@
-import reporter from "gatsby/reporter"
+import { Reporter } from "gatsby/reporter"
 import { formatLogMessage } from "~/utils/format-log-message"
 import { IPluginOptions } from "./gatsby-api"
-
-type Reporter = typeof reporter
 
 type ITimerReporter = ReturnType<Reporter["activityTimer"]>
 

--- a/packages/gatsby-source-wordpress/src/models/logger.ts
+++ b/packages/gatsby-source-wordpress/src/models/logger.ts
@@ -1,6 +1,8 @@
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
 import { formatLogMessage } from "~/utils/format-log-message"
 import { IPluginOptions } from "./gatsby-api"
+
+type Reporter = typeof reporter
 
 type ITimerReporter = ReturnType<Reporter["activityTimer"]>
 

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -17,9 +17,7 @@ import { formatLogMessage } from "~/utils/format-log-message"
 import { touchValidNodes } from "../source-nodes/update-nodes/fetch-node-updates"
 
 import { IPluginOptions } from "~/models/gatsby-api"
-import reporter from "gatsby/reporter"
-
-type Reporter = typeof reporter
+import { Reporter } from "gatsby/reporter"
 
 export const inPreviewMode = (): boolean =>
   !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT &&

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -17,7 +17,9 @@ import { formatLogMessage } from "~/utils/format-log-message"
 import { touchValidNodes } from "../source-nodes/update-nodes/fetch-node-updates"
 
 import { IPluginOptions } from "~/models/gatsby-api"
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
+
+type Reporter = typeof reporter
 
 export const inPreviewMode = (): boolean =>
   !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT &&

--- a/packages/gatsby-source-wordpress/src/steps/temp-prevent-multiple-instances.ts
+++ b/packages/gatsby-source-wordpress/src/steps/temp-prevent-multiple-instances.ts
@@ -1,5 +1,8 @@
-import { Reporter } from "gatsby"
+import reporter from "gatsby/reporter"
 import { formatLogMessage } from "../utils/format-log-message"
+
+type Reporter = typeof reporter
+
 let isWpSourcePluginInstalled = false
 
 /**

--- a/packages/gatsby-source-wordpress/src/steps/temp-prevent-multiple-instances.ts
+++ b/packages/gatsby-source-wordpress/src/steps/temp-prevent-multiple-instances.ts
@@ -1,7 +1,5 @@
-import reporter from "gatsby/reporter"
+import { Reporter } from "gatsby/reporter"
 import { formatLogMessage } from "../utils/format-log-message"
-
-type Reporter = typeof reporter
 
 let isWpSourcePluginInstalled = false
 

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -4,7 +4,7 @@ const extendNodeType = require(`../extend-node-type`)
 const { createContentDigest } = require(`gatsby-core-utils`)
 const { typeDefs } = require(`../create-schema-customization`)
 
-jest.mock(`gatsby-cli/lib/reporter`, () => {
+jest.mock(`gatsby/reporter`, () => {
   return {
     log: jest.fn(),
     info: jest.fn(),

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -205,6 +205,8 @@
     "gatsby-admin-public/",
     "graphql.js",
     "graphql.d.ts",
+    "reporter.js",
+    "reporter.d.ts",
     "index.d.ts",
     "scripts/postinstall.js",
     "utils.js",

--- a/packages/gatsby/reporter.d.ts
+++ b/packages/gatsby/reporter.d.ts
@@ -1,0 +1,1 @@
+export { default } from "gatsby-cli/lib/reporter"

--- a/packages/gatsby/reporter.d.ts
+++ b/packages/gatsby/reporter.d.ts
@@ -1,1 +1,4 @@
-export { default } from "gatsby-cli/lib/reporter"
+import reporter from "gatsby-cli/lib/reporter"
+
+export default reporter
+export type Reporter = typeof reporter

--- a/packages/gatsby/reporter.js
+++ b/packages/gatsby/reporter.js
@@ -1,0 +1,3 @@
+"use strict"
+
+module.exports = require('gatsby-cli/lib/reporter/index.js').default;


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Shimming the reporter in gatsby allows us to refactor it in the future without a breaking change. I was supprised so little packages were relying on the direct import of reporter.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
[ch23107]
