### PR TITLE
fix(gatsby): better detection of Babel rules for HMR when customizing the Webpack config

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -827,7 +827,7 @@ module.exports = async (
         ? rule.use.map(useEntry =>
             typeof useEntry === `string` ? useEntry : useEntry.loader
           )
-        : [rule.use.loader ?? rule.loader]
+        : [rule.use?.loader ?? rule.loader]
 
       const hasBabelLoader = ruleLoaders.some(
         loader => loader === babelLoaderLoc

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -823,10 +823,15 @@ module.exports = async (
         continue
       }
 
-      const hasBabelLoader = (Array.isArray(rule.use)
-        ? rule.use
-        : [rule.use ?? { loader: rule.loader }]
-      ).some(loaderConfig => loaderConfig.loader === babelLoaderLoc)
+      const ruleLoaders = Array.isArray(rule.use)
+        ? rule.use.map(useEntry =>
+            typeof useEntry === `string` ? useEntry : useEntry.loader
+          )
+        : [rule.use.loader ?? rule.loader]
+
+      const hasBabelLoader = ruleLoaders.some(
+        loader => loader === babelLoaderLoc
+      )
 
       if (hasBabelLoader) {
         fastRefreshIncludes.push(rule.test)

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -819,13 +819,13 @@ module.exports = async (
     const fastRefreshIncludes = []
     const babelLoaderLoc = require.resolve(`./babel-loader`)
     for (const rule of getConfig().module.rules) {
-      if (!rule.use) {
+      if (!rule.use && !rule.loader) {
         continue
       }
 
       const hasBabelLoader = (Array.isArray(rule.use)
         ? rule.use
-        : [rule.use]
+        : [rule.use ?? { loader: rule.loader }]
       ).some(loaderConfig => loaderConfig.loader === babelLoaderLoc)
 
       if (hasBabelLoader) {


### PR DESCRIPTION
## Description

I've spent a couple of hours trying to figure out why React Fast Refresh was not working in our Gatsby applications. The console output was correct when files were modified, but changes didn't appear for React components, just for e.g. SCSS files. 

```
[HMR] bundle rebuilding
client.js:250 [HMR] bundle rebuilt in 4637ms
process-update.js:51 [HMR] Checking for updates on the server...
process-update.js:125 [HMR] Updated modules:
process-update.js:127 [HMR]  - ../../../libs/gatsby-theme-myci/src/pages/index.js
process-update.js:132 [HMR] App is up to date.
```

The reason was that we were overriding the default JSX rule by a custom one. However, we were using a shorthand loader syntax that [Webpack supports](https://webpack.js.org/configuration/module/#ruleloader) in addition to specifying `use` as an array (not sure about objects, not documented).

Our previous configuration, Fast Refresh not working:

```js
const config = getConfig();

config.module.rules = [
  ...config.module.rules.map(rule =>
    includes('jsx', String(rule.test))
      ? {
          ...loaders.js(),
          test: /\.(js|mjs|jsx|ts|tsx)$/,
          options: {
            ...loaders.js().options,
            rootMode: 'upward',
          },
          type: 'javascript/auto',
          resolve: {
            fullySpecified: false,
          },
          exclude: modulePath =>
            excludedModulesRegExp.test(modulePath) && !/\@(?:ci|cbs|myci)/.test(modulePath),
        }
      : rule
  ),
];

actions.replaceWebpackConfig(config);
```

Fixed configuration, Fast Refresh working like a charm:

```js
const config = getConfig();

config.module.rules = [
  ...config.module.rules.map(rule =>
    includes('jsx', String(rule.test))
      ? {
          test: /\.(js|mjs|jsx|ts|tsx)$/,
          use: [
            {
              ...loaders.js(),
              options: {
                ...loaders.js().options,
                rootMode: 'upward',
              },
            },
          ],
          type: 'javascript/auto',
          resolve: {
            fullySpecified: false,
          },
          exclude: modulePath =>
            excludedModulesRegExp.test(modulePath) && !/\@(?:ci|cbs|myci)/.test(modulePath),
        }
      : rule
  ),
];

actions.replaceWebpackConfig(config);
```

This PR contains changes so it's possible to use all approaches that Webpack supports (except for specifying `rule.use` as a function). I've tested the changes locally by modifying `node_modules/gatsby` and using the first configuration -- Fast Refresh started working.

Technically, the issue has a workaround, but it's really difficult to track down. Might as well save someone future headaches.

### Documentation

Probably irrelevant, since this is a fix related to a custom Webpack config override.

## Related Issues

None that I could find.