### PR TITLE
 feat(gatsby): do not store result in variable

### DIFF
--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -149,7 +149,7 @@ export async function flush(): Promise<void> {
     // This is why we need this check
     if (page) {
       if (
-        program?._?.[0] === `develop` &&
+        process.env.gatsby_executing_command === `develop` &&
         process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
       ) {
         // check if already did run query for this page
@@ -181,7 +181,7 @@ export async function flush(): Promise<void> {
         }
       )
 
-      if (program?._?.[0] === `develop`) {
+      if (process.env.gatsby_executing_command === `develop`) {
         websocketManager.emitPageData({
           id: pagePath,
           result,
@@ -204,10 +204,14 @@ export async function flush(): Promise<void> {
   }
 
   if (!flushQueue.idle()) {
-    await new Promise(resolve => {
-      flushQueue.drain = resolve as () => unknown
+    await new Promise<void>(resolve => {
+      flushQueue.drain = resolve
     })
   }
+
+  await new Promise<void>(resolve => {
+    process.nextTick(() => resolve())
+  })
 
   isFlushing = false
   return

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -174,6 +174,7 @@ export async function flush(): Promise<void> {
       const staticQueryHashes =
         staticQueriesByTemplate.get(page.componentPath) || []
 
+      // Do not save result to a variable to keep memory pressure down
       if (process.env.gatsby_executing_command === `develop`) {
         const result = await writePageData(publicFolder, {
           ...page,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
We shouldn't store writePage data in a result when we don't need it, it keeps it in memory too long.

This dropped memory usage from 8GB to 4GB in our customer.

## Related Issues

Fixes [ch26306]
