### PR TITLE
chore(docs): set process polyfill correctly

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -469,12 +469,14 @@ If you're using any other process properties, you want to polyfill process.
 2. Configure webpack to use the process polyfill.
 
 ```diff:title=gatby-node.js
-exports.onCreateWebpackConfig = ({ actions }) => {
-  actions.setWebpackConfig({
-    plugins: [
-      new plugins.provide({ process: 'process/browser' })
-    ]
-  })
+exports.onCreateWebpackConfig = ({ actions, stage, plugins }) => {
+  if (stage === 'build-javascript' || stage === 'develop') {
+    actions.setWebpackConfig({
+      plugins: [
+        plugins.provide({ process: 'process/browser' })
+      ]
+    })
+  }
 }
 ```
 


### PR DESCRIPTION
The current for the `process/browser` polyfill are not correct:

- they are missing the argument declaration 
- `plugins.provide` is not a constructor but a functions
- the build will crash if you set the polyfill outside of the `build-javascript` or `develop` stage

I therefore updated the documentation accordingly