### PR TITLE
fix(release-notes): adjust casing in link to migration guide

### DIFF
--- a/docs/docs/reference/release-notes/v3.0/index.md
+++ b/docs/docs/reference/release-notes/v3.0/index.md
@@ -77,7 +77,7 @@ const someUntrackedInput = fs.readFileSync(`some-path.txt`)
 
 While Gatsby could also track files that are read, the custom code that does those reads might have some special logic that Gatsby is not aware of. In the above example the filename could be generated and changed between builds, or the file read itself could change -- so we see this as "arbitrary" file reading. If Gatsby discovers that `fs` modules are used, it will disable "Incremental Builds"-mode to stay on the safe side (there will be warnings mentioning "unsafe builtin method").
 
-If your `gatsby-ssr` (either site itself or plugin) make use of `fs` reads, head over to [migrating from v2 to v3 guide](/docs/reference/release-notes/migrating-from-v2-to-v3/#using-fs-in-SSR) and check how to migrate.
+If your `gatsby-ssr` (either site itself or plugin) make use of `fs` reads, head over to [migrating from v2 to v3 guide](/docs/reference/release-notes/migrating-from-v2-to-v3/#using-fs-in-ssr) and check how to migrate.
 
 ## Fast Refresh
 


### PR DESCRIPTION
Was almost correct ;) 