### PR TITLE
fix(gatsby-plugin-mdx): timeToRead returns NaN when word count is undefined

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -44,9 +44,9 @@ async function getCounts({ mdast }) {
   }
 
   return {
-    paragraphs: counts.ParagraphNode,
-    sentences: counts.SentenceNode,
-    words: counts.WordNode,
+    paragraphs: counts.ParagraphNode || 0,
+    sentences: counts.SentenceNode || 0,
+    words: counts.WordNode || 0,
   }
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
It's possible to have an mdx components without words for example we sometimes have embedded videos/ youtube.

So in this use case the `getCounts` function returns `words` property of `undefined` because the AST visitor never hits a word/paragraph. Thus the calculation for `timeToRead` (`Math.round(words / avgWPM)`) returns `NaN`. 

I propose we fallback to `0` for these properties returned in `getCounts` and then `timeToRead` can default to `1`.  

<!-- Write a brief description of the changes introduced by this PR -->


<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
### Related Issue

https://github.com/gatsbyjs/gatsby/issues/30490
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
