### PR TITLE
fix(plugin-netlify-cms): align mini-css-extract-plugin version

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -13,7 +13,7 @@
     "html-webpack-plugin": "^3.2.0",
     "html-webpack-tags-plugin": "^2.0.17",
     "lodash": "^4.17.20",
-    "mini-css-extract-plugin": "^0.12.0",
+    "mini-css-extract-plugin": "^0.11.2",
     "netlify-identity-widget": "^1.9.1",
     "webpack": "^4.46.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17557,16 +17557,6 @@ mini-css-extract-plugin@^0.11.2:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-mini-css-extract-plugin@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.12.0.tgz#ddeb74fd6304ca9f99c1db74acc7d5b507705454"
-  integrity sha512-z6PQCe9rd1XUwZ8gMaEVwwRyZlrYy8Ba1gRjFP5HcV51HkXX+XlwZ+a1iAYTjSYwgNBXoNR7mhx79mDpOn5fdw==
-  dependencies:
-    loader-utils "^1.1.0"
-    normalize-url "1.9.1"
-    schema-utils "^1.0.0"
-    webpack-sources "^1.1.0"
-
 mini-svg-data-uri@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.2.3.tgz#e16baa92ad55ddaa1c2c135759129f41910bc39f"


### PR DESCRIPTION
## Description

**TLDR**: having mismatching versions of `mini-css-extract-plugin` in Gatsby and the Netlify CMS plugin causes build errors.
In Gatsby v3 this was fixed by aligning the versions, but the fix was not back ported to v2.

This PR ports back the fix to a branch named `gatsby-plugin-netlify-cms_v4` which is based on the tag `gatsby-plugin-netlify-cms@4.10.0`. I believe `v4.10.0` is the last non v5 release of the plugin.

To fix the issue for Gatsby v2 users, we'll need to merge this PR and release a new version of the plugin based on the `gatsby-plugin-netlify-cms_v4` branch (probably `gatsby-plugin-netlify-cms@4.10.1`).

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/24577 for Gatsby v2 users per https://github.com/gatsbyjs/gatsby/issues/24577#issuecomment-784329598 and https://github.com/gatsbyjs/gatsby/issues/24577#issuecomment-828373246
