### PR TITLE
fix(gatsby): eslint linting

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -31,7 +31,6 @@
     "ansi-html": "^0.0.7",
     "autoprefixer": "^9.8.4",
     "axios": "^0.21.1",
-    "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -1,11 +1,11 @@
 import { printSchema, GraphQLSchema } from "graphql"
-import { CLIEngine } from "eslint"
+import { ESLint } from "eslint"
 import path from "path"
 
 const eslintRulePaths = path.resolve(`${__dirname}/eslint-rules`)
 const eslintRequirePreset = require.resolve(`./eslint/required`)
 
-export const eslintRequiredConfig: CLIEngine.Options = {
+export const eslintRequiredConfig: ESLint.Options = {
   rulePaths: [eslintRulePaths],
   useEslintrc: false,
   allowInlineConfig: false,
@@ -19,6 +19,12 @@ export const eslintRequiredConfig: CLIEngine.Options = {
       ecmaFeatures: {
         jsx: true,
       },
+      // TODO proper check for custom babel & plugins config
+      // Currently when a babelrc is added to the project, it will override our babelOptions
+      babelOptions: {
+        presets: [`babel-preset-gatsby`],
+      },
+      requireConfigFile: false,
     },
     globals: {
       graphql: true,
@@ -32,7 +38,7 @@ export const eslintRequiredConfig: CLIEngine.Options = {
 export const eslintConfig = (
   schema: GraphQLSchema,
   usingJsxRuntime: boolean
-): CLIEngine.Options => {
+): ESLint.Options => {
   return {
     useEslintrc: false,
     resolvePluginsRelativeTo: __dirname,
@@ -47,6 +53,20 @@ export const eslintConfig = (
         require.resolve(`eslint-config-react-app`),
         eslintRequirePreset,
       ],
+      parser: require.resolve(`@babel/eslint-parser`),
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: `module`,
+        ecmaFeatures: {
+          jsx: true,
+        },
+        // TODO proper check for custom babel & plugins config
+        // Currently when a babelrc is added to the project, it will override our babelOptions
+        babelOptions: {
+          presets: [`babel-preset-gatsby`],
+        },
+        requireConfigFile: false,
+      },
       plugins: [`graphql`],
       rules: {
         // New versions of react use a special jsx runtime that remove the requirement
@@ -75,13 +95,12 @@ export const eslintConfig = (
         "jsx-a11y/aria-proptypes": `warn`,
         "jsx-a11y/aria-role": `warn`,
         "jsx-a11y/aria-unsupported-elements": `warn`,
-        // TODO: It looks like the `autocomplete-valid` rule hasn't been published yet
-        // "jsx-a11y/autocomplete-valid": [
-        //   "warn",
-        //   {
-        //     inputComponents: [],
-        //   },
-        // ],
+        "jsx-a11y/autocomplete-valid": [
+          `warn`,
+          {
+            inputComponents: [],
+          },
+        ],
         "jsx-a11y/click-events-have-key-events": `warn`,
         "jsx-a11y/control-has-associated-label": [
           `warn`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fix eslint issues when .eslintrc is present + overall improvements
- Disable require babelrc file
- force @babel/eslint-parser for default eslint rules

