### PR TITLE
chore(gatsby-plugin-styled-components): Remove breaking changes section

### DIFF
--- a/packages/gatsby-plugin-styled-components/README.md
+++ b/packages/gatsby-plugin-styled-components/README.md
@@ -38,20 +38,3 @@ options: {
 ```
 
 Note: The `ssr` option will be ignored. Gatsby will apply it automatically when needed.
-
-### Breaking changes history
-
-<!-- Please keep the breaking changes list ordered with the newest change at the top -->
-
-#### v4.0.0
-
-Released to support upgrade to Gatsby v3.
-
-#### v3.0.0
-
-Supports Gatsby v2 only.
-
-#### v2.0.1
-
-`styled-components` is moved to a peer dependency. Installing the package
-alongside `gatsby-plugin-styled-components` is now required. Use `npm install styled-components`

--- a/packages/gatsby-plugin-styled-components/README.md
+++ b/packages/gatsby-plugin-styled-components/README.md
@@ -43,9 +43,13 @@ Note: The `ssr` option will be ignored. Gatsby will apply it automatically when 
 
 <!-- Please keep the breaking changes list ordered with the newest change at the top -->
 
+#### v4.0.0
+
+Released to support upgrade to Gatsby v3.
+
 #### v3.0.0
 
-support Gatsby v2 only
+Supports Gatsby v2 only.
 
 #### v2.0.1
 


### PR DESCRIPTION
As noted in https://github.com/gatsbyjs/gatsby/issues/30543#issuecomment-817204219 — the v4 release isn't mentioned.
