### PR TITLE
fix(gatsby-plugin-sharp): Add srcSetType `image/avif` to gatsby-plugin-sharp

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -617,6 +617,9 @@ async function fluid({ file, args = {}, reporter, cache }) {
       case `webp`:
         srcSetType = `image/webp`
         break
+      case `avif`:
+        srcSetType = `image/avif`
+        break
       case ``:
       case `no_change`:
       default:


### PR DESCRIPTION
## Related Issues

Addresses #29757
