### PR TITLE
Fixes a bug related to filters appended onto next links for gatsby-source-drupal.

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -249,7 +249,17 @@ exports.sourceNodes = async (
             // See https://www.drupal.org/docs/8/modules/jsonapi/filtering
             if (typeof filters === `object`) {
               if (filters.hasOwnProperty(type)) {
-                url = url + `?${filters[type]}`
+                url = new URL(url)
+                const filterParams = new URLSearchParams(filters[type])
+                const filterKeys = Array.from(filterParams.keys())
+                filterKeys.forEach(filterKey => {
+                  // Only add filter params to url if it has not already been
+                  // added.
+                  if (!url.searchParams.has(filterKey)) {
+                    url.searchParams.set(filterKey, filterParams.get(filterKey))
+                  }
+                })
+                url = url.toString()
               }
             }
           }


### PR DESCRIPTION


## Description

This fixes the bug related to filters being appended multiple times in gatsby-source-drupal. I made it so that filters are only added to the url query params if they don't exist already, since jsonapi in Drupal automatically adds them to the url after the first page of results.

## Related Issues

Fixes #31123 
