### PR TITLE
fix(gatsby-source-wordpress): error when sourcing nodes, change `console.warning` to `console.warn`

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -837,7 +837,7 @@ const replaceNodeHtmlLinks = ({ wpUrl, nodeString, node }) => {
           nodeString = nodeString.replace(thisMatchRegex, normalizedPath)
         } catch (e) {
           console.error(e)
-          console.warning(
+          console.warn(
             formatLogMessage(
               `Failed to process inline html links in ${node.__typename} ${node.id}`
             )


### PR DESCRIPTION
## Description
Dev server is throwing `console.warning() is not a function` and exiting when it should just log the message on the console.

