### PR TITLE
fix(gatsby-source-wordpress): Remove search and replace regex literal recommendation

### DIFF
--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -804,7 +804,7 @@ An array of options to search and replace strings in nodes. See below for option
 
 ### searchAndReplace[].search
 
-The regex rule used to search a terme.
+The regex rule used to search when replacing strings in node data. It will search the stringified JSON of each node to capture strings at any nested depth.
 
 **Field type**: `String`
 

--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -804,7 +804,7 @@ An array of options to search and replace strings in nodes. See below for option
 
 ### searchAndReplace[].search
 
-The regex rule used to search a string. Using a 'regular expression literal' is recommended over a simple regex string.
+The regex rule used to search a terme.
 
 **Field type**: `String`
 

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
@@ -538,9 +538,7 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
       .items(
         Joi.object({
           search: Joi.string()
-            .description(
-              `The regex rule used to search a terme. Using a 'regular expression literal' is recommended over a simple regex string.`
-            )
+            .description(`The regex rule used to search a terme.`)
             .meta({
               example: wrapOptions(`
                 searchAndReplace: [

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
@@ -538,7 +538,7 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
       .items(
         Joi.object({
           search: Joi.string()
-            .description(`The regex rule used to search a terme.`)
+            .description(`The regex rule used to search when replacing strings in node data. It will search the stringified JSON of each node to capture strings at any nested depth.`)
             .meta({
               example: wrapOptions(`
                 searchAndReplace: [

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
@@ -538,7 +538,9 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
       .items(
         Joi.object({
           search: Joi.string()
-            .description(`The regex rule used to search when replacing strings in node data. It will search the stringified JSON of each node to capture strings at any nested depth.`)
+            .description(
+              `The regex rule used to search when replacing strings in node data. It will search the stringified JSON of each node to capture strings at any nested depth.`
+            )
             .meta({
               example: wrapOptions(`
                 searchAndReplace: [


### PR DESCRIPTION
~~A regular expression literal generate a RegExp object at compile time. We need to allow string or object in the option schema.~~

EDIT: I decided to remove the documentation entry recommending a Regex literal, instead of the above solution.

Improvements can be made in the future.

cc @TylerBarnes

## Related Issues

Fix #31411
Related to #31091