### PR TITLE
feat(gatsby): Only load gatsby-recipes in develop if Admin is enabled

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -203,8 +203,11 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
         `develop`,
         (args: yargs.Arguments, cmd: (args: yargs.Arguments) => unknown) => {
           process.env.NODE_ENV = process.env.NODE_ENV || `development`
-          const { startGraphQLServer } = require(`gatsby-recipes`)
-          startGraphQLServer(siteInfo.directory, true)
+
+          if (process.env.GATSBY_EXPERIMENTAL_ENABLE_ADMIN) {
+            const { startGraphQLServer } = require(`gatsby-recipes`)
+            startGraphQLServer(siteInfo.directory, true)
+          }
 
           if (args.hasOwnProperty(`inspect`)) {
             args.inspect = args.inspect || 9229


### PR DESCRIPTION
Follow-up to https://github.com/gatsbyjs/gatsby/pull/31134

I realized that gatsby-recipes is only used in develop by Admin so put loading recipes behind a flag. A follow-up could be making starting the recipes server conditional upon visiting Admin — e.g. put accessing the API behind a proxy which starts the API when it gets a request.