### PR TITLE
fix(gatsby-transformer-sharp): Fix options override

### DIFF
--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -465,7 +465,6 @@ const imageNodeType = ({
         not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
         both PNG and JPG is not supported and will be ignored.
         `,
-        defaultValue: [``, `webp`],
       },
       outputPixelDensities: {
         type: GraphQLList(GraphQLFloat),


### PR DESCRIPTION
Formats can be changed with gatsby-plugin-sharp options. This works for StaticImage but currently breaks for GatsbyImage because gatsby-transformer-sharp defaults it for you. Since we're already handling it inside plugin-sharp we can remove the resolver default.