### PR TITLE
fix(gatsby-plugin-sharp): Handle fractional image sizes

### DIFF
--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -236,7 +236,9 @@ export async function generateImageData({
   const primaryIndex =
     layout === `fullWidth`
       ? imageSizes.sizes.length - 1 // The largest image
-      : imageSizes.sizes.findIndex(size => size === imageSizes.unscaledWidth)
+      : imageSizes.sizes.findIndex(
+          size => size === Math.round(imageSizes.unscaledWidth)
+        )
 
   if (primaryIndex === -1) {
     reporter.error(

--- a/packages/gatsby-plugin-sharp/src/plugin-options.js
+++ b/packages/gatsby-plugin-sharp/src/plugin-options.js
@@ -119,9 +119,11 @@ exports.healOptions = (
   // only set width to 400 if neither width nor height is passed
   if (options.width === undefined && options.height === undefined) {
     options.width = 400
-  } else if (options.width !== undefined) {
+  }
+  if (options.width !== undefined) {
     options.width = parseInt(options.width, 10)
-  } else if (options.height !== undefined) {
+  }
+  if (options.height !== undefined) {
     options.height = parseInt(options.height, 10)
   }
 
@@ -141,7 +143,6 @@ exports.healOptions = (
       )
     }
   })
-
   return options
 }
 


### PR DESCRIPTION
This PR includes two fixes to the handling of fractional image sizes.

- Fix `healOptions` to correctly round the dimensions. Fixes #31014
- Fix `generateImageData` to correctly find the default image when StaticImage passes a fractional size.