### PR TITLE
fix(gatsby-source-wordpress): Enable preview mode in PINC builds

### DIFF
--- a/packages/gatsby-source-wordpress/src/models/develop.ts
+++ b/packages/gatsby-source-wordpress/src/models/develop.ts
@@ -1,3 +1,4 @@
+import { inPreviewMode } from "~/steps/preview"
 export interface IDevelopState {
   refreshPollingIsPaused: boolean
 }
@@ -19,20 +20,14 @@ const developStore: IPreviewStore = {
 
   reducers: {
     pauseRefreshPolling(state) {
-      if (
-        process.env.NODE_ENV === `development` &&
-        !process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
-      ) {
+      if (!inPreviewMode()) {
         state.refreshPollingIsPaused = true
       }
 
       return state
     },
     resumeRefreshPolling(state) {
-      if (
-        process.env.NODE_ENV === `development` &&
-        !process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
-      ) {
+      if (!inPreviewMode()) {
         state.refreshPollingIsPaused = false
       }
 

--- a/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
@@ -3,6 +3,7 @@ import merge from "lodash/merge"
 import { createRemoteMediaItemNode } from "~/steps/source-nodes/create-nodes/create-remote-media-item-node"
 import { menuBeforeChangeNode } from "~/steps/source-nodes/before-change-node/menu"
 import { cloneDeep } from "lodash"
+import { inPreviewMode } from "~/steps/preview"
 
 export interface IPluginOptionsPreset {
   presetName: string
@@ -13,15 +14,9 @@ export interface IPluginOptionsPreset {
   options: IPluginOptions
 }
 
-const inDevelopPreview =
-  process.env.NODE_ENV === `development` &&
-  !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
-
-const inPreviewRunner = process.env.RUNNER_TYPE === `PREVIEW`
-
 export const previewOptimizationPreset: IPluginOptionsPreset = {
   presetName: `PREVIEW_OPTIMIZATION`,
-  useIf: (): boolean => inDevelopPreview || inPreviewRunner,
+  useIf: inPreviewMode,
   options: {
     html: {
       useGatsbyImage: false,

--- a/packages/gatsby-source-wordpress/src/models/preview.ts
+++ b/packages/gatsby-source-wordpress/src/models/preview.ts
@@ -8,7 +8,6 @@ export interface IStoredPage {
 }
 
 export interface IPreviewState {
-  inPreviewMode: boolean
   nodePageCreatedCallbacks: {
     [nodeId: string]: OnPageCreatedCallback
   }
@@ -56,19 +55,12 @@ export interface IPreviewStore {
 
 const previewStore: IPreviewStore = {
   state: {
-    inPreviewMode: false,
     nodePageCreatedCallbacks: {},
     nodeIdsToCreatedPages: {},
     pagePathToNodeDependencyId: {},
   },
 
   reducers: {
-    setInPreviewMode(state, inPreviewMode) {
-      state.inPreviewMode = inPreviewMode
-
-      return state
-    },
-
     unSubscribeToPagesCreatedFromNodeById(state, { nodeId }) {
       if (state.nodePageCreatedCallbacks?.[nodeId]) {
         delete state.nodePageCreatedCallbacks[nodeId]

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -25,7 +25,8 @@ const inDevelopPreview =
 
 const inPreviewRunner =
   process.env.RUNNER_TYPE === `PREVIEW` ||
-  process.env.RUNNER_TYPE === `INCREMENTAL_PREVIEWS`
+  process.env.RUNNER_TYPE === `INCREMENTAL_PREVIEWS` ||
+  !!process.env.IS_GATSBY_PREVIEW
 
 // this is a function simply because many places in the code expect it to be.
 // it used to call store.getState() and check for some state to determine preview mode

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -19,9 +19,17 @@ import { touchValidNodes } from "../source-nodes/update-nodes/fetch-node-updates
 import { IPluginOptions } from "~/models/gatsby-api"
 import { Reporter } from "gatsby/reporter"
 
-export const inPreviewMode = (): boolean =>
-  !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT &&
-  !!store.getState().previewStore.inPreviewMode
+const inDevelopPreview =
+  process.env.NODE_ENV === `development` &&
+  !!process.env.ENABLE_GATSBY_REFRESH_ENDPOINT
+
+const inPreviewRunner =
+  process.env.RUNNER_TYPE === `PREVIEW` ||
+  process.env.RUNNER_TYPE === `INCREMENTAL_PREVIEWS`
+
+// this is a function simply because many places in the code expect it to be.
+// it used to call store.getState() and check for some state to determine preview mode
+export const inPreviewMode = (): boolean => inDevelopPreview || inPreviewRunner
 
 export type PreviewStatusUnion =
   | `PREVIEW_SUCCESS`
@@ -278,8 +286,6 @@ export const sourcePreview = async (
 
     return
   }
-
-  store.dispatch.previewStore.setInPreviewMode(true)
 
   // this callback will be invoked when the page is created/updated for this node
   // then it'll send a mutation to WPGraphQL so that WP knows the preview is ready


### PR DESCRIPTION
PINC builds almost works with WP except that WP doesn't know to start up in preview mode. This PR fixes that.