### PR TITLE
fix(gatsby): workaround graphql-compose issue

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -73,11 +73,12 @@ const buildSchema = async ({
     inferenceMetadata,
     parentSpan,
   })
+  // const { printSchema } = require(`graphql`)
+  const schema = schemaComposer.buildSchema()
+
   // Freeze all type composers except SitePage (as we will rebuild it at a later stage)
   freezeTypeComposers(schemaComposer, new Set([`SitePage`]))
 
-  // const { printSchema } = require(`graphql`)
-  const schema = schemaComposer.buildSchema()
   // console.log(printSchema(schema))
   return schema
 }

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -73,6 +73,9 @@ const buildSchema = async ({
     inferenceMetadata,
     parentSpan,
   })
+  // Freeze all type composers except SitePage (as we will rebuild it at a later stage)
+  freezeTypeComposers(schemaComposer, new Set([`SitePage`]))
+
   // const { printSchema } = require(`graphql`)
   const schema = schemaComposer.buildSchema()
   // console.log(printSchema(schema))
@@ -119,6 +122,25 @@ const rebuildSchemaWithSitePage = async ({
 module.exports = {
   buildSchema,
   rebuildSchemaWithSitePage,
+}
+
+// Workaround for https://github.com/graphql-compose/graphql-compose/issues/319
+//  FIXME: remove this when fixed in graphql-compose
+const freezeTypeComposers = (schemaComposer, excluded) => {
+  Array.from(schemaComposer.values()).forEach(tc => {
+    const isCompositeTC =
+      tc instanceof ObjectTypeComposer || tc instanceof InterfaceTypeComposer
+
+    if (isCompositeTC && !excluded.has(tc.getTypeName())) {
+      // typeComposer.getType() actually mutates the underlying GraphQL type
+      //   and always re-assigns type._fields with a thunk.
+      //   It causes continuous redundant field re-definitions when running queries
+      //   (affects performance significantly).
+      //   Prevent the mutation and "freeze" the type:
+      const type = tc.getType()
+      tc.getType = () => type
+    }
+  })
 }
 
 const updateSchemaComposer = async ({


### PR DESCRIPTION
## Description

We've noticed that the query running step on v3 is pretty slow. After investigation, the issue was discovered in `graphql-compose`: https://github.com/graphql-compose/graphql-compose/issues/319

This PR is a workaround for it. But the proper fix should be added in `graphql-compose` itself. Once fixed upstream, we can remove this workaround.
