### PR TITLE
fix(gatsby-remark-copy-linked-files): replace checking parent node type to 'dir'

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -272,6 +272,23 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     expect(fsExtra.copy).not.toHaveBeenCalled()
   })
 
+  it(`do nothing if dir is not found`, async () => {
+    const getNode = () => {
+      return {
+        internal: {
+          type: `Node`,
+        },
+      }
+    }
+    const path = `images/sample-image.gif`
+
+    const markdownAST = remark.parse(`![sample][1]\n\n[1]: ${path}`)
+
+    await plugin({ files: getFiles(path), markdownAST, markdownNode, getNode })
+
+    expect(fsExtra.copy).not.toHaveBeenCalled()
+  })
+
   describe(`respects pathPrefix`, () => {
     const imageName = `sample-image`
     const imageRelativePath = `images/${imageName}.svg`

--- a/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/__tests__/index.js
@@ -24,19 +24,20 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     fsExtra.copy.mockReset()
   })
 
+  const parentDir = `/`
   const markdownNode = {
     parent: {},
   }
   const getNode = () => {
     return {
-      dir: ``,
+      dir: parentDir,
       internal: {
         type: `File`,
       },
     }
   }
   const getFiles = filePath => {
-    const absolutePath = path.posix.normalize(filePath)
+    const absolutePath = path.posix.normalize(parentDir + filePath)
     return [
       {
         absolutePath,
@@ -273,12 +274,13 @@ describe(`gatsby-remark-copy-linked-files`, () => {
 
   describe(`respects pathPrefix`, () => {
     const imageName = `sample-image`
-    const imagePath = `images/${imageName}.svg`
+    const imageRelativePath = `images/${imageName}.svg`
+    const imagePath = parentDir + imageRelativePath
 
     // pathPrefix passed to plugins already combine pathPrefix and assetPrefix
     it(`relative pathPrefix (no assetPrefix)`, async () => {
       const pathPrefix = `/path-prefix`
-      const markdownAST = remark.parse(`![some image](${imagePath})`)
+      const markdownAST = remark.parse(`![some image](${imageRelativePath})`)
 
       const expectedNewPath = path.posix.join(
         process.cwd(),
@@ -304,7 +306,7 @@ describe(`gatsby-remark-copy-linked-files`, () => {
 
     it(`absolute pathPrefix (with assetPrefix, empty base path prefix)`, async () => {
       const pathPrefix = `https://cdn.mysiteassets.com`
-      const markdownAST = remark.parse(`![some image](${imagePath})`)
+      const markdownAST = remark.parse(`![some image](${imageRelativePath})`)
 
       const expectedNewPath = path.posix.join(
         process.cwd(),
@@ -330,7 +332,7 @@ describe(`gatsby-remark-copy-linked-files`, () => {
 
     it(`absolute pathPrefix (with assetPrefix, and non-empty base path prefix)`, async () => {
       const pathPrefix = `https://cdn.mysiteassets.com/path-prefix`
-      const markdownAST = remark.parse(`![some image](${imagePath})`)
+      const markdownAST = remark.parse(`![some image](${imageRelativePath})`)
 
       const expectedNewPath = path.posix.join(
         process.cwd(),
@@ -357,10 +359,13 @@ describe(`gatsby-remark-copy-linked-files`, () => {
 
   describe(`options.destinationDir`, () => {
     const imageName = `sample-image`
-    const imagePath = `images/${imageName}.gif`
+    const imageRelativePath = `images/${imageName}.gif`
+    const imagePath = parentDir + imageRelativePath
 
     it(`throws an error if the destination supplied by destinationDir points outside of the root dir`, async () => {
-      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const markdownAST = remark.parse(
+        `![some absolute image](${imageRelativePath})`
+      )
       const invalidDestinationDir = `../destination`
       expect.assertions(2)
       return plugin(
@@ -375,7 +380,9 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     })
 
     it(`throws an error if the destination supplied by the destinationDir function points outside of the root dir`, async () => {
-      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const markdownAST = remark.parse(
+        `![some absolute image](${imageRelativePath})`
+      )
       const invalidDestinationDir = `../destination`
       const customDestinationDir = f =>
         `../destination/${f.hash}/${f.name}/${f.notexist}`
@@ -392,7 +399,9 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     })
 
     it(`copies file to the destination supplied by destinationDir`, async () => {
-      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const markdownAST = remark.parse(
+        `![some absolute image](${imageRelativePath})`
+      )
       const validDestinationDir = `path/to/dir`
       const fileLocationPart = `some-hash/${imageName}.gif`
       const expectedNewPath = path.posix.join(
@@ -417,7 +426,9 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     })
 
     it(`copies file to the destination supplied by the destinationDir function`, async () => {
-      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const markdownAST = remark.parse(
+        `![some absolute image](${imageRelativePath})`
+      )
       const customDestinationDir = f => `foo/${f.hash}--bar`
       const expectedDestination = `foo/some-hash--bar.gif`
       expect.assertions(3)
@@ -435,7 +446,9 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     })
 
     it(`copies file to the destination supplied by destinationDir (with pathPrefix)`, async () => {
-      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const markdownAST = remark.parse(
+        `![some absolute image](${imageRelativePath})`
+      )
       const pathPrefix = `/blog`
       const validDestinationDir = `path/to/dir`
 
@@ -468,7 +481,9 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     })
 
     it(`copies file to the destination supplied by the destinationDir function (with pathPrefix)`, async () => {
-      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const markdownAST = remark.parse(
+        `![some absolute image](${imageRelativePath})`
+      )
       const pathPrefix = `/blog`
       const customDestinationDir = f => `hello${f.name}123`
       const expectedDestination = `hello${imageName}123.gif`
@@ -495,7 +510,9 @@ describe(`gatsby-remark-copy-linked-files`, () => {
     })
 
     it(`copies file to the root dir when destinationDir is not supplied`, async () => {
-      const markdownAST = remark.parse(`![some absolute image](${imagePath})`)
+      const markdownAST = remark.parse(
+        `![some absolute image](${imageRelativePath})`
+      )
       const expectedNewPath = path.posix.join(
         process.cwd(),
         `public`,

--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -89,10 +89,7 @@ module.exports = (
   // Copy linked files to the destination directory and modify the AST to point
   // to new location of the files.
   const visitor = link => {
-    if (
-      isRelativeUrl(link.url) &&
-      getNode(markdownNode.parent).internal.type === `File`
-    ) {
+    if (isRelativeUrl(link.url) && getNode(markdownNode.parent).dir) {
       const linkPath = path.posix.join(
         getNode(markdownNode.parent).dir,
         link.url
@@ -193,11 +190,8 @@ module.exports = (
       return
     }
 
-    // since dir will be undefined on non-files
-    if (
-      markdownNode.parent &&
-      getNode(markdownNode.parent).internal.type !== `File`
-    ) {
+    // Just make sure the parent node has dir
+    if (markdownNode.parent && !getNode(markdownNode.parent).dir) {
       return
     }
 


### PR DESCRIPTION
## Description

Remove checking whether parent node is `File` type so that even though the markdown node has different type of parent node, the plugin still can process it. Then, we just need to make sure its parent node has `dir` value to get directory path for the files.

This detail was posted at https://github.com/gatsbyjs/gatsby/discussions/31592