### PR TITLE
fix(gatsby-source-wordpress): fix union resolvers for wp-graphql-gravity-forms

### DIFF
--- a/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
+++ b/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
@@ -23,6 +23,7 @@ interface IRemoteSchemaState {
     internal: string
     plugin: string
     actionOptions: string
+    fields: string
   }
 }
 
@@ -97,6 +98,7 @@ const remoteSchema: IRemoteSchemaStore = {
       internal: `wpInternal`,
       plugin: `wpPlugin`,
       actionOptions: `wpActionOptions`,
+      fields: 'wpFields',
     },
   },
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
@@ -29,12 +29,12 @@ const unionType = typeBuilderApi => {
     name: buildTypeName(type.name),
     types,
     resolveType: node => {
-      if (node.type) {
-        return buildTypeName(node.type)
+      if (node?.__typename) {
+        return buildTypeName(node.__typename)
       }
 
-      if (node.__typename) {
-        return buildTypeName(node.__typename)
+      if (node?.type) {
+        return buildTypeName(node.type)
       }
 
       return null

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
@@ -20,6 +20,12 @@ export const buildTypeName = name => {
     return name
   }
 
+  // this is for cases where buildTypeName is called
+  // on a field name that's already been transformed
+  if (name.startsWith(prefix)) {
+    return name
+  }
+
   return prefix + name
 }
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-object.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-object.js
@@ -54,7 +54,7 @@ export const buildGatsbyNodeObjectResolver = ({ field, fieldName }) => async (
     schema: { typePrefix: prefix },
   } = getPluginOptions()
 
-  if (!existingNode.__typename.startsWith(prefix)) {
+  if (existingNode?.__typename && !existingNode.__typename.startsWith(prefix)) {
     existingNode.__typename = buildTypeName(existingNode.__typename)
   }
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
@@ -55,8 +55,11 @@ export const transformListOfUnions = ({ field, fieldName }) => {
 
         if (node) {
           accumulator.push(node)
-        } else if (!item.id) {
-          accumulator.push(item)
+        } else {
+          accumulator.push({
+            ...item,
+            __typename: buildTypeName(item.__typename),
+          })
         }
 
         return accumulator


### PR DESCRIPTION
The wpFields field was not properly resolving - we can't merge this until we have some better tests for gatsby-source-wordpress related to these resolvers. We used to have them but they were removed when our test suite was simplified when Rikki was adding docker into the mix.