### PR TITLE
fix(gatsby-plugin-netlify-cms): Fix typo in semver

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -14,7 +14,7 @@
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "1.3.9",
     "netlify-identity-widget": "^1.9.1",
-    "webpack": "^5.23.00"
+    "webpack": "^5.23.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27028,7 +27028,7 @@ webpack@^4.44.2:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@^5.23.00:
+webpack@^5.23.0:
   version "5.23.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.23.0.tgz#9ed57e9a54b267b3549899271ad780cddc6ee316"
   integrity sha512-RC6dwDuRxiU75F8XC4H08NtzUrMfufw5LDnO8dTtaKU2+fszEdySCgZhNwSBBn516iNaJbQI7T7OPHIgCwcJmg==


### PR DESCRIPTION
There's a typo in the webpack semver, which is invalid and not resolved by yarn 2+

Fixes #30291