### PR TITLE
fix(gatsby): set program.verbose when VERBOSE env var is used

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -46,7 +46,10 @@ import {
 import { updateSiteMetadata, isTruthy } from "gatsby-core-utils"
 
 module.exports = async function build(program: IBuildArgs): Promise<void> {
-  report.setVerbose(isTruthy(process.env.VERBOSE) || program.verbose)
+  if (isTruthy(process.env.VERBOSE)) {
+    program.verbose = true
+  }
+  report.setVerbose(program.verbose)
 
   if (program.profile) {
     report.warn(

--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -80,7 +80,10 @@ const openDebuggerPort = (debugInfo: IDebugInfo): void => {
 }
 
 module.exports = async (program: IDevelopArgs): Promise<void> => {
-  reporter.setVerbose(isTruthy(process.env.VERBOSE) || program.verbose)
+  if (isTruthy(process.env.VERBOSE)) {
+    program.verbose = true
+  }
+  reporter.setVerbose(program.verbose)
 
   if (program.debugInfo) {
     openDebuggerPort(program.debugInfo)


### PR DESCRIPTION
## Description

Small adjustment for https://github.com/gatsbyjs/gatsby/pull/29708#pullrequestreview-607185166

Without this change we won't log state transition changes with `VERBOSE` env var: https://github.com/gatsbyjs/gatsby/pull/29708#pullrequestreview-607185166