### PR TITLE
fix(gatsby-react-router-scroll): fix useScrollRestoration to run when location changes

### DIFF
--- a/packages/gatsby-react-router-scroll/src/use-scroll-restoration.ts
+++ b/packages/gatsby-react-router-scroll/src/use-scroll-restoration.ts
@@ -19,7 +19,7 @@ export function useScrollRestoration(
       const position = state.read(location, identifier)
       ref.current.scrollTo(0, position || 0)
     }
-  }, [])
+  }, [location])
 
   return {
     ref,


### PR DESCRIPTION
## Related Issues
Fixes #31012
