### PR TITLE
fix(hmr): accept hot updates for modules above page templates

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/gatsby-browser.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/gatsby-browser.js
@@ -1,0 +1,24 @@
+const TEST_ID = `gatsby-browser-hmr`
+
+describe(`hot reloading above page template (gatsby-browser)`, () => {
+  beforeEach(() => {
+    cy.visit(`/`).waitForRouteChange()
+  })
+  it(`displays placeholder content on launch`, () => {
+    cy.getTestElement(TEST_ID).should(
+      `contain.text`,
+      `%TEST_HMR_IN_GATSBY_BROWSER%`
+    )
+  })
+
+  it(`hot reloads with new content`, () => {
+    const text = `HMR_IN_GATSBY_BROWSER_WORKS`
+    cy.exec(
+      `npm run update -- --file src/wrap-root-element.js --replacements "TEST_HMR_IN_GATSBY_BROWSER:${text}"`
+    )
+
+    cy.waitForHmr()
+
+    cy.getTestElement(TEST_ID).should(`contain.text`, text)
+  })
+})

--- a/e2e-tests/development-runtime/gatsby-browser.js
+++ b/e2e-tests/development-runtime/gatsby-browser.js
@@ -1,4 +1,6 @@
-const Wrapper = require(`./src/wrap-root-element`).default
+// const Wrapper = require(`./src/wrap-root-element`).default
+import WrapRootElement from "./src/wrap-root-element"
+import * as React from "react"
 
 if (typeof window !== `undefined`) {
   window.___PageComponentLifecycleCallsLog = []
@@ -11,16 +13,21 @@ const addLogEntry = (action, location) => {
   })
 }
 
-exports.onPreRouteUpdate = ({ location }) => {
-  addLogEntry(`onPreRouteUpdate`, location)
+// export const onPreRouteUpdate = ({ location }) => {
+//   addLogEntry(`onPreRouteUpdate`, location)
+// }
+
+// export const onRouteUpdate = ({ location }) => {
+//   addLogEntry(`onRouteUpdate`, location)
+// }
+// export const onPrefetchPathname = ({ pathname }) => {
+//   addLogEntry(`onPrefetchPathname`, pathname)
+// }
+
+export const wrapPageElement = ({ element }) => {
+  return <div style={{ borderLeft: "30px solid yellow" }}>{element}</div>
 }
 
-exports.onRouteUpdate = ({ location }) => {
-  addLogEntry(`onRouteUpdate`, location)
-}
-
-exports.onPrefetchPathname = ({ pathname }) => {
-  addLogEntry(`onPrefetchPathname`, pathname)
-}
-
-exports.wrapRootElement = Wrapper
+export const wrapRootElement = ({ element }) => (
+  <WrapRootElement element={element} />
+)

--- a/e2e-tests/development-runtime/gatsby-browser.js
+++ b/e2e-tests/development-runtime/gatsby-browser.js
@@ -1,4 +1,3 @@
-// const Wrapper = require(`./src/wrap-root-element`).default
 import WrapRootElement from "./src/wrap-root-element"
 import * as React from "react"
 

--- a/e2e-tests/development-runtime/gatsby-browser.js
+++ b/e2e-tests/development-runtime/gatsby-browser.js
@@ -13,19 +13,15 @@ const addLogEntry = (action, location) => {
   })
 }
 
-// export const onPreRouteUpdate = ({ location }) => {
-//   addLogEntry(`onPreRouteUpdate`, location)
-// }
+export const onPreRouteUpdate = ({ location }) => {
+  addLogEntry(`onPreRouteUpdate`, location)
+}
 
-// export const onRouteUpdate = ({ location }) => {
-//   addLogEntry(`onRouteUpdate`, location)
-// }
-// export const onPrefetchPathname = ({ pathname }) => {
-//   addLogEntry(`onPrefetchPathname`, pathname)
-// }
-
-export const wrapPageElement = ({ element }) => {
-  return <div style={{ borderLeft: "30px solid yellow" }}>{element}</div>
+export const onRouteUpdate = ({ location }) => {
+  addLogEntry(`onRouteUpdate`, location)
+}
+export const onPrefetchPathname = ({ pathname }) => {
+  addLogEntry(`onPrefetchPathname`, pathname)
 }
 
 export const wrapRootElement = ({ element }) => (

--- a/e2e-tests/development-runtime/src/wrap-root-element.js
+++ b/e2e-tests/development-runtime/src/wrap-root-element.js
@@ -22,6 +22,9 @@ const WrapRootElement = ({ element }) => (
         <div>
           StaticQuery in wrapRootElement test (should show site title):
           <span data-testid="wrap-root-element-result">{title}</span>
+          <div data-testid="gatsby-browser-hmr">
+            %TEST_HMR_IN_GATSBY_BROWSER%
+          </div>
         </div>
       </>
     )}

--- a/e2e-tests/development-runtime/src/wrap-root-element.js
+++ b/e2e-tests/development-runtime/src/wrap-root-element.js
@@ -1,34 +1,40 @@
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 
-const WrapRootElement = ({ element }) => (
-  <StaticQuery
-    query={graphql`
-      query MetaQuery {
-        site {
-          siteMetadata {
-            title
+const Wat = ({ element }, ...args) => {
+  console.log(`re-render`, args)
+  return (
+    <>
+      {/* <StaticQuery
+        query={graphql`
+          query MetaQuery {
+            site {
+              siteMetadata {
+                title
+              }
+            }
           }
-        }
-      }
-    `}
-    render={({
-      site: {
-        siteMetadata: { title },
-      },
-    }) => (
-      <>
-        {element}
-        <div>
-          StaticQuery in wrapRootElement test (should show site title):
-          <span data-testid="wrap-root-element-result">{title}</span>
-          <div data-testid="gatsby-browser-hmr">
-            %TEST_HMR_IN_GATSBY_BROWSER%
-          </div>
-        </div>
-      </>
-    )}
-  />
-)
-
-export default WrapRootElement
+        `}
+        render={({
+          site: {
+            siteMetadata: { title },
+          },
+        }) => (
+          <>
+            {element}
+            <div>
+              StaticQuery in wrapRootElement test (should show site title):
+              <span data-testid="wrap-root-element-result">{title}</span>
+            </div>
+          </>
+        )}
+      /> */}
+      {element}
+      <div data-testid="gatsby-browser-hmr">
+        aHMR_IN_GATSBY_BROWSER_WORKS9xzzzvaaddadsabgg
+      </div>
+    </>
+  )
+}
+export default Wat
+// export { WrapRootElement }

--- a/e2e-tests/development-runtime/src/wrap-root-element.js
+++ b/e2e-tests/development-runtime/src/wrap-root-element.js
@@ -1,40 +1,34 @@
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 
-const Wat = ({ element }, ...args) => {
-  console.log(`re-render`, args)
-  return (
-    <>
-      {/* <StaticQuery
-        query={graphql`
-          query MetaQuery {
-            site {
-              siteMetadata {
-                title
-              }
-            }
+const WrapRootElement = ({ element }) => (
+  <StaticQuery
+    query={graphql`
+      query MetaQuery {
+        site {
+          siteMetadata {
+            title
           }
-        `}
-        render={({
-          site: {
-            siteMetadata: { title },
-          },
-        }) => (
-          <>
-            {element}
-            <div>
-              StaticQuery in wrapRootElement test (should show site title):
-              <span data-testid="wrap-root-element-result">{title}</span>
-            </div>
-          </>
-        )}
-      /> */}
-      {element}
-      <div data-testid="gatsby-browser-hmr">
-        aHMR_IN_GATSBY_BROWSER_WORKS9xzzzvaaddadsabgg
-      </div>
-    </>
-  )
-}
-export default Wat
-// export { WrapRootElement }
+        }
+      }
+    `}
+    render={({
+      site: {
+        siteMetadata: { title },
+      },
+    }) => (
+      <>
+        {element}
+        <div>
+          StaticQuery in wrapRootElement test (should show site title):
+          <span data-testid="wrap-root-element-result">{title}</span>
+          <div data-testid="gatsby-browser-hmr">
+            %TEST_HMR_IN_GATSBY_BROWSER%
+          </div>
+        </div>
+      </>
+    )}
+  />
+)
+
+export default WrapRootElement

--- a/packages/gatsby/cache-dir/api-runner-browser.js
+++ b/packages/gatsby/cache-dir/api-runner-browser.js
@@ -5,6 +5,20 @@ const {
   loadPageSync,
 } = require(`./loader`).publicLoader
 
+function getApi(api, plugin) {
+  if (plugin[api]) {
+    return plugin[api]
+  }
+
+  if (api === `wrapPageElement`) {
+    return plugin[`WrapPageElement`]
+  } else if (api === `wrapRootElement`) {
+    return plugin[`WrapRootElement`]
+  }
+
+  return false
+}
+
 exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
   // Hooks for gatsby-cypress's API handler
   if (process.env.CYPRESS_SUPPORT) {
@@ -18,15 +32,19 @@ exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
   }
 
   let results = plugins.map(plugin => {
-    if (!plugin.plugin[api]) {
+    const apiToRun = getApi(api, plugin.plugin)
+    if (!apiToRun) {
       return undefined
     }
+    // if (!plugin.plugin[api]) {
+    //   return undefined
+    // }
 
     args.getResourceURLsForPathname = getResourceURLsForPathname
     args.loadPage = loadPage
     args.loadPageSync = loadPageSync
 
-    const result = plugin.plugin[api](args, plugin.options)
+    const result = apiToRun(args, plugin.options)
     if (result && argTransform) {
       args = argTransform({ args, result, plugin })
     }
@@ -46,10 +64,10 @@ exports.apiRunner = (api, args = {}, defaultReturn, argTransform) => {
 }
 
 exports.apiRunnerAsync = (api, args, defaultReturn) =>
-  plugins.reduce(
-    (previous, next) =>
-      next.plugin[api]
-        ? previous.then(() => next.plugin[api](args, next.options))
-        : previous,
-    Promise.resolve()
-  )
+  plugins.reduce((previous, next) => {
+    const apiToRun = getApi(api, next.plugin)
+
+    return apiToRun
+      ? previous.then(() => apiToRun(args, next.options))
+      : previous
+  }, Promise.resolve())

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -13,16 +13,14 @@ import asyncRequires from "$virtual/async-requires"
 // Generated during bootstrap
 import matchPaths from "$virtual/match-paths.json"
 import { LoadingIndicatorEventHandler } from "./loading-indicator"
-
+import Root from "./root"
 // ensure in develop we have at least some .css (even if it's empty).
 // this is so there is no warning about not matching content-type when site doesn't include any regular css (for example when css-in-js is used)
 // this also make sure that if all css is removed in develop we are not left with stale commons.css that have stale content
 import "./blank.css"
 
-// Enable fast-refresh for virtual sync-requires
-module.hot.accept(`$virtual/async-requires`, () => {
-  // Manually reload
-})
+// Enable fast-refresh for virtual sync-requires and gatsby-browser
+module.hot.accept([`$virtual/async-requires`, `./api-runner-browser`])
 
 window.___emitter = emitter
 
@@ -160,8 +158,6 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     loader.loadPage(`/404.html`),
     loader.loadPage(window.location.pathname),
   ]).then(() => {
-    const preferDefault = m => (m && m.default) || m
-    const Root = preferDefault(require(`./root`))
     domReady(() => {
       if (dismissLoadingIndicator) {
         dismissLoadingIndicator()
@@ -186,16 +182,6 @@ apiRunnerAsync(`onClientEntry`).then(() => {
             indicatorMountElement
           )
         }
-      })
-
-      module.hot.accept([`./root`, `./api-runner-browser`], () => {
-        // because `./root` for some reason is imported with commonjs
-        // we need to re-require it - https://webpack.js.org/api/hot-module-replacement/#accept
-        // > When using CommonJS you need to update dependencies manually by using require()
-        // > in the callback.Omitting the callback doesn't make sense here.
-
-        const NewRoot = preferDefault(require(`./root`))
-        renderer(<NewRoot />, rootElement)
       })
     })
   })

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -187,6 +187,16 @@ apiRunnerAsync(`onClientEntry`).then(() => {
           )
         }
       })
+
+      module.hot.accept([`./root`, `./api-runner-browser`], () => {
+        // because `./root` for some reason is imported with commonjs
+        // we need to re-require it - https://webpack.js.org/api/hot-module-replacement/#accept
+        // > When using CommonJS you need to update dependencies manually by using require()
+        // > in the callback.Omitting the callback doesn't make sense here.
+
+        const NewRoot = preferDefault(require(`./root`))
+        renderer(<NewRoot />, rootElement)
+      })
     })
   })
 })

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -14,6 +14,7 @@ import asyncRequires from "$virtual/async-requires"
 import matchPaths from "$virtual/match-paths.json"
 import { LoadingIndicatorEventHandler } from "./loading-indicator"
 import Root from "./root"
+import { init as navigationInit } from "./navigation"
 // ensure in develop we have at least some .css (even if it's empty).
 // this is so there is no warning about not matching content-type when site doesn't include any regular css (for example when css-in-js is used)
 // this also make sure that if all css is removed in develop we are not left with stale commons.css that have stale content
@@ -29,6 +30,8 @@ setLoader(loader)
 loader.setApiRunner(apiRunner)
 
 window.___loader = publicLoader
+
+navigationInit()
 
 // Do dummy dynamic import so the jsonp __webpack_require__.e is added to the commons.js
 // bundle. This ensures hot reloading doesn't break when someone first adds

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -31,8 +31,6 @@ loader.setApiRunner(apiRunner)
 
 window.___loader = publicLoader
 
-navigationInit()
-
 // Do dummy dynamic import so the jsonp __webpack_require__.e is added to the commons.js
 // bundle. This ensures hot reloading doesn't break when someone first adds
 // a dynamic import.
@@ -161,6 +159,8 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     loader.loadPage(`/404.html`),
     loader.loadPage(window.location.pathname),
   ]).then(() => {
+    navigationInit()
+
     domReady(() => {
       if (dismissLoadingIndicator) {
         dismissLoadingIndicator()

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -103,7 +103,7 @@ const Root = () => (
 )
 
 // Let site, plugins wrap the site e.g. for Redux.
-const WrappedRoot = apiRunner(
+const rootWrappedWithWrapRootElement = apiRunner(
   `wrapRootElement`,
   { element: <Root /> },
   <Root />,
@@ -112,8 +112,12 @@ const WrappedRoot = apiRunner(
   }
 ).pop()
 
-export default () => (
-  <FastRefreshOverlay>
-    <StaticQueryStore>{WrappedRoot}</StaticQueryStore>
-  </FastRefreshOverlay>
-)
+function RootWrappedWithOverlayAndProvider() {
+  return (
+    <FastRefreshOverlay>
+      <StaticQueryStore>{rootWrappedWithWrapRootElement}</StaticQueryStore>
+    </FastRefreshOverlay>
+  )
+}
+
+export default RootWrappedWithOverlayAndProvider

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -2,18 +2,12 @@ import React from "react"
 import { Router, Location, BaseContext } from "@reach/router"
 import { ScrollContext } from "gatsby-react-router-scroll"
 
-import {
-  shouldUpdateScroll,
-  init as navigationInit,
-  RouteUpdates,
-} from "./navigation"
+import { shouldUpdateScroll, RouteUpdates } from "./navigation"
 import { apiRunner } from "./api-runner-browser"
 import loader from "./loader"
 import { PageQueryStore, StaticQueryStore } from "./query-result-store"
 import EnsureResources from "./ensure-resources"
 import FastRefreshOverlay from "./fast-refresh-overlay"
-
-navigationInit()
 
 // In gatsby v2 if Router is used in page using matchPaths
 // paths need to contain full path.

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -731,29 +731,32 @@ export const createWebpackUtils = (
     }
   ): CssMinimizerPlugin => new CssMinimizerPlugin(options)
 
-  plugins.fastRefresh = ({ modulesThatUseGatsby }): Plugin =>
-    new ReactRefreshWebpackPlugin({
+  plugins.fastRefresh = ({ modulesThatUseGatsby }): Plugin => {
+    const regExpToHack = /node_modules/
+    regExpToHack.test = (modulePath: string): boolean => {
+      // when it's not coming from node_modules we treat it as a source file.
+      if (!vendorRegex.test(modulePath)) {
+        return false
+      }
+
+      // If the module uses Gatsby as a dependency
+      // we want to treat it as src because of shadowing
+      return !modulesThatUseGatsby.some(module =>
+        modulePath.includes(module.path)
+      )
+    }
+
+    return new ReactRefreshWebpackPlugin({
       overlay: {
         sockIntegration: `whm`,
         module: path.join(__dirname, `fast-refresh-module`),
       },
       // this is a bit hacky - exclude expect string or regexp or array of those
-      // so this is tricking ReactRefreshWebpackPlugin that we provide RegExp
-      exclude: {
-        test: modulePath => {
-          // when it's not coming from node_modules we treat it as a source file.
-          if (!vendorRegex.test(modulePath)) {
-            return false
-          }
-
-          // If the module uses Gatsby as a dependency
-          // we want to treat it as src because of shadowing
-          return !modulesThatUseGatsby.some(module =>
-            modulePath.includes(module.path)
-          )
-        },
-      } as RegExp,
+      // so this is tricking ReactRefreshWebpackPlugin with providing regexp with
+      // overwritten .test method
+      exclude: regExpToHack,
     })
+  }
 
   plugins.extractText = (options: any): Plugin =>
     new MiniCssExtractPlugin({

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -216,7 +216,7 @@ module.exports = async (
       case `develop`: {
         configPlugins = configPlugins
           .concat([
-            plugins.fastRefresh(),
+            plugins.fastRefresh({ modulesThatUseGatsby }),
             plugins.hotModuleReplacement(),
             plugins.noEmitOnErrors(),
             plugins.eslintGraphqlSchemaReload(),

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -272,7 +272,7 @@ module.exports = async (
   function getDevtool() {
     switch (stage) {
       case `develop`:
-        return `eval-cheap-module-source-map`
+        return `cheap-module-source-map`
       // use a normal `source-map` for the html phases since
       // it gives better line and column numbers
       case `develop-html`:

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -272,7 +272,7 @@ module.exports = async (
   function getDevtool() {
     switch (stage) {
       case `develop`:
-        return `cheap-module-source-map`
+        return `eval-cheap-module-source-map`
       // use a normal `source-map` for the html phases since
       // it gives better line and column numbers
       case `develop-html`:


### PR DESCRIPTION
## Description

After dropping `react-hot-loader` we need to accept hot updates ourselves. We do so today for page templates but not above those. Anything imported by `gatsby-browser` files is above page templates in webpack's hierarchy and so those are not handled.

TODO:
 - [x] add tests to e2e/development-runtime
 - [x] try to get rid of explicit re-rerending of root and hopefuly let fast-refresh do this job for us

## Related Issues

https://github.com/system-ui/theme-ui/issues/1440 (not in our repo, but pretty much our issue)