### PR TITLE
chore(docs): GATSBY_ACTIVE_ENV is undefined by default

### DIFF
--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -201,4 +201,4 @@ Local testing of the `staging` environment can be done with:
 GATSBY_ACTIVE_ENV=staging npm run develop
 ```
 
-Note that GATSBY_ACTIVE_ENV will NOT be set automatically only if explicitly added at the beginning of `gatsby develop` or `gatsby build` (otheriwse it's just `undefined`).
+**Note:** The `GATSBY_ACTIVE_ENV` will not be set automatically. You have to explicitly set the environment variable (e.g. by adding it to the `gatsby` command or setting it inside your terminal and/or CI provider). If not set it'll be `undefined`.

--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -200,3 +200,5 @@ Local testing of the `staging` environment can be done with:
 ```shell
 GATSBY_ACTIVE_ENV=staging npm run develop
 ```
+
+Note that GATSBY_ACTIVE_ENV will NOT be set automatically only if explicitly added at the beginning of `gatsby develop` or `gatsby build` (otheriwse it's just `undefined`).


### PR DESCRIPTION
As it's not very clear from the doc, I thought I'd stick it at the end, but I'm obviously open for suggestions: I even saw it mentioned in an SO answer that gatsby was setting GATSBY_ACTIVE_ENV to development in dev, and production in prod, but this wasn't actually the case. It took me a while to figure out. It has to explicitly be set, otherwise it's just `undefined`.