### PR TITLE
fix(gatsby-core-utils): fetch-remote-file download failure when missing content-length header

### DIFF
--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -97,7 +97,11 @@ const requestRemoteNode = (
 
     let haveAllBytesBeenWritten = false
     responseStream.on(`downloadProgress`, progress => {
-      if (progress.transferred === progress.total || progress.total === null) {
+      if (
+        progress.transferred === progress.total ||
+        progress.total === null ||
+        progress.total === undefined
+      ) {
         haveAllBytesBeenWritten = true
       }
     })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

When downloading a remote file using `got`, in some cases the remote server won't return `Content-Length` header.  When this happens, the `total` property on the `downloadProgress` results will be `undefined`.

https://github.com/sindresorhus/got#downloadprogress
![image](https://user-images.githubusercontent.com/1935258/114288575-f247aa00-9a0c-11eb-8296-b42340be17d4.png)

I can only assume that it may sometimes return `null` as well, since this already accounts for it?  I am also assuming that the reason the `null` check is there is to assume the download was successful even if there was no `total` reported.

I've just added the `undefined` check to the `downloadProgress` event listener as well so that it also doesn't fail the download when there is no `Content-Length` header

