### PR TITLE
fix(gatsby-plugin-image): add @babel/core peer dependency

### DIFF
--- a/packages/gatsby-plugin-image/package.json
+++ b/packages/gatsby-plugin-image/package.json
@@ -64,6 +64,7 @@
     "typescript": "^4.1.5"
   },
   "peerDependencies": {
+    "@babel/core": "^7.12.3",
     "gatsby": "^3.0.0-next.0",
     "gatsby-plugin-sharp": "^3.0.0-next.0",
     "gatsby-source-filesystem": "^3.0.0-next.0",


### PR DESCRIPTION
## Description

When resolving the dependencies of a project using `gatsby-plugin-image` with Yarn 2, the following warning is printed:

```
➤ YN0002: │ gatsby-plugin-image@npm:1.4.0 [558ef] doesn't provide @babel/core (p64f0e), requested by babel-plugin-remove-graphql-queries
```

This adds the peer dependency [as recommended by Yarn](https://yarnpkg.com/advanced/error-codes#yn0002---missing_peer_dependency).

## Related Issues

Related to #20949.

## Note to watchers

You can work around this warning in your projects by adding this to your `.yarnrc.yml` in the meantime:

```
packageExtensions:
  # awaiting fix: https://github.com/gatsbyjs/gatsby/pull/31188
  'gatsby-plugin-image@*':
    peerDependenciesMeta:
      '@babel/core':
        optional: true
```