### PR TITLE
chore(docs): Add link to latest migration doc

### DIFF
--- a/docs/docs/reference/release-notes/upgrade-gatsby-and-dependencies.md
+++ b/docs/docs/reference/release-notes/upgrade-gatsby-and-dependencies.md
@@ -114,6 +114,7 @@ In case you get stuck in dependencies conflicts, you can use the [npm-force-reso
 ## Related content
 
 Check out these related guides for major upgrades of Gatsby:
+
 - [Migrating from v2 to v3](/docs/reference/release-notes/migrating-from-v2-to-v3/)
 - [Migrating from v1 to v2](/docs/reference/release-notes/migrating-from-v1-to-v2/)
 - [Migrating from v0 to v1](/docs/reference/release-notes/migrating-from-v0-to-v1/)

--- a/docs/docs/reference/release-notes/upgrade-gatsby-and-dependencies.md
+++ b/docs/docs/reference/release-notes/upgrade-gatsby-and-dependencies.md
@@ -114,6 +114,6 @@ In case you get stuck in dependencies conflicts, you can use the [npm-force-reso
 ## Related content
 
 Check out these related guides for major upgrades of Gatsby:
-- [Migrating from v2 to v2](/docs/reference/release-notes/migrating-from-v2-to-v3/)
+- [Migrating from v2 to v3](/docs/reference/release-notes/migrating-from-v2-to-v3/)
 - [Migrating from v1 to v2](/docs/reference/release-notes/migrating-from-v1-to-v2/)
 - [Migrating from v0 to v1](/docs/reference/release-notes/migrating-from-v0-to-v1/)

--- a/docs/docs/reference/release-notes/upgrade-gatsby-and-dependencies.md
+++ b/docs/docs/reference/release-notes/upgrade-gatsby-and-dependencies.md
@@ -114,6 +114,6 @@ In case you get stuck in dependencies conflicts, you can use the [npm-force-reso
 ## Related content
 
 Check out these related guides for major upgrades of Gatsby:
-
+- [Migrating from v2 to v2](/docs/reference/release-notes/migrating-from-v2-to-v3/)
 - [Migrating from v1 to v2](/docs/reference/release-notes/migrating-from-v1-to-v2/)
 - [Migrating from v0 to v1](/docs/reference/release-notes/migrating-from-v0-to-v1/)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Add a relative link for v2 to v3 guidance to the list of migration guides. 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
