### PR TITLE
chore(gatsby): don't terminate dev server if graphql wasn't imported from gatsby

### DIFF
--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`File parser extracts query AST correctly from files: panic 1`] = `
+exports[`File parser extracts query AST correctly from files: panicOnBuild 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -274,7 +274,7 @@ export default () => {
     // The second param is a "hint", see: https://jestjs.io/docs/en/expect#tomatchsnapshotpropertymatchers-hint
     expect(results).toMatchSnapshot({}, `results`)
     expect(reporter.warn).toMatchSnapshot({}, `warn`)
-    expect(reporter.panic).toMatchSnapshot({}, `panic`)
+    expect(reporter.panicOnBuild).toMatchSnapshot({}, `panicOnBuild`)
     expect(errors.length).toEqual(1)
   })
 

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -139,7 +139,7 @@ async function parseToAst(filePath, fileStr, { parentSpan, addError } = {}) {
 }
 
 const panicOnGlobalTag = file =>
-  report.panic(
+  report.panicOnBuild(
     `Using the global \`graphql\` tag for Gatsby's queries isn't supported as of v3.\n` +
       `Import it instead like:  import { graphql } from 'gatsby' in file:\n` +
       file


### PR DESCRIPTION
## Description

This is just DX change to not terminate dev server - this is specifically annoying when migrating as we get 1 error per `gatsby develop` and not full list when `panic`-icking on first file that doesn't import graphql.