### PR TITLE
feat(gatsby-source-wordpress): auto-alias any field named `fields` to prevent conflicts with Gatsby core

### DIFF
--- a/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
+++ b/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
@@ -97,6 +97,7 @@ const remoteSchema: IRemoteSchemaStore = {
       internal: `wpInternal`,
       plugin: `wpPlugin`,
       actionOptions: `wpActionOptions`,
+      fields: `wpFields`,
     },
   },
 

--- a/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
+++ b/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
@@ -23,6 +23,7 @@ interface IRemoteSchemaState {
     internal: string
     plugin: string
     actionOptions: string
+    fields: string
   }
 }
 


### PR DESCRIPTION
## Description

@TylerBarnes  PR to add an alias for the field 'fields' when sourcing form from Wordpress using wp-graphql-ninja-forms as discussed in the slack channel.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
