### PR TITLE
fix(gatsby-plugin-image): Better StaticImage errors

### DIFF
--- a/packages/gatsby-plugin-image/package.json
+++ b/packages/gatsby-plugin-image/package.json
@@ -71,9 +71,10 @@
     "react-dom": "^16.9.0 || ^17.0.0"
   },
   "dependencies": {
+    "@babel/code-frame": "^7.12.13",
     "@babel/parser": "^7.12.5",
     "@babel/traverse": "^7.12.5",
-    "babel-jsx-utils": "^1.0.1",
+    "babel-jsx-utils": "^1.1.0",
     "babel-plugin-remove-graphql-queries": "^3.2.0-next.0",
     "camelcase": "^5.3.1",
     "chokidar": "^3.5.1",

--- a/packages/gatsby-plugin-image/src/babel-helpers.ts
+++ b/packages/gatsby-plugin-image/src/babel-helpers.ts
@@ -51,7 +51,7 @@ export function normalizeProps(
 
 export function evaluateImageAttributes(
   nodePath: NodePath<JSXOpeningElement>,
-  onError?: (prop: string) => void
+  onError?: (prop: string, nodePath: NodePath<any>) => void
 ): Record<string, unknown> {
   // Only get attributes that we need for generating the images
   return normalizeProps(getAttributeValues(nodePath, onError, SHARP_ATTRIBUTES))

--- a/packages/gatsby-plugin-image/src/node-apis/image-processing.ts
+++ b/packages/gatsby-plugin-image/src/node-apis/image-processing.ts
@@ -88,7 +88,7 @@ export async function writeImages({
       let file: FileSystemNode | undefined
       let fullPath
       if (!src) {
-        reporter.warn(`Missing StaticImage "src" in ${filename}`)
+        reporter.warn(`Missing StaticImage "src" in ${filename}.`)
         return
       }
       if (isRemoteURL(src)) {
@@ -129,7 +129,7 @@ export async function writeImages({
 
         if (!fs.existsSync(fullPath)) {
           reporter.warn(
-            `Could not find image "${src}" in "${filename}". Looked for ${fullPath}`
+            `Could not find image "${src}" in "${filename}". Looked for ${fullPath}.`
           )
           return
         }

--- a/packages/gatsby-plugin-image/src/node-apis/image-processing.ts
+++ b/packages/gatsby-plugin-image/src/node-apis/image-processing.ts
@@ -70,6 +70,7 @@ export async function writeImages({
   createNodeId,
   createNode,
   store,
+  filename,
 }: {
   images: Map<string, IStaticImageProps>
   pathPrefix: string
@@ -80,11 +81,16 @@ export async function writeImages({
   createNodeId: ParentSpanPluginArgs["createNodeId"]
   createNode: Actions["createNode"]
   store: Store
+  filename: string
 }): Promise<void> {
   const promises = [...images.entries()].map(
     async ([hash, { src, ...args }]) => {
       let file: FileSystemNode | undefined
       let fullPath
+      if (!src) {
+        reporter.warn(`Missing StaticImage "src" in ${filename}`)
+        return
+      }
       if (isRemoteURL(src)) {
         let createRemoteFileNode
         try {
@@ -122,7 +128,9 @@ export async function writeImages({
         fullPath = path.resolve(sourceDir, src)
 
         if (!fs.existsSync(fullPath)) {
-          reporter.warn(`Could not find image "${src}". Looked for ${fullPath}`)
+          reporter.warn(
+            `Could not find image "${src}" in "${filename}". Looked for ${fullPath}`
+          )
           return
         }
 

--- a/packages/gatsby-plugin-image/src/node-apis/parser.ts
+++ b/packages/gatsby-plugin-image/src/node-apis/parser.ts
@@ -73,7 +73,8 @@ export function babelParseToAst(
  * Extracts and returns the props from any that are found
  */
 export const extractStaticImageProps = (
-  ast: babel.types.File
+  ast: babel.types.File,
+  onError?: (prop: string, nodePath: NodePath) => void
 ): Map<string, IStaticImageProps> => {
   const images: Map<string, IStaticImageProps> = new Map()
 
@@ -89,7 +90,8 @@ export const extractStaticImageProps = (
       }
       const image = (evaluateImageAttributes(
         // There's a conflict between the definition of NodePath in @babel/core and @babel/traverse
-        (nodePath as unknown) as NodePath<JSXOpeningElement>
+        (nodePath as unknown) as NodePath<JSXOpeningElement>,
+        onError
       ) as unknown) as IStaticImageProps
       images.set(hashOptions(image), image)
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6132,10 +6132,10 @@ babel-jest@^24.9.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
-babel-jsx-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/babel-jsx-utils/-/babel-jsx-utils-1.0.1.tgz#f2d171cba526594e7d69e9893d634502cf950f07"
-  integrity sha512-Qph/atlQiSvfmkoIZ9VA+t8dA0ex2TwL37rkhLT9YLJdhaTMZ2HSM2QGzbqjLWanKA+I3wRQJjjhtuIEgesuLw==
+babel-jsx-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-jsx-utils/-/babel-jsx-utils-1.1.0.tgz#304ce4fce0c86cbeee849551a45eb4ed1036381a"
+  integrity sha512-Mh1j/rw4xM9T3YICkw22aBQ78FhsHdsmlb9NEk4uVAFBOg+Ez9ZgXXHugoBPCZui3XLomk/7/JBBH4daJqTkQQ==
 
 babel-loader@^8.2.2:
   version "8.2.2"


### PR DESCRIPTION
The error when props were not resolved in StaticImage was unclear, leading to a lot of confusion, e.g. in #30143 . This PR uses the babel node path to generate a structured error, with a codeframe and link to the docs

![image](https://user-images.githubusercontent.com/213306/111302367-3a142500-864b-11eb-8768-d46e452e70f1.png)
