### PR TITLE
chore(gatsby-plugin-postcss): Update README to show correct usage

### DIFF
--- a/packages/gatsby-plugin-postcss/README.md
+++ b/packages/gatsby-plugin-postcss/README.md
@@ -16,7 +16,7 @@ Gatsby plugin to handle PostCSS.
 plugins: [`gatsby-plugin-postcss`],
 ```
 
-If you need to pass options to PostCSS use the plugins options; see [postcss-loader](https://github.com/postcss/postcss-loader) for all available options.
+If you need to pass options to PostCSS use the plugins options; see [`postcss-loader`](https://github.com/postcss/postcss-loader) for all available options.
 
 ### With CSS Modules
 
@@ -56,7 +56,7 @@ module.exports = () => ({
 
 If you need to override the default options passed into [`css-loader`](https://github.com/webpack-contrib/css-loader).
 
-In this example css-loader is configured to output classnames as is, instead of converting them to camel case (previously controlled by the `camelCase` option). Named exports must be disabled for this to work, and so you have to import css using `import css from './file.css` instead of `import * as css from './file.module.css'`
+In this example `css-loader` is configured to output classnames as is, instead of converting them to camel case. Named exports must be disabled for this to work, and so you have to import CSS using `import styles from './file.css` instead of `import * as styles from './file.module.css'`
 
 ```javascript
 // in gatsby-config.js

--- a/packages/gatsby-plugin-postcss/README.md
+++ b/packages/gatsby-plugin-postcss/README.md
@@ -54,8 +54,9 @@ module.exports = () => ({
 })
 ```
 
-If you need to override the default options passed into [`css-loader`](https://github.com/webpack-contrib/css-loader/tree/version-1)
-**Note:** Gatsby is using `css-loader@1.0.1`.
+If you need to override the default options passed into [`css-loader`](https://github.com/webpack-contrib/css-loader).
+
+In this example css-loader is configured to output classnames as is, instead of converting them to camel case (previously controlled by the `camelCase` option). Named exports must be disabled for this to work, and so you have to import css using `import css from './file.css` instead of `import * as css from './file.module.css'`
 
 ```javascript
 // in gatsby-config.js
@@ -64,7 +65,8 @@ plugins: [
     resolve: `gatsby-plugin-postcss`,
     options: {
       cssLoaderOptions: {
-        camelCase: false,
+        exportLocalsConvention: false,
+        namedExport: false,
       },
     },
   },


### PR DESCRIPTION
## Description

The example given in the README for the postcss plugin uses syntax from css-loader version 1. Gatsby is now using version 5 and the API for setting the camelCase option has gone through two revisions. I have amended the example to be functionally identical, while actually working with the latest version of Gatsby.

I added a bit of text describing what else needs to change for the option to be applied, as this took me some time to debug and figure out myself.

### Documentation

The updated usage comes straight out of css-loader's README: https://github.com/webpack-contrib/css-loader#exportlocalsconvention

## Related Issues

I was not able to find any related issues.