### PR TITLE
fix(gatsby-telemetry): Read installedGatsbyVersion correctly for workspaces

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -215,14 +215,18 @@ export class AnalyticsTracker {
   }
 
   getGatsbyVersion(): SemVer {
-    const packageInfo = require(join(
-      process.cwd(),
-      `node_modules`,
-      `gatsby`,
-      `package.json`
-    ))
     try {
-      return packageInfo.version
+      const packageJson = join(
+        require
+          .resolve(`gatsby`)
+          .split(sep) // Resolve where current gatsby would be loaded from.
+          .slice(0, -3) // drop cache-dir/commonjs/gatsby-browser-entry.js
+          .join(sep),
+        `package.json`
+      )
+
+      const { version } = JSON.parse(fs.readFileSync(packageJson, `utf-8`))
+      return version
     } catch (e) {
       // ignore
     }

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -216,15 +216,7 @@ export class AnalyticsTracker {
 
   getGatsbyVersion(): SemVer {
     try {
-      const packageJson = join(
-        require
-          .resolve(`gatsby`)
-          .split(sep) // Resolve where current gatsby would be loaded from.
-          .slice(0, -3) // drop cache-dir/commonjs/gatsby-browser-entry.js
-          .join(sep),
-        `package.json`
-      )
-
+      const packageJson = require.resolve(`gatsby/package.json`)
       const { version } = JSON.parse(fs.readFileSync(packageJson, `utf-8`))
       return version
     } catch (e) {


### PR DESCRIPTION
For yarn workspaces (when `process.cwd()`) is not the parent directory where `node_modules` includes `gatsby`, the current code is unable to read the installed gatsby version. This attempts to fix that. 

Remember that `main` for the `gatsby` package is `cache-dir/commonjs/gatsby-browser-entry.js` so we need to strip out three segments to be able to resolve to root

Co drafted with the wonderful @jamo 