### PR TITLE
fix(gatsby-source-contentful): Set image source format

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -720,12 +720,18 @@ exports.extendNodeType = ({ type, store }) => {
   const resolveGatsbyImageData = async (image, options) => {
     if (!isImage(image)) return null
 
-    const { baseUrl, ...sourceMetadata } = getBasicImageProps(image, options)
-
+    const { baseUrl, contentType, width, height } = getBasicImageProps(
+      image,
+      options
+    )
+    let [, format] = contentType.split(`/`)
+    if (format === `jpeg`) {
+      format = `jpg`
+    }
     const imageProps = generateImageData({
       ...options,
       pluginName: `gatsby-source-contentful`,
-      sourceMetadata,
+      sourceMetadata: { width, height, format },
       filename: baseUrl,
       generateImageSource,
       fit: fitMap.get(options.resizingBehavior),


### PR DESCRIPTION
When generating image data, use the source image format coming from Contentful, rather than making the plugin helper infer it from the file extention. Fixes #30069