### PR TITLE
fix(gatsby): handle case of changing page path casing on case-insensitive fs

### DIFF
--- a/packages/gatsby/src/commands/build-utils.ts
+++ b/packages/gatsby/src/commands/build-utils.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra"
 import path from "path"
-
+import { platform } from "os"
 import reporter from "gatsby-cli/lib/reporter"
 
 import {
@@ -70,6 +70,11 @@ function normalizePagePath(path: string): string {
   if (path === `/`) {
     return `/`
   }
+
+  if (platform() === `win32` || platform() === `darwin`) {
+    path = path.toLowerCase()
+  }
+
   return path.endsWith(`/`) ? path.slice(0, -1) : path
 }
 

--- a/packages/gatsby/src/commands/build-utils.ts
+++ b/packages/gatsby/src/commands/build-utils.ts
@@ -66,12 +66,15 @@ export const removePageFiles = async (
   })
 }
 
+const FSisCaseInsensitive = platform() === `win32` || platform() === `darwin`
 function normalizePagePath(path: string): string {
   if (path === `/`) {
     return `/`
   }
 
-  if (platform() === `win32` || platform() === `darwin`) {
+  if (FSisCaseInsensitive) {
+    // e.g. /TEST/ and /test/ would produce "same" artifacts on case insensitive
+    // file systems
     path = path.toLowerCase()
   }
 
@@ -110,7 +113,8 @@ export function calcDirtyHtmlFiles(
    * to regenerate and more importantly - to delete (so we don't delete html and page-data file
    * when path changes slightly but it would still result in same html and page-data filenames
    * for example adding/removing trailing slash between builds or even mid build with plugins
-   * like `gatsby-plugin-remove-trailing-slashes`)
+   * like `gatsby-plugin-remove-trailing-slashes`). Additionally similar consideration need to
+   * be accounted for cases where page paths casing on case-insensitive file systems.
    */
   function markActionForPage(path: string, action: PageGenerationAction): void {
     const normalizedPagePath = normalizePagePath(path)


### PR DESCRIPTION
## Description

On Windows and MacOs if you change casing of page path it results in page being generated and then deleted. 

Consider scenario of creating `/TEST/` page and then in `onCreatePage` adjust page path to lower case which results in `/test/` page. What currently happen is that `/test/` is generated and `/TEST/` is scheduled for deletion. In case insensitive filesystems it means we will delete same files we just created.

## Related Issues

fixes #31055