### PR TITLE
fix(gatsby-source-wordpress): schema customization errors

### DIFF
--- a/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
@@ -78,6 +78,34 @@ describe(`data resolution`, () => {
     expect(gatsbyResult.data.allWpContentNode.length).toBe(17)
   })
 
+  it(`resolves interface fields which are a mix of Gatsby nodes and regular object data with no node`, async () => {
+    const query = /* GraphQL */ `
+      query {
+        wpPost(id: { eq: "cG9zdDox" }) {
+          id
+          comments {
+            nodes {
+              author {
+                # this is an interface of WpUser (Gatsby node type) and WpCommentAuthor (no node for this so needs to be fetched on the comment)
+                node {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    // this will throw an error if there are gql errors
+    const gatsbyResult = await fetchGraphQL({
+      url,
+      query,
+    })
+
+    expect(gatsbyResult.data.wpPost.comments.length).toBe(1)
+  })
+
   it(`resolves hierarchichal categories`, async () => {
     const gatsbyResult = await fetchGraphql({
       url,

--- a/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
@@ -29,12 +29,10 @@ describe(`data resolution`, () => {
     expect(data[`allWpPage`].totalCount).toBe(1)
     expect(data[`allWpPost`].totalCount).toBe(1)
     expect(data[`allWpComment`].totalCount).toBe(1)
-    // expect(data[`allWpProject`].totalCount).toBe(1)
     expect(data[`allWpTaxonomy`].totalCount).toBe(3)
     expect(data[`allWpCategory`].totalCount).toBe(9)
     expect(data[`allWpMenu`].totalCount).toBe(1)
     expect(data[`allWpMenuItem`].totalCount).toBe(4)
-    // expect(data[`allWpTeamMember`].totalCount).toBe(1)
     expect(data[`allWpPostFormat`].totalCount).toBe(0)
     expect(data[`allWpContentType`].totalCount).toBe(6)
   })
@@ -51,6 +49,33 @@ describe(`data resolution`, () => {
       gatsby: `wpPage`,
       wpgql: `page`,
     },
+  })
+
+  it(`resolves node interfaces without errors`, async () => {
+    const query = /* GraphQL */ `
+      query {
+        allWpTermNode {
+          nodes {
+            id
+          }
+        }
+
+        allWpContentNode {
+          nodes {
+            id
+          }
+        }
+      }
+    `
+
+    // this will throw if there are gql errors
+    const gatsbyResult = await fetchGraphQL({
+      url,
+      query,
+    })
+
+    expect(gatsbyResult.data.allWpTermNode.length).toBe(14)
+    expect(gatsbyResult.data.allWpContentNode.length).toBe(17)
   })
 
   it(`resolves hierarchichal categories`, async () => {

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
@@ -7,6 +7,7 @@ import {
   getTypeSettingsByType,
   filterTypeDefinition,
 } from "./helpers"
+import { getPluginOptions } from "../../utils/get-gatsby-api"
 
 const unionType = typeBuilderApi => {
   const { schema, type, pluginOptions } = typeBuilderApi
@@ -29,12 +30,14 @@ const unionType = typeBuilderApi => {
     name: buildTypeName(type.name),
     types,
     resolveType: node => {
-      if (node.type) {
-        return buildTypeName(node.type)
-      }
-
       if (node.__typename) {
-        return buildTypeName(node.__typename)
+        const {
+          schema: { typePrefix: prefix },
+        } = getPluginOptions()
+
+        return node.__typename.startsWith(prefix)
+          ? node.__typename
+          : buildTypeName(node.__typename)
       }
 
       return null

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
@@ -104,7 +104,7 @@ const interfaceType = typeBuilderApi => {
   } else {
     // otherwise this is a regular interface type so we need to resolve the type name
     typeDef.resolveType = node =>
-      node && node.__typename ? buildTypeName(node.__typename) : null
+      node?.__typename ? buildTypeName(node.__typename) : null
   }
 
   // @todo add this as a plugin option

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
@@ -24,6 +24,10 @@ export const buildTypeName = name => {
     name = `FilterType`
   }
 
+  if (name.startsWith(prefix)) {
+    return name
+  }
+
   return prefix + name
 }
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
@@ -5,6 +5,8 @@ import { fieldOfTypeWasFetched } from "./helpers"
 import buildType from "./build-types"
 import { getGatsbyNodeTypeNames } from "../source-nodes/fetch-nodes/fetch-nodes"
 import { typeIsExcluded } from "~/steps/ingest-remote-schema/is-excluded"
+import { formatLogMessage } from "../../utils/format-log-message"
+import { CODES } from "../../utils/report"
 
 /**
  * createSchemaCustomization
@@ -96,7 +98,12 @@ const createSchemaCustomization = async api => {
   try {
     await customizeSchema(api)
   } catch (e) {
-    api.reporter.panic(e)
+    api.reporter.panic({
+      id: CODES.SourcePluginCodeError,
+      context: {
+        sourceMessage: formatLogMessage(e.stack),
+      },
+    })
   }
 }
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/default-resolver.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/default-resolver.js
@@ -1,6 +1,7 @@
 import { findTypeName } from "~/steps/create-schema-customization/helpers"
 
 import { buildGatsbyNodeObjectResolver } from "~/steps/create-schema-customization/transform-fields/transform-object"
+import { buildTypeName } from "../helpers"
 
 export const buildDefaultResolver = transformerApi => (source, _, context) => {
   const { fieldName, field, gatsbyNodeTypes } = transformerApi
@@ -43,6 +44,12 @@ export const buildDefaultResolver = transformerApi => (source, _, context) => {
     typeof aliasedField2 !== `undefined`
   ) {
     finalFieldValue = aliasedField2
+  }
+
+  if (finalFieldValue?.__typename) {
+    // in Gatsby V3 this property is used to determine the type of an interface field
+    // instead of the resolveType fn. This means we need to prefix it so that gql doesn't throw errors about missing types.
+    finalFieldValue.__typename = buildTypeName(finalFieldValue.__typename)
   }
 
   const isANodeConnection =

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-object.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-object.js
@@ -64,6 +64,12 @@ export const buildGatsbyNodeObjectResolver = ({ field, fieldName }) => async (
 
   const queryInfo = getQueryInfoByTypeName(field.type.name)
 
+  if (!queryInfo) {
+    // if we don't have query info for a type
+    // it probably means this type is excluded in plugin options
+    return null
+  }
+
   const isLazyMediaItem =
     queryInfo.typeInfo.nodesTypeName === `MediaItem` &&
     queryInfo.settings.lazyNodes

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields.js
@@ -306,7 +306,7 @@ export function transformField({
     // or this type has a possible type which is a gatsby node type
     typeMap
       .get(typeName)
-      ?.possibleTypes?.find(possibleType =>
+      ?.possibleTypes?.every(possibleType =>
         gatsbyNodesInfo.typeNames.includes(possibleType.name)
       )
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-nodes.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-nodes.js
@@ -48,13 +48,16 @@ export const createNodeWithSideEffects = ({
     })
   }
 
+  const builtTypename = buildTypeName(node.__typename)
+
   let remoteNode = {
     ...node,
+    __typename: builtTypename,
     id: node.id,
     parent: null,
     internal: {
       contentDigest: createContentDigest(node),
-      type: type || buildTypeName(node.type),
+      type: type || builtTypename,
     },
   }
 


### PR DESCRIPTION
This PR fixes:
- On Gatsby v3 the type of nodes in node interfaces seem to be resolved slightly differently - which is by the __typename field on the node object. The WP plugin wasn't storing the prefixed typename which resulted in gel errors like `Abstract type \"WpTermNode\" was resolve to a type \"Category\" that does not exist inside schema.` since the typename is actually WpCategory.
- fixes #30310 
- Uses the new reporter.panic signature in the try/catch around schema customization so errors aren't swallowed by Gatsby
- fixes #30280
- fixes #30311