### PR TITLE
fix(gatsby): merge inherited interfaces when merging types

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -16,7 +16,6 @@ const {
   InputTypeComposer,
   ScalarTypeComposer,
   EnumTypeComposer,
-  defineFieldMapToConfig,
 } = require(`graphql-compose`)
 const { getNode, getNodesByType } = require(`../redux/nodes`)
 
@@ -397,22 +396,14 @@ const mergeTypes = ({
     }
   }
 
-  if (type instanceof ObjectTypeComposer) {
+  if (
+    type instanceof ObjectTypeComposer ||
+    type instanceof InterfaceTypeComposer ||
+    type instanceof GraphQLObjectType ||
+    type instanceof GraphQLInterfaceType
+  ) {
     mergeFields({ typeComposer, fields: type.getFields() })
     type.getInterfaces().forEach(iface => typeComposer.addInterface(iface))
-  } else if (type instanceof InterfaceTypeComposer) {
-    mergeFields({ typeComposer, fields: type.getFields() })
-  } else if (type instanceof GraphQLObjectType) {
-    mergeFields({
-      typeComposer,
-      fields: defineFieldMapToConfig(type.getFields()),
-    })
-    type.getInterfaces().forEach(iface => typeComposer.addInterface(iface))
-  } else if (type instanceof GraphQLInterfaceType) {
-    mergeFields({
-      typeComposer,
-      fields: defineFieldMapToConfig(type.getFields()),
-    })
   }
 
   if (isNamedTypeComposer(type)) {


### PR DESCRIPTION
## Description

This PR unifies the behavior for `Object` and `Interface` types when merging inherited interfaces. GraphQL 15 supports interface inheritance, so we can have the same merging logic for both `Objects` and `Interfaces`.

## Related Issues

Discovered by @TylerBarnes . See also https://github.com/gatsbyjs/gatsby/pull/30496

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
