### PR TITLE
chore: fix reset hard in assert-changed-files (#29328)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,6 +466,9 @@ jobs:
       shell: powershell.exe
     steps:
       - checkout
+      - run:
+          command: ./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*|.circleci/*|yarn.lock"
+          shell: bash.exe
       # Restoring cache takes as long as installing node modules, so skipping
       # - restore_cache:
       #     keys:
@@ -482,9 +485,6 @@ jobs:
       #     paths:
       #       - C:\Users\circleci\AppData\Local\Yarn\Cache
       #     key: yarn-packages-v2-{{ checksum "yarn.lock" }}
-      - run:
-          command: ./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*|.circleci/*"
-          shell: bash.exe
       - run: yarn npm-run-all -s check-versions "lerna-prepare --concurrency=4 --stream"
       - run:
           name: "Run Tests"

--- a/scripts/assert-changed-files.sh
+++ b/scripts/assert-changed-files.sh
@@ -14,6 +14,12 @@ if [ "$IS_CI" = true ]; then
   if [ $? -ne 0 ]; then
     echo "Branch has conflicts with master, rolling back test."
     git merge --abort
+
+    if [ $? -ne 0]; then
+      # seems like we can't abort merge - script doesn't really handle that, we should fail this step because something is wonky
+      echo "Something went wrong, we could not abort our merge command. Please re-run the test."
+      exit 1
+    fi
   fi
 
   git config --local --unset user.name
@@ -23,8 +29,10 @@ fi
 
 FILES_COUNT="$(git diff-tree --no-commit-id --name-only -r "$CIRCLE_BRANCH" origin/master | grep -E "$GREP_PATTERN" -c)"
 
-# reset to previous state
-git reset --hard HEAD@{1}
+if [ "$IS_CI" = true ]; then
+  # reset to previous state
+  git reset --hard $CIRCLE_SHA1
+fi
 
 if [ "$FILES_COUNT" -eq 0 ]; then
   echo "0 files matching '$GREP_PATTERN'; exiting and marking successful."


### PR DESCRIPTION
Backport #29328 to release 2.32 so that Windows tests work in the release branch

(cherry picked from commit 79518c4e1e8d7559f49a46f192ea87584dd4bbfc)
