### PR TITLE
fix(gatsby): lower memory pressure in SSR

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -19,7 +19,6 @@ import db from "../db"
 import { store } from "../redux"
 import * as appDataUtil from "../utils/app-data"
 import { flush as flushPendingPageDataWrites } from "../utils/page-data"
-import * as WorkerPool from "../utils/worker/pool"
 import {
   structureWebpackErrors,
   reportWebpackWarnings,
@@ -79,7 +78,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   const buildSpan = buildActivity.span
   buildSpan.setTag(`directory`, program.directory)
 
-  const { gatsbyNodeGraphQLFunction } = await bootstrap({
+  const { gatsbyNodeGraphQLFunction, workerPool } = await bootstrap({
     program,
     parentSpan: buildSpan,
   })
@@ -136,8 +135,6 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   } finally {
     buildActivityTimer.end()
   }
-
-  const workerPool = WorkerPool.create()
 
   const webpackCompilationHash = stats.hash
   if (


### PR DESCRIPTION
## Description

#### 1. Lower memory pressure

This PR lowers peak memory consumption of gatsby builds up to 2x.

Before this PR we put massive pressure on memory and FS while running SSR in workers. This PR restricts concurrency of html-file writes as well as page-data file reads which greatly reduces this pressure.

The improvement is proportional to the number of CPU cores and the size of your page-data files and HTML. On my test site, memory consumption per SSR worker dropped from 500MB+ to ~200MB.

For a machine with 4 physical cores, it means ~1200MB reduction of peak memory.

#### 2. WorkerPool unification

Also, I've noticed that we create SSR worker pool twice. One worker pool was effectively used for develop and the other - for builds but they both were created for `gatsby build`.

This PR unifies the build and develop behavior - now both use the same Worker pool and we don't create unnecessary processes.

Note that those two changes are independant.