### PR TITLE
fix(gatsby-plugin-gatsby-cloud): fix cloud being bundled

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/package.json
+++ b/packages/gatsby-plugin-gatsby-cloud/package.json
@@ -44,6 +44,7 @@
     "url": "https://github.com/gatsbyjs/gatsby.git",
     "directory": "packages/gatsby-plugin-gatsby-cloud"
   },
+  "sideEffects": false,
   "scripts": {
     "build": "babel src --out-dir . --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The gatsby-plugin-gatsby-cloud plugin has a mix of ESM & CJS which makes it difficult for webpack to figure out if sideffects are happening. We add sideEffects false to the list so wepback can remove unnecessary code
This shows that a gatsby-plugin-bundler would be a good idea.


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #31597