### PR TITLE
feat(gatsby): don't duplicate page data into SitePage nodes

### DIFF
--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -216,6 +216,8 @@ exports.createResolvers = ({ createResolvers }) => {
                   return false
                 }
               }
+
+              return true
             })
           }
           // Limit

--- a/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/internal-data-bridge/gatsby-node.js
@@ -168,29 +168,105 @@ exports.createResolvers = ({ createResolvers }) => {
       },
     },
   }
+
+  if (process.env.GATSBY_EXPERIMENTAL_NO_PAGE_NODES) {
+    resolvers.Query = {
+      // TODO add JSON field for page context.
+      sitePage: {
+        type: `SitePage`,
+        resolve(source, args, context, info) {
+          const { pages } = store.getState()
+          let pagePath = ``
+          if (args.path?.eq && pages.get(args.path.eq)) {
+            pagePath = args.path.eq
+          } else {
+            pagePath = pages.keys().next().value
+          }
+          const page = pages.get(pagePath)
+          page.id = pagePath
+          return page
+        },
+      },
+      allSitePage: {
+        type: `SitePageConnection`,
+        resolve(source, args, context, info) {
+          console.log({ source, args: JSON.stringify(args), context })
+          const { pages } = store.getState()
+          let mappedPages = [...pages.values()].map(page => {
+            page.id = page.path
+            return page
+          })
+
+          // Sort
+          // Filter
+          if (args.filter) {
+            // Support a few common ones.
+            mappedPages = mappedPages.filter(node => {
+              if (args.filter.path?.ne) {
+                if (node.path === args.filter.path.ne) {
+                  return false
+                } else {
+                  return true
+                }
+              }
+              if (args.filter.path?.eq) {
+                if (node.path === args.filter.path.eq) {
+                  return true
+                } else {
+                  return false
+                }
+              }
+            })
+          }
+          // Limit
+          if (args.limit) {
+            mappedPages = mappedPages.slice(0, args.limit)
+          }
+
+          const edges = mappedPages.map(node => {
+            return {
+              node,
+            }
+          })
+
+          return {
+            totalCount: pages.length,
+            edges,
+            nodes: mappedPages,
+            pagesInfo: {
+              totalCount: pages.length,
+            },
+          }
+        },
+      },
+    }
+  }
+
   createResolvers(resolvers)
 }
 
 exports.onCreatePage = ({ createContentDigest, page, actions }) => {
-  const { createNode } = actions
-  // eslint-disable-next-line
-  const { updatedAt, ...pageWithoutUpdated } = page
+  if (!process.env.GATSBY_EXPERIMENTAL_NO_PAGE_NODES) {
+    const { createNode } = actions
+    // eslint-disable-next-line
+    const { updatedAt, ...pageWithoutUpdated } = page
 
-  // Add page.
-  createNode({
-    ...pageWithoutUpdated,
-    id: createPageId(page.path),
-    parent: null,
-    children: [],
-    internal: {
-      type: `SitePage`,
-      contentDigest: createContentDigest(pageWithoutUpdated),
-      description:
-        page.pluginCreatorId === `Plugin default-site-plugin`
-          ? `Your site's "gatsby-node.js"`
-          : page.pluginCreatorId,
-    },
-  })
+    // Add page.
+    createNode({
+      ...pageWithoutUpdated,
+      id: createPageId(page.path),
+      parent: null,
+      children: [],
+      internal: {
+        type: `SitePage`,
+        contentDigest: createContentDigest(pageWithoutUpdated),
+        description:
+          page.pluginCreatorId === `Plugin default-site-plugin`
+            ? `Your site's "gatsby-node.js"`
+            : page.pluginCreatorId,
+      },
+    })
+  }
 }
 
 // Listen for DELETE_PAGE and delete page nodes.

--- a/packages/gatsby/src/services/rebuild-schema-with-site-pages.ts
+++ b/packages/gatsby/src/services/rebuild-schema-with-site-pages.ts
@@ -5,10 +5,12 @@ import { IQueryRunningContext } from "../state-machines/query-running/types"
 export async function rebuildSchemaWithSitePage({
   parentSpan,
 }: Partial<IQueryRunningContext>): Promise<void> {
-  const activity = reporter.activityTimer(`update schema`, {
-    parentSpan,
-  })
-  activity.start()
-  await rebuildWithSitePage({ parentSpan })
-  activity.end()
+  if (!process.env.GATSBY_EXPERIMENTAL_NO_PAGE_NODES) {
+    const activity = reporter.activityTimer(`update schema`, {
+      parentSpan,
+    })
+    activity.start()
+    await rebuildWithSitePage({ parentSpan })
+    activity.end()
+  }
 }

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -166,6 +166,17 @@ const activeFlags: Array<IFlag> = [
     umbrellaIssue: `https://gatsby.dev/parallel-sourcing-feedback`,
     testFitness: (): fitnessEnum => true,
   },
+  {
+    name: `NO_PAGE_NODES`,
+    env: `GATSBY_EXPERIMENTAL_NO_PAGE_NODES`,
+    command: `all`,
+    experimental: false,
+    telemetryId: `NoPageNodes`,
+    description: `Don't create page nodes. Saves time when creating pages for larger sites. Will be the new default behavior in v3.`,
+    umbrellaIssue: `https://github.com/gatsbyjs/gatsby/discussions/29233`,
+    // testFitness: (): fitnessEnum => true,
+    testFitness: (): fitnessEnum => `LOCKED_IN`,
+  },
 ]
 
 export default activeFlags


### PR DESCRIPTION
Follow up PR to https://github.com/gatsbyjs/gatsby/pull/30768

Implemented behind a flag as it's a breaking change as SitePage nodes are no longer directly available.

Drops time for the `createPages` activity for 100k pages in the create-pages benchmark a further 87% from 13.5s to 1.7s. It also drops peak memory usage from ~2.4gb -> ~1.4gb or a 42% drop (the % drop would be much smaller for most sites as a) they'd have less pages and b) they'd have nodes for real data so SitePage wouldn't make up as big of percentage. But the absolute drop of memory would be the same on the order of 1gb / 100k pages).

The savings come from:
- not creating nodes (a CPU & memory expensive operation so most (~80%) of the improvement)
- avoiding running the `onCreatePage` api unless there's an implementing plugin (This saves around ~20% of the time).

We still want to expose the page data through our graphql API (the original reason for copying the page data into nodes). A number of plugins use it like gatsby-plugin-sitemap & gatsby-plugin-preload-fonts. For now, I've added a custom resolver that emulates the normal query running enough that this change is usable for most people. Searching for [`allSitePage`](https://github.com/search?q=allSitePage&type=code) on GitHub does turn up queries that this wouldn't handle so we should look at seeing if we can make our internal query runner use page data in addition to node data.