### PR TITLE
chore(docs): Update gatsby-plugin-image typos

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -250,7 +250,7 @@ These source plugins support using `gatsby-plugin-image` with images served from
 
 A dedicated image CDN can be used with sources that don't have their own CDN, or where you need more transforms or formats than the CDN offers.
 
-- [imgix](https://github.com/imgix/gatsby)
+- [imgix](/plugins/@imgix/gatsby)
 
 ### Plugin authors
 

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -43,7 +43,7 @@ Note that `gatsby-source-filesystem` is not included in this config. If you are 
 
 ### Decide which component to use
 
-The Gatsby Image plugin includes two image components: one for static and one for dynamic images. The simplest way to decide which you need to is to ask yourself: _"will this image be the same every time the component or template is used?"_. If it will always be the same, then use `StaticImage`. If it will change, whether through data coming from a CMS or different values passed to a component each time you use it, then it is a dynamic image and you should use the `GatsbyImage` component.
+The Gatsby Image plugin includes two image components: one for static and one for dynamic images. The simplest way to decide which you need is to ask yourself: _"will this image be the same every time the component or template is used?"_. If it will always be the same, then use `StaticImage`. If it will change, whether through data coming from a CMS or different values passed to a component each time you use it, then it is a dynamic image and you should use the `GatsbyImage` component.
 
 ### Static images
 
@@ -233,24 +233,24 @@ module.exports = {
 
 ## Using images from a CMS or CDN
 
-Many source plugins have native support for `gatsby-plugin-image`, with images served directly from a content delivery network (CDN). This means that builds are faster, because there is no need download images and process them locally. The query syntax varies according to the plugin, as do the supported transformation features and image formats. Make sure you update to the latest version of the source plugin to ensure there is support. For plugins that are not in this list you can use [dynamic images from `gatsby-transformer-sharp`](#dynamic-images).
+Many source plugins have native support for `gatsby-plugin-image`, with images served directly from a content delivery network (CDN). This means that builds are faster, because there is no need to download images and process them locally. The query syntax varies according to the plugin, as do the supported transformation features and image formats. Make sure you update to the latest version of the source plugin to ensure there is support. For plugins that are not in this list you can use [dynamic images from `gatsby-transformer-sharp`](#dynamic-images).
 
 ### Source plugins
 
 These source plugins support using `gatsby-plugin-image` with images served from their CDN.
 
 - [AgilityCMS](https://github.com/agility/gatsby-image-agilitycms)
-- [Contentful](/plugins/gatsby-source-contentful/#using-the-new-gatsby-image-plugin)
-- [DatoCMS](/plugins/gatsby-source-datocms/#integration-with-gatsby-image)
-- [GraphCMS](/plugins/gatsby-source-graphcms/#usage-with-gatsby-plugin-image)
-- [Sanity](/plugins/gatsby-source-sanity/#using-images)
+- [Contentful](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#using-the-new-gatsby-image-plugin)
+- [DatoCMS](https://github.com/datocms/gatsby-source-datocms#integration-with-gatsby-image)
+- [GraphCMS](https://github.com/GraphCMS/gatsby-source-graphcms#usage-with-gatsby-plugin-image)
+- [Sanity](https://github.com/sanity-io/gatsby-source-sanity#using-images)
 - [Shopify](https://github.com/gatsbyjs/gatsby-source-shopify-experimental#images)
 
 ### Image CDNs
 
 A dedicated image CDN can be used with sources that don't have their own CDN, or where you need more transforms or formats than the CDN offers.
 
-- [imgix](/plugins/@imgix/gatsby/)
+- [imgix](https://github.com/imgix/gatsby)
 
 ### Plugin authors
 
@@ -364,7 +364,7 @@ If not, check steps 1 and 2 above.
 
 If you're using GatsbyImage:
 
-Run the query you're using in your site. Does it return a gatsbyImageData object?
+Run the query you're using in your site. Does it return a `gatsbyImageData` object?
 
 If not, check steps 1 and 2 above.
 

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -250,7 +250,7 @@ These source plugins support using `gatsby-plugin-image` with images served from
 
 A dedicated image CDN can be used with sources that don't have their own CDN, or where you need more transforms or formats than the CDN offers.
 
-- [imgix](/plugins/@imgix/gatsby)
+- [imgix](/plugins/@imgix/gatsby/)
 
 ### Plugin authors
 

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -240,10 +240,10 @@ Many source plugins have native support for `gatsby-plugin-image`, with images s
 These source plugins support using `gatsby-plugin-image` with images served from their CDN.
 
 - [AgilityCMS](https://github.com/agility/gatsby-image-agilitycms)
-- [Contentful](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-contentful#using-the-new-gatsby-image-plugin)
-- [DatoCMS](https://github.com/datocms/gatsby-source-datocms#integration-with-gatsby-image)
-- [GraphCMS](https://github.com/GraphCMS/gatsby-source-graphcms#usage-with-gatsby-plugin-image)
-- [Sanity](https://github.com/sanity-io/gatsby-source-sanity#using-images)
+- [Contentful](/plugins/gatsby-source-contentful#using-the-new-gatsby-image-plugin)
+- [DatoCMS](/plugins/gatsby-source-datocms#integration-with-gatsby-image)
+- [GraphCMS](/plugins/gatsby-source-graphcms#usage-with-gatsby-plugin-image)
+- [Sanity](/plugins/gatsby-source-sanity#using-images)
 - [Shopify](https://github.com/gatsbyjs/gatsby-source-shopify-experimental#images)
 
 ### Image CDNs

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -240,10 +240,10 @@ Many source plugins have native support for `gatsby-plugin-image`, with images s
 These source plugins support using `gatsby-plugin-image` with images served from their CDN.
 
 - [AgilityCMS](https://github.com/agility/gatsby-image-agilitycms)
-- [Contentful](/plugins/gatsby-source-contentful#using-the-new-gatsby-image-plugin)
-- [DatoCMS](/plugins/gatsby-source-datocms#integration-with-gatsby-image)
-- [GraphCMS](/plugins/gatsby-source-graphcms#usage-with-gatsby-plugin-image)
-- [Sanity](/plugins/gatsby-source-sanity#using-images)
+- [Contentful](/plugins/gatsby-source-contentful/#using-the-new-gatsby-image-plugin)
+- [DatoCMS](/plugins/gatsby-source-datocms/#integration-with-gatsby-image)
+- [GraphCMS](/plugins/gatsby-source-graphcms/#usage-with-gatsby-plugin-image)
+- [Sanity](/plugins/gatsby-source-sanity/#using-images)
 - [Shopify](https://github.com/gatsbyjs/gatsby-source-shopify-experimental#images)
 
 ### Image CDNs


### PR DESCRIPTION
 - Fix a few typos.
 - Update link for `@imgix/gatsby` package, as this was a dead link.
 - Update links for Source plugins: Contentful, DatoCMS, GraphCMS and Sanity

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
