### PR TITLE
Add AVIF image format to ContentfulImageFormat enum

### DIFF
--- a/packages/gatsby-source-contentful/src/schemes.js
+++ b/packages/gatsby-source-contentful/src/schemes.js
@@ -8,6 +8,7 @@ const ImageFormatType = new GraphQLEnumType({
     JPG: { value: `jpg` },
     PNG: { value: `png` },
     WEBP: { value: `webp` },
+    AVIF: { value: `avif` },
   },
 })
 


### PR DESCRIPTION
## Description

Allow the .avif format to be queried from the image transformer by adding it to the ContentfulImageFormat enum.

I'm fairly sure this will work but I'm not sure how to set up one of my local Gatsby sites to test this. I believe the format just needs to be allowed as the transformer-sharp should already be creating it.

### Documentation

This isn't currently specifically documented in the gatsby-source-contentful docs.
