### PR TITLE
docs(migrating-from-v2-to-v3): drop "work-in-progress" note

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -4,7 +4,7 @@ title: Migrating from v2 to v3
 
 Looking for the [v2 docs](https://v2.gatsbyjs.com)?
 
-> This document is a work in progress. Have you run into something that's not covered here? [Add your changes to GitHub!](https://github.com/gatsbyjs/gatsby/tree/master/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md)
+> Have you run into something that's not covered here? [Add your changes to GitHub!](https://github.com/gatsbyjs/gatsby/tree/master/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md)
 
 ## Introduction
 


### PR DESCRIPTION
## Description

This document is no longer "work in progress" - we still might add to it as we will find specific quirks and edge cases mostly exposed by upstream bumps and user reports, but this document does already cover all Gatsby specific changes