### PR TITLE
chore(docs): Update Jest instructions for v27

### DIFF
--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -65,8 +65,11 @@ const babelOptions = {
   presets: ["babel-preset-gatsby"],
 }
 
-module.exports = require("babel-jest").createTransformer(babelOptions)
+module.exports = require("babel-jest").default.createTransformer(babelOptions)
 ```
+
+> Note: if you're using Jest 26.6.3 or below, `module.exports` has to be changed to
+> `module.exports = require("babel-jest").createTransformer(babelOptions)`
 
 - The next option is `moduleNameMapper`. This
   section works a bit like webpack rules and tells Jest how to handle imports.

--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -68,7 +68,7 @@ const babelOptions = {
 module.exports = require("babel-jest").default.createTransformer(babelOptions)
 ```
 
-> Note: if you're using Jest 26.6.3 or below, `module.exports` has to be changed to
+> **Note:** If you're using Jest 26.6.3 or below, the last line has to be changed to
 > `module.exports = require("babel-jest").createTransformer(babelOptions)`
 
 - The next option is `moduleNameMapper`. This


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description


Due to change in Jest v27.0.0, the code snippet in jest-preprocess.js will throw an error because of function, `createTransformer` being exported as `default`. 

In this PR, I have updated the docs to fix this change.

## Related Issue

Fixes #31618
