### PR TITLE
fix(release notes): Add qualifier to peak memory claim

### DIFF
--- a/docs/docs/reference/release-notes/v3.3/index.md
+++ b/docs/docs/reference/release-notes/v3.3/index.md
@@ -38,8 +38,8 @@ you will likely see modest improvements.
 
 ### Lower peak memory usage
 
-This release restricts concurrency of html-file generation which greatly reduces memory and disk pressure
-and decreases spikes in memory usage. With our example site we saw a decrease in peak memory usage from
+This release restricts concurrency of html-file generation which can greatly reduce memory and disk pressure
+and decrease spikes in memory usage—especially for sites with many 100s+ pages and large page-data.json files. With our example site we saw a decrease in peak memory usage from
 ~3.5 GB to ~1.7 GB (without negative effects to build time).
 
 [Original PR](https://github.com/gatsbyjs/gatsby/pull/30793)

--- a/docs/docs/reference/release-notes/v3.3/index.md
+++ b/docs/docs/reference/release-notes/v3.3/index.md
@@ -39,8 +39,7 @@ you will likely see modest improvements.
 ### Lower peak memory usage
 
 This release restricts concurrency of html-file generation which can greatly reduce memory and disk pressure
-and decrease spikes in memory usage — especially for sites with many 100s+ pages and large page-data.json files. With our example site we saw a decrease in peak memory usage from
-~3.5 GB to ~1.7 GB (without negative effects to build time).
+and decrease spikes in memory usage — especially for sites with many 100s+ pages and large page-data.json files. With our example site we saw a decrease in peak memory usage from ~3.5 GB to ~1.7 GB (without negative effects to build time).
 
 [Original PR](https://github.com/gatsbyjs/gatsby/pull/30793)
 

--- a/docs/docs/reference/release-notes/v3.3/index.md
+++ b/docs/docs/reference/release-notes/v3.3/index.md
@@ -39,7 +39,7 @@ you will likely see modest improvements.
 ### Lower peak memory usage
 
 This release restricts concurrency of html-file generation which can greatly reduce memory and disk pressure
-and decrease spikes in memory usage—especially for sites with many 100s+ pages and large page-data.json files. With our example site we saw a decrease in peak memory usage from
+and decrease spikes in memory usage — especially for sites with many 100s+ pages and large page-data.json files. With our example site we saw a decrease in peak memory usage from
 ~3.5 GB to ~1.7 GB (without negative effects to build time).
 
 [Original PR](https://github.com/gatsbyjs/gatsby/pull/30793)


### PR DESCRIPTION
There'll be small sites w/ few pages or ones w/ small page-query.json files that won't see much of a difference.