### PR TITLE
fix(docs): update library link in docs

### DIFF
--- a/examples/using-page-transitions/README.md
+++ b/examples/using-page-transitions/README.md
@@ -2,6 +2,6 @@
 
 Gatsby example site using page transitions.
 
-This example uses `react-transition-group` in conjunction with `gatsby-plugin-layout`. For more complex page transitions and no `gatsby-plugin-layout` dependency, you can make use of [`react-pose`](https://github.com/Popmotion/popmotion/tree/master/packages/react-pose).
+This example uses `react-transition-group` in conjunction with `gatsby-plugin-layout`. For more complex page transitions and no `gatsby-plugin-layout` dependency, you can make use of [`framer-motion`](https://www.framer.com/motion/).
 
 [View the live demo](https://using-page-transitions.netlify.app/)


### PR DESCRIPTION
## Description

This PR fixed outdated docs.
[react-pose has been deprecated by framer motion](https://popmotion.io/pose/).