### PR TITLE
feat(gatsby-source-wordpress): Fix false positive error if the URL and the responsePath are the same

### DIFF
--- a/packages/gatsby-source-wordpress/src/utils/fetch-graphql.ts
+++ b/packages/gatsby-source-wordpress/src/utils/fetch-graphql.ts
@@ -745,7 +745,11 @@ const fetchGraphql = async ({
 
     const responsePath = response.request.path
 
-    if (path !== responsePath && responsePath !== undefined) {
+    if (
+      path !== responsePath &&
+      responsePath !== undefined &&
+      responsePath !== url
+    ) {
       throw new Error(`GraphQL request was redirected to ${responsePath}`)
     }
 


### PR DESCRIPTION
:wave: 

## Description

It is possible to get this output from the response:
```json
{
  "responsePath": "https://<xxx>/graphql",
  "path": "/graphql",
  "url": "https://<xxx>/graphql"
}
```
instead of
```json
{
  "responsePath": "/graphql",
  "path": "/graphql",
  "url": "https://<xxx>/graphql"
}
```
It doesn't make sense to reject the request with the error: _GraphQL request was redirected_
as the responsePath _is_ the url.


I tried this fix to build my website, and it works fine. 
