### PR TITLE
test(gatsby): check if worker can access node created in different process

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
     `<rootDir>/node_modules/`,
     `<rootDir>/packages/gatsby-admin/.cache/`,
     `<rootDir>/packages/gatsby-plugin-gatsby-cloud/src/__tests__/mocks/`,
+    `<rootDir>/packages/gatsby/src/utils/worker/__tests__/test-helpers/`,
     `<rootDir>/deprecated-packages/`,
     `__tests__/fixtures`,
     `__testfixtures__/`,

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -165,6 +165,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
+    "@babel/register": "^7.13.16",
     "@babel/runtime": "^7.14.0",
     "@types/eslint": "^7.2.6",
     "@types/micromatch": "^4.0.1",

--- a/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
+++ b/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
@@ -8,7 +8,9 @@ import { emitter, replaceReducer } from "../../redux"
 
 const rootDbFile =
   process.env.NODE_ENV === `test`
-    ? `test-datastore-${process.env.JEST_WORKER_ID}`
+    ? `test-datastore-${
+        process.env.FORCE_TEST_DATABASE_ID ?? process.env.JEST_WORKER_ID
+      }`
     : `datastore`
 
 let rootDb

--- a/packages/gatsby/src/utils/worker/__tests__/datastore.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/datastore.ts
@@ -1,0 +1,59 @@
+import {
+  createTestWorker,
+  GatsbyTestWorkerPool,
+  itWhenLMDB,
+} from "./test-helpers"
+import { store } from "../../../redux"
+import { actions } from "../../../redux/actions"
+import { getDataStore } from "../../../datastore"
+
+let worker: GatsbyTestWorkerPool | undefined
+
+beforeEach(() => {
+  store.dispatch({ type: `DELETE_CACHE` })
+})
+
+afterEach(() => {
+  if (worker) {
+    worker.end()
+    worker = undefined
+  }
+})
+
+itWhenLMDB(`worker can access node created in main process`, async () => {
+  worker = createTestWorker()
+
+  const testNodeId = `shared-node`
+
+  expect(getDataStore().getNode(testNodeId)).toBeFalsy()
+  expect(await worker.getNodeFromWorker(testNodeId)).toBeFalsy()
+
+  const node = {
+    id: testNodeId,
+    parent: null,
+    children: [],
+    internal: { type: `SharedNode`, contentDigest: `0` },
+    field: `should-be-accessible-in-worker`,
+  }
+  await store.dispatch(actions.createNode(node, { name: `test` }))
+  await getDataStore().ready()
+
+  const nodeStoredInMainProcess = getDataStore().getNode(testNodeId)
+  const nodeStoredInWorkerProcess = await worker.getNodeFromWorker(testNodeId)
+
+  expect(nodeStoredInWorkerProcess).toMatchInlineSnapshot(`
+    Object {
+      "children": Array [],
+      "field": "should-be-accessible-in-worker",
+      "id": "shared-node",
+      "internal": Object {
+        "contentDigest": "0",
+        "counter": 1,
+        "owner": "test",
+        "type": "SharedNode",
+      },
+      "parent": null,
+    }
+  `)
+  expect(nodeStoredInWorkerProcess).toEqual(nodeStoredInMainProcess)
+})

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/child-for-tests.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/child-for-tests.ts
@@ -1,0 +1,9 @@
+import { getNode } from "../../../../datastore"
+
+// re-export all usual methods from production worker
+export * from "../../child"
+
+// additional functions to be able to write assertions that won't be available in production code
+export function getNodeFromWorker(nodeId: string): ReturnType<typeof getNode> {
+  return getNode(nodeId)
+}

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/create-test-worker.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/create-test-worker.ts
@@ -1,0 +1,22 @@
+import Worker from "jest-worker"
+import type { CreateWorkerPoolType } from "../../types"
+
+export type GatsbyTestWorkerPool = CreateWorkerPoolType<
+  typeof import("./child-for-tests")
+>
+
+export function createTestWorker(): GatsbyTestWorkerPool {
+  // all child processes of this worker pool would have JEST_WORKER_ID set to 1
+  // but running jest tests would create processes with possibly other IDs
+  // this will let child processes use same database ID as parent process (one that executes test)
+  process.env.FORCE_TEST_DATABASE_ID = process.env.JEST_WORKER_ID
+
+  const worker = new Worker(require.resolve(`./wrapper-for-tests`), {
+    numWorkers: 1,
+    forkOptions: {
+      silent: false,
+    },
+    maxRetries: 1,
+  }) as GatsbyTestWorkerPool
+  return worker
+}

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/index.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/index.ts
@@ -1,0 +1,2 @@
+export * from "./create-test-worker"
+export * from "./jest-helpers"

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/jest-helpers.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/jest-helpers.ts
@@ -1,0 +1,3 @@
+export const itWhenLMDB = process.env.GATSBY_EXPERIMENTAL_LMDB_STORE
+  ? it
+  : it.skip

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/jest-helpers.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/jest-helpers.ts
@@ -1,3 +1,7 @@
+// spawning processing will occasionally exceed default time for test
+// this sets up a bit longer time for each test to avoid flakiness due to tests not being executed within short time frame
+jest.setTimeout(35000)
+
 export const itWhenLMDB = process.env.GATSBY_EXPERIMENTAL_LMDB_STORE
   ? it
   : it.skip

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/wrapper-for-tests.js
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/wrapper-for-tests.js
@@ -1,0 +1,7 @@
+// spawned process won't use jest config to support TS, so we need to add support ourselves
+require(`@babel/register`)({
+  extensions: [`.js`, `.ts`],
+  configFile: require.resolve(`../../../../../babel.config.js`),
+})
+
+module.exports = require(`./child-for-tests`)


### PR DESCRIPTION
## Description

Building on https://github.com/gatsbyjs/gatsby/pull/31768

This adds setup and helpers to be able to execute tests covering workerpool. This adds single test that checks if worker can get node created by different process. But main point of this PR is to setup test helpers and structure for the future.

Overview of setup:
 - `createTestWorker` creates actual worker (separate process)
 - `packages/gatsby/src/utils/worker/__tests__/test-helpers/child-for-tests.ts` is a place to add additional helper functions so tests could interact with worker that shouldn't be available in actual production worker pool
 - `itWhenLMDB` is just convience wrapper around jest's `it` to only execute tests when `LMDB_STORE` flag/env is set

## Related Issues

[ch32034]
