### PR TITLE
fix(gatsby-plugin-netlify-cms): Don't use StaticQueryMapper

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -28,9 +28,7 @@ function deepMap(obj, fn) {
   return obj
 }
 
-const cssTests = []
-
-function replaceRule(value, stage) {
+function replaceRule(value) {
   // If `value` does not have a `test` property, it isn't a rule object.
   if (!value || !value.test) {
     return value
@@ -96,20 +94,6 @@ exports.onCreateWebpackConfig = (
     return Promise.resolve()
   }
 
-  // populate cssTests array later used by isCssRule
-  if (`develop` === stage) {
-    cssTests.push(
-      ...[
-        rules.cssModules().test,
-        rules.css().test,
-        /\.s(a|c)ss$/,
-        /\.module\.s(a|c)ss$/,
-        /\.less$/,
-        /\.module\.less$/,
-      ].map(t => t.toString())
-    )
-  }
-
   const gatsbyConfig = getConfig()
   const { program } = store.getState()
   const publicPathClean = trim(publicPath, `/`)
@@ -161,7 +145,7 @@ exports.onCreateWebpackConfig = (
     },
     module: {
       rules: deepMap(gatsbyConfig.module.rules, value =>
-        replaceRule(value, stage)
+        replaceRule(value)
       ).filter(Boolean),
     },
     plugins: [
@@ -169,7 +153,11 @@ exports.onCreateWebpackConfig = (
       // application, or that we want to replace with our own instance.
       ...gatsbyConfig.plugins.filter(
         plugin =>
-          ![`MiniCssExtractPlugin`, `GatsbyWebpackStatsExtractor`].find(
+          ![
+            `MiniCssExtractPlugin`,
+            `GatsbyWebpackStatsExtractor`,
+            `StaticQueryMapper`,
+          ].find(
             pluginName =>
               plugin.constructor && plugin.constructor.name === pluginName
           )
@@ -210,7 +198,8 @@ exports.onCreateWebpackConfig = (
       // Exclude CSS from index.html, as any imported styles are assumed to be
       // targeting the editor preview pane. Uses `excludeAssets` option from
       // `HtmlWebpackPlugin` config
-      // not compatible with webpack 5
+      // HtmlWebpackExcludeAssetsPlugin is not compatible with webpack 5
+      // TODO: Replace `html-webpack-exclude-assets-plugin` with `html-webpack-skip-assets-plugin`
       // new HtmlWebpackExcludeAssetsPlugin(),
 
       // Pass in needed Gatsby config values.


### PR DESCRIPTION
## Description

This PR makes sure that the `StaticQueryMapper` plugin isn't used by the webpack instance of `gatsby-plugin-netlify-cms`.

The Netlify CMS plugin is spinning an extra webpack instance with almost every plugin from gatsby. Reusing the `StaticQueryMapper` plugin [caused issues](https://github.com/gatsbyjs/gatsby/issues/29951) given how it's dealing with a Gatsby state. 

This PR also:
- Removes the `cssTests` variable which wasn't used anymore
- Adds a clear TODO comment for how to get `excludeAssets` to be taken into account again. A webpack plugin had been removed to make this package compatible with webpack 5, but the functionality hasn't been put back. (Edit: this means that since `gatsby-plugin-netlify-cms` was made compatible with webpack 5, all of the CSS that is imported is included in its HTML SPA template. Maybe there's a bug report out there already, but that means there could be CSS from the website polluting the CSS of the admin page) 

## Related Issues

Fixes #29951