### PR TITLE
feat(gatsby): speedup cli startup by lazily requiring modules

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -429,7 +429,7 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
     }: yargs.Arguments<{
       cmd: string | undefined
     }>) => {
-      const pluginHandler = require(`./handlers/plugin`)
+      const pluginHandler = require(`./handlers/plugin`).default
       await pluginHandler(siteInfo.directory, cmd)
     },
   })

--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -10,7 +10,6 @@ import {
   setTelemetryEnabled,
   isTrackingEnabled,
 } from "gatsby-telemetry"
-import { startGraphQLServer } from "gatsby-recipes"
 import { run as runCreateGatsby } from "create-gatsby"
 import report from "./reporter"
 import { setStore } from "./reporter/redux"
@@ -19,10 +18,8 @@ import { initStarter } from "./init-starter"
 import { login } from "./login"
 import { logout } from "./logout"
 import { whoami } from "./whoami"
-import { recipesHandler } from "./recipes"
 import { getPackageManager, setPackageManager } from "./util/package-manager"
 import reporter from "./reporter"
-import pluginHandler from "./handlers/plugin"
 
 const handlerP = (fn: (args: yargs.Arguments) => void) => (
   args: yargs.Arguments
@@ -206,6 +203,7 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
         `develop`,
         (args: yargs.Arguments, cmd: (args: yargs.Arguments) => unknown) => {
           process.env.NODE_ENV = process.env.NODE_ENV || `development`
+          const { startGraphQLServer } = require(`gatsby-recipes`)
           startGraphQLServer(siteInfo.directory, true)
 
           if (args.hasOwnProperty(`inspect`)) {
@@ -402,6 +400,7 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
         describe: `Install recipe (defaults to plan mode)`,
       }),
     handler: handlerP(async ({ recipe, develop, install }: yargs.Arguments) => {
+      const { recipesHandler } = require(`./recipes`)
       await recipesHandler(
         siteInfo.directory,
         recipe as string,
@@ -430,6 +429,7 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
     }: yargs.Arguments<{
       cmd: string | undefined
     }>) => {
+      const pluginHandler = require(`./handlers/plugin`)
       await pluginHandler(siteInfo.directory, cmd)
     },
   })


### PR DESCRIPTION
gatsby-recipes isn't alwasy needed so let's lazily require it.

This change dropped the number of required modules (at the end of src/services/initalize.ts) from 9552 -> 8726 (8% drop). The process time to get to that point dropped from 3s to 2.4s (20% improvement).

Investigation helped out by this handy package: https://github.com/Jaguard/time-require

Before:
<img width="1382" alt="Screen Shot 2021-04-30 at 11 44 32 AM" src="https://user-images.githubusercontent.com/71047/116741075-b4ee9080-a9aa-11eb-8c53-c7c968c92801.png">

After:
<img width="1335" alt="Screen Shot 2021-04-30 at 11 46 50 AM" src="https://user-images.githubusercontent.com/71047/116741087-b91aae00-a9aa-11eb-9422-c48494c0f6db.png">
