### PR TITLE
fix(gatsby-plugin-gatsby-cloud): Copying manifest

### DIFF
--- a/integration-tests/functions/package.json
+++ b/integration-tests/functions/package.json
@@ -22,8 +22,8 @@
     "start-server-and-test": "^1.11.3"
   },
   "dependencies": {
-    "gatsby": "3.4.0-next.2-dev-1618947033238",
-    "gatsby-plugin-gatsby-cloud": "latest",
+    "gatsby": "^3.5.0-next.0",
+    "gatsby-plugin-gatsby-cloud": "^2.5.0-next.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   }

--- a/integration-tests/gatsby-pipeline/gatsby-config.js
+++ b/integration-tests/gatsby-pipeline/gatsby-config.js
@@ -15,5 +15,6 @@ module.exports = {
     },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
+    `gatsby-plugin-gatsby-cloud`
   ],
 }

--- a/integration-tests/gatsby-pipeline/package.json
+++ b/integration-tests/gatsby-pipeline/package.json
@@ -6,14 +6,15 @@
   "dependencies": {
     "gatsby": "latest",
     "gatsby-image": "latest",
+    "gatsby-plugin-gatsby-cloud": "latest",
     "gatsby-plugin-react-helmet": "latest",
     "gatsby-plugin-sharp": "latest",
     "gatsby-source-filesystem": "latest",
     "gatsby-transformer-sharp": "latest",
-    "prop-types": "^15.6.2",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
-    "react-helmet": "^5.2.0"
+    "prop-types": "^15.7.2",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-helmet": "^6.1.0"
   },
   "keywords": [
     "gatsby"

--- a/integration-tests/gatsby-pipeline/src/components/seo.js
+++ b/integration-tests/gatsby-pipeline/src/components/seo.js
@@ -1,6 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import Helmet from "react-helmet"
+import { Helmet } from "react-helmet"
 import { StaticQuery, graphql } from "gatsby"
 
 function SEO({ description, lang, meta, keywords, title }) {

--- a/packages/gatsby-plugin-gatsby-cloud/src/copy-functions-manifest.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/copy-functions-manifest.js
@@ -1,13 +1,17 @@
-import { copyFile } from "fs-extra"
+import { copyFile, existsSync } from "fs-extra"
 import {
   PUBLIC_FUNCTIONS_FILENAME,
   CACHE_FUNCTIONS_FILENAME,
 } from "./constants"
 
-export default async function copyFunctionsManifest(pluginData, siteDirectory) {
+export default async function copyFunctionsManifest(pluginData) {
   const { publicFolder, functionsFolder } = pluginData
   const manifestPath = functionsFolder(CACHE_FUNCTIONS_FILENAME)
   const publicManifestPath = publicFolder(PUBLIC_FUNCTIONS_FILENAME)
 
-  await copyFile(manifestPath, publicManifestPath)
+  const hasManifestFile = existsSync(manifestPath)
+
+  if (hasManifestFile) {
+    await copyFile(manifestPath, publicManifestPath)
+  }
 }

--- a/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
@@ -56,7 +56,7 @@ exports.onPostBuild = async (
   await Promise.all([
     buildHeadersProgram(pluginData, pluginOptions, reporter),
     createRedirects(pluginData, redirects, rewrites),
-    copyFunctionsManifest(pluginData, redirects, rewrites),
+    copyFunctionsManifest(pluginData),
   ])
 }
 


### PR DESCRIPTION
## Description

This was introduced in https://github.com/gatsbyjs/gatsby/pull/30904. When having `gatsby-plugin-gatsby-cloud` installed but not using functions then the manifest file doesn't exists and thus can't be copied.

In the first step of this PR I added `gatsby-plugin-gatsby-cloud` to an integration test without any function call and the test fails as expected: https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/62308/workflows/159728d1-333c-4f51-bba2-10ab0b0b6a7b/jobs/680283

The second commit fixed it by checking for the existence of the manifest file and the test `gatsby-pipeline` now should pass.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/31090
