### PR TITLE
feat(gatsby): enable gatsby-plugin-gatsby-cloud by default

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -118,6 +118,7 @@
     "normalize-path": "^3.0.0",
     "null-loader": "^4.0.1",
     "opentracing": "^0.14.4",
+    "resolve-from": "^5.0.0",
     "p-defer": "^3.0.0",
     "parseurl": "^1.3.3",
     "path-to-regexp": "0.1.7",

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -51,7 +51,7 @@ describe(`Load plugins`, () => {
     })
 
   it(`Load plugins for a site`, async () => {
-    let plugins = await loadPlugins({ plugins: [] })
+    let plugins = await loadPlugins({ plugins: [] }, process.cwd())
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -67,7 +67,7 @@ describe(`Load plugins`, () => {
       ],
     }
 
-    let plugins = await loadPlugins(config)
+    let plugins = await loadPlugins(config, process.cwd())
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -88,7 +88,7 @@ describe(`Load plugins`, () => {
     }
 
     try {
-      await loadPlugins(config)
+      await loadPlugins(config, process.cwd())
     } catch (err) {
       expect(err.message).toMatchSnapshot()
     }
@@ -107,7 +107,7 @@ describe(`Load plugins`, () => {
       ],
     }
 
-    let plugins = await loadPlugins(config)
+    let plugins = await loadPlugins(config, process.cwd())
 
     plugins = replaceFieldsThatCanVary(plugins)
 
@@ -120,7 +120,7 @@ describe(`Load plugins`, () => {
         plugins: [],
       }
 
-      let plugins = await loadPlugins(config)
+      let plugins = await loadPlugins(config, process.cwd())
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -145,7 +145,7 @@ describe(`Load plugins`, () => {
         ],
       }
 
-      let plugins = await loadPlugins(config)
+      let plugins = await loadPlugins(config, process.cwd())
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -183,7 +183,7 @@ describe(`Load plugins`, () => {
         ],
       }
 
-      let plugins = await loadPlugins(config)
+      let plugins = await loadPlugins(config, process.cwd())
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -214,9 +214,12 @@ describe(`Load plugins`, () => {
           },
         },
       ]
-      await loadPlugins({
-        plugins: invalidPlugins,
-      })
+      await loadPlugins(
+        {
+          plugins: invalidPlugins,
+        },
+        process.cwd()
+      )
 
       expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(
         invalidPlugins.length
@@ -309,9 +312,12 @@ describe(`Load plugins`, () => {
           },
         },
       ]
-      await loadPlugins({
-        plugins,
-      })
+      await loadPlugins(
+        {
+          plugins,
+        },
+        process.cwd()
+      )
 
       expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(0)
       expect(reporter.warn as jest.Mock).toHaveBeenCalledTimes(1)
@@ -325,16 +331,19 @@ describe(`Load plugins`, () => {
     })
 
     it(`defaults plugin options to the ones defined in the schema`, async () => {
-      let plugins = await loadPlugins({
-        plugins: [
-          {
-            resolve: `gatsby-plugin-google-analytics`,
-            options: {
-              trackingId: `fake`,
+      let plugins = await loadPlugins(
+        {
+          plugins: [
+            {
+              resolve: `gatsby-plugin-google-analytics`,
+              options: {
+                trackingId: `fake`,
+              },
             },
-          },
-        ],
-      })
+          ],
+        },
+        process.cwd()
+      )
 
       plugins = replaceFieldsThatCanVary(plugins)
 
@@ -354,23 +363,26 @@ describe(`Load plugins`, () => {
     })
 
     it(`validates subplugin schemas`, async () => {
-      await loadPlugins({
-        plugins: [
-          {
-            resolve: `gatsby-transformer-remark`,
-            options: {
-              plugins: [
-                {
-                  resolve: `gatsby-remark-autolink-headers`,
-                  options: {
-                    maintainCase: `should be boolean`,
+      await loadPlugins(
+        {
+          plugins: [
+            {
+              resolve: `gatsby-transformer-remark`,
+              options: {
+                plugins: [
+                  {
+                    resolve: `gatsby-remark-autolink-headers`,
+                    options: {
+                      maintainCase: `should be boolean`,
+                    },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        ],
-      })
+          ],
+        },
+        process.cwd()
+      )
 
       expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(1)
       expect((reporter.error as jest.Mock).mock.calls[0])
@@ -403,16 +415,19 @@ describe(`Load plugins`, () => {
     })
 
     it(`validates local plugin schemas using require.resolve`, async () => {
-      await loadPlugins({
-        plugins: [
-          {
-            resolve: require.resolve(`./fixtures/local-plugin`),
-            options: {
-              optionalString: 1234,
+      await loadPlugins(
+        {
+          plugins: [
+            {
+              resolve: require.resolve(`./fixtures/local-plugin`),
+              options: {
+                optionalString: 1234,
+              },
             },
-          },
-        ],
-      })
+          ],
+        },
+        process.cwd()
+      )
 
       expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(1)
       expect((reporter.error as jest.Mock).mock.calls[0])

--- a/packages/gatsby/src/bootstrap/load-plugins/index.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.ts
@@ -82,7 +82,7 @@ const normalizeConfig = (config: IRawSiteConfig = {}): ISiteConfig => {
 
 export async function loadPlugins(
   rawConfig: IRawSiteConfig = {},
-  rootDir: string | null = null
+  rootDir: string
 ): Promise<Array<IFlattenedPlugin>> {
   // Turn all strings in plugins: [`...`] into the { resolve: ``, options: {} } form
   const config = normalizeConfig(rawConfig)

--- a/packages/gatsby/src/bootstrap/load-plugins/load.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.ts
@@ -285,7 +285,7 @@ export function loadPlugins(
   if (!configuredPluginNames.has(TYPESCRIPT_PLUGIN_NAME)) {
     plugins.push(
       processPlugin({
-        resolve: require.resolve(`gatsby-plugin-typescript`),
+        resolve: require.resolve(TYPESCRIPT_PLUGIN_NAME),
         options: {
           // TODO(@mxstbr): Do not hard-code these defaults but infer them from the
           // pluginOptionsSchema of gatsby-plugin-typescript

--- a/packages/gatsby/src/bootstrap/load-plugins/load.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.ts
@@ -18,6 +18,10 @@ import {
 } from "./types"
 import { PackageJson } from "../../.."
 import reporter from "gatsby-cli/lib/reporter"
+import { silent as resolveFromSilent } from "resolve-from"
+
+const GATSBY_CLOUD_PLUGIN_NAME = `gatsby-plugin-gatsby-cloud`
+const TYPESCRIPT_PLUGIN_NAME = `gatsby-plugin-typescript`
 
 function createFileContentHash(root: string, globPattern: string): string {
   const hash = crypto.createHash(`md5`)
@@ -141,12 +145,33 @@ export function resolvePlugin(
   }
 }
 
+function addGatsbyPluginCloudPluginWhenInstalled(
+  plugins: Array<IPluginInfo>,
+  processPlugin: (plugin: PluginRef) => IPluginInfo,
+  rootDir: string
+): void {
+  const cloudPluginLocation = resolveFromSilent(
+    rootDir,
+    GATSBY_CLOUD_PLUGIN_NAME
+  )
+
+  if (cloudPluginLocation) {
+    plugins.push(
+      processPlugin({
+        resolve: cloudPluginLocation,
+        options: {},
+      })
+    )
+  }
+}
+
 export function loadPlugins(
   config: ISiteConfig = {},
-  rootDir: string | null = null
+  rootDir: string
 ): Array<IPluginInfo> {
   // Instantiate plugins.
   const plugins: Array<IPluginInfo> = []
+  const configuredPluginNames = new Set()
 
   // Create fake little site with a plugin for testing this
   // w/ snapshots. Move plugin processing to its own module.
@@ -229,7 +254,9 @@ export function loadPlugins(
   // Add plugins from the site config.
   if (config.plugins) {
     config.plugins.forEach(plugin => {
-      plugins.push(processPlugin(plugin))
+      const processedPlugin = processPlugin(plugin)
+      plugins.push(processedPlugin)
+      configuredPluginNames.add(processedPlugin.name)
     })
   }
 
@@ -250,12 +277,12 @@ export function loadPlugins(
     )
   })
 
-  // TypeScript support by default! use the user-provided one if it exists
-  const typescriptPlugin = (config.plugins || []).find(
-    plugin => plugin.resolve === `gatsby-plugin-typescript`
-  )
+  if (!configuredPluginNames.has(GATSBY_CLOUD_PLUGIN_NAME)) {
+    addGatsbyPluginCloudPluginWhenInstalled(plugins, processPlugin, rootDir)
+  }
 
-  if (typescriptPlugin === undefined) {
+  // Suppor Typescript by default but allow users to override it
+  if (!configuredPluginNames.has(TYPESCRIPT_PLUGIN_NAME)) {
     plugins.push(
       processPlugin({
         resolve: require.resolve(`gatsby-plugin-typescript`),


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Enable auto-enable gatsby-plugin-gatsby-cloud when it's installed but not configured. This allows us to automatically enable it in Gatsby Cloud

- [x]  update tests
