### PR TITLE
fix(tests): update cheerio snapshots (#31298)

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.js.snap
@@ -14,8 +14,6 @@ export default (() => {
 exports[`babel-plugin-remove-graphql-queries Allow alternative import of useStaticQuery 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -26,6 +24,10 @@ var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\
 var React = _interopRequireWildcard(require(\\"react\\"));
 
 var Gatsby = _interopRequireWildcard(require(\\"gatsby\\"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => {
   const query = \\"426988268\\";
@@ -54,8 +56,6 @@ const fragment = \\"4176178832\\";"
 exports[`babel-plugin-remove-graphql-queries Doesn't add data import for non static queries 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -66,6 +66,10 @@ var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\
 var React = _interopRequireWildcard(require(\\"react\\"));
 
 var _gatsby = require(\\"gatsby\\");
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 const Test = () => /*#__PURE__*/React.createElement(_gatsby.StaticQuery, {
   query: \\"426988268\\",
@@ -91,8 +95,6 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
 exports[`babel-plugin-remove-graphql-queries Handles closing StaticQuery tag 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -103,6 +105,10 @@ var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\
 var React = _interopRequireWildcard(require(\\"react\\"));
 
 var _gatsby = require(\\"gatsby\\");
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => /*#__PURE__*/React.createElement(_gatsby.StaticQuery, {
   query: \\"426988268\\",
@@ -126,14 +132,16 @@ export const query = graphql\`
 exports[`babel-plugin-remove-graphql-queries Leaves other graphql tags alone 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 exports.__esModule = true;
 exports.query = exports.default = void 0;
 
 var React = _interopRequireWildcard(require(\\"react\\"));
 
 var _relay = require(\\"relay\\");
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => /*#__PURE__*/React.createElement(\\"div\\", null, data.site.siteMetadata.title);
 
@@ -158,12 +166,14 @@ export default (() => {
 exports[`babel-plugin-remove-graphql-queries Only runs transforms if useStaticQuery is imported from gatsby 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 exports.__esModule = true;
 exports.default = void 0;
 
 var React = _interopRequireWildcard(require(\\"react\\"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => {
   const query = \\"426988268\\";
@@ -246,8 +256,6 @@ export const query = \\"426988268\\";"
 exports[`babel-plugin-remove-graphql-queries Transforms exported queries in useStaticQuery 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -256,6 +264,10 @@ exports.query = exports.default = void 0;
 var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
 
 var React = _interopRequireWildcard(require(\\"react\\"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => {
   const data = _.default.data;
@@ -320,8 +332,6 @@ export default (() => {
 exports[`babel-plugin-remove-graphql-queries Transforms queries and preserves destructuring in useStaticQuery 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -330,6 +340,10 @@ exports.default = void 0;
 var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
 
 var React = _interopRequireWildcard(require(\\"react\\"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => {
   const query = \\"426988268\\";
@@ -357,8 +371,6 @@ export default (() => {
 exports[`babel-plugin-remove-graphql-queries Transforms queries and preserves variable type in useStaticQuery 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -367,6 +379,10 @@ exports.default = void 0;
 var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
 
 var React = _interopRequireWildcard(require(\\"react\\"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => {
   const query = \\"426988268\\";
@@ -394,8 +410,6 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
 exports[`babel-plugin-remove-graphql-queries Transforms queries defined in own variable in <StaticQuery> 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -406,6 +420,10 @@ var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\
 var React = _interopRequireWildcard(require(\\"react\\"));
 
 var _gatsby = require(\\"gatsby\\");
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 const query = \\"426988268\\";
 
@@ -431,8 +449,6 @@ export default (() => {
 exports[`babel-plugin-remove-graphql-queries Transforms queries defined in own variable in useStaticQuery 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -441,6 +457,10 @@ exports.default = void 0;
 var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
 
 var React = _interopRequireWildcard(require(\\"react\\"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => {
   const query = \\"426988268\\";
@@ -465,8 +485,6 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
 exports[`babel-plugin-remove-graphql-queries Transforms queries in <StaticQuery> 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -477,6 +495,10 @@ var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\
 var React = _interopRequireWildcard(require(\\"react\\"));
 
 var _gatsby = require(\\"gatsby\\");
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => /*#__PURE__*/React.createElement(_gatsby.StaticQuery, {
   query: \\"426988268\\",
@@ -507,8 +529,6 @@ export default (() => {
 exports[`babel-plugin-remove-graphql-queries Transforms queries in useStaticQuery 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -517,6 +537,10 @@ exports.default = void 0;
 var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
 
 var React = _interopRequireWildcard(require(\\"react\\"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var _default = () => {
   const siteTitle = _.default.data;
@@ -665,8 +689,6 @@ export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
 exports[`babel-plugin-remove-graphql-queries transforms exported variable queries in <StaticQuery> 2`] = `
 "\\"use strict\\";
 
-var _interopRequireWildcard = require(\\"@babel/runtime/helpers/interopRequireWildcard\\");
-
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 
 exports.__esModule = true;
@@ -677,6 +699,10 @@ var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\
 var React = _interopRequireWildcard(require(\\"react\\"));
 
 var _gatsby = require(\\"gatsby\\");
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== \\"object\\" && typeof obj !== \\"function\\") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== \\"default\\" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 const query = \\"426988268\\";
 exports.query = query;

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.9",
     "gatsby-core-utils": "^2.5.0",
     "glob": "^7.1.6",
     "idb-keyval": "^3.2.0",

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "cheerio": "^1.0.0-rc.8",
+    "cheerio": "^1.0.0-rc.9",
     "fs-extra": "^8.1.0",
     "is-relative-url": "^3.0.0",
     "lodash": "^4.17.21",

--- a/packages/gatsby-remark-graphviz/package.json
+++ b/packages/gatsby-remark-graphviz/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.9",
     "unist-util-visit": "^2.0.3",
     "viz.js": "^2.1.2"
   },

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -18,7 +18,7 @@
     "@babel/runtime": "^7.12.5",
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.9",
     "is-relative-url": "^3.0.0",
     "lodash": "^4.17.21",
     "semver": "^7.3.2",

--- a/packages/gatsby-remark-images-contentful/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images-contentful/src/__tests__/__snapshots__/index.js.snap
@@ -3,8 +3,8 @@
 exports[`it transforms HTML img tags 1`] = `
 "<a class=\\"gatsby-resp-image-link\\" href=\\"https://images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg\\" style=\\"display: block\\" target=\\"_blank\\" rel=\\"noopener\\">
           <span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; display: block; ; max-width: 600px; margin-left: auto; margin-right: auto;\\">
-        <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 100%; position: relative; bottom: 0; left: 0; background-image: url(&apos;data:image;&apos;); background-size: cover; display: block;\\">
-          <img class=\\"gatsby-resp-image-image\\" style=\\"width: 100%; height: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px white;\\" alt=\\"quwowooybuqbl6ntboz3\\" title src=\\"https://images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg\\" srcset=\\"srcSet\\" sizes=\\"128px,250px\\" loading=\\"lazy\\">
+        <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 100%; position: relative; bottom: 0; left: 0; background-image: url('data:image;'); background-size: cover; display: block;\\">
+          <img class=\\"gatsby-resp-image-image\\" style=\\"width: 100%; height: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0; box-shadow: inset 0px 0px 0px 400px white;\\" alt=\\"quwowooybuqbl6ntboz3\\" title=\\"\\" src=\\"https://images.ctfassets.net/rocybtov1ozk/wtrHxeu3zEoEce2MokCSi/73dce36715f16e27cf5ff0d2d97d7dff/quwowooybuqbl6ntboz3.jpg\\" srcset=\\"srcSet\\" sizes=\\"128px,250px\\" loading=\\"lazy\\">
         </span>
       </span>
         </a>"

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "chalk": "^4.1.0",
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.9",
     "gatsby-core-utils": "^2.5.0",
     "is-relative-url": "^3.0.0",
     "lodash": "^4.17.21",

--- a/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-images/src/__tests__/__snapshots__/index.js.snap
@@ -167,7 +167,7 @@ exports[`it leaves images that are already linked alone 1`] = `
 exports[`it leaves linked HTML img tags alone 1`] = `
 "<a href=\\"https://example.org\\">
   <span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; display: block; margin-left: auto; margin-right: auto; max-width: 300px; \\">
-      <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url(&apos;data:image/png;base64,iVBORw&apos;); background-size: cover; display: block;\\"></span>
+      <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/png;base64,iVBORw'); background-size: cover; display: block;\\"></span>
   <img class=\\"gatsby-resp-image-image\\" alt=\\"this image already has a link\\" title=\\"this image already has a link\\" src=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg\\" srcset=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg, not-a-real-dir/images/this-image-already-has-a-link.jpeg\\" sizes=\\"(max-width: 650px) 100vw, 650px\\" style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;\\" loading=\\"lazy\\">
     </span>
 </a>"
@@ -175,7 +175,7 @@ exports[`it leaves linked HTML img tags alone 1`] = `
 
 exports[`it leaves single-line linked HTML img tags alone 1`] = `
 "<span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; display: block; margin-left: auto; margin-right: auto; max-width: 300px; \\">
-      <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url(&apos;data:image/png;base64,iVBORw&apos;); background-size: cover; display: block;\\"></span>
+      <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/png;base64,iVBORw'); background-size: cover; display: block;\\"></span>
   <img class=\\"gatsby-resp-image-image\\" alt=\\"this image already has a link\\" title=\\"this image already has a link\\" src=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg\\" srcset=\\"not-a-real-dir/images/this-image-already-has-a-link.jpeg, not-a-real-dir/images/this-image-already-has-a-link.jpeg\\" sizes=\\"(max-width: 650px) 100vw, 650px\\" style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;\\" loading=\\"lazy\\">
     </span>"
 `;
@@ -183,7 +183,7 @@ exports[`it leaves single-line linked HTML img tags alone 1`] = `
 exports[`it transforms HTML img tags 1`] = `
 "<span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; display: block; margin-left: auto; margin-right: auto; max-width: 300px; \\">
       <a class=\\"gatsby-resp-image-link\\" href=\\"not-a-real-dir/image/my-image.jpeg\\" style=\\"display: block\\" target=\\"_blank\\" rel=\\"noopener\\">
-    <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url(&apos;data:image/png;base64,iVBORw&apos;); background-size: cover; display: block;\\"></span>
+    <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/png;base64,iVBORw'); background-size: cover; display: block;\\"></span>
   <img class=\\"gatsby-resp-image-image\\" alt=\\"my image\\" title=\\"my image\\" src=\\"not-a-real-dir/image/my-image.jpeg\\" srcset=\\"not-a-real-dir/image/my-image.jpeg, not-a-real-dir/image/my-image.jpeg\\" sizes=\\"(max-width: 650px) 100vw, 650px\\" style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;\\" loading=\\"lazy\\">
   </a>
     </span>"
@@ -192,7 +192,7 @@ exports[`it transforms HTML img tags 1`] = `
 exports[`it transforms HTML img tags with query strings 1`] = `
 "<span class=\\"gatsby-resp-image-wrapper\\" style=\\"position: relative; display: block; margin-left: auto; margin-right: auto; max-width: 300px; \\">
       <a class=\\"gatsby-resp-image-link\\" href=\\"not-a-real-dir/image/my-image.jpeg\\" style=\\"display: block\\" target=\\"_blank\\" rel=\\"noopener\\">
-    <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url(&apos;data:image/png;base64,iVBORw&apos;); background-size: cover; display: block;\\"></span>
+    <span class=\\"gatsby-resp-image-background-image\\" style=\\"padding-bottom: 133.33333333333331%; position: relative; bottom: 0; left: 0; background-image: url('data:image/png;base64,iVBORw'); background-size: cover; display: block;\\"></span>
   <img class=\\"gatsby-resp-image-image\\" alt=\\"my image\\" title=\\"my image\\" src=\\"not-a-real-dir/image/my-image.jpeg\\" srcset=\\"not-a-real-dir/image/my-image.jpeg, not-a-real-dir/image/my-image.jpeg\\" sizes=\\"(max-width: 650px) 100vw, 650px\\" style=\\"width:100%;height:100%;margin:0;vertical-align:middle;position:absolute;top:0;left:0;\\" loading=\\"lazy\\">
   </a>
     </span>"

--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -15,7 +15,7 @@
     "@babel/cli": "^7.12.1",
     "@babel/core": "^7.12.3",
     "babel-preset-gatsby-package": "^1.5.0",
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.9",
     "cross-env": "^7.0.3",
     "prismjs": "^1.21.0",
     "remark": "^13.0.0"

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.9",
     "common-tags": "^1.8.0",
     "lodash": "^4.17.21",
     "unist-util-visit": "^2.0.3"

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -19,7 +19,7 @@
     "cache-manager": "^3.4.0",
     "cache-manager-fs-hash": "^0.0.9",
     "chalk": "^4.1.0",
-    "cheerio": "^1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.9",
     "clipboardy": "^2.1.0",
     "diff": "^5.0.0",
     "dumper.js": "^1.3.1",

--- a/packages/gatsby/src/bootstrap/__tests__/__snapshots__/resolve-module-exports.js.snap
+++ b/packages/gatsby/src/bootstrap/__tests__/__snapshots__/resolve-module-exports.js.snap
@@ -3,7 +3,7 @@
 exports[`Resolve module exports Show meaningful error message for invalid JavaScript 1`] = `
 Array [
   "Syntax error in \\"/bad/file\\":
-Const declarations require an initialization value (1:13)
+'Const declarations' require an initialization value. (1:13)
 > 1 | const exports.blah = () = }}}
     |             ^",
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7856,7 +7856,7 @@ cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-cheerio@^1.0.0-rc.3, cheerio@^1.0.0-rc.8:
+cheerio@^1.0.0-rc.9:
   version "1.0.0-rc.9"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.9.tgz#a3ae6b7ce7af80675302ff836f628e7cb786a67f"
   integrity sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==


### PR DESCRIPTION
Backporting #31298 to the `release/3.5` branch

(cherry picked from commit e06599d9acc53442f8830b04f8fa2c749a820cc5)

Conflicts:
- packages/gatsby-plugin-offline/package.json
- packages/gatsby-remark-images/package.json
- packages/gatsby-remark-prismjs/package.json
