### PR TITLE
fix(gatsby): fix PNP resolving from the .cache folder

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -6,6 +6,7 @@ const fs = require(`fs-extra`)
 const path = require(`path`)
 const dotenv = require(`dotenv`)
 const { CoreJSResolver } = require(`./webpack/corejs-resolver`)
+const { CacheFolderResolver } = require(`./webpack/cache-folder-resolver`)
 const { store } = require(`../redux`)
 const { actions } = require(`../redux/actions`)
 const { getPublicPath } = require(`./get-public-path`)
@@ -442,7 +443,10 @@ module.exports = async (
         ),
         $virtual: getAbsolutePathForVirtualModule(`$virtual`),
       },
-      plugins: [new CoreJSResolver()],
+      plugins: [
+        new CoreJSResolver(),
+        new CacheFolderResolver(path.join(program.directory, `.cache`)),
+      ],
     }
 
     const target =

--- a/packages/gatsby/src/utils/webpack/cache-folder-resolver.ts
+++ b/packages/gatsby/src/utils/webpack/cache-folder-resolver.ts
@@ -1,0 +1,76 @@
+import Resolver from "enhanced-resolve/lib/Resolver"
+
+interface IRequest {
+  request?: string
+  path: string
+}
+
+type ProcessWithPNP = NodeJS.ProcessVersions & { pnp?: string }
+
+/**
+ * To support PNP we have to make sure dependencies resolved from the .cache folder should be resolved from the gatsby package directory
+ */
+export class CacheFolderResolver {
+  private requestsFolder: string
+
+  constructor(requestsFolder: string) {
+    this.requestsFolder = requestsFolder
+  }
+
+  apply(resolver: Resolver): void {
+    if (!(process.versions as ProcessWithPNP).pnp) {
+      return
+    }
+
+    const target = resolver.ensureHook(`raw-module`)
+    resolver
+      .getHook(`raw-module`)
+      .tapAsync(
+        `CacheFolderResolver`,
+        (
+          request: IRequest,
+          resolveContext: unknown,
+          callback: (err?: Error | null, result?: unknown) => void
+        ) => {
+          const req = request.request
+          if (!req) {
+            return callback()
+          }
+
+          if (!request.path.startsWith(this.requestsFolder)) {
+            return callback()
+          }
+
+          const packageMatch = /^(@[^/]+\/)?[^/]+/.exec(req)
+          if (!packageMatch) {
+            return callback()
+          }
+
+          // We change the issuer but keep everything as is and re-run resolve
+          const obj = {
+            ...request,
+            path: __dirname,
+          }
+
+          return resolver.doResolve(
+            target,
+            obj,
+            `change issuer to gatsby package by cache-folder-resolver to fix pnp`,
+            resolveContext,
+            (err, result) => {
+              if (err) {
+                return callback(err)
+              }
+
+              if (result) {
+                return callback(null, result)
+              }
+
+              // Skip alternatives
+              return callback(null, null)
+            }
+          )
+        }
+      )
+  }
+}

--- a/packages/gatsby/src/utils/webpack/cache-folder-resolver.ts
+++ b/packages/gatsby/src/utils/webpack/cache-folder-resolver.ts
@@ -57,18 +57,7 @@ export class CacheFolderResolver {
             obj,
             `change issuer to gatsby package by cache-folder-resolver to fix pnp`,
             resolveContext,
-            (err, result) => {
-              if (err) {
-                return callback(err)
-              }
-
-              if (result) {
-                return callback(null, result)
-              }
-
-              // Skip alternatives
-              return callback(null, null)
-            }
+            callback
           )
         }
       )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Add an extra resolver to route dependencies used in the .cache folder from "gatsby" package to actually route properly through PNP.

## Related Issues
Fixes #30114 #19316
[ch32208]