### PR TITLE
fix(gatsby): filter out not applicable flags (isCi / command) when constructing flags message

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/handle-flags.ts.snap
@@ -50,11 +50,9 @@ The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
 
-There are 5 other flags available that you might be interested in:
+There are 3 other flags available that you might be interested in:
 - FAST_DEV · Enable all experiments aimed at improving develop server start time
 - DEV_SSR · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/28138)) · SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.
-- QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
-- ONLY_BUILDS · (Umbrella Issue (test)) · test
 - YET_ANOTHER · (Umbrella Issue (test)) · test
 ",
   "unknownFlagMessage": "",
@@ -152,11 +150,9 @@ The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
 
-There are 5 other flags available that you might be interested in:
+There are 3 other flags available that you might be interested in:
 - FAST_DEV · Enable all experiments aimed at improving develop server start time
 - DEV_SSR · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/28138)) · SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.
-- QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
-- ONLY_BUILDS · (Umbrella Issue (test)) · test
 - YET_ANOTHER · (Umbrella Issue (test)) · test
 ",
   "unknownFlagMessage": "The following flag(s) found in your gatsby-config.js are not known:
@@ -251,10 +247,6 @@ flags: {
 The following flags were automatically enabled on your site:
 - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
 - PARTIAL_RELEASE_ONLY_NEW_LODASH · (Umbrella Issue (test)) · test
-
-There are 2 other flags available that you might be interested in:
-- ONLY_BUILDS · (Umbrella Issue (test)) · test
-- YET_ANOTHER · (Umbrella Issue (test)) · test
 ",
   "unknownFlagMessage": "",
 }

--- a/packages/gatsby/src/utils/__tests__/handle-flags.ts
+++ b/packages/gatsby/src/utils/__tests__/handle-flags.ts
@@ -261,10 +261,8 @@ describe(`handle flags`, () => {
       - ALWAYS_OPT_IN · (Umbrella Issue (test)) · test
       - DEV_SSR · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/28138)) · SSR pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.
 
-      There are 7 other flags available that you might be interested in:
+      There are 5 other flags available that you might be interested in:
       - FAST_DEV · Enable all experiments aimed at improving develop server start time
-      - QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
-      - ONLY_BUILDS · (Umbrella Issue (test)) · test
       - ALL_COMMANDS · (Umbrella Issue (test)) · test
       - YET_ANOTHER · (Umbrella Issue (test)) · test
       - PARTIAL_RELEASE · (Umbrella Issue (test)) · test
@@ -332,6 +330,60 @@ describe(`handle flags`, () => {
       `)
     })
 
+    it(`Display message when LOCKED_IN applies to command different than currently executed`, () => {
+      const response = handleFlags(
+        [
+          {
+            name: `ALWAYS_LOCKED_IN_SET_IN_CONFIG_FOR_DEVELOP`,
+            env: `GATSBY_ALWAYS_LOCKED_IN_SET_IN_CONFIG_FOR_DEVELOP`,
+            command: `develop`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            // this will always LOCKED IN
+            testFitness: (): fitnessEnum => `LOCKED_IN`,
+          },
+          {
+            name: `SOME_FLAG`,
+            env: `GATSBY_SOME_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => true,
+          },
+        ],
+        {
+          // this has no effect, but we want to show to user that
+          SOME_FLAG: true,
+        },
+        `build`
+      )
+
+      expect(response).toMatchInlineSnapshot(`
+        Object {
+          "enabledConfigFlags": Array [
+            Object {
+              "command": "all",
+              "description": "test",
+              "env": "GATSBY_SOME_FLAG",
+              "experimental": false,
+              "name": "SOME_FLAG",
+              "telemetryId": "test",
+              "testFitness": [Function],
+              "umbrellaIssue": "test",
+            },
+          ],
+          "message": "The following flags are active:
+        - SOME_FLAG · (Umbrella Issue (test)) · test
+        ",
+          "unknownFlagMessage": "",
+        }
+      `)
+    })
+
     it(`Kitchen sink`, () => {
       const response = handleFlags(
         activeFlags.concat([
@@ -385,10 +437,8 @@ describe(`handle flags`, () => {
         Those flags no longer have any effect and you can remove them from config:
         - ALWAYS_LOCKED_IN_SET_IN_CONFIG · (Umbrella Issue (test)) · test
 
-        There are 5 other flags available that you might be interested in:
+        There are 3 other flags available that you might be interested in:
         - FAST_DEV · Enable all experiments aimed at improving develop server start time
-        - QUERY_ON_DEMAND · (Umbrella Issue (https://github.com/gatsbyjs/gatsby/discussions/27620)) · Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.
-        - ONLY_BUILDS · (Umbrella Issue (test)) · test
         - ALL_COMMANDS · (Umbrella Issue (test)) · test
         - YET_ANOTHER · (Umbrella Issue (test)) · test
         - PARTIAL_RELEASE · (Umbrella Issue (test)) · test

--- a/packages/gatsby/src/utils/handle-flags.ts
+++ b/packages/gatsby/src/utils/handle-flags.ts
@@ -69,12 +69,13 @@ const handleFlags = (
   const lockedInFlags = new Map<string, IFlag>()
   const lockedInFlagsThatAreInConfig = new Map<string, IFlag>()
   availableFlags.forEach(flag => {
-    const isForCommand =
-      flag.command === `all` || flag.command === executingCommand
-    // If we're in CI, filter out any flags that don't want to be enabled in CI
-    const isForCi = isCI() ? flag.noCI !== true : true
+    if (flag.command !== `all` && flag.command !== executingCommand) {
+      // if flag is not for all commands and current command doesn't match command flag is for - skip
+      return
+    }
 
-    if (!isForCommand || !isForCi) {
+    if (flag.noCI && isCI()) {
+      // If we're in CI and flag is not available for CI - skip
       return
     }
 
@@ -102,15 +103,18 @@ const handleFlags = (
 
   // Filter enabledConfigFlags against various tests
   enabledConfigFlags = enabledConfigFlags.filter(flag => {
-    // Is this flag available for this command?
-    const isForCommand =
-      flag.command === `all` || flag.command === executingCommand
-    // If we're in CI, filter out any flags that don't want to be enabled in CI
-    const isForCi = isCI() ? flag.noCI !== true : true
+    if (flag.command !== `all` && flag.command !== executingCommand) {
+      // if flag is not for all commands and current command doesn't match command flag is for - skip
+      return false
+    }
 
-    const passesFitness = flag.testFitness(flag)
+    if (flag.noCI && isCI()) {
+      // If we're in CI and flag is not available for CI - skip
+      return false
+    }
 
-    return isForCommand && isForCi && passesFitness
+    // finally check if flag passes fitness check
+    return flag.testFitness(flag)
   })
 
   const addIncluded = (flag): void => {

--- a/packages/gatsby/src/utils/handle-flags.ts
+++ b/packages/gatsby/src/utils/handle-flags.ts
@@ -69,6 +69,15 @@ const handleFlags = (
   const lockedInFlags = new Map<string, IFlag>()
   const lockedInFlagsThatAreInConfig = new Map<string, IFlag>()
   availableFlags.forEach(flag => {
+    const isForCommand =
+      flag.command === `all` || flag.command === executingCommand
+    // If we're in CI, filter out any flags that don't want to be enabled in CI
+    const isForCi = isCI() ? flag.noCI !== true : true
+
+    if (!isForCommand || !isForCi) {
+      return
+    }
+
     const fitness = flag.testFitness(flag)
 
     const flagIsSetInConfig = typeof configFlags[flag.name] !== `undefined`


### PR DESCRIPTION
## Description

Noticed weird CLI messages during work on https://github.com/gatsbyjs/gatsby/pull/30857 where message wouldn't be displayed correctly due https://github.com/gatsbyjs/gatsby/blob/06687500de521d8ce8710a96ec817f87430f80a0/packages/gatsby/src/utils/handle-flags.ts#L145-L155

not being satisfied and not displaying which flags are active because `lockedInFlags` would contain flags for develop which were not actually enabled.

This also make it so only applicable flags (so flags that satisfy CI condition and command condition) are listed in messages (i.e. `DEV_SSR` won't be printed for builds)