### PR TITLE
Allows sitemap output on root of public folder

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-ssr.js.snap
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-ssr.js.snap
@@ -44,4 +44,26 @@ exports[`gatsby-plugin-sitemap SSR API should create a Link if createLinkInHead 
 }
 `;
 
+exports[`gatsby-plugin-sitemap SSR API should create a Link in root when output is "/" 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        <link
+          href="/sitemap-index.xml"
+          rel="sitemap"
+          type="application/xml"
+        />,
+      ],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`gatsby-plugin-sitemap SSR API should not create Link if createLinkInHead is false 1`] = `[MockFunction]`;

--- a/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-ssr.js
@@ -28,6 +28,23 @@ describe(`gatsby-plugin-sitemap SSR API`, () => {
     expect(setHeadComponents).toMatchSnapshot()
     expect(setHeadComponents).toHaveBeenCalledTimes(1)
   })
+  it(`should create a Link in root when output is "/"`, async () => {
+    const pluginOptions = {
+      createLinkInHead: true,
+      output: `/`,
+    }
+    const setHeadComponents = jest.fn()
+
+    await onRenderBody(
+      {
+        setHeadComponents,
+      },
+      pluginOptions
+    )
+
+    expect(setHeadComponents).toMatchSnapshot()
+    expect(setHeadComponents).toHaveBeenCalledTimes(1)
+  })
   it(`should not create Link if createLinkInHead is false`, async () => {
     const pluginOptions = {
       createLinkInHead: false,

--- a/packages/gatsby-plugin-sitemap/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-ssr.js
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { withPrefix as fallbackWithPrefix, withAssetPrefix } from "gatsby"
-import { withoutTrailingSlash } from "./internals"
+import { posix } from "path"
 
 // TODO: Remove for v3 - Fix janky path/asset prefixing
 const withPrefix = withAssetPrefix || fallbackWithPrefix
@@ -17,7 +17,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
       key={`gatsby-plugin-sitemap`}
       rel="sitemap"
       type="application/xml"
-      href={withPrefix(withoutTrailingSlash(output) + `/sitemap-index.xml`)}
+      href={withPrefix(posix.join(output, `/sitemap-index.xml`))}
     />,
   ])
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
All this PR does is allow developers to set the `output` option on the `gatsby-sitemap-plugin` to `""` (empty string) so that the files can be written to the root of the public folder.

Some (like me) might prefer that instead of creating a subfolder to store the files, plus this mitigates a separate issue where the index file always points to the root folder instead of the specified output folder.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #31095