### PR TITLE
fix(gatsby): Fix argument order for onPreRouteUpdate

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -242,9 +242,9 @@ class RouteUpdates extends React.Component {
     onRouteUpdate(this.props.location, null)
   }
 
-  shouldComponentUpdate(prevProps) {
-    if (compareLocationProps(prevProps.location, this.props.location)) {
-      onPreRouteUpdate(this.props.location, prevProps.location)
+  shouldComponentUpdate(nextProps) {
+    if (compareLocationProps(this.props.location, nextProps.location)) {
+      onPreRouteUpdate(nextProps.location, this.props.location)
       return true
     }
     return false


### PR DESCRIPTION
This PR is completely untested; I wrote it in the GitHub UI.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The argument for `shouldComponentUpdate` is the *next* props, not the *previous* props, so `onPreRouteUpdate` was getting called with arguments in the reverse order.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#onPreRouteUpdate

No doc update necessary; this PR brings the behavior in line with the existing docs.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

I didn't find any.