### PR TITLE
feat(gatsby): enable concurrent features

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -31,9 +31,12 @@ module.hot.accept([
 
 window.___emitter = emitter
 
-if (process.env.GATSBY_CONCURRENT_FEATURES && !ReactDOM.unstable_createRoot) {
+if (
+  process.env.GATSBY_EXPERIMENTAL_CONCURRENT_FEATURES &&
+  !ReactDOM.unstable_createRoot
+) {
   throw new Error(
-    `The GATSBY_CONCURRENT_FEATURES flag is not compatible with your React version. Please install "react@0.0.0-experimental-57768ef90" and "react-dom@0.0.0-experimental-57768ef90" or higher.`
+    `The GATSBY_EXPERIMENTAL_CONCURRENT_FEATURES flag is not compatible with your React version. Please install "react@0.0.0-experimental-57768ef90" and "react-dom@0.0.0-experimental-57768ef90" or higher.`
   )
 }
 
@@ -139,7 +142,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   let defaultRenderer = ReactDOM.render
   if (focusEl && focusEl.children.length) {
     if (
-      process.env.GATSBY_CONCURRENT_FEATURES &&
+      process.env.GATSBY_EXPERIMENTAL_CONCURRENT_FEATURES &&
       ReactDOM.unstable_createRoot
     ) {
       defaultRenderer = ReactDOM.unstable_createRoot

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -193,7 +193,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
     const renderer = apiRunner(
       `replaceHydrateFunction`,
       undefined,
-      process.env.GATSBY_CONCURRENT_FEATURES
+      process.env.GATSBY_EXPERIMENTAL_CONCURRENT_FEATURES
         ? ReactDOM.unstable_createRoot
         : ReactDOM.hydrate
     )[0]

--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -175,24 +175,42 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       }
     ).pop()
 
-    const App = () => <GatsbyRoot>{SiteRoot}</GatsbyRoot>
+    const App = function App() {
+      const onClientEntryRanRef = React.useRef(false)
+
+      React.useEffect(() => {
+        if (!onClientEntryRanRef.current) {
+          onClientEntryRanRef.current = true
+          performance.mark(`onInitialClientRender`)
+
+          apiRunner(`onInitialClientRender`)
+        }
+      }, [])
+
+      return <GatsbyRoot>{SiteRoot}</GatsbyRoot>
+    }
 
     const renderer = apiRunner(
       `replaceHydrateFunction`,
       undefined,
-      ReactDOM.hydrate
+      process.env.GATSBY_CONCURRENT_FEATURES
+        ? ReactDOM.unstable_createRoot
+        : ReactDOM.hydrate
     )[0]
 
     domReady(() => {
-      renderer(
-        <App />,
+      const container =
         typeof window !== `undefined`
           ? document.getElementById(`___gatsby`)
-          : void 0,
-        () => {
-          apiRunner(`onInitialClientRender`)
-        }
-      )
+          : null
+
+      if (renderer === ReactDOM.unstable_createRoot) {
+        renderer(container, {
+          hydrate: true,
+        }).render(<App />)
+      } else {
+        renderer(<App />, container)
+      }
     })
   })
 })

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -178,7 +178,7 @@ const activeFlags: Array<IFlag> = [
   },
   {
     name: `CONCURRENT_FEATURES`,
-    env: `GATSBY_CONCURRENT_FEATURES`,
+    env: `GATSBY_EXPERIMENTAL_CONCURRENT_FEATURES`,
     command: `all`,
     telemetryId: `ConcurrentFeatures`,
     experimental: true,

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -184,7 +184,21 @@ const activeFlags: Array<IFlag> = [
     experimental: true,
     description: `Enable React's concurrent features`,
     // umbrellaIssue: `https://gatsby.dev/concurrent-features`,
-    testFitness: (): fitnessEnum => true,
+    testFitness: (): fitnessEnum => {
+      // Because of this, this flag will never show up
+      const semverConstraints = {
+        react: `^0.0.0-experimental-57768ef90`,
+        "react-dom": `^0.0.0-experimental-57768ef90`,
+      }
+
+      if (satisfiesSemvers(semverConstraints)) {
+        return true
+      } else {
+        // react & react-dom is either not installed or not new enough so
+        // just disable — it won't work anyways.
+        return false
+      }
+    },
   },
 ]
 

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -176,6 +176,16 @@ const activeFlags: Array<IFlag> = [
     umbrellaIssue: `https://gatsby.dev/functions-feedback`,
     testFitness: (): fitnessEnum => true,
   },
+  {
+    name: `CONCURRENT_FEATURES`,
+    env: `GATSBY_CONCURRENT_FEATURES`,
+    command: `all`,
+    telemetryId: `ConcurrentFeatures`,
+    experimental: true,
+    description: `Enable React's concurrent features`,
+    umbrellaIssue: `https://gatsby.dev/concurrent-features`,
+    testFitness: (): fitnessEnum => true,
+  },
 ]
 
 export default activeFlags

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -183,7 +183,7 @@ const activeFlags: Array<IFlag> = [
     telemetryId: `ConcurrentFeatures`,
     experimental: true,
     description: `Enable React's concurrent features`,
-    umbrellaIssue: `https://gatsby.dev/concurrent-features`,
+    // umbrellaIssue: `https://gatsby.dev/concurrent-features`,
     testFitness: (): fitnessEnum => true,
   },
 ]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
React is moving forward with concurrent mode. It's going to rebrand it to React concurrent features. We'll be adding early support for it.

Swapping `ReactDOM.render` to `ReactDOM.unstable_createRoot`. It should be 99% equal to regular hydrate but some behavior changes might occur.

There is no hydration callback anymore so I swapped it to `onMount`.
