### PR TITLE
chore(docs): Fixing JSON in configuration options

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -305,9 +305,9 @@ module.exports = {
           jpgOptions: {},
           pngOptions: {},
           webpOptions: {},
-          avifOptions: {}
-        }
-      }
+          avifOptions: {},
+        },
+      },
     },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-image`,

--- a/docs/docs/reference/built-in-components/gatsby-plugin-image.md
+++ b/docs/docs/reference/built-in-components/gatsby-plugin-image.md
@@ -296,15 +296,15 @@ module.exports = {
       options: {
         defaults: {
           formats: [`auto`, `webp`],
-          placeholder: `dominantColor`
-          quality: 50
-          breakpoints: [750, 1080, 1366, 1920]
-          backgroundColor: `transparent`
-          tracedSVGOptions: {}
-          blurredOptions: {}
-          jpgOptions: {}
-          pngOptions: {}
-          webpOptions: {}
+          placeholder: `dominantColor`,
+          quality: 50,
+          breakpoints: [750, 1080, 1366, 1920],
+          backgroundColor: `transparent`,
+          tracedSVGOptions: {},
+          blurredOptions: {},
+          jpgOptions: {},
+          pngOptions: {},
+          webpOptions: {},
           avifOptions: {}
         }
       }


### PR DESCRIPTION
The config options JSON was missing some commas

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
