### PR TITLE
fix(gatsby): Add dir=ltr to Fast Refresh overlay

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/overlay.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/overlay.js
@@ -63,6 +63,7 @@ export function Overlay({ children }) {
         aria-labelledby="gatsby-overlay-labelledby"
         aria-describedby="gatsby-overlay-describedby"
         aria-modal="true"
+        dir="ltr"
       >
         {children}
       </div>


### PR DESCRIPTION
## Description

Adds a "ltr" [direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) to prevent issues when working within "rtl" sites. The most problematic fix is the stack trace which gets completely mangled:

![Screenshot 2021-03-01 203731](https://user-images.githubusercontent.com/11328618/109555865-fad3c900-7acd-11eb-946e-b9551b06df52.png)
