### PR TITLE
fix(gatsby): fix tests for state persistence with lmdb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,12 +239,12 @@ jobs:
       image: "14"
     <<: *test_template
 
-  unit_tests_node14_strict_mode:
+  unit_tests_node14_lmdb_store:
     executor:
       name: node
       image: "14"
     environment:
-      GATSBY_EXPERIMENTAL_STRICT_MODE: 1
+      GATSBY_EXPERIMENTAL_LMDB_STORE: 1
     <<: *test_template
 
   integration_tests_gatsby_source_wordpress:
@@ -643,7 +643,7 @@ workflows:
             - lint
             - typecheck
             - bootstrap
-      - unit_tests_node14_strict_mode:
+      - unit_tests_node14_lmdb_store:
           <<: *ignore_docs
           # rebuild to get correct version of lmdb-store (compiled for node14 not node12)
           npm_rebuild: true

--- a/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
+++ b/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
@@ -161,8 +161,10 @@ export function setupLmdbStore(): IDataStore {
     getNodesByType,
   }
   replaceReducer({
-    nodes: (state = new Map(), _) => state,
-    nodesByType: (state = new Map(), _) => state,
+    nodes: (state = new Map(), action) =>
+      action.type === `DELETE_CACHE` ? new Map() : state,
+    nodesByType: (state = new Map(), action) =>
+      action.type === `DELETE_CACHE` ? new Map() : state,
   })
   emitter.on(`*`, action => {
     if (action) {

--- a/packages/gatsby/src/redux/__tests__/index.js
+++ b/packages/gatsby/src/redux/__tests__/index.js
@@ -434,7 +434,7 @@ describe(`redux db`, () => {
 
     persistedState = readState()
 
-    // With lmdb store we always restore a single dummy node to bypass
+    // With lmdb store we always persist a single dummy node to bypass
     //  "Cache exists but contains no nodes..." warning
     if (isLmdbStore()) {
       expect(persistedState.nodes?.size).toEqual(1)


### PR DESCRIPTION
## Description

We've renamed the env variable from `GATSBY_EXPERIMENTAL_STRICT_MODE` to `GATSBY_EXPERIMENTAL_LMDB_STORE` in #31371 but missed changing it in cricleci config.

This PR sets the correct variable and fixes tests that were actually failing (rather minor things)