### PR TITLE
fix(gatsby): Fix broken reporter call

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -234,7 +234,7 @@ function extendLocalReporterToCatchPluginErrors({
     panicOnBuild,
     activityTimer: (...args) => {
       // eslint-disable-next-line prefer-spread
-      const activity = reporter.activityTimer(reporter, args)
+      const activity = reporter.activityTimer.apply(reporter, args)
 
       const originalStart = activity.start
       const originalEnd = activity.end


### PR DESCRIPTION
Fix a broken call to `reporter.activityTimer`