### PR TITLE
fix(gatsby-source-wordpress): only log out duplicate nodes if we have all the data we want to log (#30751)

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
@@ -95,24 +95,35 @@ const paginatedWpNodeFetch = async ({
     nodes.forEach(node => {
       const existingId = idSet.has(node.id)
 
-      if (existingId) {
+      if (
+        existingId &&
+        // when the since variable is present
+        // we're fetching lists of node updates from WPGQL
+        // in that case we don't need to worry about logging duplicates
+        !(`since` in variables)
+      ) {
         const existingNode = allContentNodes.find(
           innerNode => innerNode.id === node.id
         )
 
-        if (!hasLoggedDuplicateMessage) {
-          hasLoggedDuplicateMessage = true
-          helpers.reporter.warn(
-            formatLogMessage(
-              `Found a duplicate ID in WordPress - this means you will have fewer nodes in Gatsby than in WordPress. This will need to be resolved in WP by identifying and fixing the underlying bug with your WP plugins or custom code.`
+        if (existingNode) {
+          if (!hasLoggedDuplicateMessage) {
+            hasLoggedDuplicateMessage = true
+            helpers.reporter.warn(
+              formatLogMessage(
+                `Found a duplicate ID in WordPress - this means you will have fewer nodes in Gatsby than in WordPress. This will need to be resolved in WP by identifying and fixing the underlying bug with your WP plugins or custom code.`
+              )
             )
-          )
+          }
+
+          if (node?.databaseId && node?.uri && existingNode?.uri) {
+            helpers.reporter.info(
+              formatLogMessage(
+                `#${node.databaseId} (${node.uri}) is a duplicate of ${existingNode.databaseId} (${existingNode.uri})`
+              )
+            )
+          }
         }
-        helpers.reporter.info(
-          formatLogMessage(
-            `#${node.databaseId} (${node?.uri}) is a duplicate of ${existingNode.databaseId} (${existingNode?.uri})`
-          )
-        )
       } else {
         idSet.add(node.id)
       }


### PR DESCRIPTION
Backporting #30751 to the 3.2 release branch

(cherry picked from commit 2bdd5a5865b696e0d31dd8ff3c0dde6fdd7cb181)

Fixes https://github.com/gatsbyjs/gatsby/issues/30722