### PR TITLE
feat(gatsby): Add note to DEV_SSR flag about custom webpack config

### DIFF
--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -92,7 +92,7 @@ const activeFlags: Array<IFlag> = [
     command: `develop`,
     telemetryId: `DevSsr`,
     experimental: false,
-    description: `Server Side Render (SSR) pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds.`,
+    description: `Server Side Render (SSR) pages on full reloads during develop. Helps you detect SSR bugs and fix them without needing to do full builds. See umbrella issue for how to update custom webpack config.`,
     umbrellaIssue: `https://gatsby.dev/dev-ssr-feedback`,
     testFitness: (): fitnessEnum => {
       if (sampleSiteForExperiment(`DEV_SSR`, 20)) {


### PR DESCRIPTION
If someone modifies their config for the `build-html` stage and haven't for `develop-html`, they'll probably also need to update it to modify `develop-html` stage as well https://github.com/gatsbyjs/gatsby/discussions/28138#discussioncomment-598599

The docs for the most common use case here (using `loader.null()` for problematic modules) was updated a while ago but people with old code can still run into this https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/debugging-html-builds.md#fixing-third-party-modules