### PR TITLE
docs: Add info on using CMS images

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -212,6 +212,8 @@ A dedicated image CDN can be used with sources that don't have their own CDN, or
 
 - [imgix](https://www.gatsbyjs.com/plugins/@imgix/gatsby/)
 
+### Plugin authors
+
 If you maintain a source plugin or image CDN, there is a toolkit to help you add support for `gatsby-plugin-image`. See [Adding Gatbsy Image support to your plugin](/docs/how-to/plugins-and-themes/adding-gatsby-image-support/) for more details. You can then open a PR to add your plugin to this list.
 
 ## Migrating


### PR DESCRIPTION
Adds links to plugins with built-in gatsby-plugin-image support