### PR TITLE
fix(gatsby-plugin-mdx): timeToRead returns NaN when word count is 0 (#30489)

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
+++ b/packages/gatsby-plugin-mdx/gatsby/source-nodes.js
@@ -44,9 +44,9 @@ async function getCounts({ mdast }) {
   }
 
   return {
-    paragraphs: counts.ParagraphNode,
-    sentences: counts.SentenceNode,
-    words: counts.WordNode,
+    paragraphs: counts.ParagraphNode || 0,
+    sentences: counts.SentenceNode || 0,
+    words: counts.WordNode || 0,
   }
 }
 


### PR DESCRIPTION
Backporting #30489 to the 3.2 release branch

(cherry picked from commit 75e234ac9116e16fbd177d24f3b98d7c14409b4e)