### PR TITLE
feat(gatsby-remark-prismjs): add autolinker plugin 

### DIFF
--- a/packages/gatsby-remark-prismjs/src/__tests__/plugins/prism-autolinker.js
+++ b/packages/gatsby-remark-prismjs/src/__tests__/plugins/prism-autolinker.js
@@ -1,0 +1,11 @@
+const loadPrismAutoLinker = require(`../../plugins/prism-autolinker`)
+
+describe(`prism-autolinker`, () => {
+  test(`should export a function`, () => {
+    expect(typeof loadPrismAutoLinker).toBe(`function`)
+  })
+
+  test(`should not return`, () => {
+    expect(loadPrismAutoLinker()).toBeUndefined()
+  })
+})

--- a/packages/gatsby-remark-prismjs/src/index.js
+++ b/packages/gatsby-remark-prismjs/src/index.js
@@ -5,6 +5,7 @@ const highlightCode = require(`./highlight-code`)
 const addLineNumbers = require(`./add-line-numbers`)
 const commandLine = require(`./command-line`)
 const loadPrismShowInvisibles = require(`./plugins/prism-show-invisibles`)
+const loadPrismAutoLinker = require(`./plugins/prism-autolinker`)
 
 module.exports = (
   { markdownAST },
@@ -15,6 +16,7 @@ module.exports = (
     noInlineHighlight = false,
     showLineNumbers: showLineNumbersGlobal = false,
     showInvisibles = false,
+    autoLinker = false,
     languageExtensions = [],
     prompt = {
       user: `root`,
@@ -95,6 +97,10 @@ module.exports = (
 
     if (showInvisibles) {
       loadPrismShowInvisibles(languageName)
+    }
+
+    if (autoLinker) {
+      loadPrismAutoLinker(languageName)
     }
 
     const useCommandLine =

--- a/packages/gatsby-remark-prismjs/src/plugins/prism-autolinker.js
+++ b/packages/gatsby-remark-prismjs/src/plugins/prism-autolinker.js
@@ -1,0 +1,106 @@
+const Prism = require(`prismjs`);
+
+const env = {
+  grammar: undefined
+};
+
+function loadEnv(language) {
+  env.grammar = Prism.languages[language];
+  if (!env.grammar) return;
+}
+
+module.exports = (language = `html`) => {
+  loadEnv(language);
+
+  // Gatsby Prism Autolinker Plugin
+  //
+  // This file serves as an adapter module
+  // for the original Prism Show Invisibles
+  // implementation. The ported plugin code
+  // is from npm's prismjs@1.21.0.
+  //
+  // @see https://github.com/PrismJS/prism/blob/v1.17.1/plugins/autolinker/prism-autolinker.js
+  //
+  // prism-autolinker.js:start
+  if (
+    (typeof self !== `undefined` && !self.Prism) ||
+    (typeof global !== `undefined` && !global.Prism)
+  ) {
+    return
+  }
+
+  var url = /\b([a-z]{3,7}:\/\/|tel:)[\w\-+%~/.:=&@]+(?:\?[\w\-+%~/.:=?&!$'()*,;@]*)?(?:#[\w\-+%~/.:#=?&!$'()*,;@]*)?/,
+    email = /\b\S+@[\w.]+[a-z]{2}/,
+    linkMd = /\[([^\]]+)]\(([^)]+)\)/,
+
+    // Tokens that may contain URLs and emails
+    candidates = ['comment', 'url', 'attr-value', 'string'];
+
+  Prism.plugins.autolinker = {
+    processGrammar: function (grammar) {
+      // Abort if grammar has already been processed
+      if (!grammar || grammar['url-link']) {
+        return;
+      }
+
+      Prism.languages.DFS(grammar, function (key, def, type) {
+        if (candidates.indexOf(type) > -1 && !Array.isArray(def)) {
+          if (!def.pattern) {
+            def = this[key] = {
+              pattern: def
+            };
+          }
+
+          def.inside = def.inside || {};
+
+          if (type == 'comment') {
+            def.inside['md-link'] = linkMd;
+          }
+          if (type == 'attr-value') {
+            Prism.languages.insertBefore('inside', 'punctuation', { 'url-link': url }, def);
+          }
+          else {
+            def.inside['url-link'] = url;
+          }
+
+          def.inside['email-link'] = email;
+        }
+      });
+      grammar['url-link'] = url;
+      grammar['email-link'] = email;
+    }
+  };
+
+  Prism.hooks.add('before-highlight', function(env) {
+    Prism.plugins.autolinker.processGrammar(env.grammar);
+  });
+
+  Prism.hooks.add('wrap', function(env) {
+    if (/-link$/.test(env.type)) {
+      env.tag = 'a';
+
+      var href = env.content;
+
+      if (env.type == 'email-link' && href.indexOf('mailto:') != 0) {
+        href = 'mailto:' + href;
+      }
+      else if (env.type == 'md-link') {
+        // Markdown
+        var match = env.content.match(linkMd);
+
+        href = match[2];
+        env.content = match[1];
+      }
+
+      env.attributes.href = href;
+
+      // Silently catch any error thrown by decodeURIComponent (#1186)
+      try {
+        env.content = decodeURIComponent(env.content);
+      } catch(e) {}
+    }
+  });
+  // prism-autolinker.js:end
+
+  Prism.plugins.autolinker.processGrammar(env.grammar);
+}

--- a/packages/gatsby-remark-prismjs/src/plugins/prism-autolinker.js
+++ b/packages/gatsby-remark-prismjs/src/plugins/prism-autolinker.js
@@ -15,7 +15,7 @@ module.exports = (language = `html`) => {
   // Gatsby Prism Autolinker Plugin
   //
   // This file serves as an adapter module
-  // for the original Prism Show Invisibles
+  // for the original Prism Autolinker
   // implementation. The ported plugin code
   // is from npm's prismjs@1.21.0.
   //


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
[Prism Autolinker plugin](https://prismjs.com/plugins/autolinker/) for **gatsby-remark-prismjs**.


<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
Documentation must be added.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

