### PR TITLE
chore(renovate): update typescript as its own group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -77,6 +77,12 @@
       dependencyDashboardApproval: false,
     },
     {
+      groupName: "typescript",
+      paths: ["package.json", "packages/**"],
+      packageNames: ["typescript"],
+      dependencyDashboardApproval: false,
+    },
+    {
       groupName: "babel monorepo",
       paths: ["package.json", "packages/**"],
       sourceUrlPrefixes: ["https://github.com/babel/babel"],
@@ -96,7 +102,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for babel-preset-gatsby-package",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -116,7 +122,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-design-tokens",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -136,7 +142,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-legacy-polyfills",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -156,7 +162,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-no-sourcemaps",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -176,7 +182,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-schema-snapshot",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -196,7 +202,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-theme",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -216,7 +222,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for babel-plugin-remove-graphql-queries",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -236,7 +242,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-codemods",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -256,7 +262,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-core-utils",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -276,7 +282,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-cypress",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -296,7 +302,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-dev-cli",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -316,7 +322,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-graphiql-explorer",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -336,7 +342,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-image",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -356,7 +362,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-link",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -376,7 +382,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-benchmark-reporting",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -396,7 +402,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-canonical-urls",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -416,7 +422,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-catch-links",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -436,7 +442,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-coffeescript",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -456,7 +462,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-create-client-paths",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -476,7 +482,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-cxs",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -496,7 +502,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-emotion",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -516,7 +522,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-facebook-analytics",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -536,7 +542,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-feed",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -556,7 +562,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-flow",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -576,7 +582,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-fullstory",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -596,7 +602,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-glamor",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -616,7 +622,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-google-analytics",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -636,7 +642,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-google-gtag",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -656,7 +662,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-google-tagmanager",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -676,7 +682,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-graphql-config",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -696,7 +702,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-guess-js",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -716,7 +722,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-jss",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -736,7 +742,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-layout",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -756,7 +762,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-less",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -776,7 +782,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-lodash",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -796,7 +802,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-netlify-cms",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -816,7 +822,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-netlify",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -836,7 +842,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-nprogress",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -856,7 +862,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-postcss",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -876,7 +882,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-preact",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -896,7 +902,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-react-css-modules",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -916,7 +922,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-react-helmet",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -936,7 +942,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-remove-trailing-slashes",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -956,7 +962,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-sass",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -976,7 +982,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-sitemap",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -996,7 +1002,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-styled-components",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1016,7 +1022,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-styled-jsx",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1036,7 +1042,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-styletron",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1056,7 +1062,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-stylus",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1076,7 +1082,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-subfont",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1096,7 +1102,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-twitter",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1116,7 +1122,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-typography",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1136,7 +1142,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-react-router-scroll",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1156,7 +1162,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-autolink-headers",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1176,7 +1182,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-code-repls",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1196,7 +1202,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-copy-linked-files",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1216,7 +1222,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-custom-blocks",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1236,7 +1242,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-embed-snippet",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1256,7 +1262,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-graphviz",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1276,7 +1282,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-images-contentful",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1296,7 +1302,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-katex",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1316,7 +1322,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-prismjs",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1336,7 +1342,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-responsive-iframe",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1356,7 +1362,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-smartypants",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1376,7 +1382,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-faker",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1396,7 +1402,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-graphql",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1416,7 +1422,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-hacker-news",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1436,7 +1442,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-lever",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1456,7 +1462,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-medium",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1476,7 +1482,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-mongodb",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1496,7 +1502,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-npm-package-search",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1516,7 +1522,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-wikipedia",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1536,7 +1542,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-asciidoc",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1556,7 +1562,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-csv",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1576,7 +1582,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-documentationjs",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1596,7 +1602,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-excel",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1616,7 +1622,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-hjson",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1636,7 +1642,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-javascript-frontmatter",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1656,7 +1662,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-javascript-static-exports",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1676,7 +1682,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-json",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1696,7 +1702,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-pdf",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1716,7 +1722,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-react-docgen",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1736,7 +1742,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-screenshot",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1756,7 +1762,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-sharp",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1776,7 +1782,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-toml",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1796,7 +1802,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-xml",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1816,7 +1822,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-yaml",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1836,7 +1842,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for babel-preset-gatsby",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1856,7 +1862,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-page-utils",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1876,7 +1882,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-manifest",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1896,7 +1902,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-mdx",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1916,7 +1922,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-offline",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1936,7 +1942,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-preload-fonts",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1956,7 +1962,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-sharp",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1976,7 +1982,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-typescript",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -1996,7 +2002,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-remark-images",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2016,7 +2022,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-filesystem",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "msw"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "msw", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2037,7 +2043,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-telemetry",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2057,7 +2063,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-remark",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2077,7 +2083,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-page-creator",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2097,7 +2103,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-recipes",
       commitMessageExtra: "",
-      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "react-reconciler", "remark-mdx", "remark-mdxjs"],
+      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "react-reconciler", "remark-mdx", "remark-mdxjs", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2118,7 +2124,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-contentful",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2138,7 +2144,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-drupal",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2158,7 +2164,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-shopify",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2178,7 +2184,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-wordpress",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2198,7 +2204,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-transformer-sqip",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2218,7 +2224,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-cli",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2238,7 +2244,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby",
       commitMessageExtra: "",
-      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "remark-mdx", "remark-mdxjs", "webpack-virtual-modules"],
+      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "remark-mdx", "remark-mdxjs", "typescript", "webpack-virtual-modules"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2249,7 +2255,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby",
       excludePackageNames: ["cross-env"],
-      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "remark-mdx", "remark-mdxjs", "webpack-virtual-modules"],
+      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "remark-mdx", "remark-mdxjs", "typescript", "webpack-virtual-modules"],
     },
     {
       groupName: "minor and patch for gatsby-admin",
@@ -2259,7 +2265,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-admin",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "theme-ui"],
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "theme-ui", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {


### PR DESCRIPTION
Changes `renovate.json5` to update `typescript` as its own group. minor Typescript updates introduce new compiler options that can break builds.