### PR TITLE
fix(gatsby-plugin-image): Correctly calculate aspect ratio when width and height are both set

### DIFF
--- a/packages/gatsby-plugin-image/src/__tests__/image-utils.ts
+++ b/packages/gatsby-plugin-image/src/__tests__/image-utils.ts
@@ -311,6 +311,11 @@ describe(`the helper utils`, () => {
     expect(url).toEqual(`https://example.com/afile.jpg/20/15/image.jpg`)
   })
 
+  it(`gets a low-resolution image URL when width and height are set`, () => {
+    const url = getLowResolutionImageURL({ ...args, width: 200, height: 200 })
+    expect(url).toEqual(`https://example.com/afile.jpg/20/20/image.jpg`)
+  })
+
   it(`gets a low-resolution image URL with correct aspect ratio`, () => {
     const url = getLowResolutionImageURL({
       ...fullWidthArgs,

--- a/packages/gatsby-plugin-image/src/image-utils.ts
+++ b/packages/gatsby-plugin-image/src/image-utils.ts
@@ -168,7 +168,7 @@ export function setDefaultDimensions(
   layout = camelCase(layout) as Layout
 
   if (width && height) {
-    return { ...args, formats, layout }
+    return { ...args, formats, layout, aspectRatio: width / height }
   }
   if (sourceMetadata.width && sourceMetadata.height && !aspectRatio) {
     aspectRatio = sourceMetadata.width / sourceMetadata.height


### PR DESCRIPTION
When width and height are both set we weren't returning the calculated aspect ratio. This is needed in generateLowResolutionImageURL.