### PR TITLE
fix: don't print deprecation warning for touchNode for the sample plugin multiple times

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -798,7 +798,7 @@ actions.createNode = (...args) => dispatch => {
   })
 }
 
-let touchNodeDeprecationWarningDisplayedMessages = new Set()
+const touchNodeDeprecationWarningDisplayedMessages = new Set()
 
 /**
  * "Touch" a node. Tells Gatsby a node still exists and shouldn't

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -798,6 +798,8 @@ actions.createNode = (...args) => dispatch => {
   })
 }
 
+let touchNodeDeprecationWarningDisplayedMessages = new Set()
+
 /**
  * "Touch" a node. Tells Gatsby a node still exists and shouldn't
  * be garbage collected. Primarily useful for source plugins fetching
@@ -819,7 +821,10 @@ actions.touchNode = (node: any, plugin?: Plugin) => {
       msg = msg + ` "touchNode" was called by ${plugin.name}`
     }
 
-    report.warn(msg)
+    if (!touchNodeDeprecationWarningDisplayedMessages.has(msg)) {
+      report.warn(msg)
+      touchNodeDeprecationWarningDisplayedMessages.add(msg)
+    }
 
     node = getNode(node.nodeId)
   }


### PR DESCRIPTION
## Description

One deprecation warning per plugin is enough - let's not spam terminal output for each usage

## Related Issues

[ch25565]