### PR TITLE
chore(gatsby-source-wordpress): Test html link transforms

### DIFF
--- a/packages/gatsby-source-wordpress/__tests__/process-node.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/process-node.test.js
@@ -1,6 +1,9 @@
+import execall from "execall"
+
 import {
   getImgSrcRemoteFileMatchesFromNodeString,
   getImgTagMatchesWithUrl,
+  getWpLinkRegex,
 } from "../dist/steps/source-nodes/create-nodes/process-node"
 
 const wpUrl = `wp.fakesite.com`
@@ -22,4 +25,21 @@ test(`HTML image transformation regex matches images`, async () => {
   })
 
   expect(imgTagMatches.length).toBe(3)
+})
+
+test(`HTML link transformation regex matches links`, async () => {
+  const nodeString = `<a href=\\"https://${wpUrl}/wp-content/uploads/2020/01/©SDM-Yep-©Hi-000-Header.jpg\\" />Not a transformable link</a>
+
+  <a href=\\"https://other-site.com/hi\\" />Not a transformable link</a>
+
+  <a href=\\"https://${wpUrl}/page-1\\">
+    page 1
+  </a>
+
+  <a href=\\"https://${wpUrl}/\\">Home</a>`
+
+  const wpLinkRegex = getWpLinkRegex(`https://${wpUrl}`)
+  const matches = execall(wpLinkRegex, nodeString)
+
+  expect(matches.length).toBe(2)
 })

--- a/packages/gatsby-source-wordpress/__tests__/process-node.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/process-node.test.js
@@ -3,14 +3,14 @@ import {
   getImgTagMatchesWithUrl,
 } from "../dist/steps/source-nodes/create-nodes/process-node"
 
+const wpUrl = `wp.fakesite.com`
+
 test(`HTML image transformation regex matches images`, async () => {
-  const wpUrl = `http://wp.fakesite.com`
+  const nodeString = `<img src=\\"https://${wpUrl}/wp-content/uploads/2020/01/©SDM-Yep-©Hi-000-Header.jpg\\" />
 
-  const nodeString = `<img src=\\"https://wp.fakesite.com/wp-content/uploads/2020/01/©SDM-Yep-©Hi-000-Header.jpg />
+  <img src=\\"http://${wpUrl}/wp-content/uploads/2020/01/©SDM-Yep-©Hi-000-Header.jpg\\" />
 
-  <img src=\\"http://wp.fakesite.com/wp-content/uploads/2020/01/©SDM-Yep-©Hi-000-Header.jpg />
-
-  <img src=\\"/wp-content/uploads/2020/01/©SDM-Yep-©Hi-000-Header.jpg />`
+  <img src=\\"/wp-content/uploads/2020/01/©SDM-Yep-©Hi-000-Header.jpg\\" />`
 
   const matches = getImgSrcRemoteFileMatchesFromNodeString(nodeString)
 
@@ -18,7 +18,7 @@ test(`HTML image transformation regex matches images`, async () => {
 
   const imgTagMatches = getImgTagMatchesWithUrl({
     nodeString,
-    wpUrl,
+    wpUrl: `https://${wpUrl}`,
   })
 
   expect(imgTagMatches.length).toBe(3)

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -805,13 +805,15 @@ const replaceFileLinks = async ({
   return nodeString
 }
 
-// replaces any url which is a front-end WP url with a relative path
-const replaceNodeHtmlLinks = ({ wpUrl, nodeString, node }) => {
-  const wpLinkRegex = new RegExp(
+export const getWpLinkRegex = wpUrl =>
+  new RegExp(
     `["']${wpUrl}(?!/wp-content|/wp-admin|/wp-includes)(/[^'"]+)["']`,
     `gim`
   )
 
+// replaces any url which is a front-end WP url with a relative path
+const replaceNodeHtmlLinks = ({ wpUrl, nodeString, node }) => {
+  const wpLinkRegex = getWpLinkRegex(wpUrl)
   const linkMatches = execall(wpLinkRegex, nodeString)
 
   if (linkMatches.length) {


### PR DESCRIPTION
This PR adds a test for html field link transforms (from absolute urls to relative paths).