### PR TITLE
chore(gatsby-source-wordpress): Fix typos

### DIFF
--- a/packages/gatsby-source-wordpress/docs/features/compatibility-api.md
+++ b/packages/gatsby-source-wordpress/docs/features/compatibility-api.md
@@ -1,8 +1,8 @@
 # Compatibility API
 
-Because we have so many remote depencies (WordPress, WPGraphQL, and WPGatsby), we've baked a remote compatibility API into this plugin.
+Because we have so many remote dependencies (WordPress, WPGraphQL, and WPGatsby), we've baked a remote compatibility API into this plugin.
 
-Anytime the build or develop process starts, the source plugin will send the WPGatsby and WPGraphQL semver version ranges it supports to WPGatsby. WPGatsby will return wether or not the currently installed plugins are within the supported range.
+Anytime the build or develop process starts, the source plugin will send the WPGatsby and WPGraphQL semver version ranges it supports to WPGatsby. WPGatsby will return whether or not the currently installed plugins are within the supported range.
 
 If your dependencies are out of the supported range, the build process will exit and provide a link to download the correct dependency versions.
 


### PR DESCRIPTION
Two typos, corrected