### PR TITLE
feat(gatsby): Speedup building Functions by disabling minification

### DIFF
--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -232,6 +232,11 @@ const createWebpackConfig = async ({
     },
     target: `node`,
 
+    // Minification is expensive and not as helpful for serverless functions.
+    optimization: {
+      minimize: false,
+    },
+
     mode: isProductionEnv ? `production` : `development`,
     // watch: !isProductionEnv,
     module: {


### PR DESCRIPTION
This speeds up building Functions in the functions integration test from 2.3s to 0.65s.

Minification is much more useful for preparing JS for browsers vs. serverless functions as many browsers are running on slow devices on slow networks so we want to make JS bundles as small as possible.

Serverless functions, on the other hand, are loaded by servers over very fast networks so the extra CPU/memory costs to minify isn't worth it.