### PR TITLE
Corrected "from" instead of "by" in lookup

### DIFF
--- a/docs/docs/reference/graphql-data-layer/schema-customization.md
+++ b/docs/docs/reference/graphql-data-layer/schema-customization.md
@@ -428,7 +428,7 @@ type MarkdownRemark implements Node {
 }
 type Frontmatter {
   author: AuthorJson @link # default foreign-key relation by `id`
-  reviewers: [AuthorJson] @link(by: "email") # foreign-key relation by custom field
+  reviewers: [AuthorJson] @link(from: "email") # foreign-key relation by custom field
 }
 type AuthorJson implements Node {
   posts: [MarkdownRemark] @link(by: "frontmatter.author.email", from: "email") # easy back-ref


### PR DESCRIPTION
Corrected syntax error "from" instead of "by" when referencing using foreign keys.

## Related Issues

Fixes #30157