### PR TITLE
feat(create-gatsby): Add support for cloud plugin

### DIFF
--- a/packages/create-gatsby/src/features.json
+++ b/packages/create-gatsby/src/features.json
@@ -1,4 +1,7 @@
 {
+  "gatsby-plugin-gatsby-cloud": {
+    "message": "Build and host for free on Gatsby Cloud"
+  },
   "gatsby-plugin-image": {
     "message": "Add responsive images",
     "plugins": [


### PR DESCRIPTION
Adds support for installing the cloud plugin with npm init gatsby