### PR TITLE
fix(gatsby-source-wordpress): requestConcurrency

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -315,6 +315,7 @@ export const createRemoteMediaItemNode = async ({
         url: mediaItemUrl,
         auth,
         ...createFileNodeRequirements,
+        pluginOptions,
       })
 
       return node


### PR DESCRIPTION
## Description

This passes in `pluginOptions` to the `createRemoteFileNode` call so that user defined [media item request concurrency](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/plugin-options.md#typemediaitemlocalfilerequestconcurrency) is honored. 

See: https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js#L382

## Related Issues
Fixes #29744
Addresses #30347
