### PR TITLE
Require files from the .cache directory so user can run es/commonjs

### DIFF
--- a/packages/gatsby-plugin-functions/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-functions/src/gatsby-node.ts
@@ -108,8 +108,7 @@ export async function onPreBootstrap(
       })
     )
   } catch (e) {
-    reporter.error(`Failed to compile Gatsby Functions.`)
-    reporter.panicOnBuild(e)
+    activity.panic(`Failed to compile Gatsby Functions.`, e)
   }
 
   activity.end()

--- a/packages/gatsby-plugin-functions/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-functions/src/gatsby-node.ts
@@ -93,7 +93,7 @@ export async function onPreBootstrap(
           // }
 
           webpack(config).run((err, stats) => {
-            if (stats?.compilation?.warnings) {
+            if (stats?.compilation?.warnings?.length > 0) {
               reporter.warn(stats.compilation.warnings)
             }
 
@@ -106,7 +106,8 @@ export async function onPreBootstrap(
       })
     )
   } catch (e) {
-    reporter.panicOnBuild(e.message)
+    reporter.error(`Failed to compile Gatsby Functions.`)
+    reporter.panicOnBuild(e)
   }
 
   activity.end()
@@ -152,14 +153,14 @@ export async function onCreateDevServer(
         `js`
       )
 
-      const fn = require(path.join(compiledFunctionsDir, funcNameToJs))
-
-      const fnToExecute = (fn && fn.default) || fn
-
       try {
+        const fn = require(path.join(compiledFunctionsDir, funcNameToJs))
+
+        const fnToExecute = (fn && fn.default) || fn
+
         fnToExecute(req, res)
       } catch (e) {
-        reporter.error(e.message)
+        reporter.error(e)
       }
       activity.end()
     } else {

--- a/packages/gatsby-plugin-functions/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-functions/src/gatsby-node.ts
@@ -127,7 +127,7 @@ export async function onCreateDevServer(
   )
   const files = await glob(functionsGlob, { cwd: functionsDirectory })
 
-  reporter.info(`Attaching Functions to development server.`)
+  reporter.verbose(`Attaching functions to development server`)
 
   const knownFunctions = new Map(
     files.map(file => [
@@ -156,9 +156,7 @@ export async function onCreateDevServer(
           `.cache`,
           `functions`
         )
-        const funcNameToJs = (knownFunctions.get(
-          functionName
-        ) as string).replace(`ts`, `js`)
+        const funcNameToJs = knownFunctions.get(functionName) as string
 
         try {
           const fn = require(path.join(compiledFunctionsDir, funcNameToJs))

--- a/packages/gatsby-plugin-functions/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-functions/src/gatsby-node.ts
@@ -143,12 +143,21 @@ export async function onCreateDevServer(
     const { functionName } = req.params
 
     if (knownFunctions.has(functionName)) {
-      const fn = require(path.join(
-        functionsDirectory,
-        knownFunctions.get(functionName) as string
-      ))
+      const compiledFunctionsDir = path.join(
+        process.cwd(),
+        `.cache`,
+        `functions`
+      )
+      const funcNameToJs = (knownFunctions.get(functionName) as string).replace(
+        `js`,
+        `ts`
+      )
 
-      fn(req, res)
+      const fn = require(path.join(compiledFunctionsDir, funcNameToJs))
+
+      const fnToExecute = (fn && fn.default) || fn
+
+      fnToExecute(req, res)
     } else {
       next()
     }

--- a/packages/gatsby-plugin-functions/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-functions/src/gatsby-node.ts
@@ -35,7 +35,12 @@ export async function onPreBootstrap(
   const files = await glob(functionsGlob, { cwd: functionsDirectory })
 
   if (files?.length === 0) {
-    reporter.warn(`No functions found in directory: ${functionsDirectory}.`)
+    reporter.warn(
+      `No functions found in directory: ${path.relative(
+        process.cwd(),
+        functionsDirectory
+      )}`
+    )
     return
   }
 


### PR DESCRIPTION
Getting errors running functions written with default exports

```
 ERROR 

/Users/abhiaiyer/gatsby/gatsby-functions/src/functions/dog.ts:3
export default async (req, res) => {
^^^^^^

SyntaxError: Unexpected token 'export'
```

So moved the require to the compiled dir.