### PR TITLE
chore(docs): Update deploying-to-digitalocean-droplet

### DIFF
--- a/docs/docs/deploying-to-digitalocean-droplet.md
+++ b/docs/docs/deploying-to-digitalocean-droplet.md
@@ -30,7 +30,7 @@ Follow these instructions for installs on an Ubuntu droplet.
 
    ```shell
    sudo apt-get update
-   sudo apt-get install node
+   sudo apt-get install nodejs
    ```
 
 3. Install npm

--- a/docs/docs/deploying-to-digitalocean-droplet.md
+++ b/docs/docs/deploying-to-digitalocean-droplet.md
@@ -42,7 +42,7 @@ Follow these instructions for installs on an Ubuntu droplet.
    To view the version of Node.js and npm installed, run,
 
    ```shell
-   node -v
+   nodejs -v
    npm -v
    ```
 
@@ -57,7 +57,7 @@ Follow these instructions for installs on an Ubuntu droplet.
    > You can either exit and restart your terminal or refresh the cache by running the following commands:
 
    ```shell
-   hash node
+   hash nodejs
    hash npm
    ```
 


### PR DESCRIPTION
Related to: `Deploying to a DigitalOcean Droplet`
https://www.gatsbyjs.com/docs/deploying-to-digitalocean-droplet/

## Description

Changed `sudo apt-get install node` to `sudo apt-get nodejs`. I couldn't install `node` as `node`, I had to install it as `nodejs`. I've seen other online tutorials also install `node` using `nodejs`.

### Documentation

In the deployment guide to a DigitalOcean droplet (`deploying-to-digitalocean-droplet.md`). I'm not sure where else this issue exists (if at all)

## Related Issues

Didn't find any issues related to this.
