### PR TITLE
perf(gatsby-plugin-page-creator): De-dupe collection pages

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -109,43 +109,42 @@ ${errors.map(error => error.message).join(`\n`)}`.trim(),
 
   // 3. Loop through each node and create the page, also save the path it creates to pass to the watcher
   //    the watcher will use this data to delete the pages if the query changes significantly.
-  const paths = nodes
-    .map((node: Record<string, Record<string, unknown>>) => {
-      // URL path for the component and node
-      const { derivedPath, errors } = derivePath(
-        filePath,
-        node,
-        reporter,
-        slugifyOptions
-      )
-      const path = createPath(derivedPath)
-      // We've already created a page with this path
-      if (knownPagePaths.has(path)) {
-        return false
-      }
-      knownPagePaths.add(path)
-      // Params is supplied to the FE component on props.params
-      const params = getCollectionRouteParams(createPath(filePath), path)
-      // nodeParams is fed to the graphql query for the component
-      const nodeParams = reverseLookupParams(node, absolutePath)
-      // matchPath is an optional value. It's used if someone does a path like `{foo}/[bar].js`
-      const matchPath = getMatchPath(path)
+  const paths: Array<string> = []
+  nodes.forEach((node: Record<string, Record<string, unknown>>) => {
+    // URL path for the component and node
+    const { derivedPath, errors } = derivePath(
+      filePath,
+      node,
+      reporter,
+      slugifyOptions
+    )
+    const path = createPath(derivedPath)
+    // We've already created a page with this path
+    if (knownPagePaths.has(path)) {
+      return
+    }
+    knownPagePaths.add(path)
+    // Params is supplied to the FE component on props.params
+    const params = getCollectionRouteParams(createPath(filePath), path)
+    // nodeParams is fed to the graphql query for the component
+    const nodeParams = reverseLookupParams(node, absolutePath)
+    // matchPath is an optional value. It's used if someone does a path like `{foo}/[bar].js`
+    const matchPath = getMatchPath(path)
 
-      actions.createPage({
-        path: path,
-        matchPath,
-        component: absolutePath,
-        context: {
-          ...nodeParams,
-          __params: params,
-        },
-      })
-
-      derivePathErrors += errors
-
-      return path
+    actions.createPage({
+      path: path,
+      matchPath,
+      component: absolutePath,
+      context: {
+        ...nodeParams,
+        __params: params,
+      },
     })
-    .filter((value): value is string => Boolean(value))
+
+    derivePathErrors += errors
+
+    paths.push(path)
+  })
 
   if (derivePathErrors > 0) {
     reporter.panicOnBuild({


### PR DESCRIPTION
There are scenarios where the filesystem route API will create pages with the same path for many pages. This would happen where a page is created based on a non-unique property of the node, which is useful for creating listing or index pages based on a field that isn;t a node type itself. e.g.
`src/pages/products/{ShopifyProduct.productType}/index.jsx` which would try to create `/products/toys/` for every product with the `"toys"` type. Currently we will create a new page with the same path for every node. This could potentially happen hundreds or thousands of times, e.g. the 30k SKU shopify site recreates each "type" page around 2000 times on each build, with similar numbers for `tags` pages.

This PR adds a `knownPagePaths` `Set` which tracks which paths have been created in that collection. This is only for a single collection, so it won't catch cases where multiple collections try to write to the same path, but those would be undefined behaviour anyway.

There are some potential caveats. This may technically be a breaking change, as currently the last page created "wins", whereas now it will be the first page. This is unlikely to make a difference as this sort of page is unlikely to be using any fields that would be different, and the current behavior is unexpected in any case.

I don't _think_ there is an issue with dependencies and stale pages, as these track the path which would still be found. However this isn't an area of the codebase that I'm super-familiar with so I'd welcome comment from @lekoarts in particular.