### PR TITLE
chore(dosc): Update deploying-to-digitalocean-droplet

### DIFF
--- a/docs/docs/deploying-to-digitalocean-droplet.md
+++ b/docs/docs/deploying-to-digitalocean-droplet.md
@@ -127,7 +127,7 @@ Nginx is web-server. It provides the infrastructure code for handling client req
    sudo ufw allow 'Nginx HTTP'
    sudo ufw allow 'Nginx HTTPS'
    ```
-   
+
    > Note: You may have to allow access to port 443 explicitly using `sudo ufw allow 443/tcp`.
 
 3. To check the access,
@@ -135,7 +135,7 @@ Nginx is web-server. It provides the infrastructure code for handling client req
    ```shell
    sudo ufw app list
    ```
-   
+
 4. If `ufw` status is disabled/inactive, you can enable it with the following command:
 
    ```shell

--- a/docs/docs/deploying-to-digitalocean-droplet.md
+++ b/docs/docs/deploying-to-digitalocean-droplet.md
@@ -127,13 +127,15 @@ Nginx is web-server. It provides the infrastructure code for handling client req
    sudo ufw allow 'Nginx HTTP'
    sudo ufw allow 'Nginx HTTPS'
    ```
+   
+   > Note: You may have to allow access to port 443 explicitly using `sudo ufw allow 443/tcp`.
 
 3. To check the access,
 
    ```shell
    sudo ufw app list
    ```
-
+   
 4. If `ufw` status is disabled/inactive, you can enable it with the following command:
 
    ```shell


### PR DESCRIPTION
## Description

Added `sudo ufw allow 443/tcp`.

In my setup, I had to explicitly allow access on port 443 before my site could allow traffic on https. I followed the guide (including `sudo ufw allow 'Nginx HTTPS'`) but I still had to explicitly allow access on port 443.

### Documentation

`Update deploying-to-digitalocean-droplet.md`

## Related Issues

Haven't found any related issues
