### PR TITLE
fix(gatsby-legacy-polyfills): add dom collections to polyfills

### DIFF
--- a/packages/gatsby-legacy-polyfills/src/exclude.js
+++ b/packages/gatsby-legacy-polyfills/src/exclude.js
@@ -76,6 +76,7 @@ module.exports = {
     `features/regexp`,
     `features/symbol`,
     `features/promise`,
+    `features/dom-collections`,
   ],
   // Will be used by preset-env to exclude already polyfilled features from the automatic polyfilling option
   CORE_JS_POLYFILL_EXCLUDE_LIST: [


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Enable dom iterables polyfill for nodeList.forEach and others.

You can test it with this snippet in IE11
```
import React from "react"

export default function Home() {
  const myRef = React.useRef()

  React.useEffect(() => {
    // console.log(myRef.current)
    myRef.current.querySelectorAll("li").forEach(node => {
      console.log(node.innerHTML)
    })
  }, [])

  return (
    <div>
      <ul ref={myRef}>
        <li>hello</li>
        <li>hi</li>
        <li>yo</li>
      </ul>
    </div>
  )
}

```

## Related Issues

Fixes #30473