### PR TITLE
fix(gatsby): add generic type to GatsbyFunctionResponse

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1531,7 +1531,7 @@ type Send<T> = (body: T) => void
 /**
  * Gatsby Function route response
  */
-export interface GatsbyFunctionResponse extends ServerResponse {
+export interface GatsbyFunctionResponse<T = any> extends ServerResponse {
   /**
    * Send `any` data in response
    */


### PR DESCRIPTION
## Description
This PR adds the missing generic type on `GatsbyFunctionResponse` interface in `gatsby` package.

## Additional Context
![Screenshot 2021-05-02 at 16 51 44](https://user-images.githubusercontent.com/2034840/116819162-afd64080-ab66-11eb-84cd-1fb0c57ba0a5.png)

Fixes https://github.com/gatsbyjs/gatsby/issues/31135