### PR TITLE
fix(gatsby): Fix static queries in `yarn link`-ed packages not compiled

### DIFF
--- a/packages/gatsby/src/utils/webpack/static-query-mapper.ts
+++ b/packages/gatsby/src/utils/webpack/static-query-mapper.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import fs from "fs"
 import { Store } from "redux"
 import { Compiler, Module, NormalModule, Compilation } from "webpack"
 import ConcatenatedModule from "webpack/lib/optimize/ConcatenatedModule"
@@ -39,7 +40,7 @@ function getRealPath(
   componentPath: string
 ): string {
   if (!cache.has(componentPath)) {
-    cache.set(componentPath, path.resolve(componentPath))
+    cache.set(componentPath, fs.realpathSync(path.resolve(componentPath)))
   }
 
   return cache.get(componentPath) as string


### PR DESCRIPTION
## Description

I `yarn link`-ed a in-development theme to a site project. And I found the static queries in the theme is NOT compiled. After a long time debugging Gatsby, I found that for the same file the path of "Webpack's output module" and "the module used a static query" is different. The former is the real path without symlink and the latter is the not resolved path with symlink.

My site project is `/home/Menci/Projects/CS-wiki` and I `yarn link`-ed `gatsby-theme-oi-wiki` to `/home/Menci/Projects/CS-wiki/node_modules/gatsby-theme-oi-wiki`. The `componentPath` in Gatsby's `staticQueries` references the linked path:

![image](https://user-images.githubusercontent.com/11341955/115960367-94a27a00-a543-11eb-8b58-f6e12267553f.png)

But Webpack's module object's `resource` property references the resolved path without symlink:

![image](https://user-images.githubusercontent.com/11341955/115960437-067ac380-a544-11eb-99c6-aa183508a751.png)

The mismatch of the paths causes that Gatsby thinks the file doesn't use that static query so the static query will not compiled and sent to frontend.

This PR fixes the issue by converting all paths to real path with `fs.realpathSync` in `static-query-mapper.ts`.