### PR TITLE
docs(tutorial): fix import typo

### DIFF
--- a/docs/docs/tutorial/part-2/index.mdx
+++ b/docs/docs/tutorial/part-2/index.mdx
@@ -608,7 +608,7 @@ Then, in your component `.js` file, import each class separately and apply it to
 
 ```javascript:title=src/components/my-component.js
 import * as React from 'react'
-import { title } from './layout.module.css' // highlight-line
+import { title } from './my-component.module.css' // highlight-line
 
 const MyComponent = () => {
   return (


### PR DESCRIPTION
## Description

Fixes a typo in one of the imports in a code example in the Tutorial.

### Documentation

`/docs/tutorial/part-2`