### PR TITLE
fix(gatsby-plugin-feed): Replace deprecated "fs.exists" call (#29616)

### DIFF
--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.12.5",
     "@hapi/joi": "^15.1.1",
     "common-tags": "^1.8.0",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^9.1.0",
     "gatsby-plugin-utils": "^0.9.0",
     "lodash.merge": "^4.6.2",
     "rss": "^1.2.2"

--- a/packages/gatsby-plugin-feed/src/gatsby-node.js
+++ b/packages/gatsby-plugin-feed/src/gatsby-node.js
@@ -59,7 +59,7 @@ exports.onPostBuild = async ({ graphql }, pluginOptions) => {
 
     const outputPath = path.join(publicPath, feed.output)
     const outputDir = path.dirname(outputPath)
-    if (!(await fs.exists(outputDir))) {
+    if (!(await fs.pathExists(outputDir))) {
       await fs.mkdirp(outputDir)
     }
     await fs.writeFile(outputPath, rssFeed.xml())


### PR DESCRIPTION
…(#29616)

Co-authored-by: Hector Alcazar <halcaza@US-C02DKA1XMD6M>
Co-authored-by: gatsbybot <mathews.kyle+gatsbybot@gmail.com>
(cherry picked from commit 5fb606416a2d0697319501787a0a47cf74142001)

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
