### PR TITLE
chore: add extra type arg to getGatsbyImageFieldConfig

### DIFF
--- a/packages/gatsby-plugin-image/src/resolver-utils.ts
+++ b/packages/gatsby-plugin-image/src/resolver-utils.ts
@@ -125,6 +125,10 @@ export function getGatsbyImageResolver<TSource, TContext, TArgs>(
   }
 }
 
+export function getGatsbyImageFieldConfig<TSource, TContext, TArgs>(
+  resolve: GraphQLFieldResolver<TSource, TContext>,
+  extraArgs?: GraphQLFieldConfigArgumentMap
+): GraphQLFieldConfig<TSource, TContext, TArgs>
 export function getGatsbyImageFieldConfig<TSource, TContext>(
   resolve: GraphQLFieldResolver<TSource, TContext>,
   extraArgs?: GraphQLFieldConfigArgumentMap


### PR DESCRIPTION
## Description

This PR adds an overload to the `getGatsbyImageFieldConfig` API to make it easier to ensure the type of the args is being passed around correctly when using Typescript.

### Documentation

Not necessary. 

## Related Issues

N/A