### PR TITLE
fix(gatsby): with some custom babel configs array spreading with Set is not safe

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/graphql-errors.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/graphql-errors.js
@@ -59,7 +59,9 @@ function WrappedAccordionItem({ error, open }) {
 }
 
 export function GraphqlErrors({ errors, dismiss }) {
-  const deduplicatedErrors = React.useMemo(() => [...new Set(errors)], [errors])
+  const deduplicatedErrors = React.useMemo(() => Array.from(new Set(errors)), [
+    errors,
+  ])
   const hasMultipleErrors = deduplicatedErrors.length > 1
   return (
     <Overlay>

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/runtime-errors.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/runtime-errors.js
@@ -53,7 +53,9 @@ function WrappedAccordionItem({ error, open }) {
 }
 
 export function RuntimeErrors({ errors, dismiss }) {
-  const deduplicatedErrors = React.useMemo(() => [...new Set(errors)], [errors])
+  const deduplicatedErrors = React.useMemo(() => Array.from(new Set(errors)), [
+    errors,
+  ])
   const hasMultipleErrors = deduplicatedErrors.length > 1
 
   return (


### PR DESCRIPTION
## Description

With some custom `.babelrc` configs those can result in wrong transpiled code:

```
  var deduplicatedErrors = react__WEBPACK_IMPORTED_MODULE_6__.useMemo(function () {
    return [].concat(new Set(errors));
  }, [errors]);
```

`Array.from` does same thing without above:

```
  var deduplicatedErrors = react__WEBPACK_IMPORTED_MODULE_6__.useMemo(function () {
    return Array.from(new Set(errors));
  }, [errors]);
```