### PR TITLE
feat(gatsby): Don't send error for function errors if headers are already sent

### DIFF
--- a/integration-tests/functions/package.json
+++ b/integration-tests/functions/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "description": "functions",
   "author": "Kyle Mathews",
-  "keywords": [
-    "gatsby"
-  ],
+  "keywords": ["gatsby"],
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
@@ -25,7 +23,7 @@
     "start-server-and-test": "^1.11.3"
   },
   "dependencies": {
-    "gatsby": "^3.5.0-next.0",
+    "gatsby": "next",
     "gatsby-plugin-gatsby-cloud": "^2.5.0-next.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/integration-tests/functions/src/api/error-send-function-twice.js
+++ b/integration-tests/functions/src/api/error-send-function-twice.js
@@ -1,0 +1,4 @@
+export default function handler(req, res) {
+  res.send(`hi`)
+  res.json({ willCauseError: true })
+}

--- a/integration-tests/functions/test-helpers.js
+++ b/integration-tests/functions/test-helpers.js
@@ -85,6 +85,15 @@ export function runTests(env, host) {
       })
     })
 
+    describe(`function errors don't crash the server`, () => {
+      // This test mainly just shows that the server doesn't crash.
+      test(`normal`, async () => {
+        const result = await fetch(`${host}/api/error-send-function-twice`)
+
+        expect(result.status).toEqual(200)
+      })
+    })
+
     describe(`response formats`, () => {
       test(`returns json correctly`, async () => {
         const res = await fetch(`${host}/api/i-am-json`)
@@ -217,14 +226,6 @@ export function runTests(env, host) {
         const result = await fetch(`${host}/api/redirect-me`)
 
         expect(result.url).toEqual(host + `/`)
-      })
-    })
-
-    describe(`function errors don't crash the server`, () => {
-      test(`normal`, async () => {
-        const result = await fetch(`${host}/api/error-send-function-twice`)
-
-        expect(result.statusCode).toEqual(200)
       })
     })
 

--- a/integration-tests/functions/test-helpers.js
+++ b/integration-tests/functions/test-helpers.js
@@ -220,6 +220,14 @@ export function runTests(env, host) {
       })
     })
 
+    describe(`function errors don't crash the server`, () => {
+      test(`normal`, async () => {
+        const result = await fetch(`${host}/api/error-send-function-twice`)
+
+        expect(result.statusCode).toEqual(200)
+      })
+    })
+
     describe(`functions can have custom middleware`, () => {
       test(`normal`, async () => {
         const result = await fetch(`${host}/api/cors`)

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -195,11 +195,7 @@ module.exports = async (program: IServeProgram): Promise<void> => {
           } catch (e) {
             console.error(e)
             // Don't send the error if that would cause another error.
-            if (
-              !e.message.includes(
-                `Cannot set headers after they are sent to the client`
-              )
-            ) {
+            if (!res.headersSent) {
               res.sendStatus(500)
             }
           }

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -194,7 +194,14 @@ module.exports = async (program: IServeProgram): Promise<void> => {
             await Promise.resolve(fnToExecute(req, res))
           } catch (e) {
             console.error(e)
-            res.sendStatus(500)
+            // Don't send the error if that would cause another error.
+            if (
+              !e.message.includes(
+                `Cannot set headers after they are sent to the client`
+              )
+            ) {
+              res.sendStatus(500)
+            }
           }
 
           const end = Date.now()

--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -364,11 +364,18 @@ export async function onCreateDevServer({
           await Promise.resolve(fnToExecute(req, res))
         } catch (e) {
           reporter.error(e)
-          res
-            .status(500)
-            .send(
-              `Error when executing function "${functionObj.originalFilePath}": "${e.message}"`
+          // Don't send the error if that would cause another error.
+          if (
+            !e.message.includes(
+              `Cannot set headers after they are sent to the client`
             )
+          ) {
+            res
+              .status(500)
+              .send(
+                `Error when executing function "${functionObj.originalFilePath}": "${e.message}"`
+              )
+          }
         }
 
         const end = Date.now()

--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -365,11 +365,7 @@ export async function onCreateDevServer({
         } catch (e) {
           reporter.error(e)
           // Don't send the error if that would cause another error.
-          if (
-            !e.message.includes(
-              `Cannot set headers after they are sent to the client`
-            )
-          ) {
+          if (!res.headersSent) {
             res
               .status(500)
               .send(


### PR DESCRIPTION
We catch errors from functions and previously always then sent that to the browser. That crashes the
server when the error is "Cannot set headers after they are sent to the client" which happens
when the function does e.g. a `res.send('hi')` followed by another `res.send` e.g. an early return
that wasn't returned.