### PR TITLE
fix: use cpuCount for all parallel parts

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -1,7 +1,7 @@
 import * as fs from "fs"
 import * as path from "path"
 import sharp from "./safe-sharp"
-import { createContentDigest, cpuCoreCount, slash } from "gatsby-core-utils"
+import { createContentDigest, slash } from "gatsby-core-utils"
 import { defaultIcons, addDigestToPath, favicons } from "./common"
 import { doesIconExist } from "./node-helpers"
 
@@ -9,10 +9,8 @@ import pluginOptionsSchema from "./pluginOptionsSchema"
 
 sharp.simd(true)
 
-// Handle Sharp's concurrency based on the Gatsby CPU count
-// See: http://sharp.pixelplumbing.com/en/stable/api-utility/#concurrency
-// See: https://www.gatsbyjs.org/docs/multi-core-builds/
-sharp.concurrency(cpuCoreCount() - 1)
+// force it to be 1 as we only resize one image
+sharp.concurrency(1)
 
 async function generateIcon(icon, srcIcon) {
   const imgPath = path.join(`public`, icon.src)

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -12,7 +12,7 @@ sharp.simd(true)
 // Handle Sharp's concurrency based on the Gatsby CPU count
 // See: http://sharp.pixelplumbing.com/en/stable/api-utility/#concurrency
 // See: https://www.gatsbyjs.org/docs/multi-core-builds/
-sharp.concurrency(cpuCoreCount())
+sharp.concurrency(cpuCoreCount() - 1)
 
 async function generateIcon(icon, srcIcon) {
   const imgPath = path.join(`public`, icon.src)

--- a/packages/gatsby-plugin-sharp/src/gatsby-worker.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-worker.js
@@ -32,7 +32,7 @@ const q = queue(
         args.pluginOptions
       )
     ),
-  cpuCoreCount() - 1
+  Math.max(1, cpuCoreCount() - 1)
 )
 
 /**

--- a/packages/gatsby-plugin-sharp/src/gatsby-worker.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-worker.js
@@ -32,7 +32,7 @@ const q = queue(
         args.pluginOptions
       )
     ),
-  cpuCoreCount()
+  cpuCoreCount() - 1
 )
 
 /**

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -660,7 +660,7 @@ export const createWebpackUtils = (
         },
         ...terserOptions,
       },
-      parallel: cpuCoreCount() - 1,
+      parallel: Math.max(1, cpuCoreCount() - 1),
       ...options,
     })
 
@@ -731,7 +731,7 @@ export const createWebpackUtils = (
     }
   ): CssMinimizerPlugin =>
     new CssMinimizerPlugin({
-      parallel: cpuCoreCount() - 1,
+      parallel: Math.max(1, cpuCoreCount() - 1),
       ...options,
     })
 

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -1,7 +1,6 @@
 import * as path from "path"
 import { Loader, RuleSetRule, Plugin } from "webpack"
 import { GraphQLSchema } from "graphql"
-import postcss from "postcss"
 import autoprefixer from "autoprefixer"
 import flexbugs from "postcss-flexbugs-fixes"
 import TerserPlugin from "terser-webpack-plugin"
@@ -10,7 +9,7 @@ import CssMinimizerPlugin from "css-minimizer-webpack-plugin"
 import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin"
 import { getBrowsersList } from "./browserslist"
 import ESLintPlugin from "eslint-webpack-plugin"
-
+import { cpuCoreCount } from "gatsby-core-utils"
 import { GatsbyWebpackStatsExtractor } from "./gatsby-webpack-stats-extractor"
 import { GatsbyWebpackEslintGraphqlSchemaReload } from "./gatsby-webpack-eslint-graphql-schema-reload-plugin"
 import {
@@ -661,6 +660,7 @@ export const createWebpackUtils = (
         },
         ...terserOptions,
       },
+      parallel: cpuCoreCount() - 1,
       ...options,
     })
 
@@ -729,7 +729,11 @@ export const createWebpackUtils = (
         ],
       },
     }
-  ): CssMinimizerPlugin => new CssMinimizerPlugin(options)
+  ): CssMinimizerPlugin =>
+    new CssMinimizerPlugin({
+      parallel: cpuCoreCount() - 1,
+      ...options,
+    })
 
   plugins.fastRefresh = ({ modulesThatUseGatsby }): Plugin => {
     const regExpToHack = /node_modules/

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -3,7 +3,7 @@ import { cpuCoreCount } from "gatsby-core-utils"
 
 export const create = (): Worker =>
   new Worker(require.resolve(`./child`), {
-    numWorkers: cpuCoreCount(),
+    numWorkers: cpuCoreCount() - 1,
     forkOptions: {
       silent: false,
     },

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -3,7 +3,7 @@ import { cpuCoreCount } from "gatsby-core-utils"
 
 export const create = (): Worker =>
   new Worker(require.resolve(`./child`), {
-    numWorkers: cpuCoreCount() - 1,
+    numWorkers: Math.max(1, cpuCoreCount() - 1),
     forkOptions: {
       silent: false,
     },


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Not every part of Gatsby is using `cpuCoreCount` and we should always do -1 to make sure the main process is left alone.

