### PR TITLE
fix(gatsby-plugin-image): Apply defaults when width and height are set

### DIFF
--- a/packages/gatsby-plugin-image/src/image-utils.ts
+++ b/packages/gatsby-plugin-image/src/image-utils.ts
@@ -170,7 +170,7 @@ export function setDefaultDimensions(
   layout = camelCase(layout) as Layout
 
   if (width && height) {
-    return args
+    return { ...args, formats, layout }
   }
   if (sourceMetadata.width && sourceMetadata.height && !aspectRatio) {
     aspectRatio = sourceMetadata.width / sourceMetadata.height


### PR DESCRIPTION
Fix a bug in the image plugin toolkit where default layout and formats were not set if width and height were provided