### PR TITLE
fix(gatsby): Update example sites to build with Gatsby v3

### DIFF
--- a/examples/gatsbygram/gatsby-config.js
+++ b/examples/gatsbygram/gatsby-config.js
@@ -53,6 +53,7 @@ module.exports = {
         background_color: `#f7f7f7`,
         theme_color: `#191919`,
         display: `minimal-ui`,
+        icon: `./static/images/logo.png`,
       },
     },
     // This plugin generates a service worker and AppShell

--- a/examples/using-contentful/src/pages/image-api.js
+++ b/examples/using-contentful/src/pages/image-api.js
@@ -201,7 +201,6 @@ const ImageAPI = props => {
       node {
         title
         fluid(maxWidth: 613) {
-          sizes
           src
           srcSet
         }
@@ -275,14 +274,14 @@ const ImageAPI = props => {
       <h2>Traced SVG previews</h2>
       <p>
         You can show a traced SVG preview to your users. This works equivalent
-        to the responsive sizes feature except that you have to use the
-        GatsbyContentfulSizes_tracedSVG fragment
+        to the responsive fluid feature except that you have to use the
+        GatsbyContentfulFixed_tracedSVG fragment
       </p>
       {assets.map(({ node: { title, traced } }) => (
         <Img
           key={traced.src}
           alt={title}
-          sizes={traced}
+          fluid={traced}
           style={{
             marginRight: rhythm(1 / 2),
             marginBottom: rhythm(1 / 2),
@@ -299,8 +298,8 @@ const ImageAPI = props => {
     edges {
       node {
         title
-        sizes(maxWidth: 614) {
-          ...GatsbyContentfulSizes_tracedSVG
+        fluid(maxWidth: 614) {
+          ...GatsbyContentfulFluid_tracedSVG
         }
       }
     }
@@ -338,8 +337,8 @@ export const pageQuery = graphql`
           fluid(maxWidth: 613) {
             ...GatsbyContentfulFluid_noBase64
           }
-          traced: sizes(maxWidth: 614) {
-            ...GatsbyContentfulSizes_tracedSVG
+          traced: fluid(maxWidth: 614) {
+            ...GatsbyContentfulFluid_tracedSVG
           }
         }
       }

--- a/examples/using-emotion-prismjs/package.json
+++ b/examples/using-emotion-prismjs/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/core": "7.11.6",
+    "@emotion/css": "^11.1.3",
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
     "emotion": "^11.0.0",

--- a/examples/using-emotion-prismjs/src/components/layout.js
+++ b/examples/using-emotion-prismjs/src/components/layout.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react"
 import { Link, StaticQuery, graphql } from "gatsby"
 import PropTypes from "prop-types"
-import { css } from "emotion"
+import { css } from "@emotion/css"
 import { Helmet } from "react-helmet"
 
 import { rhythm } from "../utils/typography"

--- a/examples/using-emotion-prismjs/src/pages/index.js
+++ b/examples/using-emotion-prismjs/src/pages/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
-import { css } from "emotion"
+import { css } from "@emotion/css"
 import get from "lodash/get"
 import { rhythm, scale } from "../utils/typography"
 

--- a/examples/using-emotion-prismjs/src/prism-styles.js
+++ b/examples/using-emotion-prismjs/src/prism-styles.js
@@ -1,4 +1,4 @@
-import { injectGlobal } from "emotion"
+import { injectGlobal } from "@emotion/css"
 
 const colors = {
   dark: `#282c34`,

--- a/examples/using-emotion-prismjs/src/templates/blog-post.js
+++ b/examples/using-emotion-prismjs/src/templates/blog-post.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import { css } from "emotion"
+import { css } from "@emotion/css"
 import { graphql } from "gatsby"
 import { rhythm, scale } from "../utils/typography"
 

--- a/examples/using-emotion/package.json
+++ b/examples/using-emotion/package.json
@@ -4,6 +4,7 @@
   "description": "Gatsby example site using using-emotion",
   "author": "Tegan Churchill <churchill.tegan@gmail.com>",
   "dependencies": {
+    "@emotion/css": "^11.1.3",
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
     "emotion": "^11.0.0",

--- a/examples/using-emotion/src/pages/index.js
+++ b/examples/using-emotion/src/pages/index.js
@@ -1,7 +1,8 @@
 import React, { Fragment } from "react"
 import { Helmet } from "react-helmet"
 import styled from "@emotion/styled"
-import { css, Global } from "@emotion/react"
+import { Global } from "@emotion/react"
+import { css } from "@emotion/css"
 
 // Emotion supports different styling options, all of which are supported by gatsby-plugin-emotion out of the box
 

--- a/examples/using-gatsby-image/package.json
+++ b/examples/using-gatsby-image/package.json
@@ -4,8 +4,10 @@
   "description": "Gatsby example site using using-gatsby-image",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
+    "@emotion/css": "^11.1.3",
     "@emotion/react": "^11.0.0",
     "@emotion/styled": "^11.0.0",
+    "buffer": "^6.0.3",
     "emotion": "^11.0.0",
     "gatsby": "next",
     "gatsby-image": "next",

--- a/examples/using-gatsby-image/src/components/image-gallery.js
+++ b/examples/using-gatsby-image/src/components/image-gallery.js
@@ -6,6 +6,8 @@ import numeral from "numeral"
 import { mq, gutter, offset, offsetXxl } from "../utils/presets"
 import { options, scale } from "../utils/typography"
 
+const Buffer = require("buffer/").Buffer
+
 const OuterContainer = styled(`div`)`
   background: #fff;
 

--- a/examples/using-gatsby-image/src/components/navigation.js
+++ b/examples/using-gatsby-image/src/components/navigation.js
@@ -1,8 +1,7 @@
 import React from "react"
 import { Link } from "gatsby"
-import { css as cssClass } from "emotion"
+import { css } from "@emotion/css"
 import styled from "@emotion/styled"
-import { css } from "@emotion/react"
 import { MdLink } from "react-icons/md"
 import { scale, rhythm, options } from "../utils/typography"
 import { mq, elevation, gutter, colors, animation } from "../utils/presets"
@@ -40,7 +39,7 @@ const linkStyle = css`
 const assignActiveStyles = ({ isPartiallyCurrent }) =>
   isPartiallyCurrent
     ? {
-        className: cssClass`
+        className: css`
           ${linkStyle};
 
           && {
@@ -65,7 +64,7 @@ const assignActiveStyles = ({ isPartiallyCurrent }) =>
         `,
       }
     : {
-        className: cssClass`
+        className: css`
           ${linkStyle};
         `,
       }

--- a/examples/using-gatsby-image/src/components/page-title.js
+++ b/examples/using-gatsby-image/src/components/page-title.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { css } from "@emotion/css"
 
 const PageTitle = ({ children }) => <h2 css={{ marginTop: 0 }}>{children}</h2>
 

--- a/examples/using-gatsby-image/src/pages/index.js
+++ b/examples/using-gatsby-image/src/pages/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
 import styled from "@emotion/styled"
-import { css } from "@emotion/react"
+import { css } from "@emotion/css"
 import { FaGithub } from "react-icons/fa"
 
 import Layout from "../components/layout"

--- a/examples/using-remark-copy-linked-files/gatsby-config.js
+++ b/examples/using-remark-copy-linked-files/gatsby-config.js
@@ -48,12 +48,12 @@ module.exports = {
     },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
-    {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        //trackingId: `ADD YOUR TRACKING ID HERE`,
-      },
-    },
+    // {
+    // resolve: `gatsby-plugin-google-analytics`,
+    // options: {
+    // trackingId: `ADD YOUR TRACKING ID HERE`,
+    // },
+    // },
     `gatsby-plugin-offline`,
     `gatsby-plugin-react-helmet`,
     {

--- a/examples/using-shopify/src/components/image-picker.js
+++ b/examples/using-shopify/src/components/image-picker.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import Image from "gatsby-image"
 
-import styles from "./image-picker.module.css"
+import * as styles from "./image-picker.module.css"
 
 function ImagePicker({ images }) {
   const [activeIndex, setActiveIndex] = useState(0)

--- a/examples/using-shopify/src/components/product-list.js
+++ b/examples/using-shopify/src/components/product-list.js
@@ -1,6 +1,6 @@
 import React from "react"
 
-import styles from "./product-list.module.css"
+import * as styles from "./product-list.module.css"
 
 function ProductList({ children }) {
   return <div className={styles.container}>{children}</div>

--- a/examples/using-shopify/src/components/product.js
+++ b/examples/using-shopify/src/components/product.js
@@ -6,7 +6,6 @@ import ImagePicker from "./image-picker"
 
 import * as styles from "./product.module.css"
 
-console.log({ styles })
 function Product({ description, fields, showDetail, title, images }) {
   return (
     <div className={styles.product}>

--- a/examples/using-shopify/src/components/product.js
+++ b/examples/using-shopify/src/components/product.js
@@ -4,8 +4,9 @@ import { MdChevronRight } from "react-icons/md"
 
 import ImagePicker from "./image-picker"
 
-import styles from "./product.module.css"
+import * as styles from "./product.module.css"
 
+console.log({ styles })
 function Product({ description, fields, showDetail, title, images }) {
   return (
     <div className={styles.product}>

--- a/examples/using-square-payments/package.json
+++ b/examples/using-square-payments/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-offline": "next",
     "gatsby-plugin-react-helmet": "next",
     "gatsby-plugin-sharp": "next",
-    "gatsby-plugin-square-payment-form": "next",
+    "gatsby-plugin-square-payment-form": "latest",
     "gatsby-source-filesystem": "next",
     "gatsby-transformer-sharp": "next",
     "prop-types": "^15.7.2",
@@ -22,9 +22,7 @@
   "devDependencies": {
     "prettier": "2.1.1"
   },
-  "keywords": [
-    "gatsby"
-  ],
+  "keywords": ["gatsby"],
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",

--- a/examples/using-stylus/src/pages/css-modules.js
+++ b/examples/using-stylus/src/pages/css-modules.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Link } from "gatsby"
-import s from "./css-modules.module.styl"
+import * as s from "./css-modules.module.styl"
 
 class CssModules extends React.Component {
   render() {


### PR DESCRIPTION
All of them build except for the WordPress sites which haven't yet been upgraded for the major release of gatsby-source-wordpress.

The following sites emit warnings about upgrading to gatsby-plugin-image:

- gatsbygram
- using-mdx
- using-cypress
- using-drupal
- using-gatsby-image
- using-multiple-themes
- using-shopify