### PR TITLE
fix(gatsby): change browserlist to web/es5

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -506,9 +506,7 @@ module.exports = async (
     const [major, minor] = process.version.replace(`v`, ``).split(`.`)
     config.target = `node12.13`
   } else {
-    config.target = `browserslist:${getBrowsersList(program.directory).join(
-      `,`
-    )}`
+    config.target = [`web`, `es5`]
   }
 
   const isCssModule = module => module.type === `css/mini-extract`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Move away from browserlist config until we have a better way to set browserlist properly in gatsby

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #29943