### PR TITLE
feat: retry 3 times when remote file node creation fails

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -57,6 +57,8 @@ const queue = new Queue(pushToQueue, {
   id: `url`,
   merge: (old, _, cb) => cb(old),
   concurrent: process.env.GATSBY_CONCURRENT_DOWNLOAD || 200,
+  maxRetries: 3,
+  retryDelay: 1000,
 })
 
 /**


### PR DESCRIPTION
Users with huge website projects that use the `downloadLocal` feature of gatsby-source-contentful, report irregular broken builds due to network hickups.

As soon one asset fails downloading, the whole build process would fail. [It does not, as the relevant code just ignores the error instead of reporting it](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/src/download-contentful-assets.js#L97). That way builds do not fail, but have unreliable results as files might be there.. or not.


This (proposed) fix would allow us to merge https://github.com/gatsbyjs/gatsby/pull/24288/files and would increase the overall reliability of Gatsby.

I am very open to any fix that would allow downloading remote files even on shaky connections (or simply huge builds with thousands of assets)


Additionally this fix should be backported to v2.


Maybe relevant: In early GatsbyJS days, this function did retry (as far as I remember). But the retry feature got removed from `got` and never got reimplemented to Gatsby.