### PR TITLE
fix(gatsby-plugin-mdx): fix relative imports

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby/on-create-node.js
@@ -1,7 +1,7 @@
 const fs = require(`fs`)
 const path = require(`path`)
 const babel = require(`@babel/core`)
-const { createContentDigest } = require(`gatsby-core-utils`)
+const { createContentDigest, slash } = require(`gatsby-core-utils`)
 
 const defaultOptions = require(`../utils/default-options`)
 const {
@@ -221,9 +221,11 @@ class BabelPluginTransformRelativeImports {
               const valueAbsPath = path.resolve(parentFilepath, nodePath)
               const replacementPath =
                 loaders +
-                path.relative(
-                  path.join(cache.directory, MDX_SCOPES_LOCATION),
-                  valueAbsPath
+                slash(
+                  path.relative(
+                    path.join(cache.directory, MDX_SCOPES_LOCATION),
+                    valueAbsPath
+                  )
                 )
               node.value = replacementPath
             }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fix relative import resolution in mdx for windows
```mdx
import image from './your-image.png'
```

It generates `import image from "..\\..\\..\\..\\content\\your-image.png";`
With this PR we convert it to `import image from "../../../../content/your-image.png";`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
