### PR TITLE
feat: skip rewriting page-data file if content didn't change

### DIFF
--- a/packages/gatsby/src/utils/__tests__/get-page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/get-page-data.ts
@@ -81,6 +81,8 @@ describe(`get-page-data-util`, () => {
   beforeEach(() => {
     store.dispatch({
       type: `DELETE_CACHE`,
+      // we delete pageData files, so we need to let html reducer know that
+      cacheIsCorrupt: true,
     })
     deletePageDataFilesFromFs()
   })

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -98,17 +98,25 @@ export async function writePageData(
   // transform asset size to kB (from bytes) to fit 64 bit to numbers
   const pageDataSize = Buffer.byteLength(bodyStr) / 1000
 
+  const pageDataHash = createContentDigest(bodyStr)
+  const previousPageDataHash = store
+    .getState()
+    .html.trackedHtmlFiles.get(pagePath)?.pageDataHash
+
   store.dispatch({
     type: `ADD_PAGE_DATA_STATS`,
     payload: {
       pagePath,
       filePath: outputFilePath,
       size: pageDataSize,
-      pageDataHash: createContentDigest(bodyStr),
+      pageDataHash,
     },
   })
 
-  await fs.outputFile(outputFilePath, bodyStr)
+  if (pageDataHash !== previousPageDataHash) {
+    await fs.outputFile(outputFilePath, bodyStr)
+  }
+
   return body
 }
 


### PR DESCRIPTION
## Description

Bit hacky (part that checks into `html` reducer), but seems to work - for now just draft to see how this change behave with artifacts test and how it handles deletions, changes all the trailing slashes normalizations, etc 