### PR TITLE
chore: adjust npm release dist tag for v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "publish-preminor": "node scripts/clear-package-dir preminor --verbose && lerna publish preminor --pre-dist-tag=next --preid=next --force-publish --allow-branch=master --message=\"chore(release): Publish next pre-minor\"",
     "publish-next": "node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=next --preid=next --allow-branch=master --message=\"chore(release): Publish next\"",
     "publish-rc": "node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=rc --preid=rc --message=\"chore(release): Publish rc\"",
-    "publish-release": "node scripts/clear-package-dir patch --verbose && lerna publish patch",
+    "publish-release": "node scripts/clear-package-dir patch --verbose && lerna publish patch --dist-tag=latest-v2",
     "test": "npm-run-all -s lint jest test:peril",
     "test:coverage": "jest --coverage",
     "test:update": "jest --updateSnapshot",


### PR DESCRIPTION
## Description

V3 is out and this should be latest, but we still will be releasing patches for v2 so those stable releases should not be tagged as `latest`