### PR TITLE
fix(contentful): Add restricted content model names

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -22,6 +22,8 @@ const restrictedNodeFields = [
   `id`,
   `internal`,
   `parent`,
+  `Entity`,
+  `Reference`,
 ]
 
 exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`).extendNodeType


### PR DESCRIPTION
# Description
This PR adds 2 restricted model names to ```restrictedNodeFields``` array so that when one uses those 2 model names, the error notifies the developer about it. Those 2 model names are ```Reference``` and ```Entity```. The related issue explains why those 2 names cannot be used.
# Related issues
Fixes #30089