### PR TITLE
fix(gatsby): temporarily pin mini-css-extract-plugin version

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -109,7 +109,7 @@
     "memoizee": "^0.4.15",
     "micromatch": "^4.0.2",
     "mime": "^2.4.6",
-    "mini-css-extract-plugin": "^1.3.8",
+    "mini-css-extract-plugin": "1.3.8",
     "mitt": "^1.2.0",
     "mkdirp": "^0.5.1",
     "moment": "^2.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18602,7 +18602,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mini-css-extract-plugin@^1.3.8:
+mini-css-extract-plugin@1.3.8, mini-css-extract-plugin@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.8.tgz#639047b78c2ee728704285aa468d2a5a8d91d566"
   integrity sha512-u+2kVov/Gcs74iz+x3phEBWMAGw2djjnKfYez+Pl/b5dyXL7aM4Lp5QQtIq16CDwRHT/woUJki49gBNMhfm1eA==


### PR DESCRIPTION
## Description

The latest release of `mini-css-extract-plugin` breaks us (discovered this via failing production e2e tests). This PR pins `mini-css-extract-plugin` to the previous working version to unblock us (for now).

This PR seems to cause the problem for us: https://github.com/webpack-contrib/mini-css-extract-plugin/pull/703