### PR TITLE
fix(gatsby-cli): Switch host env to GATSBY_ prefix

### DIFF
--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -78,12 +78,12 @@ development server.
 
 #### Options
 
-|     Option      | Description                                     |          Default          |
-| :-------------: | ----------------------------------------------- | :-----------------------: |
-| `-H`, `--host`  | Set host.                                       | `env.HOST` or `localhost` |
-| `-p`, `--port`  | Set port.                                       |   `env.PORT` or `8000`    |
-| `-o`, `--open`  | Open the site in your (default) browser for you |                           |
-| `-S`, `--https` | Use HTTPS                                       |                           |
+|     Option      | Description                                     |             Default              |
+| :-------------: | ----------------------------------------------- | :------------------------------: |
+| `-H`, `--host`  | Set host.                                       | `env.GATSBY_HOST` or `localhost` |
+| `-p`, `--port`  | Set port.                                       |       `env.PORT` or `8000`       |
+| `-o`, `--open`  | Open the site in your (default) browser for you |                                  |
+| `-S`, `--https` | Use HTTPS                                       |                                  |
 
 Follow the [Local HTTPS guide](https://www.gatsbyjs.org/docs/local-https/)
 to find out how you can set up an HTTPS development server using Gatsby.

--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -141,9 +141,9 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
       _.option(`H`, {
         alias: `host`,
         type: `string`,
-        default: process.env.HOST || defaultHost,
-        describe: process.env.HOST
-          ? `Set host. Defaults to ${process.env.HOST} (set by env.HOST) (otherwise defaults ${defaultHost})`
+        default: process.env.GATSBY_HOST || defaultHost,
+        describe: process.env.GATSBY_HOST
+          ? `Set host. Defaults to ${process.env.GATSBY_HOST} (set by env.GATSBY_HOST) (otherwise defaults ${defaultHost})`
           : `Set host. Defaults to ${defaultHost}`,
       })
         .option(`p`, {


### PR DESCRIPTION
Hello Gatsbytes! 
The recent PR #26712 that I merged added support for using `HOST` to set the host to listen for develop. Unfortunately, the `HOST` var is often populated by default, and in those cases the develop server doesn't listen on localhost, but just on the value of the var. This PR switches it to use an env var that is Gatsby-specific, so that it doesn't happen by mistake.