### PR TITLE
fix(gatsby-source-contentful): fix progress bar

### DIFF
--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -79,6 +79,7 @@ module.exports = async function contentfulFetch({
 }) {
   // Fetch articles.
   let syncProgress
+  let syncItemCount = 0
   const pageLimit = pluginConfig.get(`pageLimit`)
   const contentfulClientOptions = {
     space: pluginConfig.get(`spaceId`),
@@ -110,6 +111,8 @@ module.exports = async function contentfulFetch({
         !response.isAxiosError &&
         response?.data.items
       ) {
+        syncItemCount += response.data.items.length
+        syncProgress.total = syncItemCount
         syncProgress.tick(response.data.items.length)
       }
 


### PR DESCRIPTION
## Description

For some reason the progress bar is messed up for me with the latest Contentful plugin (on Windows/cmder):

https://user-images.githubusercontent.com/115628/118710341-59485200-b848-11eb-9538-4d74c62394ba.mp4

So what's happening is that we don't update the total count and so current progress is always greater than the total count which messes CLI rendering of the progress.

With this PR it seems to be working correctly:

https://user-images.githubusercontent.com/115628/118710512-97de0c80-b848-11eb-9605-e18a8664fa70.mp4

Code from this PR was originally in the plugin. But it was removed in #30257. Not sure if it was intentional or not @axe312ger ? If not, then we should restore it back I guess.
