### PR TITLE
fix(gatsby-plugin-page-creator): support index routes when using the File System Route API

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -265,6 +265,45 @@ describe(`derive-path`, () => {
     ).toEqual(`foo/dolores/[...name]`)
   })
 
+  it(`supports index paths`, () => {
+    expect(
+      derivePath(
+        `{Page.path}`,
+        {
+          path: `/`,
+        },
+        reporter
+      ).derivedPath
+    ).toEqual(`index`)
+    expect(
+      derivePath(
+        `{Page.path}.js`,
+        {
+          path: `/`,
+        },
+        reporter
+      ).derivedPath
+    ).toEqual(`index.js`)
+    expect(
+      derivePath(
+        `foo/{Page.path}`,
+        {
+          path: `/`,
+        },
+        reporter
+      ).derivedPath
+    ).toEqual(`foo`)
+    expect(
+      derivePath(
+        `foo/{Page.path}/bar`,
+        {
+          path: `/`,
+        },
+        reporter
+      ).derivedPath
+    ).toEqual(`foo/bar`)
+  })
+
   it(`handles special chars`, () => {
     expect(
       derivePath(

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -6,9 +6,11 @@ import {
   extractAllCollectionSegments,
   switchToPeriodDelimiters,
   stripTrailingSlash,
+  removeFileExtension,
 } from "./path-utils"
 
 const doubleForwardSlashes = /\/\/+/g
+const indexRoute = /^\/?$/
 
 // Generates the path for the page from the file path
 // product/{Product.id} => /product/:id, pulls from nodes.id
@@ -63,6 +65,14 @@ export function derivePath(
 
   // 4.  Remove double forward slashes that could occur in the final URL
   modifiedPath = modifiedPath.replace(doubleForwardSlashes, `/`)
+
+  // 5.  Remove trailing slashes that could occur in the final URL
+  modifiedPath = stripTrailingSlash(modifiedPath)
+
+  // 6.  If the final URL appears to be an index path, use the "index" file naming convention
+  if (indexRoute.test(removeFileExtension(modifiedPath))) {
+    modifiedPath = `index${modifiedPath}`
+  }
 
   const derivedPath = modifiedPath
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This PR adds root index URL support to the File System Route API.

Without the changes in this PR, the File System Route API behaves like the following example:

**File name**: `{Model.path}.js`
**Model**: `{ "path": "/" }`
**Resulting path**: `.js`
**Final URL**: `/.js`

With the changes in this PR, the File System Route API behaves like the following example:

**File name**: `{Model.path}.js`
**Model**: `{ "path": "/" }`
**Resulting path**: `index.js`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
