### PR TITLE
Update migrating-from-v2-to-v3.md

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -357,6 +357,8 @@ const Box = ({ children }) => (
 export default Box
 ```
 
+You can also still import all styles using the `import * as styles` sytax e.g. `import * as styles from './mystyles.module.css'`.
+
 ### File assets (fonts, pdfs, ...) are imported as ESModules
 
 Assets are handled as ESM modules. Make sure to switch your require functions into imports.


### PR DESCRIPTION
Note you can use `import * as X` syntax for CSS Modules.