### PR TITLE
docs(tutorial): add a link to "Starter for creating a Gatsby Theme workspace using Yalc"

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/building-themes.md
+++ b/docs/docs/how-to/plugins-and-themes/building-themes.md
@@ -113,3 +113,4 @@ Check out how some existing themes are built:
 - The official [Gatsby Blog Theme](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-blog)
 - The official [Gatsby Notes Theme](https://github.com/gatsbyjs/themes/tree/master/packages/gatsby-theme-notes)
 - The [Apollo themes](https://github.com/apollographql/gatsby-theme-apollo/tree/master/packages/). (_You might also be interested in the [Apollo case study on themes](/blog/2019-07-03-using-themes-for-distributed-docs/) on the blog._)
+- [Starter for creating a Gatsby Theme workspace using Yalc](https://github.com/DanailMinchev/gatsby-starter-theme-yalc-workspace). (_If you prefer to use [Yalc](https://github.com/wclr/yalc) for local theme development._)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add a link to [Starter for creating a Gatsby Theme workspace using Yalc](https://github.com/DanailMinchev/gatsby-starter-theme-yalc-workspace) as a Yarn alternative to local theme development.

### Documentation

This PR adds [Starter for creating a Gatsby Theme workspace using Yalc](https://github.com/DanailMinchev/gatsby-starter-theme-yalc-workspace) link to https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/building-themes/ page.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
