### PR TITLE
fix(gatsby-source-contentful): De-dupe type names

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -24,6 +24,7 @@ const {
   ImageResizingBehavior,
   ImageCropFocusType,
   ImageLayoutType,
+  ImagePlaceholderType,
 } = require(`./schemes`)
 
 // By default store the images in `.cache` but allow the user to override
@@ -800,6 +801,15 @@ exports.extendNodeType = ({ type, store }) => {
             FULL_WIDTH: The image resizes to fit its container, even if that is larger than the source image.
             Pass a value to "sizes" if the container is not the full width of the screen.
         `,
+      },
+      placeholder: {
+        type: ImagePlaceholderType,
+        description: stripIndent`
+            Format of generated placeholder image, displayed while the main image loads.
+            BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
+            DOMINANT_COLOR: a solid color, calculated from the dominant color of the image.
+            TRACED_SVG: a low-resolution traced SVG of the image.
+            NONE: no placeholder. Set the argument "backgroundColor" to use a fixed background color.`,
       },
       formats: {
         type: GraphQLList(ImageFormatType),

--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -23,6 +23,7 @@ const {
   ImageFormatType,
   ImageResizingBehavior,
   ImageCropFocusType,
+  ImageLayoutType,
 } = require(`./schemes`)
 
 // By default store the images in `.cache` but allow the user to override
@@ -789,6 +790,16 @@ exports.extendNodeType = ({ type, store }) => {
       quality: {
         type: GraphQLInt,
         defaultValue: 50,
+      },
+      layout: {
+        type: ImageLayoutType,
+        description: stripIndent`
+            The layout for the image.
+            CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size. 
+            FIXED: A static image size, that does not resize according to the screen width
+            FULL_WIDTH: The image resizes to fit its container, even if that is larger than the source image.
+            Pass a value to "sizes" if the container is not the full width of the screen.
+        `,
       },
       formats: {
         type: GraphQLList(ImageFormatType),

--- a/packages/gatsby-source-contentful/src/schemes.js
+++ b/packages/gatsby-source-contentful/src/schemes.js
@@ -11,6 +11,15 @@ const ImageFormatType = new GraphQLEnumType({
   },
 })
 
+const ImageLayoutType = new GraphQLEnumType({
+  name: `ContentfulImageLayout`,
+  values: {
+    FIXED: { value: `fixed` },
+    FULL_WIDTH: { value: `fullWidth` },
+    CONSTRAINED: { value: `constrained` },
+  },
+})
+
 const ImageResizingBehavior = new GraphQLEnumType({
   name: `ImageResizingBehavior`,
   values: {
@@ -59,6 +68,7 @@ const ImageCropFocusType = new GraphQLEnumType({
 })
 
 module.exports = {
+  ImageLayoutType,
   ImageFormatType,
   ImageResizingBehavior,
   ImageCropFocusType,

--- a/packages/gatsby-source-contentful/src/schemes.js
+++ b/packages/gatsby-source-contentful/src/schemes.js
@@ -20,6 +20,16 @@ const ImageLayoutType = new GraphQLEnumType({
   },
 })
 
+const ImagePlaceholderType = new GraphQLEnumType({
+  name: `ContentfulImagePlaceholder`,
+  values: {
+    DOMINANT_COLOR: { value: `dominantColor` },
+    TRACED_SVG: { value: `tracedSVG` },
+    BLURRED: { value: `blurred` },
+    NONE: { value: `none` },
+  },
+})
+
 const ImageResizingBehavior = new GraphQLEnumType({
   name: `ImageResizingBehavior`,
   values: {
@@ -69,6 +79,7 @@ const ImageCropFocusType = new GraphQLEnumType({
 
 module.exports = {
   ImageLayoutType,
+  ImagePlaceholderType,
   ImageFormatType,
   ImageResizingBehavior,
   ImageCropFocusType,


### PR DESCRIPTION
Because this plugin uses `setFieldsOnGraphQLNodeType` rather than `createSchemaCustomization`, type names are not merged and deduped. This leads to [bugs like this](https://github.com/gatsbyjs/gatsby-source-shopify-experimental/issues/65). This PR is a quick fix that renames the offending types. The proper fix though is to switch to the newer API that handles types properly.