### PR TITLE
fix(gatsby): try to get linenumber from compile error

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/build-error.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/build-error.js
@@ -14,6 +14,12 @@ export function BuildError({ error }) {
   const decoded = prettifyStack(error)
   const [filePath] = decoded
   const file = filePath.content.split(`\n`)[0]
+  const lineMatch = filePath.content.match(/\((\d+)[^)]+\)/)
+  let line = 1
+
+  if (lineMatch) {
+    line = lineMatch[1]
+  }
 
   return (
     <Overlay>
@@ -22,7 +28,10 @@ export function BuildError({ error }) {
           <h1 id="gatsby-overlay-labelledby">Failed to compile</h1>
           <span>{file}</span>
         </div>
-        <HeaderOpenClose open={() => openInEditor(file, 1)} dismiss={false} />
+        <HeaderOpenClose
+          open={() => openInEditor(file, line)}
+          dismiss={false}
+        />
       </Header>
       <Body>
         <h2>Source</h2>

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/utils.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/utils.js
@@ -23,7 +23,7 @@ export function prettifyStack(errorInformation) {
 }
 
 export function openInEditor(file, lineNumber = 1) {
-  window.fetch(
+  fetch(
     `/__open-stack-frame-in-editor?fileName=` +
       window.encodeURIComponent(file) +
       `&lineNumber=` +


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Try to get the correct line number from the error message in fast refresh.

