### PR TITLE
fix(gatsby-plugin-mdx): fix gatsby develop on windows

### DIFF
--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -113,10 +113,9 @@ module.exports = async function mdxLoader(content) {
   if (isolateMDXComponent && !resourceQuery.includes(`type=component`)) {
     const { data } = grayMatter(content)
 
-    const requestPath = `/${path.relative(
-      this.rootContext,
-      this.resourcePath
-    )}?type=component`
+    const requestPath = slash(
+      `/${path.relative(this.rootContext, this.resourcePath)}?type=component`
+    )
 
     return callback(
       null,


### PR DESCRIPTION
## Description

Current code doesn't work as expected on windows as `requestPath` result in in values like `/src\\pages\\test.mdx` and apparently webpack looses backslashes along the way (?)

In any case, good old `slash` to use slashes instead fixes the issue

## Related Issues

fixes #31392