### PR TITLE
chore(docs): Update links to Diátaxis framework

### DIFF
--- a/docs/contributing/docs-contributions/docs-structure.md
+++ b/docs/contributing/docs-contributions/docs-structure.md
@@ -17,7 +17,7 @@ The [Gatsby documentation site](/docs) includes four different types of material
 
 ![Each of the four types of docs has a different intended audience. The Tutorial is for learning-oriented readers, who want practical steps to help when they're studying. How-To Guides are for problem-oriented readers, who want practical steps to help when they're working. Reference Guides are for information-oriented readers, who want theoretical knowledge to help when they're working. Conceptual Guides are for understanding-oriented readers, who want theoretical knowledge to help when they're studying.](./doc-type-quadrants.svg)
 
-> This documentation structure is based on the [Divio documentation system](https://documentation.divio.com) created by Daniele Procida.
+> This documentation structure is based on the [Diátaxis documentation system](https://diataxis.fr) created by Daniele Procida.
 
 ### Choosing what type of doc to write
 

--- a/docs/contributing/docs-contributions/how-to-write-a-conceptual-guide.md
+++ b/docs/contributing/docs-contributions/how-to-write-a-conceptual-guide.md
@@ -10,9 +10,9 @@ Rather than focusing on specific technical details, Conceptual Guides take a ste
 
 You can think of a Conceptual Guide as a discussion. It compares the benefits and risks of different approaches. It provides additional historical context to explain how things ended up the way they are.
 
-> For more information on Conceptual Guides, check out the [Divio documentation system](https://documentation.divio.com/explanation/), which the Gatsby docs are based on.
+> For more information on Conceptual Guides, check out the [Diátaxis documentation system](https://diataxis.fr/explanation/), which the Gatsby docs are based on.
 >
-> **Note:** In the Divio system, these types of docs are called "Explanations" instead of "Conceptual Guides".
+> **Note:** In the Diátaxis system, these types of docs are called "Explanations" instead of "Conceptual Guides".
 
 ## A near-perfect example of a Conceptual Guide
 

--- a/docs/contributing/docs-contributions/how-to-write-a-how-to-guide.md
+++ b/docs/contributing/docs-contributions/how-to-write-a-how-to-guide.md
@@ -10,7 +10,7 @@ How-To Guides work well for outlining procedures that readers need to follow. Yo
 
 A How-To Guide can include _some_ details to help users understand the steps they're following. For example, you should add a quick sentence before showing a code snippet, to explain what the code does (at a high level) and which pieces to pay special attention to. If you find yourself wanting to provide deeper explanations of how something works, consider creating a separate [Reference Guide](/contributing/docs-contributions/how-to-write-a-reference-guide) or [Conceptual Guide](/contributing/docs-contributions/how-to-write-a-conceptual-guide) and then linking to it in the How-To Guide.
 
-> For more information on How-To Guides, check out the [Divio documentation system](https://documentation.divio.com/how-to-guides/), which the Gatsby docs are based on.
+> For more information on How-To Guides, check out the [Diátaxis documentation system](https://diataxis.fr/how-to-guides/), which the Gatsby docs are based on.
 
 ## How-To Guides audience
 

--- a/docs/contributing/docs-contributions/how-to-write-a-reference-guide.md
+++ b/docs/contributing/docs-contributions/how-to-write-a-reference-guide.md
@@ -12,7 +12,7 @@ Reference Guides work well for describing the nuts and bolts of how to use a Gat
 
 A Reference Guide isn't meant to be read from start to finish. Rather, it's meant to be used by developers who are actively working on a project and need to look up some details about how a particular Gatsby feature works. It might include code examples to show how to use a feature in context, but it doesn't provide a full step-by-step process like what you'd expect from a [How-To Guide](/contributing/docs-contributions/how-to-write-a-how-to-guide) or [Tutorial](/contributing/docs-contributions/how-to-write-a-tutorial)
 
-> For more information on Reference Guides, check out the [Divio documentation system](https://documentation.divio.com/reference-guides/), which the Gatsby docs are based on.
+> For more information on Reference Guides, check out the [Diátaxis documentation system](https://diataxis.fr/reference-guides/), which the Gatsby docs are based on.
 
 ## A near-perfect example of a Reference Guide
 


### PR DESCRIPTION
The Diátaxis documentation framework used by Gatsby is now maintained
and updated at https://diataxis.fr.