### PR TITLE
feat(gatsby-plugin-image): data-srcset should be used to prevent overly eager loading on chrome

### DIFF
--- a/integration-tests/images/__tests__/images.ts
+++ b/integration-tests/images/__tests__/images.ts
@@ -52,7 +52,7 @@ function getImages(testId: string, dom: HTMLDivElement) {
 
   sources?.forEach(source => {
     const format = source.getAttribute("type")
-    const srcset = source.getAttribute("data-srcset")
+    const srcset = source.dataset.srcset
     if (format && srcset) {
       srcsets.push({ format, srcset: parseSrcSet(srcset) })
     }

--- a/integration-tests/images/__tests__/images.ts
+++ b/integration-tests/images/__tests__/images.ts
@@ -52,7 +52,7 @@ function getImages(testId: string, dom: HTMLDivElement) {
 
   sources?.forEach(source => {
     const format = source.getAttribute("type")
-    const srcset = source.getAttribute("srcset")
+    const srcset = source.getAttribute("data-srcset")
     if (format && srcset) {
       srcsets.push({ format, srcset: parseSrcSet(srcset) })
     }

--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.server.tsx
@@ -297,9 +297,9 @@ icon.svg`,
       expect(picture).toMatchInlineSnapshot(`
         <picture>
           <source
+            data-srcset="icon32px.png 32w,icon64px.png 64w,icon-retina.png 2x,icon-ultra.png 3x,icon.svg"
             media="some-media"
             sizes="192x192"
-            srcset="icon32px.png 32w,icon64px.png 64w,icon-retina.png 2x,icon-ultra.png 3x,icon.svg"
           />
           <img
             alt="A fake image for testing purpose"

--- a/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
+++ b/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
@@ -24,9 +24,11 @@ if (hasNativeLazyLoadSupport) {
       mainImage.setAttribute('src', mainImage.dataset.src)
       mainImage.removeAttribute('data-src')
     }
-    if (mainImage.dataset.srcset) {
-      mainImage.setAttribute('srcset', mainImage.dataset.srcset)
-      mainImage.removeAttribute('data-srcset')
+
+    const sources = mainImage.parentNode.querySelectorAll('source[data-srcset]');
+    for (let source of sources) {
+      source.setAttribute('srcset', source.dataset.srcset)
+      source.removeAttribute('data-srcset')
     }
 
     if (mainImage.complete) {

--- a/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
+++ b/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
@@ -24,6 +24,10 @@ if (hasNativeLazyLoadSupport) {
       mainImage.setAttribute('src', mainImage.dataset.src)
       mainImage.removeAttribute('data-src')
     }
+    if (mainImage.dataset.srcset) {
+      mainImage.setAttribute('srcset', mainImage.dataset.srcset)
+      mainImage.removeAttribute('data-srcset')
+    }
 
     const sources = mainImage.parentNode.querySelectorAll('source[data-srcset]');
     for (let source of sources) {

--- a/packages/gatsby-plugin-image/src/components/picture.tsx
+++ b/packages/gatsby-plugin-image/src/components/picture.tsx
@@ -91,7 +91,8 @@ export const Picture = forwardRef<HTMLImageElement, PictureProps>(
             key={`${media}-${type}-${srcSet}`}
             type={type}
             media={media}
-            srcSet={srcSet}
+            srcSet={shouldLoad ? srcSet : undefined}
+            data-srcset={!shouldLoad ? srcSet : undefined}
             sizes={sizes}
           />
         ))}

--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -91,12 +91,6 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
       }
       const placeholder = imageWrapper.querySelector("[data-placeholder-image]");
 
-      const sources = target.parentNode.querySelectorAll('source[data-srcset]');
-      for (const source of sources) {
-        source.setAttribute('src', source.dataset.src)
-        source.removeAttribute('data-src')
-      }
-
       const img = new Image();
       img.src = target.currentSrc;
       // We decode the img through javascript so we're sure the blur-up effect works

--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -91,6 +91,11 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
       }
       const placeholder = imageWrapper.querySelector("[data-placeholder-image]");
 
+      const sources = target.parentNode.querySelectorAll('source[data-srcset]');
+      for (const source of sources) {
+        source.setAttribute('src', source.dataset.src)
+        source.removeAttribute('data-src')
+      }
 
       const img = new Image();
       img.src = target.currentSrc;


### PR DESCRIPTION
Removed in #30221 and shouldn't have been