### PR TITLE
fix(gatsby-transformer-sharp): Dereference symlinks when copying files

### DIFF
--- a/packages/gatsby-transformer-sharp/src/customize-schema.js
+++ b/packages/gatsby-transformer-sharp/src/customize-schema.js
@@ -593,21 +593,26 @@ const createFields = ({
           // keep track of in progress copy, we should rely on `existsSync` but
           // a race condition exists between the exists check and the copy
           inProgressCopy.add(publicPath)
-          fs.copy(details.absolutePath, publicPath, err => {
-            // this is no longer in progress
-            inProgressCopy.delete(publicPath)
-            if (err) {
-              reporter.panic(
-                {
-                  id: prefixId(CODES.MissingResource),
-                  context: {
-                    sourceMessage: `error copying file from ${details.absolutePath} to ${publicPath}`,
+          fs.copy(
+            details.absolutePath,
+            publicPath,
+            { dereference: true },
+            err => {
+              // this is no longer in progress
+              inProgressCopy.delete(publicPath)
+              if (err) {
+                reporter.panic(
+                  {
+                    id: prefixId(CODES.MissingResource),
+                    context: {
+                      sourceMessage: `error copying file from ${details.absolutePath} to ${publicPath}`,
+                    },
                   },
-                },
-                err
-              )
+                  err
+                )
+              }
             }
-          })
+          )
         }
 
         return {


### PR DESCRIPTION
## Description

Without dereferencing the symlink itself is copied which has two problems:

* It might point at the wrong location for a relative symlink.
* The next time around the copy operation will fail with an EEXIST (file already exists) error. This requires then a `gatsby clean` to be able to build again.

As this is the second time, I stumble upon an issue of this sort it Gatsby, I wonder if anything can be done to prevent the same issue from cropping up again in the future? But I don't see anything obvious or cheap solution ...

### Why do I have symlinks?

My Gatsby site has many images and committing them directly to the Git repository wouldn't be a good idea due to the file size.Instead I'm using git-annex which replaces the files with relative symbolic links.

## Related Issues

An equivalent fix was previously done for gatsby-source-filesystem in #24025.
