### PR TITLE
fix(gatsby): fix routing for paths with characters like `@` etc

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -143,6 +143,41 @@ describe(`navigation`, () => {
     })
   })
 
+  describe(`Supports encodable characters in urls`, () => {
+    it(`Can navigate directly`, () => {
+      cy.visit(encodeURI(`/foo/@something/bar`)).waitForRouteChange()
+      cy.getTestElement(`page-2-message`)
+        .invoke(`text`)
+        .should(`equal`, `Hi from the second page`)
+    })
+
+    it(`Can navigate on client`, () => {
+      cy.visit(`/`).waitForRouteChange()
+      cy.getTestElement(`page-with-encodable-path`).click().waitForRouteChange()
+
+      cy.getTestElement(`page-2-message`)
+        .invoke(`text`)
+        .should(`equal`, `Hi from the second page`)
+    })
+
+    it(`should show 404 page when url with unicode characters point to a non-existent page route when navigating directly`, () => {
+      cy.visit(encodeURI(`/foo/@something/bar404/`), {
+        failOnStatusCode: false,
+      }).waitForRouteChange()
+
+      cy.get(`h1`).invoke(`text`).should(`eq`, `Gatsby.js development 404 page`)
+    })
+
+    it(`should show 404 page when url with unicode characters point to a non-existent page route when navigating on client`, () => {
+      cy.visit(`/`).waitForRouteChange()
+      cy.window()
+        .then(win => win.___navigate(`/foo/@something/bar404/`))
+        .waitForRouteChange()
+
+      cy.get(`h1`).invoke(`text`).should(`eq`, `Gatsby.js development 404 page`)
+    })
+  })
+
   // TODO: Check if this is the correct behavior
   describe(`All location changes should trigger an effect (fast-refresh)`, () => {
     beforeEach(() => {

--- a/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/linking.js
@@ -145,7 +145,7 @@ describe(`navigation`, () => {
 
   describe(`Supports encodable characters in urls`, () => {
     it(`Can navigate directly`, () => {
-      cy.visit(encodeURI(`/foo/@something/bar`)).waitForRouteChange()
+      cy.visit(`/foo/@something/bar`).waitForRouteChange()
       cy.getTestElement(`page-2-message`)
         .invoke(`text`)
         .should(`equal`, `Hi from the second page`)
@@ -161,7 +161,7 @@ describe(`navigation`, () => {
     })
 
     it(`should show 404 page when url with unicode characters point to a non-existent page route when navigating directly`, () => {
-      cy.visit(encodeURI(`/foo/@something/bar404/`), {
+      cy.visit(`/foo/@something/bar404/`, {
         failOnStatusCode: false,
       }).waitForRouteChange()
 

--- a/e2e-tests/development-runtime/gatsby-node.js
+++ b/e2e-tests/development-runtime/gatsby-node.js
@@ -84,6 +84,11 @@ exports.createPages = async function createPages({
   })
 
   createPage({
+    path: `/foo/@something/bar`,
+    component: path.resolve(`src/pages/page-2.js`),
+  })
+
+  createPage({
     path: `/client-only-paths/static`,
     component: path.resolve(`src/templates/static-page.js`),
   })

--- a/e2e-tests/development-runtime/src/pages/index.js
+++ b/e2e-tests/development-runtime/src/pages/index.js
@@ -23,6 +23,9 @@ const IndexPage = ({ data }) => (
     <Link to="/안녕" data-testid="page-with-unicode-path">
       Go to page with unicode path
     </Link>
+    <Link to="/foo/@something/bar" data-testid="page-with-encodable-path">
+      Go to page with unicode path
+    </Link>
     <Link to="/__non_existent_page__/" data-testid="broken-link">
       Go to a broken link
     </Link>

--- a/e2e-tests/production-runtime/cypress/integration/1-production.js
+++ b/e2e-tests/production-runtime/cypress/integration/1-production.js
@@ -172,4 +172,39 @@ describe(`Production build tests`, () => {
       cy.getTestElement(`404`).should(`exist`)
     })
   })
+
+  describe(`Supports encodable characters in urls`, () => {
+    it(`Can navigate directly`, () => {
+      cy.visit(encodeURI(`/foo/@something/bar`)).waitForRouteChange()
+      cy.getTestElement(`page-2-message`)
+        .invoke(`text`)
+        .should(`equal`, `Hi from the second page`)
+    })
+
+    it(`Can navigate on client`, () => {
+      cy.visit(`/`).waitForRouteChange()
+      cy.getTestElement(`page-with-encodable-path`).click().waitForRouteChange()
+
+      cy.getTestElement(`page-2-message`)
+        .invoke(`text`)
+        .should(`equal`, `Hi from the second page`)
+    })
+
+    it(`should show 404 page when url with unicode characters point to a non-existent page route when navigating directly`, () => {
+      cy.visit(encodeURI(`/foo/@something/bar404/`), {
+        failOnStatusCode: false,
+      }).waitForRouteChange()
+
+      cy.getTestElement(`404`).should(`exist`)
+    })
+
+    it(`should show 404 page when url with unicode characters point to a non-existent page route when navigating on client`, () => {
+      cy.visit(`/`).waitForRouteChange()
+      cy.window()
+        .then(win => win.___navigate(`/foo/@something/bar404/`))
+        .waitForRouteChange()
+
+      cy.getTestElement(`404`).should(`exist`)
+    })
+  })
 })

--- a/e2e-tests/production-runtime/cypress/integration/1-production.js
+++ b/e2e-tests/production-runtime/cypress/integration/1-production.js
@@ -175,7 +175,7 @@ describe(`Production build tests`, () => {
 
   describe(`Supports encodable characters in urls`, () => {
     it(`Can navigate directly`, () => {
-      cy.visit(encodeURI(`/foo/@something/bar`)).waitForRouteChange()
+      cy.visit(`/foo/@something/bar`).waitForRouteChange()
       cy.getTestElement(`page-2-message`)
         .invoke(`text`)
         .should(`equal`, `Hi from the second page`)
@@ -191,7 +191,7 @@ describe(`Production build tests`, () => {
     })
 
     it(`should show 404 page when url with unicode characters point to a non-existent page route when navigating directly`, () => {
-      cy.visit(encodeURI(`/foo/@something/bar404/`), {
+      cy.visit(`/foo/@something/bar404/`, {
         failOnStatusCode: false,
       }).waitForRouteChange()
 

--- a/e2e-tests/production-runtime/gatsby-node.js
+++ b/e2e-tests/production-runtime/gatsby-node.js
@@ -43,6 +43,11 @@ exports.createPages = ({ actions: { createPage, createRedirect } }) => {
   })
 
   createPage({
+    path: `/foo/@something/bar`,
+    component: path.resolve(`src/pages/page-2.js`),
+  })
+
+  createPage({
     path: `/client-only-paths/static`,
     component: path.resolve(`src/templates/static-page.js`),
   })

--- a/e2e-tests/production-runtime/src/pages/index.js
+++ b/e2e-tests/production-runtime/src/pages/index.js
@@ -62,6 +62,11 @@ const IndexPage = ({ pageContext }) => (
         </Link>
       </li>
       <li>
+        <Link to="/foo/@something/bar" data-testid="page-with-encodable-path">
+          Go to page with unicode path
+        </Link>
+      </li>
+      <li>
         <Link to="subdirectory/page-1" data-testid="subdir-link">
           Go to subdirectory
         </Link>

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -17,7 +17,7 @@
     "@babel/runtime": "^7.12.5",
     "@babel/traverse": "^7.12.5",
     "@babel/types": "^7.12.6",
-    "@gatsbyjs/reach-router": "^1.3.5",
+    "@gatsbyjs/reach-router": "^1.3.6",
     "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
     "@mikaelkristiansson/domready": "^1.0.10",
     "@nodelib/fs.walk": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,10 +2634,10 @@
   resolved "https://registry.yarnpkg.com/@feedback-fish/react/-/react-1.2.1.tgz#b4d226f310df936517e9e5e82397806a5df4e2d8"
   integrity sha512-4YFD2hE93xBIT/Ko0x0l6UB0OyaxJcWKLGrnznsUVoLE5Q9vB8I1LEbMySYyuvbU9ul3yM3FjGkVZhYVPdwEyA==
 
-"@gatsbyjs/reach-router@^1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@gatsbyjs/reach-router/-/reach-router-1.3.5.tgz#e5d86b341957611153279da353d0a39a82f34a8e"
-  integrity sha512-O7sTZajwCtbjuuUYwjEZdSw7CmAxA6ugDaXtw4hfKoTfj4RZUAB8nYRlecUVuNAQbgHiXJSx2jKfu1hmE9mggA==
+"@gatsbyjs/reach-router@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@gatsbyjs/reach-router/-/reach-router-1.3.6.tgz#4e8225836959be247890b66f21a3198a0589e34d"
+  integrity sha512-RW9ZBir9kqtw4IWm+Z+DLWGOeoJxoaTvNVrnR5fV9zD8EmfAhbBN/hS6i6VnTMFZ7rdd6mnpx2/XtnMvYfsaVQ==
   dependencies:
     invariant "^2.2.3"
     prop-types "^15.6.1"


### PR DESCRIPTION
## Description

Just tests for the start

