### PR TITLE
fix(gatsby): Fix hot reloading for Safari

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -135,7 +135,9 @@ module.exports = async (
       case `develop`:
         return {
           path: directory,
-          filename: `[name].js`,
+          // Adding a timestamp fixes a Safari bug
+          // @see https://github.com/gatsbyjs/gatsby/issues/29952
+          filename: `[name].js?v=${Date.now()}`,
           // Add /* filename */ comments to generated require()s in the output.
           pathinfo: true,
           // Point sourcemap entries to original disk location (format as URL on Windows)


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/29952

It fixes the case for page queries, but at the moment it doesn't fix the issue that other updates (e.g. updating the React component's content itself) triggers an update.

For some reason only on Safari it doesn't find it:

<img width="1247" alt="Bildschirmfoto 2021-03-03 um 14 48 32" src="https://user-images.githubusercontent.com/16143594/109822569-5c637700-7c37-11eb-984e-0c623898bf59.png">

However, adding the timestamp at least doesn't show the error overlay anymore. More to investigate to make real hot reloading work everywhere for Safari.

## Related Issues

https://github.com/vuejs/vue-cli/issues/1132

In commits [33dad39](https://github.com/vuejs/vue-cli/commit/33dad3906ff221d99310242447901e81391fd4fb), [52dbdf8](https://github.com/vuejs/vue-cli/commit/52dbdf88ffac1e7ed54d28fa45cce1a6b75fb50c), and [0909bc8](https://github.com/vuejs/vue-cli/commit/0909bc86880d526e4015c3e642e9afa63adab2b1) of Vue CLI some things were tried, but they reverted them.

[ch26278]