### PR TITLE
fix: Add async to actions.createNode so that returned value always can be …

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -790,7 +790,7 @@ const createNode = (
   }
 }
 
-actions.createNode = (...args) => dispatch => {
+actions.createNode = async (...args) => dispatch => {
   const actions = createNode(...args)
 
   dispatch(actions)


### PR DESCRIPTION
# Description
This PR adds ```async``` to the ```actions.createNode``` function, so that the returned value always can be ```then```'d. It usually returns a promise, but, on some edge cases, it can return undefined and it is impossible to use ```then``` keyword.
# Related issues
Fixes #30578