### PR TITLE
fix(gatsby-source-wordpress): previewing drafts requires using the preview query

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -20,7 +20,6 @@ export const fetchAndCreateSingleNode = async ({
   id,
   actionType,
   cachedNodeIds,
-  isDraft,
   token = null,
   isPreview = false,
   userDatabaseId = null,
@@ -33,7 +32,7 @@ export const fetchAndCreateSingleNode = async ({
     // if it's a preview but it's the initial blank node
     // then use the regular node query as the preview query wont
     // return anything
-    const query = isPreview && !isDraft ? previewQuery : nodeQuery
+    const query = isPreview ? previewQuery : nodeQuery
 
     return query
   }


### PR DESCRIPTION
Following the release of this PR https://github.com/gatsbyjs/wp-gatsby/pull/161 in WPGatsby, previewing drafts now "works" in that it redirects you to the right place at the right time. We also need the change in this PR so that previewing a draft uses the preview query instead of the regular node query.