### PR TITLE
fix(tutorial): add trailing slashes to 'next part' links

### DIFF
--- a/docs/docs/tutorial/part-0/index.mdx
+++ b/docs/docs/tutorial/part-0/index.mdx
@@ -346,7 +346,7 @@ Use the "Was this doc helpful to you?" form at the bottom of this page to let us
 In Part 1 of the Tutorial, you'll create your first Gatsby site and deploy it online for everyone to see.
 
 <LinkButton
-  to="/docs/tutorial/part-1"
+  to="/docs/tutorial/part-1/"
   rightIcon={<MdArrowForward />}
   variant="SECONDARY"
 >

--- a/docs/docs/tutorial/part-1/index.mdx
+++ b/docs/docs/tutorial/part-1/index.mdx
@@ -319,7 +319,7 @@ Use the "Was this doc helpful to you?" form at the bottom of this page to let us
 Now that you have a default Gatsby site up and running, it's time to make it your own. In Part 2 of the Tutorial, you'll learn how to use React to customize the design and contents of your site.
 
 <LinkButton
-  to="/docs/tutorial/part-2"
+  to="/docs/tutorial/part-2/"
   rightIcon={<MdArrowForward />}
   variant="SECONDARY"
 >

--- a/docs/docs/tutorial/part-2/index.mdx
+++ b/docs/docs/tutorial/part-2/index.mdx
@@ -808,7 +808,7 @@ Use the "Was this doc helpful to you?" form at the bottom of this page to let us
 In Part 3 of the Tutorial, you'll learn about how to use Gatsby plugins to add more pre-built functionality to your site.
 
 <LinkButton
-  to="/docs/tutorial/part-3"
+  to="/docs/tutorial/part-3/"
   rightIcon={<MdArrowForward />}
   variant="SECONDARY"
 >


### PR DESCRIPTION
## Description

Adds trailing slashes to the URLs in the "Continue to Part X" links at the end of each section. This should fix the redundant URLs in Google Analytics.
