### PR TITLE
Change the 'idKey' parameter's default value

### DIFF
--- a/packages/gatsby-source-wordpress/docs/tutorials/using-wordpress-menus.md
+++ b/packages/gatsby-source-wordpress/docs/tutorials/using-wordpress-menus.md
@@ -163,7 +163,7 @@ To do this, we can use a function like the following:
 ```javascript
 const flatListToHierarchical = (
   data = [],
-  { idKey = "key", parentKey = "parentId", childrenKey = "children" } = {}
+  { idKey = "id", parentKey = "parentId", childrenKey = "children" } = {}
 ) => {
   const tree = []
   const childrenOf = {}


### PR DESCRIPTION
I think it is easier for beginners to use the function, because the default value for the id key is 'id', not 'key'

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
