### PR TITLE
docs: Update beta/deprecation status of image plugins

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-image.md
@@ -4,6 +4,8 @@ title: Using Gatsby Image to Prevent Image Bloat
 
 import ImageModel from "@components/layer-model/image-model"
 
+_This doc is for the deprecated `gatsby-image` package. See [Using the Gatsby Image plugin](/docs/how-to/images-and-media/using-gatsby-plugin-image) for the new image plugin._
+
 Using images in Gatsby components and pages requires four steps to take advantage of performance benefits.
 
 <ImageModel initialLayer="Install" />

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -8,8 +8,6 @@ Adding responsive images to your site while maintaining high performance scores 
 
 Want to learn more about image optimization challenges? Read the Conceptual Guide: [Why Gatsby's Automatic Image Optimizations Matter](/docs/conceptual/using-gatsby-image/). For full documentation on all configuration options, see [the reference guide](/docs/reference/built-in-components/gatsby-plugin-image).
 
-The new Gatsby Image plugin is currently in beta, but you can try it out now and see what it can do for the performance of your site.
-
 ## Getting started
 
 1. Install the following packages:


### PR DESCRIPTION
Add a deprecation banner to gatsby-image doc, and remove the beta warning from gatsby-plugin-image