### PR TITLE
chore(docs): Add link to art direction docs

### DIFF
--- a/docs/docs/reference/release-notes/image-migration-guide.md
+++ b/docs/docs/reference/release-notes/image-migration-guide.md
@@ -118,7 +118,7 @@ Due to the changes to `gatsby-plugin-image`, there is some functionality that is
 
 1. `GatsbyImage` is no longer a class component and therefore cannot be extended. You can use [composition](https://reactjs.org/docs/composition-vs-inheritance.html) instead.
 2. `fluid` images no longer exist, and the `fullWidth` replacement does not take `maxWidth` or `maxHeight`.
-3. The art direction API has changed, See the [`gatsby-plugin-image` Reference Guide](/docs/reference/built-in-components/gatsby-plugin-image#withartdirection) for specifics.
+3. The art direction API has changed, see the [`gatsby-plugin-image` reference guide](/docs/reference/built-in-components/gatsby-plugin-image#withartdirection) for specifics.
 4. The component no longer takes a decomposed object, and the following code is not valid. You should avoid accessing or changing the contents of the `gatsbyImageData` object, as it is not considered to be a public API, so can be changed without notice.
 
    ```javascript

--- a/docs/docs/reference/release-notes/image-migration-guide.md
+++ b/docs/docs/reference/release-notes/image-migration-guide.md
@@ -118,7 +118,7 @@ Due to the changes to `gatsby-plugin-image`, there is some functionality that is
 
 1. `GatsbyImage` is no longer a class component and therefore cannot be extended. You can use [composition](https://reactjs.org/docs/composition-vs-inheritance.html) instead.
 2. `fluid` images no longer exist, and the `fullWidth` replacement does not take `maxWidth` or `maxHeight`.
-3. Art direction is no longer supported.
+3. The art direction API has changed, See the [`gatsby-plugin-image` Reference Guide](/docs/reference/built-in-components/gatsby-plugin-image#withartdirection) for specifics.
 4. The component no longer takes a decomposed object, and the following code is not valid. You should avoid accessing or changing the contents of the `gatsbyImageData` object, as it is not considered to be a public API, so can be changed without notice.
 
    ```javascript


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Documentation change:
Previously this guide suggested that art direction was no longer supported.
This change adds a link to the reference docs where the new API is explained. 

### Documentation
As above
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
n/a
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
