### PR TITLE
fix(gatsby): Edge case in shadowing

### DIFF
--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/e2e.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/e2e.js
@@ -55,6 +55,43 @@ test.each([
     `./src/theme-a/components.js`,
   ],
   [
+    // This means one has wants to shadow package-a/src/theme.js
+    // With src/package-a/theme/index.js
+    // Instead of shadowing with src/package-a/theme.js
+    `shadows a single .js file with the folder-index pattern`,
+    {
+      mode: `development`,
+      entry: `./index.js`,
+      resolve: {
+        plugins: [
+          new ShadowRealm({
+            extensions: [`.wasm`, `.mjs`, `.js`, `.json`],
+            themes: [
+              {
+                themeName: `theme-a`,
+                themeDir: path.join(
+                  __dirname,
+                  `./fixtures/test-sites/folder-index-shadowing/node_modules/theme-a`
+                ),
+              },
+            ],
+            projectRoot: path.resolve(
+              __dirname,
+              `fixtures/test-sites/folder-index-shadowing`
+            ),
+          }),
+        ],
+      },
+    },
+    {
+      context: path.resolve(
+        __dirname,
+        `fixtures/test-sites/folder-index-shadowing`
+      ),
+    },
+    `./src/theme-a/theme/index.js`,
+  ],
+  [
     `shadows a single .css file`,
     {
       mode: `development`,

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/fixtures/test-sites/.gitignore
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/fixtures/test-sites/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/fixtures/test-sites/folder-index-shadowing/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/fixtures/test-sites/folder-index-shadowing/index.js
@@ -1,0 +1,1 @@
+const theme = require(`theme-a/src/theme`)

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/fixtures/test-sites/folder-index-shadowing/node_modules/theme-a/src/theme.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/fixtures/test-sites/folder-index-shadowing/node_modules/theme-a/src/theme.js
@@ -1,0 +1,1 @@
+module.exports = "theme.js from theme-a";

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/fixtures/test-sites/folder-index-shadowing/src/theme-a/theme/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/fixtures/test-sites/folder-index-shadowing/src/theme-a/theme/index.js
@@ -1,0 +1,1 @@
+module.exports = `theme from 'site'`

--- a/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/index.js
+++ b/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/__tests__/index.js
@@ -1,5 +1,5 @@
-import path from "path"
-import ShadowingPlugin from "../"
+const path = require(`path`)
+const ShadowingPlugin = require(`../`)
 
 // allow writing paths like path/to/thing, even on windows
 const xplatPath = uri => uri.split(`/`).join(path.sep)
@@ -13,6 +13,15 @@ describe(`Component Shadowing`, () => {
         themeName: `a-theme`,
       },
       `/components/a-component`,
+    ],
+    [
+      // simple request path to a theme's component with folder index pattern
+      `/some/place/a-theme/src/components/a-component/index.js`,
+      {
+        themeDir: `/some/place/a-theme`,
+        themeName: `a-theme`,
+      },
+      `/components/a-component/index.js`,
     ],
     [
       // request to a shadowed component in theme b


### PR DESCRIPTION
## Description

Follow-up to https://github.com/gatsbyjs/gatsby/pull/30435

Before this PR this worked:

package-a/src/theme.js => shadowed by src/package-a/theme/index.js

After this PR this doesn't work anymore and has to do:

shadowed by src/package-a/theme.js
