### PR TITLE
fix(wordpress-source-plugin): create nodes properly for images who exceed maxFileSizeBytes

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -268,10 +268,10 @@ export const createRemoteMediaItemNode = async ({
 
   let imageNode
 
-  const shouldFetchImage = fileSize > maxFileSizeBytes
+  const doNotFetchImage = fileSize > maxFileSizeBytes
 
   // if this file is larger than maxFileSizeBytes, don't fetch the remote file
-  if (shouldFetchImage) {
+  if (doNotFetchImage) {
     reporter.warn(
       formatLogMessage(
         `Remote media item not fetched because its size exceeded the maxFileSizeBytes config option: ${mediaItemNode?.mediaDetails?.file}`
@@ -377,7 +377,7 @@ export const createRemoteMediaItemNode = async ({
     modifiedGmt,
   })
 
-  if (hardCacheMediaFiles && shouldFetchImage) {
+  if (hardCacheMediaFiles && doNotFetchImage) {
     try {
       // make sure the directory exists
       await fs.ensureDir(path.dirname(hardCachedFilePath))

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -232,11 +232,21 @@ export const createRemoteMediaItemNode = async ({
 
   // if this file is larger than maxFileSizeBytes, don't fetch the remote file
   if (fileSize > maxFileSizeBytes) {
+    reporter.warn(
+      formatLogMessage(
+        `Remote media item node not created because its size exceeded the maxFileSizeBytes config option ${mediaItemNode}`
+      )
+    )
     return null
   }
 
   // if this type of file is excluded, don't fetch the remote file
   if (excludeByMimeTypes.includes(mimeType)) {
+    reporter.warn(
+      formatLogMessage(
+        `Remote media item node not created because its mimetype was specified in the "exludeByMimeTypes" config option`
+      )
+    )
     return null
   }
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -377,7 +377,7 @@ export const createRemoteMediaItemNode = async ({
     modifiedGmt,
   })
 
-  if (hardCacheMediaFiles && doNotFetchImage) {
+  if (hardCacheMediaFiles && !doNotFetchImage) {
     try {
       // make sure the directory exists
       await fs.ensureDir(path.dirname(hardCachedFilePath))

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-media-item-node.js
@@ -234,7 +234,7 @@ export const createRemoteMediaItemNode = async ({
   if (fileSize > maxFileSizeBytes) {
     reporter.warn(
       formatLogMessage(
-        `Remote media item node not created because its size exceeded the maxFileSizeBytes config option ${mediaItemNode}`
+        `\n\n\tRemote media item node not created because its size exceeded the maxFileSizeBytes config option:\n\t${mediaItemNode?.mediaDetails?.file}\n\n`
       )
     )
     return null
@@ -244,7 +244,7 @@ export const createRemoteMediaItemNode = async ({
   if (excludeByMimeTypes.includes(mimeType)) {
     reporter.warn(
       formatLogMessage(
-        `Remote media item node not created because its mimetype was specified in the "exludeByMimeTypes" config option`
+        `\n\n\tRemote media item node not created because its mimetype was specified in the "exludeByMimeTypes" config option\n\n`
       )
     )
     return null

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -266,7 +266,6 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
         const nodeEditLink = getNodeEditLink(node)
 
         if (typeof e === `string` && e.includes(`404`)) {
-          helpers.reporter.log(``)
           helpers.reporter.warn(
             formatLogMessage(
               `\n\nReceived a 404 ${sharedError}\n\nMost likely this image was uploaded to this ${node.__typename} and then deleted from the media library.\nYou'll need to fix this and re-save this ${node.__typename} to remove this warning at\n${nodeEditLink}.\n\n`


### PR DESCRIPTION
## Description

The WordPress source plugin was returning incorrectly formatted node data for page/post `featuredImages` whose size exceeded the `maxFileSizeBytes` config option. The result of this was that the `featuredImage.node` field would be set to `null` and not return other relevant info about the featured image.

Previously if a file was detected to be too big, we would set the `post.node.featuredImage.node` field to `null`. Now we create a node of type `RemoteFile` without fetching the image and then set the `localFile` field to `null` since we never fetched an image and stored it on disk. This means that `post.node.featuredImage.node` is populated with useful data.

This means that a query for `allWpPost` or `allWpPage` will no longer return this result:
```js
"allWpPost": {
      "nodes": [
        {
          "id": "cG9zdDo1",
          "featuredImage": {
            // this isn't great because we don't know important info like at what url this resource can be found at
            "node": null
          }
        },
      ]
    }
```
```js
"allWpPost": {
      "nodes": [
        { at
          "id": "cG9zdDo1",
          "featuredImage": {
            // now important node information is returned
            "node": {
              "id": "cG9zdDo2",
              "sourceUrl": "http://wordpresssite.com/wp-content/uploads/2021/05/picture-scaled.jpg",
              "localFile": null
            }
          }
        },
      ]
    }
```

## Related Issues

Fixes #30755 

