### PR TITLE
feat(gatsby-source-wordpress): Add WP_GATSBY_PREVIEW_DEBUG env var to enable preview debug mode

### DIFF
--- a/packages/gatsby-source-wordpress/docs/debugging-and-troubleshooting.md
+++ b/packages/gatsby-source-wordpress/docs/debugging-and-troubleshooting.md
@@ -176,7 +176,7 @@ If post revisions are enabled on your site and previews are still not working, p
 
 ## Preview debug mode
 
-You can enable Preview debug mode to help you debug issues with the Gatsby Preview build process. Visit the [plugin options page](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/plugin-options.md#debugpreview-boolean) to see how to enable this debug option. This option will log addition info to the terminal output including the contents of the webhook body that was sent to the Gatsby process, a list of the Preview change events Gatsby receives, as well as the node Preview data that was sourced during the Preview.
+You can enable Preview debug mode to help you debug issues with the Gatsby Preview build process. Visit the [plugin options page](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/plugin-options.md#debugpreview-boolean) to see how to enable this debug option or enable this option by setting the env variable `WP_GATSBY_PREVIEW_DEBUG`. This option will log addition info to the terminal output including the contents of the webhook body that was sent to the Gatsby process, a list of the Preview change events Gatsby receives, as well as the node Preview data that was sourced during the Preview.
 
 # Up Next :point_right:
 

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -307,8 +307,11 @@ export const sourcePreviews = async (
   pluginOptions: IPluginOptions
 ): Promise<void> => {
   const {
-    debug: { preview: inPreviewDebugMode },
+    debug: { preview: inPreviewDebugModeOption },
   } = getPluginOptions()
+
+  const inPreviewDebugMode =
+    inPreviewDebugModeOption || process.env.WP_GATSBY_PREVIEW_DEBUG
 
   if (inPreviewDebugMode) {
     reporter.info(`Sourcing previews for the following webhook:`)


### PR DESCRIPTION
To make debugging preview on Cloud a bit easier, I've added an env var to enable preview debug mode for WP (`WP_GATSBY_PREVIEW_DEBUG`).