### PR TITLE
feat(gatsby-plugin-canonical-urls): Add plugin validation

### DIFF
--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-node.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-node.js
@@ -1,0 +1,9 @@
+exports.pluginOptionsSchema = ({ Joi }) =>
+  Joi.object({
+    siteUrl: Joi.string()
+      .required()
+      .description(`The full URL for the site e.g. https://www.example.com`),
+    stripQueryString: Joi.boolean().description(
+      `Enables stripQueryString to strip query strings from paths e.g. /blog?tag=foobar becomes /blog.`
+    ),
+  })


### PR DESCRIPTION
Fix https://github.com/gatsbyjs/gatsby/discussions/28138#discussioncomment-342251

With `DEV_SSR`, the plugin now errors if you don't set the required `siteUrl` option. It didn't actually work before but at least it didn't work silently :-D