### PR TITLE
chore(docs): Fix missing closing ```

### DIFF
--- a/docs/docs/tutorial/part-2/index.mdx
+++ b/docs/docs/tutorial/part-2/index.mdx
@@ -615,6 +615,7 @@ Follow the steps below to style your `Layout` component using CSS Modules.
   max-width: 500px;
   font-family: sans-serif;
 }
+```
 
 3. Then import that class into your `Layout` component `.js` file, and use the `className` prop to assign it to the `<main>` element:
 


### PR DESCRIPTION
Just noticed the following issue in tutorial part 2.

![image](https://user-images.githubusercontent.com/5466341/118061778-9e114c00-b363-11eb-86ce-1ff2dfa523f7.png)

This is just to put the missing closing ``` in place.

