### PR TITLE
docs(gatsby-plugin-image): Warn about `styled(StaticImage)` usage

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -51,7 +51,7 @@ This does not work:
 
 export function Logo({ logo }) {
   // You can't use a prop passed into the parent component
-  return <StaticImage src={logo}>
+  return <StaticImage src={logo} />
 }
 ```
 
@@ -61,9 +61,9 @@ export function Logo({ logo }) {
 // ⚠️ Doesn't work
 
 export function Dino() {
-    // Props can't come from function calls
-    const width = getTheWidthFromSomewhere();
-    return <StaticImage src="trex.png" width={width}>
+  // Props can't come from function calls
+  const width = getTheWidthFromSomewhere()
+  return <StaticImage src="trex.png" width={width} />
 }
 ```
 
@@ -71,10 +71,10 @@ You can use variables and expressions if they're in the scope of the file, e.g.:
 
 ```js
 // OK
-export function Dino()  {
-    // Local variables are fine
-    const width = 300
-    return <StaticImage src="trex.png" width={width}>
+export function Dino() {
+  // Local variables are fine
+  const width = 300
+  return <StaticImage src="trex.png" width={width} />
 }
 ```
 
@@ -84,14 +84,64 @@ export function Dino()  {
 // A variable in the same file is fine.
 const width = 300
 
-export function Dino()  {
-    // This works because the value can be statically-analyzed
-    const height = width * 16 / 9
-    return <StaticImage src="trex.png" width={width} height={height}>
+export function Dino() {
+  // This works because the value can be statically-analyzed
+  const height = (width * 16) / 9
+  return <StaticImage src="trex.png" width={width} height={height} />
 }
 ```
 
 If you find yourself wishing you could use a prop for the image `src` then it's likely that you should be using a dynamic image.
+
+#### Using `StaticImage` with CSS-in-JS libraries
+
+The `StaticImage` component does not support higher-order components which includes the `styled` function from libraries such as Emotion and styled-components.
+
+```js
+// ⚠️ Doesn't work
+
+const AwesomeImage = styled(StaticImage)`
+  border: 4px green dashed;
+`
+
+export function Dino() {
+  return <AwesomeImage src="trex.png" />
+}
+```
+
+You should instead use the `css` prop provided by these libraries:
+
+```jsx
+// 👩‍🎤 Emotion
+
+export function Dino() {
+  return (
+    <StaticImage
+      src="trex.png"
+      css={css`
+        border: 4px green dashed;
+      `}
+    />
+  )
+}
+```
+
+```jsx
+// 💅 styled-components
+
+export function Dino() {
+  return (
+    <StaticImage
+      src="trex.png"
+      css={`
+        border: 4px green dashed;
+      `}
+    />
+  )
+}
+```
+
+You can also use a regular `style` or `className` prop. Note that in all of these cases the styling is applied to the wrapper, not the image itself. If you need to style the `<img>` tag, you can use `imgStyle` or `imgClassName`.
 
 ### `GatsbyImage`
 

--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -95,7 +95,7 @@ If you find yourself wishing you could use a prop for the image `src` then it's 
 
 #### Using `StaticImage` with CSS-in-JS libraries
 
-The `StaticImage` component does not support higher-order components which includes the `styled` function from libraries such as Emotion and styled-components.
+The `StaticImage` component does not support higher-order components, which includes the `styled` function from libraries such as Emotion and styled-components. The parser relies on being able to identify `StaticImage` components in the source, and passing them to a function means this is not possible.
 
 ```js
 // ⚠️ Doesn't work
@@ -105,6 +105,7 @@ const AwesomeImage = styled(StaticImage)`
 `
 
 export function Dino() {
+  // Parser doesn't know that this is a StaticImage
   return <AwesomeImage src="trex.png" />
 }
 ```

--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -112,7 +112,7 @@ export function Dino() {
 You should instead use the `css` prop provided by these libraries:
 
 ```jsx
-// 👩‍🎤 Emotion
+// Emotion
 
 export function Dino() {
   return (
@@ -127,7 +127,7 @@ export function Dino() {
 ```
 
 ```jsx
-// 💅 styled-components
+// styled-components
 
 export function Dino() {
   return (


### PR DESCRIPTION
The `StaticImage` component doesn't work with higher-order components like the `styled` function from styled-components or Emotion. This explains how you should use the css prop instead.