### PR TITLE
chore(README): Adjust heading hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@
   Gatsby v3
 </h1>
 
-<h3 align="center">
+<p align="center">
   ⚛️ 📄 🚀
-</h3>
-<h3 align="center">
-  Fast in every way that matters
-</h3>
+</p>
+<p align="center">
+  <strong>
+    Fast in every way that matters
+  </strong>
+</p>
 <p align="center">
   Gatsby is a free and open source framework based on React that helps developers build blazing fast websites and apps
 </p>
@@ -40,7 +42,7 @@
   </a>
 </p>
 
-<h3 align="center">
+<h2 align="center">
   <a href="https://www.gatsbyjs.com/docs/">Quickstart</a>
   <span> · </span>
   <a href="https://www.gatsbyjs.com/tutorial/">Tutorial</a>
@@ -56,7 +58,7 @@
   Support: <a href="https://twitter.com/AskGatsbyJS">Twitter</a>, <a href="https://github.com/gatsbyjs/gatsby/discussions">Discussions</a>
   <span> & </span>
   <a href="https://gatsby.dev/discord">Discord</a>
-</h3>
+</h2>
 
 Gatsby is a modern web framework for blazing fast websites.
 


### PR DESCRIPTION
Ref. https://twitter.com/natfriedman/status/1375430850620256257:

> GitHub now automatically creates a table of contents for your http://README.md files from your headers.

The main repo README has three `<h3>`s following the main (`<h1>`) headline.  
This "broken" heading hierarchy results in a slightly weird indention in the auto-generated ToC;
also we IMO don't want the three emojis nor the "Fast in every way…" in it:

![image (9)](https://user-images.githubusercontent.com/21834/112773200-62315a00-9035-11eb-96f4-d9d9378b9caa.png)

This PR

* replaces the first two `<h3>`s with `<p>` — renders a bit smaller, but now these do not appear in the ToC anymore
* turns the last `<h3>` into a `<h2>`

Link to the rendered doc (unfortunately no way to preview the ToC it seems): https://github.com/gatsbyjs/gatsby/blob/f855bc55e0c18afbb8dbbd46ade9e96410226970/README.md
