### PR TITLE
CTF-v6: locale per context (DRAFT)

### DIFF
--- a/packages/gatsby-source-contentful/src/cascaded-context.js
+++ b/packages/gatsby-source-contentful/src/cascaded-context.js
@@ -1,0 +1,66 @@
+function getPath(path, currentPath) {
+  if (path === undefined) {
+    throw new Error(`path was undefined`)
+  }
+  const newPath = currentPath ? `${path.key}:${currentPath}` : String(path.key)
+  if (!path.prev) {
+    return newPath
+  }
+  return getPath(path.prev, newPath)
+}
+function findLongestPrefix(target, prefixes) {
+  let match
+  let matchLength = 0
+  for (const prefix of prefixes) {
+    if (target.startsWith(prefix)) {
+      const length = prefix.length
+      if (length > matchLength) {
+        match = prefix
+        matchLength = length
+      }
+    }
+  }
+  return match
+}
+export class CascadedContext {
+  /*
+    Stores a value by prefix like
+
+    a:b       : true
+    a:b:c:d   : false
+    a:b:c:d:e : true
+
+    the prefix is determined by walking the `info.path` property
+    and concatenating it by `:`
+    
+    By finding the longest matching prefix for a given other path,
+    we can determine the current state of the variable for that part of the cascade
+  */
+  cascadeMap = new Map()
+
+  constructor() {}
+  set(info, value) {
+    const path = getPath(info.path)
+    this.cascadeMap.set(path, value)
+  }
+  get(info) {
+    const path = getPath(info.path)
+    const cascadeKeys = [...this.cascadeMap.keys()]
+    const lastCascade = findLongestPrefix(path, cascadeKeys)
+    if (lastCascade) {
+      // Since we pulled this out of the cascade keys,
+      // there is always a T for this key
+      return this.cascadeMap.get(lastCascade)
+    } else {
+      return this.defaultValue
+    }
+  }
+  has(value) {
+    for (const v of this.cascadeMap.values()) {
+      if (v === value) {
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -148,6 +148,40 @@ const localeState = new CascadedContext()
 
 exports.createSchemaCustomization = ({ actions }) => {
   actions.createResolverContext({ localeState })
+  actions.createFieldExtension({
+    name: `contentfulLocalized`,
+    args: {
+      contentfulFieldId: {
+        type: `String!`,
+      },
+    },
+    extend(options) {
+      return {
+        args: {
+          locale: `String`,
+        },
+        resolve(source, args, context, info) {
+          console.log(
+            JSON.stringify(
+              { source, args, context: context.sourceContentful },
+              null,
+              2
+            )
+          )
+
+          let locale
+          if (args.locale) {
+            context.sourceContentful.localeState.set(info, args.locale)
+            locale = args.locale
+          } else {
+            locale = context.sourceContentful.localeState.get(info) || `en-US` // @todo we need default locale
+          }
+          const fieldValue = source.localeTest[options.contentfulFieldId] || {}
+          return fieldValue[locale] || null
+        },
+      }
+    },
+  })
 }
 
 exports.createResolvers = ({ createResolvers }) => {

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -13,6 +13,7 @@ const { restrictedNodeFields } = require(`./config`)
 const { generateSchema } = require(`./generate-schema`)
 const { createPluginConfig, maskText } = require(`./plugin-options`)
 const { downloadContentfulAssets } = require(`./download-contentful-assets`)
+const { CascadedContext } = require(`./cascaded-context`)
 
 const conflictFieldPrefix = `contentful`
 
@@ -142,6 +143,48 @@ List of locales and their codes can be found in Contentful app -> Settings -> Lo
     .external(validateContentfulAccess)
 
 exports.pluginOptionsSchema = pluginOptionsSchema
+
+const localeState = new CascadedContext()
+
+exports.createSchemaCustomization = ({ actions }) => {
+  actions.createResolverContext({ localeState })
+}
+
+exports.createResolvers = ({ createResolvers }) => {
+  const resolvers = {
+    Query: {
+      contentfulNumberLocalized: {
+        type: [`ContentfulNumber`],
+        args: {
+          locale: `String`, // "input PostsCountInput { min: Int, max: Int }",
+        },
+        resolve(source, args, context, info) {
+          let locale
+
+          if (args.locale) {
+            context.sourceContentful.localeState.set(info, args.locale)
+            locale = args.locale
+          } else {
+            locale = context.sourceContentful.localeState.get(info) || `en-US` // @todo where to get default locale from?
+          }
+
+          console.log({ locale })
+
+          return context.nodeModel.runQuery({
+            query: {
+              filter: {
+                sys: { locale: { eq: locale } },
+              },
+            },
+            type: `ContentfulNumber`,
+            firstOnly: false,
+          })
+        },
+      },
+    },
+  }
+  createResolvers(resolvers)
+}
 
 /***
  * Localization algorithm
@@ -366,7 +409,13 @@ exports.sourceNodes = async (
   processingActivity.start()
 
   // Generate schemas based on Contentful content model
-  generateSchema({ createTypes, schema, pluginConfig, contentTypeItems })
+  generateSchema({
+    createTypes,
+    schema,
+    pluginConfig,
+    contentTypeItems,
+    defaultLocale,
+  })
 
   // Create a map of up to date entries and assets
   function mergeSyncData(previous, current, deleted) {

--- a/packages/gatsby-source-contentful/src/generate-schema.js
+++ b/packages/gatsby-source-contentful/src/generate-schema.js
@@ -7,7 +7,6 @@ export function generateSchema({
   schema,
   pluginConfig,
   contentTypeItems,
-  defaultLocale,
 }) {
   const getLinkFieldType = (linkType, field) => {
     return {
@@ -47,8 +46,15 @@ export function generateSchema({
   const ContentfulDataTypes = new Map([
     [
       `Symbol`,
-      () => {
-        return { type: `String` }
+      field => {
+        return {
+          type: `String`,
+          extensions: {
+            contentfulLocalized: {
+              contentfulFieldId: field.id,
+            },
+          },
+        }
       },
     ],
     [
@@ -67,49 +73,39 @@ export function generateSchema({
     ],
     [
       `Integer`,
-      () => {
+      field => {
         return {
           type: `Int`,
-          resolve(source, args, context, info) {
-            let locale
-            if (args.locale) {
-              context.sourceContentful.localeState.set(info, args.locale)
-              locale = args.locale
-            } else {
-              locale =
-                context.sourceContentful.localeState.get(info) || defaultLocale
-            }
-
-            console.log(
-              JSON.stringify(
-                {
-                  source,
-                  args,
-                  context: context.sourceContentful,
-                  info,
-                  locale,
-                },
-                null,
-                2
-              )
-            )
-            return source[info.fieldName]
+          extensions: {
+            contentfulLocalized: {
+              contentfulFieldId: field.id,
+            },
           },
         }
       },
     ],
     [
       `Number`,
-      () => {
-        return { type: `Float` }
+      field => {
+        return {
+          type: `Float`,
+          extensions: {
+            contentfulLocalized: {
+              contentfulFieldId: field.id,
+            },
+          },
+        }
       },
     ],
     [
       `Date`,
-      () => {
+      field => {
         return {
           type: `Date`,
           extensions: {
+            contentfulLocalized: {
+              contentfulFieldId: field.id,
+            },
             dateformat: {},
           },
         }
@@ -117,26 +113,54 @@ export function generateSchema({
     ],
     [
       `Object`,
-      () => {
-        return { type: `JSON` }
+      field => {
+        return {
+          type: `JSON`,
+          extensions: {
+            contentfulLocalized: {
+              contentfulFieldId: field.id,
+            },
+          },
+        }
       },
     ],
     [
       `Boolean`,
-      () => {
-        return { type: `Boolean` }
+      field => {
+        return {
+          type: `Boolean`,
+          extensions: {
+            contentfulLocalized: {
+              contentfulFieldId: field.id,
+            },
+          },
+        }
       },
     ],
     [
       `Location`,
-      () => {
-        return { type: `ContentfulNodeTypeLocation` }
+      field => {
+        return {
+          type: `ContentfulNodeTypeLocation`,
+          extensions: {
+            contentfulLocalized: {
+              contentfulFieldId: field.id,
+            },
+          },
+        }
       },
     ],
     [
       `RichText`,
-      () => {
-        return { type: `ContentfulNodeTypeRichText` }
+      field => {
+        return {
+          type: `ContentfulNodeTypeRichText`,
+          extensions: {
+            contentfulLocalized: {
+              contentfulFieldId: field.id,
+            },
+          },
+        }
       },
     ],
   ])

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -391,6 +391,7 @@ exports.createNodesForContentType = ({
             publishedAt: entryItem.sys.updatedAt,
             publishedVersion: entryItem.sys.revision,
           },
+          localeTest: entryItem.fields,
         }
 
         // Replace text fields with text nodes so we can process their markdown


### PR DESCRIPTION
The current plugin creates a node for every translation you have for each entry. This leads to DB bloat, especially if you content is only partly translated.

This is part of #31385


This change will:

* pass the page locale as page context to the query, no more hard coded locales
* get a field in another language. Useful for linking news in other languages.
* will reduce the node count drastically. Before (entries + assets) * locales + a few, soon we will have  entries + assets + a few
* potentially allowing custom locale fallbacks 