### PR TITLE
chore: update renovatebot config to support more packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -59,6 +59,7 @@
       packageNames: ["remark", "retext"],
       packagePatterns: ["^remark-", "^retext-"],
       dependencyDashboardApproval: false,
+      excludePackageNames: ["remark-mdx", "remark-mdxjs"],
     },
     {
       groupName: "eslint",
@@ -2300,6 +2301,7 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby",
       commitMessageExtra: "",
+      matchDepTypes: ["peerDependencies", "dependencies"],
       excludePackageNames: [
         "@mdx-js/mdx",
         "@mdx-js/react",
@@ -2324,6 +2326,52 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby",
       excludePackageNames: ["cross-env"],
+      matchDepTypes: ["peerDependencies", "dependencies"],
+      packageNames: [
+        "@mdx-js/mdx",
+        "@mdx-js/react",
+        "@mdx-js/runtime",
+        "express-graphql",
+        "remark-mdx",
+        "remark-mdxjs",
+        "typescript",
+        "webpack-virtual-modules",
+      ],
+    },
+    {
+      groupName: "minor and patch for gatsby dev dependencies",
+      paths: ["packages/gatsby/"],
+      groupSlug: "gatsby",
+      updateTypes: ["minor", "patch"],
+      // force pr title to be the plugin name
+      commitMessageTopic: "minor and patch for gatsby",
+      commitMessageExtra: "",
+      excludePackageNames: [
+        "@mdx-js/mdx",
+        "@mdx-js/react",
+        "@mdx-js/runtime",
+        "cross-env",
+        "express-graphql",
+        "lodash",
+        "lodash-es",
+        "remark-mdx",
+        "remark-mdxjs",
+        "typescript",
+        "webpack-virtual-modules",
+        "mini-css-extract-plugin",
+      ],
+      matchDepTypes: ["devDependencies"],
+      excludePackagePatterns: ["^lodash/", "^@babel/"],
+    },
+    {
+      groupName: "major for gatsby dev dependencies",
+      paths: ["packages/gatsby/"],
+      groupSlug: "gatsby-major",
+      updateTypes: ["major"],
+      // force pr title to be the plugin name
+      commitMessageSuffix: "for gatsby",
+      excludePackageNames: ["cross-env"],
+      matchDepTypes: ["devDependencies"],
       packageNames: [
         "@mdx-js/mdx",
         "@mdx-js/react",

--- a/renovate.json5
+++ b/renovate.json5
@@ -55,7 +55,7 @@
     {
       groupName: "remark docs linting",
       updateTypes: ["major", "minor", "patch", "pin"],
-      paths: ["package.json"],
+      paths: ["./package.json"],
       packageNames: ["remark", "retext"],
       packagePatterns: ["^remark-", "^retext-"],
       dependencyDashboardApproval: false,
@@ -63,38 +63,38 @@
     {
       groupName: "eslint",
       updateTypes: ["major", "minor", "patch", "pin"],
-      paths: ["package.json"],
+      paths: ["./package.json"],
       packageNames: ["eslint"],
       packagePatterns: ["^eslint-"],
       dependencyDashboardApproval: false,
     },
     {
       groupName: "cross-env",
-      paths: ["package.json", "packages/**"],
+      paths: ["./package.json", "packages/**"],
       packageNames: ["cross-env"],
       dependencyDashboardApproval: false,
     },
     {
       groupName: "mini-css-extract-plugin",
-      paths: ["package.json", "packages/**"],
+      paths: ["./package.json", "packages/**"],
       packageNames: ["mini-css-extract-plugin"],
       dependencyDashboardApproval: false,
     },
     {
       groupName: "typescript",
-      paths: ["package.json", "packages/**"],
+      paths: ["./package.json", "packages/**"],
       packageNames: ["typescript"],
       dependencyDashboardApproval: false,
     },
     {
       groupName: "babel monorepo",
-      paths: ["package.json", "packages/**"],
+      paths: ["./package.json", "packages/**"],
       sourceUrlPrefixes: ["https://github.com/babel/babel"],
       dependencyDashboardApproval: false,
     },
     {
       groupName: "lodash monorepo",
-      paths: ["package.json", "packages/**"],
+      paths: ["./package.json", "packages/**"],
       sourceUrlPrefixes: ["https://github.com/lodash"],
       dependencyDashboardApproval: false,
     },
@@ -116,6 +116,26 @@
       updateTypes: ["major"],
       // force pr title to be the plugin name
       commitMessageSuffix: "for babel-preset-gatsby-package",
+      excludePackageNames: ["cross-env"],
+    },
+    {
+      groupName: "minor and patch for create-gatsby",
+      paths: ["packages/create-gatsby/"],
+      groupSlug: "create-gatsby",
+      updateTypes: ["minor", "patch"],
+      // force pr title to be the plugin name
+      commitMessageTopic: "minor and patch for create-gatsby",
+      commitMessageExtra: "",
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
+      excludePackagePatterns: ["^lodash/", "^@babel/"],
+    },
+    {
+      groupName: "major for create-gatsby",
+      paths: ["packages/create-gatsby/"],
+      groupSlug: "create-gatsby-major",
+      updateTypes: ["major"],
+      // force pr title to be the plugin name
+      commitMessageSuffix: "for create-gatsby",
       excludePackageNames: ["cross-env"],
     },
     {
@@ -699,6 +719,26 @@
       excludePackageNames: ["cross-env"],
     },
     {
+      groupName: "minor and patch for gatsby-plugin-image",
+      paths: ["packages/gatsby-plugin-image/"],
+      groupSlug: "gatsby-plugin-image",
+      updateTypes: ["minor", "patch"],
+      // force pr title to be the plugin name
+      commitMessageTopic: "minor and patch for gatsby-plugin-image",
+      commitMessageExtra: "",
+      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
+      excludePackagePatterns: ["^lodash/", "^@babel/"],
+    },
+    {
+      groupName: "major for gatsby-plugin-image",
+      paths: ["packages/gatsby-plugin-image/"],
+      groupSlug: "gatsby-plugin-image-major",
+      updateTypes: ["major"],
+      // force pr title to be the plugin name
+      commitMessageSuffix: "for gatsby-plugin-image",
+      excludePackageNames: ["cross-env"],
+    },
+    {
       groupName: "minor and patch for gatsby-plugin-jss",
       paths: ["packages/gatsby-plugin-jss/"],
       groupSlug: "gatsby-plugin-jss",
@@ -786,7 +826,13 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-plugin-netlify-cms",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript", "mini-css-extract-plugin"],
+      excludePackageNames: [
+        "cross-env",
+        "lodash",
+        "lodash-es",
+        "typescript",
+        "mini-css-extract-plugin",
+      ],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2006,7 +2052,13 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-source-filesystem",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "msw", "typescript"],
+      excludePackageNames: [
+        "cross-env",
+        "lodash",
+        "lodash-es",
+        "msw",
+        "typescript",
+      ],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2087,7 +2139,19 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-recipes",
       commitMessageExtra: "",
-      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "react-reconciler", "remark-mdx", "remark-mdxjs", "typescript"],
+      excludePackageNames: [
+        "@mdx-js/mdx",
+        "@mdx-js/react",
+        "@mdx-js/runtime",
+        "cross-env",
+        "express-graphql",
+        "lodash",
+        "lodash-es",
+        "react-reconciler",
+        "remark-mdx",
+        "remark-mdxjs",
+        "typescript",
+      ],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2098,7 +2162,15 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby-recipes",
       excludePackageNames: ["cross-env"],
-      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "react-reconciler", "remark-mdx", "remark-mdxjs"],
+      packageNames: [
+        "@mdx-js/mdx",
+        "@mdx-js/react",
+        "@mdx-js/runtime",
+        "express-graphql",
+        "react-reconciler",
+        "remark-mdx",
+        "remark-mdxjs",
+      ],
     },
     {
       groupName: "minor and patch for gatsby-source-contentful",
@@ -2228,7 +2300,20 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby",
       commitMessageExtra: "",
-      excludePackageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "cross-env", "express-graphql", "lodash", "lodash-es", "remark-mdx", "remark-mdxjs", "typescript", "webpack-virtual-modules", "mini-css-extract-plugin"],
+      excludePackageNames: [
+        "@mdx-js/mdx",
+        "@mdx-js/react",
+        "@mdx-js/runtime",
+        "cross-env",
+        "express-graphql",
+        "lodash",
+        "lodash-es",
+        "remark-mdx",
+        "remark-mdxjs",
+        "typescript",
+        "webpack-virtual-modules",
+        "mini-css-extract-plugin",
+      ],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {
@@ -2239,7 +2324,16 @@
       // force pr title to be the plugin name
       commitMessageSuffix: "for gatsby",
       excludePackageNames: ["cross-env"],
-      packageNames: ["@mdx-js/mdx", "@mdx-js/react", "@mdx-js/runtime", "express-graphql", "remark-mdx", "remark-mdxjs", "typescript", "webpack-virtual-modules"],
+      packageNames: [
+        "@mdx-js/mdx",
+        "@mdx-js/react",
+        "@mdx-js/runtime",
+        "express-graphql",
+        "remark-mdx",
+        "remark-mdxjs",
+        "typescript",
+        "webpack-virtual-modules",
+      ],
     },
     {
       groupName: "minor and patch for gatsby-admin",
@@ -2249,7 +2343,13 @@
       // force pr title to be the plugin name
       commitMessageTopic: "minor and patch for gatsby-admin",
       commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "theme-ui", "typescript"],
+      excludePackageNames: [
+        "cross-env",
+        "lodash",
+        "lodash-es",
+        "theme-ui",
+        "typescript",
+      ],
       excludePackagePatterns: ["^lodash/", "^@babel/"],
     },
     {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Not all new packages where part of renovate config. I added them

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
