### PR TITLE
fix: fast-refresh-overlay: infinite loop

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
@@ -31,7 +31,12 @@ export function useStackFrame({ moduleId, lineNumber, columnNumber }) {
         sourcePosition,
       })
     }
-    fetchData()
+    try{
+      fetchData()
+    }
+    catch (err){
+      console.error("Error Caught while fetching the overlays: ", err)
+    }
   }, [])
 
   return response


### PR DESCRIPTION
## Description

As mentioned by #31553 , throwing error inside render will cause infinite loop when offline.
I fixed that up by wrapping it with try catch block.

## Related Issue

Fixes #31553 

