### PR TITLE
chore(docs): include autoprefixer in tailwind install command

### DIFF
--- a/docs/docs/how-to/styling/tailwind-css.md
+++ b/docs/docs/how-to/styling/tailwind-css.md
@@ -21,7 +21,7 @@ This guide assumes that you have a Gatsby project set up. If you need to set up 
 ### 1. Install Tailwind
 
 ```shell
-npm install tailwindcss --save-dev
+npm install tailwindcss autoprefixer --save-dev
 ```
 
 ### 2. Generate Tailwind config file (optional)


### PR DESCRIPTION
## Description

[The Tailwind install guide](https://www.gatsbyjs.com/docs/how-to/styling/tailwind-css/) seems to be missing the required module `autoprefixer` in the inital command. This is required for `npx tailwindcss init` to run in the next step. This is what you get if you init without `autoprefixer` installed:

![Screenshot 2021-04-06 at 13 54 28](https://user-images.githubusercontent.com/785676/113707233-e5127e80-96df-11eb-8154-2978b3f4a512.png)

## Related Issues

Fixes #30537 
