### PR TITLE
docs: Add background images docs

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -218,9 +218,9 @@ If you maintain a source plugin or image CDN, there is a toolkit to help you add
 
 ## Background images
 
-CSS has more limited support for responsive image handling than the `<picture>` element. Most importantly, it does not handle fallback for next-gen image formats such as AVIF and WebP. You can get the benefits of `gatsby-plugin-image` for background images without any extra components.
+Using CSS to display background images has more limited support for responsive image handling than the `<picture>` element. Most importantly, it does not handle fallback for next-gen image formats such as AVIF and WebP. You can get the benefits of `gatsby-plugin-image` for background images without any extra components.
 
-This is an example of creating a hero image component, with text overlaying an image background. It uses CSS grid to stack the elements on top of each other.
+This is an example of a hero image component with text overlaying an image background. It uses CSS grid to stack the elements on top of each other.
 
 ```jsx
 import * as React from "react"

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -216,6 +216,55 @@ A dedicated image CDN can be used with sources that don't have their own CDN, or
 
 If you maintain a source plugin or image CDN, there is a toolkit to help you add support for `gatsby-plugin-image`. See [Adding Gatbsy Image support to your plugin](/docs/how-to/plugins-and-themes/adding-gatsby-image-support/) for more details. You can then open a PR to add your plugin to this list.
 
+## Background images
+
+CSS has more limited support for responsive image handling than the `<picture>` element. Most importantly, it does not handle fallback for next-gen image formats such as AVIF and WebP. You can get the benefits of `gatsby-plugin-image` for background images without any extra components.
+
+This is an example of creating a hero image component, with text overlaying an image background. It uses CSS grid to stack the elements on top of each other.
+
+```jsx
+import * as React from "react"
+import { StaticImage } from "gatsby-plugin-image"
+
+export function Hero() {
+  return (
+    <div style={{ display: "grid" }}>
+      {/* You can use a GatsbyImage component if the image is dynamic */}
+      <StaticImage
+        style={{
+          gridArea: "1/1",
+          // You can set a maximum height for the image, if you wish.
+          // maxHeight: 600,
+        }}
+        layout="fullWidth"
+        // You can optionally force an aspect ratio for the generated image
+        aspectRatio={3 / 1}
+        // This is a presentational image, so the alt should be an empty string
+        alt=""
+        // Assisi, Perúgia, Itália by Bernardo Ferrari, via Unsplash
+        src={
+          "https://images.unsplash.com/photo-1604975999044-188783d54fb3?w=2589"
+        }
+        formats={["auto", "webp", "avif"]}
+      />
+      <div
+        style={{
+          // By using the same grid area for both, they are stacked on top of each other
+          gridArea: "1/1",
+          position: "relative",
+          // This centers the other elements inside the hero component
+          placeItems: "center",
+          display: "grid",
+        }}
+      >
+        {/* Any content here will be centered in the component */}
+        <h1>Hero text</h1>
+      </div>
+    </div>
+  )
+}
+```
+
 ## Migrating
 
 If your site uses the old `gatsby-image` component, you can use a codemod to help you migrate to the new Gatsby Image components. This can update the code for most sites. To use the codemod, run this command in the root of your site:


### PR DESCRIPTION
Several people have been trying to use the new image plugin for background images, and having trouble trying to use it with third party background image components. This PR adds some docs about using CSS grid to create a hero image with a background image using `StaticImage`