### PR TITLE
fix(gatsby): don't ignore SOURCE_FILE_CHANGED event

### DIFF
--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -276,8 +276,6 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
         ADD_NODE_MUTATION: {
           actions: `callApi`,
         },
-        // Ignore, because we're about to extract them anyway
-        SOURCE_FILE_CHANGED: undefined,
       },
       invoke: {
         src: `reloadData`,


### PR DESCRIPTION
## Description

We are currently ignoring `SOURCE_FILE_CHANGED` event in `reloadingData` state. This seems to cause problems:

If we are in this state and we ignore that event, but 
https://github.com/gatsbyjs/gatsby/blob/a8f7101e1ff6f1b437c44d78bb9f3eafa81dc539/packages/gatsby/src/services/start-webpack-server.ts#L47-L55
will mark webpack recompilation to run but it won't (until something else potentially in the future trigger another recompilation).

This _might_ result in at least some runs getting stuck - `GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT` reporting things like:
```
Activity "Building development bundle" of type "pending" is currently in state "NOT_STARTED"
```

This might also be source of at least some of double save issues