### PR TITLE
chore(gatsby-plugin-gatsby-cloud): Update for gatsby v3

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/package.json
+++ b/packages/gatsby-plugin-gatsby-cloud/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-gatsby-cloud/package.json
+++ b/packages/gatsby-plugin-gatsby-cloud/package.json
@@ -11,7 +11,7 @@
     "fs-extra": "^8.1.0",
     "kebab-hash": "^0.1.2",
     "lodash": "^4.17.20",
-    "webpack-assets-manifest": "^3.1.1"
+    "webpack-assets-manifest": "^5.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",


### PR DESCRIPTION
Updating the manifest plugin for use with Webpack 5 and updating Gatsby peer dependency to 3