### PR TITLE
feat(gatsby): test using ldmb as store instad of file system

### DIFF
--- a/benchmarks/create-pages/package.json
+++ b/benchmarks/create-pages/package.json
@@ -9,7 +9,8 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
-    "gatsby": "^3.4.0",
+    "gatsby": "^3.6.0-next.0",
+    "lmdb-store": "^1.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -164,7 +164,18 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     rewriteActivityTimer.end()
   }
 
+  const flushTimer = report.activityTimer(
+    `Writing page-data.json files to disk`,
+    {
+      parentSpan: buildSpan,
+    }
+  )
+  flushTimer.start()
   await flushPendingPageDataWrites()
+  flushTimer.end()
+
+  console.log(`time elapased — ${process.uptime()}`)
+  process.exit()
   markWebpackStatusAsDone()
 
   if (telemetry.isTrackingEnabled()) {

--- a/packages/gatsby/src/query/index.js
+++ b/packages/gatsby/src/query/index.js
@@ -13,7 +13,7 @@ if (process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) {
 }
 
 const concurrency =
-  Number(process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) || 4
+  Number(process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) || 60
 
 /**
  * Calculates the set of dirty query IDs (page.paths, or staticQuery.id's).

--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -14,6 +14,7 @@ import errorParser from "./error-parser"
 import { GraphQLRunner } from "./graphql-runner"
 import { IExecutionResult, PageContext } from "./types"
 import { pageDataExists } from "../utils/page-data"
+import ldmbStore from "../utils/lmdb"
 
 const resultHashes = new Map()
 
@@ -181,7 +182,8 @@ export async function queryRunner(
         `json`,
         `${queryJob.id.replace(/\//g, `_`)}.json`
       )
-      await fs.outputFile(resultPath, resultJSON)
+      // await fs.outputFile(resultPath, resultJSON)
+      await ldmbStore.put(resultPath, resultJSON)
       store.dispatch({
         type: `ADD_PENDING_PAGE_DATA_WRITE`,
         payload: {

--- a/packages/gatsby/src/utils/lmdb.ts
+++ b/packages/gatsby/src/utils/lmdb.ts
@@ -1,0 +1,15 @@
+import { open } from "lmdb-store"
+
+const myStore = open({
+  path: `my-store`,
+  // any options go here, we can turn on compression like this:
+  // compression: true,
+})
+// await myStore.put("greeting", { someText: "Hello, World!" })
+// myStore.get("greeting").someText // 'Hello, World!'
+// or
+// myStore.transactionAsync(() => {
+// myStore.put("greeting", { someText: "Hello, World!" })
+// myStore.get("greeting").someText // 'Hello, World!'
+// })
+export default myStore

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -9,6 +9,7 @@ import { websocketManager } from "./websocket-manager"
 import { isWebpackStatusPending } from "./webpack-status"
 import { store } from "../redux"
 import { hasFlag, FLAG_DIRTY_NEW_PAGE } from "../redux/reducers/queries"
+import ldmbStore from "../utils/lmdb"
 
 import { IExecutionResult } from "../query/types"
 
@@ -85,7 +86,8 @@ export async function writePageData(
   )
 
   const outputFilePath = getFilePath(publicDir, pagePath)
-  const result = await fs.readJSON(inputFilePath)
+  // const result = await fs.readJSON(inputFilePath)
+  const result = JSON.parse(ldmbStore.get(inputFilePath))
   const body = {
     componentChunkName,
     path: pagePath,
@@ -108,7 +110,8 @@ export async function writePageData(
     },
   })
 
-  await fs.outputFile(outputFilePath, bodyStr)
+  // await fs.outputFile(outputFilePath, bodyStr)
+  await ldmbStore.put(outputFilePath, bodyStr)
   return body
 }
 
@@ -197,7 +200,7 @@ export async function flush(): Promise<void> {
     })
 
     return cb(null, true)
-  }, 25)
+  }, 50)
 
   for (const pagePath of pagesToWrite) {
     flushQueue.push(pagePath, () => {})


### PR DESCRIPTION
Testing/demoing an idea. This won't ever be merged.

For create-pages benchmark, this speeds up considerably the two fs IO heavy operations:

- query-running drops from from 11.5s to 4.2s
- writing page-data.json files drops from 17s to 5s.

Total time (to when just after writing page-data.json files to disk) drops from 43s to 23s.

One caveat to the above. This is measuring a drop in overhead. So the speed up for query running — 7 seconds / 100k queries — which is a big drop for create-pages which doesn nothing other than file IO essentially but would be less significant for comparatively more expensive query running e.g. markdown processing. So the relative drop will vary greatly. But every site should see around ~15-20s drop / 100k pages which is nothing to sneeze at.