### PR TITLE
Fix small typo

### DIFF
--- a/docs/docs/how-to/local-development/troubleshooting-common-errors.md
+++ b/docs/docs/how-to/local-development/troubleshooting-common-errors.md
@@ -175,7 +175,7 @@ Another possibility that could cause this issue is from empty strings used for i
 
 ### Problems installing `sharp` with `gatsby-plugin-sharp` - gyp ERR! build error
 
-If you see an error message in the console when installing dependencies that look related to sharp like `gyp ERR! build error` and `npm ERR! Failed at the sharp@x.x.x install script`, they can often be resolved by deleting the `node_nodules` folder in the root of your project and installing dependencies again:
+If you see an error message in the console when installing dependencies that look related to sharp like `gyp ERR! build error` and `npm ERR! Failed at the sharp@x.x.x install script`, they can often be resolved by deleting the `node_modules` folder in the root of your project and installing dependencies again:
 
 ```shell
 # be careful as this command will delete all files recursively in


### PR DESCRIPTION
Fixed a really small typo ("Nodules" instead of "Modules")

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
