### PR TITLE
fix(renovate): add breaking minor updates to major updates list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2237,7 +2237,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "express-graphql", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "express-graphql", "lodash", "lodash-es", "webpack-virtual-modules"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2248,7 +2248,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby",
       excludePackageNames: ["cross-env"],
-      packageNames: ["express-graphql"],
+      packageNames: ["express-graphql", "webpack-virtual-modules"],
     },
     {
       groupName: "minor and patch for gatsby-admin",

--- a/renovate.json5
+++ b/renovate.json5
@@ -2259,7 +2259,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-admin",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "theme-ui"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2270,6 +2270,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby-admin",
       excludePackageNames: ["cross-env"],
+      packageNames: ["theme-ui"],
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -2016,7 +2016,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-filesystem",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "msw"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2027,6 +2027,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby-source-filesystem",
       excludePackageNames: ["cross-env"],
+      packageNames: ["msw"],
     },
     {
       groupName: "minor and patch for gatsby-telemetry",

--- a/renovate.json5
+++ b/renovate.json5
@@ -2096,7 +2096,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-recipes",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "express-graphql", "lodash", "lodash-es", "react-reconciler"],
+      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "react-reconciler", "remark-mdx", "remark-mdxjs"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2107,7 +2107,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby-recipes",
       excludePackageNames: ["cross-env"],
-      packageNames: ["express-graphql", "react-reconciler"],
+      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "react-reconciler", "remark-mdx", "remark-mdxjs"],
     },
     {
       groupName: "minor and patch for gatsby-source-contentful",
@@ -2237,7 +2237,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "express-graphql", "lodash", "lodash-es", "webpack-virtual-modules"],
+      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "remark-mdx", "remark-mdxjs", "webpack-virtual-modules"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2248,7 +2248,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby",
       excludePackageNames: ["cross-env"],
-      packageNames: ["express-graphql", "webpack-virtual-modules"],
+      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "remark-mdx", "remark-mdxjs", "webpack-virtual-modules"],
     },
     {
       groupName: "minor and patch for gatsby-admin",


### PR DESCRIPTION
Updates `renovate.json5` to exclude breaking minor updates from minor update PRs. Should unblock #27092, #27134, #28358, #29380 once their manual override boxes are checked in #16840.