### PR TITLE
fix(docs): edits to Gatsby Node APIs doc

### DIFF
--- a/docs/docs/reference/config-files/gatsby-node.md
+++ b/docs/docs/reference/config-files/gatsby-node.md
@@ -7,9 +7,11 @@ apiCalls: NodeAPI
 
 ## Introduction
 
-Gatsby gives plugins and site builders many APIs for controlling your site's data in the GraphQL data layer. Code in the file `gatsby-node.js` is run once in the process of building your site. You can use it to create pages dynamically, add nodes in GraphQL, or respond to events during the build lifecycle. To use the [Gatsby Node APIs](/docs/reference/config-files/gatsby-node/), create a file named `gatsby-node.js` in the root of your site. Export any of the APIs you wish to use in this file.
+Gatsby gives plugins and site builders many APIs for building your site. Code in the file `gatsby-node.js` is run once in the process of building your site. You can use its APIs to create pages dynamically, add data into GraphQL, or respond to events during the build lifecycle. To use the [Gatsby Node APIs](/docs/reference/config-files/gatsby-node/), create a file named `gatsby-node.js` in the root of your site. Export any of the APIs you wish to use in this file.
 
-Every Gatsby Node API passes a [set of Node API helpers](/docs/reference/config-files/node-api-helpers/). These let you access several methods like reporting, or perform actions like creating new pages.
+Every Gatsby Node API gets passed a [set of helper functions](/docs/reference/config-files/node-api-helpers/). These let you access several methods like reporting, or perform actions like creating new pages.
+
+An example gatsby-node.js file that implements two APIs, `onPostBuild`, and `createPages`.
 
 ```js:title=gatsby-node.js
 const path = require(`path`)
@@ -45,7 +47,7 @@ exports.createPages = async ({ graphql, actions }) => {
 }
 ```
 
-## Async plugins
+## Async vs. sync work
 
 If your plugin performs async operations (disk I/O, database access, calling remote APIs, etc.) you must either return a promise (explicitly using `Promise` API or implicitly using `async`/`await` syntax) or use the callback passed to the 3rd argument. Gatsby needs to know when plugins are finished as some APIs, to work correctly, require previous APIs to be complete first. See [Debugging Async Lifecycles](/docs/debugging-async-lifecycles/) for more info.
 
@@ -71,7 +73,3 @@ exports.createPages = (_, pluginOptions, cb) => {
 ```
 
 If your plugin does not do async work, you can return directly.
-
-## Usage
-
-Implement any of these APIs by exporting them from a file named `gatsby-node.js` in the root of your project.

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -6,9 +6,11 @@
 export const resolvableExtensions = true
 
 /**
- * Tell plugins to add pages. This extension point is called only after the initial
+ * Create pages dynamically. This extension point is called only after the initial
  * sourcing and transformation of nodes plus creation of the GraphQL schema are
  * complete so you can query your data in order to create pages.
+ *
+ * You can also fetch data from remote or local sources to create pages.
  *
  * See also [the documentation for the action `createPage`](/docs/actions/#createPage).
  *
@@ -54,7 +56,7 @@ export const resolvableExtensions = true
  *         component: blogPostTemplate,
  *         context: {
  *           // Add optional context data to be inserted
- *           // as props into the page component..
+ *           // as props into the page component.
  *           //
  *           // The context data can also be used as
  *           // arguments to the page GraphQL query.
@@ -94,6 +96,10 @@ export const createPagesStatefully = true
  * will be called exactly once after all of your source plugins have finished
  * creating nodes.
  *
+ * The [Creating a Source
+ * Plugin](/docs/how-to/plugins-and-themes/creating-a-source-plugin/) tutorial
+ * demonstrates a way a plugin or site might use this API.
+ *
  * See also the documentation for [`createNode`](/docs/actions/#createNode).
  * @example
  * exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
@@ -132,6 +138,11 @@ export const sourceNodes = true
  *
  * See also the documentation for [`createNode`](/docs/actions/#createNode)
  * and [`createNodeField`](/docs/actions/#createNodeField)
+ *
+ * The [Creating a Source
+ * Plugin](/docs/how-to/plugins-and-themes/creating-a-source-plugin/) tutorial
+ * demonstrates a way a plugin or site might use this API.
+ *
  * @example
  * exports.onCreateNode = ({ node, actions }) => {
  *   const { createNode, createNodeField } = actions


### PR DESCRIPTION
Small edits.

It'd be nice to have a lifecycle diagram at the top for when APIs are called as it's not really clear reading through it.