### PR TITLE
Update tutorial to match latest style of exporting rhythm from Typography 

### DIFF
--- a/docs/docs/tutorial/part-four/index.md
+++ b/docs/docs/tutorial/part-four/index.md
@@ -165,8 +165,8 @@ import kirkhamTheme from "typography-theme-kirkham"
 
 const typography = new Typography(kirkhamTheme)
 
-export default typography
-export const rhythm = typography.rhythm
+const { rhythm, scale } = typography;
+export { rhythm, scale, typography as default };
 ```
 
 `gatsby-config.js` (must be in the root of your project, not under src)


### PR DESCRIPTION
## Description

Update `typography.js` according to updates mentioned at https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v1-to-v2/#typographyjs-plugin-config-changes. 

Without the update, I was getting the error:

```
_utils_typography__WEBPACK_IMPORTED_MODULE_2__.rhythm) is not a function
```


### Documentation

NA

## Related Issues

None