### PR TITLE
fix(gatsby-plugin-sitemap): Remove reporter.verbose calls

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -21,14 +21,6 @@ exports.onPostBuild = async (
 ) => {
   const { data: queryRecords } = await graphql(query)
 
-  reporter.verbose(
-    `${REPORTER_PREFIX} Query Results:\n${JSON.stringify(
-      queryRecords,
-      null,
-      2
-    )}`
-  )
-
   // resolvePages and resolveSuteUrl are allowed to be sync or async. The Promise.resolve handles each possibility
   const allPages = await Promise.resolve(
     resolvePages(queryRecords)


### PR DESCRIPTION
## Description

Gatsby Cloud is using the `verbose` mode and on a large site (even with 500 pages) logging everything makes the "Raw logs" unusable