### PR TITLE
chore(docs): Updated warning icon to use emoji

### DIFF
--- a/packages/gatsby-image/README.md
+++ b/packages/gatsby-image/README.md
@@ -1,4 +1,4 @@
-## :warning: This package is now deprecated
+## ⚠️ This package is now deprecated
 
 The `gatsby-image` package is now deprecated. The new [Gatsby image plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-image) has better performance, cool new features and a simpler API. See [the migration guide](https://www.gatsbyjs.com/docs/reference/release-notes/image-migration-guide/) to learn how to upgrade.
 


### PR DESCRIPTION
The Gatsby site doesn't support converting the `:warning:` string to a symbol, so I replaced it with the emoji character itself to fix this. This is probably a temporary workaround, as ideally the Gatsby site would parse the `:warning:` string into an emoji.