### PR TITLE
fix(e2e-development-runtime): fix typo / optiosn is not defined

### DIFF
--- a/e2e-tests/development-runtime/cypress/support/commands.js
+++ b/e2e-tests/development-runtime/cypress/support/commands.js
@@ -91,7 +91,7 @@ Cypress.Commands.overwrite("visit", (orig, url, options = {}) => {
     ...options,
     onBeforeLoad: win => {
       if (options.onBeforeLoad) {
-        optiosn.onBeforeLoad(win)
+        options.onBeforeLoad(win)
       }
 
       cy.spy(win.console, "log").as(`hmrConsoleLog`)


### PR DESCRIPTION
Just noticed this in some tests - did it work at all?

![Screenshot 2021-02-23 at 20 09 59](https://user-images.githubusercontent.com/419821/108894902-345e8d00-7613-11eb-9816-45b5ddb17d12.png)
