### PR TITLE
feat(gatsby): Add darkmode support to Fast Refresh overlay

### DIFF
--- a/packages/gatsby/cache-dir/.eslintrc.json
+++ b/packages/gatsby/cache-dir/.eslintrc.json
@@ -5,5 +5,10 @@
   "globals": {
     "__PATH_PREFIX__": false,
     "___emitter": false
+  },
+  "parserOptions": {
+    "babelOptions": {
+      "configFile": "../../../.babelrc.js"
+    }
   }
 }

--- a/packages/gatsby/cache-dir/.eslintrc.json
+++ b/packages/gatsby/cache-dir/.eslintrc.json
@@ -5,10 +5,5 @@
   "globals": {
     "__PATH_PREFIX__": false,
     "___emitter": false
-  },
-  "parserOptions": {
-    "babelOptions": {
-      "configFile": "../../../.babelrc.js"
-    }
   }
 }

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/style.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/style.js
@@ -66,7 +66,6 @@ export const Style = () => (
           height: 100%;
           width: 100%;
           backdrop-filter: blur(10px);
-          cursor: not-allowed;
           z-index: var(--z-index-backdrop);
         }
 
@@ -318,6 +317,7 @@ export const Style = () => (
           padding: 1em 0;
           cursor: pointer;
           appearance: none;
+          user-select: text;
         }
 
         [data-gatsby-overlay="accordion__item__heading"] svg {

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/style.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/style.js
@@ -192,6 +192,8 @@ export const Style = () => (
         }
 
         [data-gatsby-overlay="header__open-in-editor"] {
+          --ring-opacity: 0.9;
+          --ring-color: rgba(54, 32, 102, var(--ring-opacity));
           align-items: center;
           border-radius: var(--radii);
           justify-content: center;
@@ -407,7 +409,8 @@ export const Style = () => (
             --ring-color: rgba(217, 186, 232, var(--ring-opacity));
           }
 
-          [data-gatsby-overlay="header__close-button"] {
+          [data-gatsby-overlay="header__close-button"],
+          [data-gatsby-overlay="header__open-in-editor"] {
             --ring-color: rgba(177, 122, 204, var(--ring-opacity));
           }
         }

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/style.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/style.js
@@ -15,7 +15,6 @@ export const Style = () => (
         :host {
           --color-ansi-selection: rgba(95, 126, 151, 0.48);
           --color-ansi-bg: #fafafa;
-          --color-ansi-bg-darker: #eeeeee;
           --color-ansi-fg: #545454;
           --color-ansi-white: #969896;
           --color-ansi-black: #141414;
@@ -36,12 +35,13 @@ export const Style = () => (
           --importantLight: #ffffff;
           --importantDark: #000000;
           --backdrop: rgba(72, 67, 79, 0.5);
-          --color: rgb(69, 74, 83);
+          --color: #454a53;
           --background: var(--color-ansi-bright-white);
           --primary: #663399;
           --primaryLight: #9158ca;
           --link: var(--primary);
-          --dimmedBg: rgba(255, 255, 255, 0.8);
+          --line: #e0e0e0;
+          --colorHeader: rgba(255, 255, 255, 0.8);
           --codeFrame-bg: #eeeeee;
           --codeFrame-color: #414141;
           --codeFrame-button-bg: white;
@@ -51,6 +51,9 @@ export const Style = () => (
           --space: 1.5em;
           --space-sm: 1em;
           --space-lg: 2.5em;
+          --rootBoxShadowOpacity: 0.08;
+          --ring-opacity: 0.65;
+          --ring-color: rgba(138, 75, 175, var(--ring-opacity));
         }
 
         [data-gatsby-overlay="backdrop"] {
@@ -81,8 +84,9 @@ export const Style = () => (
           top: 50%;
           left: 50%;
           transform: translateX(-50%) translateY(-50%);
-          box-shadow: rgba(46, 41, 51, 0.08) 0px 7px 19px 11px,
-            rgba(71, 63, 79, 0.08) 0px 2px 4px;
+          box-shadow: rgba(46, 41, 51, var(--rootBoxShadowOpacity)) 0px 7px 19px
+              11px,
+            rgba(71, 63, 79, var(--rootBoxShadowOpacity)) 0px 2px 4px;
           border-radius: var(--radii);
           display: inline-flex;
           flex-direction: column;
@@ -93,6 +97,14 @@ export const Style = () => (
           color: var(--link);
           text-decoration: none;
           font-weight: 500;
+          padding: 0.25em;
+          border-radius: 4px;
+        }
+
+        [data-gatsby-overlay="root"] button:focus,
+        [data-gatsby-overlay="root"] a:focus {
+          outline: 4px solid transparent;
+          box-shadow: 0 0 0 4px var(--ring-color);
         }
 
         [data-gatsby-overlay="root"] a:hover {
@@ -103,7 +115,7 @@ export const Style = () => (
           display: grid;
           grid-gap: var(--space-sm);
           grid-template-columns: 1fr auto;
-          color: var(--dimmedBg);
+          color: var(--colorHeader);
           background: var(--primary);
           padding: var(--space);
           border-top-left-radius: var(--radii);
@@ -216,7 +228,7 @@ export const Style = () => (
           background: var(--codeFrame-button-bg);
           font-size: 0.9em;
           min-width: 2em;
-          padding: 0.25em 0.75em;
+          padding: 0.35em 0.75em;
           appearance: none;
           margin-right: var(--space-sm);
         }
@@ -229,6 +241,8 @@ export const Style = () => (
         }
 
         [data-gatsby-overlay="header__close-button"] {
+          --ring-opacity: 0.9;
+          --ring-color: rgba(54, 32, 102, var(--ring-opacity));
           cursor: pointer;
           border: 0;
           padding: 0;
@@ -280,7 +294,7 @@ export const Style = () => (
         [data-gatsby-overlay="accordion__item"] {
           overflow: visible;
           box-sizing: border-box;
-          border-top: 1px solid #e0e0e0;
+          border-top: 1px solid var(--line);
           transition: all 110ms cubic-bezier(0.2, 0, 0.38, 0.9);
           margin: 0;
           padding: 0;
@@ -309,6 +323,7 @@ export const Style = () => (
           width: 1em;
           height: 1em;
           margin: 2px 1em 0 0;
+          color: var(--importantDark);
         }
 
         [data-gatsby-overlay="accordion__item__title"] {
@@ -354,6 +369,46 @@ export const Style = () => (
           [data-gatsby-overlay="header"],
           [data-gatsby-error-type="build-error"][data-gatsby-overlay="header"] {
             grid-template-columns: 1fr auto;
+          }
+        }
+
+        @media (prefers-color-scheme: dark) {
+          :host {
+            --color-ansi-bg: #2b2b2b;
+            --color-ansi-fg: #d1d5db;
+            --color-ansi-white: #ffffff;
+            --color-ansi-black: #d4d0ab;
+            --color-ansi-blue: #4791ff;
+            --color-ansi-cyan: #00e0e0;
+            --color-ansi-green: #abe338;
+            --color-ansi-magenta: #dcc6e0;
+            --color-ansi-red: #ffa07a;
+            --color-ansi-yellow: #ffd700;
+            --color-ansi-bright-white: #ffffff;
+            --color-ansi-bright-black: #d4d0ab;
+            --color-ansi-bright-blue: #4791ff;
+            --color-ansi-bright-cyan: #00e0e0;
+            --color-ansi-bright-green: #abe338;
+            --color-ansi-bright-magenta: #dcc6e0;
+            --color-ansi-bright-red: #ffa07a;
+            --color-ansi-bright-yellow: #ffd700;
+            --importantDark: white;
+            --backdrop: rgba(48, 48, 50, 0.75);
+            --color: #d1d5db;
+            --link: #d9bae8;
+            --background: #232129;
+            --primary: #452475;
+            --primaryLight: #663399;
+            --line: #464647;
+            --codeFrame-bg: #18171d;
+            --codeFrame-color: #d1d5db;
+            --codeFrame-button-bg: #232129;
+            --rootBoxShadowOpacity: 0.15;
+            --ring-color: rgba(217, 186, 232, var(--ring-opacity));
+          }
+
+          [data-gatsby-overlay="header__close-button"] {
+            --ring-color: rgba(177, 122, 204, var(--ring-opacity));
           }
         }
       `,


### PR DESCRIPTION
## Description

Adds darkmode support to the Fast Refresh overlay.

I also improved the focus style as until now it showed the default browser outline (in Chrome a black border), added a bit of padding to `a` (to have a larger click area if on mobile).

Both the already existing light syntax highlighting theme + now the new dark one is from https://github.com/ericwbailey/a11y-syntax-highlighting/tree/main/dist/highlight to have an accessible theme 👍 

### Videos

Video of an error with the Accordion and a link:

https://user-images.githubusercontent.com/16143594/110101058-6d30fb80-7da3-11eb-9dd6-8075b3674b56.mp4

Video of an error with some proper syntax highlighting show-off:

https://user-images.githubusercontent.com/16143594/110101148-8174f880-7da3-11eb-97db-df664b0f8c80.mp4

## Related Issues

[ch26074]
