### PR TITLE
Added reporter.panic to empty catch in load-themes

### DIFF
--- a/packages/gatsby/src/bootstrap/load-themes/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/index.js
@@ -38,6 +38,15 @@ const resolveTheme = async (
         themeDir = resolve
       } catch (localErr) {
         // catch shouldn't be empty :shrug:
+        reporter.panic({
+        id: `10226`,
+        context: {
+          themeName,
+          configFilePath: configFileThatDeclaredTheme,
+          pathToLocalTheme,
+          nodeResolutionPaths,
+        },
+      })
       }
     }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Added reporter.panic to load-themes

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
Fixed empty catch block in load themes

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes #29545

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
