### PR TITLE
refactor: align Rich Text field structure to Contentful GraphQL API

### DIFF
--- a/e2e-tests/contentful/src/pages/rich-text.js
+++ b/e2e-tests/contentful/src/pages/rich-text.js
@@ -20,13 +20,13 @@ function renderReferencedComponent(ref) {
   return <Component {...ref} />
 }
 
-const options = {
+const makeOptions = ({ assetBlockMap, entryBlockMap, entryInlineMap }) => ({
   renderMark: {
     [MARKS.BOLD]: text => <strong data-cy-strong>{text}</strong>,
   },
   renderNode: {
     [BLOCKS.EMBEDDED_ASSET]: node => {
-      const asset = node.data.target
+      const asset = assetBlockMap.get(node?.data?.target?.sys.id)
       if (asset.fluid) {
         return <GatsbyImage {...asset} style={{ width: 200 }} />
       }
@@ -40,7 +40,7 @@ const options = {
       )
     },
     [BLOCKS.EMBEDDED_ENTRY]: node => {
-      const entry = node?.data?.target
+      const entry = entryBlockMap.get(node?.data?.target?.sys.id)
       if (!entry) {
         throw new Error(
           `Entity not available for node:\n${JSON.stringify(node, null, 2)}`
@@ -49,7 +49,7 @@ const options = {
       return renderReferencedComponent(entry)
     },
     [INLINES.EMBEDDED_ENTRY]: node => {
-      const entry = node.data.target
+      const entry = entryInlineMap.get(node?.data?.target?.sys.id)
       if (entry.__typename === "ContentfulText") {
         return (
           <span data-cy-id="inline-text">
@@ -64,7 +64,7 @@ const options = {
       )
     },
   },
-}
+})
 
 const RichTextPage = ({ data }) => {
   const entries = data.allContentfulRichText.nodes
@@ -75,7 +75,7 @@ const RichTextPage = ({ data }) => {
         return (
           <div data-cy-id={slug} key={id}>
             <h2>{title}</h2>
-            {renderRichText(richText, options)}
+            {renderRichText(richText, makeOptions)}
             <hr />
           </div>
         )
@@ -93,77 +93,94 @@ export const pageQuery = graphql`
         id
         title
         richText {
-          raw
-          references {
-            __typename
-            sys {
-              id
-            }
-            ... on ContentfulAsset {
-              fluid(maxWidth: 200) {
-                ...GatsbyContentfulFluid
+          json
+          links {
+            assets {
+              block {
+                sys {
+                  id
+                }
+                fluid(maxWidth: 200) {
+                  ...GatsbyContentfulFluid
+                }
               }
             }
-            ... on ContentfulText {
-              title
-              short
-            }
-            ... on ContentfulLocation {
-              location {
-                lat
-                lon
-              }
-            }
-            ... on ContentfulContentReference {
-              title
-              one {
+            entries {
+              block {
                 __typename
                 sys {
                   id
+                  type
                 }
                 ... on ContentfulText {
                   title
                   short
                 }
+                ... on ContentfulLocation {
+                  location {
+                    lat
+                    lon
+                  }
+                }
                 ... on ContentfulContentReference {
                   title
                   one {
+                    __typename
+                    sys {
+                      id
+                    }
+                    ... on ContentfulText {
+                      title
+                      short
+                    }
                     ... on ContentfulContentReference {
                       title
+                      one {
+                        ... on ContentfulContentReference {
+                          title
+                        }
+                      }
+                      many {
+                        ... on ContentfulContentReference {
+                          title
+                        }
+                      }
                     }
                   }
                   many {
+                    __typename
+                    sys {
+                      id
+                    }
+                    ... on ContentfulText {
+                      title
+                      short
+                    }
+                    ... on ContentfulNumber {
+                      title
+                      integer
+                    }
                     ... on ContentfulContentReference {
                       title
+                      one {
+                        ... on ContentfulContentReference {
+                          title
+                        }
+                      }
+                      many {
+                        ... on ContentfulContentReference {
+                          title
+                        }
+                      }
                     }
                   }
                 }
               }
-              many {
+              inline {
                 __typename
                 sys {
                   id
-                }
-                ... on ContentfulText {
-                  title
-                  short
-                }
-                ... on ContentfulNumber {
-                  title
-                  integer
-                }
-                ... on ContentfulContentReference {
-                  title
-                  one {
-                    ... on ContentfulContentReference {
-                      title
-                    }
-                  }
-                  many {
-                    ... on ContentfulContentReference {
-                      title
-                    }
-                  }
+                  type
                 }
               }
             }

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "@contentful/rich-text-links": "^14.1.2",
     "@contentful/rich-text-react-renderer": "^14.1.2",
     "@contentful/rich-text-types": "^14.1.2",
     "@hapi/joi": "^15.1.1",

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -1,47 +1,48 @@
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
-import resolveResponse from "contentful-resolve-response"
 
-function renderRichText({ raw, references }, options = {}) {
-  const richText = raw
+function renderRichText({ json, links }, makeOptions) {
+  const options = makeOptions(generateLinkMaps(links))
 
-  // If no references are given, there is no need to resolve them
-  if (!references || !references.length) {
-    return documentToReactComponents(richText, options)
-  }
-
-  // Create dummy response so we can use official libraries for resolving the entries
-  const dummyResponse = {
-    items: [
-      {
-        sys: { type: `Entry` },
-        richText,
-      },
-    ],
-    includes: {
-      Entry: references
-        .filter(({ __typename }) => __typename !== `ContentfulAsset`)
-        .map(reference => {
-          return {
-            ...reference,
-            sys: { type: `Entry`, id: reference.sys.id },
-          }
-        }),
-      Asset: references
-        .filter(({ __typename }) => __typename === `ContentfulAsset`)
-        .map(reference => {
-          return {
-            ...reference,
-            sys: { type: `Asset`, id: reference.sys.id },
-          }
-        }),
-    },
-  }
-
-  const resolved = resolveResponse(dummyResponse, {
-    removeUnresolved: true,
-  })
-
-  return documentToReactComponents(resolved[0].richText, options)
+  return documentToReactComponents(json, options)
 }
 
 exports.renderRichText = renderRichText
+
+/**
+ * Helper function to simplify Rich Text rendering. Based on:
+ * https://www.contentful.com/blog/2021/04/14/rendering-linked-assets-entries-in-contentful/
+ */
+function generateLinkMaps(links) {
+  const assetBlockMap = new Map()
+  for (const asset of links.assets.block || []) {
+    assetBlockMap.set(asset.sys.id, asset)
+  }
+
+  const assetHyperlinkMap = new Map()
+  for (const asset of links.assets.hyperlink || []) {
+    assetHyperlinkMap.set(asset.sys.id, asset)
+  }
+
+  const entryBlockMap = new Map()
+  for (const entry of links.entries.block || []) {
+    entryBlockMap.set(entry.sys.id, entry)
+  }
+
+  const entryInlineMap = new Map()
+  for (const entry of links.entries.inline || []) {
+    entryInlineMap.set(entry.sys.id, entry)
+  }
+
+  const entryHyperlinkMap = new Map()
+  for (const entry of links.entries.hyperlink || []) {
+    entryHyperlinkMap.set(entry.sys.id, entry)
+  }
+
+  return {
+    assetBlockMap,
+    assetHyperlinkMap,
+    entryBlockMap,
+    entryInlineMap,
+    entryHyperlinkMap,
+  }
+}

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -1,7 +1,10 @@
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 
-function renderRichText({ json, links }, makeOptions) {
-  const options = makeOptions(generateLinkMaps(links))
+function renderRichText({ json, links }, makeOptions = {}) {
+  const options =
+    typeof makeOptions === `function`
+      ? makeOptions(generateLinkMaps(links))
+      : makeOptions
 
   return documentToReactComponents(json, options)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,6 +1428,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@contentful/rich-text-links@^14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-links/-/rich-text-links-14.1.2.tgz#993cd086d55af11f5d31b76060c02a9866c93a01"
+  integrity sha512-oK+y/c42fOJOdRM6XDKNLqw7uwVHZUIRGKzk9fJLDaOt5tygDm0pvgJ9bkvadaBwbAioxlQ0hHS0i5JP+UHkvA==
+  dependencies:
+    "@contentful/rich-text-types" "^14.1.2"
+
 "@contentful/rich-text-react-renderer@^14.1.2":
   version "14.1.2"
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-14.1.2.tgz#b7fff19faa0512f034f1717774a0d9b348bb07fc"


### PR DESCRIPTION
This converts the Gatsby Rich Text field type structure to the same as the Contentful GraphQL API uses.

### Old schema

```graphql
type ContentfulRichTextRichText {
  raw: String
  references: [ContentfulAssetContentfulContentReferenceContentfulLocationContentfulTextUnion] @link(by: "id", from: "references___NODE")
}
union ContentfulAssetContentfulContentReferenceContentfulLocationContentfulTextUnion = ContentfulAsset | ContentfulContentReference | ContentfulLocation | ContentfulText
```


### New schema

```graphql
type ContentfulNodeTypeRichText @dontInfer {
  json: JSON
  links: ContentfulNodeTypeRichTextLinks
}

type ContentfulNodeTypeRichTextLinks {
  assets: ContentfulNodeTypeRichTextAssets
  entries: ContentfulNodeTypeRichTextEntries
}

type ContentfulNodeTypeRichTextAssets {
  block: [ContentfulAsset]!
  hyperlink: [ContentfulAsset]!
}

type ContentfulNodeTypeRichTextEntries {
  inline: [ContentfulEntry]!
  block: [ContentfulEntry]!
  hyperlink: [ContentfulEntry]!
}
```

### Rendering changes

Instead of passing your option object into `renderRichText()` you now pass a option factory:

```diff
-const options = {
+const makeOptions = ({ assetBlockMap, entryBlockMap, entryInlineMap }) => ({
```

```diff
    [BLOCKS.EMBEDDED_ENTRY]: node => {
-      const entry = node?.data?.target
+      const entry = entryBlockMap.get(node?.data?.target?.sys.id)
    }
```

```diff
-<div>{renderRichText(richText, options)}</div>
+<div>{renderRichText(richText, makeOptions)}</div>
```