### PR TITLE
Update contentful package version to 8.2.0

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -15,7 +15,7 @@
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
     "common-tags": "^1.8.0",
-    "contentful": "^8.1.8",
+    "contentful": "^8.2.0",
     "fs-extra": "^9.1.0",
     "gatsby-core-utils": "^2.1.0-next.1",
     "gatsby-plugin-image": "^1.1.0-next.1",

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -15,7 +15,7 @@
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
     "common-tags": "^1.8.0",
-    "contentful": "^8.1.7",
+    "contentful": "^8.1.8",
     "fs-extra": "^9.1.0",
     "gatsby-core-utils": "^2.1.0-next.1",
     "gatsby-plugin-image": "^1.1.0-next.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9199,10 +9199,10 @@ contentful-sdk-core@^6.5.0, contentful-sdk-core@^6.7.0:
     fast-copy "^2.1.0"
     qs "^6.9.4"
 
-contentful@^8.1.8:
-  version "8.1.8"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-8.1.8.tgz#bb53f94cbcac5cd432465d6b188bbdcfcecf86d3"
-  integrity sha512-FsDGowoaUpA9fxA5o3SLc7zAvSrgir8INi2Fsg0lJflD1/TZiGEM9f7MnY76vnXjJ69J6RoViNqgV+IQZTNKDw==
+contentful@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-8.2.0.tgz#b9b2cab2ce72afcd4a7eba87b689da401fdec791"
+  integrity sha512-q/4HZZUI1fT3QBnPMUP/FQromfbuNwggS3RQZjTzYj6bU6M5xamuuPWrYcrOhhuG06ii8HopsYbV/K4E13jGig==
   dependencies:
     axios "^0.21.1"
     contentful-resolve-response "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9199,12 +9199,12 @@ contentful-sdk-core@^6.5.0, contentful-sdk-core@^6.7.0:
     fast-copy "^2.1.0"
     qs "^6.9.4"
 
-contentful@^8.1.7:
-  version "8.1.7"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-8.1.7.tgz#24786d5eb98118368cafd2a7bf718de9a1f99bae"
-  integrity sha512-dFlpRjkrTp+TG6kCjERIgzsBRTfjflRnjosE0uQus7dENrz2nrVEYhFO/T3WrKQfAbTyozKcTpWr5pEZiXpm2A==
+contentful@^8.1.8:
+  version "8.1.8"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-8.1.8.tgz#bb53f94cbcac5cd432465d6b188bbdcfcecf86d3"
+  integrity sha512-FsDGowoaUpA9fxA5o3SLc7zAvSrgir8INi2Fsg0lJflD1/TZiGEM9f7MnY76vnXjJ69J6RoViNqgV+IQZTNKDw==
   dependencies:
-    axios "^0.21.0"
+    axios "^0.21.1"
     contentful-resolve-response "^1.3.0"
     contentful-sdk-core "^6.5.0"
     fast-copy "^2.1.0"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This package version contains the axios package v0.21.1 which fixes the Server-Side Request Forgery vulnerability. It is found by `npm audit` and classified as "high".

Edit: Contentful updated their package to version 8.2.0

## Related Issues
Refers to PR [#631 Updated axios dependency](https://github.com/contentful/contentful.js/pull/631) @ contentful/contentful.js

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
