### PR TITLE
chore(gatsby-plugin-image): Remove version note

### DIFF
--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -20,8 +20,6 @@ For full documentation on all configuration options, see [the Gatsby Image Plugi
 npm install gatsby-plugin-image gatsby-plugin-sharp gatsby-source-filesystem gatsby-transformer-sharp
 ```
 
-1. Upgrade `gatsby` to at least `3.0.0-next.0`.
-
 2. Add the plugins to your `gatsby-config.js`:
 
 ```javascript

--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -20,7 +20,7 @@ For full documentation on all configuration options, see [the Gatsby Image Plugi
 npm install gatsby-plugin-image gatsby-plugin-sharp gatsby-source-filesystem gatsby-transformer-sharp
 ```
 
-1. Upgrade `gatsby` to at least `2.24.78`.
+1. Upgrade `gatsby` to at least `3.0.0-next.0`.
 
 2. Add the plugins to your `gatsby-config.js`:
 


### PR DESCRIPTION
This PR updates the required gatsby version for gatsby-plugin-image to work.

Closes #30757

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
