### PR TITLE
chore(docs): Update debugging-html-builds

### DIFF
--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -63,7 +63,7 @@ rendering.
 
 ```js:title=gatsby-node.js
 exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
-  if (stage === "build-html") {
+  if (stage === "build-html" || stage === "develop-html") {
     actions.setWebpackConfig({
       module: {
         rules: [


### PR DESCRIPTION
We're rolling out SSR for the develop server so people will need to adjust custom/plugin code to account for the `develop-html` stage as well as `build-html`.