### PR TITLE
fix(gatsby-plugin-image): Allow draggable=false on images

### DIFF
--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -22,7 +22,6 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
     overflow: hidden;
   }
   .gatsby-image-wrapper img {
-    all: inherit;
     bottom: 0;
     height: 100%;
     left: 0;


### PR DESCRIPTION
Setting `all: inherit` on `img` was causing issues with props not being applied to the element. The specific bug is #30666, which is where draggable is not being applied. I'm not sure why we needed this rule in the first place, but it seems to work fine without it.