### PR TITLE
fix(gatsby): "Cannot find module 'babel-preset-gatsby'" error

### DIFF
--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -22,7 +22,7 @@ export const eslintRequiredConfig: ESLint.Options = {
       // TODO proper check for custom babel & plugins config
       // Currently when a babelrc is added to the project, it will override our babelOptions
       babelOptions: {
-        presets: [`babel-preset-gatsby`],
+        presets: [require.resolve(`babel-preset-gatsby`)],
       },
       requireConfigFile: false,
     },
@@ -63,7 +63,7 @@ export const eslintConfig = (
         // TODO proper check for custom babel & plugins config
         // Currently when a babelrc is added to the project, it will override our babelOptions
         babelOptions: {
-          presets: [`babel-preset-gatsby`],
+          presets: [require.resolve(`babel-preset-gatsby`)],
         },
         requireConfigFile: false,
       },


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fixes the webpack error "Cannot find module 'babel-preset-gatsby'" when running in `develop` mode.

This is very likely an issue with pnpm, and so will probably be an issue with yarn2 as well.

When these babel presets/plugins are not resolved to an absolute path, babel attempts to resolve them relative to its current working directory.  `babel-preset-gatsby` does not exist as a dependency of my project, so babel is unable to find it.

This change will resolve the preset based on the location of the `eslintConfig()` function instead.

## Temporary workaround

Installing `babel-preset-gatsby` in the default site project fixes the issue, because then babel is able to resolve the package.

## Related Issues

Related to (fixes?) #30110
  - I can't say for sure if the cause of that issue is the same, because it doesn't really look like any of them were using pnpm.  It would be odd for the error to be generated with `yarn`, but it is possible if `babel-preset-gatsby` doesn't get hoisted for some reason.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
