### PR TITLE
fix(gatsby): Allow Engine.IO protocol v3

### DIFF
--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -54,6 +54,9 @@ export class WebsocketManager {
         origin: true,
       },
       cookie: true,
+      // gatsby-cloud needs to support both socket.io v2 and v3, so this needs to
+      // continue supporting older clients to connect.
+      allowEIO3: true,
     })
     this.websocket = websocket
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

gatsby-cloud needs to support both socket.io v2 and v3, so this needs to continue supporting older clients to connect.

https://socket.io/docs/v3/migrating-from-2-x-to-3-0/#How-to-upgrade-an-existing-production-deployment

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
