### PR TITLE
fix(contentful): ensure fragments are properly distributed

### DIFF
--- a/packages/gatsby-source-contentful/.npmignore
+++ b/packages/gatsby-source-contentful/.npmignore
@@ -27,7 +27,8 @@ build/Release
 node_modules
 *.un~
 yarn.lock
-src
+src/**/*
+!src/fragments.js
 scripts
 flow-typed
 coverage


### PR DESCRIPTION
Fragments are broken in current state. This will make them available again.

--edit by @pieh
This is fixing regression introduced in https://github.com/gatsbyjs/gatsby/pull/30414 which ignored untranspiled `fragments.js` file and therefore Gatsby didn't extract and register those making old-school Contentful gatsby-image fragments broken. Issue was discovered in https://github.com/gatsbyjs/gatsby/pull/30390 