### PR TITLE
fix(gatsby): prevent infinite loop in fast-refresh-overlay

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
@@ -36,7 +36,7 @@ export function useStackFrame({ moduleId, lineNumber, columnNumber }) {
       } catch (err) {
         setResponse({
           ...initialResponse,
-          decoded: prettifyStack(err.stack || err.message),
+          decoded: prettifyStack(err.message),
         })
       }
     }

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
@@ -1,6 +1,15 @@
 import * as React from "react"
 import { prettifyStack } from "../utils"
 
+const initialResponse = {
+  decoded: null,
+  sourcePosition: {
+    line: null,
+    number: null,
+  },
+  sourceContent: null,
+}
+
 export function useStackFrame({ moduleId, lineNumber, columnNumber }) {
   const url =
     `/__original-stack-frame?moduleId=` +
@@ -10,14 +19,7 @@ export function useStackFrame({ moduleId, lineNumber, columnNumber }) {
     `&columnNumber=` +
     window.encodeURIComponent(columnNumber)
 
-  const [response, setResponse] = React.useState({
-    decoded: null,
-    sourcePosition: {
-      line: null,
-      number: null,
-    },
-    sourceContent: null,
-  })
+  const [response, setResponse] = React.useState(initialResponse)
 
   React.useEffect(() => {
     async function fetchData() {

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
@@ -23,15 +23,22 @@ export function useStackFrame({ moduleId, lineNumber, columnNumber }) {
 
   React.useEffect(() => {
     async function fetchData() {
-      const res = await fetch(url)
-      const json = await res.json()
-      const decoded = prettifyStack(json.codeFrame)
-      const { sourcePosition, sourceContent } = json
-      setResponse({
-        decoded,
-        sourceContent,
-        sourcePosition,
-      })
+      try {
+        const res = await fetch(url)
+        const json = await res.json()
+        const decoded = prettifyStack(json.codeFrame)
+        const { sourcePosition, sourceContent } = json
+        setResponse({
+          decoded,
+          sourceContent,
+          sourcePosition,
+        })
+      } catch (err) {
+        setResponse({
+          ...initialResponse,
+          decoded: prettifyStack(err.stack || err.message),
+        })
+      }
     }
     fetchData()
   }, [])


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Catch error that caused infinite loop.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #31553