### PR TITLE
chore(docs): Migrating from v2 to v3

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -585,6 +585,28 @@ exports.createSchemaCustomization = function createSchemaCustomization({ actions
 }
 ```
 
+## Using `fs` in SSR
+
+Gatsby v3 introduce incremental builds for HTML generation. For this feature to work correctly Gatsby needs to track all inputs used to generate HTML file. Arbitrary code execution in `gatsby-ssr.js` files allow usage of `fs` module which is marked as unsafe and result in disabling of this feature. To migrate you can use `import` instead of `fs`:
+
+```diff:title=gatsby-ssr.js
+import * as React from "react"
+-import * as fs from "fs"
+-import * as path from "path"
++import stylesToInline from "!!raw-loader!/some-auto-generated.css"
+
+export function onRenderBody({ setHeadComponents }) {
+-  const stylesToInline = fs.readFileSync(path.join(process.cwd(), `some-auto-generated.css`))
+  setHeadComponents(
+    <style
+      dangerouslySetInnerHTML={{
+        __html: stylesToInline,
+      }}
+    />
+  )
+}
+```
+
 ## For Plugin Maintainers
 
 In most cases you won't have to do anything to be v3 compatible, but there are a few things you can do to be certain your plugin won't throw any warnings or errors.

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -125,7 +125,10 @@ This section explains breaking changes that were made for Gatsby v3. Most, if no
 
 ### Minimal Node.js version 12.13.0
 
-Gatsby now requires at least `12.13.0` for its Node.js version.
+We are dropping support for Node 10 as it is approaching maintenance EOL date (2021-04-30).
+The new required version of Node is `12.13.0`. See the main changes in [Node 12 release notes](https://nodejs.org/en/blog/release/v12.0.0/).
+
+Check [Node’s releases document](https://github.com/nodejs/Release#nodejs-release-working-group) for version statuses.
 
 ### Webpack upgraded from version 4 to version 5
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -378,7 +378,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 To make upgrade easier, check the CLI output of your site on the latest v2 and follow suggestions
 when you see a warning like this:
 
-```
+```shell
 warning Deprecation warning: In Gatsby v3 fields `Foo.childBar` and `Foo.childrenBar`
 will not be added automatically because type `Bar` does not explicitly list type `Foo`
 in `childOf` extension.
@@ -431,7 +431,7 @@ In Gatsby v2 we add those extensions for you automatically but display a depreca
 To make upgrade easier, check the CLI output of your site on the latest v2 and follow suggestions
 when you see a warning like this:
 
-```
+```shell
 warning Deprecation warning: adding inferred extension `link` for field Foo.bar
 In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.
 Add the following type definition to fix this:

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -1,0 +1,570 @@
+---
+title: Migrating from v2 to v3
+---
+
+Looking for the v2 docs? [Find them here.](https://v2.gatsbyjs.com)
+
+> This document is a work in progress. Have you run into something that's not covered here? [Add you changes to GitHub!](#link-to-github)
+
+## Introduction
+
+This is a reference for upgrading your site from Gatsby v2 to Gatsby v3. TODO
+
+> If you want to start fresh, run `npm init gatsby` or `yarn create gatsby` in your terminal.
+
+## Why you should upgrade
+
+This documentation page covers the _how_ of migrating from v2 to v3. If you're curious what's new, read the [v3.0 release notes](#link-to-release-notes).
+
+## What we'll cover
+
+short list of contents, point to sidebar at the right
+
+## Updating Your Dependencies
+
+First, you need to update your dependencies.
+
+### Update Gatsby version
+
+You need to update your `package.json` to use the latest version of Gatsby.
+
+```json:title=package.json
+{
+  "dependencies": {
+    "gatsby": "^3.0.0"
+  }
+}
+```
+
+Or run
+
+```shell
+npm install gatsby@latest
+```
+
+### Update Gatsby related packages
+
+Update your `package.json` to use the latest version of Gatsby related packages. You should upgrade any package name that starts with `gatsby-*`. Note, this only applies to plugins managed in the [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby) repository. If you're using community plugins, they might not be upgraded yet. Many plugins won't need updating so they well might keep working (if not, please check their repository for the current status). You can run an npm script to see all outdated dependencies.
+
+```shell
+npm outdated
+```
+
+Compare the "Wanted" and "Latest" versions and update their versions accordingly. For example, if you have this oudated version:
+
+```shell
+> npm outdated
+
+Package                  Current   Wanted  Latest  Location
+gatsby-plugin-sharp      2.14.1    2.14.1  3.0.0   test
+```
+
+Install the new package with:
+
+```shell
+npm install gatsby-plugin-sharp@latest
+```
+
+## Handling Breaking Changes
+
+### Gatsby's Link component
+
+The APIs `push`, `replace` & `navigateTo` in `gatsby-link` (an internal package) were deprecated in v2 and now with v3 completely removed. Please use `navigate` instead.
+
+```diff
+import React from "react"
+- import { navigateTo, push, replace } from "gatsby"
++ import { navigate } from "gatsby"
+
+const Form = () => (
+  <form
+    onSubmit={event => {
+      event.preventDefault()
+
+-     navigateTo("/form-submitted/") // or push() or replace()
++     navigate("/form-submitted/")
+    }}
+  >
+)
+```
+
+### Removal of `__experimentalThemes`
+
+The deprecated `__experimentalThemes` key inside `gatsby-config.js` was removed. You'll need to define your Gatsby themes inside the `plugins` array like any other plugin.
+
+```diff:title=gatsby-config.js
+module.exports = {
+- __experimentalThemes: ["gatsby-theme-blog"]
++ plugins: ["gatsby-theme-blog"]
+}
+```
+
+### Removal of `pathContext`
+
+The deprecated API `pathContext` was removed. You need to rename instances of it to `pageContext`. For example, if you passed information inside your `gatsby-node.js` and accessed it in your page:
+
+```diff:title=src/templates/context.jsx
+import React from "react"
+
+- const ContextPage = ({ pathContext }) => (
++ const ContextPage = ({ pageContext }) => (
+  <main>
+    <h1>Hello from a page that uses the old pathContext</h1>
+    <p>It was deprecated in favor of pageContext</p>
+-   <p>{pathContext.foo}</p>
++   <p>{pageContext.foo}</p>
+  </main>
+)
+
+export default ContextPage
+```
+
+### Removal of `boundActionCreators`
+
+The deprecated API `boundActionCreators` was removed. Please rename its instances to `actions` to keep the same behavior. For example, in your `gatsby-node.js` file:
+
+```diff:title=gatsby-node.js
+exports.createPages = (gatsbyArgs, pluginArgs) => {
+- const { boundActionCreators } = gatsbyArgs
++ const { actions } = gatsbyArgs
+}
+```
+
+### Removal of `deleteNodes`
+
+The deprecated API `deleteNodes` was removed. Please iterate over the `nodes` yourself and call `deleteNode`:
+
+```diff
+const nodes = ["an-array-of-nodes"]
+- deleteNodes(nodes)
++ nodes.forEach(node => deleteNode(node))
+```
+
+### Removal of `fieldName` & `fieldValue` from `createNodeField`
+
+The arguments `fieldName` and `fieldValue` were removed from the `createNodeField` API. Please use `name` and `value` instead.
+
+```diff:title=gatsby-node.js
+exports.onCreateNode = ({ node, actions }) => {
+  const { createNodeField } = actions
+
+  createNodeField({
+    node,
+-   fieldName: "slug",
+-   fieldValue: "my-custom-slug",
++   name: "slug",
++   value: "my-custom-slug",
+  })
+}
+```
+
+### Removal of `hasNodeChanged` from public API surface
+
+The check whether a node has changed or not is already happening internally so it's not necessary to use this API in your plugins anymore.
+
+### Removal of `sizes` & `resolutions` for image queries
+
+The `sizes` and `resolutions` queries were deprecated in v2 in favor of `fluid` and `fixed`.
+
+```diff
+import React from "react"
+import { graphql } from "gatsby"
+
+const Example = ({ data }) => {
+  <div>
+-    <Img sizes={data.foo.childImageSharp.sizes} />
+-    <Img resolutions={data.bar.childImageSharp.resolutions} />
++    <Img fluid={data.foo.childImageSharp.fluid} />
++    <Img fixed={data.bar.childImageSharp.fixed} />
+  </div>
+}
+
+export default Example
+
+export const pageQuery = graphql`
+  query IndexQuery {
+    foo: file(relativePath: { regex: "/foo.jpg/" }) {
+      childImageSharp {
+-        sizes(maxWidth: 700) {
+-          ...GatsbyImageSharpSizes_tracedSVG
++        fluid(maxWidth: 700) {
++          ...GatsbyImageSharpFluid_tracedSVG
+        }
+      }
+    }
+    bar: file(relativePath: { regex: "/bar.jpg/" }) {
+      childImageSharp {
+-        resolutions(width: 500) {
+-          ...GatsbyImageSharpResolutions_withWebp
++        fixed(width: 500) {
++          ...GatsbyImageSharpFixed_withWebp
+        }
+      }
+    }
+  }
+`
+```
+
+### Calling `touchNode` with the node id
+
+Calling `touchNode` with a string (the node id) was deprecated in Gatsby v2. Pass the full `node` to `touchNode` now.
+
+```diff:title=gatsby-node.js
+exports.sourceNodes = ({ actions, getNodesByType }) => {
+  const { touchNode } = actions
+
+- getNodesByType("YourSourceType").forEach(node => touchNode(node.id))
++ getNodesByType("YourSourceType").forEach(node => touchNode(node))
+}
+```
+
+### Calling `deleteNode` with the node id
+
+Calling `deleteNode` with a string (the node id) was deprecated in Gatsby v2. Pass the full `node` to `deleteNode` now.
+
+```diff:title=gatsby-node.js
+exports.onCreateNode = ({ actions, node }) => {
+  const { deleteNode } = actions
+
+- deleteNode(node.id)
++ deleteNode(node)
+}
+```
+
+### Removal of three `gatsby-browser` APIs
+
+A couple of `gatsby-browser` APIs were removed. In the list below you can find the old APIs and their replacements:
+
+- `getResourcesForPathnameSync` => `loadPageSync`
+- `getResourcesForPathname` => `loadPage`
+- `replaceComponentRenderer` => `wrapPageElement`
+
+### Using a global `graphql` tag for queries
+
+Until now your were able to use the `graphql` tag for queries without explicitly importing it from Gatsby. You now have to import it: `import { graphql } from 'gatsby'`
+
+```diff:title=src/pages/index.js
+import React from "react"
++ import { graphql } from "gatsby"
+
+const Page = ({ data }) => (
+  <div>Show my data: {JSON.stringify(data, null, 2)}</div>
+)
+
+export default Page
+
+export const query = graphql`
+  {
+    site {
+      siteMetadata {
+        description
+      }
+    }
+  }
+`
+```
+
+### CSS Modules are imported as ESModules
+
+The web moves forward and so are we. ESModules allow us to better treeshake and generate smaller files. From now on you'll need to import cssModules as: `import { box } from './mystyles.module.css'`
+
+```diff:title=src/components/Box.js
+import React from "react"
+- import styles from './mystyles.module.css'
++ import { box } from './mystyles.module.css'
+
+const Box = ({ children }) => (
+-  <div className={styles.box}>{children}</div>
++  <div className={box}>{children}</div>
+)
+
+export default Box
+```
+
+### GraphQL: character escape sequences in `regex` filter
+
+In v2 backslashes in `regex` filters of GraphQL queries had to be escaped
+_twice_, so `/\w+/` needed to be written as `"/\\\\w+/"`.
+
+In v3 you only need to escape once:
+
+```diff:title=src/pages/index.js
+const query = {
+  allFile(
+    filter: {
+-      relativePath: { regex: "/\\\\.png/" }
++      relativePath: { regex: "/\\.png/" }
+    }
+  ) {
+    nodes {
+      relativePath
+    }
+  }
+}
+```
+
+### GraphQL: `__typename` field is no longer added automatically
+
+In v2 we used to add implicit `__typename` field when querying for a field of abstract type (interface or union).
+In v3 `__typename` has to be added explicitly in your query:
+
+```diff:title=src/pages/index.js
+import React from "react"
+import { graphql } from "gatsby"
+
+const Page = ({ data }) => {
+  if (data.foo.someUnion.__typename === `A`) {
+    return data.foo.someUnion.a
+  }
+  if (data.foo.someUnion.__typename === `B`) {
+    return data.foo.someUnion.b
+  }
+  return null
+}
+
+export default Page
+
+export const query = graphql`
+  {
+    foo {
+      someUnion {
++       __typename
+        ... on A { a }
+        ... on B { b }
+      }
+    }
+  }
+`
+```
+
+### Schema customization: add explicit `childOf` extension to types with disabled inference
+
+Imagine you have node type `Foo` that has several child nodes of type `Bar` (so you expect field `Foo.childBar` to exist).
+In Gatsby v2 this field was added automatically even if inference was disabled for type `Foo`.
+
+In Gatsby v3 you must declare paret-child relationship explicitly for this case:
+
+```diff:title=gatsby-node.js
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+    type Foo implemenst Node @dontInfer {
+       id: ID!
+    }
+-   type Bar implements Node {
++   type Bar implements Node @childOf(types: ["Foo"]) {
+      id: ID!
+    }
+  `)
+}
+```
+
+To make upgrade easier, check the CLI output of your site on the latest v2 and follow suggestions
+when you see a warning like this:
+
+```
+warning Deprecation warning: In Gatsby v3 fields `Foo.childBar` and `Foo.childrenBar`
+will not be added automatically because type `Bar` does not explicitly list type `Foo`
+in `childOf` extension.
+
+Add the following type definition to fix this:
+
+  type Bar implements Node @childOf(types: ["Foo"]) {
+    id: ID!
+  }
+
+https://www.gatsbyjs.com/docs/actions/#createTypes
+```
+
+If you don't see any warnings - you are safe to upgrade to v3.
+
+If this warning is displayed for a type defined by some plugin - open an issue in the plugin repo
+with suggestion to upgrade (and a link to this guide).
+
+You can still fix those warnings temporarily in your site's `gatsby-node.js` until it is fixed in the plugin.
+
+Related docs:
+
+- [childOf directive](https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#defining-child-relations)
+- [Child/parent fields](https://www.gatsbyjs.com/docs/schema-inference/#childparent-fields)
+- [Schema generation](https://www.gatsbyjs.com/docs/schema-generation/#4-parent--children-relationships)
+
+### Schema customization: extensions must be set explicitly
+
+Starting with v3 whenever you define a field of complex type, you must also assign
+the corresponding extension (or a custom resolver):
+
+```diff:title=gatsby-node.js
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+    type MyType {
+-     date: Date
++     date: Date @dateformat
+-     image: File
++     image: File @fileByRelativePath
+-     authorByEmail: Author
++     authorByEmail: Author @link
+    }
+  `)
+}
+```
+
+In Gatsby v2 we add those extensions for you automatically but display a deprecation warning.
+
+To make upgrade easier, check the CLI output of your site on the latest v2 and follow suggestions
+when you see a warning like this:
+
+```
+warning Deprecation warning: adding inferred extension `link` for field Foo.bar
+In Gatsby v3, only fields with an explicit directive/extension will be resolved correctly.
+Add the following type definition to fix this:
+
+  type Foo implements Node {
+    bar: [Bar] @link(by: "id", from: "bar___NODE")
+  }
+
+https://www.gatsbyjs.com/docs/actions/#createTypes
+```
+
+If this warning is displayed for a type defined by some plugin - open an issue in the plugin repo
+with suggestion to upgrade (and a link to this guide).
+
+You can still fix those warnings temporarily in your site's `gatsby-node.js` until it is fixed in the plugin.
+
+If you don't see any warnings - you are safe to upgrade to v3. Read more about custom extensions in [this blog post](https://www.gatsbyjs.com/blog/2019-05-17-improvements-to-schema-customization/).
+
+### Schema customization: removed `noDefaultResolvers` argument from inference directives
+
+Search for `noDefaultResolvers` entries and remove them:
+
+```diff:title=gatsby-node.js
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+-   type Foo implements Node @infer(noDefaultResolvers: true)
++   type Foo implements Node @infer
+    {
+      id: ID!
+    }
+
+-   type Bar implements Node @dontInfer(noDefaultResolvers: true)
++   type Foo implements Node @dontInfer
+    {
+      id: ID!
+    }
+
+  `)
+}
+```
+
+[Read deprecation announcement](https://www.gatsbyjs.com/blog/2019-05-17-improvements-to-schema-customization/#-nodefaultresolvers-and-inference-modes).
+
+### Schema customization: remove `many` argument from `childOf` directive
+
+It is no longer needed in Gatsby v3:
+
+```diff:title=gatsby-node.js
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  createTypes(`
+-   type Foo implements Node @childOf(types: ["Bar"], many: true)
++   type Foo implements Node @childOf(types: ["Bar"])
+    {
+      id: ID!
+    }
+  `)
+}
+```
+
+### Schema customization: consistent return for `nodeModel.runQuery`
+
+For Gatsby v2, `nodeModel.runQuery` with `firstOnly: false` returns `null` when nothing is found.
+In v3 it returns an empty array instead.
+
+To upgrade, find all occurrences of `runQuery` (with `firstOnly: false` or not set) and make sure checks for emptiness
+are correct:
+
+```diff:title=gatsby-node.js
+exports.createResolvers = ({ createResolvers }) => {
+  const resolvers = {
+    Foo: {
+      bars: {
+        resolve(source, args, context, info) {
+          const result = context.nodeModel.runQuery({
+            query: {/* */},
+            type: "Bar",
+            firstOnly: false,
+          })
+-         if (result === null) {
++         if (result.length === 0) {
+            throw new Error("Not found!")
+          }
+          return result
+        },
+      },
+    },
+  }
+  createResolvers(resolvers)
+}
+```
+
+**Note:** when using argument `firstOnly: true` the returned value is `object` or `null`.
+So do not confuse those two cases.
+
+## Resolving Deprecations
+
+### `touchNode`
+
+For Gatsby v2 the `touchNode` API accepted `nodeId` as a named argument. This now has been deprecated in favor of passing the full `node` to the function.
+
+```diff:title=gatsby-node.js
+exports.sourceNodes = ({ actions, getNodesByType }) => {
+  const { touchNode } = actions
+
+- getNodesByType("YourSourceType").forEach(node => touchNode({ nodeId: node.id }))
++ getNodesByType("YourSourceType").forEach(node => touchNode(node))
+}
+```
+
+In case you only have an ID at hand (e.g. getting it from cache or as `__NODE`) you can use the `getNode()` API:
+
+```js:title=gatsby-node.js
+exports.sourceNodes = async ({ actions, getNodesByType, cache }) => {
+  const { touchNode, getNode } = actions
+  const myNodeId = await cache.get("some-key")
+
+  touchNode(getNode(myNodeId))
+}
+```
+
+### `deleteNode`
+
+For Gatsby v2 the `deleteNode` API accepted `node` as a named argument. This now has been deprecated in favor of passing the full `node` to the function.
+
+```diff:title=gatsby-node.js
+exports.onCreateNode = ({ actions, node }) => {
+  const { deleteNode } = actions
+
+- deleteNode({ node })
++ deleteNode(node)
+}
+```
+
+### `@nodeInterface`
+
+For Gatsby v2 `@nodeInterface` was the recommended way to implement [queryable interfaces](https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#queryable-interfaces-with-the-nodeinterface-extension).
+Now it is deprecated in favor of interface inheritance:
+
+```diff:title=gatsby-node.js
+exports.createSchemaCustomization = function createSchemaCustomization({ actions }) {
+  const { createTypes } = actions
+  createTypes(`
+-   interface Foo @nodeInterface
++   interface Foo implements Node
+    {
+      id: ID!
+    }
+  `)
+}
+```

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -775,3 +775,27 @@ File: node_modules/gatsby-link/index.js:24:13
 ```
 
 Make sure that you have updated all dependencies. It's also possible that you have an outdated `.cache` folder around. Run `gatsby clean` to remove the outdated cache.
+
+In some situations the webpack alias will be ignored, so you will need to add your own alias. The most common example is in Jest tests. For these you should add the following to your Jest config:
+
+Configuring using a `jest.config.js` file:
+
+```js
+module.exports = {
+  moduleNameMapper: {
+    "^@reach/router(.*)": "<rootDir>/node_modules/@gatsbyjs/reach-router$1",
+  },
+}
+```
+
+Configuring using `package.json`:
+
+```json
+{
+  "jest": {
+    "moduleNameMapper": {
+      "^@reach/router(.*)": "<rootDir>/node_modules/@gatsbyjs/reach-router$1"
+    }
+  }
+}
+```

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -36,7 +36,7 @@ npm install gatsby@latest
 
 ### Update Gatsby related packages
 
-Update your `package.json` to use the latest version of Gatsby related packages. You should upgrade any package name that starts with `gatsby-*`. Note, this only applies to plugins managed in the [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby) repository. If you're using community plugins, they might not be upgraded yet. Many plugins won't need updating so they well might keep working (if not, please check their repository for the current status). You can run an npm script to see all outdated dependencies.
+Update your `package.json` to use the latest version of Gatsby related packages. You should upgrade any package name that starts with `gatsby-*`. Note, this only applies to plugins managed in the [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby) repository. If you're using community plugins, they might not be upgraded yet. Many plugins won't need updating so they may keep working (if not, please check their repository for the current status). You can run an npm script to see all outdated dependencies.
 
 #### npm
 
@@ -98,7 +98,7 @@ const Form = () => (
 
 ### Removal of `__experimentalThemes`
 
-The deprecated `__experimentalThemes` key inside `gatsby-config.js` was removed. You'll need to define your Gatsby themes inside the `plugins` array like any other plugin.
+The deprecated `__experimentalThemes` key inside `gatsby-config.js` was removed. You'll need to define your Gatsby themes inside the `plugins` array instead.
 
 ```diff:title=gatsby-config.js
 module.exports = {
@@ -140,7 +140,7 @@ exports.createPages = (gatsbyArgs, pluginArgs) => {
 
 ### Removal of `deleteNodes`
 
-The deprecated API `deleteNodes` was removed. Please iterate over the `nodes` yourself and call `deleteNode`:
+The deprecated API `deleteNodes` was removed. Please iterate over the `nodes` instead and call `deleteNode`:
 
 ```diff
 const nodes = ["an-array-of-nodes"]
@@ -168,7 +168,7 @@ exports.onCreateNode = ({ node, actions }) => {
 
 ### Removal of `hasNodeChanged` from public API surface
 
-The check whether a node has changed or not is already happening internally so it's not necessary to use this API in your plugins anymore.
+This API is no longer necessary as there is an internal check for whether or not a node has changed.
 
 ### Removal of `sizes` & `resolutions` for image queries
 
@@ -274,7 +274,7 @@ export const query = graphql`
 
 ### CSS Modules are imported as ESModules
 
-The web moves forward and so are we. ESModules allow us to better treeshake and generate smaller files. From now on you'll need to import cssModules as: `import { box } from './mystyles.module.css'`
+The web moves forward and so do we. ESModules allow us to better treeshake and generate smaller files. From now on you'll need to import cssModules as: `import { box } from './mystyles.module.css'`
 
 ```diff:title=src/components/Box.js
 import React from "react"
@@ -313,7 +313,7 @@ const query = {
 
 ### GraphQL: `__typename` field is no longer added automatically
 
-In v2 we used to add implicit `__typename` field when querying for a field of abstract type (interface or union).
+In v2 we used to add the `__typename` field implicitly when querying for a field of abstract type (interface or union).
 In v3 `__typename` has to be added explicitly in your query:
 
 ```diff:title=src/pages/index.js
@@ -350,7 +350,7 @@ export const query = graphql`
 Imagine you have node type `Foo` that has several child nodes of type `Bar` (so you expect field `Foo.childBar` to exist).
 In Gatsby v2 this field was added automatically even if inference was disabled for type `Foo`.
 
-In Gatsby v3 you must declare paret-child relationship explicitly for this case:
+In Gatsby v3 you must declare a parent-child relationship explicitly for this case:
 
 ```diff:title=gatsby-node.js
 exports.createSchemaCustomization = ({ actions }) => {
@@ -367,7 +367,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 }
 ```
 
-To make upgrade easier, check the CLI output of your site on the latest v2 and follow suggestions
+To make upgrading easier, check the CLI output of your site on the latest v2 and follow the suggestions
 when you see a warning like this:
 
 ```shell
@@ -387,7 +387,7 @@ https://www.gatsbyjs.com/docs/actions/#createTypes
 If you don't see any warnings - you are safe to upgrade to v3.
 
 If this warning is displayed for a type defined by some plugin - open an issue in the plugin repo
-with suggestion to upgrade (and a link to this guide).
+with a suggestion to upgrade (and a link to this guide).
 
 You can still fix those warnings temporarily in your site's `gatsby-node.js` until it is fixed in the plugin.
 
@@ -420,7 +420,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
 In Gatsby v2 we add those extensions for you automatically but display a deprecation warning.
 
-To make upgrade easier, check the CLI output of your site on the latest v2 and follow suggestions
+To make upgrading easier, check the CLI output of your site on the latest v2 and follow suggestions
 when you see a warning like this:
 
 ```shell
@@ -436,7 +436,7 @@ https://www.gatsbyjs.com/docs/actions/#createTypes
 ```
 
 If this warning is displayed for a type defined by some plugin - open an issue in the plugin repo
-with suggestion to upgrade (and a link to this guide).
+with a suggestion to upgrade (and a link to this guide).
 
 You can still fix those warnings temporarily in your site's `gatsby-node.js` until it is fixed in the plugin.
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -16,7 +16,7 @@ This is a reference for upgrading your site from Gatsby v2 to Gatsby v3. Since t
 
 - [Updating Your Dependencies](#updating-your-dependencies)
 - [Handling Breaking Changes](#handling-breaking-changes)
-- [Resolving Deprecations](#resolving-deprecations)
+- [Future Breaking Changes](#future-breaking-changes)
 - [For Plugin Maintainers](#for-plugin-maintainers)
 - [Known issues](#known-issues)
 
@@ -132,7 +132,7 @@ Check [Node’s releases document](https://github.com/nodejs/Release#nodejs-rele
 
 ### webpack upgraded from version 4 to version 5
 
-We tried our best to mitigate as much of the breaking change as we could. Some are sadly inevitable. In our breaking change section and deprecation section, you'll find the most common problems and how to solve them. We suggest looking at the [official webpack 5 blog post](https://webpack.js.org/blog/2020-10-10-webpack-5-release/) to get a comprehensive list of what changed.
+We tried our best to mitigate as much of the breaking change as we could. Some are sadly inevitable. We suggest looking at the [official webpack 5 blog post](https://webpack.js.org/blog/2020-10-10-webpack-5-release/) to get a comprehensive list of what changed.
 
 If you hit any problems along the way, make sure the Gatsby plugin or webpack plugin supports version 5.
 
@@ -340,9 +340,9 @@ export const query = graphql`
 `
 ```
 
-### CSS Modules are imported as ESModules
+### CSS Modules are imported as ES Modules
 
-The web moves forward and so do we. ESModules allow us to better treeshake and generate smaller files. From now on you'll need to import cssModules as: `import { box } from './mystyles.module.css'`
+The web moves forward and so do we. ES Modules allow us to better treeshake and generate smaller files. From now on you'll need to import cssModules as: `import { box } from './mystyles.module.css'`
 
 ```diff:title=src/components/Box.js
 import React from "react"
@@ -359,9 +359,9 @@ export default Box
 
 You can also still import all styles using the `import * as styles` sytax e.g. `import * as styles from './mystyles.module.css'`.
 
-### File assets (fonts, pdfs, ...) are imported as ESModules
+### File assets (fonts, pdfs, ...) are imported as ES Modules
 
-Assets are handled as ESM modules. Make sure to switch your require functions into imports.
+Assets are handled as ES Modules. Make sure to switch your require functions into imports.
 
 ```diff:title=src/components/Layout.js
 import React from "react"
@@ -554,8 +554,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
 In Gatsby v2, we add those extensions for you automatically but display a deprecation warning.
 
-To make upgrading easier, check the CLI output of your site on the latest v2 and follow suggestions
-when you see a warning like this:
+To make upgrading easier, when you see a warning like the one below, check the CLI output of your site on the latest v2 and follow the suggestions provided.
 
 ```shell
 warning Deprecation warning: adding inferred extension `link` for field Foo.bar
@@ -654,9 +653,9 @@ exports.createResolvers = ({ createResolvers }) => {
 **Note:** When using argument `firstOnly: true` the returned value is `object` or `null`.
 So do not confuse those two cases.
 
-## Resolving Deprecations
+## Future Breaking Changes
 
-This section explains deprecations that were made for Gatsby v3. The old behaviors will be removed in v4. You can still use the old behaviors in v3 but we recommend updating to the new signatures.
+This section explains deprecations that were made for Gatsby v3. These old behaviors will be removed in v4, at which point they will no longer work. For now, you can still use the old behaviors in v3, but we recommend updating to the new signatures to make future updates easier.
 
 ### `touchNode`
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -595,7 +595,7 @@ In most cases you won't have to do anything to be v3 compatible, but there are a
 
 ```diff:title=package.json
 "peerDependencies": {
--  "gatsby": "^2.32.0"
-+  "gatsby": "^3.0.0"
+-  "gatsby": "^2.32.0",
++  "gatsby": "^3.0.0",
 }
 ```

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -774,4 +774,4 @@ is correct.
 File: node_modules/gatsby-link/index.js:24:13
 ```
 
-This is because in your `.cache` you still have the old package and its imports around. Run `gatsby clean` to remove the outdated cache.
+Make sure that you have updated all dependencies. It's also possible that you have an outdated `.cache` folder around. Run `gatsby clean` to remove the outdated cache.

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -8,17 +8,9 @@ Looking for the v2 docs? [Find them here.](https://v2.gatsbyjs.com)
 
 ## Introduction
 
-This is a reference for upgrading your site from Gatsby v2 to Gatsby v3. TODO
+This is a reference for upgrading your site from Gatsby v2 to Gatsby v3. Since the last major release was in September 2018, Gatsby v3 includes a couple of breaking changes. If you're curious what's new, head over to the [v3.0 release notes](/docs/reference/release-notes/v3.0).
 
 > If you want to start fresh, run `npm init gatsby` or `yarn create gatsby` in your terminal.
-
-## Why you should upgrade
-
-This documentation page covers the _how_ of migrating from v2 to v3. If you're curious what's new, read the [v3.0 release notes](/docs/reference/release-notes/v3.0).
-
-## What we'll cover
-
-short list of contents, point to sidebar at the right
 
 ## Updating Your Dependencies
 
@@ -584,5 +576,20 @@ exports.createSchemaCustomization = function createSchemaCustomization({ actions
       id: ID!
     }
   `)
+}
+```
+
+## For Plugin Maintainers
+
+In most cases you won't have to do anything to be v3 compatible, but there are a few things you can do to be certain your plugin won't throw any warnings or errors.
+
+### Setting the proper peer dependencies
+
+`gatsby` should be included under `peerDependencies` of your plugin and it should specify the proper versions of support.
+
+```diff:title=package.json
+"peerDependencies": {
+-  "gatsby": "^2.32.0"
++  "gatsby": "^3.0.0"
 }
 ```

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -89,7 +89,13 @@ Using community plugins you might see warnings like these in your terminal:
 warning Plugin gatsby-plugin-acme is not compatible with your gatsby version 3.0.0 - It requires gatsby@^2.32.0
 ```
 
-This is because the plugin needs to set its `peerDependencies` to the new version of Gatsby (see section [for plugin maintainers](#for-plugin-maintainers)). While this might indicate that the plugin has incompatibilities, in most cases they should continue to work. Please look for already opened issues or PRs on the plugin's repository to see the status. If you don't see any, help the maintainers by opening an issue or PR yourself! :)
+If you are using npm 7, the warning may instead be an error:
+
+```shell
+npm ERR! ERESOLVE unable to resolve dependency tree
+```
+
+This is because the plugin needs to set its `peerDependencies` to the new version of Gatsby (see section [for plugin maintainers](#for-plugin-maintainers)). While this might indicate that the plugin has incompatibilities, in most cases they should continue to work. When using npm 7, you can pass the `--legacy-peer-deps` to ignore the warning and install anyway. Please look for already opened issues or PRs on the plugin's repository to see the status. If you don't see any, help the maintainers by opening an issue or PR yourself! :)
 
 #### Handling dependencies for plugins that are not yet updated
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -18,7 +18,7 @@ This is a reference for upgrading your site from Gatsby v2 to Gatsby v3. Since t
 - [Handling Breaking Changes](#handling-breaking-changes)
 - [Future Breaking Changes](#future-breaking-changes)
 - [For Plugin Maintainers](#for-plugin-maintainers)
-- [Known issues](#known-issues)
+- [Known Issues](#known-issues)
 
 ## Updating Your Dependencies
 
@@ -357,7 +357,7 @@ const Box = ({ children }) => (
 export default Box
 ```
 
-You can also still import all styles using the `import * as styles` sytax e.g. `import * as styles from './mystyles.module.css'`.
+You can also still import all styles using the `import * as styles` sytax e.g. `import * as styles from './mystyles.module.css'`. However, this won't allow webpack to treeshake your styles so we discourage you from using this syntax.
 
 ### File assets (fonts, pdfs, ...) are imported as ES Modules
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -379,6 +379,25 @@ const Layout = ({ children }) => (
 export default Layout
 ```
 
+When you're using `require with expression` or `require.context` which is not recommended. You'll have to append `.default` to your require statement to make it work.
+
+```diff:title=src/components/Layout.js
+import React from "react"
+import { Helmet } from "react-helmet";
+
+const Layout = ({ children, font }) => (
+  <div>
+    <Helmet>
+-      <link rel="preload" href={require('../assets/fonts/' + font + '.woff2')} as="fonts/woff2" crossOrigin="anonymous" type="font/woff2" />
++      <link rel="preload" href={require('../assets/fonts/' + font + '.woff2').default} as="fonts/woff2" crossOrigin="anonymous" type="font/woff2" /
+    </Helmet>
+    {children}
+  </div>
+)
+
+export default Layout
+```
+
 ### Webpack 5 node configuration changed (node.fs, node.path, ...)
 
 Some components need you to patch/disable node apis in the browser like path or fs. Webpack removed these automatic polyfills. You now have to manually set them in your configurations

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -805,3 +805,22 @@ Configuring using `package.json`:
   }
 }
 ```
+
+### webpack EACCES
+
+You might see errors like these when using Windows or WSL:
+
+```shell
+Watchpack Error (initial scan): Error: EACCES: permission denied, lstat '/c/DumpStack.log.tmp'
+Watchpack Error (initial scan): Error: EACCES: permission denied, lstat '/c/hiberfil.sys'
+Watchpack Error (initial scan): Error: EACCES: permission denied, lstat '/c/pagefile.sys'
+Watchpack Error (initial scan): Error: EACCES: permission denied, lstat '/c/swapfile.sys'
+```
+
+Gatsby will continue to work. Please track the [upstream issue](https://github.com/webpack/watchpack/issues/187) to see how and when this will be fixed.
+
+### yarn workspaces
+
+Workspaces and their hoisting of dependencies can cause you troubles if you incrementally want to update a package. For example, if you use `gatsby-plugin-emotion` in multiple packages but only update its version in one, you might end up with multiple versions inside your project. Run `yarn why package-name` (in this example `yarn why gatsby-plugin-emotion`) to check if different versions are installed.
+
+We recommend updating all dependencies at once and re-checking it with `yarn why package-name`. You should only see one version found now.

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -99,11 +99,11 @@ This is because the plugin needs to set its `peerDependencies` to the new versio
 
 #### Handling dependencies for plugins that are not yet updated
 
-If you run into the scenarios listed below, you will need to leverage yarn resolutions until the plugin authors upgrade the plugins they maintain.
+If you run into the scenarios listed below, you will need to use yarn resolutions until the plugin authors upgrade the plugins they maintain.
 
 Gatsby has an _amazing_ ecosystem of plugins that make it easier to get up and running, and to incorporate various data sources and functionality into your Gatsby project. Part of that huge ecosystem includes dependency trees!
 
-Depending on how the plugin authors have declared dependencies (e.g. marking a package as a dependency instead of a peerDependency) within those plugins, there could be a myriad of failures that arise. If you encounter any of these issues when migrating your project to Gatsby Version 3, we recommend that you leverage [Yarn resolutions](https://yarnpkg.com/configuration/manifest#resolutions) within your `package.json`.
+Depending on how the plugin authors have declared dependencies (e.g. marking a package as a dependency instead of a peerDependency) within those plugins, there could be a myriad of failures that arise. If you encounter any of these issues when migrating your project to Gatsby Version 3, we recommend that you use [Yarn resolutions](https://yarnpkg.com/configuration/manifest#resolutions) within your `package.json`.
 
 **Please note:** If your rely on a plugin that is not found within the [list of plugins within the Gatsby framework](https://github.com/gatsbyjs/gatsby/tree/master/packages), you very well may need to use the following resolutions in the near term.
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -85,13 +85,13 @@ This is because the plugin needs to set its `peerDependencies` to the new versio
 
 #### Handling dependencies for plugins that are not yet updated
 
-ℹ️ If you run into the scenarios listed below, you will need to leverage yarn resolutions until the plugin authors upgrade the plugins they maintain.
+If you run into the scenarios listed below, you will need to leverage yarn resolutions until the plugin authors upgrade the plugins they maintain.
 
-Gatsby has an _amazing_ ecosystem of plugins that make it easier to get up and running, and to incorporate various data sources and functionality into your Gatsby project. Part of that huge ecosystem includes ... 🥁 ... dependency trees!
+Gatsby has an _amazing_ ecosystem of plugins that make it easier to get up and running, and to incorporate various data sources and functionality into your Gatsby project. Part of that huge ecosystem includes dependency trees!
 
 Depending on how the plugin authors have declared dependencies (e.g. marking a package as a dependency instead of a peerDependency) within those plugins, there could be a myriad of failures that arise. If you encounter any of these issues when migrating your project to Gatsby Version 3, we recommend that you leverage [Yarn resolutions](https://yarnpkg.com/configuration/manifest#resolutions) within your `package.json`.
 
-👉 Hint: If your rely on a plugin that is not found within the [list of plugins within the Gatsby framework](https://github.com/gatsbyjs/gatsby/tree/master/packages), you very well may need to use the following resolutions in the near term.
+**Please note:** If your rely on a plugin that is not found within the [list of plugins within the Gatsby framework](https://github.com/gatsbyjs/gatsby/tree/master/packages), you very well may need to use the following resolutions in the near term.
 
 The specific resolutions we recommend at this time are found below:
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -594,8 +594,10 @@ In most cases you won't have to do anything to be v3 compatible, but there are a
 `gatsby` should be included under `peerDependencies` of your plugin and it should specify the proper versions of support.
 
 ```diff:title=package.json
-"peerDependencies": {
--  "gatsby": "^2.32.0",
-+  "gatsby": "^3.0.0",
+{
+  "peerDependencies": {
+-   "gatsby": "^2.32.0",
++   "gatsby": "^3.0.0",
+  }
 }
 ```

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -770,9 +770,7 @@ export function onRenderBody({ setHeadComponents }) {
 
 ## For Plugin Maintainers
 
-In most cases, you won't have to do anything to be v3 compatible, but there are a few things you can do to be certain your plugin won't throw any warnings or errors.
-
-### Setting the proper peer dependencies
+In most cases, you won't have to do anything to be v3 compatible. But one thing you can do to be certain your plugin won't throw any warnings or errors is to set the proper peer dependencies.
 
 `gatsby` should be included under `peerDependencies` of your plugin and it should specify the proper versions of support.
 
@@ -804,7 +802,7 @@ is correct.
 File: node_modules/gatsby-link/index.js:24:13
 ```
 
-Make sure that you have updated all dependencies. It's also possible that you have an outdated `.cache` folder around. Run `gatsby clean` to remove the outdated cache.
+To resolve the error above, make sure that you have updated all dependencies. It's also possible that you have an outdated `.cache` folder around. Run `gatsby clean` to remove the outdated cache.
 
 In some situations the webpack alias will be ignored, so you will need to add your own alias. The most common example is in Jest tests. For these, you should add the following to your Jest config:
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -190,7 +190,7 @@ This API is no longer necessary as there is an internal check for whether or not
 
 The `sizes` and `resolutions` queries were deprecated in v2 in favor of `fluid` and `fixed`.
 
-While `fluid`, `fixed`, and `gatsby-image` will continue to work in v3, we highly recommend migrating to the new `gatsby-plugin-image`. Read the [Using the Gatsby Image plugin](/docs/how-to/images-and-media/using-gatsby-plugin-image/) guide to learn more about its benefits and on how to use it.
+While `fluid`, `fixed`, and `gatsby-image` will continue to work in v3, we highly recommend migrating to the new `gatsby-plugin-image`. Read the [Migrating from gatsby-image to gatsby-plugin-image](/docs/reference/release-notes/image-migration-guide/) guide to learn more about its benefits and on how to use it.
 
 ```diff
 import React from "react"

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -12,6 +12,14 @@ This is a reference for upgrading your site from Gatsby v2 to Gatsby v3. Since t
 
 > If you want to start fresh, run `npm init gatsby` or `yarn create gatsby` in your terminal.
 
+## Table of Contents
+
+- [Updating Your Dependencies](#updating-your-dependencies)
+- [Handling Breaking Changes](#handling-breaking-changes)
+- [Resolving Deprecations](#resolving-deprecations)
+- [For Plugin Maintainers](#for-plugin-maintainers)
+- [Known issues](#known-issues)
+
 ## Updating Your Dependencies
 
 First, you need to update your dependencies.
@@ -704,9 +712,9 @@ const Navigation = () => (
 export default Navigation
 ```
 
-### Webpack deprecation Messages
+### webpack deprecation messages
 
-When running community gatsby plugins, you might see "DEP*WEBPACK*" messages popup during the "Building Javascript" phase or the "Building SSR bundle" phase. These often mean that the plugin is not compatible with Webpack 5 yet. Contact the Gatsby plugin author or the webpack plugin author to flag this issue. Most of the time Gatsby will built fine. There are cases that it won't and the reasons why could be cryptic.
+When running community Gatsby plugins, you might see `[DEP_WEBPACK]` messages popup during the "Building Javascript" or the "Building SSR bundle" phase. These often mean that the plugin is not compatible with webpack 5 yet. Contact the Gatsby plugin author or the webpack plugin author to flag this issue. Most of the time Gatsby will build fine, however there are cases that it won't and the reasons why could be cryptic.
 
 ## Using `fs` in SSR
 
@@ -746,3 +754,24 @@ In most cases you won't have to do anything to be v3 compatible, but there are a
   }
 }
 ```
+
+## Known Issues
+
+This section is a work in progress and will be expanded when necessary. It's a list of known issues you might run into while upgrading Gatsby to v3 and how to solve them.
+
+### `reach-router`
+
+We vendored [reach-router](https://github.com/gatsbyjs/reach-router) to make it work for React 17. We added a webpack alias so that you can continue using it as usual, however you might run into an error like this after upgrading:
+
+```shell
+Generating development JavaScript bundle failed
+
+Can't resolve '@gatsbyjs/reach-router/lib/utils' in '/c/Users/xxx/test/node_modules/gatsby-link'
+
+If you're trying to use a package make sure that '@gatsbyjs/reach-router/lib/utils' is installed. If you're trying to use a local file make sure that the path
+is correct.
+
+File: node_modules/gatsby-link/index.js:24:13
+```
+
+This is because in your `.cache` you still have the old package and its imports around. Run `gatsby clean` to remove the outdated cache.

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -34,6 +34,12 @@ Or run
 npm install gatsby@latest
 ```
 
+**Please note:** If you use **npm 7** you'll want to use the `--legacy-peer-deps` option when following the instructions in this guide. For example, the above command would be:
+
+```shell
+npm install gatsby@latest --legacy-peer-deps
+```
+
 ### Update Gatsby related packages
 
 Update your `package.json` to use the latest version of Gatsby related packages. You should upgrade any package name that starts with `gatsby-*`. Note, this only applies to plugins managed in the [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby) repository. If you're using community plugins, they might not be upgraded yet. Many plugins won't need updating so they may keep working (if not, please check their repository for the current status). You can run an npm script to see all outdated dependencies.
@@ -61,7 +67,11 @@ npm install gatsby-plugin-sharp@latest
 
 #### yarn
 
-TODO
+```shell
+yarn upgrade-interactive --latest
+```
+
+You'll be given an overview of packages where you can select to upgrade them to `latest`.
 
 #### Updating community plugins
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -190,9 +190,12 @@ This API is no longer necessary as there is an internal check for whether or not
 
 The `sizes` and `resolutions` queries were deprecated in v2 in favor of `fluid` and `fixed`.
 
+While `fluid`, `fixed`, and `gatsby-image` will continue to work in v3, we highly recommend migrating to the new `gatsby-plugin-image`. Read the [Using the Gatsby Image plugin](/docs/how-to/images-and-media/using-gatsby-plugin-image/) guide to learn more about its benefits and on how to use it.
+
 ```diff
 import React from "react"
 import { graphql } from "gatsby"
+import Img from "gatsby-image"
 
 const Example = ({ data }) => {
   <div>
@@ -409,9 +412,9 @@ You can still fix those warnings temporarily in your site's `gatsby-node.js` unt
 
 Related docs:
 
-- [childOf directive](https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#defining-child-relations)
-- [Child/parent fields](https://www.gatsbyjs.com/docs/schema-inference/#childparent-fields)
-- [Schema generation](https://www.gatsbyjs.com/docs/schema-generation/#4-parent--children-relationships)
+- [childOf directive](/docs/reference/graphql-data-layer/schema-customization/#defining-child-relations)
+- [child/parent fields](/docs/schema-inference/#childparent-fields)
+- [schema generation](/docs/schema-generation/#4-parent--children-relationships)
 
 ### Schema Customization: Extensions must be set explicitly
 
@@ -456,7 +459,7 @@ with a suggestion to upgrade (and a link to this guide).
 
 You can still fix those warnings temporarily in your site's `gatsby-node.js` until it is fixed in the plugin.
 
-If you don't see any warnings - you are safe to upgrade to v3. Read more about custom extensions in [this blog post](https://www.gatsbyjs.com/blog/2019-05-17-improvements-to-schema-customization/).
+If you don't see any warnings - you are safe to upgrade to v3. Read more about custom extensions in [this blog post](/blog/2019-05-17-improvements-to-schema-customization/).
 
 ### Schema Customization: Removed `noDefaultResolvers` argument from inference directives
 
@@ -482,7 +485,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 }
 ```
 
-[Read deprecation announcement](https://www.gatsbyjs.com/blog/2019-05-17-improvements-to-schema-customization/#-nodefaultresolvers-and-inference-modes).
+[Read deprecation announcement](/blog/2019-05-17-improvements-to-schema-customization/#-nodefaultresolvers-and-inference-modes).
 
 ### Schema Customization: Remove `many` argument from `childOf` directive
 
@@ -533,7 +536,7 @@ exports.createResolvers = ({ createResolvers }) => {
 }
 ```
 
-**Note:** when using argument `firstOnly: true` the returned value is `object` or `null`.
+**Note:** When using argument `firstOnly: true` the returned value is `object` or `null`.
 So do not confuse those two cases.
 
 ## Resolving Deprecations
@@ -579,7 +582,7 @@ exports.onCreateNode = ({ actions, node }) => {
 
 ### `@nodeInterface`
 
-For Gatsby v2 `@nodeInterface` was the recommended way to implement [queryable interfaces](https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#queryable-interfaces-with-the-nodeinterface-extension).
+For Gatsby v2 `@nodeInterface` was the recommended way to implement [queryable interfaces](/docs/reference/graphql-data-layer/schema-customization/#queryable-interfaces-with-the-nodeinterface-extension).
 Now it is deprecated in favor of interface inheritance:
 
 ```diff:title=gatsby-node.js

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -65,7 +65,13 @@ TODO
 
 #### Updating community plugins
 
-TODO: What about peerDependencies? → We should add a note in the section “Update Gatsby Related Packages” since people will get warnings in their console. Ward suggests we drop the full warning in the migration doc with then a tip on how to resolve.
+Using community plugins you might see warnings like these in your terminal:
+
+```shell
+warning Plugin gatsby-plugin-acme is not compatible with your gatsby version 3.0.0 - It requires gatsby@^2.32.0
+```
+
+This is because the plugin needs to set its `peerDependencies` to the new version of Gatsby (see section [for plugin maintainers](#for-plugin-maintainers)). While this might indicate that the plugin has incompatibilities, in most cases they should continue to work. Please look for already opened issues or PRs on the plugin's repository to see the status. If you don't see any, help the maintainers by opening an issue or PR yourself! :)
 
 ## Handling Breaking Changes
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -4,7 +4,7 @@ title: Migrating from v2 to v3
 
 Looking for the v2 docs? [Find them here.](https://v2.gatsbyjs.com)
 
-> This document is a work in progress. Have you run into something that's not covered here? [Add you changes to GitHub!](#link-to-github)
+> This document is a work in progress. Have you run into something that's not covered here? [Add your changes to GitHub!](https://github.com/gatsbyjs/gatsby/tree/master/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md)
 
 ## Introduction
 
@@ -14,7 +14,7 @@ This is a reference for upgrading your site from Gatsby v2 to Gatsby v3. TODO
 
 ## Why you should upgrade
 
-This documentation page covers the _how_ of migrating from v2 to v3. If you're curious what's new, read the [v3.0 release notes](#link-to-release-notes).
+This documentation page covers the _how_ of migrating from v2 to v3. If you're curious what's new, read the [v3.0 release notes](/docs/reference/release-notes/v3.0).
 
 ## What we'll cover
 
@@ -46,6 +46,8 @@ npm install gatsby@latest
 
 Update your `package.json` to use the latest version of Gatsby related packages. You should upgrade any package name that starts with `gatsby-*`. Note, this only applies to plugins managed in the [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby) repository. If you're using community plugins, they might not be upgraded yet. Many plugins won't need updating so they well might keep working (if not, please check their repository for the current status). You can run an npm script to see all outdated dependencies.
 
+#### npm
+
 ```shell
 npm outdated
 ```
@@ -65,7 +67,21 @@ Install the new package with:
 npm install gatsby-plugin-sharp@latest
 ```
 
+#### yarn
+
+TODO
+
+#### Updating community plugins
+
+TODO: What about peerDependencies? → We should add a note in the section “Update Gatsby Related Packages” since people will get warnings in their console. Ward suggests we drop the full warning in the migration doc with then a tip on how to resolve.
+
 ## Handling Breaking Changes
+
+This section explains breaking changes that were made for Gatsby v3. Most, if not all, of those changes had a deprecation message in v2. In order to successfully update you'll need to resolve these changes.
+
+### Minimal Node.js version 12.13.0
+
+Gatsby now requires at least `12.13.0` for its Node.js version.
 
 ### Gatsby's Link component
 
@@ -337,7 +353,7 @@ export const query = graphql`
 `
 ```
 
-### Schema customization: add explicit `childOf` extension to types with disabled inference
+### Schema Customization: Add explicit `childOf` extension to types with disabled inference
 
 Imagine you have node type `Foo` that has several child nodes of type `Bar` (so you expect field `Foo.childBar` to exist).
 In Gatsby v2 this field was added automatically even if inference was disabled for type `Foo`.
@@ -389,7 +405,7 @@ Related docs:
 - [Child/parent fields](https://www.gatsbyjs.com/docs/schema-inference/#childparent-fields)
 - [Schema generation](https://www.gatsbyjs.com/docs/schema-generation/#4-parent--children-relationships)
 
-### Schema customization: extensions must be set explicitly
+### Schema Customization: Extensions must be set explicitly
 
 Starting with v3 whenever you define a field of complex type, you must also assign
 the corresponding extension (or a custom resolver):
@@ -434,7 +450,7 @@ You can still fix those warnings temporarily in your site's `gatsby-node.js` unt
 
 If you don't see any warnings - you are safe to upgrade to v3. Read more about custom extensions in [this blog post](https://www.gatsbyjs.com/blog/2019-05-17-improvements-to-schema-customization/).
 
-### Schema customization: removed `noDefaultResolvers` argument from inference directives
+### Schema Customization: Removed `noDefaultResolvers` argument from inference directives
 
 Search for `noDefaultResolvers` entries and remove them:
 
@@ -460,7 +476,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 
 [Read deprecation announcement](https://www.gatsbyjs.com/blog/2019-05-17-improvements-to-schema-customization/#-nodefaultresolvers-and-inference-modes).
 
-### Schema customization: remove `many` argument from `childOf` directive
+### Schema Customization: Remove `many` argument from `childOf` directive
 
 It is no longer needed in Gatsby v3:
 
@@ -477,7 +493,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 }
 ```
 
-### Schema customization: consistent return for `nodeModel.runQuery`
+### Schema Customization: Consistent return for `nodeModel.runQuery`
 
 For Gatsby v2, `nodeModel.runQuery` with `firstOnly: false` returns `null` when nothing is found.
 In v3 it returns an empty array instead.
@@ -513,6 +529,8 @@ exports.createResolvers = ({ createResolvers }) => {
 So do not confuse those two cases.
 
 ## Resolving Deprecations
+
+This section explains deprecations that were made for Gatsby v3. The old behaviors will be removed in v4. You can still use the old behaviors in v3 but we recommend updating to the new signatures.
 
 ### `touchNode`
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -2,7 +2,7 @@
 title: Migrating from v2 to v3
 ---
 
-Looking for the v2 docs? [Find them here.](https://v2.gatsbyjs.com)
+Looking for the [v2 docs](https://v2.gatsbyjs.com)?
 
 > This document is a work in progress. Have you run into something that's not covered here? [Add your changes to GitHub!](https://github.com/gatsbyjs/gatsby/tree/master/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md)
 
@@ -58,7 +58,7 @@ Update your `package.json` to use the latest version of Gatsby related packages.
 npm outdated
 ```
 
-Compare the "Wanted" and "Latest" versions and update their versions accordingly. For example, if you have this oudated version:
+Compare the "Wanted" and "Latest" versions and update their versions accordingly. For example, if you have this outdated version:
 
 ```shell
 > npm outdated
@@ -83,7 +83,7 @@ You'll be given an overview of packages where you can select to upgrade them to 
 
 #### Updating community plugins
 
-Using community plugins you might see warnings like these in your terminal:
+Using community plugins, you might see warnings like these in your terminal:
 
 ```shell
 warning Plugin gatsby-plugin-acme is not compatible with your gatsby version 3.0.0 - It requires gatsby@^2.32.0
@@ -121,7 +121,7 @@ The specific resolutions we recommend at this time are found below:
 
 ## Handling Breaking Changes
 
-This section explains breaking changes that were made for Gatsby v3. Most, if not all, of those changes had a deprecation message in v2. In order to successfully update you'll need to resolve these changes.
+This section explains breaking changes that were made for Gatsby v3. Most, if not all, of those changes had a deprecation message in v2. In order to successfully update, you'll need to resolve these changes.
 
 ### Minimal Node.js version 12.13.0
 
@@ -130,17 +130,17 @@ The new required version of Node is `12.13.0`. See the main changes in [Node 12 
 
 Check [Node’s releases document](https://github.com/nodejs/Release#nodejs-release-working-group) for version statuses.
 
-### Webpack upgraded from version 4 to version 5
+### webpack upgraded from version 4 to version 5
 
 We tried our best to mitigate as much of the breaking change as we could. Some are sadly inevitable. In our breaking change section and deprecation section, you'll find the most common problems and how to solve them. We suggest looking at the [official webpack 5 blog post](https://webpack.js.org/blog/2020-10-10-webpack-5-release/) to get a comprehensive list of what changed.
 
-If you hit any problems along the way, make sure the gatsby plugin or webpack plugin supports version 5.
+If you hit any problems along the way, make sure the Gatsby plugin or webpack plugin supports version 5.
 
-### Eslint upgraded from version 6 to version 7
+### ESLint upgraded from version 6 to version 7
 
-If you're using Gatsby's default eslint rules (no custom eslintrc file), you shouldn't notice any issues. If you do have a custom eslint config, make sure to read the [Eslint 6 to 7 migration guide](https://eslint.org/docs/user-guide/migrating-to-7.0.0)
+If you're using Gatsby's default ESLint rules (no custom `eslintrc` file), you shouldn't notice any issues. If you do have a custom ESLint config, make sure to read the [ESLint 6 to 7 migration guide](https://eslint.org/docs/user-guide/migrating-to-7.0.0)
 
-### Gatsby's Link component
+### Gatsby's `Link` component
 
 The APIs `push`, `replace` & `navigateTo` in `gatsby-link` (an internal package) were deprecated in v2 and now with v3 completely removed. Please use `navigate` instead.
 
@@ -233,13 +233,13 @@ exports.onCreateNode = ({ node, actions }) => {
 
 ### Removal of `hasNodeChanged` from public API surface
 
-This API is no longer necessary as there is an internal check for whether or not a node has changed.
+This API is no longer necessary, as there is an internal check for whether or not a node has changed.
 
 ### Removal of `sizes` & `resolutions` for image queries
 
 The `sizes` and `resolutions` queries were deprecated in v2 in favor of `fluid` and `fixed`.
 
-While `fluid`, `fixed`, and `gatsby-image` will continue to work in v3, we highly recommend migrating to the new `gatsby-plugin-image`. Read the [Migrating from gatsby-image to gatsby-plugin-image](/docs/reference/release-notes/image-migration-guide/) guide to learn more about its benefits and on how to use it.
+While `fluid`, `fixed`, and `gatsby-image` will continue to work in v3, we highly recommend migrating to the new `gatsby-plugin-image`. Read the [Migrating from `gatsby-image` to `gatsby-plugin-image`](/docs/reference/release-notes/image-migration-guide/) guide to learn more about its benefits and how to use it.
 
 ```diff
 import React from "react"
@@ -317,7 +317,7 @@ A couple of `gatsby-browser` APIs were removed. In the list below you can find t
 
 ### Using a global `graphql` tag for queries
 
-Until now your were able to use the `graphql` tag for queries without explicitly importing it from Gatsby. You now have to import it: `import { graphql } from 'gatsby'`
+Until now you were able to use the `graphql` tag for queries without explicitly importing it from Gatsby. You now have to import it: `import { graphql } from 'gatsby'`
 
 ```diff:title=src/pages/index.js
 import React from "react"
@@ -381,7 +381,7 @@ const Layout = ({ children }) => (
 export default Layout
 ```
 
-When you're using `require with expression` or `require.context` which is not recommended. You'll have to append `.default` to your require statement to make it work.
+If you're using `require with expression` or `require.context` (which is not recommended), you'll have to append `.default` to your require statement to make it work.
 
 ```diff:title=src/components/Layout.js
 import React from "react"
@@ -400,9 +400,9 @@ const Layout = ({ children, font }) => (
 export default Layout
 ```
 
-### Webpack 5 node configuration changed (node.fs, node.path, ...)
+### webpack 5 node configuration changed (node.fs, node.path, ...)
 
-Some components need you to patch/disable node apis in the browser like path or fs. Webpack removed these automatic polyfills. You now have to manually set them in your configurations
+Some components need you to patch/disable node APIs in the browser, like `path` or `fs`. webpack removed these automatic polyfills. You now have to manually set them in your configurations:
 
 ```diff:title=gatsby-node.js
 exports.onCreateWebpackConfig = ({ actions }) => {
@@ -425,10 +425,10 @@ exports.onCreateWebpackConfig = ({ actions }) => {
 
 ### GraphQL: character escape sequences in `regex` filter
 
-In v2 backslashes in `regex` filters of GraphQL queries had to be escaped
+In v2, backslashes in `regex` filters of GraphQL queries had to be escaped
 _twice_, so `/\w+/` needed to be written as `"/\\\\w+/"`.
 
-In v3 you only need to escape once:
+In v3, you only need to escape once:
 
 ```diff:title=src/pages/index.js
 const query = {
@@ -447,8 +447,8 @@ const query = {
 
 ### GraphQL: `__typename` field is no longer added automatically
 
-In v2 we used to add the `__typename` field implicitly when querying for a field of abstract type (interface or union).
-In v3 `__typename` has to be added explicitly in your query:
+In v2, the `__typename` field used to be added implicitly when querying for a field of abstract type (interface or union).
+In v3, `__typename` has to be added explicitly in your query:
 
 ```diff:title=src/pages/index.js
 import React from "react"
@@ -518,12 +518,12 @@ Add the following type definition to fix this:
 https://www.gatsbyjs.com/docs/actions/#createTypes
 ```
 
-If you don't see any warnings - you are safe to upgrade to v3.
+If you don't see any warnings, you are safe to upgrade to v3.
 
-If this warning is displayed for a type defined by some plugin - open an issue in the plugin repo
+If this warning is displayed for a type defined by some plugin, open an issue in the plugin repo
 with a suggestion to upgrade (and a link to this guide).
 
-You can still fix those warnings temporarily in your site's `gatsby-node.js` until it is fixed in the plugin.
+You can still fix those warnings temporarily in your site's `gatsby-node.js` file until it is fixed in the plugin.
 
 Related docs:
 
@@ -533,7 +533,7 @@ Related docs:
 
 ### Schema Customization: Extensions must be set explicitly
 
-Starting with v3 whenever you define a field of complex type, you must also assign
+Starting with v3, whenever you define a field of complex type, you must also assign
 the corresponding extension (or a custom resolver):
 
 ```diff:title=gatsby-node.js
@@ -552,7 +552,7 @@ exports.createSchemaCustomization = ({ actions }) => {
 }
 ```
 
-In Gatsby v2 we add those extensions for you automatically but display a deprecation warning.
+In Gatsby v2, we add those extensions for you automatically but display a deprecation warning.
 
 To make upgrading easier, check the CLI output of your site on the latest v2 and follow suggestions
 when you see a warning like this:
@@ -569,12 +569,12 @@ Add the following type definition to fix this:
 https://www.gatsbyjs.com/docs/actions/#createTypes
 ```
 
-If this warning is displayed for a type defined by some plugin - open an issue in the plugin repo
+If this warning is displayed for a type defined by some plugin, open an issue in the plugin repo
 with a suggestion to upgrade (and a link to this guide).
 
 You can still fix those warnings temporarily in your site's `gatsby-node.js` until it is fixed in the plugin.
 
-If you don't see any warnings - you are safe to upgrade to v3. Read more about custom extensions in [this blog post](/blog/2019-05-17-improvements-to-schema-customization/).
+If you don't see any warnings, you are safe to upgrade to v3. Read more about custom extensions in [this blog post](/blog/2019-05-17-improvements-to-schema-customization/).
 
 ### Schema Customization: Removed `noDefaultResolvers` argument from inference directives
 
@@ -600,11 +600,11 @@ exports.createSchemaCustomization = ({ actions }) => {
 }
 ```
 
-[Read deprecation announcement](/blog/2019-05-17-improvements-to-schema-customization/#-nodefaultresolvers-and-inference-modes).
+[Deprecation announcement for `noDefaultResolvers`](/blog/2019-05-17-improvements-to-schema-customization/#-nodefaultresolvers-and-inference-modes).
 
 ### Schema Customization: Remove `many` argument from `childOf` directive
 
-It is no longer needed in Gatsby v3:
+The `many` argument is no longer needed for the `childOf` directive in Gatsby v3:
 
 ```diff:title=gatsby-node.js
 exports.createSchemaCustomization = ({ actions }) => {
@@ -671,7 +671,7 @@ exports.sourceNodes = ({ actions, getNodesByType }) => {
 }
 ```
 
-In case you only have an ID at hand (e.g. getting it from cache or as `__NODE`) you can use the `getNode()` API:
+In case you only have an ID at hand (e.g. getting it from cache or as `__NODE`), you can use the `getNode()` API:
 
 ```js:title=gatsby-node.js
 exports.sourceNodes = async ({ actions, getNodesByType, cache }) => {
@@ -684,7 +684,7 @@ exports.sourceNodes = async ({ actions, getNodesByType, cache }) => {
 
 ### `deleteNode`
 
-For Gatsby v2 the `deleteNode` API accepted `node` as a named argument. This now has been deprecated in favor of passing the full `node` to the function.
+For Gatsby v2, the `deleteNode` API accepted `node` as a named argument. This now has been deprecated in favor of passing the full `node` to the function.
 
 ```diff:title=gatsby-node.js
 exports.onCreateNode = ({ actions, node }) => {
@@ -697,7 +697,7 @@ exports.onCreateNode = ({ actions, node }) => {
 
 ### `@nodeInterface`
 
-For Gatsby v2 `@nodeInterface` was the recommended way to implement [queryable interfaces](/docs/reference/graphql-data-layer/schema-customization/#queryable-interfaces-with-the-nodeinterface-extension).
+For Gatsby v2, `@nodeInterface` was the recommended way to implement [queryable interfaces](/docs/reference/graphql-data-layer/schema-customization/#queryable-interfaces-with-the-nodeinterface-extension).
 Now it is deprecated in favor of interface inheritance:
 
 ```diff:title=gatsby-node.js
@@ -713,9 +713,9 @@ exports.createSchemaCustomization = function createSchemaCustomization({ actions
 }
 ```
 
-### JSON imports - follow the JSON modules web spec
+### JSON imports: follow the JSON modules web spec
 
-JSON modules are coming to the web. JSON modules only allow you to import the default export and no sub properties. If you do import properties, you'll get a warning along these lines:
+JSON modules are coming to the web. JSON modules only allow you to import the default export and no sub-properties. If you do import properties, you'll get a warning along these lines:
 
 ```
 Should not import the named export 'myProp' from default-exporting module (only default export is available soon)
@@ -770,7 +770,7 @@ export function onRenderBody({ setHeadComponents }) {
 
 ## For Plugin Maintainers
 
-In most cases you won't have to do anything to be v3 compatible, but there are a few things you can do to be certain your plugin won't throw any warnings or errors.
+In most cases, you won't have to do anything to be v3 compatible, but there are a few things you can do to be certain your plugin won't throw any warnings or errors.
 
 ### Setting the proper peer dependencies
 
@@ -791,7 +791,7 @@ This section is a work in progress and will be expanded when necessary. It's a l
 
 ### `reach-router`
 
-We vendored [reach-router](https://github.com/gatsbyjs/reach-router) to make it work for React 17. We added a webpack alias so that you can continue using it as usual, however you might run into an error like this after upgrading:
+We vendored [reach-router](https://github.com/gatsbyjs/reach-router) to make it work for React 17. We added a webpack alias so that you can continue using it as usual. However, you might run into an error like this after upgrading:
 
 ```shell
 Generating development JavaScript bundle failed
@@ -806,7 +806,7 @@ File: node_modules/gatsby-link/index.js:24:13
 
 Make sure that you have updated all dependencies. It's also possible that you have an outdated `.cache` folder around. Run `gatsby clean` to remove the outdated cache.
 
-In some situations the webpack alias will be ignored, so you will need to add your own alias. The most common example is in Jest tests. For these you should add the following to your Jest config:
+In some situations the webpack alias will be ignored, so you will need to add your own alias. The most common example is in Jest tests. For these, you should add the following to your Jest config:
 
 Configuring using a `jest.config.js` file:
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -83,6 +83,28 @@ warning Plugin gatsby-plugin-acme is not compatible with your gatsby version 3.0
 
 This is because the plugin needs to set its `peerDependencies` to the new version of Gatsby (see section [for plugin maintainers](#for-plugin-maintainers)). While this might indicate that the plugin has incompatibilities, in most cases they should continue to work. Please look for already opened issues or PRs on the plugin's repository to see the status. If you don't see any, help the maintainers by opening an issue or PR yourself! :)
 
+#### Handling dependencies for plugins that are not yet updated
+
+ℹ️ If you run into the scenarios listed below, you will need to leverage yarn resolutions until the plugin authors upgrade the plugins they maintain.
+
+Gatsby has an _amazing_ ecosystem of plugins that make it easier to get up and running, and to incorporate various data sources and functionality into your Gatsby project. Part of that huge ecosystem includes ... 🥁 ... dependency trees!
+
+Depending on how the plugin authors have declared dependencies (e.g. marking a package as a dependency instead of a peerDependency) within those plugins, there could be a myriad of failures that arise. If you encounter any of these issues when migrating your project to Gatsby Version 3, we recommend that you leverage [Yarn resolutions](https://yarnpkg.com/configuration/manifest#resolutions) within your `package.json`.
+
+👉 Hint: If your rely on a plugin that is not found within the [list of plugins within the Gatsby framework](https://github.com/gatsbyjs/gatsby/tree/master/packages), you very well may need to use the following resolutions in the near term.
+
+The specific resolutions we recommend at this time are found below:
+
+```json:title=package.json
+{
+  "resolutions": {
+    "graphql": "^15.4.0",
+    "graphql-compose": "^7.25.0",
+    "webpack": "^5.24.2"
+  }
+}
+```
+
 ## Handling Breaking Changes
 
 This section explains breaking changes that were made for Gatsby v3. Most, if not all, of those changes had a deprecation message in v2. In order to successfully update you'll need to resolve these changes.

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -357,6 +357,8 @@ const Box = ({ children }) => (
 export default Box
 ```
 
+You can also still import all styles using the `import * as styles` sytax e.g. `import * as styles from './mystyles.module.css'`.
+
 ### File assets (fonts, pdfs, ...) are imported as ESModules
 
 Assets are handled as ESM modules. Make sure to switch your require functions into imports.

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -748,7 +748,7 @@ When running community Gatsby plugins, you might see `[DEP_WEBPACK]` messages po
 
 ## Using `fs` in SSR
 
-Gatsby v3 introduce incremental builds for HTML generation. For this feature to work correctly Gatsby needs to track all inputs used to generate HTML file. Arbitrary code execution in `gatsby-ssr.js` files allow usage of `fs` module which is marked as unsafe and result in disabling of this feature. To migrate you can use `import` instead of `fs`:
+Gatsby v3 introduces incremental builds for HTML generation. For this feature to work correctly, Gatsby needs to track all inputs used to generate HTML file. Arbitrary code execution in `gatsby-ssr.js` files allow usage of `fs` module, which is marked as unsafe and results in disabling of this feature. To migrate, you can use `import` instead of `fs`:
 
 ```diff:title=gatsby-ssr.js
 import * as React from "react"


### PR DESCRIPTION
Includes drafted content up to, and including "escape sequence for `regex` filter".

[Rendered view](https://github.com/gatsbyjs/gatsby/blob/docs/v3-migration-guide/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md)

[ch24734]

---

Previous two migration guides:
https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/reference/release-notes/migrating-from-v0-to-v1.md
https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/reference/release-notes/migrating-from-v1-to-v2.md