### PR TITLE
feat(gatsby-source-wordpress): generate webp images

### DIFF
--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -47,6 +47,7 @@
   - [html.fallbackImageMaxWidth](#htmlfallbackimagemaxwidth)
   - [html.imageQuality](#htmlimagequality)
   - [html.createStaticFiles](#htmlcreatestaticfiles)
+  - [html.generateWebpImages](#htmlgeneratewebpimages)
 - [type](#type)
   - [type.\_\_all](#type__all)
     - [type.\_\_all.where](#type__allwhere)
@@ -954,6 +955,26 @@ When this is true, any url's which are wrapped in "", '', or () and which contai
   options: {
     html: {
       createStaticFiles: true,
+    },
+  },
+}
+
+```
+
+### html.generateWebpImages
+
+When this is true, .webp images will be generated for images in html fields in addition to the images gatsby-image normally generates.
+
+**Field type**: `Boolean`
+
+**Default value**: `false`
+
+```js
+{
+  resolve: `gatsby-source-wordpress`,
+  options: {
+    html: {
+      generateWebpImages: false,
     },
   },
 }

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
@@ -646,7 +646,7 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
         .default(false)
         .allow(null)
         .description(
-          `When this is true, .webp images would be generated in addition to the same file format as the source images`
+          `When this is true, .webp images will be generated for images in html fields in addition to the images gatsby-image normally generates.`
         )
         .meta({
           example: wrapOptions(`

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
@@ -642,6 +642,19 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
               },
             `),
         }),
+      generateWebpImages: Joi.boolean()
+        .default(false)
+        .allow(null)
+        .description(
+          `When this is true, .webp images would be generated in addition to the same file format as the source images`
+        )
+        .meta({
+          example: wrapOptions(`
+              html: {
+                generateWebpImages: false,
+              },
+            `),
+        }),
     })
       .description(`Options related to html field processing.`)
       .meta({

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -608,6 +608,20 @@ const replaceNodeHtmlImages = async ({
               reporter,
               cache,
             })
+
+            const webpResult = await fluid({
+              file: fileNode,
+              args: {
+                maxWidth,
+                quality,
+                pathPrefix,
+                toFormat: `WEBP`,
+              },
+              reporter,
+              cache,
+            })
+
+            fluidResult.srcSetWebp = webpResult.srcSet
           } catch (e) {
             reporter.error(e)
             reporter.warn(

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -609,19 +609,21 @@ const replaceNodeHtmlImages = async ({
               cache,
             })
 
-            const webpResult = await fluid({
-              file: fileNode,
-              args: {
-                maxWidth,
-                quality,
-                pathPrefix,
-                toFormat: `WEBP`,
-              },
-              reporter,
-              cache,
-            })
+            if (pluginOptions?.html?.generateWebpImages) {
+              const webpResult = await fluid({
+                file: fileNode,
+                args: {
+                  maxWidth,
+                  quality,
+                  pathPrefix,
+                  toFormat: `WEBP`,
+                },
+                reporter,
+                cache,
+              })
 
-            fluidResult.srcSetWebp = webpResult.srcSet
+              fluidResult.srcSetWebp = webpResult.srcSet
+            }
           } catch (e) {
             reporter.error(e)
             reporter.warn(


### PR DESCRIPTION
## Description

This PR adds support for webp image format.

Previously the plugin created scaled versions of the source images in the same format as the source image (e.g. only `.png` for `.png` files). This PR additionally generates `.webp` so that webp images would be served to the browsers that support it.

## Related Issues
Fixes #30895 
