### PR TITLE
chore(docs): Remove duplicate "releases & migration" doc

### DIFF
--- a/docs/docs/releases-and-migration.md
+++ b/docs/docs/releases-and-migration.md
@@ -1,7 +1,0 @@
----
-title: Releases & Migration
----
-
-Find release notes and guides on how to upgrade Gatsby along with third-party packages.
-
-<GuideList slug={props.slug} />


### PR DESCRIPTION
## Description

We have https://www.gatsbyjs.com/docs/reference/release-notes/ now so we don't need this doc anymore.
Should be merged with mansion PR.

## Related Issues

[ch26376]
