### PR TITLE
chore(docs): Fix link to markdown-syntax

### DIFF
--- a/docs/docs/glossary/markdown.md
+++ b/docs/docs/glossary/markdown.md
@@ -59,7 +59,7 @@ You can also try a [Gatsby starter](https://www.gatsbyjs.com/starters/?c=Markdow
 
 ## Learn more about Markdown
 
-- [Markdown syntax](/docs/how-to/routing/mdx/markdown-syntax/) from the Gatsby docs
+- [Markdown syntax](/docs/reference/markdown-syntax/) from the Gatsby docs
 - [CommonMark](https://commonmark.org/), a proposed Markdown specification
 - [Sourcing from the Filesystem](/docs/how-to/sourcing-data/sourcing-from-the-filesystem) from the Gatsby docs
 - [Adding Markdown Pages](/docs/how-to/routing/adding-markdown-pages/) from the Gatsby docs


### PR DESCRIPTION
Fixes link to the "Markdown Syntax" page from the "Markdown" glossary page
