### PR TITLE
docs(gatsby-plugin-image): Add GraphCMS to supported list

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -203,14 +203,15 @@ These source plugins support using `gatsby-plugin-image` with images served from
 - [AgilityCMS](https://github.com/agility/gatsby-image-agilitycms)
 - [Contentful](/plugins/gatsby-source-contentful/#using-the-new-gatsby-image-plugin)
 - [DatoCMS](/plugins/gatsby-source-datocms/#integration-with-gatsby-image)
-- [Sanity](https://www.gatsbyjs.com/plugins/gatsby-source-sanity/#using-images)
+- [GraphCMS](/plugins/gatsby-source-graphcms/#usage-with-gatsby-plugin-image)
+- [Sanity](/plugins/gatsby-source-sanity/#using-images)
 - [Shopify](https://github.com/gatsbyjs/gatsby-source-shopify-experimental#images)
 
 ### Image CDNs
 
 A dedicated image CDN can be used with sources that don't have their own CDN, or where you need more transforms or formats than the CDN offers.
 
-- [imgix](https://www.gatsbyjs.com/plugins/@imgix/gatsby/)
+- [imgix](/plugins/@imgix/gatsby/)
 
 ### Plugin authors
 


### PR DESCRIPTION
GraphCMS now supports the image plugin