### PR TITLE
docs(gatsby-plugin-subfont): correct property name

### DIFF
--- a/packages/gatsby-plugin-subfont/README.md
+++ b/packages/gatsby-plugin-subfont/README.md
@@ -22,7 +22,7 @@ module.exports = {
       resolve: `gatsby-plugin-subfont`,
       options: {
         silent: true,
-        fallback: false,
+        fallbacks: false,
         inlineFonts: true,
       },
     },


### PR DESCRIPTION

## Description

Tiny typo fix 🔎 

