### PR TITLE
[DRAFT] feat(gatsby-link): force trailing slash option

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -38,6 +38,12 @@ const getGlobalBasePrefix = () =>
       ? __BASE_PATH__
       : undefined
     : __BASE_PATH__
+const getGlobalTrailingSlash = () =>
+  process.env.NODE_ENV !== `production`
+    ? typeof __TRAILING_SLASHES__ !== `undefined`
+      ? __TRAILING_SLASHES__
+      : undefined
+    : __TRAILING_SLASHES__
 
 const isLocalLink = path =>
   path &&
@@ -64,7 +70,16 @@ const rewriteLinkPath = (path, relativeTo) => {
   if (!isLocalLink(path)) {
     return path
   }
-  return isAbsolutePath(path) ? withPrefix(path) : absolutify(path, relativeTo)
+  // see if the option to set trailing slashes is set and insert before navigating
+  const { pathname, search, hash } = parsePath(path)
+  const TRAILING_SLASHES = getGlobalTrailingSlash()
+  let shouldAddTrailingSlash = !pathname.endsWith(`/`)
+  const adjustedPath = `${pathname}${
+    TRAILING_SLASHES && shouldAddTrailingSlash ? `/` : ``
+  }${search}${hash}`
+  return isAbsolutePath(adjustedPath)
+    ? withPrefix(adjustedPath)
+    : absolutify(adjustedPath, relativeTo)
 }
 
 const NavLinkPropTypes = {

--- a/packages/gatsby/src/joi-schemas/__tests__/joi.ts
+++ b/packages/gatsby/src/joi-schemas/__tests__/joi.ts
@@ -107,6 +107,26 @@ describe(`gatsby config`, () => {
       `[Error: assetPrefix must be an absolute URI when used with pathPrefix]`
     )
   })
+
+  it(`returns true for trailingSlash when not set`, () => {
+    const config = {}
+
+    const result = gatsbyConfigSchema.validate(config)
+    expect(result.value).toEqual(
+      expect.objectContaining({
+        trailingSlash: true,
+      })
+    )
+  })
+
+  it(`throws when trailingSlash is set to non boolean value`, () => {
+    const config = {
+      trailingSlash: `true`,
+    }
+
+    const result = gatsbyConfigSchema.validate(config)
+    expect(result.error).toMatchInlineSnapshot(`undefined`)
+  })
 })
 
 describe(`node schema`, () => {

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -32,6 +32,7 @@ export const gatsbyConfigSchema: Joi.ObjectSchema<IGatsbyConfig> = Joi.object()
           .replace(/^\/$/, ``)
       )
     ),
+    trailingSlash: Joi.boolean().default(true),
     linkPrefix: Joi.forbidden().error(
       new Error(`"linkPrefix" should be changed to "pathPrefix"`)
     ),

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -208,6 +208,8 @@ module.exports = async (
         __ASSET_PREFIX__: JSON.stringify(
           program.prefixPaths ? assetPrefix : ``
         ),
+        // TODO pull this from the gatsby-config somehow
+        __TRAILING_SLASHES__: JSON.stringify(true),
       }),
 
       plugins.virtualModules(),


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

I've been exploring a commonly requested addition to the core framework, adding a config option to force trailing slashes. This PR adds `trailingSlash` as an option in `gatsby-config`, that when set to true will enforce a `/` being appended to any path or page if it hasn't already been added. 

This touches several places (and has some that still have to be done):
- [x] the `gatsby-config` schema
- [x] `gatsby-link` and it's helper functions
- [ ] `gatsby` core and likely somewhere like the `createPages` action to write pages to the cache with the enforced option

Each of these places should have some more tests added to verify that all possible paths are still constructed correctly: `/test`, `/test/`, `/test#hash`, `/test/#hash`, `/test?search=asdf`, etc

### Documentation

- [ ] include an addition in the [Gatsby Config API doc](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config)

## Example 

This example clip has `trailingSlash: true`, and shows `Link`s without trailing slashes being SSR'd with a trailing slash, as well as navigating to the proper path with a trailing slash.

https://user-images.githubusercontent.com/21114044/111004294-fd43e780-8345-11eb-811f-19a6e2fcad00.mp4


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to #6365
Related to #3402