### PR TITLE
chore(docs): Correct image guide on CSS-in-JS usage

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -110,7 +110,7 @@ export function Dino() {
 }
 ```
 
-You should instead use the `css` prop provided by these libraries:
+If you use Emotion you can use the provided `css` prop:
 
 ```jsx
 // Emotion
@@ -127,22 +127,9 @@ export function Dino() {
 }
 ```
 
-```jsx
-// styled-components
+Unfortunately the [`css` prop from styled-components](https://styled-components.com/docs/api#css-prop) turns the code into a `styled` function under the hood and as explained above `StaticImage` doesn't support that syntax.
 
-export function Dino() {
-  return (
-    <StaticImage
-      src="trex.png"
-      css={`
-        border: 4px green dashed;
-      `}
-    />
-  )
-}
-```
-
-You can also use a regular `style` or `className` prop. Note that in all of these cases the styling is applied to the wrapper, not the image itself. If you need to style the `<img>` tag, you can use `imgStyle` or `imgClassName`.
+You can also use a regular `style` or `className` prop. Note that in all of these cases the styling is applied to the wrapper, not the image itself. If you need to style the `<img>` tag, you can use `imgStyle` or `imgClassName`. The `className` or `imgClassName` prop is helpful if your styling library is giving you a computed class name string instead of the computed styles.
 
 ### `GatsbyImage`
 

--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -110,7 +110,7 @@ export function Dino() {
 }
 ```
 
-If you use Emotion you can use the provided `css` prop:
+If you use Emotion you can use the provided `css` prop instead:
 
 ```jsx
 // Emotion

--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -129,7 +129,7 @@ export function Dino() {
 
 Unfortunately the [`css` prop from styled-components](https://styled-components.com/docs/api#css-prop) turns the code into a `styled` function under the hood and as explained above `StaticImage` doesn't support that syntax.
 
-You can also use a regular `style` or `className` prop. Note that in all of these cases the styling is applied to the wrapper, not the image itself. If you need to style the `<img>` tag, you can use `imgStyle` or `imgClassName`. The `className` or `imgClassName` prop is helpful if your styling library is giving you a computed class name string instead of the computed styles.
+You can also use a regular `style` or `className` prop. Note that in all of these cases the styling is applied to the wrapper, not the image itself. If you need to style the `<img>` tag, you can use `imgStyle` or `imgClassName`. The `className` or `imgClassName` prop is helpful if your styling library is giving you a computed class name string instead of the computed styles (e.g. if you use libraries like [linaria](https://github.com/callstack/linaria)).
 
 ### `GatsbyImage`
 


### PR DESCRIPTION
## Description

Our current documentation is slightly incorrect. It was probably assumed that the `css` prop behaves the same across libraries, however that's not the case.

While Emotion generates a `React.createElement` call (https://emotion.sh/docs/css-prop#get-started), styled-components just calls `styled` function under the hood (https://styled-components.com/docs/api#css-prop) -- and that styled function is not supported.

I've also added a note about the className props in regards to libraries like e.g. linaria

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/30880
