### PR TITLE
fix: query on demand loading indicator always active on preact.

### DIFF
--- a/packages/gatsby/cache-dir/loading-indicator/indicator.js
+++ b/packages/gatsby/cache-dir/loading-indicator/indicator.js
@@ -42,7 +42,8 @@ export function Indicator({ visible = true }) {
       <Style />
       <div
         data-gatsby-loading-indicator="root"
-        data-gatsby-loading-indicator-visible={visible}
+        // preact doesn't render data attributes with a literal bool false value to dom
+        data-gatsby-loading-indicator-visible={visible.toString()}
         aria-live="assertive"
       >
         <div data-gatsby-loading-indicator="spinner" aria-hidden="true">


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR fixes the query on-demand loading indicator always being active when using gatsby with preact.
![image](https://user-images.githubusercontent.com/8491552/109410552-24a5c680-79ce-11eb-9377-d5d09b90b573.png)

This is caused by preact not rendering attributes with a literal bool `false` value. Turning the bool value into a string before passing it to preact solved the issue.

## Related Issues

Fixes #29051
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
