### PR TITLE
Update rfc-process.md

### DIFF
--- a/docs/contributing/rfc-process.md
+++ b/docs/contributing/rfc-process.md
@@ -13,7 +13,7 @@ a bit of a design process and produce a consensus among the Gatsby core team.
 The "RFC" (request for comments) process is intended to provide a consistent
 and controlled path for new features to enter the project.
 
-[Active RFC List](https://github.com/gatsbyjs/gatsby/pulls?q=is%3Aopen+is%3Apr+label%3A%22type%3A+rfc%22)
+[Active RFC List](https://github.com/gatsbyjs/rfcs/tree/master/text)
 
 Gatsby is still **actively developing** this process, and it will still change
 as more features are implemented and the community settles on specific


### PR DESCRIPTION
The Link was pointing to the old repo. The RFCs now have their own repo. I updated the link to point to the text folder where the current RFCs are stored.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
