### PR TITLE
Add reporter.panic as in docs

### DIFF
--- a/packages/gatsby/src/bootstrap/load-themes/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/index.js
@@ -37,7 +37,7 @@ const resolveTheme = async (
         const { resolve } = resolvePlugin(themeName, rootDir)
         themeDir = resolve
       } catch (localErr) {
-        // catch shouldn't be empty :shrug:
+        reporter.panic("resolvePlugin failed", localErr)
       }
     }
 


### PR DESCRIPTION
This PR fixes the https://github.com/gatsbyjs/gatsby/issues/29545 issue:
Added ```reporter.panic``` to an empty ```catch``` block in ```load-themes/index.js```. 
The issue already had a PR that could potentially be merged. However, the documentation for reporter.panic says that the first argument should be a message string and then an Error.
```reporter.panic(`text`, new Error('something'))```
This PR adds reporter.panic with the same arguments.