### PR TITLE
fix(docs): Update 'Adding Markdown Pages' to use Collection Routes

### DIFF
--- a/docs/docs/how-to/routing/adding-markdown-pages.md
+++ b/docs/docs/how-to/routing/adding-markdown-pages.md
@@ -10,8 +10,7 @@ Here are the steps Gatsby follows for making this happen.
 1. Read files into Gatsby from the filesystem
 2. Transform Markdown to HTML and [frontmatter](#frontmatter-for-metadata-in-markdown-files) to data
 3. Add a Markdown file
-4. Create a page component for the Markdown files
-5. Create static pages using Gatsby's Node.js `createPage` API
+4. Create a Collection Route component for the Markdown files
 
 ## Read files into Gatsby from the filesystem
 

--- a/docs/docs/how-to/routing/adding-markdown-pages.md
+++ b/docs/docs/how-to/routing/adding-markdown-pages.md
@@ -23,20 +23,23 @@ Use the plugin [`gatsby-source-filesystem`](/plugins/gatsby-source-filesystem/#g
 
 ### Add plugin
 
-**NOTE:** There are two ways to add a plugin in `gatsby-config.js`. Either you can pass a string with the plugin name or in case you want to include options, pass an object.
-
-Open `gatsby-config.js` to add the `gatsby-source-filesystem` plugin. Now pass the object from the next block to the `plugins` array. By passing an object that includes the key `path`, you set the file system path.
+Open `gatsby-config.js` to add the `gatsby-source-filesystem` plugin. The `path` option is how you set the directory to search for files.
 
 ```javascript:title=gatsby-config.js
-plugins: [
-  {
-    resolve: `gatsby-source-filesystem`,
-    options: {
-      name: `markdown-pages`,
-      path: `${__dirname}/src/markdown-pages`,
-    },
+module.exports = {
+  siteMetadata: {
+    title: "My Gatsby Site",
   },
-]
+  plugins: [
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `markdown-pages`,
+        path: `${__dirname}/src/markdown-pages`,
+      },
+    },
+  ],
+}
 ```
 
 Completing the above step means that you've "sourced" the Markdown files from the filesystem. You can now "transform" the Markdown to HTML and the YAML frontmatter to JSON.
@@ -54,16 +57,22 @@ You'll use the plugin [`gatsby-transformer-remark`](/plugins/gatsby-transformer-
 Add this to `gatsby-config.js` after the previously added `gatsby-source-filesystem`.
 
 ```javascript:title=gatsby-config.js
-plugins: [
-  {
-    resolve: `gatsby-source-filesystem`,
-    options: {
-      path: `${__dirname}/src/markdown-pages`,
-      name: `markdown-pages`,
-    },
+module.exports = {
+  siteMetadata: {
+    title: "My Gatsby Site",
   },
-  `gatsby-transformer-remark`,
-]
+  plugins: [
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `markdown-pages`,
+        path: `${__dirname}/src/markdown-pages`,
+      },
+    },
+    // highlight-next-line
+    `gatsby-transformer-remark`,
+  ],
+}
 ```
 
 ## Add a Markdown file
@@ -73,7 +82,7 @@ Now create a Markdown file inside it with the name `post-1.md`.
 
 ### Frontmatter for metadata in Markdown files
 
-When you create a Markdown file, you can include a set of key value pairs that can be used to provide additional data relevant to specific pages in the GraphQL data layer. This data is called frontmatter and is denoted by the triple dashes at the start and end of the block. This block will be parsed by `gatsby-transformer-remark` as `frontmatter`. The GraphQL API will provide the key value pairs as data in your React components.
+When you create a Markdown file, you can include a set of key/value pairs that can be used to provide additional data relevant to specific pages in the GraphQL data layer. This data is called "frontmatter" and is denoted by the triple dashes at the start and end of the block. This block will be parsed by `gatsby-transformer-remark` as YAML. You can then query the data through the GraphQL API from your React components.
 
 ```markdown:title=src/markdown-pages/post-1.md
 ---
@@ -85,12 +94,11 @@ title: "My first blog post"
 
 What is important in this step is the key pair `slug`. The value that is assigned to the key `slug` is used in order to navigate to your post.
 
-## Create a page template for the Markdown files
+## Create a Collection Route for the Markdown files
 
-Create a folder in the `/src` directory of your Gatsby application called `templates`.
-Now create a `blogTemplate.js` inside it with the following content:
+Create `src/pages/{MarkdownRemark.frontmatter__slug}.js` and add the following code:
 
-```jsx:title=src/templates/blogTemplate.js
+```jsx:title=src/pages/{MarkdownRemark.frontmatter__slug}.js
 import React from "react"
 import { graphql } from "gatsby"
 
@@ -114,8 +122,8 @@ export default function Template({
 }
 
 export const pageQuery = graphql`
-  query($slug: String!) {
-    markdownRemark(frontmatter: { slug: { eq: $slug } }) {
+  query($id: String!) {
+    markdownRemark(id: { eq: $id }) {
       html
       frontmatter {
         date(formatString: "MMMM DD, YYYY")
@@ -133,59 +141,11 @@ Two things are important in the file above:
 
    **Note: To learn more about GraphQL, consider this [excellent resource](https://www.howtographql.com/)**
 
-2. The result of the query is injected by Gatsby into the `Template` component as `data`. `markdownRemark` is the property that you'll find has all the details of the Markdown file. You can use that to construct a template for your blog post view. Since it's a React component, you could style it with any of the [recommended styling systems](/docs/styling/) in Gatsby.
+2. The result of the query is injected by Gatsby into the component as the `data` prop. `props.data.markdownRemark` is the property that has all the details of the Markdown file. You can use that to construct a template for your blog post view. Since it's a React component, you could style it with any of the [recommended styling systems](/docs/styling/) in Gatsby.
 
 ### Create static pages using Gatsby’s Node.js `createPage` API
 
-Gatsby exposes a powerful Node.js API, which allows for functionality such as creating dynamic pages. This API is invoked via the `gatsby-node.js` file in the root directory of your project, at the same level as `gatsby-config.js`. If the file does not exist you may create it and copy the code below. Each export found in this file will be run by Gatsby, as detailed in its [Node API specification](/docs/reference/config-files/gatsby-node/). However, you should only care about one particular API in this instance, `createPages`.
-
-Use the `graphql` to query Markdown file data as below. Next, use the `createPage` action creator to create a page for each of the Markdown files using the `blogTemplate.js` you created in the previous step.
-
-**NOTE:** Gatsby calls the `createPages` API (if present) at build time with injected parameters, `actions` and `graphql`.
-
-```javascript:title=gatsby-node.js
-exports.createPages = async ({ actions, graphql, reporter }) => {
-  const { createPage } = actions
-
-  const blogPostTemplate = require.resolve(`./src/templates/blogTemplate.js`)
-
-  const result = await graphql(`
-    {
-      allMarkdownRemark(
-        sort: { order: DESC, fields: [frontmatter___date] }
-        limit: 1000
-      ) {
-        edges {
-          node {
-            frontmatter {
-              slug
-            }
-          }
-        }
-      }
-    }
-  `)
-
-  // Handle errors
-  if (result.errors) {
-    reporter.panicOnBuild(`Error while running GraphQL query.`)
-    return
-  }
-
-  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
-    createPage({
-      path: node.frontmatter.slug,
-      component: blogPostTemplate,
-      context: {
-        // additional data can be passed via context
-        slug: node.frontmatter.slug,
-      },
-    })
-  })
-}
-```
-
-This should get you started on some basic Markdown functionality in your Gatsby site. You can further customize the frontmatter and the template file to get desired effects!
+This should get you started on some basic Markdown functionality in your Gatsby site. You can further customize the frontmatter and the component file to get desired effects!
 
 For more information, have a look in the working example `using-markdown-pages`. You can find it in the [Gatsby examples section](https://github.com/gatsbyjs/gatsby/tree/master/examples).
 

--- a/docs/docs/how-to/routing/adding-markdown-pages.md
+++ b/docs/docs/how-to/routing/adding-markdown-pages.md
@@ -140,7 +140,9 @@ Two things are important in the file above:
 
    **Note: To learn more about GraphQL, consider this [excellent resource](https://www.howtographql.com/)**
 
-2. The result of the query is injected by Gatsby into the component as the `data` prop. `props.data.markdownRemark` is the property that has all the details of the Markdown file. You can use that to construct a template for your blog post view. Since it's a React component, you could style it with any of the [recommended styling systems](/docs/styling/) in Gatsby.
+2. The result of the query is injected by Gatsby into the component as the `data` prop. `props.data.markdownRemark` is the property that has all the details of the Markdown file.
+
+Next you could create a page component at `src/pages/blog/index.js` to serve as a listing page for all your blog posts.
 
 ### Create static pages using Gatsby’s Node.js `createPage` API
 


### PR DESCRIPTION
Can delete 1/4 of the tutorial with the new collection routes!