### PR TITLE
fix(gatsby): work around webpack watching issue

### DIFF
--- a/packages/gatsby/src/services/listen-to-webpack.ts
+++ b/packages/gatsby/src/services/listen-to-webpack.ts
@@ -7,6 +7,20 @@ export const createWebpackWatcher = (compiler: Compiler): InvokeCallback => (
 ): void => {
   compiler.hooks.invalid.tap(`file invalidation`, file => {
     reporter.verbose(`Webpack file changed: ${file}`)
-    callback({ type: `SOURCE_FILE_CHANGED`, file })
+
+    // Webpack fires `invalid` event as soon as any file changes
+    //   but it doesn't start recompiling at this point. Instead, it aggregates changes with debounce
+    //   and recompile on a tail of debounce.
+    //   For example, you may save a file multiple times quickly but webpack will only recompile once.
+    //   Unfortunately webpack doesn't expose any event for aggregated changes.
+    //   But we actually need it. If we start recompiling immediately on `invalid` we can miss some changes.
+    // Hack below is a workaround for this missing webpack event
+    // @ts-ignore
+    const watcher = compiler.watchFileSystem.watcher // Watchpack instance
+    watcher.once(`aggregated`, () => {
+      callback({ type: `SOURCE_FILE_CHANGED`, file })
+    })
+
+    // TODO: fallback to timeout?
   })
 }

--- a/packages/gatsby/src/services/recompile.ts
+++ b/packages/gatsby/src/services/recompile.ts
@@ -20,6 +20,12 @@ export async function recompile({
       resolve(stats)
     }
     emitter.on(`COMPILATION_DONE`, finish)
+
+    // Wild fix to prevent watcher from pausing in webpack:
+    // @ts-ignore
+    webpackWatching.watcher = null
+
+    // Run re-compilation of aggregated changes
     webpackWatching.resume()
     // Suspending is just a flag, so it's safe to re-suspend right away
     webpackWatching.suspend()

--- a/packages/gatsby/src/services/recompile.ts
+++ b/packages/gatsby/src/services/recompile.ts
@@ -17,6 +17,10 @@ export async function recompile({
   return new Promise(resolve => {
     function finish(stats: Stats): void {
       emitter.off(`COMPILATION_DONE`, finish)
+      if (webpackWatching) {
+        // Suspend only when compilation is done
+        webpackWatching.suspend()
+      }
       resolve(stats)
     }
     emitter.on(`COMPILATION_DONE`, finish)
@@ -30,7 +34,5 @@ export async function recompile({
 
     // Run re-compilation of aggregated changes
     webpackWatching.resume()
-    // Suspending is just a flag, so it's safe to re-suspend right away
-    webpackWatching.suspend()
   })
 }

--- a/packages/gatsby/src/services/recompile.ts
+++ b/packages/gatsby/src/services/recompile.ts
@@ -17,22 +17,13 @@ export async function recompile({
   return new Promise(resolve => {
     function finish(stats: Stats): void {
       emitter.off(`COMPILATION_DONE`, finish)
-      if (webpackWatching) {
-        // Suspend only when compilation is done
-        webpackWatching.suspend()
-      }
+
       resolve(stats)
     }
     emitter.on(`COMPILATION_DONE`, finish)
 
-    // Wild fix to prevent watcher from pausing in webpack
-    // (which causes changes that occur _during_ recompilation to be ignored by webpack)
-    // @ts-ignore
-    webpackWatching.pausedWatchher = webpackWatching.watcher
-    // @ts-ignore
-    webpackWatching.watcher = null
-
     // Run re-compilation of aggregated changes
     webpackWatching.resume()
+    webpackWatching.suspend()
   })
 }

--- a/packages/gatsby/src/services/recompile.ts
+++ b/packages/gatsby/src/services/recompile.ts
@@ -21,7 +21,10 @@ export async function recompile({
     }
     emitter.on(`COMPILATION_DONE`, finish)
 
-    // Wild fix to prevent watcher from pausing in webpack:
+    // Wild fix to prevent watcher from pausing in webpack
+    // (which causes changes that occur _during_ recompilation to be ignored by webpack)
+    // @ts-ignore
+    webpackWatching.pausedWatchher = webpackWatching.watcher
     // @ts-ignore
     webpackWatching.watcher = null
 

--- a/packages/gatsby/src/services/recompile.ts
+++ b/packages/gatsby/src/services/recompile.ts
@@ -17,11 +17,22 @@ export async function recompile({
   return new Promise(resolve => {
     function finish(stats: Stats): void {
       emitter.off(`COMPILATION_DONE`, finish)
+      if (webpackWatching) {
+        // Suspend only when compilation is done
+        webpackWatching.suspend()
+      }
       resolve(stats)
     }
     emitter.on(`COMPILATION_DONE`, finish)
+
+    // Wild fix to prevent watcher from pausing in webpack
+    // (which causes changes that occur _during_ recompilation to be ignored by webpack)
+    // @ts-ignore
+    webpackWatching.pausedWatchher = webpackWatching.watcher
+    // @ts-ignore
+    webpackWatching.watcher = null
+
+    // Run re-compilation of aggregated changes
     webpackWatching.resume()
-    // Suspending is just a flag, so it's safe to re-suspend right away
-    webpackWatching.suspend()
   })
 }

--- a/packages/gatsby/src/services/recompile.ts
+++ b/packages/gatsby/src/services/recompile.ts
@@ -17,13 +17,12 @@ export async function recompile({
   return new Promise(resolve => {
     function finish(stats: Stats): void {
       emitter.off(`COMPILATION_DONE`, finish)
-
       resolve(stats)
     }
     emitter.on(`COMPILATION_DONE`, finish)
 
-    // Run re-compilation of aggregated changes
     webpackWatching.resume()
+    // Suspending is just a flag, so it's safe to re-suspend right away
     webpackWatching.suspend()
   })
 }

--- a/packages/gatsby/src/services/recompile.ts
+++ b/packages/gatsby/src/services/recompile.ts
@@ -20,7 +20,6 @@ export async function recompile({
       resolve(stats)
     }
     emitter.on(`COMPILATION_DONE`, finish)
-
     webpackWatching.resume()
     // Suspending is just a flag, so it's safe to re-suspend right away
     webpackWatching.suspend()

--- a/packages/gatsby/src/state-machines/waiting/index.ts
+++ b/packages/gatsby/src/state-machines/waiting/index.ts
@@ -29,13 +29,13 @@ export const waitingStates: MachineConfig<IWaitingContext, any, any> = {
           cond: (ctx): boolean => !!ctx.nodeMutationBatch.length,
           target: `batchingNodeMutations`,
         },
-        {
-          // If source files are dirty upon entering this state,
-          // move immediately to aggregatingFileChanges to force re-compilation
-          // See https://github.com/gatsbyjs/gatsby/issues/27609
-          target: `aggregatingFileChanges`,
-          cond: ({ sourceFilesDirty }): boolean => Boolean(sourceFilesDirty),
-        },
+        // {
+        //   // If source files are dirty upon entering this state,
+        //   // move immediately to aggregatingFileChanges to force re-compilation
+        //   // See https://github.com/gatsbyjs/gatsby/issues/27609
+        //   target: `aggregatingFileChanges`,
+        //   cond: ({ sourceFilesDirty }): boolean => Boolean(sourceFilesDirty),
+        // },
       ],
       on: {
         ADD_NODE_MUTATION: {
@@ -45,33 +45,34 @@ export const waitingStates: MachineConfig<IWaitingContext, any, any> = {
         // We only listen for this when idling because if we receive it at any
         // other point we're already going to create pages etc
         SOURCE_FILE_CHANGED: {
-          target: `aggregatingFileChanges`,
-        },
-      },
-    },
-    aggregatingFileChanges: {
-      // Sigh. This is because webpack doesn't expose the Watchpack
-      // aggregated file invalidation events. If we compile immediately,
-      // we won't pick up the changed files
-      after: {
-        // The aggregation timeout
-        [FILE_CHANGE_AGGREGATION_TIMEOUT]: {
           actions: `extractQueries`,
           target: `idle`,
         },
       },
-      on: {
-        ADD_NODE_MUTATION: {
-          actions: `addNodeMutation`,
-          target: `batchingNodeMutations`,
-        },
-        SOURCE_FILE_CHANGED: {
-          target: undefined,
-          // External self-transition reset the timer
-          internal: false,
-        },
-      },
     },
+    // aggregatingFileChanges: {
+    //   // Sigh. This is because webpack doesn't expose the Watchpack
+    //   // aggregated file invalidation events. If we compile immediately,
+    //   // we won't pick up the changed files
+    //   after: {
+    //     // The aggregation timeout
+    //     [FILE_CHANGE_AGGREGATION_TIMEOUT]: {
+    //       actions: `extractQueries`,
+    //       target: `idle`,
+    //     },
+    //   },
+    //   on: {
+    //     ADD_NODE_MUTATION: {
+    //       actions: `addNodeMutation`,
+    //       target: `batchingNodeMutations`,
+    //     },
+    //     SOURCE_FILE_CHANGED: {
+    //       target: undefined,
+    //       // External self-transition reset the timer
+    //       internal: false,
+    //     },
+    //   },
+    // },
     batchingNodeMutations: {
       // Check if the batch is already full on entry
       always: {

--- a/packages/gatsby/src/state-machines/waiting/index.ts
+++ b/packages/gatsby/src/state-machines/waiting/index.ts
@@ -5,7 +5,7 @@ import { waitingServices } from "./services"
 
 const NODE_MUTATION_BATCH_SIZE = 100
 const NODE_MUTATION_BATCH_TIMEOUT = 500
-const FILE_CHANGE_AGGREGATION_TIMEOUT = 200
+// const FILE_CHANGE_AGGREGATION_TIMEOUT = 200
 
 export type WaitingResult = Pick<IWaitingContext, "nodeMutationBatch">
 


### PR DESCRIPTION
## Description

This PR aims to fix "double save" issues in Gatsby (when some saves are being lost). The issue is caused by `resume` and `suspend` flow of webpack. There are (at least) two issues in webpack itself with this flow that make it hard to make use of `suspend` and `resume` at random points in time:

https://github.com/webpack/webpack/issues/12882
https://github.com/webpack/webpack/issues/12898

If those issues are fixed, then this PR won't be needed. Otherwise, we will have to properly coordinate calls of `resume` and `suspend` to make sure they are invoked at specific moments (and when webpack is in a specific state).

I've published a canary `gatsby@3.1.0-alpha-hmr-fix.16+831f9a9d64` with this fix for anyone who wants to try it.

## Related Issues

Fixes #27609
