### PR TITLE
fix(gatsby): do not fail on 3rd-party schemas with relay-classic support

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -789,7 +789,7 @@ const addThirdPartySchemas = ({
         type.name !== `Date` &&
         type.name !== `JSON`
       ) {
-        const isCompositeType =
+        const typeHasFields =
           type instanceof GraphQLObjectType ||
           type instanceof GraphQLInterfaceType
 
@@ -805,13 +805,13 @@ const addThirdPartySchemas = ({
         //   This unexpected `Query` composer messes up with our own Query type composer and produces duplicate types.
         //   The workaround is to make sure fields of the GitHub type are lazy and are evaluated only when
         //   this Query type is already replaced with our own root `Query` type (see processThirdPartyTypeFields):
-        if (isCompositeType && typeof type._fields === `object`) {
+        if (typeHasFields && typeof type._fields === `object`) {
           const fields = type._fields
           type._fields = () => fields
         }
         // ^^^ workaround done
         const typeComposer = schemaComposer.createTC(type)
-        if (isCompositeType) {
+        if (typeHasFields) {
           processThirdPartyTypeFields({
             typeComposer,
             type,

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -770,7 +770,11 @@ const addThirdPartySchemas = ({
   thirdPartySchemas.forEach(schema => {
     const schemaQueryType = schema.getQueryType()
     const queryTC = schemaComposer.createTempTC(schemaQueryType)
-    processThirdPartyTypeFields({ typeComposer: queryTC, schemaQueryType })
+    processThirdPartyTypeFields({
+      typeComposer: queryTC,
+      type: schemaQueryType,
+      schemaQueryType,
+    })
     schemaComposer.Query.addFields(queryTC.getFields())
 
     // Explicitly add the third-party schema's types, so they can be targeted
@@ -785,12 +789,34 @@ const addThirdPartySchemas = ({
         type.name !== `Date` &&
         type.name !== `JSON`
       ) {
+        const isCompositeType =
+          type instanceof GraphQLObjectType ||
+          type instanceof GraphQLInterfaceType
+
+        // Workaround for an edge case typical for Relay Classic-compatible schemas.
+        // For example, GitHub API contains this piece:
+        //   type Query { relay: Query }
+        // And gatsby-source-graphql transforms it to:
+        //   type Query { github: GitHub }
+        //   type GitHub { relay: Query }
+        // The problem:
+        //   schemaComposer.createTC(type) for type `GitHub` will eagerly create type composers
+        //   for all fields (including `relay` and it's type: `Query` of the third-party schema)
+        //   This unexpected `Query` composer messes up with our own Query type composer and produces duplicate types.
+        //   The workaround is to make sure fields of the GitHub type are lazy and are evaluated only when
+        //   this Query type is already replaced with our own root `Query` type (see processThirdPartyTypeFields):
+        if (isCompositeType && typeof type._fields === `object`) {
+          const fields = type._fields
+          type._fields = () => fields
+        }
+        // ^^^ workaround done
         const typeComposer = schemaComposer.createTC(type)
-        if (
-          typeComposer instanceof ObjectTypeComposer ||
-          typeComposer instanceof InterfaceTypeComposer
-        ) {
-          processThirdPartyTypeFields({ typeComposer, schemaQueryType })
+        if (isCompositeType) {
+          processThirdPartyTypeFields({
+            typeComposer,
+            type,
+            schemaQueryType,
+          })
         }
         typeComposer.setExtension(`createdFrom`, `thirdPartySchema`)
         schemaComposer.addSchemaMustHaveType(typeComposer)
@@ -830,15 +856,19 @@ const resetOverriddenThirdPartyTypeFields = ({ typeComposer }) => {
   })
 }
 
-const processThirdPartyTypeFields = ({ typeComposer, schemaQueryType }) => {
+const processThirdPartyTypeFields = ({
+  typeComposer,
+  type,
+  schemaQueryType,
+}) => {
   resetOverriddenThirdPartyTypeFields({ typeComposer })
 
   // Fix for types that refer to Query. Thanks Relay Classic!
+  const fields = type.getFields()
   typeComposer.getFieldNames().forEach(fieldName => {
     // Remove customization that we could have added via `createResolvers`
     // to make it work with schema rebuilding
-    const field = typeComposer.getField(fieldName)
-    const fieldType = field.type.getTypeName()
+    const fieldType = String(fields[fieldName].type)
     if (fieldType.replace(/[[\]!]/g, ``) === schemaQueryType.name) {
       typeComposer.extendField(fieldName, {
         type: fieldType.replace(schemaQueryType.name, `Query`),

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -861,11 +861,9 @@ const processThirdPartyTypeFields = ({
   type,
   schemaQueryType,
 }) => {
-  resetOverriddenThirdPartyTypeFields({ typeComposer })
-
   // Fix for types that refer to Query. Thanks Relay Classic!
   const fields = type.getFields()
-  typeComposer.getFieldNames().forEach(fieldName => {
+  Object.keys(fields).forEach(fieldName => {
     // Remove customization that we could have added via `createResolvers`
     // to make it work with schema rebuilding
     const fieldType = String(fields[fieldName].type)
@@ -875,6 +873,7 @@ const processThirdPartyTypeFields = ({
       })
     }
   })
+  resetOverriddenThirdPartyTypeFields({ typeComposer })
 }
 
 const addCustomResolveFunctions = async ({ schemaComposer, parentSpan }) => {


### PR DESCRIPTION
## Description

Workaround for an edge case typical for Relay Classic-compatible schemas. It is easier to explain with an example.

For example, GitHub API fed to `gatsby-source-graphql` contains this piece:

```graphql
type Query {
  github: GitHub
}
type GitHub {
  relay: Query
}
```

During the initial schema building, we replace the third-party `Query` type with our own `Query` type. `graphql-compose` does that by mutating the original `GraphQLSchema` instance of the third-party schema.

**The problem:**
When we rebuild the schema our own instance of `Query` type from the previous build leaks into the new schema (via mutated third-party `GraphQLSchema` instance) and produces the dreaded error:

```
Schema must contain uniquely named types but contains multiple types named "Foo"
```

In theory, it should not happen because we mutate third-party schema again when rebuilding and replace the old `Query` type with the new one here:
https://github.com/gatsbyjs/gatsby/blob/33aa3570ecb38ee2df09f1ad6de1be5fed13c156/packages/gatsby/src/schema/schema.js#L842-L846

But behavior change in `graphql-compose@7` introduced a new codepath which made it possible. It happens indirectly when creating a composer for type `GitHub` here:

https://github.com/gatsbyjs/gatsby/blob/33aa3570ecb38ee2df09f1ad6de1be5fed13c156/packages/gatsby/src/schema/schema.js#L788-L794

`processThirdPartyTypeFields` would have replaced the old `Query` type with the new one but `createTC` kicks in first and recursively creates type composers for all nested types, including the old `Query` via `relay` field.

To prevent this we must make sure that fields of the `GitHub` type are initialized lazily. Then `graphql-compose` won't traverse everything recursively when creating type composer and `processThirdPartyTypeFields` will have a chance to replace the old `Query` type with the new one before bad type composer for the old `Query` type is created.

This is a mess and was extremely hard to debug. So I've decided to document it better here for a paper trail in case we hit related problems in the future 😒

Fixes #30199