### PR TITLE
Don't remove gatsby-source-filesystem

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -415,7 +415,7 @@ export async function initialize({
         ]
 
         if (process.env.GATSBY_EXPERIMENTAL_PRESERVE_FILE_DOWNLOAD_CACHE) {
-          // Stop the caches directory from being deleted, add all sub directories, 
+          // Stop the caches directory from being deleted, add all sub directories,
           // but remove gatsby-source-filesystem
           deleteGlobs.push(`!${cacheDirectory}/caches`)
           deleteGlobs.push(`${cacheDirectory}/caches/*`)

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -415,7 +415,10 @@ export async function initialize({
         ]
 
         if (process.env.GATSBY_EXPERIMENTAL_PRESERVE_FILE_DOWNLOAD_CACHE) {
-          // Add gatsby-source-filesystem
+          // Stop the caches directory from being deleted, add all sub directories, 
+          // but remove gatsby-source-filesystem
+          deleteGlobs.push(`!${cacheDirectory}/caches`)
+          deleteGlobs.push(`${cacheDirectory}/caches/*`)
           deleteGlobs.push(`!${cacheDirectory}/caches/gatsby-source-filesystem`)
         }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

See discussion about preserving the file download cache. https://github.com/gatsbyjs/gatsby/discussions/28331#discussioncomment-661715

The `caches` folder was getting removed that then removed the `gatsby-source-filesystem` folder. This prevents the removal of the `caches` folder and then removes everything under it apart from the `gatsby-source-filesystem` folder.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
Currently discussed on https://github.com/gatsbyjs/gatsby/discussions/28331

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

No related issue, just the comment in the discussion.

https://github.com/gatsbyjs/gatsby/discussions/28331#discussioncomment-661715
