### PR TITLE
chore(docs): Fix typo in createPages doc

### DIFF
--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -14,7 +14,7 @@ export const resolvableExtensions = true
  *
  * @param {object} $0 See the [documentation for `Node API Helpers` for more details](/docs/node-api-helpers)
  * @param {Actions} $0.actions See the [list of documented actions](/docs/actions)
- * @param {function} $0.actions.createPages [Documentation for this action](/docs/actions/#createPage)
+ * @param {function} $0.actions.createPage [Documentation for this action](/docs/actions/#createPage)
  * @param {function} $0.graphql: Query GraphQL API. See [examples here](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs)
  * @param {GatsbyReporter} $0.reporter Log issues. See [GatsbyReporter documentation](/docs/node-api-helpers/#GatsbyReporter) for more details
  * @returns {Promise<void>} No return value required, but the caller will `await` any promise that's returned


### PR DESCRIPTION
The action is `createPage` and not `createPages`.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fix a documentation typography. The action seems to be `createPage` and not `createPages`.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
