### PR TITLE
fix(gatsby): workaround some webpack issues causing first save after running gatsby develop to not have any effect

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/__tests__/requires-writer.js
@@ -20,6 +20,7 @@ const generatePagesState = pages => {
 jest.mock(`fs-extra`, () => {
   return {
     writeFile: () => Promise.resolve(),
+    outputFileSync: () => {},
     move: () => {},
   }
 })

--- a/packages/gatsby/src/utils/gatsby-webpack-virtual-modules.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-virtual-modules.ts
@@ -49,10 +49,7 @@ export function writeModule(filePath: string, fileContents: string): void {
 
   // workaround webpack marking virtual modules as deleted because those files don't really exist
   // so we create those files just so watchpack doesn't mark them as initially missing
-  fs.outputFileSync(
-    adjustedFilePath
-    fileContents
-  )
+  fs.outputFileSync(adjustedFilePath, fileContents)
 
   fileContentLookup[adjustedFilePath] = fileContents
 

--- a/packages/gatsby/src/utils/gatsby-webpack-virtual-modules.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-virtual-modules.ts
@@ -50,7 +50,7 @@ export function writeModule(filePath: string, fileContents: string): void {
   // workaround webpack marking virtual modules as deleted because those files don't really exist
   // so we create those files just so watchpack doesn't mark them as initially missing
   fs.outputFileSync(
-    path.join(process.cwd(), VIRTUAL_MODULES_BASE_PATH, filePath),
+    adjustedFilePath
     fileContents
   )
 

--- a/packages/gatsby/src/utils/gatsby-webpack-virtual-modules.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-virtual-modules.ts
@@ -1,5 +1,6 @@
 import VirtualModulesPlugin from "webpack-virtual-modules"
 import * as path from "path"
+import * as fs from "fs-extra"
 /*
  * This module allows creating virtual (in memory only) modules / files
  * that webpack compilation can access without the need to write module
@@ -45,6 +46,13 @@ export function writeModule(filePath: string, fileContents: string): void {
     // we already have this, no need to cause invalidation
     return
   }
+
+  // workaround webpack marking virtual modules as deleted because those files don't really exist
+  // so we create those files just so watchpack doesn't mark them as initially missing
+  fs.outputFileSync(
+    path.join(process.cwd(), VIRTUAL_MODULES_BASE_PATH, filePath),
+    fileContents
+  )
 
   fileContentLookup[adjustedFilePath] = fileContents
 

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -78,6 +78,11 @@ export async function startServer(
   })
   webpackActivity.start()
 
+  // loading indicator
+  // write virtual module always to not fail webpack compilation, but only add express route handlers when
+  // query on demand is enabled and loading indicator is not disabled
+  writeVirtualLoadingIndicatorModule()
+
   const THIRTY_SECONDS = 30 * 1000
   let cancelDevJSNotice: CancelExperimentNoticeCallbackOrUndefined
   if (
@@ -486,10 +491,6 @@ module.exports = {
     route({ app, program, store })
   }
 
-  // loading indicator
-  // write virtual module always to not fail webpack compilation, but only add express route handlers when
-  // query on demand is enabled and loading indicator is not disabled
-  writeVirtualLoadingIndicatorModule()
   if (
     process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
     process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`


### PR DESCRIPTION
Gather around, I will tell a story ...

## Description

`gatsby develop` react to `invalid` events coming from webpack to decide wether webpack need to recompile or not, however first compilation has some issues with virtual modules - because those are not real modules first time we start watching, `watchpack` will report all virtual modules as "deleted" ( https://github.com/webpack/watchpack/blob/f1b5e2da2d5dfd46f99b9b405c97b9d6441687d5/lib/watchpack.js#L176-L180 ). This doesn't result in `invalid` event because those only happen on `change` events ( https://github.com/webpack/webpack/blob/3f7f059d502e1e174f0c9432d927c3ec9b028241/lib/node/NodeWatchFileSystem.js#L68-L70 ). Funnily enough - deletion however do cause `aggregated` event ( https://github.com/webpack/watchpack/blob/f1b5e2da2d5dfd46f99b9b405c97b9d6441687d5/lib/watchpack.js#L315-L323 ) and because `NodeWatchFileSystem` and wepback's Watching manager only react `once` to `change` or `aggregated` events, in first compilation what happens is that we receive `aggregated` event without individual `invalid` event so gatsby never mark webpack to recompile. 

Then when user make their first change we receive `invalid` event and mark things to recompile, but we won't receive `aggregated` event after that, which means that new change won't be compiled ... after that initial first re-compilation watcher gets recreated and everything become happy again ...

So to workaround this 2 things:
 - to avoid marking virtual modules as deleted we actually create those files (tho we won't use them)
 - move writing initial loading-indicator module before we start compilation to avoid marking this file as changed

## Related Issues

Fixes #30183