### PR TITLE
Update .gitignore with pnpm debug lock.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ package-lock.json
 !themes/gatsby-starter-notes-theme/package-lock.json
 !themes/gatsby-starter-theme/package-lock.json
 !themes/gatsby-starter-theme-workspace/package-lock.json
+
+# PNPM files
+
+pnpm-debug.lock


### PR DESCRIPTION
PNPM is a better alternative to npm that uses symlinks instead of downloading the packages multiple times. PNPM creates a debug lock file that takes up space and should be git ignored.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

I added the pnpm lock file to the .gitignore. 

### Documentation

https://pnpm.io/

## Related Issues

N/A
