### PR TITLE
fix(create-gatsby): Use legacy peer deps

### DIFF
--- a/packages/create-gatsby/src/__tests__/init-starter.ts
+++ b/packages/create-gatsby/src/__tests__/init-starter.ts
@@ -153,7 +153,15 @@ describe(`init-starter`, () => {
       )
       expect(execa).toBeCalledWith(
         `npm`,
-        [`install`, `--loglevel`, `error`, `--color`, `always`, `one-package`],
+        [
+          `install`,
+          `--loglevel`,
+          `error`,
+          `--color`,
+          `always`,
+          `--legacy-peer-deps`,
+          `one-package`,
+        ],
         { stderr: `inherit` }
       )
     })

--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -99,7 +99,7 @@ const setNameInPackage = async (
     delete packageJson.author
   }
 
-  await fs.writeJSON(packageJsonPath, packageJson)
+  await fs.writeJSON(packageJsonPath, packageJson, { spaces: 2 })
 }
 
 // Executes `npm install` or `yarn install` in rootPath.
@@ -139,7 +139,11 @@ const install = async (
       reporter.success(`Installed Gatsby`)
       reporter.info(`${c.blueBright(c.symbols.pointer)} Installing plugins...`)
 
-      await execa(`npm`, [`install`, ...config, ...packages], options)
+      await execa(
+        `npm`,
+        [`install`, ...config, `--legacy-peer-deps`, ...packages],
+        options
+      )
       await clearLine()
     }
 


### PR DESCRIPTION
Two npm 7 fixes. Passes `--legacy-peer-deps` to npm when setting-up, to align behaviour across versions. Also formats package.json, as installing no longer does