### PR TITLE
Refactor: using-contentful to use gatsby-plugin-image exclusively

### DIFF
--- a/examples/using-contentful/package.json
+++ b/examples/using-contentful/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "gatsby": "next",
     "gatsby-core-utils": "next",
-    "gatsby-image": "next",
     "gatsby-plugin-image": "next",
     "gatsby-plugin-sharp": "next",
     "gatsby-plugin-typography": "next",

--- a/examples/using-contentful/src/layouts/index.js
+++ b/examples/using-contentful/src/layouts/index.js
@@ -9,38 +9,48 @@ const propTypes = {
 }
 
 const DefaultLayout = ({ children }) => (
-  <div
-    style={{
-      margin: `0 auto`,
-      marginTop: rhythm(1.5),
-      marginBottom: rhythm(1.5),
-      maxWidth: 650,
-      paddingLeft: rhythm(3 / 4),
-      paddingRight: rhythm(3 / 4),
-    }}
-  >
-    <Link style={{ textDecoration: `none` }} to="/">
-      <h3 style={{ color: `tomato`, marginBottom: rhythm(1.5) }}>
-        Example of using Contentful as a data source for a Gatsby site
-      </h3>
-    </Link>
-    {children}
-    <hr style={{ marginTop: rhythm(3) }} />
-    <p>
-      The src for this website is at
-      {` `}
-      <a href="https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful">
-        https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful
-      </a>
-    </p>
-    <p>
-      The Contentful site that is providing the data for this site is at
-      {` `}
-      <a href="https://discovery.contentful.com/entries/by-content-type/2PqfXUJwE8qSYKuM0U6w8M?delivery_access_token=e481b0f7c5572374474b29f81a91e8ac487bb27d70a6f14dd12142837d8e980a&space_id=ubriaw6jfhm1">
-        https://discovery.contentful.com/entries/by-content-type/2PqfXUJwE8qSYKuM0U6w8M?delivery_access_token=e481b0f7c5572374474b29f81a91e8ac487bb27d70a6f14dd12142837d8e980a&space_id=ubriaw6jfhm1
-      </a>
-    </p>
-  </div>
+  <>
+    <header
+      style={{
+        textAlign: "center",
+        backgroundColor: `tomato`,
+        padding: rhythm(1 / 2),
+      }}
+    >
+      <Link style={{ textDecoration: `none` }} to="/">
+        <h4 style={{ color: `white`, marginBottom: 0 }}>
+          Example of using Contentful as a data source for a Gatsby site
+        </h4>
+      </Link>
+    </header>
+    <div
+      style={{
+        margin: `0 auto`,
+        marginTop: rhythm(1.5),
+        marginBottom: rhythm(1.5),
+        maxWidth: 650,
+        paddingLeft: rhythm(3 / 4),
+        paddingRight: rhythm(3 / 4),
+      }}
+    >
+      {children}
+      <hr style={{ marginTop: rhythm(3) }} />
+      <p>
+        The src for this website is at
+        {` `}
+        <a href="https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful">
+          https://github.com/gatsbyjs/gatsby/tree/master/examples/using-contentful
+        </a>
+      </p>
+      <p>
+        The Contentful site that is providing the data for this site is at
+        {` `}
+        <a href="https://discovery.contentful.com/entries/by-content-type/2PqfXUJwE8qSYKuM0U6w8M?delivery_access_token=e481b0f7c5572374474b29f81a91e8ac487bb27d70a6f14dd12142837d8e980a&space_id=ubriaw6jfhm1">
+          https://discovery.contentful.com/entries/by-content-type/2PqfXUJwE8qSYKuM0U6w8M?delivery_access_token=e481b0f7c5572374474b29f81a91e8ac487bb27d70a6f14dd12142837d8e980a&space_id=ubriaw6jfhm1
+        </a>
+      </p>
+    </div>
+  </>
 )
 
 DefaultLayout.propTypes = propTypes

--- a/examples/using-contentful/src/pages/image-api.js
+++ b/examples/using-contentful/src/pages/image-api.js
@@ -1,13 +1,14 @@
 import React from "react"
 import { graphql } from "gatsby"
 import { GatsbyImage } from "gatsby-plugin-image"
+
 import Layout from "../layouts"
 import { rhythm } from "../utils/typography"
 
 const ImageAPI = props => {
   const assets = props.data.allContentfulAsset.edges
   return (
-    <>
+    <Layout>
       <div
         style={{
           margin: `0 auto`,
@@ -161,12 +162,11 @@ const ImageAPI = props => {
         image={assets[1].node.fullWidth}
         style={{}}
       />
-      <Layout>
-        <h4>GraphQL query</h4>
-        <pre style={{ background: `#efeded`, padding: rhythm(3 / 4) }}>
-          <code
-            dangerouslySetInnerHTML={{
-              __html: `{
+      <h4>GraphQL query</h4>
+      <pre style={{ background: `#efeded`, padding: rhythm(3 / 4) }}>
+        <code
+          dangerouslySetInnerHTML={{
+            __html: `{
   allContentfulAsset {
     edges {
       node {
@@ -176,36 +176,36 @@ const ImageAPI = props => {
     }
   }
 }`,
-            }}
-          />
-        </pre>
-        <h2 id="dominant">Dominant color previews</h2>
-        <p>
-          This calculates the dominant color of the source image and uses it as
-          a solid background color.
-        </p>
-        <div
-          style={{
-            display: `grid`,
-            gridTemplateColumns: `repeat(3, minmax(0, 1fr))`,
-            gap: rhythm(1),
           }}
-        >
-          {assets.map(({ node: { id, title, dominant } }) => (
-            <div key={id}>
-              <GatsbyImage
-                image={dominant}
-                alt={title}
-                style={{ border: `1px solid red` }}
-              />
-            </div>
-          ))}
-        </div>
-        <h4>GraphQL query</h4>
-        <pre style={{ background: `#efeded`, padding: rhythm(3 / 4) }}>
-          <code
-            dangerouslySetInnerHTML={{
-              __html: `{
+        />
+      </pre>
+      <h2 id="dominant">Dominant color previews</h2>
+      <p>
+        This calculates the dominant color of the source image and uses it as a
+        solid background color.
+      </p>
+      <div
+        style={{
+          display: `grid`,
+          gridTemplateColumns: `repeat(3, minmax(0, 1fr))`,
+          gap: rhythm(1),
+        }}
+      >
+        {assets.map(({ node: { id, title, dominant } }) => (
+          <div key={id}>
+            <GatsbyImage
+              image={dominant}
+              alt={title}
+              style={{ border: `1px solid red` }}
+            />
+          </div>
+        ))}
+      </div>
+      <h4>GraphQL query</h4>
+      <pre style={{ background: `#efeded`, padding: rhythm(3 / 4) }}>
+        <code
+          dangerouslySetInnerHTML={{
+            __html: `{
   allContentfulAsset {
     edges {
       node {
@@ -219,36 +219,36 @@ const ImageAPI = props => {
     }
   }
 }`,
-            }}
-          />
-        </pre>
-        <h2 id="blurred">Blurred previews</h2>
-        <p>
-          This generates a very low-resolution version of the source image and
-          displays it as a blurred background.
-        </p>
-        <div
-          style={{
-            display: `grid`,
-            gridTemplateColumns: `repeat(3, minmax(0, 1fr))`,
-            gap: rhythm(1),
           }}
-        >
-          {assets.map(({ node: { id, title, blurred } }) => (
-            <div key={id}>
-              <GatsbyImage
-                image={blurred}
-                alt={title}
-                style={{ border: `1px solid red` }}
-              />
-            </div>
-          ))}
-        </div>
-        <h4>GraphQL query</h4>
-        <pre style={{ background: `#efeded`, padding: rhythm(3 / 4) }}>
-          <code
-            dangerouslySetInnerHTML={{
-              __html: `{
+        />
+      </pre>
+      <h2 id="blurred">Blurred previews</h2>
+      <p>
+        This generates a very low-resolution version of the source image and
+        displays it as a blurred background.
+      </p>
+      <div
+        style={{
+          display: `grid`,
+          gridTemplateColumns: `repeat(3, minmax(0, 1fr))`,
+          gap: rhythm(1),
+        }}
+      >
+        {assets.map(({ node: { id, title, blurred } }) => (
+          <div key={id}>
+            <GatsbyImage
+              image={blurred}
+              alt={title}
+              style={{ border: `1px solid red` }}
+            />
+          </div>
+        ))}
+      </div>
+      <h4>GraphQL query</h4>
+      <pre style={{ background: `#efeded`, padding: rhythm(3 / 4) }}>
+        <code
+          dangerouslySetInnerHTML={{
+            __html: `{
   allContentfulAsset {
     edges {
       node {
@@ -262,37 +262,37 @@ const ImageAPI = props => {
     }
   }
 }`,
-            }}
-          />
-        </pre>
-        <h2 id="traced">Traced SVG previews</h2>
-        <p>
-          This generates a simplified, flat SVG version of the source image,
-          which it displays as a placeholder. This works well for images with
-          simple shapes or that include transparency.
-        </p>
-        <div
-          style={{
-            display: `grid`,
-            gridTemplateColumns: `repeat(3, minmax(0, 1fr))`,
-            gap: rhythm(1),
           }}
-        >
-          {assets.map(({ node: { id, title, traced } }) => (
-            <div key={id}>
-              <GatsbyImage
-                image={traced}
-                alt={title}
-                style={{ border: `1px solid red` }}
-              />
-            </div>
-          ))}
-        </div>
-        <h4>GraphQL query</h4>
-        <pre style={{ background: `#efeded`, padding: rhythm(3 / 4) }}>
-          <code
-            dangerouslySetInnerHTML={{
-              __html: `{
+        />
+      </pre>
+      <h2 id="traced">Traced SVG previews</h2>
+      <p>
+        This generates a simplified, flat SVG version of the source image, which
+        it displays as a placeholder. This works well for images with simple
+        shapes or that include transparency.
+      </p>
+      <div
+        style={{
+          display: `grid`,
+          gridTemplateColumns: `repeat(3, minmax(0, 1fr))`,
+          gap: rhythm(1),
+        }}
+      >
+        {assets.map(({ node: { id, title, traced } }) => (
+          <div key={id}>
+            <GatsbyImage
+              image={traced}
+              alt={title}
+              style={{ border: `1px solid red` }}
+            />
+          </div>
+        ))}
+      </div>
+      <h4>GraphQL query</h4>
+      <pre style={{ background: `#efeded`, padding: rhythm(3 / 4) }}>
+        <code
+          dangerouslySetInnerHTML={{
+            __html: `{
   allContentfulAsset {
     edges {
       node {
@@ -306,11 +306,10 @@ const ImageAPI = props => {
     }
   }
 }`,
-            }}
-          />
-        </pre>
-      </Layout>
-    </>
+          }}
+        />
+      </pre>
+    </Layout>
   )
 }
 

--- a/examples/using-contentful/src/pages/index.js
+++ b/examples/using-contentful/src/pages/index.js
@@ -1,7 +1,9 @@
 import React from "react"
-import { Link, graphql } from "gatsby"
 import * as PropTypes from "prop-types"
-import Img from "gatsby-image"
+
+import { Link, graphql } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
+
 import { rhythm } from "../utils/typography"
 import Layout from "../layouts"
 
@@ -25,8 +27,11 @@ const Product = ({ node }) => (
         }}
       >
         <div style={{ marginRight: rhythm(1 / 2) }}>
-          {node.image[0].fixed.src && (
-            <Img style={{ margin: 0 }} fixed={node.image[0].fixed} />
+          {node.image[0].gatsbyImageData && (
+            <GatsbyImage
+              style={{ margin: 0 }}
+              image={node.image[0].gatsbyImageData}
+            />
           )}
         </div>
         <div style={{ flex: 1 }}>{node.productName.productName}</div>
@@ -89,9 +94,7 @@ export const pageQuery = graphql`
             productName
           }
           image {
-            fixed(width: 75) {
-              ...GatsbyContentfulFixed
-            }
+            gatsbyImageData(layout: FIXED, width: 75)
           }
         }
       }
@@ -104,9 +107,7 @@ export const pageQuery = graphql`
             productName
           }
           image {
-            fixed(width: 75) {
-              ...GatsbyContentfulFixed
-            }
+            gatsbyImageData(layout: FIXED, width: 75)
           }
         }
       }

--- a/examples/using-contentful/src/templates/category.js
+++ b/examples/using-contentful/src/templates/category.js
@@ -1,9 +1,10 @@
 import React from "react"
-import { Link, graphql } from "gatsby"
 import * as PropTypes from "prop-types"
-import Img from "gatsby-image"
-import Layout from "../layouts"
 
+import { Link, graphql } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
+
+import Layout from "../layouts"
 import { rhythm } from "../utils/typography"
 
 const propTypes = {
@@ -18,29 +19,28 @@ class CategoryTemplate extends React.Component {
       product,
       icon,
     } = category
-    const iconImg = icon.fixed
+    const iconImg = icon.gatsbyImageData
     return (
       <Layout>
         <div
           style={{
             display: `flex`,
             alignItems: `center`,
-            marginBottom: rhythm(1 / 2),
+            marginBottom: rhythm(1),
           }}
         >
-          <Img
-            style={{
-              height: iconImg.height,
-              width: iconImg.width,
-              marginRight: rhythm(1 / 2),
-            }}
-            fixed={iconImg}
-          />
-          <h4 style={{ marginBottom: 0 }}>{title}</h4>
+          {iconImg && (
+            <GatsbyImage
+              style={{
+                marginRight: rhythm(1 / 2),
+              }}
+              image={iconImg}
+            />
+          )}
+          <h1 style={{ marginBottom: 0 }}>Category: {title}</h1>
         </div>
-        <h1>{title}</h1>
         <div>
-          <span>Products</span>
+          <h2>Products</h2>
           <ul>
             {product &&
               product.map((p, i) => (
@@ -68,13 +68,7 @@ export const pageQuery = graphql`
         title
       }
       icon {
-        fixed(width: 75) {
-          base64
-          src
-          srcSet
-          height
-          width
-        }
+        gatsbyImageData(layout: FIXED, width: 75)
       }
       product {
         id

--- a/examples/using-contentful/src/templates/product.js
+++ b/examples/using-contentful/src/templates/product.js
@@ -1,8 +1,11 @@
 import React from "react"
-import { Link, graphql } from "gatsby"
 import * as PropTypes from "prop-types"
-import Img from "gatsby-image"
+
+import { Link, graphql } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
+
 import Layout from "../layouts"
+import { rhythm } from "../utils/typography"
 
 const propTypes = {
   data: PropTypes.object.isRequired,
@@ -19,18 +22,23 @@ class ProductTemplate extends React.Component {
       brand,
       categories,
     } = product
+    const productImg = image[0]?.gatsbyImageData
     return (
       <Layout>
         <div
           style={{
             display: `flex`,
-            alignItems: `center`,
+            justifyContent: `center`,
           }}
         >
-          <Img fixed={image[0].fixed} />
-          <h4>{productName}</h4>
+          {productImg && (
+            <GatsbyImage
+              style={{ marginBottom: rhythm(1) }}
+              image={productImg}
+            />
+          )}
         </div>
-        <h1>{productName}</h1>
+        <h1 style={{ marginBottom: rhythm(1 / 2) }}>{productName}</h1>
         <h4>Made by {brand.companyName.companyName}</h4>
         <div>
           <span>Price: ${price}</span>
@@ -74,13 +82,7 @@ export const pageQuery = graphql`
       }
       price
       image {
-        fixed(width: 50, height: 50) {
-          base64
-          src
-          srcSet
-          height
-          width
-        }
+        gatsbyImageData(width: 200)
       }
       brand {
         companyName {


### PR DESCRIPTION
This is a follow up for #29526 which removes all left-overs from `gatsby-image`

As the output looked very unfinished, I gave the layout and output a few css updates.

The code related to gatsby-image removal is in the first commit