### PR TITLE
chore(docs): Update MDX frontmatter for programmatic pages

### DIFF
--- a/docs/docs/how-to/routing/mdx.md
+++ b/docs/docs/how-to/routing/mdx.md
@@ -94,7 +94,7 @@ query {
 >
 > Check out the How-To Guide: [How to Source Data from the Filesystem](/docs/how-to/sourcing-data/sourcing-from-the-filesystem/).
 
-Frontmatter is also available in `props.mdx.frontmatter` and
+Frontmatter is also available in `props.pageContext.frontmatter` and
 can be accessed in blocks of JSX in your MDX document:
 
 ```mdx
@@ -103,17 +103,10 @@ title: Building with Gatsby
 author: Jay Gatsby
 ---
 
-<h1>{props.frontmatter.title}</h1>
-<span>{props.frontmatter.author}</span>
+<h1>{props.pageContext.frontmatter.title}</h1>
+<span>{props.pageContext.frontmatter.author}</span>
 
 (Blog post content, components, etc.)
-```
-
-Make sure to pass frontmatter to the MDXRenderer component like below:
-
-```
-<MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
-
 ```
 
 ## Part 3: Importing JSX components and MDX documents

--- a/docs/docs/how-to/routing/mdx.md
+++ b/docs/docs/how-to/routing/mdx.md
@@ -94,7 +94,7 @@ query {
 >
 > Check out the How-To Guide: [How to Source Data from the Filesystem](/docs/how-to/sourcing-data/sourcing-from-the-filesystem/).
 
-Frontmatter is also available in `props.pageContext.frontmatter` and
+Frontmatter is also available in `props.mdx.frontmatter` and
 can be accessed in blocks of JSX in your MDX document:
 
 ```mdx
@@ -103,10 +103,17 @@ title: Building with Gatsby
 author: Jay Gatsby
 ---
 
-<h1>{props.pageContext.frontmatter.title}</h1>
-<span>{props.pageContext.frontmatter.author}</span>
+<h1>{props.frontmatter.title}</h1>
+<span>{props.frontmatter.author}</span>
 
 (Blog post content, components, etc.)
+```
+
+Make sure to pass frontmatter to the MDXRenderer component like below:
+
+```
+<MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
+
 ```
 
 ## Part 3: Importing JSX components and MDX documents

--- a/docs/docs/mdx/programmatically-creating-pages.md
+++ b/docs/docs/mdx/programmatically-creating-pages.md
@@ -229,6 +229,8 @@ For now, to update imports within `.mdx` files, you should rerun your Gatsby dev
 First, create a component that accepts the queried MDX data (which will be
 added in the next step).
 
+
+
 ```jsx:title=src/components/posts-page-layout.js
 import React from "react"
 import { graphql } from "gatsby"
@@ -243,7 +245,7 @@ export default function PageTemplate({ data: { mdx } }) {
     <div>
       <h1>{mdx.frontmatter.title}</h1>
       <MDXProvider components={shortcodes}>
-        <MDXRenderer>{mdx.body}</MDXRenderer>
+        <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>
     </div>
   )
@@ -285,7 +287,7 @@ export default function PageTemplate({ data: { mdx } }) {
     <div>
       <h1>{mdx.frontmatter.title}</h1>
       <MDXProvider components={shortcodes}>
-        <MDXRenderer>{mdx.body}</MDXRenderer>
+        <MDXRenderer frontmatter={mdx.frontmatter}>{mdx.body}</MDXRenderer>
       </MDXProvider>
     </div>
   )

--- a/docs/docs/mdx/programmatically-creating-pages.md
+++ b/docs/docs/mdx/programmatically-creating-pages.md
@@ -229,8 +229,6 @@ For now, to update imports within `.mdx` files, you should rerun your Gatsby dev
 First, create a component that accepts the queried MDX data (which will be
 added in the next step).
 
-
-
 ```jsx:title=src/components/posts-page-layout.js
 import React from "react"
 import { graphql } from "gatsby"


### PR DESCRIPTION
## Description

Updating gatsby documentation to tell the user to pass frontmatter in MDXRenderer component.
As suggested in this issue: https://github.com/gatsbyjs/gatsby/issues/21241

### Documentation

docs here: https://www.gatsbyjs.com/docs/mdx/programmatically-creating-pages/
@gatsbyjs/documentation please review

## Related Issues

Fixes #21241
