### PR TITLE
fix(example): import styles as ESModules

### DIFF
--- a/examples/using-css-modules/src/pages/another-page.js
+++ b/examples/using-css-modules/src/pages/another-page.js
@@ -1,14 +1,14 @@
 import React from "react"
 import { Link } from "gatsby"
 
-import styles from "../styles/another-page.module.css"
+import { page, link, header } from "../styles/another-page.module.css"
 
 class IndexComponent extends React.Component {
   render() {
     return (
-      <div className={styles.page}>
-        <h1 className={styles.header}>Hello mildly weary world</h1>
-        <Link to="/" className={styles.link}>
+      <div className={page}>
+        <h1 className={header}>Hello mildly weary world</h1>
+        <Link to="/" className={link}>
           Back home
         </Link>
       </div>

--- a/examples/using-css-modules/src/pages/index.js
+++ b/examples/using-css-modules/src/pages/index.js
@@ -1,30 +1,30 @@
 import React from "react"
 import { Link } from "gatsby"
 
-import indexStyles from "../styles/index.module.css"
+import { index, subheader, link } from "../styles/index.module.css"
 
 class IndexComponent extends React.Component {
   render() {
     return (
-      <div className={indexStyles.index}>
+      <div className={index}>
         <h1>Hello world</h1>
-        <h2 className={indexStyles.subheader}>
+        <h2 className={subheader}>
           {`You've`} arrived at the world renowned css modules & gatsby example
           site
         </h2>
         <p>
-          <Link className={indexStyles.link} to="/another-page/">
+          <Link className={link} to="/another-page/">
             Travel through the cyber linkspace
           </Link>
         </p>
         <p>
-          <Link className={indexStyles.link} to="/sassy-page/">
+          <Link className={link} to="/sassy-page/">
             Partake of sassy goodness
           </Link>
         </p>
         <p>
           <a
-            className={indexStyles.link}
+            className={link}
             href="https://github.com/gatsbyjs/gatsby/tree/master/examples/using-css-modules"
           >
             Code for example site on GitHub

--- a/examples/using-css-modules/src/pages/sassy-page.js
+++ b/examples/using-css-modules/src/pages/sassy-page.js
@@ -1,15 +1,15 @@
 import React from "react"
 import { Link } from "gatsby"
 
-import styles from "../styles/sass.module.scss"
+import { page, header, link } from "../styles/sass.module.scss"
 
 class IndexComponent extends React.Component {
   render() {
     return (
-      <div className={styles.page}>
-        <h1 className={styles.header}>Cheese: Do you like it?</h1>
-        <h1 className={styles.header}>🧀 🧀 🧀 🧀 🧀 🧀 🧀</h1>
-        <Link to="/" className={styles.link}>
+      <div className={page}>
+        <h1 className={header}>Cheese: Do you like it?</h1>
+        <h1 className={header}>🧀 🧀 🧀 🧀 🧀 🧀 🧀</h1>
+        <Link to="/" className={link}>
           Back home
         </Link>
       </div>

--- a/examples/using-css-modules/src/styles/another-page.module.css
+++ b/examples/using-css-modules/src/styles/another-page.module.css
@@ -8,9 +8,10 @@
   font-size: 10rem;
   line-height: 1.5;
   text-decoration: none;
-  &:hover {
-    text-decoration: underline;
-  }
+}
+
+.link:hover {
+  text-decoration: underline;
 }
 
 .header {


### PR DESCRIPTION
## Description

This PR fixed a broken using-css-modules example.
In Gatsby v3, CSS Modules are imported as ESModules.