### PR TITLE
Revert "tests: Check for dirty yarn.lock (#29728)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,6 @@ jobs:
       - <<: *install_node_modules
       - <<: *persist_cache
       - run: yarn bootstrap -- concurrency=2
-      - run: git status yarn.lock -s | grep "M yarn.lock" && echo "yarn.lock is dirty. Please ensure changes have been committed" && exit 1
       # Persist the workspace again with all packages already built
       - persist_to_workspace:
           root: ./


### PR DESCRIPTION
This reverts commit d85638fb from #29728 to unblock us.

The check will be restored in https://github.com/gatsbyjs/gatsby/pull/29730