### PR TITLE
fix(gatsby-plugin-image): Use template from core package

### DIFF
--- a/packages/gatsby-plugin-image/src/babel-plugin-parse-static-images.ts
+++ b/packages/gatsby-plugin-image/src/babel-plugin-parse-static-images.ts
@@ -1,5 +1,8 @@
-import * as types from "@babel/types"
-import { PluginObj } from "@babel/core"
+import type {
+  PluginObj,
+  template as BabelTemplate,
+  types as BabelTypes,
+} from "@babel/core"
 import { hashOptions, evaluateImageAttributes } from "./babel-helpers"
 import fs from "fs-extra"
 import path from "path"
@@ -16,8 +19,8 @@ export default function attrs({
   types: t,
   template,
 }: {
-  types: typeof types
-  template: any
+  types: typeof BabelTypes
+  template: typeof BabelTemplate
 }): PluginObj {
   return {
     visitor: {

--- a/packages/gatsby-plugin-image/src/babel-plugin-parse-static-images.ts
+++ b/packages/gatsby-plugin-image/src/babel-plugin-parse-static-images.ts
@@ -5,7 +5,6 @@ import fs from "fs-extra"
 import path from "path"
 import { slash } from "gatsby-core-utils"
 
-import template from "@babel/template"
 import { stripIndent } from "common-tags"
 
 /**
@@ -15,8 +14,10 @@ import { stripIndent } from "common-tags"
 
 export default function attrs({
   types: t,
+  template,
 }: {
   types: typeof types
+  template: any
 }): PluginObj {
   return {
     visitor: {


### PR DESCRIPTION
We were importing @babel/template without adding it as a dep. It works because this is including in the core package, so we should grab it accordingly.