### PR TITLE
fix(gatsby-plugin-image): Check for root container before render

### DIFF
--- a/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
+++ b/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
@@ -83,10 +83,12 @@ export function lazyHydrate(
     </LayoutWrapper>
   )
 
-  // Force render to mitigate "Expected server HTML to contain a matching" in develop
-  const doRender = hydrated.current || forceHydrate.current ? render : hydrate
-  doRender(component, root.current)
-  hydrated.current = true
+  if (root.current) {
+    // Force render to mitigate "Expected server HTML to contain a matching" in develop
+    const doRender = hydrated.current || forceHydrate.current ? render : hydrate
+    doRender(component, root.current)
+    hydrated.current = true
+  }
 
   return (): void => {
     if (root.current) {


### PR DESCRIPTION
Check for root container before attempting to lazy hydrate. Fixes #29982