### PR TITLE
fix(gatsby-plugin-mdx): Img w/ lessBabel option in src/pages not working

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -135,6 +135,7 @@ module.exports = async function mdxLoader(content) {
         content,
         options,
         getNodesByType,
+        getNode: rawGetNode,
       }))
     } else {
       mdxNode = await createMdxNodeExtraBabel({


### PR DESCRIPTION
## Description

While working on my own site I noticed a bug:

- Use `gatsby-remark-images` with `gatsby-plugin-mdx`
- use `lessBabel: true` option
- `src/pages/art/index.mdx`
- That MDX file uses an image in the same directory:

```mdx
Some text blabla

![Alt text](./link-to-image.jpg)
```

When running `gatsby develop` the process failed on `TypeError: getNode is not a function` on this line:

https://github.com/gatsbyjs/gatsby/blob/3bcb6e26d5a44ee0687894eb4b02dcfcf013770a/packages/gatsby-remark-images/src/index.js#L132

All the helper functions including `getNode` were `undefined`.

I don't understand why they are not all passed down anyways but for now I only added `getNode`
