### PR TITLE
fix(gatsby): be less aggressive when marking builtin methods as unsafe (#30216)

### DIFF
--- a/packages/gatsby/cache-dir/ssr-builtin-trackers/http.js
+++ b/packages/gatsby/cache-dir/ssr-builtin-trackers/http.js
@@ -1,3 +1,3 @@
 const { wrapModuleWithTracking } = require(`./tracking-unsafe-module-wrapper`)
 
-module.exports = wrapModuleWithTracking(`http`)
+module.exports = wrapModuleWithTracking(`http`, { ignore: [`http.Agent`] })

--- a/packages/gatsby/cache-dir/ssr-builtin-trackers/https.js
+++ b/packages/gatsby/cache-dir/ssr-builtin-trackers/https.js
@@ -1,3 +1,3 @@
 const { wrapModuleWithTracking } = require(`./tracking-unsafe-module-wrapper`)
 
-module.exports = wrapModuleWithTracking(`https`)
+module.exports = wrapModuleWithTracking(`https`, { ignore: [`https.Agent`] })


### PR DESCRIPTION
Backporting #30216 to the 3.1 release branch

(cherry picked from commit 331d76e41533db65d896df2c08c55b929219d124)