### PR TITLE
fix(gatsby): merge inherited interfaces when merging types (#30501)

### DIFF
--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -16,7 +16,6 @@ const {
   InputTypeComposer,
   ScalarTypeComposer,
   EnumTypeComposer,
-  defineFieldMapToConfig,
 } = require(`graphql-compose`)
 const { getNode, getNodesByType } = require(`../redux/nodes`)
 
@@ -397,22 +396,14 @@ const mergeTypes = ({
     }
   }
 
-  if (type instanceof ObjectTypeComposer) {
+  if (
+    type instanceof ObjectTypeComposer ||
+    type instanceof InterfaceTypeComposer ||
+    type instanceof GraphQLObjectType ||
+    type instanceof GraphQLInterfaceType
+  ) {
     mergeFields({ typeComposer, fields: type.getFields() })
     type.getInterfaces().forEach(iface => typeComposer.addInterface(iface))
-  } else if (type instanceof InterfaceTypeComposer) {
-    mergeFields({ typeComposer, fields: type.getFields() })
-  } else if (type instanceof GraphQLObjectType) {
-    mergeFields({
-      typeComposer,
-      fields: defineFieldMapToConfig(type.getFields()),
-    })
-    type.getInterfaces().forEach(iface => typeComposer.addInterface(iface))
-  } else if (type instanceof GraphQLInterfaceType) {
-    mergeFields({
-      typeComposer,
-      fields: defineFieldMapToConfig(type.getFields()),
-    })
   }
 
   if (isNamedTypeComposer(type)) {


### PR DESCRIPTION
Backporting #30501 to the 3.2 release branch

(cherry picked from commit e1f1656b36e4912c1712cada0124fc38f4b4e07e)