### PR TITLE
docs: Updates file name suggestion in babel.md

### DIFF
--- a/docs/docs/how-to/custom-configuration/babel.md
+++ b/docs/docs/how-to/custom-configuration/babel.md
@@ -14,7 +14,7 @@ If you only target newer browsers, see the [Browser Support](/docs/how-to/custom
 
 ## How to use a custom `.babelrc` file
 
-Gatsby ships with a default `.babelrc` setup that should work for most sites. If you'd like to add custom Babel presets or plugins, you can create your own `.babelrc` at the root of your site, import [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby), and add additional plugins, presets, and pass options to `babel-preset-gatsby`, e.g. `targets`.
+Gatsby ships with a default `.babelrc` setup that should work for most sites. If you'd like to add custom Babel presets or plugins, you can create your own `.babelrc` at the root of your site, import [`babel-preset-gatsby`](https://github.com/gatsbyjs/gatsby/tree/master/packages/babel-preset-gatsby), and add additional plugins, presets, and pass options to `babel-preset-gatsby`, e.g. `targets`. In case of using a [monorepo](https://babeljs.io/docs/en/configuration), you may want to call this file `babel.config.json`.
 
 ```shell
 npm install --save-dev babel-preset-gatsby


### PR DESCRIPTION
## Description

Currently I tried to override my projects' babel configuration. However, adding a `.babelrc` at the project root (as suggested [here](https://www.gatsbyjs.com/docs/how-to/custom-configuration/babel/#how-to-use-a-custom-babelrc-file) and at other places in the documentation) showed no effect at all as I kept on receiving babel error messages.

Turns out: Monorepo projects are better off calling this file `babel.config.json` (as explained [here](https://babeljs.io/docs/en/configuration)) which, indeed, resolves earlier errors thrown by babel compiler.

### Documentation

Updates babel.md