### PR TITLE
chore: update peerdeps to latest major versions

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/package.json
+++ b/packages/gatsby-plugin-gatsby-cloud/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^3.0.0"
+    "gatsby": "^3.0.0-next.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -47,7 +47,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": ">2.0.15"
+    "gatsby": "^3.0.0-next.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -27,7 +27,7 @@
   ],
   "peerDependencies": {
     "gatsby": "^3.0.0-next.0",
-    "gatsby-remark-prismjs": "^3.0.0"
+    "gatsby-remark-prismjs": "^3.0.0-next.0"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -41,7 +41,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^3.0.0-next.0",
-    "gatsby-plugin-sharp": "^2.0.0-beta.5"
+    "gatsby-plugin-sharp": "^3.0.0-next.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -46,7 +46,7 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^3.0.0-next.0",
-    "gatsby-plugin-sharp": "^2.6.14",
+    "gatsby-plugin-sharp": "^3.0.0-next.0",
     "sharp": "^0.26.0"
   },
   "repository": {

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -73,8 +73,8 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^3.0.0-next.0",
-    "gatsby-plugin-sharp": "^2.6.8",
-    "gatsby-transformer-sharp": "^2.5.10"
+    "gatsby-plugin-sharp": "^3.0.0-next.0",
+    "gatsby-transformer-sharp": "^3.0.0-next.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-javascript-frontmatter/package.json
+++ b/packages/gatsby-transformer-javascript-frontmatter/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^3.0.0-next.0",
-    "gatsby-source-filesystem": "^2.0.3"
+    "gatsby-source-filesystem": "^3.0.0-next.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^3.0.0-next.0",
-    "gatsby-plugin-sharp": "^2.0.0-beta.3"
+    "gatsby-plugin-sharp": "^3.0.0-next.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -24,8 +24,8 @@
   },
   "peerDependencies": {
     "gatsby": "^3.0.0-next.0",
-    "gatsby-source-contentful": "^2.0.0",
-    "gatsby-transformer-sharp": "^2.0.0"
+    "gatsby-source-contentful": "^5.0.0-next.0",
+    "gatsby-transformer-sharp": "^3.0.0-next.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip#readme",
   "keywords": [


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Make sure peerdeps are pointing to new version
We should figure a better version strategy out :D

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
