### PR TITLE
feat(gatsby-plugin-image): Apply `draggable` to picture element

### DIFF
--- a/packages/gatsby-plugin-image/src/components/picture.tsx
+++ b/packages/gatsby-plugin-image/src/components/picture.tsx
@@ -84,8 +84,11 @@ export const Picture = forwardRef<HTMLImageElement, PictureProps>(
       return fallbackImage
     }
 
+    // Default is true, so only attach the prop if the value is explicitly set to `false`
+    const pictureProps = props.draggable === false ? { draggable: false } : {}
+
     return (
-      <picture>
+      <picture {...pictureProps}>
         {sources.map(({ media, srcSet, type }) => (
           <source
             key={`${media}-${type}-${srcSet}`}


### PR DESCRIPTION
For some reason, disabling dragging on an image requires `draggable` to be set to false on the `picture` element, rather than the `img`. This seems like a bug, because all other image and layout props are applied to the `img` tag. Anyway, this fixes the problem by applying `draggable={false}` to the picture element too, if set. Default value is true, so we skip it unless explicitly set to false.

Fixes #30666