### PR TITLE
chore: Add Fast Refresh/Hot Reloading E2E tests

### DIFF
--- a/e2e-tests/development-runtime/.eslintrc
+++ b/e2e-tests/development-runtime/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "parserOptions": {
+    "babelOptions": {
+      "configFile": "../../.babelrc.js"
+    }
+  }
+}

--- a/e2e-tests/development-runtime/content/error-recovery/page-query.json
+++ b/e2e-tests/development-runtime/content/error-recovery/page-query.json
@@ -1,0 +1,4 @@
+{
+  "selector": "page-query",
+  "hasError": false
+}

--- a/e2e-tests/development-runtime/content/error-recovery/static-query.json
+++ b/e2e-tests/development-runtime/content/error-recovery/static-query.json
@@ -1,0 +1,4 @@
+{
+  "selector": "static-query",
+  "hasError": false
+}

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
@@ -24,8 +24,8 @@ describe(`testing error overlay and ability to automatically recover from webpac
       `npm run update -- --file src/pages/error-handling/compile-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    // cy.getOverlayIframe().contains(`Failed to compile`)
-    // cy.getOverlayIframe().contains(`Unexpected token, expected ";"`)
+    cy.getFastRefreshOverlay().find('#gatsby-overlay-labelledby').should('contain.text', 'Failed to compile')
+    cy.getFastRefreshOverlay().find('[data-gatsby-overlay="header__cause-file"] span').should('contain.text', './src/pages/error-handling/compile-error.js')
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -34,6 +34,6 @@ describe(`testing error overlay and ability to automatically recover from webpac
     )
 
     cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
-    // cy.assertNoOverlayIframe()
+    cy.assertNoFastRefreshOverlay()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
@@ -24,8 +24,22 @@ describe(`testing error overlay and ability to automatically recover from webpac
       `npm run update -- --file src/pages/error-handling/compile-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    cy.getFastRefreshOverlay().find('#gatsby-overlay-labelledby').should('contain.text', 'Failed to compile')
-    cy.getFastRefreshOverlay().find('[data-gatsby-overlay="header__cause-file"] span').should('contain.text', './src/pages/error-handling/compile-error.js')
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-labelledby`)
+      .should(`contain.text`, `Failed to compile`)
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-describedby`)
+      .should(
+        `contain.text`,
+        `This error occurred during the build process and can only be dismissed by fixing the error.`
+      )
+    cy.getFastRefreshOverlay()
+      .find(`[data-gatsby-overlay="header__cause-file"] span`)
+      .should(`contain.text`, `./src/pages/error-handling/compile-error.js`)
+    cy.getFastRefreshOverlay()
+      .find(`[data-gatsby-overlay="body"] h2`)
+      .should(`contain.text`, `Source`)
+    cy.getFastRefreshOverlay().find(`[data-gatsby-overlay="body"] pre`)
   })
 
   it(`can recover without need to refresh manually`, () => {

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
@@ -16,7 +16,7 @@ const errorReplacement = `a b`
 describe(`testing error overlay and ability to automatically recover from webpack compile errors`, () => {
   it(`displays content initially (no errors yet)`, () => {
     cy.visit(`/error-handling/compile-error/`).waitForRouteChange()
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Working`)
   })
 
   it(`displays error with overlay on compilation errors`, () => {
@@ -25,8 +25,7 @@ describe(`testing error overlay and ability to automatically recover from webpac
     )
 
     cy.getOverlayIframe().contains(`Failed to compile`)
-    cy.getOverlayIframe().contains(`Parsing error: Unexpected token`)
-    cy.screenshot()
+    cy.getOverlayIframe().contains(`Unexpected token, expected ";"`)
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -34,8 +33,7 @@ describe(`testing error overlay and ability to automatically recover from webpac
       `npm run update -- --file src/pages/error-handling/compile-error.js --replacements "Working:Updated" --replacements "${errorReplacement}:${errorPlaceholder}" --exact`
     )
 
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
     cy.assertNoOverlayIframe()
-    cy.screenshot()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
@@ -24,8 +24,8 @@ describe(`testing error overlay and ability to automatically recover from webpac
       `npm run update -- --file src/pages/error-handling/compile-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    cy.getOverlayIframe().contains(`Failed to compile`)
-    cy.getOverlayIframe().contains(`Unexpected token, expected ";"`)
+    // cy.getOverlayIframe().contains(`Failed to compile`)
+    // cy.getOverlayIframe().contains(`Unexpected token, expected ";"`)
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -34,6 +34,6 @@ describe(`testing error overlay and ability to automatically recover from webpac
     )
 
     cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
-    cy.assertNoOverlayIframe()
+    // cy.assertNoOverlayIframe()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/compile-error.js
@@ -1,0 +1,41 @@
+before(() => {
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/compile-error.js --restore`
+  )
+})
+
+after(() => {
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/compile-error.js --restore`
+  )
+})
+
+const errorPlaceholder = `// compile-error`
+const errorReplacement = `a b`
+
+describe(`testing error overlay and ability to automatically recover from webpack compile errors`, () => {
+  it(`displays content initially (no errors yet)`, () => {
+    cy.visit(`/error-handling/compile-error/`).waitForRouteChange()
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
+  })
+
+  it(`displays error with overlay on compilation errors`, () => {
+    cy.exec(
+      `npm run update -- --file src/pages/error-handling/compile-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
+    )
+
+    cy.getOverlayIframe().contains(`Failed to compile`)
+    cy.getOverlayIframe().contains(`Parsing error: Unexpected token`)
+    cy.screenshot()
+  })
+
+  it(`can recover without need to refresh manually`, () => {
+    cy.exec(
+      `npm run update -- --file src/pages/error-handling/compile-error.js --replacements "Working:Updated" --replacements "${errorReplacement}:${errorPlaceholder}" --exact`
+    )
+
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
+    cy.assertNoOverlayIframe()
+    cy.screenshot()
+  })
+})

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
@@ -1,0 +1,69 @@
+Cypress.on("uncaught:exception", (err, runnable) => {
+  // returning false here prevents Cypress from
+  // failing the test
+  return false
+})
+
+before(() => {
+  cy.exec(
+    `npm run update -- --file content/error-recovery/page-query.json --restore`
+  )
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/page-query-result-runtime-error.js --restore`
+  )
+})
+
+after(() => {
+  cy.exec(
+    `npm run update -- --file content/error-recovery/page-query.json --restore`
+  )
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/page-query-result-runtime-error.js --restore`
+  )
+})
+
+const errorPlaceholder = `false`
+const errorReplacement = `true`
+
+describe(`testing error overlay and ability to automatically recover runtime errors cause by content changes (page queries variant)`, () => {
+  it(`displays content initially (no errors yet)`, () => {
+    cy.visit(
+      `/error-handling/page-query-result-runtime-error/`
+    ).waitForRouteChange()
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
+    cy.getTestElement(`results`)
+      .invoke(`text`)
+      .should(`contain`, `"hasError": false`)
+  })
+
+  it(`displays error with overlay on runtime errors`, () => {
+    cy.exec(
+      `npm run update -- --file content/error-recovery/page-query.json  --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
+    )
+
+    // that's the exact error we throw and we expect to see that
+    cy.getOverlayIframe().contains(`Page query results caused runtime error`)
+    // contains details
+    cy.getOverlayIframe().contains(
+      `src/pages/error-handling/page-query-result-runtime-error.js`
+    )
+    cy.screenshot()
+  })
+
+  it(`can recover without need to refresh manually`, () => {
+    cy.exec(
+      `npm run update -- --file content/error-recovery/page-query.json  --replacements "${errorReplacement}:${errorPlaceholder}" --exact`
+    )
+    cy.exec(
+      `npm run update -- --file src/pages/error-handling/page-query-result-runtime-error.js --replacements "Working:Updated" --exact`
+    )
+
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
+    cy.getTestElement(`results`)
+      .invoke(`text`)
+      .should(`contain`, `"hasError": false`)
+
+    cy.assertNoOverlayIframe()
+    cy.screenshot()
+  })
+})

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
@@ -41,11 +41,11 @@ describe(`testing error overlay and ability to automatically recover runtime err
     )
 
     // that's the exact error we throw and we expect to see that
-    cy.getOverlayIframe().contains(`Page query results caused runtime error`)
+    // cy.getOverlayIframe().contains(`Page query results caused runtime error`)
     // contains details
-    cy.getOverlayIframe().contains(
-      `src/pages/error-handling/page-query-result-runtime-error.js`
-    )
+    // cy.getOverlayIframe().contains(
+    //   `src/pages/error-handling/page-query-result-runtime-error.js`
+    // )
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -60,6 +60,6 @@ describe(`testing error overlay and ability to automatically recover runtime err
     cy.findByTestId(`results`)
       .should(`contain.text`, `"hasError": false`)
 
-    cy.assertNoOverlayIframe()
+    // cy.assertNoOverlayIframe()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
@@ -1,8 +1,10 @@
-Cypress.on("uncaught:exception", (err, runnable) => {
-  // returning false here prevents Cypress from
-  // failing the test
-  return false
-})
+Cypress.on(
+  `uncaught:exception`,
+  (err, runnable) =>
+    // returning false here prevents Cypress from
+    // failing the test
+    false
+)
 
 before(() => {
   cy.exec(
@@ -27,12 +29,15 @@ const errorReplacement = `true`
 
 describe(`testing error overlay and ability to automatically recover runtime errors cause by content changes (page queries variant)`, () => {
   it(`displays content initially (no errors yet)`, () => {
-    cy.visit(
-      `/error-handling/page-query-result-runtime-error/`
-    ).waitForRouteChange()
+    cy.visit(`/error-handling/page-query-result-runtime-error/`, {
+      // Hacky way to disable "uncaught:exception" message in error message itself
+      // See https://github.com/cypress-io/cypress/issues/254#issuecomment-292190924
+      onBeforeLoad: win => {
+        win.onerror = null
+      },
+    }).waitForRouteChange()
     cy.findByTestId(`hot`).should(`contain.text`, `Working`)
-    cy.findByTestId(`results`)
-      .should(`contain.text`, `"hasError": false`)
+    cy.findByTestId(`results`).should(`contain.text`, `"hasError": false`)
   })
 
   it(`displays error with overlay on runtime errors`, () => {
@@ -40,12 +45,28 @@ describe(`testing error overlay and ability to automatically recover runtime err
       `npm run update -- --file content/error-recovery/page-query.json  --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    // that's the exact error we throw and we expect to see that
-    // cy.getOverlayIframe().contains(`Page query results caused runtime error`)
-    // contains details
-    // cy.getOverlayIframe().contains(
-    //   `src/pages/error-handling/page-query-result-runtime-error.js`
-    // )
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-labelledby`)
+      .should(`contain.text`, `Unhandled Runtime Error`)
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-describedby`)
+      .should(
+        `contain.text`,
+        `One unhandled runtime error found in your files. See the list below to fix it:`
+      )
+    cy.getFastRefreshOverlay()
+      .find(
+        `[data-gatsby-overlay="accordion"] [data-gatsby-overlay="accordion__item__title"]`
+      )
+      .should(
+        `contain.text`,
+        `Error in function PageQueryRuntimeError in ./src/pages/error-handling/page-query-result-runtime-error.js:7`
+      )
+    cy.getFastRefreshOverlay()
+      .find(
+        `[data-gatsby-overlay="accordion"] [data-gatsby-overlay="body__error-message"]`
+      )
+      .should(`contain.text`, `Page query results caused runtime error`)
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -57,8 +78,7 @@ describe(`testing error overlay and ability to automatically recover runtime err
     )
 
     cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
-    cy.findByTestId(`results`)
-      .should(`contain.text`, `"hasError": false`)
+    cy.findByTestId(`results`).should(`contain.text`, `"hasError": false`)
 
     cy.assertNoFastRefreshOverlay()
   })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
@@ -30,10 +30,9 @@ describe(`testing error overlay and ability to automatically recover runtime err
     cy.visit(
       `/error-handling/page-query-result-runtime-error/`
     ).waitForRouteChange()
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
-    cy.getTestElement(`results`)
-      .invoke(`text`)
-      .should(`contain`, `"hasError": false`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Working`)
+    cy.findByTestId(`results`)
+      .should(`contain.text`, `"hasError": false`)
   })
 
   it(`displays error with overlay on runtime errors`, () => {
@@ -47,7 +46,6 @@ describe(`testing error overlay and ability to automatically recover runtime err
     cy.getOverlayIframe().contains(
       `src/pages/error-handling/page-query-result-runtime-error.js`
     )
-    cy.screenshot()
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -58,12 +56,10 @@ describe(`testing error overlay and ability to automatically recover runtime err
       `npm run update -- --file src/pages/error-handling/page-query-result-runtime-error.js --replacements "Working:Updated" --exact`
     )
 
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
-    cy.getTestElement(`results`)
-      .invoke(`text`)
-      .should(`contain`, `"hasError": false`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
+    cy.findByTestId(`results`)
+      .should(`contain.text`, `"hasError": false`)
 
     cy.assertNoOverlayIframe()
-    cy.screenshot()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/page-query-result-runtime-error.js
@@ -60,6 +60,6 @@ describe(`testing error overlay and ability to automatically recover runtime err
     cy.findByTestId(`results`)
       .should(`contain.text`, `"hasError": false`)
 
-    // cy.assertNoOverlayIframe()
+    cy.assertNoFastRefreshOverlay()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
@@ -38,6 +38,6 @@ describe(`testing error overlay and ability to automatically recover from query 
     )
 
     cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
-    // cy.assertNoOverlayIframe()
+    cy.assertNoFastRefreshOverlay()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
@@ -16,7 +16,7 @@ const errorReplacement = `fieldThatDoesNotExistOnSiteMapType`
 describe(`testing error overlay and ability to automatically recover from query extraction validation errors`, () => {
   it(`displays content initially (no errors yet)`, () => {
     cy.visit(`/error-handling/query-validation-error/`).waitForRouteChange()
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Working`)
   })
 
   it(`displays error with overlay on compilation errors`, () => {
@@ -30,7 +30,6 @@ describe(`testing error overlay and ability to automatically recover from query 
     cy.getOverlayIframe().contains(
       `src/pages/error-handling/query-validation-error.js`
     )
-    cy.screenshot()
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -38,8 +37,7 @@ describe(`testing error overlay and ability to automatically recover from query 
       `npm run update -- --file src/pages/error-handling/query-validation-error.js --replacements "Working:Updated" --replacements "${errorReplacement}:${errorPlaceholder}" --exact`
     )
 
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
     cy.assertNoOverlayIframe()
-    cy.screenshot()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
@@ -1,0 +1,45 @@
+before(() => {
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/query-validation-error.js --restore`
+  )
+})
+
+after(() => {
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/query-validation-error.js --restore`
+  )
+})
+
+const errorPlaceholder = `# query-validation-error`
+const errorReplacement = `fieldThatDoesNotExistOnSiteMapType`
+
+describe(`testing error overlay and ability to automatically recover from query extraction validation errors`, () => {
+  it(`displays content initially (no errors yet)`, () => {
+    cy.visit(`/error-handling/query-validation-error/`).waitForRouteChange()
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
+  })
+
+  it(`displays error with overlay on compilation errors`, () => {
+    cy.exec(
+      `npm run update -- --file src/pages/error-handling/query-validation-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
+    )
+
+    cy.getOverlayIframe().contains(`Failed to compile`)
+    cy.getOverlayIframe().contains(`There was an error in your GraphQL query`)
+    // make sure we mark location
+    cy.getOverlayIframe().contains(
+      `src/pages/error-handling/query-validation-error.js`
+    )
+    cy.screenshot()
+  })
+
+  it(`can recover without need to refresh manually`, () => {
+    cy.exec(
+      `npm run update -- --file src/pages/error-handling/query-validation-error.js --replacements "Working:Updated" --replacements "${errorReplacement}:${errorPlaceholder}" --exact`
+    )
+
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
+    cy.assertNoOverlayIframe()
+    cy.screenshot()
+  })
+})

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
@@ -24,12 +24,23 @@ describe(`testing error overlay and ability to automatically recover from query 
       `npm run update -- --file src/pages/error-handling/query-validation-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    // cy.getOverlayIframe().contains(`Failed to compile`)
-    // cy.getOverlayIframe().contains(`There was an error in your GraphQL query`)
-    // make sure we mark location
-    // cy.getOverlayIframe().contains(
-    //   `src/pages/error-handling/query-validation-error.js`
-    // )
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-labelledby`)
+      .should(`contain.text`, `Unhandled GraphQL Error`)
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-describedby`)
+      .should(
+        `contain.text`,
+        `One unhandled GraphQL error found in your files. See the list below to fix it:`
+      )
+    cy.getFastRefreshOverlay()
+      .find(
+        `[data-gatsby-overlay="accordion"] [data-gatsby-overlay="accordion__item__title"]`
+      )
+      .should(
+        `contain.text`,
+        `Cannot query field "fieldThatDoesNotExistOnSiteMapType" on type "SiteSiteMetadata".`
+      )
   })
 
   it(`can recover without need to refresh manually`, () => {

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/query-validation-error.js
@@ -24,12 +24,12 @@ describe(`testing error overlay and ability to automatically recover from query 
       `npm run update -- --file src/pages/error-handling/query-validation-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    cy.getOverlayIframe().contains(`Failed to compile`)
-    cy.getOverlayIframe().contains(`There was an error in your GraphQL query`)
+    // cy.getOverlayIframe().contains(`Failed to compile`)
+    // cy.getOverlayIframe().contains(`There was an error in your GraphQL query`)
     // make sure we mark location
-    cy.getOverlayIframe().contains(
-      `src/pages/error-handling/query-validation-error.js`
-    )
+    // cy.getOverlayIframe().contains(
+    //   `src/pages/error-handling/query-validation-error.js`
+    // )
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -38,6 +38,6 @@ describe(`testing error overlay and ability to automatically recover from query 
     )
 
     cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
-    cy.assertNoOverlayIframe()
+    // cy.assertNoOverlayIframe()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
@@ -41,6 +41,6 @@ describe(`testing error overlay and ability to automatically recover from runtim
     )
 
     cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
-    // cy.assertNoOverlayIframe()
+    cy.assertNoFastRefreshOverlay()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
@@ -1,8 +1,10 @@
-Cypress.on("uncaught:exception", (err, runnable) => {
-  // returning false here prevents Cypress from
-  // failing the test
-  return false
-})
+Cypress.on(
+  `uncaught:exception`,
+  (err, runnable) =>
+    // returning false here prevents Cypress from
+    // failing the test
+    false
+)
 
 before(() => {
   cy.exec(
@@ -21,7 +23,13 @@ const errorReplacement = `window.a.b.c.d.e.f.g()`
 
 describe(`testing error overlay and ability to automatically recover from runtime errors`, () => {
   it(`displays content initially (no errors yet)`, () => {
-    cy.visit(`/error-handling/runtime-error/`).waitForRouteChange()
+    cy.visit(`/error-handling/runtime-error/`, {
+      // Hacky way to disable "uncaught:exception" message in error message itself
+      // See https://github.com/cypress-io/cypress/issues/254#issuecomment-292190924
+      onBeforeLoad: win => {
+        win.onerror = null
+      },
+    }).waitForRouteChange()
     cy.findByTestId(`hot`).should(`contain.text`, `Working`)
   })
 
@@ -30,9 +38,29 @@ describe(`testing error overlay and ability to automatically recover from runtim
       `npm run update -- --file src/pages/error-handling/runtime-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    // cy.getOverlayIframe().contains(`Cannot read property`)
-    // contains details
-    // cy.getOverlayIframe().contains(`src/pages/error-handling/runtime-error.js`)
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-labelledby`)
+      .should(`contain.text`, `Unhandled Runtime Error`)
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-describedby`)
+      .should(
+        `contain.text`,
+        `One unhandled runtime error found in your files. See the list below to fix it:`
+      )
+    cy.getFastRefreshOverlay()
+      .find(
+        `[data-gatsby-overlay="accordion"] [data-gatsby-overlay="accordion__item__title"]`
+      )
+      .should(
+        `contain.text`,
+        `Error in function RuntimeError in ./src/pages/error-handling/runtime-error.js:4`
+      )
+    cy.getFastRefreshOverlay()
+      .find(
+        `[data-gatsby-overlay="accordion"] [data-gatsby-overlay="body__error-message"]`
+      )
+      .should(`contain.text`, `Cannot read property 'b' of undefined`)
+    cy.getFastRefreshOverlay().find(`[data-gatsby-overlay="body"] pre`)
   })
 
   it(`can recover without need to refresh manually`, () => {

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
@@ -22,7 +22,7 @@ const errorReplacement = `window.a.b.c.d.e.f.g()`
 describe(`testing error overlay and ability to automatically recover from runtime errors`, () => {
   it(`displays content initially (no errors yet)`, () => {
     cy.visit(`/error-handling/runtime-error/`).waitForRouteChange()
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Working`)
   })
 
   it(`displays error with overlay on runtime errors`, () => {
@@ -33,7 +33,6 @@ describe(`testing error overlay and ability to automatically recover from runtim
     cy.getOverlayIframe().contains(`Cannot read property`)
     // contains details
     cy.getOverlayIframe().contains(`src/pages/error-handling/runtime-error.js`)
-    cy.screenshot()
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -41,8 +40,7 @@ describe(`testing error overlay and ability to automatically recover from runtim
       `npm run update -- --file src/pages/error-handling/runtime-error.js --replacements "Working:Updated" --replacements "${errorReplacement}:${errorPlaceholder}" --exact`
     )
 
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
     cy.assertNoOverlayIframe()
-    cy.screenshot()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
@@ -30,9 +30,9 @@ describe(`testing error overlay and ability to automatically recover from runtim
       `npm run update -- --file src/pages/error-handling/runtime-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    cy.getOverlayIframe().contains(`Cannot read property`)
+    // cy.getOverlayIframe().contains(`Cannot read property`)
     // contains details
-    cy.getOverlayIframe().contains(`src/pages/error-handling/runtime-error.js`)
+    // cy.getOverlayIframe().contains(`src/pages/error-handling/runtime-error.js`)
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -41,6 +41,6 @@ describe(`testing error overlay and ability to automatically recover from runtim
     )
 
     cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
-    cy.assertNoOverlayIframe()
+    // cy.assertNoOverlayIframe()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/runtime-error.js
@@ -1,0 +1,48 @@
+Cypress.on("uncaught:exception", (err, runnable) => {
+  // returning false here prevents Cypress from
+  // failing the test
+  return false
+})
+
+before(() => {
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/runtime-error.js --restore`
+  )
+})
+
+after(() => {
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/runtime-error.js --restore`
+  )
+})
+
+const errorPlaceholder = `// runtime-error`
+const errorReplacement = `window.a.b.c.d.e.f.g()`
+
+describe(`testing error overlay and ability to automatically recover from runtime errors`, () => {
+  it(`displays content initially (no errors yet)`, () => {
+    cy.visit(`/error-handling/runtime-error/`).waitForRouteChange()
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
+  })
+
+  it(`displays error with overlay on runtime errors`, () => {
+    cy.exec(
+      `npm run update -- --file src/pages/error-handling/runtime-error.js --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
+    )
+
+    cy.getOverlayIframe().contains(`Cannot read property`)
+    // contains details
+    cy.getOverlayIframe().contains(`src/pages/error-handling/runtime-error.js`)
+    cy.screenshot()
+  })
+
+  it(`can recover without need to refresh manually`, () => {
+    cy.exec(
+      `npm run update -- --file src/pages/error-handling/runtime-error.js --replacements "Working:Updated" --replacements "${errorReplacement}:${errorPlaceholder}" --exact`
+    )
+
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
+    cy.assertNoOverlayIframe()
+    cy.screenshot()
+  })
+})

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
@@ -30,10 +30,9 @@ describe(`testing error overlay and ability to automatically recover from runtim
     cy.visit(
       `/error-handling/static-query-result-runtime-error/`
     ).waitForRouteChange()
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
-    cy.getTestElement(`results`)
-      .invoke(`text`)
-      .should(`contain`, `"hasError": false`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Working`)
+    cy.findByTestId(`results`)
+      .should(`contain.text`, `"hasError": false`)
   })
 
   it(`displays error with overlay on runtime errors`, () => {
@@ -47,7 +46,6 @@ describe(`testing error overlay and ability to automatically recover from runtim
     cy.getOverlayIframe().contains(
       `src/pages/error-handling/static-query-result-runtime-error.js`
     )
-    cy.screenshot()
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -58,12 +56,10 @@ describe(`testing error overlay and ability to automatically recover from runtim
       `npm run update -- --file src/pages/error-handling/static-query-result-runtime-error.js --replacements "Working:Updated" --exact`
     )
 
-    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
-    cy.getTestElement(`results`)
-      .invoke(`text`)
-      .should(`contain`, `"hasError": false`)
+    cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
+    cy.findByTestId(`results`)
+      .should(`contain.text`, `"hasError": false`)
 
     cy.assertNoOverlayIframe()
-    cy.screenshot()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
@@ -1,0 +1,69 @@
+Cypress.on("uncaught:exception", (err, runnable) => {
+  // returning false here prevents Cypress from
+  // failing the test
+  return false
+})
+
+before(() => {
+  cy.exec(
+    `npm run update -- --file content/error-recovery/static-query.json --restore`
+  )
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/static-query-result-runtime-error.js --restore`
+  )
+})
+
+after(() => {
+  cy.exec(
+    `npm run update -- --file content/error-recovery/static-query.json --restore`
+  )
+  cy.exec(
+    `npm run update -- --file src/pages/error-handling/static-query-result-runtime-error.js --restore`
+  )
+})
+
+const errorPlaceholder = `false`
+const errorReplacement = `true`
+
+describe(`testing error overlay and ability to automatically recover from runtime errors (static queries variant)`, () => {
+  it(`displays content initially (no errors yet)`, () => {
+    cy.visit(
+      `/error-handling/static-query-result-runtime-error/`
+    ).waitForRouteChange()
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Working`)
+    cy.getTestElement(`results`)
+      .invoke(`text`)
+      .should(`contain`, `"hasError": false`)
+  })
+
+  it(`displays error with overlay on runtime errors`, () => {
+    cy.exec(
+      `npm run update -- --file content/error-recovery/static-query.json  --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
+    )
+
+    // that's the exact error we throw and we expect to see that
+    cy.getOverlayIframe().contains(`Static query results caused runtime error`)
+    // contains details
+    cy.getOverlayIframe().contains(
+      `src/pages/error-handling/static-query-result-runtime-error.js`
+    )
+    cy.screenshot()
+  })
+
+  it(`can recover without need to refresh manually`, () => {
+    cy.exec(
+      `npm run update -- --file content/error-recovery/static-query.json  --replacements "${errorReplacement}:${errorPlaceholder}" --exact`
+    )
+    cy.exec(
+      `npm run update -- --file src/pages/error-handling/static-query-result-runtime-error.js --replacements "Working:Updated" --exact`
+    )
+
+    cy.getTestElement(`hot`).invoke(`text`).should(`contain`, `Updated`)
+    cy.getTestElement(`results`)
+      .invoke(`text`)
+      .should(`contain`, `"hasError": false`)
+
+    cy.assertNoOverlayIframe()
+    cy.screenshot()
+  })
+})

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
@@ -60,6 +60,6 @@ describe(`testing error overlay and ability to automatically recover from runtim
     cy.findByTestId(`results`)
       .should(`contain.text`, `"hasError": false`)
 
-    // cy.assertNoOverlayIframe()
+    cy.assertNoFastRefreshOverlay()
   })
 })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
@@ -1,8 +1,10 @@
-Cypress.on("uncaught:exception", (err, runnable) => {
-  // returning false here prevents Cypress from
-  // failing the test
-  return false
-})
+Cypress.on(
+  `uncaught:exception`,
+  (err, runnable) =>
+    // returning false here prevents Cypress from
+    // failing the test
+    false
+)
 
 before(() => {
   cy.exec(
@@ -27,12 +29,15 @@ const errorReplacement = `true`
 
 describe(`testing error overlay and ability to automatically recover from runtime errors (static queries variant)`, () => {
   it(`displays content initially (no errors yet)`, () => {
-    cy.visit(
-      `/error-handling/static-query-result-runtime-error/`
-    ).waitForRouteChange()
+    cy.visit(`/error-handling/static-query-result-runtime-error/`, {
+      // Hacky way to disable "uncaught:exception" message in error message itself
+      // See https://github.com/cypress-io/cypress/issues/254#issuecomment-292190924
+      onBeforeLoad: win => {
+        win.onerror = null
+      },
+    }).waitForRouteChange()
     cy.findByTestId(`hot`).should(`contain.text`, `Working`)
-    cy.findByTestId(`results`)
-      .should(`contain.text`, `"hasError": false`)
+    cy.findByTestId(`results`).should(`contain.text`, `"hasError": false`)
   })
 
   it(`displays error with overlay on runtime errors`, () => {
@@ -40,12 +45,28 @@ describe(`testing error overlay and ability to automatically recover from runtim
       `npm run update -- --file content/error-recovery/static-query.json  --replacements "${errorPlaceholder}:${errorReplacement}" --exact`
     )
 
-    // that's the exact error we throw and we expect to see that
-    // cy.getOverlayIframe().contains(`Static query results caused runtime error`)
-    // contains details
-    // cy.getOverlayIframe().contains(
-    //   `src/pages/error-handling/static-query-result-runtime-error.js`
-    // )
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-labelledby`)
+      .should(`contain.text`, `Unhandled Runtime Error`)
+    cy.getFastRefreshOverlay()
+      .find(`#gatsby-overlay-describedby`)
+      .should(
+        `contain.text`,
+        `One unhandled runtime error found in your files. See the list below to fix it:`
+      )
+    cy.getFastRefreshOverlay()
+      .find(
+        `[data-gatsby-overlay="accordion"] [data-gatsby-overlay="accordion__item__title"]`
+      )
+      .should(
+        `contain.text`,
+        `Error in function StaticQueryRuntimeError in ./src/pages/error-handling/static-query-result-runtime-error.js:14`
+      )
+    cy.getFastRefreshOverlay()
+      .find(
+        `[data-gatsby-overlay="accordion"] [data-gatsby-overlay="body__error-message"]`
+      )
+      .should(`contain.text`, `Static query results caused runtime error`)
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -57,8 +78,7 @@ describe(`testing error overlay and ability to automatically recover from runtim
     )
 
     cy.findByTestId(`hot`).should(`contain.text`, `Updated`)
-    cy.findByTestId(`results`)
-      .should(`contain.text`, `"hasError": false`)
+    cy.findByTestId(`results`).should(`contain.text`, `"hasError": false`)
 
     cy.assertNoFastRefreshOverlay()
   })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/static-query-result-runtime-error.js
@@ -41,11 +41,11 @@ describe(`testing error overlay and ability to automatically recover from runtim
     )
 
     // that's the exact error we throw and we expect to see that
-    cy.getOverlayIframe().contains(`Static query results caused runtime error`)
+    // cy.getOverlayIframe().contains(`Static query results caused runtime error`)
     // contains details
-    cy.getOverlayIframe().contains(
-      `src/pages/error-handling/static-query-result-runtime-error.js`
-    )
+    // cy.getOverlayIframe().contains(
+    //   `src/pages/error-handling/static-query-result-runtime-error.js`
+    // )
   })
 
   it(`can recover without need to refresh manually`, () => {
@@ -60,6 +60,6 @@ describe(`testing error overlay and ability to automatically recover from runtim
     cy.findByTestId(`results`)
       .should(`contain.text`, `"hasError": false`)
 
-    cy.assertNoOverlayIframe()
+    // cy.assertNoOverlayIframe()
   })
 })

--- a/e2e-tests/development-runtime/cypress/support/commands.js
+++ b/e2e-tests/development-runtime/cypress/support/commands.js
@@ -105,3 +105,11 @@ Cypress.Commands.add(`waitForHmr`, (message = `App is up to date`) => {
   cy.get(`@hmrConsoleLog`).should(`be.calledWithMatch`, message)
   cy.wait(1000)
 })
+
+Cypress.Commands.add(`getFastRefreshOverlay`, () => (
+  cy.get('gatsby-fast-refresh').shadow()
+))
+
+Cypress.Commands.add(`assertNoFastRefreshOverlay`, () => (
+  cy.get('gatsby-fast-refresh').should('not.exist')
+))

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=true gatsby develop",
+    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=true GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND=y gatsby develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "start": "npm run develop",

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -33,8 +33,9 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=true GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND=y gatsby develop",
+    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=true gatsby develop",
     "serve": "gatsby serve",
+    "clean": "gatsby clean",
     "start": "npm run develop",
     "format": "prettier --write \"src/**/*.js\"",
     "test": "npm run start-server-and-test || (npm run reset && exit 1)",

--- a/e2e-tests/development-runtime/src/components/image.js
+++ b/e2e-tests/development-runtime/src/components/image.js
@@ -29,7 +29,7 @@ const Image = () => (
     `}
     render={data => (
       <div>
-        <StaticImage src="../images/gatsby-icon.png" />
+        <StaticImage alt="Gatsby Icon" src="../images/gatsby-icon.png" />
         <Img fluid={data.placeholderImage.childImageSharp.fluid} />
       </div>
     )}

--- a/e2e-tests/development-runtime/src/pages/error-handling/compile-error.js
+++ b/e2e-tests/development-runtime/src/pages/error-handling/compile-error.js
@@ -1,0 +1,8 @@
+import React from "react"
+
+function CompileError() {
+  // compile-error
+  return <p data-testid="hot">Working</p>
+}
+
+export default CompileError

--- a/e2e-tests/development-runtime/src/pages/error-handling/page-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/src/pages/error-handling/page-query-result-runtime-error.js
@@ -1,0 +1,25 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+function PageQueryRuntimeError({ data }) {
+  console.log(data.errorRecoveryJson)
+  if (data.errorRecoveryJson.hasError) {
+    throw new Error(`Page query results caused runtime error`)
+  }
+  return (
+    <>
+      <p data-testid="hot">Working</p>
+      <pre data-testid="results">{JSON.stringify(data, null, 2)}</pre>
+    </>
+  )
+}
+
+export default PageQueryRuntimeError
+
+export const query = graphql`
+  {
+    errorRecoveryJson(selector: { eq: "page-query" }) {
+      hasError
+    }
+  }
+`

--- a/e2e-tests/development-runtime/src/pages/error-handling/query-validation-error.js
+++ b/e2e-tests/development-runtime/src/pages/error-handling/query-validation-error.js
@@ -1,0 +1,19 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+function QueryValidationError() {
+  return <p data-testid="hot">Working</p>
+}
+
+export default QueryValidationError
+
+export const query = graphql`
+  {
+    site {
+      siteMetadata {
+        title
+        # query-validation-error
+      }
+    }
+  }
+`

--- a/e2e-tests/development-runtime/src/pages/error-handling/runtime-error.js
+++ b/e2e-tests/development-runtime/src/pages/error-handling/runtime-error.js
@@ -1,0 +1,8 @@
+import React from "react"
+
+function RuntimeError() {
+  // runtime-error
+  return <p data-testid="hot">Working</p>
+}
+
+export default RuntimeError

--- a/e2e-tests/development-runtime/src/pages/error-handling/static-query-result-runtime-error.js
+++ b/e2e-tests/development-runtime/src/pages/error-handling/static-query-result-runtime-error.js
@@ -1,0 +1,24 @@
+import React from "react"
+import { graphql, useStaticQuery } from "gatsby"
+
+function StaticQueryRuntimeError() {
+  const data = useStaticQuery(graphql`
+    {
+      errorRecoveryJson(selector: { eq: "static-query" }) {
+        hasError
+      }
+    }
+  `)
+  console.log(data.errorRecoveryJson)
+  if (data.errorRecoveryJson.hasError) {
+    throw new Error(`Static query results caused runtime error`)
+  }
+  return (
+    <>
+      <p data-testid="hot">Working</p>
+      <pre data-testid="results">{JSON.stringify(data, null, 2)}</pre>
+    </>
+  )
+}
+
+export default StaticQueryRuntimeError


### PR DESCRIPTION
## Description

This adds a suite of tests for our Hot Reloading and the new Fast Refresh overlay.

It tests our three kinds of overlays we have:

- Compile errors
- Runtime errors (page query, static query, normal runtime error)
- GraphQL errors

It validates:

- Correct title (by `#gatsby-overlay-labelledby`
- Correct description (by `#gatsby-overlay-describedby`)
- Correct accordion title / file names
- After fixing the error the overlay goes away

## Related Issues

[ch19707]

Re-Adds tests from https://github.com/gatsbyjs/gatsby/pull/27467