### PR TITLE
fix(gatsby): change order of feedbackDisabled checks to allow CI AWS lambda build

### DIFF
--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -143,7 +143,7 @@ function isFeedbackDisabled(): boolean {
   // Reasoning for this order: Checking for CI fixes issues like
   // https://github.com/gatsbyjs/gatsby/issues/30647
   // TODO: Additionally prevent getConfigStore from erroring
-  
+
   // Heuristic 2
   if (isCI()) {
     return true

--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -58,10 +58,11 @@ const randomChanceToBeTrue = (): boolean => {
 
 // We are only showing feedback requests to users in if they pass a few checks:
 // 1. They pass a Math.random() check. This is a skateboard version of not sending out all requests in one day.
-// 2. They haven't disabled the feedback mechanism
+// 2. Gatsby is not running in CI
 // 3. They don't have the environment variable to disable feedback present
-// 4. It's been at least 3 months since the last feedback request
-// 5. They are on the most recent version of Gatsby
+// 4. They haven't disabled the feedback mechanism
+// 5. It's been at least 3 months since the last feedback request
+// 6. They are on the most recent version of Gatsby
 export async function userPassesFeedbackRequestHeuristic(): Promise<boolean> {
   // Heuristic 1
   // We originally wrote this to have a single chance of hitting.
@@ -82,9 +83,9 @@ export async function userPassesFeedbackRequestHeuristic(): Promise<boolean> {
     return false
   }
 
-  // Heuristic 4
+  // Heuristic 5
   const lastDateValue = getConfigStore().get(lastDateKey)
-  // 4.a if the user has never received the feedback request, this is undefined
+  // 5.a if the user has never received the feedback request, this is undefined
   //     Which is effectively a pass, because it's been ~infinity~ since they last
   //     received a request from us.
   if (lastDateValue) {
@@ -97,7 +98,7 @@ export async function userPassesFeedbackRequestHeuristic(): Promise<boolean> {
     }
   }
 
-  // 4.b
+  // 5.b
   // we don't want to give them this survey right after the seven day feedback survey
   const sevenDayFeedback = getConfigStore().get(sevenDayKey)
   if (sevenDayFeedback) {
@@ -110,7 +111,7 @@ export async function userPassesFeedbackRequestHeuristic(): Promise<boolean> {
     }
   }
 
-  // Heuristic 5
+  // Heuristic 6
   const versionPoints = getGatsbyVersion().split(`.`)
   let latestVersionPoints: Array<string> = []
   try {

--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -139,17 +139,18 @@ export async function userPassesFeedbackRequestHeuristic(): Promise<boolean> {
 }
 
 function isFeedbackDisabled(): boolean {
+  // heuristic 2
   if (isCI()) {
-    return true
-  }
-
-  // Heuristic 2
-  if (getConfigStore().get(feedbackKey) === true) {
     return true
   }
 
   // Heuristic 3
   if (process.env.GATSBY_FEEDBACK_DISABLED === `1`) {
+    return true
+  }
+
+  // Heuristic 4
+  if (getConfigStore().get(feedbackKey) === true) {
     return true
   }
 

--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -139,6 +139,10 @@ export async function userPassesFeedbackRequestHeuristic(): Promise<boolean> {
 }
 
 function isFeedbackDisabled(): boolean {
+  if (isCI()) {
+    return true
+  }
+
   // Heuristic 2
   if (getConfigStore().get(feedbackKey) === true) {
     return true
@@ -146,10 +150,6 @@ function isFeedbackDisabled(): boolean {
 
   // Heuristic 3
   if (process.env.GATSBY_FEEDBACK_DISABLED === `1`) {
-    return true
-  }
-
-  if (isCI()) {
     return true
   }
 

--- a/packages/gatsby/src/utils/feedback.ts
+++ b/packages/gatsby/src/utils/feedback.ts
@@ -139,7 +139,11 @@ export async function userPassesFeedbackRequestHeuristic(): Promise<boolean> {
 }
 
 function isFeedbackDisabled(): boolean {
-  // heuristic 2
+  // Reasoning for this order: Checking for CI fixes issues like
+  // https://github.com/gatsbyjs/gatsby/issues/30647
+  // TODO: Additionally prevent getConfigStore from erroring
+  
+  // Heuristic 2
   if (isCI()) {
     return true
   }


### PR DESCRIPTION
## Description

Change the order of feedback disabled heuristics to check first if we are in CI, avoiding the getConfigStore() call in that case

## Related Issues

Fixes #30647