### PR TITLE
feat(docs): Add more links to examples

### DIFF
--- a/docs/docs/how-to/adding-common-features/adding-forms.md
+++ b/docs/docs/how-to/adding-common-features/adding-forms.md
@@ -1,5 +1,8 @@
 ---
 title: Adding Forms
+examples:
+  - label: Form that submits to a Function
+    href: "https://github.com/gatsbyjs/gatsby-functions-beta/tree/main/examples/basic-form"
 ---
 
 Gatsby is built on top of React. So anything that is possible with a React form is possible in Gatsby. Additional details about how to create React forms can be found in the [React forms documentation](https://reactjs.org/docs/forms.html) (which happens to be built with Gatsby!)
@@ -175,6 +178,6 @@ export default class IndexPage extends React.Component {
 }
 ```
 
-This form isn't doing anything besides showing the user information that they just entered. At this point, you may want to move this form to a component, send the form state to a backend server, or add robust validation. You can also use fantastic React form libraries like [Formik](https://github.com/jaredpalmer/formik) or [Final Form](https://github.com/final-form/react-final-form) to speed up your development process.
+This form isn't doing anything besides showing the user information that they just entered. At this point, you may want to move this form to a component, send the form state to a Function (see the [form example](https://github.com/gatsbyjs/gatsby-functions-beta/tree/main/examples/basic-form)), or add robust validation. You can also use fantastic React form libraries like [Formik](https://github.com/jaredpalmer/formik) or [Final Form](https://github.com/final-form/react-final-form) to speed up your development process.
 
 All of this is possible and more by leveraging the power of Gatsby and the React ecosystem!

--- a/docs/docs/how-to/functions/getting-started.md
+++ b/docs/docs/how-to/functions/getting-started.md
@@ -9,6 +9,8 @@ examples:
     href: "https://github.com/gatsbyjs/gatsby-functions-beta/tree/main/examples/airtable-form"
   - label: Send email with SendGrid
     href: "https://github.com/gatsbyjs/gatsby-functions-beta/tree/main/examples/sendgrid-email"
+  - label: Basic form that submits to a Function
+    href: "https://github.com/gatsbyjs/gatsby-functions-beta/tree/main/examples/basic-form"
 ---
 
 Gatsby Functions help you build [Express-like](https://expressjs.com/) backends without running servers.
@@ -118,3 +120,7 @@ export default async function postNewPersonHandler(req, res) {
   }
 }
 ```
+
+## Forms
+
+Forms and Functions are often used together. See the [basic form example](https://github.com/gatsbyjs/gatsby-functions-beta/tree/main/examples/basic-form) as well as the [Forms doc page](/docs/how-to/adding-common-features/adding-forms/) which walks you through building a custom form.

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -1,5 +1,8 @@
 ---
 title: Using the Gatsby Image plugin
+examples:
+  - label: Using Gatsby Image
+    href: "https://github.com/gatsbyjs/gatsby/tree/master/examples/using-gatsby-image"
 ---
 
 _If you're looking for a guide on using the deprecated `gatsby-image` package, it can be found in the [How to use Gatsby Image](/docs/how-to/images-and-media/using-gatsby-image) doc._

--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -1,5 +1,8 @@
 ---
 title: Gatsby Image plugin
+examples:
+  - label: Using Gatsby Image
+    href: "https://github.com/gatsbyjs/gatsby/tree/master/examples/using-gatsby-image"
 ---
 
 This guide will show you how to configure your images, including choosing layouts, placeholders and image processing options. While most of these options are available regardless of where you source your images, be sure to refer to the documentation of your source plugin if you are using images from a CMS, as the exact options are likely to vary.


### PR DESCRIPTION
Start the sprinkling of examples around the docs

<img width="1090" alt="Screen Shot 2021-05-12 at 3 28 52 PM" src="https://user-images.githubusercontent.com/71047/118052161-1b729780-b337-11eb-9740-a6e4f7a8c49e.png">
<img width="1051" alt="Screen Shot 2021-05-12 at 3 28 43 PM" src="https://user-images.githubusercontent.com/71047/118052166-1dd4f180-b337-11eb-9b71-f9df3f363d63.png">
