### PR TITLE
Update debugging-the-build-process.md

### DIFF
--- a/docs/docs/debugging-the-build-process.md
+++ b/docs/docs/debugging-the-build-process.md
@@ -70,7 +70,7 @@ If you use VS Code and its integrated terminal, you can configure it to automati
 1. Press `Ctrl + ,` or `⌘ + ,` to open your preferences. Type `node debug` into the search bar. Make sure the `Auto Attach` option is set to `on`.
    ![Search for on debug and set attach to enable](./images/set-node-attach-to-on.png)
 
-2. Using VS Code's integrated terminal run `node --nolazy node_modules/.bin/gatsby develop --inspect-brk` instead of `gatsby develop` or `node --nolazy --inspect-brk node_modules/.bin/gatsby build` instead of `gatsby build`
+2. Using VS Code's integrated terminal run `node --nolazy --inspect-brk node_modules/.bin/gatsby develop` instead of `gatsby develop` or `node --nolazy --inspect-brk node_modules/.bin/gatsby build` instead of `gatsby build`
 
 3. Set breakpoints and debug!
 
@@ -159,7 +159,7 @@ After putting a breakpoint in `gatsby-node.js` and using the `Start debugging` c
 In your project directory instead of running `npm run develop` run the following command:
 
 ```shell
-node --no-lazy node_modules/.bin/gatsby develop --inspect-brk
+node --no-lazy --inspect-brk node_modules/.bin/gatsby develop 
 ```
 
 - `--inspect-brk` will enable Node's inspector agent which will allow you to connect a debugger. It will also pause execution until the debugger is connected and then wait for you to resume it.


### PR DESCRIPTION
The `--inspect-brk` flag was not being applied to the `node` process. As such, the debugger would not pause when the command was being executed

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Documentation fix with debugging.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
