### PR TITLE
feat(gatsby-source-wordpress)  Add plugin option httpOpts for gatsby-source-wordpress

### DIFF
--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -25,6 +25,7 @@
   - [develop.nodeUpdateInterval](#developnodeupdateinterval)
   - [develop.hardCacheMediaFiles](#develophardcachemediafiles)
   - [develop.hardCacheData](#develophardcachedata)
+- [httpOpts](#httpopts)
 - [auth](#auth)
   - [auth.htaccess](#authhtaccess)
     - [auth.htaccess.username](#authhtaccessusername)
@@ -523,6 +524,32 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
   },
 }
 
+```
+
+## httpOpts
+
+Option to use a custom agent when we download the files from your WordPress.
+We use the [got](https://github.com/sindresorhus/got) to fetch the files.
+
+**Field type**: `Object`
+
+**Default value**: `{}`
+
+ex: _Set a custom agent_
+
+```js
+{
+  resolve: `gatsby-source-wordpress`,
+  options: {
+    httpOpts: {
+      // cf https://github.com/sindresorhus/got#agent
+      agent: {
+        http: new ProxyAgent(process.env.http_proxy),
+        https: new ProxyAgent(process.env.https_proxy)
+      }
+    },
+  },
+}
 ```
 
 ## auth

--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -25,7 +25,6 @@
   - [develop.nodeUpdateInterval](#developnodeupdateinterval)
   - [develop.hardCacheMediaFiles](#develophardcachemediafiles)
   - [develop.hardCacheData](#develophardcachedata)
-- [httpOpts](#httpopts)
 - [auth](#auth)
   - [auth.htaccess](#authhtaccess)
     - [auth.htaccess.username](#authhtaccessusername)
@@ -61,6 +60,7 @@
     - [type.MediaItem.lazyNodes](#typemediaitemlazynodes)
     - [type.MediaItem.localFile](#typemediaitemlocalfile)
       - [type.MediaItem.localFile.excludeByMimeTypes](#typemediaitemlocalfileexcludebymimetypes)
+      - [type.MediaItem.localFile.httpOptions](#typemediaitemlocalfilehttpoptions)
       - [type.MediaItem.localFile.maxFileSizeBytes](#typemediaitemlocalfilemaxfilesizebytes)
       - [type.MediaItem.localFile.requestConcurrency](#typemediaitemlocalfilerequestconcurrency)
 - [presets](#presets)
@@ -524,32 +524,6 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
   },
 }
 
-```
-
-## httpOpts
-
-Option to use a custom agent when we download the files from your WordPress.
-We use the [got](https://github.com/sindresorhus/got) to fetch the files.
-
-**Field type**: `Object`
-
-**Default value**: `{}`
-
-ex: _Set a custom agent_
-
-```js
-{
-  resolve: `gatsby-source-wordpress`,
-  options: {
-    httpOpts: {
-      // cf https://github.com/sindresorhus/got#agent
-      agent: {
-        http: new ProxyAgent(process.env.http_proxy),
-        https: new ProxyAgent(process.env.https_proxy)
-      }
-    },
-  },
-}
 ```
 
 ## auth
@@ -1207,6 +1181,38 @@ Allows preventing the download of files associated with MediaItem nodes by their
   },
 }
 
+```
+
+##### type.MediaItem.localFile.httpOptions
+
+Option to use a custom agent when we download the files from your WordPress.
+We use the [got](https://github.com/sindresorhus/got) to fetch the files.
+
+**Field type**: `Object`
+
+**Default value**: `{}`
+
+ex: _Set a custom agent_
+
+```js
+{
+  resolve: `gatsby-source-wordpress`,
+  options: {
+    type: {
+      MediaItem: {
+        localeFile: {
+          httpOptions: {
+            // cf https://github.com/sindresorhus/got#agent
+            agent: {
+              http: new ProxyAgent(process.env.http_proxy),
+              https: new ProxyAgent(process.env.https_proxy)
+            },
+          },
+        },
+      },
+    },
+  },
+}
 ```
 
 ##### type.MediaItem.localFile.maxFileSizeBytes

--- a/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
@@ -76,6 +76,9 @@ export interface IPluginOptions {
       password: string | null
     }
   }
+  httpOpts?: {
+    agent?: any
+  }
   schema?: {
     queryDepth: number
     circularQueryLimit: number
@@ -148,6 +151,9 @@ const defaultPluginOptions: IPluginOptions = {
       username: null,
       password: null,
     },
+  },
+  httpOpts: {
+    agent: null,
   },
   schema: {
     queryDepth: 15,

--- a/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
@@ -76,9 +76,6 @@ export interface IPluginOptions {
       password: string | null
     }
   }
-  httpOpts?: {
-    agent?: any
-  }
   schema?: {
     queryDepth: number
     circularQueryLimit: number
@@ -110,6 +107,7 @@ export interface IPluginOptions {
       lazyNodes?: boolean
       localFile?: {
         excludeByMimeTypes?: Array<string>
+        httpOptions?: any
         maxFileSizeBytes?: number
         requestConcurrency?: number
       }
@@ -151,9 +149,6 @@ const defaultPluginOptions: IPluginOptions = {
       username: null,
       password: null,
     },
-  },
-  httpOpts: {
-    agent: null,
   },
   schema: {
     queryDepth: 15,
@@ -218,6 +213,9 @@ const defaultPluginOptions: IPluginOptions = {
       lazyNodes: false,
       localFile: {
         excludeByMimeTypes: [],
+        httpOptions: {
+          agent: null,
+        },
         maxFileSizeBytes: 15728640, // 15Mb
         requestConcurrency: 100,
       },

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
@@ -729,8 +729,16 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
                 )
                 .meta({
                   example: wrapOptions(`
-                      httpOpts: {
-                        http: \`new ProxyAgent(process.env.http_proxy)\`,
+                      type: {
+                        MediaItem: {
+                          localFile: {
+                            httpOptions: {
+                              agent: {
+                                http: \`new ProxyAgent(process.env.http_proxy)\`,
+                              },
+                            },
+                          },
+                        },
                       },
                     `),
                 }),
@@ -742,29 +750,50 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
                 )
                 .meta({
                   example: wrapOptions(`
-                      httpOpts: {
-                        https: \`new ProxyAgent(process.env.https_proxy)\`,
+                      type: {
+                        MediaItem: {
+                          localFile: {
+                            httpOptions: {
+                              agent: {
+                                https: \`new ProxyAgent(process.env.https_proxy)\`,
+                              },
+                            },
+                          },
+                        },
                       },
                     `),
                 }),
             })
               .description(
-                `Custom httpOpts for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
+                `Custom httpOptions for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
               )
               .meta({
                 example: wrapOptions(`
-                    httpOpts: {
-                      agent: {}, // Add your options here :)
+                    type: {
+                      MediaItem: {
+                        localFile: {
+                          httpOptions: {
+                            agent: {}, // Add your options here
+                          },
+                        },
+                      },
                     },
+
                   `),
               }),
           })
             .description(
-              `Custom httpOpts for got wrapper when we fetch files. See below for options.`
+              `Custom httpOptions for got wrapper when we fetch files. See below for options.`
             )
             .meta({
               example: wrapOptions(`
-                  httpOpts: {}, // Add your options here :)
+                  type: {
+                    MediaItem: {
+                      localFile: {
+                        httpOptions: {}, // Add your options here
+                      },
+                    },
+                  },
                 `),
             }),
 

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
@@ -416,55 +416,6 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
           `),
       }),
 
-    httpOpts: Joi.object({
-      agent: Joi.object({
-        http: Joi.any()
-          .allow(null)
-          .default(null)
-          .description(
-            `Agent for the request cf https://nodejs.org/api/http.html#http_class_http_agent`
-          )
-          .meta({
-            example: wrapOptions(`
-                httpOpts: {
-                  http: \`new ProxyAgent(process.env.http_proxy)\`,
-                },
-              `),
-          }),
-        https: Joi.any()
-          .allow(null)
-          .default(null)
-          .description(
-            `Agent for the request cf https://nodejs.org/api/https.html#https_class_https_agent`
-          )
-          .meta({
-            example: wrapOptions(`
-                httpOpts: {
-                  https: \`new ProxyAgent(process.env.https_proxy)\`,
-                },
-              `),
-          }),
-      })
-        .description(
-          `Custom httpOpts for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
-        )
-        .meta({
-          example: wrapOptions(`
-              httpOpts: {
-                agent: {}, // Add your options here :)
-              },
-            `),
-        }),
-    })
-      .description(
-        `Custom httpOpts for got wrapper when we fetch files. See below for options.`
-      )
-      .meta({
-        example: wrapOptions(`
-            httpOpts: {}, // Add your options here :)
-          `),
-      }),
-
     schema: Joi.object({
       queryDepth: Joi.number()
         .integer()
@@ -767,6 +718,56 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
                   },
                 `),
             }),
+
+          httpOptions: Joi.object({
+            agent: Joi.object({
+              http: Joi.any()
+                .allow(null)
+                .default(null)
+                .description(
+                  `Agent for the request cf https://nodejs.org/api/http.html#http_class_http_agent`
+                )
+                .meta({
+                  example: wrapOptions(`
+                      httpOpts: {
+                        http: \`new ProxyAgent(process.env.http_proxy)\`,
+                      },
+                    `),
+                }),
+              https: Joi.any()
+                .allow(null)
+                .default(null)
+                .description(
+                  `Agent for the request cf https://nodejs.org/api/https.html#https_class_https_agent`
+                )
+                .meta({
+                  example: wrapOptions(`
+                      httpOpts: {
+                        https: \`new ProxyAgent(process.env.https_proxy)\`,
+                      },
+                    `),
+                }),
+            })
+              .description(
+                `Custom httpOpts for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
+              )
+              .meta({
+                example: wrapOptions(`
+                    httpOpts: {
+                      agent: {}, // Add your options here :)
+                    },
+                  `),
+              }),
+          })
+            .description(
+              `Custom httpOpts for got wrapper when we fetch files. See below for options.`
+            )
+            .meta({
+              example: wrapOptions(`
+                  httpOpts: {}, // Add your options here :)
+                `),
+            }),
+
           maxFileSizeBytes: Joi.number()
             .integer()
             .default(15728640)

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.ts
@@ -415,6 +415,56 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
             },
           `),
       }),
+
+    httpOpts: Joi.object({
+      agent: Joi.object({
+        http: Joi.any()
+          .allow(null)
+          .default(null)
+          .description(
+            `Agent for the request cf https://nodejs.org/api/http.html#http_class_http_agent`
+          )
+          .meta({
+            example: wrapOptions(`
+                httpOpts: {
+                  http: \`new ProxyAgent(process.env.http_proxy)\`,
+                },
+              `),
+          }),
+        https: Joi.any()
+          .allow(null)
+          .default(null)
+          .description(
+            `Agent for the request cf https://nodejs.org/api/https.html#https_class_https_agent`
+          )
+          .meta({
+            example: wrapOptions(`
+                httpOpts: {
+                  https: \`new ProxyAgent(process.env.https_proxy)\`,
+                },
+              `),
+          }),
+      })
+        .description(
+          `Custom httpOpts for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
+        )
+        .meta({
+          example: wrapOptions(`
+              httpOpts: {
+                agent: {}, // Add your options here :)
+              },
+            `),
+        }),
+    })
+      .description(
+        `Custom httpOpts for got wrapper when we fetch files. See below for options.`
+      )
+      .meta({
+        example: wrapOptions(`
+            httpOpts: {}, // Add your options here :)
+          `),
+      }),
+
     schema: Joi.object({
       queryDepth: Joi.number()
         .integer()

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
@@ -303,7 +303,6 @@ export const createLocalFileNode = async ({
         // if media items are hosted on another url like s3,
         // using the htaccess creds will throw 400 errors
         const shouldUseHtaccessCredentials = wpUrlHostname === mediaItemHostname
-        const httpOpts = pluginOptions.httpOpts
         const auth =
           htaccessCredentials && shouldUseHtaccessCredentials
             ? {
@@ -316,7 +315,6 @@ export const createLocalFileNode = async ({
         const node = await createRemoteFileNode({
           url: mediaItemUrl,
           auth,
-          httpOpts,
           ...createFileNodeRequirements,
           pluginOptions,
         })

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
@@ -303,7 +303,7 @@ export const createLocalFileNode = async ({
         // if media items are hosted on another url like s3,
         // using the htaccess creds will throw 400 errors
         const shouldUseHtaccessCredentials = wpUrlHostname === mediaItemHostname
-
+        const httpOpts = pluginOptions.httpOpts
         const auth =
           htaccessCredentials && shouldUseHtaccessCredentials
             ? {
@@ -316,6 +316,7 @@ export const createLocalFileNode = async ({
         const node = await createRemoteFileNode({
           url: mediaItemUrl,
           auth,
+          httpOpts,
           ...createFileNodeRequirements,
           pluginOptions,
         })

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -244,6 +244,7 @@ async function processRemoteNode({
   createNode,
   parentNodeId,
   auth = {},
+  httpOpts = {},
   httpHeaders = {},
   createNodeId,
   ext,
@@ -261,7 +262,6 @@ async function processRemoteNode({
 
   // Add htaccess authentication if passed in. This isn't particularly
   // extensible. We should define a proper API that we validate.
-  const httpOpts = {}
   if (auth?.htaccess_pass && auth?.htaccess_user) {
     headers[`Authorization`] = `Basic ${btoa(
       `${auth.htaccess_user}:${auth.htaccess_pass}`
@@ -376,6 +376,7 @@ module.exports = ({
   getCache,
   parentNodeId = null,
   auth = {},
+  httpOpts = {},
   httpHeaders = {},
   createNodeId,
   ext = null,
@@ -449,6 +450,7 @@ module.exports = ({
     parentNodeId,
     createNodeId,
     auth,
+    httpOpts,
     httpHeaders,
     ext,
     name,


### PR DESCRIPTION
:wave:  

## Description

Common use case, define a custom agent for requests
Inside my CI we have http_proxy set, and without a custom agent we get this error

```
RequestError: connect ENETUNREACH xxx
    at Ticket.<anonymous> (/builds/web/corp/experimentation-gatsby-for-wordpress/node_modules/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js:349:16)
``` 
   
 
    
### Documentation

With this change you can define a custom agent for the request from the file `gatsby-config.js`

I updated `gatsby-source-wordpress/docs/plugin-options.md` with this new option + a demo

