### PR TITLE
fix(gatsby): update nested input types when rebuilding SitePage

### DIFF
--- a/packages/gatsby/src/schema/__tests__/rebuild-sitepage-type.js
+++ b/packages/gatsby/src/schema/__tests__/rebuild-sitepage-type.js
@@ -171,6 +171,24 @@ describe(`build and update schema for SitePage`, () => {
     await testNestedFields()
   })
 
+  it(`updates nested input types on rebuild`, async () => {
+    // sanity-check
+    const inputFields = Object.keys(
+      schema.getType(`SitePageFieldsFilterInput`).getFields()
+    )
+    expect(inputFields.length).toBe(1)
+    expect(inputFields).toEqual([`oldKey`])
+
+    // Rebuild
+    const page = firstPage()
+    page.fields = {}
+    store.dispatch({ type: `CREATE_NODE`, payload: page })
+    await rebuildWithSitePage({})
+    schema = store.getState().schema
+
+    expect(schema.getType(`SitePageFieldsFilterInput`)).toBeUndefined()
+  })
+
   it(`respects @dontInfer on SitePage`, async () => {
     const typeDefs = `
       type SitePage implements Node @dontInfer {

--- a/packages/gatsby/src/schema/types/derived-types.ts
+++ b/packages/gatsby/src/schema/types/derived-types.ts
@@ -65,6 +65,15 @@ export const deleteFieldsOfDerivedTypes = ({ typeComposer }): void => {
   })
 }
 
+const removeTypeFromSchemaComposer = ({
+  schemaComposer,
+  typeComposer,
+}): void => {
+  schemaComposer.delete(typeComposer.getTypeName())
+  schemaComposer.delete((typeComposer as any)._gqType)
+  schemaComposer.delete(typeComposer)
+}
+
 export const clearDerivedTypes = ({
   schemaComposer,
   typeComposer,
@@ -77,15 +86,21 @@ export const clearDerivedTypes = ({
   for (const typeName of derivedTypes.values()) {
     const derivedTypeComposer = schemaComposer.getAnyTC(typeName)
     clearDerivedTypes({ schemaComposer, typeComposer: derivedTypeComposer })
-    schemaComposer.delete(typeName)
-    schemaComposer.delete((derivedTypeComposer as any)._gqType)
-    schemaComposer.delete(derivedTypeComposer)
+    removeTypeFromSchemaComposer({
+      schemaComposer,
+      typeComposer: derivedTypeComposer,
+    })
   }
 
   if (
     typeComposer instanceof ObjectTypeComposer ||
     typeComposer instanceof InterfaceTypeComposer
   ) {
+    const inputTypeComposer = typeComposer.getInputTypeComposer()
+    removeTypeFromSchemaComposer({
+      schemaComposer,
+      typeComposer: inputTypeComposer,
+    })
     typeComposer.removeInputTypeComposer()
   }
 


### PR DESCRIPTION
## Description

We properly clean up types when rebuilding with site page. But with new `graphql-compose` we must also explicitly cleanup input types. This PR adds missing pieces for it.

## Related Issues

Fixes #30203
