### PR TITLE
chore: use 2 for release instead of 1

### DIFF
--- a/docs/docs/reference/release-notes/v3.1/index.md
+++ b/docs/docs/reference/release-notes/v3.1/index.md
@@ -3,9 +3,9 @@ date: "2021-03-16"
 version: "3.1.0"
 ---
 
-# [v3.1](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.1.0-next.0...gatsby@3.1.0) (March 2021 #1)
+# [v3.1](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.1.0-next.0...gatsby@3.1.0) (March 2021 #2)
 
-Welcome to `gatsby@3.1.0` release (March 2021 #1)
+Welcome to `gatsby@3.1.0` release (March 2021 #2)
 
 Key highlights of this release:
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Small tweak to release notes