### PR TITLE
feat(gatsby): improve error messages at runtime

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/resource-loading-resilience.js
+++ b/e2e-tests/production-runtime/cypress/integration/resource-loading-resilience.js
@@ -1,27 +1,12 @@
-Cypress.on(`uncaught:exception`, (err, runnable) => {
-  // returning false here prevents Cypress from
-  // failing the test
-  console.log(err)
-  return false
-})
+// Cypress.on(`uncaught:exception`, (err, runnable) => {
+//   // returning false here prevents Cypress from
+//   // failing the test
+//   console.log(err)
+//   return false
+// })
 
 const waitForAPIOptions = {
   timeout: 10000,
-}
-
-function assertOnNavigate(
-  page = null,
-  locationAssert,
-  shouldLocationAssert,
-  assertShouldBe
-) {
-  if (page) {
-    cy.getTestElement(page).click()
-  }
-  cy.waitForAPIorTimeout(`onRouteUpdate`, waitForAPIOptions)
-    .location(`pathname`)
-    .should(locationAssert, shouldLocationAssert)
-  cy.getTestElement(`dom-marker`).contains(assertShouldBe)
 }
 
 function runTests(testNameSuffix) {
@@ -63,11 +48,11 @@ function runTests(testNameSuffix) {
   })
 }
 
-const runBlockedScenario = args => {
+const runBlockedScenario = ({ filter, pagePath }) => {
   beforeEach(() => {
     cy.task("getAssetsForPage", {
-      pagePath: args.pagePath,
-      filter: args.filter,
+      pagePath,
+      filter,
     }).then(urls => {
       for (const url of urls) {
         cy.intercept(url, {
@@ -82,17 +67,14 @@ const runBlockedScenario = args => {
   afterEach(() => {
     // check if assets are actually stubbed
     cy.task("getAssetsForPage", {
-      pagePath: args.pagePath,
-      filter: args.filter,
+      pagePath,
+      filter,
     }).then(urls => {
       expect(Object.keys(cy.state("routes")).length).to.equal(urls.length)
     })
   })
 
-  runTests(`Blocked "${args.filter}" for "${args.pagePath}"`, {
-    ...args,
-    task: "getAssetsForPage",
-  })
+  runTests(`Blocked "${filter}" for "${pagePath}"`)
 }
 
 const runSuiteForPage = (label, pagePath) => {
@@ -101,6 +83,12 @@ const runSuiteForPage = (label, pagePath) => {
       runBlockedScenario({
         pagePath,
         filter: `page-data`,
+      })
+    })
+    describe(`Missing "${label}" static query results`, () => {
+      runBlockedScenario({
+        pagePath,
+        filter: `static-query-data`,
       })
     })
     describe(`Missing "${label}" page page-template asset`, () => {

--- a/e2e-tests/production-runtime/cypress/integration/resource-loading-resilience.js
+++ b/e2e-tests/production-runtime/cypress/integration/resource-loading-resilience.js
@@ -1,10 +1,3 @@
-// Cypress.on(`uncaught:exception`, (err, runnable) => {
-//   // returning false here prevents Cypress from
-//   // failing the test
-//   console.log(err)
-//   return false
-// })
-
 const waitForAPIOptions = {
   timeout: 10000,
 }

--- a/e2e-tests/production-runtime/cypress/plugins/block-resources.js
+++ b/e2e-tests/production-runtime/cypress/plugins/block-resources.js
@@ -17,7 +17,7 @@ const filterAssets = (assetsForPath, filter) => {
   return assetsForPath.filter(asset => {
     if (filter === `all`) {
       return true
-    } else if (filter === `page-data`) {
+    } else if (filter === `page-data` || filter === "static-query-data") {
       return false
     }
 
@@ -53,6 +53,10 @@ function getAssetsForPage({ pagePath, filter }) {
 
   if (filter === `all` || filter === `page-data`) {
     assets.push(`/${pageDataUrl}`)
+  }
+
+  if (filter === `all` || filter === `static-query-data`) {
+    assets.push(`/page-data/sq/d/${pageData.staticQueryHashes[0]}.json`)
   }
 
   return assets

--- a/packages/gatsby/cache-dir/__tests__/dev-loader.js
+++ b/packages/gatsby/cache-dir/__tests__/dev-loader.js
@@ -376,7 +376,7 @@ describe(`Dev loader`, () => {
 
     it(`should return an error when component cannot be loaded`, async () => {
       const asyncRequires = createAsyncRequires({
-        chunk: false,
+        chunk: () => Promise.resolve(false),
       })
       const devLoader = new DevLoader(asyncRequires, [])
       const pageData = {

--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -25,13 +25,20 @@ function mergePageEntry(cachedPage, newPageData) {
 
 class DevLoader extends BaseLoader {
   constructor(asyncRequires, matchPaths) {
-    const loadComponent = chunkName =>
-      asyncRequires.components[chunkName]
-        ? asyncRequires.components[chunkName]()
-            .then(preferDefault)
-            // loader will handle the case when component is null
-            .catch(() => null)
-        : Promise.resolve()
+    const loadComponent = chunkName => {
+      if (!asyncRequires.components[chunkName]) {
+        throw new Error(
+          `We couldn't find the correct component chunk with the name "${chunkName}"`
+        )
+      }
+
+      return (
+        asyncRequires.components[chunkName]()
+          .then(preferDefault)
+          // loader will handle the case when component is error
+          .catch(err => err)
+      )
+    }
     super(loadComponent, matchPaths)
 
     const socket = getSocket()

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -213,11 +213,14 @@ export class BaseLoader {
     if (this.pageDb.has(pagePath)) {
       const page = this.pageDb.get(pagePath)
       if (process.env.BUILD_STAGE !== `develop` || !page.payload.stale) {
-        return Promise.resolve({
-          error: page.error,
-          status: page.status,
-          ...page.payload,
-        })
+        if (page.error) {
+          return {
+            error: page.error,
+            status: page.status,
+          }
+        }
+
+        return Promise.resolve(page.payload)
       }
     }
 
@@ -312,11 +315,14 @@ export class BaseLoader {
 
             this.pageDb.set(pagePath, finalResult)
 
-            return {
-              error: finalResult.error,
-              status: finalResult.status,
-              ...payload,
+            if (finalResult.error) {
+              return {
+                error: finalResult.error,
+                status: finalResult.status,
+              }
             }
+
+            return payload
           })
           // when static-query fail to load we throw a better error
           .catch(err => {

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -213,7 +213,11 @@ export class BaseLoader {
     if (this.pageDb.has(pagePath)) {
       const page = this.pageDb.get(pagePath)
       if (process.env.BUILD_STAGE !== `develop` || !page.payload.stale) {
-        return Promise.resolve(page.payload)
+        return Promise.resolve({
+          error: page.error,
+          status: page.status,
+          ...page.payload,
+        })
       }
     }
 
@@ -241,8 +245,9 @@ export class BaseLoader {
         component => {
           finalResult.createdAt = new Date()
           let pageResources
-          if (!component) {
+          if (!component || component instanceof Error) {
             finalResult.status = PageResourceStatus.Error
+            finalResult.error = component
           } else {
             finalResult.status = PageResourceStatus.Success
             if (result.notFound === true) {
@@ -270,10 +275,16 @@ export class BaseLoader {
 
           return this.memoizedGet(
             `${__PATH_PREFIX__}/page-data/sq/d/${staticQueryHash}.json`
-          ).then(req => {
-            const jsonPayload = JSON.parse(req.responseText)
-            return { staticQueryHash, jsonPayload }
-          })
+          )
+            .then(req => {
+              const jsonPayload = JSON.parse(req.responseText)
+              return { staticQueryHash, jsonPayload }
+            })
+            .catch(() => {
+              throw new Error(
+                `We couldn't load "${__PATH_PREFIX__}/page-data/sq/d/${staticQueryHash}.json"`
+              )
+            })
         })
       ).then(staticQueryResults => {
         const staticQueryResultsMap = {}
@@ -286,27 +297,39 @@ export class BaseLoader {
         return staticQueryResultsMap
       })
 
-      return Promise.all([componentChunkPromise, staticQueryBatchPromise]).then(
-        ([pageResources, staticQueryResults]) => {
-          let payload
-          if (pageResources) {
-            payload = { ...pageResources, staticQueryResults }
-            finalResult.payload = payload
-            emitter.emit(`onPostLoadPageResources`, {
-              page: payload,
-              pageResources: payload,
-            })
-          }
+      return (
+        Promise.all([componentChunkPromise, staticQueryBatchPromise])
+          .then(([pageResources, staticQueryResults]) => {
+            let payload
+            if (pageResources) {
+              payload = { ...pageResources, staticQueryResults }
+              finalResult.payload = payload
+              emitter.emit(`onPostLoadPageResources`, {
+                page: payload,
+                pageResources: payload,
+              })
+            }
 
-          this.pageDb.set(pagePath, finalResult)
+            this.pageDb.set(pagePath, finalResult)
 
-          return payload
-        }
+            return {
+              error: finalResult.error,
+              status: finalResult.status,
+              ...payload,
+            }
+          })
+          // when static-query fail to load we throw a better error
+          .catch(err => {
+            return {
+              error: err,
+              status: PageResourceStatus.Error,
+            }
+          })
       )
     })
 
     inFlightPromise
-      .then(response => {
+      .then(() => {
         this.inFlightDb.delete(pagePath)
       })
       .catch(error => {
@@ -449,13 +472,20 @@ const createComponentUrls = componentChunkName =>
 
 export class ProdLoader extends BaseLoader {
   constructor(asyncRequires, matchPaths) {
-    const loadComponent = chunkName =>
-      asyncRequires.components[chunkName]
-        ? asyncRequires.components[chunkName]()
-            .then(preferDefault)
-            // loader will handle the case when component is null
-            .catch(() => null)
-        : Promise.resolve()
+    const loadComponent = chunkName => {
+      if (!asyncRequires.components[chunkName]) {
+        throw new Error(
+          `We couldn't find the correct component chunk with the name ${chunkName}`
+        )
+      }
+
+      return (
+        asyncRequires.components[chunkName]()
+          .then(preferDefault)
+          // loader will handle the case when component is error
+          .catch(err => err)
+      )
+    }
 
     super(loadComponent, matchPaths)
   }

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -152,9 +152,16 @@ apiRunnerAsync(`onClientEntry`).then(() => {
 
   publicLoader.loadPage(browserLoc.pathname).then(page => {
     if (!page || page.status === PageResourceStatus.Error) {
-      throw new Error(
-        `page resources for ${browserLoc.pathname} not found. Not rendering React`
-      )
+      const message = `page resources for ${browserLoc.pathname} not found. Not rendering React`
+
+      // if the chunk throws an error we want to capture the real error
+      // This should help with https://github.com/gatsbyjs/gatsby/issues/19618
+      if (page && page.error) {
+        console.error(message)
+        throw page.error
+      }
+
+      throw new Error(message)
     }
 
     window.___webpackCompilationHash = page.page.webpackCompilationHash


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adding some better error messages in our runtime code so people can actually see what's going wrong in their error trackers.
It should help us solve https://github.com/gatsbyjs/gatsby/issues/19618

When you have a runtime error in your page component before React kicks in
```js
if (typeof window === 'undefined') {
  throw new Error('GATSBY');
}

export default function MyPage(){}
```
![image](https://user-images.githubusercontent.com/1120926/109872417-afa3ec80-7c6c-11eb-83dc-1d061fd4cd97.png)


When Static Query fails we got an unexpected JSON error, now we get:
![image](https://user-images.githubusercontent.com/1120926/109872148-520fa000-7c6c-11eb-90a6-7cb5f30a7c3f.png)

When Page Query fails, it's still the same:
![image](https://user-images.githubusercontent.com/1120926/109872207-65bb0680-7c6c-11eb-80f8-466cf46b4c40.png)


## Related Issues

Related to https://github.com/gatsbyjs/gatsby/issues/19618