### PR TITLE
refactor(gatsby): load config and plugins in worker

### DIFF
--- a/integration-tests/gatsby-cli/__tests__/build.js
+++ b/integration-tests/gatsby-cli/__tests__/build.js
@@ -12,8 +12,9 @@ describe(`gatsby build`, () => {
   it(`creates a built gatsby site`, () => {
     const [code, logs] = GatsbyCLI.from(cwd).invoke(`build`)
 
-    logs.should.contain(`success open and validate gatsby-configs`)
-    logs.should.contain(`success load plugins`)
+    logs.should.contain(
+      `success open and validate gatsby-configs, load plugins`
+    )
     logs.should.contain(`success onPreInit`)
     logs.should.contain(`success initialize cache`)
     logs.should.contain(`success copy gatsby files`)

--- a/integration-tests/gatsby-cli/__tests__/develop.js
+++ b/integration-tests/gatsby-cli/__tests__/develop.js
@@ -26,8 +26,9 @@ describe(`gatsby develop`, () => {
 
     // 3. Make sure logs for the user contain expected results
     const logs = getLogs()
-    logs.should.contain(`success open and validate gatsby-configs`)
-    logs.should.contain(`success load plugins`)
+    logs.should.contain(
+      `success open and validate gatsby-configs, load plugins`
+    )
     logs.should.contain(`success onPreInit`)
     logs.should.contain(`success initialize cache`)
     logs.should.contain(`success copy gatsby files`)

--- a/integration-tests/gatsby-cli/__tests__/repl.js
+++ b/integration-tests/gatsby-cli/__tests__/repl.js
@@ -21,8 +21,9 @@ describe(`gatsby repl`, () => {
 
     // 3. Make assertions
     const logs = getLogs()
-    logs.should.contain(`success open and validate gatsby-configs`)
-    logs.should.contain(`success load plugins`)
+    logs.should.contain(
+      `success open and validate gatsby-configs, load plugins`
+    )
     logs.should.contain(`success onPreInit`)
     logs.should.contain(`success initialize cache`)
     logs.should.contain(`success copy gatsby files`)

--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.ts
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.ts
@@ -109,6 +109,17 @@ function getPosition({
   map: BasicSourceMapConsumer | IndexedSourceMapConsumer
   frame: stackTrace.StackFrame
 }): NullableMappedPosition {
+  if (frame.getFileName().includes(`webpack:`)) {
+    // if source-map-register is initiated, stack traces would already be converted
+    return {
+      column: frame.getColumnNumber() - 1,
+      line: frame.getLineNumber(),
+      source: frame
+        .getFileName()
+        .substr(frame.getFileName().indexOf(`webpack:`)),
+    }
+  }
+
   const line = frame.getLineNumber()
   const column = frame.getColumnNumber()
   return map.originalPositionFor({ line, column })

--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.ts
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.ts
@@ -117,6 +117,7 @@ function getPosition({
       source: frame
         .getFileName()
         .substr(frame.getFileName().indexOf(`webpack:`)),
+      name: null,
     }
   }
 

--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.ts
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.ts
@@ -116,7 +116,8 @@ function getPosition({
       line: frame.getLineNumber(),
       source: frame
         .getFileName()
-        .substr(frame.getFileName().indexOf(`webpack:`)),
+        .substr(frame.getFileName().indexOf(`webpack:`))
+        .replace(/webpack:\/+/g, `webpack://`),
       name: null,
     }
   }

--- a/packages/gatsby/src/bootstrap/load-config-and-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-config-and-plugins.ts
@@ -1,0 +1,52 @@
+import reporter from "gatsby-cli/lib/reporter"
+
+import { IFlattenedPlugin } from "./load-plugins/types"
+
+import { preferDefault } from "../bootstrap/prefer-default"
+import { getConfigFile } from "../bootstrap/get-config-file"
+import { loadPlugins } from "../bootstrap/load-plugins"
+import { internalActions } from "../redux/actions"
+import loadThemes from "../bootstrap/load-themes"
+import { store } from "../redux"
+
+export async function loadConfigAndPlugins({
+  siteDirectory,
+}: {
+  siteDirectory: string
+}): Promise<{
+  config: any
+  flattenedPlugins: Array<IFlattenedPlugin>
+}> {
+  // Try opening the site's gatsby-config.js file.
+  const { configModule, configFilePath } = await getConfigFile(
+    siteDirectory,
+    `gatsby-config`
+  )
+  let config = preferDefault(configModule)
+
+  // The root config cannot be exported as a function, only theme configs
+  if (typeof config === `function`) {
+    reporter.panic({
+      id: `10126`,
+      context: {
+        configName: `gatsby-config`,
+        siteDirectory,
+      },
+    })
+  }
+
+  // theme gatsby configs can be functions or objects
+  if (config) {
+    const plugins = await loadThemes(config, {
+      configFilePath,
+      rootDir: siteDirectory,
+    })
+    config = plugins.config
+  }
+
+  store.dispatch(internalActions.setSiteConfig(config))
+
+  const flattenedPlugins = await loadPlugins(config, siteDirectory)
+
+  return { config, flattenedPlugins }
+}

--- a/packages/gatsby/src/bootstrap/load-plugins/load.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load.ts
@@ -71,9 +71,9 @@ export function resolvePlugin(
   rootDir = (!_.isString(plugin) && plugin.parentDir) || rootDir
 
   // Only find plugins when we're not given an absolute path
-  if (!existsSync(pluginName)) {
+  if (!existsSync(pluginName) && rootDir) {
     // Find the plugin in the local plugins folder
-    const resolvedPath = slash(path.resolve(`./plugins/${pluginName}`))
+    const resolvedPath = slash(path.join(rootDir, `plugins/${pluginName}`))
 
     if (existsSync(resolvedPath)) {
       if (existsSync(`${resolvedPath}/package.json`)) {

--- a/packages/gatsby/src/bootstrap/load-themes/index.js
+++ b/packages/gatsby/src/bootstrap/load-themes/index.js
@@ -31,7 +31,7 @@ const resolveTheme = async (
     // local themes with same name that do different things and name being
     // main identifier that Gatsby uses right now, it's safer not to support it for now.
     if (isMainConfig) {
-      pathToLocalTheme = path.join(path.resolve(`.`), `plugins`, themeName)
+      pathToLocalTheme = path.join(rootDir, `plugins`, themeName)
       // is a local plugin OR it doesn't exist
       try {
         const { resolve } = resolvePlugin(themeName, rootDir)

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -11,21 +11,17 @@ import apiRunnerNode from "../utils/api-runner-node"
 import handleFlags from "../utils/handle-flags"
 import { getBrowsersList } from "../utils/browserslist"
 import { Store, AnyAction } from "redux"
-import { preferDefault } from "../bootstrap/prefer-default"
 import * as WorkerPool from "../utils/worker/pool"
 import { startPluginRunner } from "../redux/plugin-runner"
-import { loadPlugins } from "../bootstrap/load-plugins"
 import { store, emitter } from "../redux"
-import loadThemes from "../bootstrap/load-themes"
 import reporter from "gatsby-cli/lib/reporter"
-import { getConfigFile } from "../bootstrap/get-config-file"
 import { removeStaleJobs } from "../bootstrap/remove-stale-jobs"
 import { IPluginInfoOptions } from "../bootstrap/load-plugins/types"
-import { internalActions } from "../redux/actions"
 import { IGatsbyState } from "../redux/types"
 import { IBuildContext } from "./types"
 import availableFlags from "../utils/flags"
 import { detectLmdbStore } from "../datastore"
+import { loadConfigAndPlugins } from "../bootstrap/load-config-and-plugins"
 
 interface IPluginResolution {
   resolve: string
@@ -137,26 +133,17 @@ export async function initialize({
   emitter.on(`END_JOB`, onEndJob)
 
   // Try opening the site's gatsby-config.js file.
-  let activity = reporter.activityTimer(`open and validate gatsby-configs`, {
-    parentSpan,
-  })
-  activity.start()
-  const { configModule, configFilePath } = await getConfigFile(
-    program.directory,
-    `gatsby-config`
+  let activity = reporter.activityTimer(
+    `open and validate gatsby-configs, load plugins`,
+    {
+      parentSpan,
+    }
   )
-  let config = preferDefault(configModule)
+  activity.start()
 
-  // The root config cannot be exported as a function, only theme configs
-  if (typeof config === `function`) {
-    reporter.panic({
-      id: `10126`,
-      context: {
-        configName: `gatsby-config`,
-        path: program.directory,
-      },
-    })
-  }
+  const { config, flattenedPlugins } = await loadConfigAndPlugins({
+    siteDirectory: program.directory,
+  })
 
   // Setup flags
   if (config) {
@@ -206,22 +193,11 @@ export async function initialize({
   }
   detectLmdbStore()
 
-  // theme gatsby configs can be functions or objects
-  if (config) {
-    const plugins = await loadThemes(config, {
-      configFilePath,
-      rootDir: program.directory,
-    })
-    config = plugins.config
-  }
-
   if (config && config.polyfill) {
     reporter.warn(
       `Support for custom Promise polyfills has been removed in Gatsby v2. We only support Babel 7's new automatic polyfilling behavior.`
     )
   }
-
-  store.dispatch(internalActions.setSiteConfig(config))
 
   activity.end()
 
@@ -240,13 +216,6 @@ export async function initialize({
 
   // run stale jobs
   store.dispatch(removeStaleJobs(store.getState()))
-
-  activity = reporter.activityTimer(`load plugins`, {
-    parentSpan,
-  })
-  activity.start()
-  const flattenedPlugins = await loadPlugins(config, program.directory)
-  activity.end()
 
   // Multiple occurrences of the same name-version-pair can occur,
   // so we report an array of unique pairs

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -8,7 +8,6 @@ import path from "path"
 import telemetry from "gatsby-telemetry"
 
 import apiRunnerNode from "../utils/api-runner-node"
-import handleFlags from "../utils/handle-flags"
 import { getBrowsersList } from "../utils/browserslist"
 import { Store, AnyAction } from "redux"
 import * as WorkerPool from "../utils/worker/pool"
@@ -19,7 +18,6 @@ import { removeStaleJobs } from "../bootstrap/remove-stale-jobs"
 import { IPluginInfoOptions } from "../bootstrap/load-plugins/types"
 import { IGatsbyState } from "../redux/types"
 import { IBuildContext } from "./types"
-import availableFlags from "../utils/flags"
 import { detectLmdbStore } from "../datastore"
 import { loadConfigAndPlugins } from "../bootstrap/load-config-and-plugins"
 
@@ -143,42 +141,8 @@ export async function initialize({
 
   const { config, flattenedPlugins } = await loadConfigAndPlugins({
     siteDirectory: program.directory,
+    processFlags: true,
   })
-
-  // Setup flags
-  if (config) {
-    // Get flags
-    const { enabledConfigFlags, unknownFlagMessage, message } = handleFlags(
-      availableFlags,
-      config.flags
-    )
-
-    if (unknownFlagMessage !== ``) {
-      reporter.warn(unknownFlagMessage)
-    }
-
-    //  set process.env for each flag
-    enabledConfigFlags.forEach(flag => {
-      process.env[flag.env] = `true`
-    })
-
-    // Print out message.
-    if (message !== ``) {
-      reporter.info(message)
-    }
-
-    //  track usage of feature
-    enabledConfigFlags.forEach(flag => {
-      if (flag.telemetryId) {
-        telemetry.trackFeatureIsUsed(flag.telemetryId)
-      }
-    })
-
-    // Track the usage of config.flags
-    if (config.flags) {
-      telemetry.trackFeatureIsUsed(`ConfigFlags`)
-    }
-  }
 
   // TODO: figure out proper way of disabling loading indicator
   // for now GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR=false gatsby develop

--- a/packages/gatsby/src/utils/worker/__tests__/config.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/config.ts
@@ -1,0 +1,31 @@
+import { createTestWorker, GatsbyTestWorkerPool } from "./test-helpers"
+import { store } from "../../../redux"
+import * as path from "path"
+
+let worker: GatsbyTestWorkerPool | undefined
+
+beforeEach(() => {
+  store.dispatch({ type: `DELETE_CACHE` })
+})
+
+afterEach(() => {
+  if (worker) {
+    worker.end()
+    worker = undefined
+  }
+})
+
+it(`can load config and execute node API in worker`, async () => {
+  worker = createTestWorker()
+
+  const siteDirectory = path.join(__dirname, `fixtures`, `sample-site`)
+
+  // plugin options for custom local plugin contains function (() => `foo`)
+  await worker.loadConfigAndPlugins({ siteDirectory })
+
+  // plugin API execute function from plugin options and store result in `global`
+  await worker.runAPI(`createSchemaCustomization`)
+
+  // getting result stored in `global`
+  expect(await worker.getAPIRunResult()).toEqual(`foo`)
+})

--- a/packages/gatsby/src/utils/worker/__tests__/fixtures/sample-site/gatsby-config.js
+++ b/packages/gatsby/src/utils/worker/__tests__/fixtures/sample-site/gatsby-config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-test`,
+      options: {
+        fn: () => `foo`
+      }
+    }
+  ],
+}

--- a/packages/gatsby/src/utils/worker/__tests__/fixtures/sample-site/plugins/gatsby-plugin-test/gatsby-node.js
+++ b/packages/gatsby/src/utils/worker/__tests__/fixtures/sample-site/plugins/gatsby-plugin-test/gatsby-node.js
@@ -1,0 +1,3 @@
+exports.createSchemaCustomization = (_, pluginOptions) => {
+  global.test = pluginOptions.fn()
+}

--- a/packages/gatsby/src/utils/worker/__tests__/fixtures/sample-site/plugins/gatsby-plugin-test/package.json
+++ b/packages/gatsby/src/utils/worker/__tests__/fixtures/sample-site/plugins/gatsby-plugin-test/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "gatsby-node.js"
+}

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/child-for-tests.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/child-for-tests.ts
@@ -1,5 +1,6 @@
 import { getNode } from "../../../../datastore"
 import reporter from "gatsby-cli/lib/reporter"
+import apiRunner from "../../../api-runner-node"
 
 // re-export all usual methods from production worker
 export * from "../../child"
@@ -15,4 +16,14 @@ export function getNodeFromWorker(nodeId: string): ReturnType<typeof getNode> {
 export function log(message: string): boolean {
   reporter.log(message)
   return true
+}
+
+// test: config
+export async function runAPI(apiName: string): Promise<any> {
+  return await apiRunner(apiName)
+}
+
+// test: config
+export function getAPIRunResult(): string | undefined {
+  return (global as any).test
 }

--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -1,2 +1,3 @@
 // Note: this doesn't check for conflicts between module exports
 export { renderHTMLProd, renderHTMLDev } from "./render-html"
+export { loadConfigAndPlugins } from "./load-config-and-plugins"

--- a/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
+++ b/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
@@ -1,0 +1,1 @@
+export { loadConfigAndPlugins } from "../../../bootstrap/load-config-and-plugins"

--- a/packages/gatsby/src/utils/worker/child/render-html.ts
+++ b/packages/gatsby/src/utils/worker/child/render-html.ts
@@ -4,9 +4,9 @@ import fs from "fs-extra"
 import Bluebird from "bluebird"
 import * as path from "path"
 
-import { getPageHtmlFilePath } from "../../utils/page-html"
-import { IPageDataWithQueryResult } from "../../utils/page-data"
-import { IRenderHtmlResult } from "../../commands/build-html"
+import { getPageHtmlFilePath } from "../../../utils/page-html"
+import { IPageDataWithQueryResult } from "../../../utils/page-data"
+import { IRenderHtmlResult } from "../../../commands/build-html"
 // we want to force posix-style joins, so Windows doesn't produce backslashes for urls
 const { join } = path.posix
 


### PR DESCRIPTION
## Description

This PR allows worker process to load `gatsby-config` and therefore also execute node APIs

[ch32027]