### PR TITLE
fix(gatsby-plugin-image): broken documentation links

### DIFF
--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -101,7 +101,7 @@ If you are using an image that will be the same each time the component is used,
 
 #### Restrictions on using `StaticImage`
 
-There are a few technical restrictions to the way you can pass props into `StaticImage`. Most importantly, you can't use any of the parent component's props. For more information, refer to the [Gatsby Image plugin reference guide](/docs/reference/built-in-components/gatsby-plugin-image#restrictions-on-using-staticimage). If you find yourself wishing you could use a prop passed from a parent for the image `src` then it's likely that you should be using a dynamic image.
+There are a few technical restrictions to the way you can pass props into `StaticImage`. Most importantly, you can't use any of the parent component's props. For more information, refer to the [Gatsby Image plugin reference guide](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/#restrictions-on-using-staticimage). If you find yourself wishing you could use a prop passed from a parent for the image `src` then it's likely that you should be using a dynamic image.
 
 ### Dynamic images
 
@@ -127,7 +127,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
 
 2. **Configure your image.**
 
-   For all the configuration options, see the [Gatsby Image plugin reference guide](/docs/reference/built-in-components/gatsby-plugin-image).
+   For all the configuration options, see the [Gatsby Image plugin reference guide](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/).
 
    You configure the image by passing arguments to the `gatsbyImageData` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
 


### PR DESCRIPTION
## Description

Fixed two broken documentation links in the Gatsby Plugin Image readme.

The first broken link can be found in this [section](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-image#restrictions-on-using-staticimage). The link was pointing towards this [relative path](https://github.com/gatsbyjs/gatsby/blob/master/docs/reference/built-in-components/gatsby-plugin-image#restrictions-on-using-staticimage) which returned a 404. The updated link in this PR now points to the [correct URL](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/#restrictions-on-using-staticimage).

The second broken link can be found in this [section](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-image#dynamic-images). The link was pointing towards this [relative path](https://github.com/gatsbyjs/gatsby/blob/master/docs/reference/built-in-components/gatsby-plugin-image) which returned a 404. The updated link in this PR now points to the [correct URL](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/).

### Documentation

See [Gatby Plugin Image](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-image) docs
