### PR TITLE
tests: Fix class component syntax

### DIFF
--- a/e2e-tests/development-runtime/src/components/class-component.js
+++ b/e2e-tests/development-runtime/src/components/class-component.js
@@ -1,11 +1,9 @@
 import React, { Component } from "react"
 
 class ClassComponent extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      custom: true,
-    }
+  // eslint-disable-next-line no-undef
+  state = {
+    custom: true,
   }
 
   render() {

--- a/e2e-tests/development-runtime/src/components/class-component.js
+++ b/e2e-tests/development-runtime/src/components/class-component.js
@@ -1,8 +1,11 @@
 import React, { Component } from "react"
 
 class ClassComponent extends Component {
-  state = {
-    custom: true,
+  constructor(props) {
+    super(props)
+    this.state = {
+      custom: true,
+    }
   }
 
   render() {


### PR DESCRIPTION
eslint-loader has decided it doesn't like instance fields, so e2e tests are failing. e.g. [this test](https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/58660/workflows/89f769eb-f61d-46ee-86e1-5d0397a5adec/jobs/628357/parallel-runs/0/steps/0-104?invite=true)