### PR TITLE
chore(gatsby-source-graphql): Update README url => uri

### DIFF
--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -200,7 +200,7 @@ module.exports = {
         createLink: pluginOptions =>
           ApolloLink.from([
             retryLink,
-            createHttpLink({ url: pluginOptions.url }),
+            createHttpLink({ uri: pluginOptions.url }),
           ]),
       },
     },
@@ -317,7 +317,7 @@ module.exports = {
       options: {
         typeName: "SWAPI",
         fieldName: "swapi",
-        uri: "https://api.graphcms.com/simple/v1/swapi",
+        url: "https://api.graphcms.com/simple/v1/swapi",
         batch: true,
       },
     },
@@ -339,7 +339,7 @@ module.exports = {
       options: {
         typeName: "SWAPI",
         fieldName: "swapi",
-        uri: "https://api.graphcms.com/simple/v1/swapi",
+        url: "https://api.graphcms.com/simple/v1/swapi",
         batch: true,
         // See https://github.com/graphql/dataloader#new-dataloaderbatchloadfn--options
         // for a full list of DataLoader options

--- a/packages/gatsby-source-graphql/README.md
+++ b/packages/gatsby-source-graphql/README.md
@@ -317,7 +317,7 @@ module.exports = {
       options: {
         typeName: "SWAPI",
         fieldName: "swapi",
-        url: "https://api.graphcms.com/simple/v1/swapi",
+        uri: "https://api.graphcms.com/simple/v1/swapi",
         batch: true,
       },
     },
@@ -339,7 +339,7 @@ module.exports = {
       options: {
         typeName: "SWAPI",
         fieldName: "swapi",
-        url: "https://api.graphcms.com/simple/v1/swapi",
+        uri: "https://api.graphcms.com/simple/v1/swapi",
         batch: true,
         // See https://github.com/graphql/dataloader#new-dataloaderbatchloadfn--options
         // for a full list of DataLoader options


### PR DESCRIPTION
## Description

Fix typo in docs.

After spending too much time figuring out why i was getting a `only absolute urls are supported` from `node-fetch` it was because of a typo in the docs. The `uri`'s fallback is set to `/graphql`.

### Documentation

Where is this feature or API documented?
https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-graphql/README.md#performance-tuning

@gatsbyjs/documentation
