### PR TITLE
chore(docs): Update migration guide for plugins that support both v2 & v3

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -860,6 +860,17 @@ In most cases, you won't have to do anything to be v3 compatible. But one thing 
 }
 ```
 
+If your plugin supports both versions:
+
+```diff:title=package.json
+{
+  "peerDependencies": {
+-   "gatsby": "^2.32.0",
++   "gatsby": "^2.32.0 || ^3.0.0",
+  }
+}
+```
+
 ## Known Issues
 
 This section is a work in progress and will be expanded when necessary. It's a list of known issues you might run into while upgrading Gatsby to v3 and how to solve them.

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -855,7 +855,7 @@ In most cases, you won't have to do anything to be v3 compatible. But one thing 
 {
   "peerDependencies": {
 -   "gatsby": "^2.32.0",
-+   "gatsby": "^3.0.0", // Or if it supports both versions — "^2.32.0 || ^3.0.0"
++   "gatsby": "^3.0.0",
   }
 }
 ```

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -855,7 +855,7 @@ In most cases, you won't have to do anything to be v3 compatible. But one thing 
 {
   "peerDependencies": {
 -   "gatsby": "^2.32.0",
-+   "gatsby": "^3.0.0",
++   "gatsby": "^3.0.0", // Or if it supports both versions — "^2.32.0 || ^3.0.0"
   }
 }
 ```


### PR DESCRIPTION
Many/most plugins should just update their peerDependencies with no other changes.