### PR TITLE
fix(gatsby-source-wordpress): only log out duplicate nodes if we have all the data we want to log

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
@@ -115,11 +115,14 @@ const paginatedWpNodeFetch = async ({
               )
             )
           }
-          helpers.reporter.info(
-            formatLogMessage(
-              `#${node.databaseId} (${node?.uri}) is a duplicate of ${existingNode.databaseId} (${existingNode?.uri})`
+
+          if (node?.databaseId && node?.uri && existingNode?.uri) {
+            helpers.reporter.info(
+              formatLogMessage(
+                `#${node.databaseId} (${node.uri}) is a duplicate of ${existingNode.databaseId} (${existingNode.uri})`
+              )
             )
-          )
+          }
         }
       } else {
         idSet.add(node.id)


### PR DESCRIPTION
Yesterday Kyle and I fixed https://github.com/gatsbyjs/gatsby/pull/30727 and we were a bit over confident and didn't try out the fix. Turns out there was an additional problem that this PR fixes.