### PR TITLE
chore(docs): update css modules docs

### DIFF
--- a/docs/docs/how-to/styling/css-modules.md
+++ b/docs/docs/how-to/styling/css-modules.md
@@ -28,7 +28,7 @@ The CSS in a CSS module is no different than normal CSS, but the extension of th
 ```jsx:title=src/components/container.js
 import React from "react"
 // highlight-next-line
-import containerStyles from "./container.module.css"
+import * as containerStyles from "./container.module.css"
 
 export default function Container({ children }) {
   return (
@@ -48,7 +48,7 @@ Here's an example where the class name `container` is added to the DOM along wit
 
 ```jsx:title=src/components/container.js
 import React from "react"
-import containerStyles from "./container.module.css"
+import * as containerStyles from "./container.module.css"
 
 export default function Container({ children }) {
   return (

--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -194,7 +194,7 @@ export default function UsersList() {
 import React from "react"
 
 // highlight-start
-import style from "./index.module.css"
+import * as style from "./index.module.css"
 
 export default function Home() {
   return (

--- a/docs/docs/reference/release-notes/migrating-from-v1-to-v2.md
+++ b/docs/docs/reference/release-notes/migrating-from-v1-to-v2.md
@@ -682,7 +682,7 @@ Here's an example with a class named `.my-class-name`:
 
 ```diff
 import React from "react"
-import myStyles from "./my.module.css"
+import * as myStyles from "./my.module.css"
 
 export default function Component({ children }) (
 -  <div className={myStyles['my-class-name']}>

--- a/docs/docs/tutorial/part-two/index.md
+++ b/docs/docs/tutorial/part-two/index.md
@@ -154,7 +154,7 @@ First, create a new `Container` component.
 
 ```jsx:title=src/components/container.js
 import React from "react"
-import containerStyles from "./container.module.css"
+import * as containerStyles from "./container.module.css"
 
 export default function Container({ children }) {
   return <div className={containerStyles.container}>{children}</div>
@@ -243,7 +243,7 @@ In this section, you'll create a list of people with names, avatars, and short L
 ```javascript:title=src/pages/about-css-modules.js
 import React from "react"
 // highlight-next-line
-import styles from "./about-css-modules.module.css"
+import * as styles from "./about-css-modules.module.css"
 import Container from "../components/container"
 
 // highlight-next-line
@@ -261,7 +261,7 @@ If you compare that to your CSS file, you'll see that each class is now a key in
 
 ```jsx:title=src/pages/about-css-modules.js
 import React from "react"
-import styles from "./about-css-modules.module.css"
+import * as styles from "./about-css-modules.module.css"
 import Container from "../components/container"
 
 console.log(styles)


### PR DESCRIPTION
## Description

Just a quick update of all docs mentioning CSS modules with a new syntax. Ideally we should rewrite those using ES modules, so something like this: 

```js
import { container } from "./container.module.css"
```

But it is much more involved. This is just a quick fix to not confuse our users.

## Related Issues

Originally flagged in #29931