### PR TITLE
fix(gatsby-source-wordpress): image fixes (#29813)

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -8,7 +8,6 @@ const { isWebUri } = require(`valid-url`)
 const Queue = require(`better-queue`)
 const readChunk = require(`read-chunk`)
 const fileType = require(`file-type`)
-const { createProgress } = require(`gatsby-source-filesystem/utils`)
 
 const { createFileNode } = require(`gatsby-source-filesystem/create-file-node`)
 const {
@@ -431,7 +430,7 @@ module.exports = ({
   }
 
   if (totalJobs === 0) {
-    bar = createProgress(`Downloading remote files`, reporter)
+    bar = reporter.createProgress(`Downloading remote files`)
     bar.start()
   }
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -138,6 +138,9 @@ export const errorPanicker = ({
       )
     )
     reporter.panic(error)
+  } else {
+    console.error(error)
+    reporter.panic()
   }
 }
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -816,7 +816,11 @@ const replaceNodeHtmlLinks = ({ wpUrl, nodeString, node }) => {
           const normalizedPath = path.replace(/\\/g, ``)
 
           // replace normalized match with relative path
-          const thisMatchRegex = new RegExp(normalizedMatch, `g`)
+          const thisMatchRegex = new RegExp(
+            normalizedMatch + `(?!/?wp-content|/?wp-admin|/?wp-includes)`,
+            `g`
+          )
+
           nodeString = nodeString.replace(thisMatchRegex, normalizedPath)
         } catch (e) {
           console.error(e)


### PR DESCRIPTION
Backport #29813 to 2.32 release
(cherry picked from commit 28124dd74b87902f9fa8cf3895ff8b4d54bc0fd6)
