### PR TITLE
fix(gatsby): don't print out flag suggestions if none are enabled or opted-in

### DIFF
--- a/packages/gatsby/src/utils/__tests__/handle-flags.ts
+++ b/packages/gatsby/src/utils/__tests__/handle-flags.ts
@@ -557,4 +557,155 @@ describe(`handle flags`, () => {
       `)
     })
   })
+
+  describe(`other flag suggestions`, () => {
+    it(`suggest other flags when there is flag explicitly enabled`, () => {
+      const response = handleFlags(
+        [
+          {
+            name: `ENABLED_FLAG`,
+            env: `GATSBY_ENABLED_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => true,
+          },
+          {
+            name: `OTHER_FLAG`,
+            env: `GATSBY_OTHER_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => true,
+          },
+        ],
+        {
+          ENABLED_FLAG: true,
+        },
+        `build`
+      )
+
+      expect(response.message).toMatchInlineSnapshot(`
+        "The following flags are active:
+        - ENABLED_FLAG · (Umbrella Issue (test)) · test
+
+        There is one other flag available that you might be interested in:
+        - OTHER_FLAG · (Umbrella Issue (test)) · test
+        "
+      `)
+    })
+
+    it(`suggest other flags when there is opted-in flag`, () => {
+      const response = handleFlags(
+        [
+          {
+            name: `OPTED_IN_FLAG`,
+            env: `GATSBY_OPTED_IN_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => `OPT_IN`,
+          },
+          {
+            name: `OTHER_FLAG`,
+            env: `GATSBY_OTHER_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => true,
+          },
+        ],
+        {},
+        `build`
+      )
+
+      expect(response.message).toMatchInlineSnapshot(`
+        "We're shipping new features! For final testing, we're rolling them out first to a small % of Gatsby users
+        and your site was automatically chosen as one of them. With your help, we'll then release them to everyone in the next minor release.
+
+        We greatly appreciate your help testing the change. Please report any feedback good or bad in the umbrella issue. If you do encounter problems, please disable the flag by setting it to false in your gatsby-config.js like:
+
+        flags: {
+          THE_FLAG: false
+        }
+
+        The following flags were automatically enabled on your site:
+        - OPTED_IN_FLAG · (Umbrella Issue (test)) · test
+
+        There is one other flag available that you might be interested in:
+        - OTHER_FLAG · (Umbrella Issue (test)) · test
+        "
+      `)
+    })
+
+    it(`doesn't suggest other flags if there are no enabled or opted in flags (no locked-in flags)`, () => {
+      const response = handleFlags(
+        [
+          {
+            name: `SOME_FLAG`,
+            env: `GATSBY_SOME_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => true,
+          },
+          {
+            name: `OTHER_FLAG`,
+            env: `GATSBY_OTHER_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => true,
+          },
+        ],
+        {},
+        `build`
+      )
+
+      expect(response.message).toMatchInlineSnapshot(`""`)
+    })
+
+    it(`doesn't suggest other flags if there are no enabled or opted in flags (with locked-in flag)`, () => {
+      const response = handleFlags(
+        [
+          {
+            name: `LOCKED_IN_FLAG`,
+            env: `GATSBY_LOCKED_IN_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => `LOCKED_IN`,
+          },
+          {
+            name: `OTHER_FLAG`,
+            env: `GATSBY_OTHER_FLAG`,
+            command: `all`,
+            description: `test`,
+            umbrellaIssue: `test`,
+            telemetryId: `test`,
+            experimental: false,
+            testFitness: (): fitnessEnum => true,
+          },
+        ],
+        {},
+        `build`
+      )
+
+      expect(response.message).toMatchInlineSnapshot(`""`)
+    })
+  })
 })

--- a/packages/gatsby/src/utils/handle-flags.ts
+++ b/packages/gatsby/src/utils/handle-flags.ts
@@ -203,28 +203,31 @@ The following flags were automatically enabled on your site:`
       })
     }
 
-    const otherFlagSuggestionLines: Array<string> = []
-    const enabledFlagsSet = new Set()
-    enabledConfigFlags.forEach(f => enabledFlagsSet.add(f.name))
-    applicableFlags.forEach(flag => {
-      if (
-        !enabledFlagsSet.has(flag.name) &&
-        typeof configFlags[flag.name] === `undefined`
-      ) {
-        // we want to suggest flag when it's not enabled and user specifically didn't use it in config
-        // we don't want to suggest flag user specifically wanted to disable
-        otherFlagSuggestionLines.push(generateFlagLine(flag))
-      }
-    })
+    if (message.length > 0) {
+      // if we will print anything about flags, let's try to suggest other available ones
+      const otherFlagSuggestionLines: Array<string> = []
+      const enabledFlagsSet = new Set()
+      enabledConfigFlags.forEach(f => enabledFlagsSet.add(f.name))
+      applicableFlags.forEach(flag => {
+        if (
+          !enabledFlagsSet.has(flag.name) &&
+          typeof configFlags[flag.name] === `undefined`
+        ) {
+          // we want to suggest flag when it's not enabled and user specifically didn't use it in config
+          // we don't want to suggest flag user specifically wanted to disable
+          otherFlagSuggestionLines.push(generateFlagLine(flag))
+        }
+      })
 
-    if (otherFlagSuggestionLines.length > 0) {
-      message += `\n\nThere ${
-        otherFlagSuggestionLines.length === 1
-          ? `is one other flag`
-          : `are ${otherFlagSuggestionLines.length} other flags`
-      } available that you might be interested in:${otherFlagSuggestionLines.join(
-        ``
-      )}`
+      if (otherFlagSuggestionLines.length > 0) {
+        message += `\n\nThere ${
+          otherFlagSuggestionLines.length === 1
+            ? `is one other flag`
+            : `are ${otherFlagSuggestionLines.length} other flags`
+        } available that you might be interested in:${otherFlagSuggestionLines.join(
+          ``
+        )}`
+      }
     }
 
     if (message.length > 0) {


### PR DESCRIPTION
## Description

`gatsby develop` due to some `LOCKED_IN` flag was always priting other flag suggestions even tho there was no explicit flags enabled by users or flags auto opted-in (both of which would print some message). It was resulting in confusing output like:

```
$ gatsby develop
info

There are 6 other flags available that you might be interested in:
- FAST_DEV · Enable all experiments aimed at improving develop server start time
- DEV_SSR · (Umbrella Issue (https://gatsby.dev/dev-ssr-feedback)) · Server Side Render (SSR) pages on full reloads during develop. Helps you detect SSR bugs
and fix them without needing to do full builds.
- PRESERVE_WEBPACK_CACHE · (Umbrella Issue (https://gatsby.dev/cache-clearing-feedback)) · Use webpack's persistent caching and don't delete webpack's cache
when changing gatsby-node.js & gatsby-config.js files.
- PRESERVE_FILE_DOWNLOAD_CACHE · (Umbrella Issue (https://gatsby.dev/cache-clearing-feedback)) · Don't delete the downloaded files cache when changing
gatsby-node.js & gatsby-config.js files.
- PARALLEL_SOURCING · EXPERIMENTAL · (Umbrella Issue (https://gatsby.dev/parallel-sourcing-feedback)) · Run all source plugins at the same time instead of
serially. For sites with multiple source plugins, this can speedup sourcing and transforming considerably.
- FUNCTIONS · EXPERIMENTAL · (Umbrella Issue (https://gatsby.dev/functions-feedback)) · Compile Serverless functions in your Gatsby project and write them to
disk, ready to deploy to Gatsby Cloud

success open and validate gatsby-configs - 0.110s
```

This PR checks wether there is any message related to flags before trying to even suggest other flags

## Related Issues

Fixes regression introduced in https://github.com/gatsbyjs/gatsby/pull/30992