### PR TITLE
fix(gatsby-plugin-image): Only use default breakpoints for fullwidth

### DIFF
--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -179,12 +179,18 @@ export function getImageData<OptionsType>({
   urlBuilder,
   sourceWidth,
   sourceHeight,
-  pluginName = `useGatsbyImage`,
+  pluginName = `getImageData`,
   formats = [`auto`],
-  breakpoints = EVERY_BREAKPOINT,
+  breakpoints,
   options,
   ...props
 }: IGetImageDataArgs<OptionsType>): IGatsbyImageData {
+  if (
+    !breakpoints?.length &&
+    (props.layout === `fullWidth` || (props.layout as string) === `FULL_WIDTH`)
+  ) {
+    breakpoints = EVERY_BREAKPOINT
+  }
   const generateImageSource = (
     baseUrl: string,
     width: number,


### PR DESCRIPTION
Previously we were using default breakpoints in the runtime image helper for all layouts. Thsi changes it to just fullWidth, as other layouts should default to calculating it from the output dimensions. This also adds tests for the helper.