### PR TITLE
Set field alias and type for gravity forms plugin

### DIFF
--- a/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
+++ b/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
@@ -23,6 +23,7 @@ interface IRemoteSchemaState {
     internal: string
     plugin: string
     actionOptions: string
+    fields: string
   }
 }
 
@@ -97,6 +98,7 @@ const remoteSchema: IRemoteSchemaStore = {
       internal: `wpInternal`,
       plugin: `wpPlugin`,
       actionOptions: `wpActionOptions`,
+      fields: 'wpFields',
     },
   },
 


### PR DESCRIPTION
## Description

Declares the GravityForms field alias to support WPGraphQL For Gravity Forms plugin. Add type check.

Replacing PR `#29685` with this one to avoid yarn.lock issues.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
