### PR TITLE
fix(gatsby): be less aggressive when marking builtin methods as unsafe

### DIFF
--- a/packages/gatsby/cache-dir/ssr-builtin-trackers/http.js
+++ b/packages/gatsby/cache-dir/ssr-builtin-trackers/http.js
@@ -1,3 +1,3 @@
 const { wrapModuleWithTracking } = require(`./tracking-unsafe-module-wrapper`)
 
-module.exports = wrapModuleWithTracking(`http`)
+module.exports = wrapModuleWithTracking(`http`, { ignore: [`http.Agent`] })

--- a/packages/gatsby/cache-dir/ssr-builtin-trackers/https.js
+++ b/packages/gatsby/cache-dir/ssr-builtin-trackers/https.js
@@ -1,3 +1,3 @@
 const { wrapModuleWithTracking } = require(`./tracking-unsafe-module-wrapper`)
 
-module.exports = wrapModuleWithTracking(`https`)
+module.exports = wrapModuleWithTracking(`https`, { ignore: [`https.Agent`] })


### PR DESCRIPTION
## Description

This PR looks to make tracking of unsafe builtins a bit more relaxed - few cases that we gathered so far:
 - creatting `http(s).Agent` itself doesn't have sideeffects, so just preparing it without making request should be safe (relevant when using `algoliasearch` package as an example)
 - `node-gyp-build` used to load some binaries should be safe to ignore (relevant when using `subscriptions-transport-ws` as an example)

[ch26858]