### PR TITLE
fix(develop): add blank .css to ensure mini-css-extract-plugin always has something to extract

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -13,6 +13,11 @@ import asyncRequires from "$virtual/async-requires"
 // Generated during bootstrap
 import matchPaths from "$virtual/match-paths.json"
 
+// ensure in develop we have at least some .css (even if it's empty).
+// this is so there is no warning about not matching content-type when site doesn't include any regular css (for example when css-in-js is used)
+// this also make sure that if all css is removed in develop we are not left with stale commons.css that have stale content
+import "./blank.css"
+
 // Enable fast-refresh for virtual sync-requires
 module.hot.accept(`$virtual/async-requires`, () => {
   // Manually reload


### PR DESCRIPTION
## Description

This handle 2 issues:

1) > Resource interpreted as Stylesheet but transferred with MIME type text/html: "http://localhost:8000/commons.css".

When there is no css, we add `commons.css` link but we don't actually generate it, so we serve our `index.html` instead for that request, which cause warning as above + generally is wonky

2) In develop when you remove "last" .css import - the styles stay behind, because `commons.css` is not "regenerated" but it continue to exist in `webpack-dev-middleware` in-memory filesystem. Having that blank `.css` import actually ensure that when user removes their last `.css` `commons.css` updates (to empty file), meaning that we don't leave stale styles behind

## Related Issues

[ch25434]