### PR TITLE
chore(starters): Update WordPress blog README

### DIFF
--- a/starters/gatsby-starter-wordpress-blog/README.md
+++ b/starters/gatsby-starter-wordpress-blog/README.md
@@ -20,7 +20,7 @@ _Have another more specific idea? You may want to check out our vibrant collecti
 
     ```shell
     # create a new Gatsby site using the blog starter
-    gatsby new my-blog-starter https://github.com/gatsbyjs/gatsby-starter-blog
+    gatsby new my-blog-starter https://github.com/gatsbyjs/gatsby-starter-wordpress-blog
     ```
 
 1.  **Start developing.**

--- a/starters/gatsby-starter-wordpress-blog/README.md
+++ b/starters/gatsby-starter-wordpress-blog/README.md
@@ -5,10 +5,10 @@
   </a>
 </p>
 <h1 align="center">
-  Gatsby's blog starter
+  Gatsby WordPress blog starter
 </h1>
 
-Kick off your project with this blog boilerplate. This starter ships with the main Gatsby configuration files you might need to get up and running blazing fast with the blazing fast app generator for React.
+Kick off your WordPress Gatsby project with this blog boilerplate. This starter ships with the main Gatsby WordPress configuration files you might need to get up and running blazing fast with the blazing fast app generator for React.
 
 _Have another more specific idea? You may want to check out our vibrant collection of [official and community-created starters](https://www.gatsbyjs.com/docs/gatsby-starters/)._
 
@@ -92,8 +92,8 @@ Looking for more guidance? Full documentation for Gatsby lives [on the website](
 
 ## 💫 Deploy
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-blog)
+[Build, Deploy, and Host On The Only Cloud Built For Gatsby](https://www.gatsbyjs.com/cloud/)
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/gatsbyjs/gatsby-starter-blog)
+Gatsby Cloud is an end-to-end cloud platform specifically built for the Gatsby framework that combines a modern developer experience with an optimized, global edge network.
 
 <!-- AUTO-GENERATED-CONTENT:END -->


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/tree/master/starters/gatsby-starter-wordpress-blog#-quick-start

## Summary

Readme file has incorrect starter name in the Quick Start section. 

Currently:
```
# create a new Gatsby site using the blog starter
gatsby new my-blog-starter https://github.com/gatsbyjs/gatsby-starter-blog
```
Should be:
```
# create a new Gatsby site using the blog starter
gatsby new my-blog-starter https://github.com/gatsbyjs/gatsby-starter-wordpress-blog
```
### Motivation

It should be corrected so that users who copy-paste from the readme file will get the correct starter.

## Steps to resolve this issue

Correct the starter blog name in the Quick Start section.

Replace:
```
# create a new Gatsby site using the blog starter
gatsby new my-blog-starter https://github.com/gatsbyjs/gatsby-starter-blog
```
With:
```
# create a new Gatsby site using the blog starter
gatsby new my-blog-starter https://github.com/gatsbyjs/gatsby-starter-wordpress-blog
```

---

Fixes https://github.com/gatsbyjs/gatsby/issues/30208