### PR TITLE
fix(gatsby-source-wordpress): Prevent "EADDRINUSE: address already in use 127.0.0.1" error

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -9,9 +9,7 @@ import { LAST_COMPLETED_SOURCE_TIME } from "../../../constants"
  * This function checks wether there is atleast 1 WPGatsby action ready to be processed by Gatsby
  * If there is, it calls the refresh webhook so that schema customization and source nodes run again.
  */
-let sourceIt = true
 const checkForNodeUpdates = async ({ cache, emitter }) => {
-  console.log(`checking for node updates`)
   // if there's atleast 1 new action, pause polling,
   // refresh Gatsby schema+nodes and continue on
   store.dispatch.develop.pauseRefreshPolling()
@@ -36,7 +34,6 @@ const checkForNodeUpdates = async ({ cache, emitter }) => {
   })
 
   if (newActions.length) {
-    console.log(`triggering webhook`)
     emitter.emit(`WEBHOOK_RECEIVED`, {
       webhookBody: {
         since,
@@ -44,10 +41,7 @@ const checkForNodeUpdates = async ({ cache, emitter }) => {
       },
       pluginName: `gatsby-source-wordpress`,
     })
-    sourceIt = false
   } else {
-    console.log(`not triggering webhook`)
-    sourceIt = true
     // set new last completed source time and move on
     await cache.set(LAST_COMPLETED_SOURCE_TIME, Date.now())
     store.dispatch.develop.resumeRefreshPolling()
@@ -63,10 +57,7 @@ const refetcher = async (
     const { refreshPollingIsPaused } = store.getState().develop
 
     if (!refreshPollingIsPaused) {
-      console.log(`refresh polling not paused`)
       await checkForNodeUpdates(helpers)
-    } else {
-      console.log(`refresh polling paused`)
     }
 
     if (reconnectionActivity) {
@@ -120,7 +111,7 @@ const refetcher = async (
 }
 
 let startedPolling = false
-let firstCompilationDone
+let firstCompilationDone = false
 
 /**
  * Starts constantly refetching the latest WordPress changes
@@ -143,7 +134,6 @@ const startPollingForContentUpdates = async helpers => {
 
   helpers.emitter.on(`COMPILATION_DONE`, () => {
     if (!firstCompilationDone) {
-      console.log(`----> compilation done`)
       firstCompilationDone = true
 
       setTimeout(() => {

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -138,7 +138,7 @@ const startPollingForContentUpdates = helpers => {
      * we only want to start our refetcher helper 1 time after the first COMPILATION_DONE event.
      * This event happens when the dev server is ready. It also happens after saving a code change. We only want to run our code 1 time.
      * onCreateDevServer (the node API we're hooking into) is called before the dev server is ready.
-     * Running our logic at that point is problematic because we could end up triggering the WEBHOOK_RECEIVED event before the dev server is ready and this can cause Gatsby to throw errors.
+     * Running our logic at that point is problematic because we could end up triggering the WEBHOOK_RECEIVED event before the dev server is ready and this can cause Gatsby to throw errors. So we're hooking into COMPILATION_DONE to avoid that problem.
      */
     if (!firstCompilationDone) {
       firstCompilationDone = true

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -120,6 +120,7 @@ const refetcher = async (
 }
 
 let startedPolling = false
+let firstCompilationDone
 
 /**
  * Starts constantly refetching the latest WordPress changes
@@ -140,11 +141,10 @@ const startPollingForContentUpdates = async helpers => {
 
   const msRefetchInterval = develop.nodeUpdateInterval
 
-  let startedRefetching
-
   helpers.emitter.on(`COMPILATION_DONE`, () => {
-    if (!startedRefetching) {
-      startedRefetching = true
+    if (!firstCompilationDone) {
+      console.log(`----> compilation done`)
+      firstCompilationDone = true
 
       setTimeout(() => {
         if (verbose) {

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -137,6 +137,7 @@ const startPollingForContentUpdates = async helpers => {
     if (!firstCompilationDone) {
       firstCompilationDone = true
 
+      // wait a second so that terminal output is more smooth
       setTimeout(() => {
         if (verbose) {
           helpers.reporter.log(``)

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -10,8 +10,9 @@ import { LAST_COMPLETED_SOURCE_TIME } from "../../../constants"
  * If there is, it calls the refresh webhook so that schema customization and source nodes run again.
  */
 const checkForNodeUpdates = async ({ cache, emitter }) => {
-  // if there's atleast 1 new action, pause polling,
-  // refresh Gatsby schema+nodes and continue on
+  // pause polling until we know wether or not there are new actions
+  // if there aren't any we will unpause below, if there are some we will unpause
+  // at the end of sourceNodes (triggered by WEBHOOK_RECEIVED below)
   store.dispatch.develop.pauseRefreshPolling()
 
   // get the last sourced time

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -136,7 +136,7 @@ const startPollingForContentUpdates = helpers => {
   helpers.emitter.on(`COMPILATION_DONE`, () => {
     /**
      * we only want to start our refetcher helper 1 time after the first COMPILATION_DONE event.
-     * This event happens when the dev server is ready.
+     * This event happens when the dev server is ready. It also happens after saving a code change. We only want to run our code 1 time.
      * onCreateDevServer (the node API we're hooking into) is called before the dev server is ready.
      * Running our logic at that point is problematic because we could end up triggering the WEBHOOK_RECEIVED event before the dev server is ready and this can cause Gatsby to throw errors.
      */

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -134,6 +134,12 @@ const startPollingForContentUpdates = async helpers => {
   const msRefetchInterval = develop.nodeUpdateInterval
 
   helpers.emitter.on(`COMPILATION_DONE`, () => {
+    /**
+     * we only want to start our refetcher helper 1 time after the first COMPILATION_DONE event.
+     * This event happens when the dev server is ready.
+     * onCreateDevServer (the node API we're hooking into) is called before the dev server is ready.
+     * Running our logic at that point is problematic because we could end up triggering the WEBHOOK_RECEIVED event before the dev server is ready and this can cause Gatsby to throw errors.
+     */
     if (!firstCompilationDone) {
       firstCompilationDone = true
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -118,7 +118,7 @@ let firstCompilationDone = false
  * Starts constantly refetching the latest WordPress changes
  * so we can update Gatsby nodes when data changes
  */
-const startPollingForContentUpdates = async helpers => {
+const startPollingForContentUpdates = helpers => {
   if (
     startedPolling ||
     process.env.WP_DISABLE_POLLING ||


### PR DESCRIPTION
It looks like the WP data update watcher code was in some cases running multiple times. It was also running before the dev server was ready. Since data updates emit a WEBHOOK_RECEIVED event to Gatsby, this was causing problems when the dev server wasn't yet ready. We were also potentially emitting this while a WEBHOOK_RECEIVED event was already being processed. This RP fixes all of these issues.