### PR TITLE
fix(gatsby-cli): Add name to Error error schema

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-schema.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-schema.ts
@@ -37,5 +37,7 @@ export const errorSchema: Joi.ObjectSchema<IStructuredError> = Joi.object().keys
     group: Joi.string(),
     panicOnBuild: Joi.boolean(),
     pluginName: Joi.string(),
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+    name: Joi.string(),
   }
 )

--- a/packages/gatsby-cli/src/structured-errors/error-schema.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-schema.ts
@@ -37,7 +37,6 @@ export const errorSchema: Joi.ObjectSchema<IStructuredError> = Joi.object().keys
     group: Joi.string(),
     panicOnBuild: Joi.boolean(),
     pluginName: Joi.string(),
-    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
     name: Joi.string(),
   }
 )


### PR DESCRIPTION
Adds `name` to the schema which is a known property documented in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error