### PR TITLE
fix(gatsby-plugin-image): print error details

### DIFF
--- a/packages/gatsby-plugin-image/src/node-apis/image-processing.ts
+++ b/packages/gatsby-plugin-image/src/node-apis/image-processing.ts
@@ -110,8 +110,7 @@ export async function writeImages({
             reporter,
           })
         } catch (err) {
-          reporter.error(`Error loading image ${src}`)
-          reporter.error(err)
+          reporter.error(`Error loading image ${src}`, err)
           return
         }
         if (

--- a/packages/gatsby-plugin-image/src/node-apis/image-processing.ts
+++ b/packages/gatsby-plugin-image/src/node-apis/image-processing.ts
@@ -111,6 +111,7 @@ export async function writeImages({
           })
         } catch (err) {
           reporter.error(`Error loading image ${src}`)
+          reporter.error(err)
           return
         }
         if (


### PR DESCRIPTION
Hello 

i got general error message "Error loading image" over and over and I could not know what was causing the error,
therefore we should print the error details.

in my case the error details was "EPERM: operation not permitted, open...."
that happened because I only worked with YARN and to solve this specific problem i had to run once `npm install`.

Thank you for this wonderful plugin!