### PR TITLE
fix(gatsby): fix some css HMR edge cases

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/styling/plain-css.js
+++ b/e2e-tests/development-runtime/cypress/integration/styling/plain-css.js
@@ -7,29 +7,179 @@ after(() => {
 })
 
 describe(`styling: plain css`, () => {
-  beforeEach(() => {
-    cy.visit(`/styling/plain-css`).waitForRouteChange()
-  })
-
   it(`initial styling is correct`, () => {
+    cy.visit(`/styling/plain-css`).waitForRouteChange()
+
     cy.getTestElement(`styled-element`).should(
       `have.css`,
       `color`,
       `rgb(255, 0, 0)`
     )
-  })
 
-  it(`updates on change`, () => {
-    cy.exec(
-      `npm run update -- --file src/pages/styling/plain-css.css --replacements "red:blue" --exact`
-    )
-
-    cy.waitForHmr()
-
-    cy.getTestElement(`styled-element`).should(
+    cy.getTestElement(`styled-element-that-is-not-styled-initially`).should(
       `have.css`,
       `color`,
-      `rgb(0, 0, 255)`
+      `rgb(0, 0, 0)`
     )
+
+    cy.getTestElement(`styled-element-by-not-visited-template`).should(
+      `have.css`,
+      `color`,
+      `rgb(255, 0, 0)`
+    )
+
+    cy.getTestElement(
+      `styled-element-that-is-not-styled-initially-by-not-visited-template`
+    ).should(`have.css`, `color`, `rgb(0, 0, 0)`)
+  })
+
+  describe(`changing styles/imports imported by visited template`, () => {
+    it(`updates on already imported css file change`, () => {
+      // we don't want to visit page for each test - we want to visit once and then test HMR
+      cy.window().then(win => {
+        cy.spy(win.console, `log`).as(`hmrConsoleLog`)
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/styling/plain-css.css --replacements "red:blue" --exact`
+      )
+
+      cy.waitForHmr()
+
+      cy.getTestElement(`styled-element`).should(
+        `have.css`,
+        `color`,
+        `rgb(0, 0, 255)`
+      )
+    })
+
+    it(`importing new css file result in styles being applied`, () => {
+      // we don't want to visit page for each test - we want to visit once and then test HMR
+      cy.window().then(win => {
+        cy.spy(win.console, `log`).as(`hmrConsoleLog`)
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/styling/plain-css.js --replacements "// UNCOMMENT-IN-TEST:/* IMPORT-TO-COMMENT-OUT-AGAIN */" --exact`
+      )
+
+      cy.waitForHmr()
+
+      cy.getTestElement(`styled-element-that-is-not-styled-initially`).should(
+        `have.css`,
+        `color`,
+        `rgb(255, 0, 0)`
+      )
+    })
+
+    it(`updating newly imported css file result in styles being applied`, () => {
+      // we don't want to visit page for each test - we want to visit once and then test HMR
+      cy.window().then(win => {
+        cy.spy(win.console, `log`).as(`hmrConsoleLog`)
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/styling/plain-css-not-imported-initially.css --replacements "red:green" --exact`
+      )
+
+      cy.waitForHmr()
+
+      cy.getTestElement(`styled-element-that-is-not-styled-initially`).should(
+        `have.css`,
+        `color`,
+        `rgb(0, 128, 0)`
+      )
+    })
+
+    it(`removing css import results in styles being removed`, () => {
+      // we don't want to visit page for each test - we want to visit once and then test HMR
+      cy.window().then(win => {
+        cy.spy(win.console, `log`).as(`hmrConsoleLog`)
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/styling/plain-css.js --replacements "/* IMPORT-TO-COMMENT-OUT-AGAIN */:// COMMENTED-AGAIN" --exact`
+      )
+
+      cy.waitForHmr()
+
+      cy.getTestElement(`styled-element-that-is-not-styled-initially`).should(
+        `have.css`,
+        `color`,
+        `rgb(0, 0, 0)`
+      )
+    })
+  })
+
+  describe(`changing styles/imports imported by NOT visited template`, () => {
+    it(`updates on already imported css file change by not visited template`, () => {
+      // we don't want to visit page for each test - we want to visit once and then test HMR
+      cy.window().then(win => {
+        cy.spy(win.console, `log`).as(`hmrConsoleLog`)
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/styling/not-visited-plain-css.css --replacements "red:blue" --exact`
+      )
+
+      cy.waitForHmr()
+
+      cy.getTestElement(`styled-element-by-not-visited-template`).should(
+        `have.css`,
+        `color`,
+        `rgb(0, 0, 255)`
+      )
+    })
+
+    it(`importing new css file result in styles being applied`, () => {
+      // we don't want to visit page for each test - we want to visit once and then test HMR
+      cy.window().then(win => {
+        cy.spy(win.console, `log`).as(`hmrConsoleLog`)
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/styling/not-visited-plain-css.js --replacements "// UNCOMMENT-IN-TEST:/* IMPORT-TO-COMMENT-OUT-AGAIN */" --exact`
+      )
+
+      cy.waitForHmr()
+
+      cy.getTestElement(
+        `styled-element-that-is-not-styled-initially-by-not-visited-template`
+      ).should(`have.css`, `color`, `rgb(255, 0, 0)`)
+    })
+
+    it(`updating newly imported css file result in styles being applied`, () => {
+      // we don't want to visit page for each test - we want to visit once and then test HMR
+      cy.window().then(win => {
+        cy.spy(win.console, `log`).as(`hmrConsoleLog`)
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/styling/not-visited-plain-css-not-imported-initially.css --replacements "red:green" --exact`
+      )
+
+      cy.waitForHmr()
+
+      cy.getTestElement(
+        `styled-element-that-is-not-styled-initially-by-not-visited-template`
+      ).should(`have.css`, `color`, `rgb(0, 128, 0)`)
+    })
+
+    it(`removing css import results in styles being removed`, () => {
+      // we don't want to visit page for each test - we want to visit once and then test HMR
+      cy.window().then(win => {
+        cy.spy(win.console, `log`).as(`hmrConsoleLog`)
+      })
+
+      cy.exec(
+        `npm run update -- --file src/pages/styling/not-visited-plain-css.js --replacements "/* IMPORT-TO-COMMENT-OUT-AGAIN */:// COMMENTED-AGAIN" --exact`
+      )
+
+      cy.waitForHmr()
+
+      cy.getTestElement(
+        `styled-element-that-is-not-styled-initially-by-not-visited-template`
+      ).should(`have.css`, `color`, `rgb(0, 0, 0)`)
+    })
   })
 })

--- a/e2e-tests/development-runtime/src/pages/styling/not-visited-plain-css-not-imported-initially.css
+++ b/e2e-tests/development-runtime/src/pages/styling/not-visited-plain-css-not-imported-initially.css
@@ -1,0 +1,3 @@
+.not-visited-plain-css-not-imported-initially {
+  color: red;
+}

--- a/e2e-tests/development-runtime/src/pages/styling/not-visited-plain-css.css
+++ b/e2e-tests/development-runtime/src/pages/styling/not-visited-plain-css.css
@@ -1,0 +1,3 @@
+.not-visited-plain-css-test {
+  color: red;
+}

--- a/e2e-tests/development-runtime/src/pages/styling/not-visited-plain-css.js
+++ b/e2e-tests/development-runtime/src/pages/styling/not-visited-plain-css.js
@@ -1,0 +1,17 @@
+import * as React from "react"
+
+import "./not-visited-plain-css.css"
+// UNCOMMENT-IN-TEST import "./not-visited-plain-css-not-imported-initially.css"
+
+export default function PlainCss() {
+  return (
+    <>
+      <p>
+        This content doesn't matter - we never visit this page in tests - but
+        because we generate single global .css file, we want to test changing
+        css files imported by this module (and also adding new css imports).css
+      </p>
+      <p>css imported by this template is tested in `./plain-css.js` page</p>
+    </>
+  )
+}

--- a/e2e-tests/development-runtime/src/pages/styling/plain-css-not-imported-initially.css
+++ b/e2e-tests/development-runtime/src/pages/styling/plain-css-not-imported-initially.css
@@ -1,0 +1,3 @@
+.plain-css-not-imported-initially {
+  color: red;
+}

--- a/e2e-tests/development-runtime/src/pages/styling/plain-css.js
+++ b/e2e-tests/development-runtime/src/pages/styling/plain-css.js
@@ -1,11 +1,32 @@
 import * as React from "react"
 
 import "./plain-css.css"
+// UNCOMMENT-IN-TEST import "./plain-css-not-imported-initially.css"
 
 export default function PlainCss() {
   return (
-    <div data-testid="styled-element" className="plain-css-test">
-      test
+    <div style={{ color: `black` }}>
+      <div data-testid="styled-element" className="plain-css-test">
+        test
+      </div>
+      <div
+        data-testid="styled-element-that-is-not-styled-initially"
+        className="plain-css-not-imported-initially"
+      >
+        test
+      </div>
+      <div
+        data-testid="styled-element-by-not-visited-template"
+        className="not-visited-plain-css-test"
+      >
+        test
+      </div>
+      <div
+        data-testid="styled-element-that-is-not-styled-initially-by-not-visited-template"
+        className="not-visited-plain-css-not-imported-initially "
+      >
+        test
+      </div>
     </div>
   )
 }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -18,6 +18,7 @@ import { createWebpackUtils } from "./webpack-utils"
 import { hasLocalEslint } from "./local-eslint-config-finder"
 import { getAbsolutePathForVirtualModule } from "./gatsby-webpack-virtual-modules"
 import { StaticQueryMapper } from "./webpack/static-query-mapper"
+import { ForceCssHMRForEdgeCases } from "./webpack/force-css-hmr-for-edge-cases"
 import { getBrowsersList } from "./browserslist"
 import { builtinModules } from "module"
 
@@ -217,6 +218,7 @@ module.exports = async (
         configPlugins = configPlugins
           .concat([
             plugins.fastRefresh({ modulesThatUseGatsby }),
+            new ForceCssHMRForEdgeCases(),
             plugins.hotModuleReplacement(),
             plugins.noEmitOnErrors(),
             plugins.eslintGraphqlSchemaReload(),

--- a/packages/gatsby/src/utils/webpack/force-css-hmr-for-edge-cases.ts
+++ b/packages/gatsby/src/utils/webpack/force-css-hmr-for-edge-cases.ts
@@ -87,7 +87,7 @@ export class ForceCssHMRForEdgeCases {
           this.blankCssKey
         ) {
           records.chunkModuleHashes[this.blankCssKey] =
-            this.originalBlankCssHash + this.hackCounter++
+            this.originalBlankCssHash + String(this.hackCounter++)
         }
 
         this.previouslySeenCss = seenCssInThisCompilation

--- a/packages/gatsby/src/utils/webpack/force-css-hmr-for-edge-cases.ts
+++ b/packages/gatsby/src/utils/webpack/force-css-hmr-for-edge-cases.ts
@@ -1,0 +1,97 @@
+import { Compiler, Module } from "webpack"
+
+/**
+ * This is total hack that is meant to handle:
+ *  - https://github.com/webpack-contrib/mini-css-extract-plugin/issues/706
+ *  - https://github.com/webpack-contrib/mini-css-extract-plugin/issues/708
+ * The way it works it is looking up what HotModuleReplacementPlugin checks internally
+ * and tricks it by checking up if any modules that uses mini-css-extract-plugin
+ * changed or was newly added and then modifying blank.css hash.
+ * blank.css is css module that is used by all pages and is there from the start
+ * so changing hash of that _should_ ensure that:
+ *  - when new css is imported it will reload css
+ *  - when css imported by not loaded (by runtime) page template changes it will reload css
+ */
+export class ForceCssHMRForEdgeCases {
+  private name: string
+  private originalBlankCssHash: string
+  private blankCssKey: string
+  private hackCounter = 0
+  private previouslySeenCss: Set<string> = new Set<string>()
+
+  constructor() {
+    this.name = `ForceCssHMRForEdgeCases`
+  }
+
+  apply(compiler: Compiler): void {
+    compiler.hooks.thisCompilation.tap(this.name, compilation => {
+      compilation.hooks.fullHash.tap(this.name, () => {
+        const chunkGraph = compilation.chunkGraph
+        const records = compilation.records
+
+        if (!records.chunkModuleHashes) {
+          return
+        }
+
+        const seenCssInThisCompilation = new Set<string>()
+
+        let anyCssChanged = false
+
+        for (const chunk of compilation.chunks) {
+          const getModuleHash = (module: Module): string => {
+            if (compilation.codeGenerationResults.has(module, chunk.runtime)) {
+              return compilation.codeGenerationResults.getHash(
+                module,
+                chunk.runtime
+              )
+            } else {
+              return chunkGraph.getModuleHash(module, chunk.runtime)
+            }
+          }
+
+          const modules = chunkGraph.getChunkModulesIterable(chunk)
+
+          if (modules !== undefined) {
+            for (const module of modules) {
+              const key = `${chunk.id}|${module.identifier()}`
+
+              if (
+                !this.originalBlankCssHash &&
+                module.rawRequest === `./blank.css`
+              ) {
+                this.blankCssKey = key
+                this.originalBlankCssHash =
+                  records.chunkModuleHashes[this.blankCssKey]
+              }
+
+              const isUsingMiniCssExtract = module.loaders?.find(loader =>
+                loader?.loader?.includes(`mini-css-extract-plugin`)
+              )
+
+              if (isUsingMiniCssExtract) {
+                seenCssInThisCompilation.add(key)
+                this.previouslySeenCss.delete(key)
+
+                const hash = getModuleHash(module)
+                if (records.chunkModuleHashes[key] !== hash) {
+                  anyCssChanged = true
+                }
+              }
+            }
+          }
+        }
+
+        if (
+          (anyCssChanged || this.previouslySeenCss.size > 0) &&
+          this.originalBlankCssHash &&
+          this.blankCssKey
+        ) {
+          records.chunkModuleHashes[this.blankCssKey] =
+            this.originalBlankCssHash + this.hackCounter++
+        }
+
+        this.previouslySeenCss = seenCssInThisCompilation
+      })
+    })
+  }
+}


### PR DESCRIPTION
## Description

Add test cases for issues described in:
 - https://github.com/webpack-contrib/mini-css-extract-plugin/issues/706
 - https://github.com/webpack-contrib/mini-css-extract-plugin/issues/708

Current status (tests for removing imports only pass because adding imports doesn't do anything :) ):
![Screenshot 2021-02-28 at 23 24 36](https://user-images.githubusercontent.com/419821/109435716-24ccb300-7a1c-11eb-92b5-d58c343cc376.png)

With this veeeeeery hacky ~fix~ workaround:
![Screenshot 2021-02-28 at 23 52 51](https://user-images.githubusercontent.com/419821/109479116-5c6a4800-7a7a-11eb-938c-708f5391d7b2.png)

## Related Issues

[ch25603]
[ch25604]
