### PR TITLE
fix(gatsby-plugin-page-creator): async createPage

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-page-wrapper.ts
@@ -20,7 +20,7 @@ function pathIsClientOnlyRoute(path: string): boolean {
   return path.includes(`[`)
 }
 
-export function createPage(
+export async function createPage(
   filePath: string,
   pagesDirectory: string,
   actions: Actions,
@@ -28,7 +28,7 @@ export function createPage(
   reporter: Reporter,
   ignore?: IPathIgnoreOptions | string | Array<string> | null,
   slugifyOptions?: ISlugifyOptions
-): void {
+): Promise<void> {
   // Filter out special components that shouldn't be made into
   // pages.
   if (!validatePath(filePath)) {
@@ -45,7 +45,7 @@ export function createPage(
   // If the page includes a `{}` in it, then we create it as a collection builder
   if (pathIsCollectionBuilder(absolutePath)) {
     trackFeatureIsUsed(`UnifiedRoutes:collection-page-builder`)
-    createPagesFromCollectionBuilder(
+    await createPagesFromCollectionBuilder(
       filePath,
       absolutePath,
       actions,

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -90,17 +90,19 @@ Please pick a path to an existing directory.`,
 
     // Get initial list of files.
     const files = await glob(pagesGlob, { cwd: pagesPath })
-    files.forEach(file => {
-      createPage(
-        file,
-        pagesDirectory,
-        actions,
-        graphql,
-        reporter,
-        ignore,
-        slugifyOptions
+    await Promise.allSettled(
+      files.map(file =>
+        createPage(
+          file,
+          pagesDirectory,
+          actions,
+          graphql,
+          reporter,
+          ignore,
+          slugifyOptions
+        )
       )
-    })
+    )
 
     const knownFiles = new Set(files)
 


### PR DESCRIPTION
## Description

I have realized that `gatsby-plugin-page-creator` does not wait for `createPage` function to complete.
As you can imagine, graphql queries results can also be fetched (i.e. by `gatsby-source-graphql`), but due to non-synchronous behavior, the pages are created too late (after `createPagesStatefully`).

For better context, please check out related link 

PS: Changes perhaps require some error handling

## Related Issues

Link to the discussion that describes the problem
https://github.com/gatsbyjs/gatsby/discussions/31357