### PR TITLE
fix(publish-starters): don't presume 'master' is default branch

### DIFF
--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -37,7 +37,8 @@ for folder in $GLOB; do
   if [ -n "$(git status --porcelain)" ]; then
     git add .
     git commit -m "$COMMIT_MESSAGE"
-    git push origin master
+    DEFAULT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+    git push origin $DEFAULT_BRANCH_NAME
   fi
 
   cd "$BASE"

--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -15,6 +15,14 @@ for folder in $GLOB; do
   cd "$BASE"
 
   NAME=$(jq -r '.name' "$folder/package.json")
+
+  # FIX-ME: there are changes in gatsbyjs/gatsby-starter-wordpress-blog that
+  # are not applied in this repo, so until we make starter in this repo
+  # source of truth we should skip it.
+  if [ "gatsby-starter-wordpress-blog" = "$NAME" ]; then
+    continue
+  fi
+
   IS_WORKSPACE=$(jq -r '.workspaces' "$folder/package.json")
   CLONE_DIR="__${NAME}__clone__"
 

--- a/scripts/publish-starters.sh
+++ b/scripts/publish-starters.sh
@@ -19,7 +19,7 @@ for folder in $GLOB; do
   # FIX-ME: there are changes in gatsbyjs/gatsby-starter-wordpress-blog that
   # are not applied in this repo, so until we make starter in this repo
   # source of truth we should skip it.
-  if [ "gatsby-starter-wordpress-blog" = "$NAME" ]; then
+  if [ "gatsby-starter-wordpress-blog" == "$NAME" ]; then
     continue
   fi
 
@@ -35,7 +35,7 @@ for folder in $GLOB; do
   find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
   cp -r "$BASE/$folder/." .
 
-  if [ "$IS_WORKSPACE" = null ]; then
+  if [ "$IS_WORKSPACE" == null ]; then
     rm -f yarn.lock
     if [ "$MINIMAL_STARTER" != "$NAME" ]; then # ignore minimal starter because we don't want any lock files for create-gatsby
       yarn import # generate a new yarn.lock file based on package-lock.json, gatsby new does this is new CLI versions but will ignore if file exists


### PR DESCRIPTION
## Description

Two things here:
 1. push to current branch and don't presume it's `master` branch
 2. skip `gatsby-starter-wordpress-blog` publishing for now as there are some changes in starter repo that are not here - so until we update starter in this repo, let's not push from it. 
