### PR TITLE
chore: Add cloud hosting option to starter README template

### DIFF
--- a/starters/README-template.md
+++ b/starters/README-template.md
@@ -39,6 +39,12 @@ _Have another more specific idea? You may want to check out our vibrant collecti
 
     Open the `my-<%= name %>-starter` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
 
+## 🚀 Quick start (Gatsby Cloud)
+
+Deploy this starter with one click on [Gatsby Cloud](https://www.gatsbyjs.com/cloud/):
+
+[<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/gatsbyjs/gatsby-starter-blog)
+
 ## 🧐 What's inside?
 
 A quick look at the top-level files and directories you'll see in a Gatsby project.

--- a/starters/README-template.md
+++ b/starters/README-template.md
@@ -43,7 +43,7 @@ _Have another more specific idea? You may want to check out our vibrant collecti
 
 Deploy this starter with one click on [Gatsby Cloud](https://www.gatsbyjs.com/cloud/):
 
-[<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/gatsbyjs/gatsby-starter-blog)
+[<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/gatsbyjs/gatsby-starter-<%= name %>)
 
 ## 🧐 What's inside?
 


### PR DESCRIPTION
Follow up to https://github.com/gatsbyjs/gatsby/pull/30792

We forgot to update the template that creates the actual READMEs in the remote repos