### PR TITLE
chore(gatsby): type exposed workerpool functions

### DIFF
--- a/packages/gatsby/src/bootstrap/index.ts
+++ b/packages/gatsby/src/bootstrap/index.ts
@@ -14,7 +14,7 @@ import {
 import { Runner, createGraphQLRunner } from "./create-graphql-runner"
 import reporter from "gatsby-cli/lib/reporter"
 import { globalTracer } from "opentracing"
-import JestWorker from "jest-worker"
+import type { GatsbyWorkerPool } from "../utils/worker/pool"
 import { handleStalePageData } from "../utils/page-data"
 
 const tracer = globalTracer()
@@ -23,7 +23,7 @@ export async function bootstrap(
   initialContext: Partial<IBuildContext>
 ): Promise<{
   gatsbyNodeGraphQLFunction: Runner
-  workerPool: JestWorker
+  workerPool: GatsbyWorkerPool
 }> {
   const spanArgs = initialContext.parentSpan
     ? { childOf: initialContext.parentSpan }

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -13,7 +13,6 @@ import { getBrowsersList } from "../utils/browserslist"
 import { Store, AnyAction } from "redux"
 import { preferDefault } from "../bootstrap/prefer-default"
 import * as WorkerPool from "../utils/worker/pool"
-import JestWorker from "jest-worker"
 import { startPluginRunner } from "../redux/plugin-runner"
 import { loadPlugins } from "../bootstrap/load-plugins"
 import { store, emitter } from "../redux"
@@ -76,7 +75,7 @@ export async function initialize({
   parentSpan,
 }: IBuildContext): Promise<{
   store: Store<IGatsbyState, AnyAction>
-  workerPool: JestWorker
+  workerPool: WorkerPool.GatsbyWorkerPool
 }> {
   if (process.env.GATSBY_DISABLE_CACHE_PERSISTENCE) {
     reporter.info(

--- a/packages/gatsby/src/services/types.ts
+++ b/packages/gatsby/src/services/types.ts
@@ -5,7 +5,7 @@ import { GraphQLRunner } from "../query/graphql-runner"
 import { Store, AnyAction } from "redux"
 import { IGatsbyState } from "../redux/types"
 import { Express } from "express"
-import JestWorker from "jest-worker"
+import type { GatsbyWorkerPool } from "../utils/worker/pool"
 import { Actor, AnyEventObject } from "xstate"
 import { Compiler } from "webpack"
 import { WebsocketManager } from "../utils/websocket-manager"
@@ -30,7 +30,7 @@ export interface IBuildContext {
   webhookBody?: Record<string, unknown>
   webhookSourcePluginName?: string
   refresh?: boolean
-  workerPool?: JestWorker
+  workerPool?: GatsbyWorkerPool
   app?: Express
   nodesMutatedDuringQueryRun?: boolean
   nodesMutatedDuringQueryRunRecompileCount?: number

--- a/packages/gatsby/src/state-machines/data-layer/types.ts
+++ b/packages/gatsby/src/state-machines/data-layer/types.ts
@@ -4,7 +4,7 @@ import { Runner } from "../../bootstrap/create-graphql-runner"
 import { GraphQLRunner } from "../../query/graphql-runner"
 import { Store, AnyAction } from "redux"
 import { IGatsbyState } from "../../redux/types"
-import JestWorker from "jest-worker"
+import type { GatsbyWorkerPool } from "../../utils/worker/pool"
 export interface IGroupedQueryIds {
   pageQueryIds: Array<string>
   staticQueryIds: Array<string>
@@ -25,7 +25,7 @@ export interface IDataLayerContext {
   webhookBody?: Record<string, unknown>
   webhookSourcePluginName?: string
   refresh?: boolean
-  workerPool?: JestWorker
+  workerPool?: GatsbyWorkerPool
   pagesToBuild?: Array<string>
   pagesToDelete?: Array<string>
   shouldRunCreatePagesStatefully?: boolean

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -41,7 +41,6 @@ import { Express } from "express"
 import * as path from "path"
 
 import { Stage, IProgram } from "../commands/types"
-import JestWorker from "jest-worker"
 import { findOriginalSourcePositionAndContent } from "./stack-trace-utils"
 import { appendPreloadHeaders } from "./develop-preload-headers"
 import {
@@ -58,7 +57,7 @@ interface IServer {
   webpackActivity: ActivityTracker
   cancelDevJSNotice: CancelExperimentNoticeCallbackOrUndefined
   websocketManager: WebsocketManager
-  workerPool: JestWorker
+  workerPool: WorkerPool.GatsbyWorkerPool
   webpackWatching: IWebpackWatchingPauseResume
 }
 
@@ -70,7 +69,7 @@ export interface IWebpackWatchingPauseResume {
 export async function startServer(
   program: IProgram,
   app: Express,
-  workerPool: JestWorker = WorkerPool.create()
+  workerPool: WorkerPool.GatsbyWorkerPool = WorkerPool.create()
 ): Promise<IServer> {
   const directory = program.directory
 

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -1,13 +1,9 @@
 import Worker from "jest-worker"
 import { cpuCoreCount } from "gatsby-core-utils"
 
-// we only import it to get types, typescript will remove it from code if it's only used for types
-import * as exposedWorkerPoolMethods from "./child"
 import type { CreateWorkerPoolType } from "./types"
 
-export type GatsbyWorkerPool = CreateWorkerPoolType<
-  typeof exposedWorkerPoolMethods
->
+export type GatsbyWorkerPool = CreateWorkerPoolType<typeof import("./child")>
 
 export const create = (): GatsbyWorkerPool =>
   new Worker(require.resolve(`./child`), {

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -1,10 +1,18 @@
 import Worker from "jest-worker"
 import { cpuCoreCount } from "gatsby-core-utils"
 
-export const create = (): Worker =>
+// we only import it to get types, typescript will remove it from code if it's only used for types
+import * as exposedWorkerPoolMethods from "./child"
+import type { CreateWorkerPoolType } from "./types"
+
+export type GatsbyWorkerPool = CreateWorkerPoolType<
+  typeof exposedWorkerPoolMethods
+>
+
+export const create = (): GatsbyWorkerPool =>
   new Worker(require.resolve(`./child`), {
     numWorkers: Math.max(1, cpuCoreCount() - 1),
     forkOptions: {
       silent: false,
     },
-  })
+  }) as GatsbyWorkerPool

--- a/packages/gatsby/src/utils/worker/render-html.ts
+++ b/packages/gatsby/src/utils/worker/render-html.ts
@@ -280,7 +280,7 @@ export const renderHTMLProd = async ({
 }: {
   htmlComponentRendererPath: string
   paths: Array<string>
-  envVars: Array<Array<string>>
+  envVars: Array<[string, string | undefined]>
   sessionId: number
 }): Promise<IRenderHtmlResult> => {
   const publicDir = join(process.cwd(), `public`)
@@ -353,7 +353,7 @@ export const renderHTMLDev = async ({
 }: {
   htmlComponentRendererPath: string
   paths: Array<string>
-  envVars: Array<Array<string>>
+  envVars: Array<[string, string | undefined]>
   sessionId: number
 }): Promise<Array<unknown>> => {
   const outputDir = join(process.cwd(), `.cache`, `develop-html`)

--- a/packages/gatsby/src/utils/worker/render-html.ts
+++ b/packages/gatsby/src/utils/worker/render-html.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+
 import fs from "fs-extra"
 import Bluebird from "bluebird"
 import * as path from "path"
@@ -7,6 +9,15 @@ import { IPageDataWithQueryResult } from "../../utils/page-data"
 import { IRenderHtmlResult } from "../../commands/build-html"
 // we want to force posix-style joins, so Windows doesn't produce backslashes for urls
 const { join } = path.posix
+
+declare global {
+  namespace NodeJS {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    interface Global {
+      unsafeBuiltinUsage: Array<string> | undefined
+    }
+  }
+}
 
 /**
  * Used to track if renderHTMLProd / renderHTMLDev are called within same "session" (from same renderHTMLQueue call).

--- a/packages/gatsby/src/utils/worker/types.ts
+++ b/packages/gatsby/src/utils/worker/types.ts
@@ -1,0 +1,24 @@
+import type Worker from "jest-worker"
+
+type WrapReturnOfAFunctionInAPromise<
+  FunctionThatDoesNotReturnAPromise extends (...args: Array<any>) => any
+> = (
+  ...a: Parameters<FunctionThatDoesNotReturnAPromise>
+) => Promise<ReturnType<FunctionThatDoesNotReturnAPromise>>
+
+// jest-worker will make sync function async, so to keep proper types we need to adjust types so all functions
+// on worker pool are async
+type EnsureFunctionReturnsAPromise<MaybeFunction> = MaybeFunction extends (
+  ...args: Array<any>
+) => Promise<any>
+  ? MaybeFunction
+  : MaybeFunction extends (...args: Array<any>) => any
+  ? WrapReturnOfAFunctionInAPromise<MaybeFunction>
+  : never
+
+export type CreateWorkerPoolType<ExposedFunctions> = Worker &
+  {
+    [FunctionName in keyof ExposedFunctions]: EnsureFunctionReturnsAPromise<
+      ExposedFunctions[FunctionName]
+    >
+  }

--- a/packages/gatsby/src/utils/worker/worker.d.ts
+++ b/packages/gatsby/src/utils/worker/worker.d.ts
@@ -1,5 +1,0 @@
-declare module NodeJS {
-  interface Global {
-    unsafeBuiltinUsage: Array<string> | undefined
-  }
-}


### PR DESCRIPTION
## Description

Currently our worker pool has type `any` when actually interacting with it (in `build-html.ts`), this just adds types to exposed functions