### PR TITLE
fix(gatsby-source-contentful): use correct name for crop parameter in query string

### DIFF
--- a/packages/gatsby-source-contentful/src/cache-image.js
+++ b/packages/gatsby-source-contentful/src/cache-image.js
@@ -34,7 +34,7 @@ module.exports = async function cacheImage(store, image, options) {
     params.push(`fit=${resizingBehavior}`)
   }
   if (cropFocus) {
-    params.push(`crop=${cropFocus}`)
+    params.push(`f=${cropFocus}`)
   }
   if (background) {
     params.push(`bg=${background}`)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Sets the "focus" parameter correctly to `f` instead of `crop`, also fixes dominant color for cropped images.

### Documentation

N/A

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #30927
