### PR TITLE
feat(gatsby-cli): Support setting host/port by env var

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -34,8 +34,8 @@ const handlerP = (fn: (args: yargs.Arguments) => void) => (
 }
 
 function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
-  const defaultHost = `localhost`
-  const defaultPort = `8000`
+  const defaultHost = process.env.DEFAULT_GATSBY_HOST || `localhost`
+  const defaultPort = process.env.DEFAULT_GATSBY_PORT || `8000`
   const directory = path.resolve(`.`)
 
   // 'not dead' query not available in browserslist used in Gatsby v1


### PR DESCRIPTION
This PR adds support for setting the default host or port via an env var as well as via a cli flag. I always run gatsby on a remote machine, and it's annoying having to remeber to always set the flag. 

This would let you do this:

```shell
DEFAULT_GATSBY_HOST=0.0.0.0 DEFAULT_GATSBY_PORT=8080 gatsby develop
```
