### PR TITLE
Revert "fix: clear tracked queries when deleting stale page-data files (#29431)

### DIFF
--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -90,20 +90,6 @@ export function queriesReducer(
       state.deletedQueries.add(action.payload.path)
       return state
     }
-    case `DELETED_STALE_PAGE_DATA_FILES`: {
-      // this action is a hack/hot fix
-      // it should be removed/reverted when we start persisting pages state
-      for (const queryId of action.payload.pagePathsToClear) {
-        for (const component of state.trackedComponents.values()) {
-          component.pages.delete(queryId)
-        }
-        state = clearNodeDependencies(state, queryId)
-        state = clearConnectionDependencies(state, queryId)
-        state.trackedQueries.delete(queryId)
-      }
-
-      return state
-    }
     case `API_FINISHED`: {
       if (action.payload.apiName !== `createPages`) {
         return state

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -372,7 +372,6 @@ export type ActionsUnion =
   | IDisableTypeInferenceAction
   | ISetProgramAction
   | ISetProgramExtensions
-  | IDeletedStalePageDataFiles
   | IRemovedHtml
   | ITrackedHtmlCleanup
   | IGeneratedHtml
@@ -818,13 +817,6 @@ interface ISetProgramAction {
 interface ISetProgramExtensions {
   type: `SET_PROGRAM_EXTENSIONS`
   payload: Array<string>
-}
-
-interface IDeletedStalePageDataFiles {
-  type: `DELETED_STALE_PAGE_DATA_FILES`
-  payload: {
-    pagePathsToClear: Set<string>
-  }
 }
 
 interface IRemovedHtml {

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -259,20 +259,10 @@ export async function handleStalePageData(): Promise<void> {
   })
 
   const deletionPromises: Array<Promise<void>> = []
-  const pagePathsToClear = new Set<string>()
-  for (const pageDataFilePath of pageDataFilesFromPreviousBuilds) {
+  pageDataFilesFromPreviousBuilds.forEach(pageDataFilePath => {
     if (!expectedPageDataFiles.has(pageDataFilePath)) {
-      const stalePageDataContent = await fs.readJson(pageDataFilePath)
-      pagePathsToClear.add(stalePageDataContent.path)
       deletionPromises.push(fs.remove(pageDataFilePath))
     }
-  }
-
-  store.dispatch({
-    type: `DELETED_STALE_PAGE_DATA_FILES`,
-    payload: {
-      pagePathsToClear,
-    },
   })
 
   await Promise.all(deletionPromises)


### PR DESCRIPTION
## Description

Reverts https://github.com/gatsbyjs/gatsby/pull/29431 which was workaround needed for clearing up state due to not persisting pages across builds. https://github.com/gatsbyjs/gatsby/pull/28590 start persisting pages so this workaround is not needed anymore.

Part of series:
 - https://github.com/gatsbyjs/gatsby/pull/28590
 - https://github.com/gatsbyjs/gatsby/pull/28760

Addressing https://github.com/gatsbyjs/gatsby/pull/28590#issuecomment-776881321