### PR TITLE
remove: unnecessary dependency #31023

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -50,7 +50,6 @@
     "prettier": "^2.0.5",
     "prop-types": "^15.6.1",
     "remark-mdx": "^2.0.0-next.4",
-    "remark-mdxjs": "^2.0.0-next.4",
     "remark-parse": "^6.0.3",
     "remark-stringify": "^8.1.0",
     "resolve-from": "^5.0.0",
@@ -118,8 +117,7 @@
     "@mdx-js/runtime": "^2.0.0-next.4",
     "graphql": "^15.4.0",
     "property-information": "5.5.0",
-    "remark-mdx": "^2.0.0-next.4",
-    "remark-mdxjs": "^2.0.0-next.4"
+    "remark-mdx": "^2.0.0-next.4"
   },
   "scripts": {
     "build": "rollup -c",

--- a/packages/gatsby-recipes/src/parser/index.js
+++ b/packages/gatsby-recipes/src/parser/index.js
@@ -1,6 +1,5 @@
 import unified from "unified"
 import remarkMdx from "remark-mdx"
-import remarkMdxjs from "remark-mdxjs"
 import remarkParse from "remark-parse"
 import remarkStringify from "remark-stringify"
 import visit from "unist-util-visit"
@@ -47,11 +46,7 @@ const applyUuid = tree => {
   return tree
 }
 
-const u = unified()
-  .use(remarkParse)
-  .use(remarkStringify)
-  .use(remarkMdx)
-  .use(remarkMdxjs)
+const u = unified().use(remarkParse).use(remarkStringify).use(remarkMdx)
 
 const partitionSteps = ast => {
   const steps = []

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -237,8 +237,7 @@
     "@mdx-js/mdx": "^2.0.0-next.3",
     "@mdx-js/react": "^2.0.0-next.3",
     "@mdx-js/runtime": "^2.0.0-next.3",
-    "remark-mdx": "^2.0.0-next.3",
-    "remark-mdxjs": "^2.0.0-next.3"
+    "remark-mdx": "^2.0.0-next.3"
   },
   "scripts": {
     "build": "npm run build:types && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",

--- a/renovate.json5
+++ b/renovate.json5
@@ -2103,7 +2103,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-recipes",
       commitMessageExtra: "",
-      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "react-reconciler", "remark-mdx", "remark-mdxjs", "typescript"],
+      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "react-reconciler", "remark-mdx", "typescript"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2114,7 +2114,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby-recipes",
       excludePackageNames: ["cross-env"],
-      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "react-reconciler", "remark-mdx", "remark-mdxjs"],
+      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "react-reconciler", "remark-mdx"],
     },
     {
       groupName: "minor and patch for gatsby-source-contentful",
@@ -2244,7 +2244,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby",
       commitMessageExtra: "",
-      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "remark-mdx", "remark-mdxjs", "typescript", "webpack-virtual-modules"],
+      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "remark-mdx", "typescript", "webpack-virtual-modules"],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2255,7 +2255,7 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby",
       excludePackageNames: ["cross-env"],
-      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "remark-mdx", "remark-mdxjs", "typescript", "webpack-virtual-modules"],
+      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "remark-mdx", "typescript", "webpack-virtual-modules"],
     },
     {
       groupName: "minor and patch for gatsby-admin",


### PR DESCRIPTION
Removed `remark-mdxjs` dependency from applicable files as it's deprecated and no longer being published.

Issue: #31023
