### PR TITLE
fix(gatsby): add support for useStaticQuery with commonjs/require

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -526,6 +526,34 @@ var _default = () => {
 exports.default = _default;"
 `;
 
+exports[`babel-plugin-remove-graphql-queries Transforms queries in useStaticQuery that use commonjs 1`] = `
+"const React = require(\\"react\\");
+
+const {
+  useStaticQuery
+} = require(\\"gatsby\\");
+
+module.exports = () => {
+  const siteTitle = useStaticQuery(\\"426988268\\");
+  return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
+};"
+`;
+
+exports[`babel-plugin-remove-graphql-queries Transforms queries in useStaticQuery that use commonjs 2`] = `
+"\\"use strict\\";
+
+const React = require(\\"react\\");
+
+const {
+  useStaticQuery
+} = require(\\"gatsby\\");
+
+module.exports = () => {
+  const siteTitle = useStaticQuery(\\"426988268\\");
+  return /*#__PURE__*/React.createElement(\\"h1\\", null, siteTitle.site.siteMetadata.title);
+};"
+`;
+
 exports[`babel-plugin-remove-graphql-queries allows the global tag 1`] = `"const query = \\"426988268\\";"`;
 
 exports[`babel-plugin-remove-graphql-queries allows the global tag 2`] = `

--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/index.js
@@ -11,6 +11,7 @@ function matchesSnapshot(query) {
     plugins: [plugin],
     filename: `src/components/test.js`,
   })
+
   expect(codeWithoutFileName).toMatchSnapshot()
   expect(codeWithFileName).toMatchSnapshot()
 }
@@ -49,6 +50,21 @@ describe(`babel-plugin-remove-graphql-queries`, () => {
   import { graphql, useStaticQuery } from 'gatsby'
 
   export default () => {
+    const siteTitle = useStaticQuery(graphql\`{site { siteMetadata { title }}}\`)
+
+    return (
+      <h1>{siteTitle.site.siteMetadata.title}</h1>
+    )
+  }
+  `)
+  })
+
+  it(`Transforms queries in useStaticQuery that use commonjs`, () => {
+    matchesSnapshot(`
+  const React = require("react")
+  const { graphql, useStaticQuery } = require("gatsby")
+
+  module.exports = () => {
     const siteTitle = useStaticQuery(graphql\`{site { siteMetadata { title }}}\`)
 
     return (

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -1497,6 +1497,80 @@ Object {
     },
     "text": "query{foo}",
   },
+  "22": Object {
+    "doc": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "loc": Object {
+            "end": 29,
+            "start": 0,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 21,
+              "start": 6,
+            },
+            "value": "StaticQueryName",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 29,
+              "start": 22,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 27,
+                  "start": 24,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 27,
+                    "start": 24,
+                  },
+                  "value": "foo",
+                },
+                "selectionSet": undefined,
+              },
+            ],
+          },
+          "variableDefinitions": Array [],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 29,
+        "start": 0,
+      },
+    },
+    "filePath": "static-query-hooks-commonjs.js",
+    "hash": 2687344169,
+    "isHook": true,
+    "isStaticQuery": true,
+    "templateLoc": SourceLocation {
+      "end": Position {
+        "column": 67,
+        "line": 3,
+      },
+      "filename": undefined,
+      "identifierName": undefined,
+      "start": Position {
+        "column": 38,
+        "line": 3,
+      },
+    },
+    "text": "query StaticQueryName{foo}",
+  },
   "3": Object {
     "doc": Object {
       "definitions": Array [

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -1571,6 +1571,80 @@ Object {
     },
     "text": "query StaticQueryName{foo}",
   },
+  "23": Object {
+    "doc": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "loc": Object {
+            "end": 44,
+            "start": 0,
+          },
+          "name": Object {
+            "kind": "Name",
+            "loc": Object {
+              "end": 36,
+              "start": 6,
+            },
+            "value": "StaticQueryNameNoDestructuring",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "loc": Object {
+              "end": 44,
+              "start": 37,
+            },
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [],
+                "directives": Array [],
+                "kind": "Field",
+                "loc": Object {
+                  "end": 42,
+                  "start": 39,
+                },
+                "name": Object {
+                  "kind": "Name",
+                  "loc": Object {
+                    "end": 42,
+                    "start": 39,
+                  },
+                  "value": "foo",
+                },
+                "selectionSet": undefined,
+              },
+            ],
+          },
+          "variableDefinitions": Array [],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 44,
+        "start": 0,
+      },
+    },
+    "filePath": "static-query-hooks-commonjs-no-destructuring.js",
+    "hash": 2462364336,
+    "isHook": true,
+    "isStaticQuery": true,
+    "templateLoc": SourceLocation {
+      "end": Position {
+        "column": 89,
+        "line": 4,
+      },
+      "filename": undefined,
+      "identifierName": undefined,
+      "start": Position {
+        "column": 45,
+        "line": 4,
+      },
+    },
+    "text": "query StaticQueryNameNoDestructuring{foo}",
+  },
   "3": Object {
     "doc": Object {
       "definitions": Array [

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -246,6 +246,12 @@ module.exports = () => {
   const data = useStaticQuery(graphql\`query StaticQueryName { foo }\`);
   return <div>{data.doo}</div>;
 }`,
+    "static-query-hooks-commonjs-no-destructuring.js": `const gatsby = require('gatsby')
+const {graphql} = require('gatsby')
+module.exports = () => {
+  const data = gatsby.useStaticQuery(graphql\`query StaticQueryNameNoDestructuring { foo }\`);
+  return <div>{data.doo}</div>;
+}`,
   }
 
   const parser = new FileParser()

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -69,11 +69,6 @@ query {
     render={data => <div>{data.doo}</div>}
   />
 )`,
-    "static-query-hooks-commonjs.js": `const { graphql, useStaticQuery } = require('gatsby')
-module.exports = () => {
-  const data = useStaticQuery(graphql\`query StaticQueryName { foo }\`);
-  return <div>{data.doo}</div>;
-}`,
     "static-query-no-name.js": `import { graphql } from 'gatsby'
   export default () => (
   <StaticQuery
@@ -246,6 +241,11 @@ export default () => {
     render={data => <div>{data.doo}</div>}
   />
 )`,
+    "static-query-hooks-commonjs.js": `const { graphql, useStaticQuery } = require('gatsby')
+module.exports = () => {
+  const data = useStaticQuery(graphql\`query StaticQueryName { foo }\`);
+  return <div>{data.doo}</div>;
+}`,
   }
 
   const parser = new FileParser()
@@ -267,6 +267,7 @@ export default () => {
     // Check that invalid entries are not in the results and thus haven't been extracted
     expect(results).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({ filePath: `static-query-hooks-commonjs.js` }),
         expect.not.objectContaining({ filePath: `no-query.js` }),
         expect.not.objectContaining({ filePath: `other-graphql-tag.js` }),
         expect.not.objectContaining({ filePath: `global-query.js` }),

--- a/packages/gatsby/src/query/__tests__/file-parser.js
+++ b/packages/gatsby/src/query/__tests__/file-parser.js
@@ -69,6 +69,11 @@ query {
     render={data => <div>{data.doo}</div>}
   />
 )`,
+    "static-query-hooks-commonjs.js": `const { graphql, useStaticQuery } = require('gatsby')
+module.exports = () => {
+  const data = useStaticQuery(graphql\`query StaticQueryName { foo }\`);
+  return <div>{data.doo}</div>;
+}`,
     "static-query-no-name.js": `import { graphql } from 'gatsby'
   export default () => (
   <StaticQuery

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -57,14 +57,19 @@ function followVariableDeclarations(binding) {
   return binding
 }
 
-function isUseStaticQuery(path) {
-  return (
-    (path.node.callee.type === `MemberExpression` &&
-      path.node.callee.property.name === `useStaticQuery` &&
-      path.get(`callee`).get(`object`).referencesImport(`gatsby`)) ||
-    (path.node.callee.name === `useStaticQuery` &&
-      path.get(`callee`).referencesImport(`gatsby`))
-  )
+function isUseStaticQuery(path): boolean {
+  const callee = path.node.callee
+  if (callee.type === `MemberExpression`) {
+    const property = callee.property
+    if (property.name === `useStaticQuery`) {
+      return path.get(`callee`).get(`object`).referencesImport(`gatsby`, ``)
+    }
+    return false
+  }
+  if (callee.name === `useStaticQuery`) {
+    return path.get(`callee`).referencesImport(`gatsby`, ``)
+  }
+  return false
 }
 
 const warnForUnknownQueryVariable = (varName, file, usageFunction) =>

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -57,7 +57,7 @@ function followVariableDeclarations(binding) {
   return binding
 }
 
-function isUseStaticQuery(path): boolean {
+function isUseStaticQuery(path) {
   const callee = path.node.callee
   if (callee.type === `MemberExpression`) {
     const property = callee.property
@@ -67,7 +67,20 @@ function isUseStaticQuery(path): boolean {
     return false
   }
   if (callee.name === `useStaticQuery`) {
-    return path.get(`callee`).referencesImport(`gatsby`, ``)
+    // This works for es6 imports
+    if (path.get(`callee`).referencesImport(`gatsby`, ``)) {
+      return true
+    } else {
+      // This finds where userStaticQuery was declared and then checks
+      // if it is a "require" and "gatsby" is the argument.
+      const declaration = path.scope.getBinding(path.node.callee.name)
+      if (
+        declaration.path.node.init.callee.name === `require` &&
+        declaration.path.node.init.arguments[0].value === `gatsby`
+      ) {
+        return true
+      }
+    }
   }
   return false
 }


### PR DESCRIPTION
Noticed other tests are all es6 so a bit of precaution to prevent possible regressions.

This also looks like it solves at least some people's problems with static queries https://github.com/gatsbyjs/gatsby/issues/24902#issuecomment-822689489 — turns out we were never checking for commonjs requires for `useStaticQuery` in `file-parser.js` which meant that these components' queries weren't loaded correctly.