### PR TITLE
fix(gatsby): handle plugin path resolution in resolvePlugin function

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/load.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.ts
@@ -47,17 +47,25 @@ const createPluginId = (
   )
 
 /**
- * @param pluginName
- * This can be a name of a local plugin, the name of a plugin located in
- * node_modules, or a Gatsby internal plugin. In the last case the pluginName
- * will be an absolute path.
+ * @param plugin
+ * This should be a plugin spec object where possible but can also be the
+ * name of a plugin.
+ *
+ * When it is a name, it can be a name of a local plugin, the name of a plugin
+ * located in node_modules, or a Gatsby internal plugin. In the last case the
+ * plugin will be an absolute path.
  * @param rootDir
  * This is the project location, from which are found the plugins
  */
 export function resolvePlugin(
-  pluginName: string,
+  plugin: PluginRef,
   rootDir: string | null
 ): IPluginInfo {
+  const pluginName = _.isString(plugin) ? plugin : plugin.resolve
+
+  // Respect the directory that the plugin was sourced from initially
+  rootDir = (!_.isString(plugin) && plugin.parentDir) || rootDir
+
   // Only find plugins when we're not given an absolute path
   if (!existsSync(pluginName)) {
     // Find the plugin in the local plugins folder
@@ -192,7 +200,7 @@ export function loadPlugins(
         }
       }
 
-      const info = resolvePlugin(plugin.resolve, plugin.parentDir || rootDir)
+      const info = resolvePlugin(plugin, rootDir)
 
       return {
         ...info,

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -189,7 +189,7 @@ async function validatePluginsOptions(
     plugins.map(async plugin => {
       let gatsbyNode
       try {
-        const resolvedPlugin = resolvePlugin(plugin.resolve, rootDir)
+        const resolvedPlugin = resolvePlugin(plugin, rootDir)
         gatsbyNode = require(`${resolvedPlugin.resolve}/gatsby-node`)
       } catch (err) {
         gatsbyNode = {}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This moves the plugin `rootDir` <-> `parentDir` resolution into the `resolvePlugin()` function, instead of relying on callers to set the correct `rootDir`

PR #29787 broke pnpm/yarn2 because it reused `resolvePlugin()` in order to resolve a plugin's details, but didn't respect the `parentDir` property set on the plugin objects.  By moving that path resolution inside of the function and documenting that the plugin object should be the preferred parameter, hopefully this can be avoided in the future?

## Related Issues

Related to PR #29787
