### PR TITLE
docs: clarify env variable prefix in gatsby-source-filesystem docs

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -341,6 +341,6 @@ module.exports = createMySqlNodes
 
 In case that due to spotty network, or slow connection, some remote files fail to download. Even after multiple retries and adjusting concurrent downloads, you can adjust timeout and retry settings with these environment variables:
 
-- `STALL_RETRY_LIMIT`, default: `3`
-- `STALL_TIMEOUT`, default: `30000`
-- `CONNECTION_TIMEOUT`, default: `30000`
+- `GATSBY_STALL_RETRY_LIMIT`, default: `3`
+- `GATSBY_STALL_TIMEOUT`, default: `30000`
+- `GATSBY_CONNECTION_TIMEOUT`, default: `30000`


### PR DESCRIPTION
## Description

This PR updates the docs to clarify that `STALL_RETRY_LIMIT`, `STALL_TIMEOUT`, and `CONNECTION_TIMEOUT` need the `GATSBY_` prefix when set as env variables. This also makes it consistent with earlier in the doc where `GATSBY_CONCURRENT_DOWNLOAD` is referenced.