### PR TITLE
fix(gatsby-plugin-image): Force render if props have changed (#30491)

### DIFF
--- a/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
+++ b/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
@@ -14,8 +14,6 @@ type LazyHydrateProps = Omit<GatsbyImageProps, "as" | "style" | "className"> & {
   ref: MutableRefObject<HTMLImageElement | undefined>
 }
 
-const IS_DEV = process.env.NODE_ENV === `development`
-
 export function lazyHydrate(
   {
     image,
@@ -32,7 +30,8 @@ export function lazyHydrate(
     ...props
   }: LazyHydrateProps,
   root: MutableRefObject<HTMLElement | undefined>,
-  hydrated: MutableRefObject<boolean>
+  hydrated: MutableRefObject<boolean>,
+  forceHydrate: MutableRefObject<boolean>
 ): (() => void) | null {
   const {
     width,
@@ -85,7 +84,7 @@ export function lazyHydrate(
   )
 
   // Force render to mitigate "Expected server HTML to contain a matching" in develop
-  const doRender = hydrated.current || IS_DEV ? render : hydrate
+  const doRender = hydrated.current || forceHydrate.current ? render : hydrate
   doRender(component, root.current)
   hydrated.current = true
 


### PR DESCRIPTION
Backporting #30491 to the 3.2 release branch

(cherry picked from commit e584b8a33f079ba5a07419173b57bb5dabb824d7)