### PR TITLE
fix(gatsby-plugin-preact): fix fast-refresh

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/index.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/index.js
@@ -54,7 +54,7 @@ function DevOverlay({ children }) {
   const [state, dispatch] = React.useReducer(reducer, initialState)
 
   React.useEffect(() => {
-    const gatsbyEvents = window._gatsbyEvents
+    const gatsbyEvents = window._gatsbyEvents || []
     window._gatsbyEvents = {
       push: ([channel, event]) => {
         if (channel === `FAST_REFRESH`) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fix fast-refresh for gatsby-plugin-preact.

The runtime module isn't being loaded when using preact so gatsbyEvents is not set. This also disables our error modals :grimacing: that's another bug to fix but at least this fixes updates

