### PR TITLE
fix(gatsby-source-contentful): use reporter progressbar instead of own

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -26,7 +26,6 @@
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",
     "p-queue": "^6.6.2",
-    "progress": "^2.0.3",
     "qs": "^6.9.6",
     "retry-axios": "^2.4.0"
   },

--- a/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
@@ -13,6 +13,7 @@ jest.mock(`gatsby-source-filesystem`, () => {
 const reporter = {
   createProgress: jest.fn(() => {
     return {
+      start: jest.fn(),
       tick: jest.fn(),
     }
   }),

--- a/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
@@ -1,15 +1,5 @@
 const { downloadContentfulAssets } = require(`../download-contentful-assets`)
 
-jest.mock(
-  `progress`,
-  () =>
-    class MockProgress {
-      constructor() {
-        this.tick = jest.fn()
-      }
-    }
-)
-
 jest.mock(`gatsby-source-filesystem`, () => {
   return {
     createRemoteFileNode: jest.fn(({ url }) => {
@@ -19,6 +9,14 @@ jest.mock(`gatsby-source-filesystem`, () => {
     }),
   }
 })
+
+const reporter = {
+  createProgress: jest.fn(() => {
+    return {
+      tick: jest.fn(),
+    }
+  }),
+}
 
 const fixtures = [
   {
@@ -66,6 +64,7 @@ describe.only(`downloadContentfulAssets`, () => {
       getNodesByType: () => fixtures,
       cache,
       assetDownloadWorkers: 50,
+      reporter,
     })
 
     fixtures.forEach(n => {

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -1,13 +1,4 @@
-const ProgressBar = require(`progress`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
-
-const bar = new ProgressBar(
-  `Downloading Contentful Assets [:bar] :current/:total :elapsed secs :percent`,
-  {
-    total: 0,
-    width: 30,
-  }
-)
 
 /**
  * @name distributeWorkload
@@ -51,8 +42,11 @@ const downloadContentfulAssets = async gatsbyFunctions => {
   // regardless of if you use `localFile` to link an asset or not.
 
   const assetNodes = getNodesByType(`ContentfulAsset`)
-  bar.total = assetNodes.length
-
+  const bar = reporter.createProgress(
+    `Downloading Contentful Assets`,
+    assetNodes.length
+  )
+  bar.start()
   await distributeWorkload(
     assetNodes.map(node => async () => {
       let fileNodeID
@@ -60,6 +54,7 @@ const downloadContentfulAssets = async gatsbyFunctions => {
       const remoteDataCacheKey = `contentful-asset-${id}-${locale}`
       const cacheRemoteData = await cache.get(remoteDataCacheKey)
       if (!node.file) {
+        reporter.log(id, locale)
         reporter.warn(`The asset with id: ${id}, contains no file.`)
         return Promise.resolve()
       }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Improves contentful progress bar. It flickered on windows as the progressbar was fighting with ink-cli.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
