### PR TITLE
feat(docs): Add new top-level CSS doc + plus clean up local/web font docs pages

### DIFF
--- a/docs/docs/how-to/styling/built-in-css.md
+++ b/docs/docs/how-to/styling/built-in-css.md
@@ -12,7 +12,7 @@ import "../styles/index.css"
 import "bootstrap/dist/css/bootstrap.min.css"
 
 export default function HomePage() {
-  ;<div>I'm styled by bootstrap & src/styles/index.css</div>
+  return <div>I'm styled by bootstrap & src/styles/index.css</div>
 }
 ```
 
@@ -26,7 +26,7 @@ CSS files with global styles like typography and colors are typically imported i
 
 We recommend using CSS Modules for component-level CSS. Gatsby has built-in support for CSS Modules.
 
-CSS Modules let you write CSS normally but with a more safety. The tool automatically generates unique class and animation names, so you don’t have to worry about selector name collisions.
+CSS Modules let you write CSS normally but with more safety. The tool automatically generates unique class and animation names, so you don’t have to worry about selector name collisions.
 
 An example of a component CSS Module file imported into its corresponding React component.
 
@@ -45,6 +45,8 @@ export default function Container({ children }) {
   return <div className={containerStyles.container}>{children}</div>
 }
 ```
+
+[Learn more about CSS Modules](/docs/how-to/styling/css-modules)
 
 ## Other CSS Options
 

--- a/docs/docs/how-to/styling/built-in-css.md
+++ b/docs/docs/how-to/styling/built-in-css.md
@@ -1,0 +1,60 @@
+---
+title: Built-in CSS Support
+---
+
+Gatsby extends `import` so you can import CSS files directly into your components.
+
+```js:title=src/pages/index.js
+import * as React from "react"
+// Import from a CSS file in your src
+import "../styles/index.css"
+// Import from an installed package
+import "bootstrap/dist/css/bootstrap.min.css"
+
+export default function HomePage() {
+  ;<div>I'm styled by bootstrap & src/styles/index.css</div>
+}
+```
+
+Gatsby automatically concatenates and minifies CSS and inlines them into the `<head>` of your HTML files for the fastest possible page load time.
+
+## Global CSS
+
+CSS files with global styles like typography and colors are typically imported into the site's [`gatsby-browser.js`](/docs/reference/config-files/gatsby-browser) file.
+
+## Component-level CSS
+
+We recommend using CSS Modules for component-level CSS. Gatsby has built-in support for CSS Modules.
+
+CSS Modules let you write CSS normally but with a more safety. The tool automatically generates unique class and animation names, so you don’t have to worry about selector name collisions.
+
+An example of a component CSS Module file imported into its corresponding React component.
+
+```css:title=src/components/container.module.css
+.container {
+  margin: 3rem auto;
+  max-width: 600px;
+}
+```
+
+```js:title=src/components/container.js
+import React from "react"
+import * as containerStyles from "./container.module.css"
+
+export default function Container({ children }) {
+  return <div className={containerStyles.container}>{children}</div>
+}
+```
+
+## Other CSS Options
+
+|                   | Example                                                                                    | Plugin                                              | Tutorial                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------------------------- |
+| Sass              | [example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-sass)              | [plugin](/plugins/gatsby-plugin-sass/)              | [tutorial](/docs/how-to/styling/sass/)                                      |
+| Tailwind          |                                                                                            |                                                     | [tutorial](/docs/how-to/styling/tailwind-css/)                              |
+| Postcss           |                                                                                            | [plugin](/plugins/gatsby-plugin-postcss/)           | [tutorial](/docs/how-to/styling/post-css/)                                  |
+| Emotion           | [example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-emotion)           | [plugin](/plugins/gatsby-plugin-emotion/)           | [tutorial](/docs/how-to/styling/emotion/)                                   |
+| Styled Components | [example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-styled-components) | [plugin](/plugins/gatsby-plugin-styled-components/) | [tutorial](https://www.gatsbyjs.com/docs/how-to/styling/styled-components/) |
+| Less              |                                                                                            | [plugin](/plugins/gatsby-plugin-less/)              |                                                                             |
+| Styled JSX        | [example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-styled-jsx)        | [plugin](/plugins/gatsby-plugin-styled-jsx/)        |                                                                             |
+| Stylus            | [example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-stylus)            | [plugin](/plugins/gatsby-plugin-stylus/)            |                                                                             |

--- a/docs/docs/how-to/styling/using-local-fonts.md
+++ b/docs/docs/how-to/styling/using-local-fonts.md
@@ -2,17 +2,17 @@
 title: Using Local Fonts
 ---
 
-If you have custom fonts hosted on your computer, Gatsby supports their use in your project. This guide covers how to add local fonts to your Gatsby site.
+This guide covers how to add local fonts to your Gatsby site.
 
 ## Prerequisites
 
-This guide uses the Gatsby [default starter](https://github.com/gatsbyjs/gatsby-starter-default) and a font file. Some common font file extensions are `.woff2`, `.ttf`, and `otf`.
+This guide uses the Gatsby [default starter](https://github.com/gatsbyjs/gatsby-starter-default) and a font file. Some common font file extensions are `.woff2` and `.woff`.
 
 ## Using local fonts in Gatsby
 
-Get started by using local fonts by adding them to your project. Copy the font file in your Gatsby project, for example, `src/fonts/fontname.woff2`.
+Get started by using local fonts by adding them to your project. Copy the font file into your Gatsby project, for example, `src/fonts/fontname.woff2`.
 
-**NOTE:** It’s recommended to limit custom font usage to only the essential needed for performance.
+**NOTE:** It’s recommended to limit custom font usage to only the essential needed for performance.to
 
 The Gatsby default starter project adds [browser safe font](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals#Default_fonts) styling in the `layout.css` file.
 

--- a/docs/docs/how-to/styling/using-local-fonts.md
+++ b/docs/docs/how-to/styling/using-local-fonts.md
@@ -12,7 +12,7 @@ This guide uses the Gatsby [default starter](https://github.com/gatsbyjs/gatsby-
 
 Get started by using local fonts by adding them to your project. Copy the font file into your Gatsby project, for example, `src/fonts/fontname.woff2`.
 
-**NOTE:** It’s recommended to limit custom font usage to only the essential needed for performance.to
+**NOTE:** It’s recommended to limit custom font usage to only the essential needed for performance.
 
 The Gatsby default starter project adds [browser safe font](https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals#Default_fonts) styling in the `layout.css` file.
 

--- a/docs/docs/how-to/styling/using-web-fonts.md
+++ b/docs/docs/how-to/styling/using-web-fonts.md
@@ -70,28 +70,30 @@ body {
 }
 ```
 
-### Install Google Fonts locally with Fontsource
+### Self-host Google Fonts with Fontsource
 
-The fastest way to get started using Google Fonts is by choosing a font from [Fontsource](https://github.com/fontsource/fontsource).
+[Fontsource](https://github.com/fontsource/fontsource) is a project to provide open source fonts from Google Fonts as NPM Packages.
 
-This example shows how to set up the [Open Sans](https://fonts.google.com/specimen/Open+Sans) font. If you have a different Google Font you want to use, you can find the corresponding package in [NPM](https://www.npmjs.com/search?q=fontsource) or the [packages directory in the Fontsource repository](https://github.com/fontsource/fontsource/tree/master/packages).
+Self-hosting your fonts can increase your site’s loading speed by up to ~300 milliseconds on desktop and 1+ seconds on 3G connections.
 
-1. Run `npm install @fontsource/open-sans` to download the necessary package files.
+This example shows how to install the [Open Sans](https://fonts.google.com/specimen/Open+Sans) font. If you have a different Google Font you want to use, you can find the corresponding package in [NPM](https://www.npmjs.com/search?q=fontsource) or the [packages directory in the Fontsource repository](https://github.com/fontsource/fontsource/tree/master/packages).
 
-2. Then within your app entry file or site component, import the font package. It is recommended you import it via the layout template (`layout.js`). However, importing via page component (`index.js`), or `gatsby-browser.js` are viable alternatives.
+1. Run `npm install @fontsource/open-sans` to install the necessary package files.
 
-```jsx:title=src/components/layout.js
+2. Then within your app entry file or site component, import the font package. It is recommended you import in your site's gatsby-browser.js file.
+
+```jsx:title=gatsby-browser.js
 import "@fontsource/open-sans" // Defaults to weight 400 with all styles included.
 ```
 
 If you wish to select a particular weight or style, you may specify it by changing the import path.
 
-```jsx:title=src/components/layout.js
+```jsx:title=gatsby-browser.js
 import "@fontsource/open-sans/500.css" // Weight 500 with all styles included.
 import "@fontsource/open-sans/900-normal.css" // Select either normal or italic.
 ```
 
-**Note**: The range of supported weights and styles a font may support is shown in each package's README file.
+**Note**: The weights and styles a font includes is shown in each package's README file.
 
 3. Once it's imported, you can reference the font name in a CSS stylesheet, CSS Module, or CSS-in-JS.
 

--- a/docs/docs/how-to/styling/using-web-fonts.md
+++ b/docs/docs/how-to/styling/using-web-fonts.md
@@ -2,11 +2,7 @@
 title: Using Web Fonts
 ---
 
-This guide covers how to add web fonts to your Gatsby site.
-
-## Web fonts and Gatsby
-
-Web fonts provide a variety of typography styling options for your site. Hosting your fonts within a Gatsby project increases your site’s speed by up to ~300 milliseconds on desktop and 1+ seconds on 3G connections.
+This guide covers how to add fonts from web services to your Gatsby site.
 
 ## Prerequisites
 
@@ -16,38 +12,11 @@ This guide uses the Gatsby [default starter](https://github.com/gatsbyjs/gatsby-
 
 Some examples of web font services include [Google Fonts](https://fonts.google.com/) and [Typekit Web Fonts](https://fonts.adobe.com/typekit).
 
-### Using Google Fonts
+## gatsby-plugin-web-font-loader
 
-The fastest way to get started using Google Fonts is by choosing a font from [Fontsource](https://github.com/fontsource/fontsource).
+`gatsby-plugin-web-font-loader` is a Gatsby plugin which makes it easy to add web fonts using the popular [Web Font Loader](https://github.com/typekit/webfontloader) library. It supports loading fonts from Google Fonts, Typekit, Fonts.com, and Fontdeck, as well as self-hosted web fonts.
 
-This example shows how to set up the [Open Sans](https://fonts.google.com/specimen/Open+Sans) font. If you have a different Google Font you want to use, you can find the corresponding package in [NPM](https://www.npmjs.com/search?q=fontsource) or the [packages directory in the Fontsource repository](https://github.com/fontsource/fontsource/tree/master/packages).
-
-1. Run `npm install @fontsource/open-sans` to download the necessary package files.
-
-2. Then within your app entry file or site component, import the font package. It is recommended you import it via the layout template (`layout.js`). However, importing via page component (`index.js`), or `gatsby-browser.js` are viable alternatives.
-
-```jsx:title=src/components/layout.js
-import "@fontsource/open-sans" // Defaults to weight 400 with all styles included.
-```
-
-If you wish to select a particular weight or style, you may specify it by changing the import path.
-
-```jsx:title=src/components/layout.js
-import "@fontsource/open-sans/500.css" // Weight 500 with all styles included.
-import "@fontsource/open-sans/900-normal.css" // Select either normal or italic.
-```
-
-**Note**: The range of supported weights and styles a font may support is shown in each package's README file.
-
-3. Once it's imported, you can reference the font name in a CSS stylesheet, CSS Module, or CSS-in-JS.
-
-```css:title=src/components/layout.css
-body {
-  font-family: "Open Sans";
-}
-```
-
-### Using Typekit Web Fonts
+### How to use Web Font Loader with Typekit
 
 You can add Typekit Web Fonts to your project by using the [gatsby-plugin-web-font-loader](https://www.gatsbyjs.org/packages/gatsby-plugin-web-font-loader/?=font) and your [Adobe Fonts project id](https://fonts.adobe.com/my_fonts#web_projects-section). For example, this is how you can add Futura to your project.
 
@@ -98,6 +67,37 @@ body {
   font-weight: normal;
   word-wrap: break-word;
   font-kerning: normal;
+}
+```
+
+### Install Google Fonts locally with Fontsource
+
+The fastest way to get started using Google Fonts is by choosing a font from [Fontsource](https://github.com/fontsource/fontsource).
+
+This example shows how to set up the [Open Sans](https://fonts.google.com/specimen/Open+Sans) font. If you have a different Google Font you want to use, you can find the corresponding package in [NPM](https://www.npmjs.com/search?q=fontsource) or the [packages directory in the Fontsource repository](https://github.com/fontsource/fontsource/tree/master/packages).
+
+1. Run `npm install @fontsource/open-sans` to download the necessary package files.
+
+2. Then within your app entry file or site component, import the font package. It is recommended you import it via the layout template (`layout.js`). However, importing via page component (`index.js`), or `gatsby-browser.js` are viable alternatives.
+
+```jsx:title=src/components/layout.js
+import "@fontsource/open-sans" // Defaults to weight 400 with all styles included.
+```
+
+If you wish to select a particular weight or style, you may specify it by changing the import path.
+
+```jsx:title=src/components/layout.js
+import "@fontsource/open-sans/500.css" // Weight 500 with all styles included.
+import "@fontsource/open-sans/900-normal.css" // Select either normal or italic.
+```
+
+**Note**: The range of supported weights and styles a font may support is shown in each package's README file.
+
+3. Once it's imported, you can reference the font name in a CSS stylesheet, CSS Module, or CSS-in-JS.
+
+```css:title=src/components/layout.css
+body {
+  font-family: "Open Sans";
 }
 ```
 


### PR DESCRIPTION
Carve out the basics of styling with Gatsby into one top-level doc with links to all the many sub-pages/plugins/examples