### PR TITLE
fix(gatsyby): improve error messages for errors outside of react"

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/ensure-resources.tsx
+++ b/packages/gatsby/cache-dir/__tests__/ensure-resources.tsx
@@ -4,6 +4,9 @@ import { render, getNodeText, cleanup } from "@testing-library/react"
 
 jest.mock(`../loader`, () => {
   return {
+    PageResourceStatus: {
+      Error: `error`,
+    },
     loadPageSync(path: string): { loadPageSync: boolean; path: string } {
       return { loadPageSync: true, path }
     },

--- a/packages/gatsby/cache-dir/ensure-resources.js
+++ b/packages/gatsby/cache-dir/ensure-resources.js
@@ -8,13 +8,17 @@ class EnsureResources extends React.Component {
     const { location, pageResources } = props
     this.state = {
       location: { ...location },
-      pageResources: pageResources || loader.loadPageSync(location.pathname),
+      pageResources:
+        pageResources ||
+        loader.loadPageSync(location.pathname, { withErrorDetails: true }),
     }
   }
 
   static getDerivedStateFromProps({ location }, prevState) {
     if (prevState.location.href !== location.href) {
-      const pageResources = loader.loadPageSync(location.pathname)
+      const pageResources = loader.loadPageSync(location.pathname, {
+        withErrorDetails: true,
+      })
 
       return {
         pageResources,

--- a/packages/gatsby/cache-dir/ensure-resources.js
+++ b/packages/gatsby/cache-dir/ensure-resources.js
@@ -15,6 +15,7 @@ class EnsureResources extends React.Component {
   static getDerivedStateFromProps({ location }, prevState) {
     if (prevState.location.href !== location.href) {
       const pageResources = loader.loadPageSync(location.pathname)
+
       return {
         pageResources,
         location: { ...location },
@@ -82,12 +83,20 @@ class EnsureResources extends React.Component {
   }
 
   render() {
-    if (process.env.NODE_ENV !== `production` && !this.state.pageResources) {
-      throw new Error(
-        `EnsureResources was not able to find resources for path: "${this.props.location.pathname}"
+    if (
+      process.env.NODE_ENV !== `production` &&
+      (!this.state.pageResources ||
+        this.state.pageResources.status === PageResourceStatus.Error)
+    ) {
+      const message = `EnsureResources was not able to find resources for path: "${this.props.location.pathname}"
 This typically means that an issue occurred building components for that path.
 Run \`gatsby clean\` to remove any cached elements.`
-      )
+      if (this.state.pageResources?.error) {
+        console.error(message)
+        throw this.state.pageResources.error
+      }
+
+      throw new Error(message)
     }
 
     return this.props.children(this.state)

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -556,7 +556,7 @@ export const publicLoader = {
   getResourceURLsForPathname: rawPath =>
     instance.getResourceURLsForPathname(rawPath),
   loadPage: rawPath => instance.loadPage(rawPath),
-  // TODO add deprecation to v4 so people use withErrorDetails and than we can remove in v5 and change default behviour
+  // TODO add deprecation to v4 so people use withErrorDetails and then we can remove in v5 and change default behaviour
   loadPageSync: (rawPath, options = {}) =>
     instance.loadPageSync(rawPath, options),
   prefetch: rawPath => instance.prefetch(rawPath),

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -349,7 +349,7 @@ export class BaseLoader {
   }
 
   // returns undefined if the page does not exists in cache
-  loadPageSync(rawPath) {
+  loadPageSync(rawPath, options = {}) {
     const pagePath = findPath(rawPath)
     if (this.pageDb.has(pagePath)) {
       const pageData = this.pageDb.get(pagePath)
@@ -358,9 +358,11 @@ export class BaseLoader {
         return pageData.payload
       }
 
-      return {
-        error: pageData.error,
-        status: pageData.status,
+      if (options?.withErrorDetails) {
+        return {
+          error: pageData.error,
+          status: pageData.status,
+        }
       }
     }
     return undefined
@@ -554,7 +556,9 @@ export const publicLoader = {
   getResourceURLsForPathname: rawPath =>
     instance.getResourceURLsForPathname(rawPath),
   loadPage: rawPath => instance.loadPage(rawPath),
-  loadPageSync: rawPath => instance.loadPageSync(rawPath),
+  // TODO add deprecation to v4 so people use withErrorDetails and than we can remove in v5 and change default behviour
+  loadPageSync: (rawPath, options = {}) =>
+    instance.loadPageSync(rawPath, options),
   prefetch: rawPath => instance.prefetch(rawPath),
   isPageNotFound: rawPath => instance.isPageNotFound(rawPath),
   hovering: rawPath => instance.hovering(rawPath),

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -348,12 +348,20 @@ export class BaseLoader {
     return inFlightPromise
   }
 
-  // returns undefined if loading page ran into errors
+  // returns undefined if the page does not exists in cache
   loadPageSync(rawPath) {
     const pagePath = findPath(rawPath)
     if (this.pageDb.has(pagePath)) {
-      const pageData = this.pageDb.get(pagePath).payload
-      return pageData
+      const pageData = this.pageDb.get(pagePath)
+
+      if (pageData.payload) {
+        return pageData.payload
+      }
+
+      return {
+        error: pageData.error,
+        status: pageData.status,
+      }
     }
     return undefined
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Updated the correct error message in develop so people know where to look

Before:
![image](https://user-images.githubusercontent.com/1120926/110111656-f995eb00-7db0-11eb-9a88-9484f927bf60.png)


After:
![image](https://user-images.githubusercontent.com/1120926/110111666-fe5a9f00-7db0-11eb-8d2a-d9a7f2709f24.png)


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/30046

[ch26500]