### PR TITLE
fix(gatsby-source-drupal): Filenames imported from Drupal via jsonapi are saved URL encoded

### DIFF
--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -1,5 +1,6 @@
 const { URL } = require(`url`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
+const path = require(`path`)
 
 const nodeFromData = (datum, createNodeId, entityReferenceRevisions = []) => {
   const { attributes: { id: attributeId, ...attributes } = {} } = datum
@@ -83,6 +84,7 @@ exports.downloadFile = async (
         : {}
     const fileNode = await createRemoteFileNode({
       url: url.href,
+      name: path.parse(decodeURIComponent(url.pathname)).name,
       store,
       cache,
       createNode,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This fixes the issue that the filename of a Drupal file is based on the `node.uri.url` property returned by jsonapi. Because jsonapi URL encodes this parameter a file named `filename with spaces.pdf` is saved as `filename%20with%20spaces.pdf`.

The fix passes the `name` parameter to the `createRemoteFileNode` call, passing it through `decodeURIComponent` so it is saved as `filename with spaces.pdf`.

Note that my first idea was to use the `node.filename` property returned by jsonapi. The problem however is that this is not necessarily the filename on the filesystem. When a file is created in Drupal with the same name as an existing file Drupal will append an incremented number to the filename stored in the filesystem, but it will leave the filename property of the entity alone.

### Important note:

Using an existing instance it is recommended to do a `gatsby clean` before building the project again. Otherwise, files that were saved earlier using an URL encoded filename, will error out at build time because the filename has changed.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #31393